### PR TITLE
feat(kb-globale): #1737 Phase 3 — FilterAccordion + KbEditorDesktop FE

### DIFF
--- a/apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx
@@ -35,6 +35,7 @@ import { type JSX, useCallback, useEffect, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { FilterAccordion } from '@/components/features/kb-globale/FilterAccordion';
 import { HeroSearch } from '@/components/features/kb-globale/HeroSearch';
 import type { KbDocViewerCitation } from '@/components/features/kb-globale/KbDocViewerDesktop';
 import { KbHomeDesktop } from '@/components/features/kb-globale/KbHomeDesktop';
@@ -44,7 +45,8 @@ import { useKbChunkDetail } from '@/hooks/queries/useKbChunkDetail';
 import { useKbDocDetail } from '@/hooks/queries/useKbDocDetail';
 import { useUserKbDocs } from '@/hooks/queries/useUserKbDocs';
 import { useKbAskStream } from '@/hooks/useKbAskStream';
-import type { SearchMode } from '@/lib/api/schemas/kb-globale.schemas';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+import type { GlobalKbSearchFilters, SearchMode } from '@/lib/api/schemas/kb-globale.schemas';
 import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
 
 // ---------------------------------------------------------------------------
@@ -63,6 +65,15 @@ const DrawerShellLazy = dynamic(
   () =>
     import('@/components/features/kb-globale/DrawerShell').then(m => ({
       default: m.DrawerShell,
+    })),
+  { ssr: false }
+);
+
+// Phase 3 (#1737): KbEditorDesktop lazy (DEC-5 — not in initial bundle)
+const KbEditorDesktopLazy = dynamic(
+  () =>
+    import('@/components/features/kb-globale/KbEditorDesktop').then(m => ({
+      default: m.KbEditorDesktop,
     })),
   { ssr: false }
 );
@@ -92,6 +103,7 @@ const LABELS = {
     errorDescription: 'Si è verificato un errore. Riprova tra qualche istante.',
     retry: 'Riprova',
     docCardAriaLabel: (doc: KbDoc) => `${doc.fileName}${doc.gameName ? ` — ${doc.gameName}` : ''}`,
+    editLabel: 'Modifica',
   },
   results: {
     resultsCount: (n: number, q: string) => `${n} risultat${n === 1 ? 'o' : 'i'} per «${q}»`,
@@ -116,6 +128,58 @@ const LABELS = {
     thumbnailsLabel: 'Pagine',
     closeLabel: 'Chiudi',
     pageOfTotal: (cur: number, total: number) => `${cur} / ${total}`,
+  },
+  // ── Phase 3 filters (Task 8 will extract to i18n catalog) ───────────────
+  filters: {
+    heading: 'Filtri',
+    docTypeLabel: 'Tipo documento',
+    gameIdLabel: 'Gioco',
+    languageLabel: 'Lingua',
+    clearAll: 'Cancella filtri',
+    docTypeOptions: {
+      Rulebook: 'Regolamento',
+      Expansion: 'Espansione',
+      Errata: 'Errata',
+      QuickStart: 'Quick Start',
+      Reference: 'Riferimento',
+      PlayerAid: 'Aiuto giocatore',
+      Other: 'Altro',
+    },
+    languageOptions: {
+      en: 'English',
+      it: 'Italiano',
+      de: 'Deutsch',
+      fr: 'Français',
+      es: 'Español',
+    },
+  },
+  // ── Phase 3 editor (Task 8 will extract to i18n catalog) ─────────────
+  editor: {
+    heading: 'Modifica metadati',
+    titleLabel: 'Titolo',
+    documentTypeLabel: 'Tipo documento',
+    languageLabel: 'Lingua',
+    tagsLabel: 'Tag',
+    saveLabel: 'Salva',
+    cancelLabel: 'Annulla',
+    notFoundError: 'Documento non trovato',
+    genericError: 'Errore generico, riprova.',
+    documentTypeOptions: {
+      Rulebook: 'Regolamento',
+      Expansion: 'Espansione',
+      Errata: 'Errata',
+      QuickStart: 'Quick Start',
+      Reference: 'Riferimento',
+      PlayerAid: 'Aiuto giocatore',
+      Other: 'Altro',
+    },
+    languageOptions: {
+      en: 'English',
+      it: 'Italiano',
+      de: 'Deutsch',
+      fr: 'Français',
+      es: 'Español',
+    },
   },
   // ── Phase 2 drawer (Task 10 will extract to i18n catalog) ──────────────
   drawer: {
@@ -198,15 +262,31 @@ export function KbGlobaleView(): JSX.Element {
   const chunkIdParam = searchParams.get('chunkId');
   const askParam = searchParams.get('ask') === '1';
 
+  // ── Phase 3 (#1737): filter + edit URL params ──────────────────────────
+  const docTypeParam = searchParams.get('docType');
+  const gameParam = searchParams.get('game');
+  const langParam = searchParams.get('lang');
+  const editParam = searchParams.get('edit') === '1';
+
+  const filters: GlobalKbSearchFilters = useMemo(() => {
+    const f: GlobalKbSearchFilters = {};
+    if (docTypeParam) f.docType = docTypeParam.split(',').filter(Boolean);
+    if (gameParam) f.gameId = gameParam.split(',').filter(Boolean);
+    if (langParam) f.language = langParam;
+    return f;
+  }, [docTypeParam, gameParam, langParam]);
+
   // ── Hooks (called unconditionally per React rules) ─────────────────────
   // useUserKbDocs: always consumed (home branch data + cached warmup).
   const recent = useUserKbDocs();
 
   // useGlobalKbSearch: always called but disabled on home branch.
+  // Phase 3 (#1737): pass server-side facet filters.
   const search = useGlobalKbSearch({
     query: q,
     mode,
     enabled: !isHomeBranch,
+    filters,
   });
 
   // useKbDocDetail: always called but gated via enabled. Returns a
@@ -273,11 +353,60 @@ export function KbGlobaleView(): JSX.Element {
     router.push(qs ? `/knowledge-base/global?${qs}` : '/knowledge-base/global');
   }, [router, searchParams]);
 
+  // ── Phase 3: filter URL update helper ─────────────────────────────────
+  const setFilters = useCallback(
+    (next: GlobalKbSearchFilters) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next.docType && next.docType.length > 0) {
+        params.set('docType', [...next.docType].join(','));
+      } else {
+        params.delete('docType');
+      }
+      if (next.gameId && next.gameId.length > 0) {
+        params.set('game', [...next.gameId].join(','));
+      } else {
+        params.delete('game');
+      }
+      if (next.language) {
+        params.set('lang', next.language);
+      } else {
+        params.delete('lang');
+      }
+      const qs = params.toString();
+      router.push(qs ? `/knowledge-base/global?${qs}` : '/knowledge-base/global');
+    },
+    [router, searchParams]
+  );
+
   // ── Derived values ─────────────────────────────────────────────────────
   const recentDocs: readonly KbDoc[] = useMemo(
     () => recent.data?.items ?? [],
     [recent.data?.items]
   );
+
+  // ── Phase 3: derive available games from useUserKbDocs (DEC-1) ────────
+  // Using the owned-docs list avoids a separate API call and limits the
+  // game dropdown to games the user actually has documents for.
+  const availableGames = useMemo(() => {
+    const seen = new Set<string>();
+    const games: { id: string; name: string }[] = [];
+    for (const doc of recentDocs) {
+      if (doc.gameId && doc.gameName && !seen.has(doc.gameId)) {
+        seen.add(doc.gameId);
+        games.push({ id: doc.gameId, name: doc.gameName });
+      }
+    }
+    return games;
+  }, [recentDocs]);
+
+  // ── Phase 3: edit affordance (DEC-3 anti-info-leak) ───────────────────
+  // Only mount KbEditorDesktop when ?edit=1 AND the target doc is found
+  // in useUserKbDocs.rawItems (which is BE-filtered to owned docs).
+  // If docId is not owned, rawItems.find() returns undefined → null → no mount.
+  const editTargetDto = useMemo<UserKbDocDto | null>(() => {
+    if (!editParam || !docIdParam) return null;
+    return recent.data?.rawItems.find((d: UserKbDocDto) => d.id === docIdParam) ?? null;
+  }, [editParam, docIdParam, recent.data?.rawItems]);
 
   // ── Phase 2: chunk-level page resolution (#1702) ──────────────────────
   // resolvedPage: uses chunkQuery.data.pageNumber when available, falls back to
@@ -359,19 +488,47 @@ export function KbGlobaleView(): JSX.Element {
           error={(recent.error as Error | null) ?? null}
           labels={LABELS.home}
           onRetry={handleHomeRetry}
+          onEditClick={doc => {
+            const params = new URLSearchParams(searchParams.toString());
+            params.set('docId', doc.id);
+            params.set('edit', '1');
+            router.push(`/knowledge-base/global?${params.toString()}`);
+          }}
         />
       ) : (
-        <KbSearchResultsDesktop
-          query={q}
-          results={search.results}
-          hasMore={search.hasMore}
-          isLoading={search.isLoading}
-          isFetchingNextPage={search.isFetchingNextPage}
-          error={search.error}
-          onLoadMore={search.fetchNextPage}
-          labels={LABELS.results}
-          onRetry={handleResultsRetry}
-          onResultClick={r => openViewer({ docId: r.docId, page: r.pageNumber ?? 1 })}
+        <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4">
+          <FilterAccordion
+            availableGames={availableGames}
+            selected={filters}
+            onChange={setFilters}
+            labels={LABELS.filters}
+          />
+          <KbSearchResultsDesktop
+            query={q}
+            results={search.results}
+            hasMore={search.hasMore}
+            isLoading={search.isLoading}
+            isFetchingNextPage={search.isFetchingNextPage}
+            error={search.error}
+            onLoadMore={search.fetchNextPage}
+            labels={LABELS.results}
+            onRetry={handleResultsRetry}
+            onResultClick={r => openViewer({ docId: r.docId, page: r.pageNumber ?? 1 })}
+          />
+        </div>
+      )}
+
+      {/* Phase 3: lazy-mount KbEditorDesktop when ?edit=1 + doc is owned (DEC-3) */}
+      {editTargetDto && (
+        <KbEditorDesktopLazy
+          doc={editTargetDto}
+          labels={LABELS.editor}
+          onClose={() => {
+            const params = new URLSearchParams(searchParams.toString());
+            params.delete('edit');
+            const qs = params.toString();
+            router.push(qs ? `/knowledge-base/global?${qs}` : '/knowledge-base/global');
+          }}
         />
       )}
 

--- a/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * KbGlobaleView Phase 3 integration tests (#1737)
+ * — MSW-mocked scenarios S1-S6 from spec-panel decisions
+ *
+ * S1: Facet apply — selecting docType refetches with filter, results filtered
+ * S2: Facet clear — clearAll resets URL + refetch baseline
+ * S3: URL SSOT round-trip — initial URL with filters pre-selects FilterAccordion
+ * S4: PATCH success — Edit→change title→Save → 200 → cache invalidates → UI updates
+ * S5: PATCH 404 — generic "Documento non trovato" message (anti-info-leak)
+ * S6: PATCH 422 — FluentValidation envelope → inline field error with aria-describedby
+ *
+ * Pattern follows KbGlobaleView.integration.test.tsx exactly:
+ *   - Shared MSW server from @/__tests__/mocks/server (started by vitest.setup.tsx)
+ *   - server.use() for per-test handler overrides; server.resetHandlers() in afterEach
+ *   - Mutable searchParamsMap for URL control without routing
+ *   - next/dynamic stubbed to resolve ssr:false components synchronously
+ *   - react-pdf mocked for viewer compatibility
+ *   - Fresh QueryClient per test (retry:false, staleTime:0, gcTime:0)
+ *
+ * 422 envelope: BE returns { errors: { field: ["msg"] } } (FluentValidation).
+ * createApiError → ValidationError.fieldErrors flattens to { field: "msg" }
+ * so KbEditorDesktop's isHttpFieldError guard picks it up via err.status === 422.
+ *
+ * @see apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx
+ * @see Issue #1737 Phase 3 — FilterAccordion + KbEditorDesktop
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { server } from '@/__tests__/mocks/server';
+import { globalRequestCache } from '@/lib/api/core/requestCache';
+
+// ─── API base (matches vitest.setup.tsx + handler convention) ────────────────
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+// ─── next/navigation mocks ────────────────────────────────────────────────────
+// Mutable state so each test can control the URL independently.
+// Same pattern as KbGlobaleView.integration.test.tsx.
+
+type SearchParamsRecord = Record<string, string | null>;
+let searchParamsMap: SearchParamsRecord = {};
+const mockRouterPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsMap[key] ?? null,
+    toString: () =>
+      Object.entries(searchParamsMap)
+        .filter(([, v]) => v != null)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v!)}`)
+        .join('&'),
+  }),
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+  }),
+  usePathname: () => '/knowledge-base/global',
+}));
+
+// ─── next/dynamic mock ────────────────────────────────────────────────────────
+// Resolves lazy imports synchronously so ssr:false dynamic components mount
+// immediately in jsdom (KbEditorDesktopLazy, KbDocViewerDesktopLazy, DrawerShellLazy).
+vi.mock('next/dynamic', () => ({
+  default: (
+    loader: () => Promise<{ default: React.ComponentType<Record<string, unknown>> }>
+  ): React.ComponentType<Record<string, unknown>> => {
+    let Inner: React.ComponentType<Record<string, unknown>> | null = null;
+    void loader().then(mod => {
+      Inner = mod.default;
+    });
+    const Wrapper = (props: Record<string, unknown>) =>
+      Inner ? React.createElement(Inner, props) : null;
+    Wrapper.displayName = 'NextDynamicStub';
+    return Wrapper;
+  },
+}));
+
+// ─── react-pdf mock ──────────────────────────────────────────────────────────
+// KbDocViewerDesktop imports react-pdf which requires canvas/browser APIs.
+vi.mock('react-pdf', () => ({
+  Document: ({
+    children,
+    onLoadSuccess,
+  }: {
+    children: ReactNode;
+    onLoadSuccess?: (p: { numPages: number }) => void;
+  }) => {
+    onLoadSuccess?.({ numPages: 5 });
+    return <div data-testid="react-pdf-document">{children}</div>;
+  },
+  Page: ({ pageNumber }: { pageNumber: number }) => <div data-testid={`pdf-page-${pageNumber}`} />,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
+}));
+
+// ─── Wrapper with fresh QueryClient per test ──────────────────────────────────
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { KbGlobaleView } from '../KbGlobaleView';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+// RFC 4122 v4 UUIDs for test fixtures — must pass Zod uuid() validation.
+const DOC_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const GAME_ID = 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a66';
+const ISO_DATE = '2026-05-31T00:00:00+00:00';
+
+const DOC_FIXTURE = {
+  id: DOC_ID,
+  gameId: GAME_ID,
+  gameName: 'Azul',
+  fileName: 'azul-rules.pdf',
+  processingState: 'Ready' as const,
+  pageCount: 24,
+  processedAt: ISO_DATE,
+  uploadedAt: ISO_DATE,
+  updatedAt: ISO_DATE,
+  title: 'Old Title',
+  tags: ['family'],
+  updatedBy: null,
+};
+
+// Two search results distinguishable by docType / snippet
+const SEARCH_RESULT_RULEBOOK = {
+  chunkId: 'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380b11',
+  docId: DOC_ID,
+  docTitle: 'Azul Rules',
+  gameId: GAME_ID,
+  gameName: 'Azul',
+  docType: 'Rulebook',
+  headingPath: 'Setup',
+  snippet: 'Place tiles on the board...',
+  pageNumber: 3,
+  score: 0.9,
+};
+
+const SEARCH_RESULT_ERRATA = {
+  chunkId: 'c1eebc99-9c0b-4ef8-bb6d-6bb9bd380b22',
+  docId: DOC_ID,
+  docTitle: 'Azul Errata',
+  gameId: GAME_ID,
+  gameName: 'Azul',
+  docType: 'Errata',
+  headingPath: 'Corrections',
+  snippet: 'Errata correction for tile placement...',
+  pageNumber: 7,
+  score: 0.75,
+};
+
+// ─── Shared MSW handlers helpers ─────────────────────────────────────────────
+
+/** kb-docs list handler — returns DOC_FIXTURE with Phase 3 fields */
+function kbDocsListHandler() {
+  return http.get(`${API_BASE}/api/v1/kb-docs`, () =>
+    HttpResponse.json({
+      items: [DOC_FIXTURE],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    })
+  );
+}
+
+/**
+ * Global search handler: returns Rulebook-only when body.docType = ['Rulebook'],
+ * returns both results otherwise (baseline).
+ */
+function globalSearchHandler() {
+  return http.post(`${API_BASE}/api/v1/knowledge-base/search/global`, async ({ request }) => {
+    const body = (await request.json()) as { docType?: string[] };
+    if (body.docType?.includes('Rulebook') && !body.docType?.includes('Errata')) {
+      return HttpResponse.json({
+        results: [SEARCH_RESULT_RULEBOOK],
+        hasMore: false,
+        nextCursor: null,
+      });
+    }
+    return HttpResponse.json({
+      results: [SEARCH_RESULT_RULEBOOK, SEARCH_RESULT_ERRATA],
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+}
+
+/**
+ * PATCH /kb-docs/:id handler:
+ * - body.title === 'TRIGGER_404' → 404
+ * - body.title === 'TRIGGER_422' → 422 { errors: { title: ['Title must not exceed 200 characters.'] } }
+ * - otherwise → 200 with updated title
+ */
+function patchKbDocHandler() {
+  return http.patch(`${API_BASE}/api/v1/kb-docs/:id`, async ({ request }) => {
+    const body = (await request.json()) as { title?: string };
+    if (body.title === 'TRIGGER_404') {
+      return new HttpResponse(null, { status: 404 });
+    }
+    if (body.title === 'TRIGGER_422') {
+      return HttpResponse.json(
+        { errors: { title: ['Title must not exceed 200 characters.'] } },
+        { status: 422 }
+      );
+    }
+    return HttpResponse.json({ ...DOC_FIXTURE, title: body.title ?? DOC_FIXTURE.title });
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('KbGlobaleView Phase 3 — S1-S6 (#1737)', () => {
+  beforeEach(() => {
+    searchParamsMap = {};
+    mockRouterPush.mockReset();
+    // Clear deduplication cache (same pattern as Phase 1+2 integration tests).
+    globalRequestCache.clear();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  // ── S1: Facet apply ────────────────────────────────────────────────────────
+  it('S1: docType filter applied — selecting Rulebook refetches and hides Errata result', async () => {
+    // Start on results branch with no filter → both results visible
+    server.use(kbDocsListHandler(), globalSearchHandler());
+    searchParamsMap = { q: 'azul' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for both results to appear (baseline — no filter)
+    await waitFor(() => {
+      expect(screen.getByText('Azul Rules')).toBeInTheDocument();
+      expect(screen.getByText('Azul Errata')).toBeInTheDocument();
+    });
+
+    // Expand the DocType accordion section and click 'Regolamento' (Rulebook)
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    fireEvent.click(screen.getByLabelText(/regolamento/i));
+
+    // The onChange handler calls router.push with ?docType=Rulebook
+    // Since we control the URL via searchParamsMap and mockRouterPush,
+    // simulate the URL update to trigger re-render with the new filter.
+    expect(mockRouterPush).toHaveBeenCalled();
+    const pushedUrl = mockRouterPush.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).toMatch(/docType=Rulebook/);
+  }, 8000);
+
+  // ── S2: Facet clear ────────────────────────────────────────────────────────
+  it('S2: clearAll resets all facets — calls router.push with cleaned URL', async () => {
+    server.use(kbDocsListHandler(), globalSearchHandler());
+
+    // Start with docType=Rulebook pre-selected via URL
+    searchParamsMap = { q: 'azul', docType: 'Rulebook' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for FilterAccordion to render (results branch + filters present)
+    await waitFor(() => {
+      // FilterAccordion shows clearAll button when hasAnyFilter=true
+      expect(screen.getByRole('button', { name: /cancella filtri/i })).toBeInTheDocument();
+    });
+
+    // Click clearAll
+    fireEvent.click(screen.getByRole('button', { name: /cancella filtri/i }));
+
+    // router.push should be called; cleared URL should not contain docType
+    expect(mockRouterPush).toHaveBeenCalled();
+    const pushedUrl = mockRouterPush.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).not.toMatch(/docType/);
+  }, 8000);
+
+  // ── S3: URL SSOT round-trip ────────────────────────────────────────────────
+  it('S3: URL ?docType=Rulebook&lang=it pre-selects FilterAccordion checkboxes', async () => {
+    server.use(kbDocsListHandler(), globalSearchHandler());
+
+    // Mount with pre-set URL filters
+    searchParamsMap = { q: 'azul', docType: 'Rulebook', lang: 'it' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for FilterAccordion to appear (results branch)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /tipo documento/i })).toBeInTheDocument();
+    });
+
+    // Expand DocType accordion
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+
+    // Regolamento (Rulebook) checkbox should be pre-checked
+    const rulebookCheckbox = screen.getByLabelText(/regolamento/i) as HTMLInputElement;
+    expect(rulebookCheckbox.checked).toBe(true);
+
+    // Expand Language accordion
+    fireEvent.click(screen.getByRole('button', { name: /lingua/i }));
+
+    // Italiano (it) radio should be pre-selected
+    const italianoRadio = screen.getByLabelText(/italiano/i) as HTMLInputElement;
+    expect(italianoRadio.checked).toBe(true);
+  }, 8000);
+
+  // ── S4: PATCH success ──────────────────────────────────────────────────────
+  it('S4: PATCH success — editor mounts pre-filled, PATCH called, router navigates away', async () => {
+    server.use(kbDocsListHandler(), patchKbDocHandler());
+
+    // Mount at home branch with ?docId + ?edit=1 → editTargetDto resolved from useUserKbDocs
+    searchParamsMap = { docId: DOC_ID, edit: '1' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for KbEditorDesktop to mount (useUserKbDocs returns DOC_FIXTURE → rawItems)
+    await waitFor(() => {
+      expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument();
+    });
+
+    // Pre-filled with existing title from DOC_FIXTURE.title
+    const titleInput = screen.getByLabelText(/titolo/i) as HTMLInputElement;
+    expect(titleInput.value).toBe('Old Title');
+
+    // Change the title
+    fireEvent.change(titleInput, { target: { value: 'Brand New Title' } });
+    expect(titleInput.value).toBe('Brand New Title');
+
+    // Submit the form
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+
+    // After PATCH success, onClose calls router.push with edit param removed.
+    // Since searchParamsMap is a static mock (doesn't update from router.push),
+    // we verify via mockRouterPush that the URL navigation happened without ?edit=1.
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalled();
+    });
+    const pushedUrl = mockRouterPush.mock.calls[
+      mockRouterPush.mock.calls.length - 1
+    ]?.[0] as string;
+    expect(pushedUrl).not.toMatch(/edit=1/);
+  }, 8000);
+
+  // ── S5: PATCH 404 ──────────────────────────────────────────────────────────
+  it('S5: PATCH 404 → generic notFoundError message (anti-info-leak)', async () => {
+    server.use(kbDocsListHandler(), patchKbDocHandler());
+
+    searchParamsMap = { docId: DOC_ID, edit: '1' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for editor to mount
+    await waitFor(() => {
+      expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument();
+    });
+
+    // Trigger 404 via sentinel title
+    fireEvent.change(screen.getByLabelText(/titolo/i), { target: { value: 'TRIGGER_404' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+
+    // Generic notFoundError message should appear
+    await waitFor(() => {
+      expect(screen.getByText(/documento non trovato/i)).toBeInTheDocument();
+    });
+
+    // Must NOT show forbidden/unauthorized text (anti-info-leak DEC-3)
+    expect(screen.queryByText(/non autorizzato|forbidden|403/i)).not.toBeInTheDocument();
+  }, 8000);
+
+  // ── S6: PATCH 422 field errors ─────────────────────────────────────────────
+  it('S6: PATCH 422 → FluentValidation envelope → inline field error with aria-describedby', async () => {
+    server.use(kbDocsListHandler(), patchKbDocHandler());
+
+    searchParamsMap = { docId: DOC_ID, edit: '1' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for editor to mount
+    await waitFor(() => {
+      expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument();
+    });
+
+    // Trigger 422 via sentinel title
+    fireEvent.change(screen.getByLabelText(/titolo/i), { target: { value: 'TRIGGER_422' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+
+    // Inline field error should appear under the title input
+    await waitFor(() => {
+      expect(screen.getByText(/title must not exceed 200/i)).toBeInTheDocument();
+    });
+
+    // Title input must have aria-describedby linking it to the error message
+    expect(screen.getByLabelText(/titolo/i)).toHaveAttribute('aria-describedby');
+
+    // Form must NOT close (error is recoverable)
+    expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument();
+  }, 8000);
+});

--- a/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UseGlobalKbSearchResult } from '@/hooks/queries/useGlobalKbSearch';
 import type { UseUserKbDocsResult } from '@/hooks/queries/useUserKbDocs';
 import type { KbDocEnvelope } from '@/lib/api/schemas/kb-chunks.schemas';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
 import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -144,6 +145,23 @@ vi.mock('next/dynamic', () => ({
 // ─── React import for JSX in mocks ───────────────────────────────────────
 import React from 'react';
 
+// ─── KbEditorDesktop mock (Phase 3) ──────────────────────────────────────
+
+vi.mock('@/components/features/kb-globale/KbEditorDesktop', () => ({
+  KbEditorDesktop: (props: Record<string, unknown>) => (
+    <div
+      data-testid="kb-editor-desktop"
+      data-doc-id={String(props['doc'] ? (props['doc'] as { id: string }).id : '')}
+    />
+  ),
+}));
+
+// ─── FilterAccordion mock (Phase 3) ──────────────────────────────────────
+
+vi.mock('@/components/features/kb-globale/FilterAccordion', () => ({
+  FilterAccordion: () => <div data-testid="filter-accordion" />,
+}));
+
 // ─── Child component mocks ────────────────────────────────────────────────
 // Replace each sub-component with a minimal stub that:
 //   1. Renders a known data-testid for presence assertions.
@@ -232,7 +250,7 @@ function makeSearchResult(): UseGlobalKbSearchResult {
 
 function makeUserKbDocsResult(): MockUserKbDocsReturn {
   return {
-    data: { items: [] as KbDoc[], total: 0, page: 1, pageSize: 20 },
+    data: { items: [] as KbDoc[], rawItems: [] as UserKbDocDto[], total: 0, page: 1, pageSize: 20 },
     isLoading: false,
     isError: false,
     error: null,
@@ -567,6 +585,125 @@ describe('KbGlobaleView (orchestrator)', () => {
       searchParamsMap = { ask: '0' };
       render(<KbGlobaleView />);
       expect(screen.queryByTestId('kb-globale-drawer')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Phase 3 (#1737): URL parsing for filters + editor ────────────────────
+  describe('KbGlobaleView — Phase 3 (#1737) URL parsing', () => {
+    it('passes docType from ?docType=Rulebook,Errata to useGlobalKbSearch filters', () => {
+      searchParamsMap = { q: 'azul', docType: 'Rulebook,Errata' };
+      render(<KbGlobaleView />);
+      const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as {
+        filters?: { docType?: string[] };
+      };
+      expect(callArg?.filters?.docType).toEqual(['Rulebook', 'Errata']);
+    });
+
+    it('passes gameId from ?game=uuid1,uuid2 to useGlobalKbSearch filters', () => {
+      searchParamsMap = {
+        q: 'azul',
+        game: '00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002',
+      };
+      render(<KbGlobaleView />);
+      const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as {
+        filters?: { gameId?: string[] };
+      };
+      expect(callArg?.filters?.gameId).toEqual([
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000002',
+      ]);
+    });
+
+    it('passes language from ?lang=it to useGlobalKbSearch filters', () => {
+      searchParamsMap = { q: 'azul', lang: 'it' };
+      render(<KbGlobaleView />);
+      const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as {
+        filters?: { language?: string };
+      };
+      expect(callArg?.filters?.language).toBe('it');
+    });
+
+    it('lazy-mounts KbEditorDesktop when ?docId=X&edit=1 present and doc is in useUserKbDocs', () => {
+      const rawDoc: UserKbDocDto = {
+        id: 'doc-owned',
+        gameId: null,
+        gameName: null,
+        fileName: 'azul.pdf',
+        processingState: 'Ready',
+        pageCount: 24,
+        processedAt: '2026-05-31T00:00:00Z',
+        uploadedAt: '2026-05-31T00:00:00Z',
+        updatedAt: '2026-05-31T00:00:00Z',
+      };
+      const kbDoc: KbDoc = {
+        id: 'doc-owned',
+        gameId: null,
+        gameName: null,
+        fileName: 'azul.pdf',
+        processingState: 'Ready',
+        pageCount: 24,
+        processedAt: '2026-05-31T00:00:00Z',
+        uploadedAt: '2026-05-31T00:00:00Z',
+        updatedAt: '2026-05-31T00:00:00Z',
+      };
+      searchParamsMap = { docId: 'doc-owned', edit: '1' };
+      useUserKbDocsMock.mockReturnValue({
+        data: {
+          items: [kbDoc],
+          rawItems: [rawDoc],
+          total: 1,
+          page: 1,
+          pageSize: 20,
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as MockUserKbDocsReturn);
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('kb-editor-desktop')).toBeInTheDocument();
+    });
+
+    it('does NOT mount KbEditorDesktop when ?docId=Y&edit=1 but doc Y not in useUserKbDocs (DEC-3)', () => {
+      const rawDoc: UserKbDocDto = {
+        id: 'doc-owned',
+        gameId: null,
+        gameName: null,
+        fileName: 'azul.pdf',
+        processingState: 'Ready',
+        pageCount: 24,
+        processedAt: '2026-05-31T00:00:00Z',
+        uploadedAt: '2026-05-31T00:00:00Z',
+        updatedAt: '2026-05-31T00:00:00Z',
+      };
+      const kbDoc: KbDoc = {
+        id: 'doc-owned',
+        gameId: null,
+        gameName: null,
+        fileName: 'azul.pdf',
+        processingState: 'Ready',
+        pageCount: 24,
+        processedAt: '2026-05-31T00:00:00Z',
+        uploadedAt: '2026-05-31T00:00:00Z',
+        updatedAt: '2026-05-31T00:00:00Z',
+      };
+      // URL requests edit for doc-NOT-OWNED (different from doc-owned in rawItems)
+      searchParamsMap = { docId: 'doc-NOT-OWNED', edit: '1' };
+      useUserKbDocsMock.mockReturnValue({
+        data: {
+          items: [kbDoc],
+          rawItems: [rawDoc],
+          total: 1,
+          page: 1,
+          pageSize: 20,
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as MockUserKbDocsReturn);
+      render(<KbGlobaleView />);
+      expect(screen.queryByTestId('kb-editor-desktop')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/components/features/kb-globale/FilterAccordion.tsx
+++ b/apps/web/src/components/features/kb-globale/FilterAccordion.tsx
@@ -1,0 +1,187 @@
+/**
+ * FilterAccordion — Phase 3 #1737 / Issue #1482 component #4.
+ *
+ * Three server-side facets backed by BE PR #1730 (#1686):
+ *   - DocType  : multi-select, 7-value allowlist (D-6 #1686); drops `faq` per DEC-7
+ *   - GameId   : multi-select, dropdown of accessible games (DEC-1: derived from useUserKbDocs)
+ *   - Language : single-select, 5-value ISO 639-1 allowlist (D-7 #1686)
+ *
+ * Controlled component — parent owns `selected` state (URL SSOT in KbGlobaleView)
+ * and reacts to `onChange`.
+ *
+ * Empty selection = no filter (D-3/D-5 #1686, byte-identical baseline).
+ *
+ * a11y: each facet section is a <details>+<summary> for native accordion;
+ * checkboxes/radios for inputs; visible clearAll button at top.
+ */
+'use client';
+
+import { type JSX } from 'react';
+
+import type { GlobalKbSearchFilters } from '@/lib/api/schemas/kb-globale.schemas';
+
+export interface FilterAccordionLabels {
+  heading: string;
+  docTypeLabel: string;
+  gameIdLabel: string;
+  languageLabel: string;
+  clearAll: string;
+  /** Map: BE enum string → display label */
+  docTypeOptions: Readonly<Record<string, string>>;
+  languageOptions: Readonly<Record<string, string>>;
+}
+
+export interface GameOption {
+  id: string;
+  name: string;
+}
+
+export interface FilterAccordionProps {
+  availableGames: readonly GameOption[];
+  selected: GlobalKbSearchFilters;
+  onChange: (next: GlobalKbSearchFilters) => void;
+  labels: FilterAccordionLabels;
+}
+
+const DOC_TYPE_ALLOWLIST = [
+  'Rulebook',
+  'Expansion',
+  'Errata',
+  'QuickStart',
+  'Reference',
+  'PlayerAid',
+  'Other',
+] as const;
+
+const LANGUAGE_ALLOWLIST = ['en', 'it', 'de', 'fr', 'es'] as const;
+
+export function FilterAccordion(props: FilterAccordionProps): JSX.Element {
+  const { availableGames, selected, onChange, labels } = props;
+  const selectedDocTypes = selected.docType ?? [];
+  const selectedGameIds = selected.gameId ?? [];
+  const selectedLanguage = selected.language ?? '';
+
+  const toggleDocType = (value: string) => {
+    const next = selectedDocTypes.includes(value)
+      ? selectedDocTypes.filter(v => v !== value)
+      : [...selectedDocTypes, value];
+    onChange({ ...selected, docType: next.length > 0 ? next : undefined });
+  };
+
+  const toggleGameId = (id: string) => {
+    const next = selectedGameIds.includes(id)
+      ? selectedGameIds.filter(v => v !== id)
+      : [...selectedGameIds, id];
+    onChange({ ...selected, gameId: next.length > 0 ? next : undefined });
+  };
+
+  const setLanguage = (lang: string) => {
+    onChange({ ...selected, language: lang || undefined });
+  };
+
+  const clearAll = () => onChange({});
+
+  const hasAnyFilter =
+    selectedDocTypes.length > 0 || selectedGameIds.length > 0 || selectedLanguage !== '';
+
+  return (
+    <aside
+      className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3"
+      aria-label={labels.heading}
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-foreground">{labels.heading}</h2>
+        {hasAnyFilter && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-sm text-muted-foreground hover:text-foreground underline"
+          >
+            {labels.clearAll}
+          </button>
+        )}
+      </div>
+
+      {/* DocType facet */}
+      <details className="border-t border-border-strong pt-2">
+        {/* role="button" is the HTML spec implicit role for <summary>; explicit for jsdom compat */}
+        <summary role="button" className="cursor-pointer font-medium text-sm text-foreground">
+          {labels.docTypeLabel}
+          {selectedDocTypes.length > 0 && (
+            <span className="ml-2 text-muted-foreground">({selectedDocTypes.length})</span>
+          )}
+        </summary>
+        <div className="mt-2 flex flex-col gap-1">
+          {DOC_TYPE_ALLOWLIST.map(opt => (
+            <label key={opt} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={selectedDocTypes.includes(opt)}
+                onChange={() => toggleDocType(opt)}
+              />
+              <span>{labels.docTypeOptions[opt] ?? opt}</span>
+            </label>
+          ))}
+        </div>
+      </details>
+
+      {/* GameId facet */}
+      <details className="border-t border-border-strong pt-2">
+        {/* role="button" is the HTML spec implicit role for <summary>; explicit for jsdom compat */}
+        <summary role="button" className="cursor-pointer font-medium text-sm text-foreground">
+          {labels.gameIdLabel}
+          {selectedGameIds.length > 0 && (
+            <span className="ml-2 text-muted-foreground">({selectedGameIds.length})</span>
+          )}
+        </summary>
+        <div className="mt-2 flex flex-col gap-1 max-h-60 overflow-auto">
+          {availableGames.map(g => (
+            <label key={g.id} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={selectedGameIds.includes(g.id)}
+                onChange={() => toggleGameId(g.id)}
+              />
+              <span>{g.name}</span>
+            </label>
+          ))}
+        </div>
+      </details>
+
+      {/* Language facet */}
+      <details className="border-t border-border-strong pt-2">
+        {/* role="button" is the HTML spec implicit role for <summary>; explicit for jsdom compat */}
+        <summary role="button" className="cursor-pointer font-medium text-sm text-foreground">
+          {labels.languageLabel}
+          {selectedLanguage && (
+            <span className="ml-2 text-muted-foreground">
+              ({labels.languageOptions[selectedLanguage] ?? selectedLanguage})
+            </span>
+          )}
+        </summary>
+        <div className="mt-2 flex flex-col gap-1" role="radiogroup">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="kb-globale-language"
+              checked={selectedLanguage === ''}
+              onChange={() => setLanguage('')}
+            />
+            <span className="text-muted-foreground">—</span>
+          </label>
+          {LANGUAGE_ALLOWLIST.map(lang => (
+            <label key={lang} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="kb-globale-language"
+                checked={selectedLanguage === lang}
+                onChange={() => setLanguage(lang)}
+              />
+              <span>{labels.languageOptions[lang] ?? lang}</span>
+            </label>
+          ))}
+        </div>
+      </details>
+    </aside>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx
+++ b/apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx
@@ -1,0 +1,264 @@
+/**
+ * KbEditorDesktop — Phase 3 #1737 / Issue #1482 component #8.
+ *
+ * Metadata-edit form for owner-curated KB docs. Calls PATCH /api/v1/kb-docs/{id}
+ * (BE PR #1732 #1687) with partial update semantics (D-4): null = no-op, ""/[] = clear.
+ *
+ * Error handling:
+ *   - 404 → generic "Documento non trovato" (D-2 anti-info-leak)
+ *   - 422 → inline field errors via aria-describedby (FluentValidation envelope)
+ *   - other → generic error toast
+ *
+ * Owner-only affordance enforcement is upstream (DEC-3 — only mounted from
+ * KbHomeDesktop recent cards which are BE-filtered to owned docs).
+ *
+ * Mounted lazy via dynamic({ ssr: false }) by KbGlobaleView (DEC-5 bundle).
+ */
+'use client';
+
+import { type JSX, useState, useId } from 'react';
+
+import { useUpdateKbDocMeta } from '@/hooks/mutations/useUpdateKbDocMeta';
+import type { PatchKbDocMetadataRequest } from '@/lib/api/schemas/kb-docs-patch.schemas';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+
+export interface KbEditorDesktopLabels {
+  heading: string;
+  titleLabel: string;
+  documentTypeLabel: string;
+  languageLabel: string;
+  tagsLabel: string;
+  saveLabel: string;
+  cancelLabel: string;
+  notFoundError: string;
+  genericError: string;
+  documentTypeOptions: Readonly<Record<string, string>>;
+  languageOptions: Readonly<Record<string, string>>;
+}
+
+export interface KbEditorDesktopProps {
+  doc: UserKbDocDto;
+  onClose: () => void;
+  labels: KbEditorDesktopLabels;
+}
+
+interface FieldError {
+  title?: string;
+  documentType?: string;
+  language?: string;
+  tags?: string;
+}
+
+interface HttpFieldError extends Error {
+  status?: number;
+  fieldErrors?: Record<string, string>;
+}
+
+function isHttpFieldError(err: unknown): err is HttpFieldError {
+  return err instanceof Error && 'status' in err;
+}
+
+function is404Error(err: unknown): boolean {
+  if (isHttpFieldError(err) && err.status === 404) return true;
+  if (err instanceof Error && err.message.includes('404')) return true;
+  return false;
+}
+
+function buildPatchBody(
+  initial: UserKbDocDto,
+  draft: { title: string; documentType: string; language: string; tags: string[] }
+): PatchKbDocMetadataRequest {
+  const body: PatchKbDocMetadataRequest = {};
+  if (draft.title !== (initial.title ?? '')) {
+    body.title = draft.title; // empty string ⇒ clear (D-4)
+  }
+  if (draft.documentType !== ((initial as { documentType?: string }).documentType ?? '')) {
+    body.documentType = draft.documentType || undefined;
+  }
+  if (draft.language !== ((initial as { language?: string }).language ?? '')) {
+    body.language = draft.language || undefined;
+  }
+  const initialTags = initial.tags ?? [];
+  const tagsChanged =
+    draft.tags.length !== initialTags.length || draft.tags.some((t, i) => t !== initialTags[i]);
+  if (tagsChanged) {
+    body.tags = draft.tags;
+  }
+  return body;
+}
+
+export function KbEditorDesktop(props: KbEditorDesktopProps): JSX.Element {
+  const { doc, onClose, labels } = props;
+  const titleId = useId();
+  const titleErrId = useId();
+  const tagsId = useId();
+  const tagsErrId = useId();
+
+  const [title, setTitle] = useState(doc.title ?? '');
+  const [documentType, setDocumentType] = useState(
+    (doc as { documentType?: string }).documentType ?? ''
+  );
+  const [language, setLanguage] = useState((doc as { language?: string }).language ?? '');
+  const [tagsInput, setTagsInput] = useState((doc.tags ?? []).join(', '));
+  const [errors, setErrors] = useState<FieldError>({});
+  const [topError, setTopError] = useState<string | null>(null);
+
+  const mutation = useUpdateKbDocMeta();
+
+  const docTypeOptions = Object.keys(labels.documentTypeOptions);
+  const languageOptions = Object.keys(labels.languageOptions);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setTopError(null);
+
+    const tagsArray = tagsInput
+      .split(',')
+      .map(t => t.trim())
+      .filter(t => t.length > 0);
+
+    const body = buildPatchBody(doc, {
+      title,
+      documentType,
+      language,
+      tags: tagsArray,
+    });
+
+    mutation.mutate(
+      { id: doc.id, body },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: (err: unknown) => {
+          if (is404Error(err)) {
+            setTopError(labels.notFoundError);
+            return;
+          }
+          if (isHttpFieldError(err) && err.status === 422 && err.fieldErrors) {
+            setErrors(err.fieldErrors as FieldError);
+            return;
+          }
+          setTopError(labels.genericError);
+        },
+      }
+    );
+  }
+
+  return (
+    <section
+      className="bg-card border border-border rounded-lg p-6 flex flex-col gap-4"
+      aria-label={labels.heading}
+    >
+      <h2 className="font-semibold text-foreground">{labels.heading}</h2>
+      {topError && (
+        <div role="alert" className="text-sm text-destructive">
+          {topError}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* Title field */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor={titleId} className="text-sm font-medium">
+            {labels.titleLabel}
+          </label>
+          <input
+            id={titleId}
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            aria-describedby={errors.title ? titleErrId : undefined}
+            aria-invalid={errors.title ? true : undefined}
+            className="border border-border rounded px-2 py-1"
+          />
+          {errors.title && (
+            <p id={titleErrId} className="text-sm text-destructive">
+              {errors.title}
+            </p>
+          )}
+        </div>
+
+        {/* DocumentType field */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium" htmlFor={`${titleId}-doctype`}>
+            {labels.documentTypeLabel}
+          </label>
+          <select
+            id={`${titleId}-doctype`}
+            value={documentType}
+            onChange={e => setDocumentType(e.target.value)}
+            className="border border-border rounded px-2 py-1"
+          >
+            <option value="">—</option>
+            {docTypeOptions.map(opt => (
+              <option key={opt} value={opt}>
+                {labels.documentTypeOptions[opt]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Language field */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium" htmlFor={`${titleId}-lang`}>
+            {labels.languageLabel}
+          </label>
+          <select
+            id={`${titleId}-lang`}
+            value={language}
+            onChange={e => setLanguage(e.target.value)}
+            className="border border-border rounded px-2 py-1"
+          >
+            <option value="">—</option>
+            {languageOptions.map(opt => (
+              <option key={opt} value={opt}>
+                {labels.languageOptions[opt]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Tags field */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor={tagsId} className="text-sm font-medium">
+            {labels.tagsLabel}
+          </label>
+          <input
+            id={tagsId}
+            type="text"
+            value={tagsInput}
+            onChange={e => setTagsInput(e.target.value)}
+            placeholder="tag1, tag2, …"
+            aria-describedby={errors.tags ? tagsErrId : undefined}
+            aria-invalid={errors.tags ? true : undefined}
+            className="border border-border rounded px-2 py-1"
+          />
+          {errors.tags && (
+            <p id={tagsErrId} className="text-sm text-destructive">
+              {errors.tags}
+            </p>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-3 mt-2">
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="bg-primary text-primary-foreground rounded px-4 py-2 hover:opacity-90 disabled:opacity-50"
+          >
+            {labels.saveLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border border-border rounded px-4 py-2 hover:bg-muted"
+          >
+            {labels.cancelLabel}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx
+++ b/apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx
@@ -19,6 +19,7 @@
 import { type JSX, useState, useId } from 'react';
 
 import { useUpdateKbDocMeta } from '@/hooks/mutations/useUpdateKbDocMeta';
+import { ApiError } from '@/lib/api/core/errors';
 import type { PatchKbDocMetadataRequest } from '@/lib/api/schemas/kb-docs-patch.schemas';
 import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
 
@@ -59,7 +60,11 @@ function isHttpFieldError(err: unknown): err is HttpFieldError {
 }
 
 function is404Error(err: unknown): boolean {
+  // Primary: real NotFoundError from httpClient (ApiError with statusCode=404).
+  if (err instanceof ApiError && err.statusCode === 404) return true;
+  // Secondary: ValidationError or other Error subclass exposing `status=404`.
   if (isHttpFieldError(err) && err.status === 404) return true;
+  // Fallback: tests/mocks that throw plain `new Error('HTTP 404')` (no statusCode).
   if (err instanceof Error && err.message.includes('404')) return true;
   return false;
 }

--- a/apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx
+++ b/apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx
@@ -48,6 +48,8 @@ export interface KbHomeDesktopLabels {
   retry?: string;
   /** Aria-label factory for each doc card (used for a11y) */
   docCardAriaLabel: (doc: KbDoc) => string;
+  /** Phase 3 (#1737): label for the per-card edit button (optional; if absent no edit button) */
+  editLabel?: string;
 }
 
 export interface KbHomeDesktopProps {
@@ -65,6 +67,12 @@ export interface KbHomeDesktopProps {
   onEmptyCtaClick?: () => void;
   /** Called when the error banner retry button is clicked */
   onRetry?: () => void;
+  /**
+   * Phase 3 (#1737): called with the doc when the per-card Edit button is clicked.
+   * DEC-3: only provide this from KbGlobaleView home branch (owned docs only).
+   * When absent, no Edit button is rendered.
+   */
+  onEditClick?: (doc: KbDoc) => void;
   /** Extra CSS classes on the root element */
   className?: string;
 }
@@ -92,10 +100,19 @@ interface DocCardProps {
   doc: KbDoc;
   ariaLabel: string;
   onDocClick?: (docId: string) => void;
+  /** Phase 3 (#1737): when provided, an Edit button is rendered (DEC-3 owner-only) */
+  onEditClick?: (doc: KbDoc) => void;
+  editLabel?: string;
 }
 
 /** Single doc card — rendered as <button> when onDocClick provided, <div> otherwise */
-function DocCard({ doc, ariaLabel, onDocClick }: DocCardProps): JSX.Element {
+function DocCard({
+  doc,
+  ariaLabel,
+  onDocClick,
+  onEditClick,
+  editLabel,
+}: DocCardProps): JSX.Element {
   const gameName = doc.gameName ?? '(senza gioco)';
 
   // Format date — simple locale date, no extra library required
@@ -132,6 +149,27 @@ function DocCard({ doc, ariaLabel, onDocClick }: DocCardProps): JSX.Element {
             </>
           )}
         </div>
+
+        {/* Phase 3 (#1737): edit affordance — owner-only (DEC-3) */}
+        {onEditClick && editLabel && (
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={e => {
+                e.stopPropagation();
+                onEditClick(doc);
+              }}
+              className={cn(
+                'inline-flex items-center rounded px-2 py-0.5 text-xs font-medium',
+                'border border-border text-muted-foreground hover:bg-muted',
+                'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-1',
+                'transition-colors duration-150'
+              )}
+            >
+              {editLabel}
+            </button>
+          </div>
+        )}
       </div>
     </>
   );
@@ -220,6 +258,7 @@ export function KbHomeDesktop({
   onDocClick,
   onEmptyCtaClick,
   onRetry,
+  onEditClick,
   className,
 }: KbHomeDesktopProps): JSX.Element {
   const isEmpty = recentDocs.length === 0 && !isLoading && !error;
@@ -256,6 +295,8 @@ export function KbHomeDesktop({
               doc={doc}
               ariaLabel={labels.docCardAriaLabel(doc)}
               onDocClick={onDocClick}
+              onEditClick={onEditClick}
+              editLabel={labels.editLabel}
             />
           ))}
         </div>

--- a/apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { FilterAccordion } from '../FilterAccordion';
+
+expect.extend(toHaveNoViolations);
+
+const DEFAULT_LABELS = {
+  heading: 'Filtri',
+  docTypeLabel: 'Tipo documento',
+  gameIdLabel: 'Gioco',
+  languageLabel: 'Lingua',
+  clearAll: 'Cancella filtri',
+  docTypeOptions: {
+    Rulebook: 'Regolamento',
+    Expansion: 'Espansione',
+    Errata: 'Errata',
+    QuickStart: 'Quick Start',
+    Reference: 'Riferimento',
+    PlayerAid: 'Aiuto giocatore',
+    Other: 'Altro',
+  },
+  languageOptions: { en: 'English', it: 'Italiano', de: 'Deutsch', fr: 'Français', es: 'Español' },
+};
+
+const GAMES_FIXTURE = [
+  { id: '00000000-0000-0000-0000-000000000001', name: 'Azul' },
+  { id: '00000000-0000-0000-0000-000000000002', name: 'Wingspan' },
+];
+
+describe('FilterAccordion (Phase 3 #1737)', () => {
+  it('renders all 3 facet sections', () => {
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    expect(screen.getByText('Tipo documento')).toBeInTheDocument();
+    expect(screen.getByText('Gioco')).toBeInTheDocument();
+    expect(screen.getByText('Lingua')).toBeInTheDocument();
+  });
+
+  it('renders 7 docType options from allowlist (drops faq per DEC-7)', () => {
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    // Open the section first (assuming default-collapsed accordion behavior).
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    expect(screen.getByLabelText('Regolamento')).toBeInTheDocument();
+    expect(screen.getByLabelText('Espansione')).toBeInTheDocument();
+    expect(screen.getByLabelText('Errata')).toBeInTheDocument();
+    expect(screen.getByLabelText('Altro')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/FAQ/i)).not.toBeInTheDocument();
+  });
+
+  // S1: facet apply
+  it('S1: calls onChange with new docType selection on toggle', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    fireEvent.click(screen.getByLabelText('Regolamento'));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ docType: ['Rulebook'] }));
+  });
+
+  // S2: facet clear
+  it('S2: clearAll button resets all facets', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ docType: ['Rulebook'], language: 'it' }}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /cancella filtri/i }));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  // S3: URL SSOT round-trip (controlled component reflects external `selected`)
+  it('S3: pre-selects facets from controlled `selected` prop', () => {
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ docType: ['Rulebook'], language: 'it' }}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    const checkbox = screen.getByLabelText('Regolamento') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('multi-select GameId: toggle adds a uuid to the array', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ gameId: ['00000000-0000-0000-0000-000000000001'] }}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /gioco/i }));
+    fireEvent.click(screen.getByLabelText('Wingspan'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameId: expect.arrayContaining([
+          '00000000-0000-0000-0000-000000000001',
+          '00000000-0000-0000-0000-000000000002',
+        ]),
+      })
+    );
+  });
+
+  it('single-select Language: replaces the previous value', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ language: 'it' }}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /lingua/i }));
+    fireEvent.click(screen.getByLabelText('English'));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ language: 'en' }));
+  });
+
+  it('a11y: no jest-axe violations', async () => {
+    const { container } = render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { JSX, ReactNode } from 'react';
+
+import { KbEditorDesktop } from '../KbEditorDesktop';
+import { api } from '@/lib/api';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+
+expect.extend(toHaveNoViolations);
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const DOC_FIXTURE: UserKbDocDto = {
+  id: '00000000-0000-0000-0000-000000000001',
+  gameId: null,
+  gameName: null,
+  fileName: 'azul.pdf',
+  processingState: 'Ready',
+  pageCount: 24,
+  processedAt: '2026-05-31T00:00:00Z',
+  uploadedAt: '2026-05-31T00:00:00Z',
+  updatedAt: '2026-05-31T00:00:00Z',
+  title: 'Old Title',
+  tags: ['family'],
+  updatedBy: null,
+};
+
+const LABELS = {
+  heading: 'Modifica metadati',
+  titleLabel: 'Titolo',
+  documentTypeLabel: 'Tipo documento',
+  languageLabel: 'Lingua',
+  tagsLabel: 'Tag',
+  saveLabel: 'Salva',
+  cancelLabel: 'Annulla',
+  notFoundError: 'Documento non trovato',
+  genericError: 'Errore generico, riprova.',
+  documentTypeOptions: { Rulebook: 'Regolamento' },
+  languageOptions: { it: 'Italiano', en: 'English' },
+};
+
+describe('KbEditorDesktop (Phase 3 #1737)', () => {
+  it('renders form pre-filled with doc fields', () => {
+    const qc = new QueryClient();
+    render(<KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />, {
+      wrapper: makeWrapper(qc),
+    });
+    expect((screen.getByLabelText('Titolo') as HTMLInputElement).value).toBe('Old Title');
+  });
+
+  // S4: PATCH success
+  it('S4: submits PATCH with changed title and closes on success', async () => {
+    const spy = vi
+      .spyOn(api.kbDocs, 'patchKbDocMetadata')
+      .mockResolvedValue({ ...DOC_FIXTURE, title: 'New Title' });
+    const onClose = vi.fn();
+    const qc = new QueryClient();
+    render(<KbEditorDesktop doc={DOC_FIXTURE} onClose={onClose} labels={LABELS} />, {
+      wrapper: makeWrapper(qc),
+    });
+    const titleInput = screen.getByLabelText('Titolo') as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: 'New Title' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(spy).toHaveBeenCalledWith(
+      DOC_FIXTURE.id,
+      expect.objectContaining({ title: 'New Title' })
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    spy.mockRestore();
+  });
+
+  // S5: PATCH 404
+  it('S5: shows generic notFoundError on 404 (anti-info-leak)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(new Error('HTTP 404'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    render(<KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />, {
+      wrapper: makeWrapper(qc),
+    });
+    fireEvent.change(screen.getByLabelText('Titolo'), { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(screen.getByText('Documento non trovato')).toBeInTheDocument());
+    spy.mockRestore();
+  });
+
+  // S6: PATCH 422 field errors
+  it('S6: shows inline field error on 422 (FluentValidation envelope)', async () => {
+    const validationError = Object.assign(new Error('HTTP 422'), {
+      status: 422,
+      fieldErrors: { title: 'Title must not exceed 200 characters.' },
+    });
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(validationError);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    render(<KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />, {
+      wrapper: makeWrapper(qc),
+    });
+    fireEvent.change(screen.getByLabelText('Titolo'), { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(screen.getByText(/title must not exceed 200/i)).toBeInTheDocument());
+    // aria-describedby links input to error
+    expect(screen.getByLabelText('Titolo')).toHaveAttribute('aria-describedby');
+    spy.mockRestore();
+  });
+
+  it('omits unchanged fields from PATCH body (partial update D-4 #1687)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DOC_FIXTURE);
+    const qc = new QueryClient();
+    render(<KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />, {
+      wrapper: makeWrapper(qc),
+    });
+    // Don't change anything, just click Save.
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const body = spy.mock.calls[0]?.[1];
+    expect(body).toEqual({}); // no-op patch
+    spy.mockRestore();
+  });
+
+  it('cancel button calls onClose without submitting', () => {
+    const onClose = vi.fn();
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata');
+    const qc = new QueryClient();
+    render(<KbEditorDesktop doc={DOC_FIXTURE} onClose={onClose} labels={LABELS} />, {
+      wrapper: makeWrapper(qc),
+    });
+    fireEvent.click(screen.getByRole('button', { name: /annulla/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('a11y: no jest-axe violations', async () => {
+    const qc = new QueryClient();
+    const { container } = render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx
@@ -14,7 +14,7 @@
  * A11y: jest-axe on loaded / loading / empty states
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { describe, expect, it, vi } from 'vitest';
@@ -255,5 +255,21 @@ describe('KbHomeDesktop', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  // ── 13. Phase 3 #1737: edit affordance per card (DEC-3) ───────────────
+  it('Phase 3 #1737: renders Edit button per recent doc when onEditClick provided', () => {
+    const onEditClick = vi.fn();
+    render(
+      <KbHomeDesktop
+        {...defaultProps({
+          recentDocs: [THREE_DOCS[0]],
+          labels: { ...LABELS, editLabel: 'Modifica' },
+          onEditClick,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /modifica/i }));
+    expect(onEditClick).toHaveBeenCalledWith(THREE_DOCS[0]);
   });
 });

--- a/apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx
+++ b/apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JSX, ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUpdateKbDocMeta } from '../useUpdateKbDocMeta';
+import { api } from '@/lib/api';
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const DTO_FIXTURE = {
+  id: '00000000-0000-0000-0000-000000000001',
+  gameId: null,
+  gameName: null,
+  fileName: 'azul.pdf',
+  processingState: 'Ready' as const,
+  pageCount: 24,
+  processedAt: '2026-05-31T00:00:00Z',
+  uploadedAt: '2026-05-31T00:00:00Z',
+  updatedAt: '2026-05-31T00:00:00Z',
+  title: 'New Title',
+  tags: ['strategy'],
+  updatedBy: '00000000-0000-0000-0000-000000000003',
+};
+
+describe('useUpdateKbDocMeta (Phase 3 #1737)', () => {
+  it('calls api.kbDocs.patchKbDocMetadata on mutate', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DTO_FIXTURE);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: '00000000-0000-0000-0000-000000000001',
+        body: { title: 'New Title' },
+      });
+    });
+    expect(spy).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000001', {
+      title: 'New Title',
+    });
+    spy.mockRestore();
+  });
+
+  it('invalidates ["kb-docs","user"] queries on success', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DTO_FIXTURE);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: '00000000-0000-0000-0000-000000000001',
+        body: { title: 'New Title' },
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['kb-docs', 'user'] });
+    spy.mockRestore();
+  });
+
+  it('invalidates ["kb-globale","search"] queries on success (DEC-2 aggressive)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DTO_FIXTURE);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: '00000000-0000-0000-0000-000000000001',
+        body: { title: 'New Title' },
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['kb-globale', 'search'] });
+    spy.mockRestore();
+  });
+
+  it('exposes error on 404 (S5 anti-info-leak)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(new Error('HTTP 404'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          id: '00000000-0000-0000-0000-000000000001',
+          body: { title: 'X' },
+        });
+      } catch {
+        /* expected */
+      }
+    });
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error?.message).toContain('404');
+    spy.mockRestore();
+  });
+
+  it('does NOT invalidate on error (cache stays consistent)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(new Error('HTTP 422'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          id: '00000000-0000-0000-0000-000000000001',
+          body: { title: 'X' },
+        });
+      } catch {
+        /* expected */
+      }
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/apps/web/src/hooks/mutations/useUpdateKbDocMeta.ts
+++ b/apps/web/src/hooks/mutations/useUpdateKbDocMeta.ts
@@ -1,0 +1,39 @@
+/**
+ * useUpdateKbDocMeta — Phase 3 #1737 mutation hook for PATCH /api/v1/kb-docs/{id}.
+ *
+ * Cache invalidation (DEC-2 aggressive — issue #1737 spec-panel):
+ *   - ['kb-docs', 'user']         → KbHomeDesktop recent docs
+ *   - ['kb-globale', 'search']    → search results (title affects display)
+ *   - ['kb-docs', 'detail', id]   → per-doc detail cache (viewer hero)
+ *
+ * BE contract (PR #1732 #1687):
+ *   - 200 + extended UserKbDocDto (Title, Tags, UpdatedBy added)
+ *   - 404 = not accessible (anti-info-leak D-2, NOT 403)
+ *   - 422 = validation envelope (FluentValidation)
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { PatchKbDocMetadataRequest } from '@/lib/api/schemas/kb-docs-patch.schemas';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+
+export interface UpdateKbDocMetaInput {
+  id: string;
+  body: PatchKbDocMetadataRequest;
+}
+
+export type UseUpdateKbDocMetaResult = UseMutationResult<UserKbDocDto, Error, UpdateKbDocMetaInput>;
+
+export function useUpdateKbDocMeta(): UseUpdateKbDocMetaResult {
+  const qc = useQueryClient();
+  return useMutation<UserKbDocDto, Error, UpdateKbDocMetaInput>({
+    mutationFn: ({ id, body }) => api.kbDocs.patchKbDocMetadata(id, body),
+    onSuccess: (_data, vars) => {
+      // DEC-2 aggressive invalidation: any cached query whose key starts with
+      // these prefixes will refetch on next mount/observer.
+      qc.invalidateQueries({ queryKey: ['kb-docs', 'user'] });
+      qc.invalidateQueries({ queryKey: ['kb-globale', 'search'] });
+      qc.invalidateQueries({ queryKey: ['kb-docs', 'detail', vars.id] });
+    },
+  });
+}

--- a/apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx
@@ -221,4 +221,82 @@ describe('useGlobalKbSearch', () => {
     expect(result.current.error?.message).toBe('Network failure');
     expect(result.current.results).toHaveLength(0);
   });
+
+  // Phase 3 #1737: filter propagation + queryKey identity tests
+  describe('useGlobalKbSearch — filters (Phase 3 #1737)', () => {
+    it('passes docType filter to client call', async () => {
+      mockSearchGlobal.mockResolvedValue({
+        results: [],
+        hasMore: false,
+        nextCursor: null,
+      });
+      renderHook(() => useGlobalKbSearch({ query: 'azul', filters: { docType: ['Rulebook'] } }), {
+        wrapper,
+      });
+      await waitFor(() =>
+        expect(mockSearchGlobal).toHaveBeenCalledWith(
+          expect.objectContaining({ docType: ['Rulebook'] })
+        )
+      );
+    });
+
+    it('passes all filter fields to client call', async () => {
+      mockSearchGlobal.mockResolvedValue({
+        results: [],
+        hasMore: false,
+        nextCursor: null,
+      });
+      renderHook(
+        () =>
+          useGlobalKbSearch({
+            query: 'azul',
+            filters: {
+              docType: ['Rulebook'],
+              gameId: ['00000000-0000-0000-0000-000000000001'],
+              language: 'it',
+            },
+          }),
+        { wrapper }
+      );
+      await waitFor(() =>
+        expect(mockSearchGlobal).toHaveBeenCalledWith(
+          expect.objectContaining({
+            docType: ['Rulebook'],
+            gameId: ['00000000-0000-0000-0000-000000000001'],
+            language: 'it',
+          })
+        )
+      );
+    });
+
+    it('queryKey includes filters (different filters = different cache entry)', async () => {
+      mockSearchGlobal.mockResolvedValue({
+        results: [],
+        hasMore: false,
+        nextCursor: null,
+      });
+      const { rerender } = renderHook(
+        ({ filters }: { filters: { docType?: readonly string[] } }) =>
+          useGlobalKbSearch({ query: 'azul', filters }),
+        { wrapper, initialProps: { filters: { docType: ['Rulebook'] } } }
+      );
+      await waitFor(() => expect(mockSearchGlobal).toHaveBeenCalledTimes(1));
+      rerender({ filters: { docType: ['Errata'] } });
+      await waitFor(() => expect(mockSearchGlobal).toHaveBeenCalledTimes(2));
+    });
+
+    it('omitted filters are not sent (backwards-compat with Phase 1+2 callers)', async () => {
+      mockSearchGlobal.mockResolvedValue({
+        results: [],
+        hasMore: false,
+        nextCursor: null,
+      });
+      renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+      await waitFor(() => expect(mockSearchGlobal).toHaveBeenCalled());
+      const call = mockSearchGlobal.mock.calls[0]?.[0];
+      expect(call).not.toHaveProperty('docType');
+      expect(call).not.toHaveProperty('gameId');
+      expect(call).not.toHaveProperty('language');
+    });
+  });
 });

--- a/apps/web/src/hooks/queries/useGlobalKbSearch.ts
+++ b/apps/web/src/hooks/queries/useGlobalKbSearch.ts
@@ -1,82 +1,60 @@
-/**
- * useGlobalKbSearch — TanStack Query useInfiniteQuery hook for cross-game KB search.
- *
- * Backend contract: `POST /api/v1/knowledge-base/search/global`.
- *  - Body: `{ query, limit?, cursor?, mode? }`
- *  - Response: `{ results, hasMore, nextCursor }`
- *
- * Gate: only fires when `query.trim().length >= 2` to avoid single-char noise.
- * Debounce: 250ms (override useDebounce default of 2000ms).
- * Cache: staleTime 5min (aligns with useUserKbDocs from Issue #1592).
- * Cursor: cursor-based pagination; queryKey change (query or mode) auto-resets cursor.
- * hasMore: computed from last page only (no totalCount cross-game per Nygard D6).
- *
- * @see apps/web/src/lib/api/clients/kbDocsClient.ts  — kbDocsClient.searchGlobal
- * @see apps/web/src/lib/api/schemas/kb-globale.schemas.ts  — Zod schemas (Task 0)
- * @see Issue #1482 Phase 1 Foundation
- */
-
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useDebounce } from '@/hooks/useDebounce';
 import { api } from '@/lib/api';
 import type {
+  GlobalKbSearchFilters,
   GlobalKbSearchResult,
   GlobalKbSearchResponse,
   SearchMode,
 } from '@/lib/api/schemas/kb-globale.schemas';
 
-export const KB_GLOBALE_SEARCH_STALE_TIME_MS = 5 * 60 * 1000; // 5 min.
+export const KB_GLOBALE_SEARCH_STALE_TIME_MS = 5 * 60 * 1000;
 
-/** Query key factory for cache coordination / invalidation. */
+/** Stable serialized form of filters for queryKey identity. */
+function serializeFilters(filters?: GlobalKbSearchFilters): string {
+  if (!filters) return '';
+  const parts: string[] = [];
+  if (filters.docType && filters.docType.length > 0) {
+    parts.push(`docType:${[...filters.docType].sort().join(',')}`);
+  }
+  if (filters.gameId && filters.gameId.length > 0) {
+    parts.push(`gameId:${[...filters.gameId].sort().join(',')}`);
+  }
+  if (filters.language) parts.push(`language:${filters.language}`);
+  return parts.join('|');
+}
+
 export const kbGlobaleSearchKeys = {
   all: ['kb-globale', 'search'] as const,
-  byQuery: (query: string, mode: SearchMode | null) =>
-    [...kbGlobaleSearchKeys.all, { query, mode }] as const,
+  byQuery: (query: string, mode: SearchMode | null, filtersKey: string) =>
+    [...kbGlobaleSearchKeys.all, { query, mode, filtersKey }] as const,
 };
 
 export interface UseGlobalKbSearchOptions {
-  /** The search query string (will be trimmed internally). */
   query: string;
-  /** Search mode — defaults to BE-side Semantic when undefined. */
   mode?: SearchMode;
-  /** Debounce delay in ms. Defaults to 250 (overrides useDebounce's 2000ms default). */
   debounceMs?: number;
-  /** Override the auto-enable gate (`query.trim().length >= 2`). */
   enabled?: boolean;
+  /** Phase 3 (#1737): optional server-side facet filters. */
+  filters?: GlobalKbSearchFilters;
 }
 
 export interface UseGlobalKbSearchResult {
-  /** Flat list of results across all fetched pages. */
   results: readonly GlobalKbSearchResult[];
-  /** Whether the last fetched page has more items (cursor pagination). */
   hasMore: boolean;
-  /** True during the initial fetch (no cached data yet). */
   isLoading: boolean;
-  /** True while fetching the next page. */
   isFetchingNextPage: boolean;
-  /** The fetch error, if any; null otherwise. */
   error: Error | null;
-  /** Trigger fetch of the next page (cursor forwarded automatically). */
   fetchNextPage: () => void;
 }
 
-/**
- * Infinite-query hook for cross-game KB semantic search.
- *
- * @example
- * ```tsx
- * const { results, hasMore, isLoading, fetchNextPage } = useGlobalKbSearch({ query });
- * ```
- */
 export function useGlobalKbSearch(opts: UseGlobalKbSearchOptions): UseGlobalKbSearchResult {
-  const { query, mode, debounceMs = 250, enabled } = opts;
+  const { query, mode, debounceMs = 250, enabled, filters } = opts;
 
-  // Debounce the trimmed query to avoid firing on every keystroke.
   const debouncedQuery = useDebounce(query.trim(), debounceMs);
-
-  // Auto-enable gate: fire only when there are at least 2 meaningful characters.
   const effectiveEnabled = enabled ?? debouncedQuery.length >= 2;
+  const filtersKey = serializeFilters(filters);
 
   const q = useInfiniteQuery<
     GlobalKbSearchResponse,
@@ -85,12 +63,18 @@ export function useGlobalKbSearch(opts: UseGlobalKbSearchOptions): UseGlobalKbSe
     ReturnType<typeof kbGlobaleSearchKeys.byQuery>,
     string | null
   >({
-    queryKey: kbGlobaleSearchKeys.byQuery(debouncedQuery, mode ?? null),
+    queryKey: kbGlobaleSearchKeys.byQuery(debouncedQuery, mode ?? null, filtersKey),
     queryFn: ({ pageParam }) =>
       api.kbDocs.searchGlobal({
         query: debouncedQuery,
         mode,
         cursor: pageParam,
+        // Phase 3: only include non-empty filters to keep wire format clean.
+        ...(filters?.docType && filters.docType.length > 0
+          ? { docType: [...filters.docType] }
+          : {}),
+        ...(filters?.gameId && filters.gameId.length > 0 ? { gameId: [...filters.gameId] } : {}),
+        ...(filters?.language ? { language: filters.language } : {}),
       }),
     initialPageParam: null,
     getNextPageParam: (lastPage: GlobalKbSearchResponse) =>
@@ -99,10 +83,7 @@ export function useGlobalKbSearch(opts: UseGlobalKbSearchOptions): UseGlobalKbSe
     staleTime: KB_GLOBALE_SEARCH_STALE_TIME_MS,
   });
 
-  // Flatten pages into a single results array.
   const results: readonly GlobalKbSearchResult[] = q.data?.pages.flatMap(p => p.results) ?? [];
-
-  // hasMore is derived exclusively from the last page to avoid stale intermediate state.
   const pages = q.data?.pages;
   const hasMore =
     pages != null && pages.length > 0 ? (pages[pages.length - 1]?.hasMore ?? false) : false;

--- a/apps/web/src/hooks/queries/useUserKbDocs.ts
+++ b/apps/web/src/hooks/queries/useUserKbDocs.ts
@@ -32,6 +32,12 @@ export function toKbDoc(dto: UserKbDocDto): KbDoc {
 export interface UseUserKbDocsResult {
   /** Adapted items (DTO → KbDoc) — what the mapper consumes. */
   items: KbDoc[];
+  /**
+   * Raw DTO items before mapping — exposed for Phase 3 (#1737) KbEditorDesktop
+   * which needs the full UserKbDocDto (title/tags/updatedBy) not available in KbDoc.
+   * Additive, no breaking change to existing consumers.
+   */
+  rawItems: UserKbDocDto[];
   total: number;
   page: number;
   pageSize: number;
@@ -49,6 +55,7 @@ export function useUserKbDocs(): UseQueryResult<UseUserKbDocsResult> {
       });
       return {
         items: response.items.map(toKbDoc),
+        rawItems: response.items,
         total: response.total,
         page: response.page,
         pageSize: response.pageSize,

--- a/apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts
@@ -1,0 +1,138 @@
+/**
+ * KB Docs Client Tests (Phase 3 #1737)
+ *
+ * Tests for patchKbDocMetadata method covering PATCH /api/v1/kb-docs/{id}
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKbDocsClient, type KbDocsClient } from '../kbDocsClient';
+import { UserKbDocDtoSchema } from '../../schemas/kb-docs.schemas';
+import { type PatchKbDocMetadataRequest } from '../../schemas/kb-docs-patch.schemas';
+
+// Mock HttpClient
+const createMockHttpClient = () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  postFile: vi.fn(),
+});
+
+describe('KbDocsClient.patchKbDocMetadata', () => {
+  let client: KbDocsClient;
+  let mockHttpClient: ReturnType<typeof createMockHttpClient>;
+
+  beforeEach(() => {
+    mockHttpClient = createMockHttpClient();
+    client = createKbDocsClient({ httpClient: mockHttpClient as any });
+  });
+
+  it('should call httpClient.patch with correct path and body', async () => {
+    const docId = '550e8400-e29b-41d4-a716-446655440000';
+    const body: PatchKbDocMetadataRequest = {
+      title: 'New Title',
+      documentType: 'expansion',
+      language: 'en',
+      tags: ['strategy', 'cooperative'],
+    };
+
+    const mockResponse = {
+      id: docId,
+      gameId: '550e8400-e29b-41d4-a716-446655440001',
+      gameName: 'Catan',
+      fileName: 'rules.pdf',
+      processingState: 'Ready',
+      pageCount: 10,
+      processedAt: '2026-05-31T10:00:00Z',
+      uploadedAt: '2026-05-30T10:00:00Z',
+      updatedAt: '2026-05-31T11:00:00Z',
+      title: 'New Title',
+      tags: ['strategy', 'cooperative'],
+      updatedBy: '550e8400-e29b-41d4-a716-446655440002',
+    };
+
+    mockHttpClient.patch.mockResolvedValueOnce(mockResponse);
+
+    const result = await client.patchKbDocMetadata(docId, body);
+
+    expect(mockHttpClient.patch).toHaveBeenCalledWith(
+      `/api/v1/kb-docs/${docId}`,
+      body,
+      UserKbDocDtoSchema
+    );
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should handle empty/optional fields in request body', async () => {
+    const docId = '550e8400-e29b-41d4-a716-446655440000';
+    const body: PatchKbDocMetadataRequest = {
+      title: '',
+      tags: [],
+    };
+
+    const mockResponse = {
+      id: docId,
+      gameId: '550e8400-e29b-41d4-a716-446655440001',
+      gameName: 'Catan',
+      fileName: 'rules.pdf',
+      processingState: 'Ready',
+      pageCount: 10,
+      processedAt: '2026-05-31T10:00:00Z',
+      uploadedAt: '2026-05-30T10:00:00Z',
+      updatedAt: '2026-05-31T11:00:00Z',
+      title: null,
+      tags: [],
+    };
+
+    mockHttpClient.patch.mockResolvedValueOnce(mockResponse);
+
+    const result = await client.patchKbDocMetadata(docId, body);
+
+    expect(mockHttpClient.patch).toHaveBeenCalledWith(
+      `/api/v1/kb-docs/${docId}`,
+      body,
+      UserKbDocDtoSchema
+    );
+    expect(result.title).toBeNull();
+    expect(result.tags).toEqual([]);
+  });
+
+  it('should validate response with UserKbDocDtoSchema', async () => {
+    const docId = '550e8400-e29b-41d4-a716-446655440000';
+    const body: PatchKbDocMetadataRequest = { title: 'Updated' };
+
+    const mockResponse = {
+      id: docId,
+      gameId: null,
+      gameName: null,
+      fileName: 'doc.pdf',
+      processingState: 'Ready',
+      pageCount: 5,
+      processedAt: '2026-05-31T10:00:00Z',
+      uploadedAt: '2026-05-30T10:00:00Z',
+      updatedAt: '2026-05-31T11:00:00Z',
+      title: 'Updated',
+    };
+
+    mockHttpClient.patch.mockResolvedValueOnce(mockResponse);
+
+    const result = await client.patchKbDocMetadata(docId, body);
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe(docId);
+    expect(result.title).toBe('Updated');
+  });
+
+  it('should handle API errors from httpClient.patch', async () => {
+    const docId = '550e8400-e29b-41d4-a716-446655440000';
+    const body: PatchKbDocMetadataRequest = { title: 'New Title' };
+    const error = new Error('API Error: 404 Not Found');
+
+    mockHttpClient.patch.mockRejectedValueOnce(error);
+
+    await expect(client.patchKbDocMetadata(docId, body)).rejects.toThrow(
+      'API Error: 404 Not Found'
+    );
+  });
+});

--- a/apps/web/src/lib/api/clients/kbDocsClient.ts
+++ b/apps/web/src/lib/api/clients/kbDocsClient.ts
@@ -7,7 +7,10 @@
  * this client is scoped to the new cross-game user listing endpoint).
  */
 
-import { type PatchKbDocMetadataRequest } from '../schemas/kb-docs-patch.schemas';
+import {
+  type PatchKbDocMetadataRequest,
+  PatchKbDocMetadataRequestSchema,
+} from '../schemas/kb-docs-patch.schemas';
 import {
   KbDocsListResponseSchema,
   type KbDocsListResponse,
@@ -67,9 +70,12 @@ export function createKbDocsClient({ httpClient }: CreateKbDocsClientParams): Kb
     },
 
     async patchKbDocMetadata(id: string, body: PatchKbDocMetadataRequest): Promise<UserKbDocDto> {
+      // Client-side pre-validation: short-circuit invalid payloads (e.g. tag >50 chars,
+      // >20 tags) before the network call, matching plan Task 2 Step 3 spec.
+      const validated = PatchKbDocMetadataRequestSchema.parse(body);
       const response = await httpClient.patch<UserKbDocDto>(
         `/api/v1/kb-docs/${id}`,
-        body,
+        validated,
         UserKbDocDtoSchema
       );
       return response;

--- a/apps/web/src/lib/api/clients/kbDocsClient.ts
+++ b/apps/web/src/lib/api/clients/kbDocsClient.ts
@@ -7,7 +7,13 @@
  * this client is scoped to the new cross-game user listing endpoint).
  */
 
-import { KbDocsListResponseSchema, type KbDocsListResponse } from '../schemas/kb-docs.schemas';
+import { type PatchKbDocMetadataRequest } from '../schemas/kb-docs-patch.schemas';
+import {
+  KbDocsListResponseSchema,
+  type KbDocsListResponse,
+  UserKbDocDtoSchema,
+  type UserKbDocDto,
+} from '../schemas/kb-docs.schemas';
 import {
   GlobalKbSearchResponseSchema,
   type GlobalKbSearchRequest,
@@ -32,6 +38,7 @@ export interface ListUserKbDocsParams {
 export interface KbDocsClient {
   listUserKbDocs(params?: ListUserKbDocsParams): Promise<KbDocsListResponse>;
   searchGlobal(req: GlobalKbSearchRequest): Promise<GlobalKbSearchResponse>;
+  patchKbDocMetadata(id: string, body: PatchKbDocMetadataRequest): Promise<UserKbDocDto>;
 }
 
 export function createKbDocsClient({ httpClient }: CreateKbDocsClientParams): KbDocsClient {
@@ -57,6 +64,15 @@ export function createKbDocsClient({ httpClient }: CreateKbDocsClientParams): Kb
         GlobalKbSearchResponseSchema
       );
       return response ?? { results: [], hasMore: false, nextCursor: null };
+    },
+
+    async patchKbDocMetadata(id: string, body: PatchKbDocMetadataRequest): Promise<UserKbDocDto> {
+      const response = await httpClient.patch<UserKbDocDto>(
+        `/api/v1/kb-docs/${id}`,
+        body,
+        UserKbDocDtoSchema
+      );
+      return response;
     },
   };
 }

--- a/apps/web/src/lib/api/core/errors.ts
+++ b/apps/web/src/lib/api/core/errors.ts
@@ -100,9 +100,26 @@ export class ConflictError extends ApiError {
 
 /**
  * 422 Validation Error - Request validation failed
+ *
+ * Phase 3 (#1737): exposes `status` (alias for statusCode) and `fieldErrors`
+ * (first message per field, flattened from FluentValidation envelope) so that
+ * KbEditorDesktop's `isHttpFieldError` type-guard can access them uniformly.
  */
 export class ValidationError extends ApiError {
   public readonly validationErrors?: Record<string, string[]>;
+
+  /**
+   * HTTP status alias (422) for consumers using `err.status` convention.
+   * Works with KbEditorDesktop's isHttpFieldError guard (`'status' in err`).
+   */
+  public readonly status = 422 as const;
+
+  /**
+   * First validation message per field — flattened from validationErrors.
+   * Maps FluentValidation's `{ errors: { field: ["msg1", "msg2"] } }` →
+   * `{ field: "msg1" }` for inline UI display.
+   */
+  public readonly fieldErrors?: Record<string, string>;
 
   constructor(
     details: Omit<ApiErrorDetails, 'statusCode'> & {
@@ -112,12 +129,20 @@ export class ValidationError extends ApiError {
     super({ ...details, statusCode: 422 });
     this.name = 'ValidationError';
     this.validationErrors = details.validationErrors;
+
+    // Flatten: take first message per field.
+    if (details.validationErrors) {
+      this.fieldErrors = Object.fromEntries(
+        Object.entries(details.validationErrors).map(([k, msgs]) => [k, msgs[0] ?? ''])
+      );
+    }
   }
 
   public override toJSON(): Record<string, unknown> {
     return {
       ...super.toJSON(),
       validationErrors: this.validationErrors,
+      fieldErrors: this.fieldErrors,
     };
   }
 }

--- a/apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { PatchKbDocMetadataRequestSchema } from '../kb-docs-patch.schemas';
+
+describe('PatchKbDocMetadataRequestSchema (Phase 3 #1737)', () => {
+  it('accepts fully populated body', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({
+      title: 'New Title',
+      documentType: 'Rulebook',
+      language: 'it',
+      tags: ['strategy', 'family'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty body (no-op)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts title=empty-string (clear semantic per D-4 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ title: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts tags=[] (clear semantic)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ tags: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects title > 200 chars (D-5 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ title: 'x'.repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects tag > 50 chars (D-8 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ tags: ['x'.repeat(51)] });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects > 20 tags (D-8 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({
+      tags: Array.from({ length: 21 }, (_, i) => `tag${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts
@@ -73,3 +73,50 @@ describe('kb-docs schemas', () => {
     expect(() => KbDocsListResponseSchema.parse(envelope)).toThrow();
   });
 });
+
+describe('UserKbDocDtoSchema — Phase 3 #1687 metadata fields', () => {
+  const baseFixture = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    gameId: '550e8400-e29b-41d4-a716-446655440002',
+    gameName: 'Azul',
+    fileName: 'azul-rules.pdf',
+    processingState: 'Ready' as const,
+    pageCount: 24,
+    processedAt: '2026-05-31T00:00:00Z',
+    uploadedAt: '2026-05-31T00:00:00Z',
+    updatedAt: '2026-05-31T00:00:00Z',
+  };
+
+  it('accepts title as nullable string', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, title: 'Azul Master Edition' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts title as null', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, title: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts tags as string array', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, tags: ['strategy', 'family'] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts tags as empty array', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, tags: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts updatedBy as nullable uuid', () => {
+    const result = UserKbDocDtoSchema.safeParse({
+      ...baseFixture,
+      updatedBy: '550e8400-e29b-41d4-a716-446655440003',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('back-compat: validates without title/tags/updatedBy (existing payloads)', () => {
+    const result = UserKbDocDtoSchema.safeParse(baseFixture);
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts
@@ -136,3 +136,42 @@ describe('KB Globale Schemas', () => {
     expect(request.query).toBe('test');
   });
 });
+
+describe('GlobalKbSearchRequestSchema — filters (Phase 3 #1737)', () => {
+  it('accepts docType as string[]', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      docType: ['Rulebook', 'Errata'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.docType).toEqual(['Rulebook', 'Errata']);
+    }
+  });
+
+  it('accepts gameId as uuid[]', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      gameId: ['550e8400-e29b-41d4-a716-446655440001'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects gameId with non-uuid string', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      gameId: ['not-a-uuid'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts language as single string', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({ query: 'azul', language: 'it' });
+    expect(result.success).toBe(true);
+  });
+
+  it('allows all filter fields to be omitted (backwards-compat)', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({ query: 'azul' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/src/lib/api/schemas/kb-docs-patch.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-docs-patch.schemas.ts
@@ -1,0 +1,33 @@
+/**
+ * PATCH /api/v1/kb-docs/{id} request schema (Phase 3 #1737, BE PR #1732 #1687).
+ *
+ * Partial update semantics (D-4 #1687):
+ * - JSON `null` (omitted in TS) = no-op
+ * - empty string ("") = clear the field
+ * - empty array ([]) = clear tags
+ *
+ * Constraints (D-5/D-8 #1687):
+ * - title: max 200 chars
+ * - tags: max 20 items, each max 50 chars
+ *
+ * Allowlist enforcement is BE-side (FE sends raw strings):
+ * - documentType: 7-value DocumentCategory enum BE-side (D-6)
+ * - language: 10-value LanguageCode whitelist BE-side (D-7)
+ */
+import { z } from 'zod';
+
+const TITLE_MAX = 200;
+const TAG_MAX_LENGTH = 50;
+const TAGS_MAX_COUNT = 20;
+
+export const PatchKbDocMetadataRequestSchema = z.object({
+  title: z.string().max(TITLE_MAX, `Title must not exceed ${TITLE_MAX} characters.`).optional(),
+  documentType: z.string().optional(),
+  language: z.string().optional(),
+  tags: z
+    .array(z.string().max(TAG_MAX_LENGTH, `Tag must not exceed ${TAG_MAX_LENGTH} characters.`))
+    .max(TAGS_MAX_COUNT, `No more than ${TAGS_MAX_COUNT} tags allowed.`)
+    .optional(),
+});
+
+export type PatchKbDocMetadataRequest = z.infer<typeof PatchKbDocMetadataRequestSchema>;

--- a/apps/web/src/lib/api/schemas/kb-docs.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-docs.schemas.ts
@@ -33,6 +33,8 @@ export type ProcessingState = z.infer<typeof ProcessingStateSchema>;
  * Does NOT include `filePath`, `fileSizeBytes`, `documentType`, etc. — see issue #1592.
  * The `updatedAt` field (issue #1645) is explicit BE-side: equals ProcessedAt ?? UploadedAt,
  * mirroring the canonical sort key from the handler.
+ * Phase 3 (#1737): adds title/tags/updatedBy per BE PR #1732 (#1687).
+ * All Phase 3 fields are optional/nullable for backwards-compat with pre-#1687 payloads.
  */
 export const UserKbDocDtoSchema = z.object({
   id: z.string().uuid(),
@@ -44,6 +46,10 @@ export const UserKbDocDtoSchema = z.object({
   processedAt: z.string().datetime({ offset: true }).nullable(),
   uploadedAt: z.string().datetime({ offset: true }),
   updatedAt: z.string().datetime({ offset: true }),
+  // Phase 3 (#1687) additions:
+  title: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  updatedBy: z.string().uuid().nullable().optional(),
 });
 
 export type UserKbDocDto = z.infer<typeof UserKbDocDtoSchema>;

--- a/apps/web/src/lib/api/schemas/kb-globale.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-globale.schemas.ts
@@ -41,15 +41,32 @@ export type GlobalKbSearchResult = z.infer<typeof GlobalKbSearchResultSchema>;
 
 /**
  * GlobalKbSearchRequest — the POST /knowledge-base/search/global request body.
+ * Phase 3 (#1737): adds optional facet filters per BE PR #1730 (#1686).
+ * - docType: 7-value allowlist BE-side (D-6 of #1686); FE sends raw strings.
+ * - gameId: UUID array; non-accessible IDs return 200 empty (D-4 anti-info-leak).
+ * - language: ISO 639-1 lowercase {en,it,de,fr,es} (D-7 of #1686).
  */
 export const GlobalKbSearchRequestSchema = z.object({
   query: z.string().min(1, 'Query must not be empty'),
   limit: z.number().int().positive().optional(),
   cursor: z.string().nullable().optional(),
   mode: SearchModeSchema.optional(),
+  docType: z.array(z.string()).optional(),
+  gameId: z.array(z.string().uuid()).optional(),
+  language: z.string().optional(),
 });
 
 export type GlobalKbSearchRequest = z.infer<typeof GlobalKbSearchRequestSchema>;
+
+/**
+ * GlobalKbSearchFilters — typed FE-side helper for the orchestrator/components.
+ * Used by useGlobalKbSearch options + FilterAccordion props.
+ */
+export interface GlobalKbSearchFilters {
+  docType?: readonly string[];
+  gameId?: readonly string[];
+  language?: string;
+}
 
 /**
  * GlobalKbSearchResponse envelope — the complete response from /knowledge-base/search/global.

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3925,6 +3925,40 @@
         "closeLabel": "Close",
         "pageOfTotal": "{cur} / {total}"
       },
+      "filters": {
+        "heading": "Filters",
+        "docTypeLabel": "Document type",
+        "gameIdLabel": "Game",
+        "languageLabel": "Language",
+        "clearAll": "Clear filters",
+        "docTypeOptions": {
+          "Rulebook": "Rulebook",
+          "Expansion": "Expansion",
+          "Errata": "Errata",
+          "QuickStart": "Quick Start",
+          "Reference": "Reference",
+          "PlayerAid": "Player aid",
+          "Other": "Other"
+        },
+        "languageOptions": {
+          "en": "English",
+          "it": "Italian",
+          "de": "German",
+          "fr": "French",
+          "es": "Spanish"
+        }
+      },
+      "editor": {
+        "heading": "Edit metadata",
+        "titleLabel": "Title",
+        "documentTypeLabel": "Document type",
+        "languageLabel": "Language",
+        "tagsLabel": "Tags",
+        "saveLabel": "Save",
+        "cancelLabel": "Cancel",
+        "notFoundError": "Document not found",
+        "genericError": "Generic error, please try again."
+      },
       "drawer": {
         "title": "Ask the Meeple",
         "subtitle": "Knowledge Base",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3978,6 +3978,40 @@
         "closeLabel": "Chiudi",
         "pageOfTotal": "{cur} / {total}"
       },
+      "filters": {
+        "heading": "Filtri",
+        "docTypeLabel": "Tipo documento",
+        "gameIdLabel": "Gioco",
+        "languageLabel": "Lingua",
+        "clearAll": "Cancella filtri",
+        "docTypeOptions": {
+          "Rulebook": "Regolamento",
+          "Expansion": "Espansione",
+          "Errata": "Errata",
+          "QuickStart": "Quick Start",
+          "Reference": "Riferimento",
+          "PlayerAid": "Aiuto giocatore",
+          "Other": "Altro"
+        },
+        "languageOptions": {
+          "en": "English",
+          "it": "Italiano",
+          "de": "Deutsch",
+          "fr": "Français",
+          "es": "Español"
+        }
+      },
+      "editor": {
+        "heading": "Modifica metadati",
+        "titleLabel": "Titolo",
+        "documentTypeLabel": "Tipo documento",
+        "languageLabel": "Lingua",
+        "tagsLabel": "Tag",
+        "saveLabel": "Salva",
+        "cancelLabel": "Annulla",
+        "notFoundError": "Documento non trovato",
+        "genericError": "Errore generico, riprova."
+      },
       "drawer": {
         "title": "Ask the Meeple",
         "subtitle": "Knowledge Base",

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -438,10 +438,10 @@ the PR review.
 | `sp4-kb-globale.jsx` | `HeroSearch` | `apps/web/src/components/features/kb-globale/HeroSearch.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
 | `sp4-kb-globale.jsx` | `KbHomeDesktop` | `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
 | `sp4-kb-globale.jsx` | `KbSearchResultsDesktop` | `apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
-| `sp4-kb-globale.jsx` | `FilterAccordion` | `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | `/knowledge-base/global` | pending | — | T A V | #1686 deferred |
+| `sp4-kb-globale.jsx` | `FilterAccordion` | `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | `/knowledge-base/global` | done | PR #TBD | T A V | #1737 |
 | `sp4-kb-globale.jsx` | `KbDocViewerDesktop` | `apps/web/src/components/features/kb-globale/KbDocViewerDesktop.tsx` | `/knowledge-base/global` | done | #TBD | T A M V | — |
 | `sp4-kb-globale.jsx` | `KbDocViewerMobile` | `apps/web/src/components/features/kb-globale/KbDocViewerMobile.tsx` | `/knowledge-base/global` | done | #TBD | T A M V | — |
-| `sp4-kb-globale.jsx` | `KbEditorDesktop` | `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | `/knowledge-base/global` | pending | — | T A V | #1687 deferred |
+| `sp4-kb-globale.jsx` | `KbEditorDesktop` | `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | `/knowledge-base/global` | done | PR #TBD | T A V | #1737 |
 | `sp4-kb-globale.jsx` | `DrawerShell` (+ `DrawerIdle` / `DrawerStreaming` / `DrawerCompleted` / `DrawerError` states) | `apps/web/src/components/features/kb-globale/Drawer*.tsx` | `/knowledge-base/global` | done | #TBD | T A V | — |
 | `sp4-kb-globale.jsx` | `CitationPill` | `apps/web/src/components/features/kb-globale/CitationPill.tsx` | `/knowledge-base/global` | done | #TBD | T A V | — |
 | `sp4-kb-globale.jsx` | `KbEmptyState` | `apps/web/src/components/features/kb-globale/KbEmptyState.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -438,10 +438,10 @@ the PR review.
 | `sp4-kb-globale.jsx` | `HeroSearch` | `apps/web/src/components/features/kb-globale/HeroSearch.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
 | `sp4-kb-globale.jsx` | `KbHomeDesktop` | `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
 | `sp4-kb-globale.jsx` | `KbSearchResultsDesktop` | `apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
-| `sp4-kb-globale.jsx` | `FilterAccordion` | `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | `/knowledge-base/global` | done | PR #TBD | T A V | #1737 |
+| `sp4-kb-globale.jsx` | `FilterAccordion` | `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | `/knowledge-base/global` | done | #1743 | T A V | #1737 |
 | `sp4-kb-globale.jsx` | `KbDocViewerDesktop` | `apps/web/src/components/features/kb-globale/KbDocViewerDesktop.tsx` | `/knowledge-base/global` | done | #TBD | T A M V | — |
 | `sp4-kb-globale.jsx` | `KbDocViewerMobile` | `apps/web/src/components/features/kb-globale/KbDocViewerMobile.tsx` | `/knowledge-base/global` | done | #TBD | T A M V | — |
-| `sp4-kb-globale.jsx` | `KbEditorDesktop` | `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | `/knowledge-base/global` | done | PR #TBD | T A V | #1737 |
+| `sp4-kb-globale.jsx` | `KbEditorDesktop` | `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | `/knowledge-base/global` | done | #1743 | T A V | #1737 |
 | `sp4-kb-globale.jsx` | `DrawerShell` (+ `DrawerIdle` / `DrawerStreaming` / `DrawerCompleted` / `DrawerError` states) | `apps/web/src/components/features/kb-globale/Drawer*.tsx` | `/knowledge-base/global` | done | #TBD | T A V | — |
 | `sp4-kb-globale.jsx` | `CitationPill` | `apps/web/src/components/features/kb-globale/CitationPill.tsx` | `/knowledge-base/global` | done | #TBD | T A V | — |
 | `sp4-kb-globale.jsx` | `KbEmptyState` | `apps/web/src/components/features/kb-globale/KbEmptyState.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |

--- a/docs/superpowers/plans/2026-05-31-kb-globale-phase3-filter-editor-fe.md
+++ b/docs/superpowers/plans/2026-05-31-kb-globale-phase3-filter-editor-fe.md
@@ -1,0 +1,2462 @@
+# KB Globale Phase 3 — FilterAccordion + KbEditorDesktop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the two deferred FE components (FilterAccordion + KbEditorDesktop) of `/knowledge-base/global`, completing Issue #1482 now that BE blockers #1686 (server-side facets) + #1687 (PATCH /kb-docs/{id}) are merged on `main-dev`.
+
+**Architecture:** FE-only single PR. Two new components + two new hooks + schema/client extensions wired into the existing `KbGlobaleView` orchestrator (Phase 1+2 PR #1688/#1701). FilterAccordion is eager-loaded (Phase 1 bundle, <5KB); KbEditorDesktop is lazy via `dynamic({ssr:false})` (mirrors Phase 2 viewer/drawer pattern). Cache invalidation aggressive post-PATCH (DEC-2). Edit affordance only in `KbHomeDesktop` recent cards (DEC-3 anti-info-leak preserved via BE 404).
+
+**Tech Stack:** Next.js App Router 16, React 19, TanStack Query v5, Zod, React Hook Form (already in tree), MSW for integration tests, Vitest + jest-axe, DS-15 design tokens.
+
+**Issue:** #1737 · **Epic:** #1475 · **Parent:** #1482 · **BE shipped:** PR #1730 (#1686) + PR #1732 (#1687) + PR #1736 (#1731)
+**Decisions doc:** [issue #1737 comment](https://github.com/meepleAi-app/meepleai-monorepo/issues/1737#issuecomment-4586313755) DEC-1..DEC-7 + S1..S6
+
+---
+
+## File Structure
+
+### Modify (5 files)
+
+| File | Change |
+|---|---|
+| `apps/web/src/lib/api/schemas/kb-globale.schemas.ts` | Extend `GlobalKbSearchRequestSchema`: add `docType?: string[]`, `gameId?: string[]`, `language?: string` |
+| `apps/web/src/lib/api/schemas/kb-docs.schemas.ts` | Extend `UserKbDocDtoSchema`: add `title?: string \| null`, `tags?: string[]` (default `[]`), `updatedBy?: string \| null` |
+| `apps/web/src/lib/api/clients/kbDocsClient.ts` | Extend `searchGlobal` to accept new filter fields; add new `patchKbDocMetadata(id, body)` method |
+| `apps/web/src/hooks/queries/useGlobalKbSearch.ts` | Extend `UseGlobalKbSearchOptions`: accept `filters?: GlobalKbSearchFilters`; include filters in `queryKey` + `queryFn` |
+| `apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx` | Parse `?docType=`/`?game=`/`?lang=`/`?edit=1`; wire filters into `useGlobalKbSearch`; lazy-mount `KbEditorDesktop`; extend LABELS |
+
+### Create (8 files)
+
+| File | Responsibility |
+|---|---|
+| `apps/web/src/lib/api/schemas/kb-docs-patch.schemas.ts` | `PatchKbDocMetadataRequestSchema` request body (Title?, DocumentType?, Language?, Tags?) |
+| `apps/web/src/hooks/mutations/useUpdateKbDocMeta.ts` | `useMutation` hook for `PATCH /kb-docs/{id}`; aggressive cache invalidation (DEC-2) |
+| `apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx` | Unit tests for mutation hook (success/404/422/cache invalidation) |
+| `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | 3 facets (DocType multi, GameId multi, Language single) with URL SSOT via callbacks |
+| `apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx` | Unit + jest-axe (S1/S2/S3 + a11y) |
+| `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | Form: title (text), documentType (select), language (select), tags (chip input); partial update; FluentValidation envelope rendering |
+| `apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx` | Unit + jest-axe (S4/S5/S6 + form a11y) |
+| `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx` | MSW integration covering S1-S6 e2e through orchestrator |
+
+### Modify (3 ancillary)
+
+| File | Change |
+|---|---|
+| `apps/web/messages/it.json` | Add `kbGlobale.filters.*` + `kbGlobale.editor.*` namespace |
+| `apps/web/messages/en.json` | Mirror it.json |
+| `docs/for-developers/frontend/v2-migration-matrix.md` | Flip kb-globale components #4 (FilterAccordion) + #8 (KbEditorDesktop) from `pending` → `done`; reference PR |
+
+---
+
+## Task 1: Schemas extension
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/kb-globale.schemas.ts`
+- Modify: `apps/web/src/lib/api/schemas/kb-docs.schemas.ts`
+- Create: `apps/web/src/lib/api/schemas/kb-docs-patch.schemas.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts` (modify, add filter tests)
+- Test: `apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts` (modify, add new field tests)
+- Test: `apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts` (create)
+
+- [ ] **Step 1: Write failing tests for GlobalKbSearchRequestSchema filters**
+
+Add to `apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { GlobalKbSearchRequestSchema } from '../kb-globale.schemas';
+
+describe('GlobalKbSearchRequestSchema — filters (Phase 3 #1737)', () => {
+  it('accepts docType as string[]', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      docType: ['Rulebook', 'Errata'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.docType).toEqual(['Rulebook', 'Errata']);
+    }
+  });
+
+  it('accepts gameId as uuid[]', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      gameId: ['00000000-0000-0000-0000-000000000001'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects gameId with non-uuid string', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      gameId: ['not-a-uuid'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts language as single string', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({ query: 'azul', language: 'it' });
+    expect(result.success).toBe(true);
+  });
+
+  it('allows all filter fields to be omitted (backwards-compat)', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({ query: 'azul' });
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts`
+Expected: 5 FAIL with "Unrecognized key" or "undefined property".
+
+- [ ] **Step 3: Extend GlobalKbSearchRequestSchema**
+
+Modify `apps/web/src/lib/api/schemas/kb-globale.schemas.ts` — replace `GlobalKbSearchRequestSchema` block:
+
+```ts
+/**
+ * GlobalKbSearchRequest — the POST /knowledge-base/search/global request body.
+ * Phase 3 (#1737): adds optional facet filters per BE PR #1730 (#1686).
+ * - docType: 7-value allowlist BE-side (D-6 of #1686); FE sends raw strings.
+ * - gameId: UUID array; non-accessible IDs return 200 empty (D-4 anti-info-leak).
+ * - language: ISO 639-1 lowercase {en,it,de,fr,es} (D-7 of #1686).
+ */
+export const GlobalKbSearchRequestSchema = z.object({
+  query: z.string().min(1, 'Query must not be empty'),
+  limit: z.number().int().positive().optional(),
+  cursor: z.string().nullable().optional(),
+  mode: SearchModeSchema.optional(),
+  docType: z.array(z.string()).optional(),
+  gameId: z.array(z.string().uuid()).optional(),
+  language: z.string().optional(),
+});
+
+export type GlobalKbSearchRequest = z.infer<typeof GlobalKbSearchRequestSchema>;
+
+/**
+ * GlobalKbSearchFilters — typed FE-side helper for the orchestrator/components.
+ * Used by useGlobalKbSearch options + FilterAccordion props.
+ */
+export interface GlobalKbSearchFilters {
+  docType?: readonly string[];
+  gameId?: readonly string[];
+  language?: string;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts`
+Expected: 5 PASS.
+
+- [ ] **Step 5: Write failing tests for UserKbDocDtoSchema extension**
+
+Add to `apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts`:
+
+```ts
+import { UserKbDocDtoSchema } from '../kb-docs.schemas';
+
+describe('UserKbDocDtoSchema — Phase 3 #1687 metadata fields', () => {
+  const baseFixture = {
+    id: '00000000-0000-0000-0000-000000000001',
+    gameId: '00000000-0000-0000-0000-000000000002',
+    gameName: 'Azul',
+    fileName: 'azul-rules.pdf',
+    processingState: 'Ready' as const,
+    pageCount: 24,
+    processedAt: '2026-05-31T00:00:00Z',
+    uploadedAt: '2026-05-31T00:00:00Z',
+    updatedAt: '2026-05-31T00:00:00Z',
+  };
+
+  it('accepts title as nullable string', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, title: 'Azul Master Edition' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts title as null', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, title: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts tags as string array', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, tags: ['strategy', 'family'] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts tags as empty array', () => {
+    const result = UserKbDocDtoSchema.safeParse({ ...baseFixture, tags: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts updatedBy as nullable uuid', () => {
+    const result = UserKbDocDtoSchema.safeParse({
+      ...baseFixture,
+      updatedBy: '00000000-0000-0000-0000-000000000003',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('back-compat: validates without title/tags/updatedBy (existing payloads)', () => {
+    const result = UserKbDocDtoSchema.safeParse(baseFixture);
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts`
+Expected: 6 FAIL.
+
+- [ ] **Step 7: Extend UserKbDocDtoSchema additively**
+
+Modify `apps/web/src/lib/api/schemas/kb-docs.schemas.ts` — replace `UserKbDocDtoSchema` block:
+
+```ts
+/**
+ * UserKbDocDto — lightweight cross-game user-scoped projection (BE-1 #1588).
+ * Phase 3 (#1737): adds title/tags/updatedBy per BE PR #1732 (#1687).
+ * All Phase 3 fields are optional/nullable for backwards-compat with pre-#1687 payloads.
+ */
+export const UserKbDocDtoSchema = z.object({
+  id: z.string().uuid(),
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  fileName: z.string().min(1),
+  processingState: ProcessingStateSchema,
+  pageCount: z.number().int().positive().nullable(),
+  processedAt: z.string().datetime({ offset: true }).nullable(),
+  uploadedAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+  // Phase 3 (#1687) additions:
+  title: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  updatedBy: z.string().uuid().nullable().optional(),
+});
+
+export type UserKbDocDto = z.infer<typeof UserKbDocDtoSchema>;
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts`
+Expected: 6 PASS (new) + all pre-existing tests still pass.
+
+- [ ] **Step 9: Write tests for new PatchKbDocMetadataRequestSchema**
+
+Create `apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { PatchKbDocMetadataRequestSchema } from '../kb-docs-patch.schemas';
+
+describe('PatchKbDocMetadataRequestSchema (Phase 3 #1737)', () => {
+  it('accepts fully populated body', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({
+      title: 'New Title',
+      documentType: 'Rulebook',
+      language: 'it',
+      tags: ['strategy', 'family'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty body (no-op)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts title=empty-string (clear semantic per D-4 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ title: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts tags=[] (clear semantic)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ tags: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects title > 200 chars (D-5 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ title: 'x'.repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects tag > 50 chars (D-8 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({ tags: ['x'.repeat(51)] });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects > 20 tags (D-8 #1687)', () => {
+    const result = PatchKbDocMetadataRequestSchema.safeParse({
+      tags: Array.from({ length: 21 }, (_, i) => `tag${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 10: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 11: Create PatchKbDocMetadataRequestSchema**
+
+Create `apps/web/src/lib/api/schemas/kb-docs-patch.schemas.ts`:
+
+```ts
+/**
+ * PATCH /api/v1/kb-docs/{id} request schema (Phase 3 #1737, BE PR #1732 #1687).
+ *
+ * Partial update semantics (D-4 #1687):
+ * - JSON `null` (omitted in TS) = no-op
+ * - empty string ("") = clear the field
+ * - empty array ([]) = clear tags
+ *
+ * Constraints (D-5/D-8 #1687):
+ * - title: max 200 chars
+ * - tags: max 20 items, each max 50 chars
+ *
+ * Allowlist enforcement is BE-side (FE sends raw strings):
+ * - documentType: 7-value DocumentCategory enum BE-side (D-6)
+ * - language: 10-value LanguageCode whitelist BE-side (D-7)
+ */
+import { z } from 'zod';
+
+const TITLE_MAX = 200;
+const TAG_MAX_LENGTH = 50;
+const TAGS_MAX_COUNT = 20;
+
+export const PatchKbDocMetadataRequestSchema = z.object({
+  title: z.string().max(TITLE_MAX, `Title must not exceed ${TITLE_MAX} characters.`).optional(),
+  documentType: z.string().optional(),
+  language: z.string().optional(),
+  tags: z
+    .array(z.string().max(TAG_MAX_LENGTH, `Tag must not exceed ${TAG_MAX_LENGTH} characters.`))
+    .max(TAGS_MAX_COUNT, `No more than ${TAGS_MAX_COUNT} tags allowed.`)
+    .optional(),
+});
+
+export type PatchKbDocMetadataRequest = z.infer<typeof PatchKbDocMetadataRequestSchema>;
+```
+
+- [ ] **Step 12: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts`
+Expected: 7 PASS.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/kb-globale.schemas.ts \
+        apps/web/src/lib/api/schemas/kb-docs.schemas.ts \
+        apps/web/src/lib/api/schemas/kb-docs-patch.schemas.ts \
+        apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts \
+        apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts \
+        apps/web/src/lib/api/schemas/__tests__/kb-docs-patch.schemas.test.ts
+git commit -m "feat(kb-globale): #1737 Task 1 — schemas for filters + PATCH metadata"
+```
+
+---
+
+## Task 2: API client extension
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/kbDocsClient.ts`
+- Test: `apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts` (modify)
+
+- [ ] **Step 1: Write failing tests for searchGlobal filters + patchKbDocMetadata**
+
+Add to `apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { createKbDocsClient } from '../kbDocsClient';
+import type { HttpClient } from '../../core/httpClient';
+
+describe('kbDocsClient.searchGlobal — filters (Phase 3 #1737)', () => {
+  it('forwards docType filter to POST body', async () => {
+    const mockPost = vi.fn().mockResolvedValue({ results: [], hasMore: false, nextCursor: null });
+    const client = createKbDocsClient({
+      httpClient: { post: mockPost, get: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn() } as unknown as HttpClient,
+    });
+    await client.searchGlobal({ query: 'azul', docType: ['Rulebook'] });
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/v1/knowledge-base/search/global',
+      expect.objectContaining({ query: 'azul', docType: ['Rulebook'] }),
+      expect.anything()
+    );
+  });
+
+  it('forwards gameId + language filters to POST body', async () => {
+    const mockPost = vi.fn().mockResolvedValue({ results: [], hasMore: false, nextCursor: null });
+    const client = createKbDocsClient({
+      httpClient: { post: mockPost, get: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn() } as unknown as HttpClient,
+    });
+    await client.searchGlobal({
+      query: 'azul',
+      gameId: ['00000000-0000-0000-0000-000000000001'],
+      language: 'it',
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/v1/knowledge-base/search/global',
+      expect.objectContaining({
+        gameId: ['00000000-0000-0000-0000-000000000001'],
+        language: 'it',
+      }),
+      expect.anything()
+    );
+  });
+});
+
+describe('kbDocsClient.patchKbDocMetadata (Phase 3 #1737)', () => {
+  it('calls PATCH /api/v1/kb-docs/{id} with body', async () => {
+    const mockPatch = vi.fn().mockResolvedValue({
+      id: '00000000-0000-0000-0000-000000000001',
+      fileName: 'azul.pdf',
+      gameId: null,
+      gameName: null,
+      processingState: 'Ready',
+      pageCount: 24,
+      processedAt: '2026-05-31T00:00:00Z',
+      uploadedAt: '2026-05-31T00:00:00Z',
+      updatedAt: '2026-05-31T00:00:00Z',
+      title: 'New Title',
+      tags: ['strategy'],
+      updatedBy: '00000000-0000-0000-0000-000000000003',
+    });
+    const client = createKbDocsClient({
+      httpClient: { post: vi.fn(), get: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: mockPatch } as unknown as HttpClient,
+    });
+    const result = await client.patchKbDocMetadata('00000000-0000-0000-0000-000000000001', {
+      title: 'New Title',
+      tags: ['strategy'],
+    });
+    expect(mockPatch).toHaveBeenCalledWith(
+      '/api/v1/kb-docs/00000000-0000-0000-0000-000000000001',
+      { title: 'New Title', tags: ['strategy'] },
+      expect.anything()
+    );
+    expect(result.title).toBe('New Title');
+  });
+
+  it('propagates 404 errors (D-2 anti-info-leak)', async () => {
+    const mockPatch = vi.fn().mockRejectedValue(new Error('HTTP 404'));
+    const client = createKbDocsClient({
+      httpClient: { post: vi.fn(), get: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: mockPatch } as unknown as HttpClient,
+    });
+    await expect(
+      client.patchKbDocMetadata('00000000-0000-0000-0000-000000000001', { title: 'X' })
+    ).rejects.toThrow('HTTP 404');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts`
+Expected: 4 FAIL — `patchKbDocMetadata` not defined; `searchGlobal` doesn't include filter fields.
+
+- [ ] **Step 3: Extend kbDocsClient**
+
+Modify `apps/web/src/lib/api/clients/kbDocsClient.ts` — replace existing implementation:
+
+```ts
+import { KbDocsListResponseSchema, type KbDocsListResponse, type UserKbDocDto, UserKbDocDtoSchema } from '../schemas/kb-docs.schemas';
+import { PatchKbDocMetadataRequestSchema, type PatchKbDocMetadataRequest } from '../schemas/kb-docs-patch.schemas';
+import {
+  GlobalKbSearchResponseSchema,
+  type GlobalKbSearchRequest,
+  type GlobalKbSearchResponse,
+} from '../schemas/kb-globale.schemas';
+
+import type { HttpClient } from '../core/httpClient';
+
+export interface CreateKbDocsClientParams {
+  httpClient: HttpClient;
+}
+
+export interface ListUserKbDocsParams {
+  page?: number;
+  pageSize?: number;
+  sortBy?: 'recent';
+  state?: 'ready' | 'all';
+}
+
+export interface KbDocsClient {
+  listUserKbDocs(params?: ListUserKbDocsParams): Promise<KbDocsListResponse>;
+  searchGlobal(req: GlobalKbSearchRequest): Promise<GlobalKbSearchResponse>;
+  /** Phase 3 #1737 / BE PR #1732 #1687 — PATCH /api/v1/kb-docs/{id} for owner metadata edit. */
+  patchKbDocMetadata(id: string, body: PatchKbDocMetadataRequest): Promise<UserKbDocDto>;
+}
+
+export function createKbDocsClient({ httpClient }: CreateKbDocsClientParams): KbDocsClient {
+  return {
+    async listUserKbDocs(params: ListUserKbDocsParams = {}): Promise<KbDocsListResponse> {
+      const qs = new URLSearchParams();
+      if (params.page !== undefined) qs.append('page', String(params.page));
+      if (params.pageSize !== undefined) qs.append('pageSize', String(params.pageSize));
+      if (params.sortBy !== undefined) qs.append('sortBy', params.sortBy);
+      if (params.state !== undefined) qs.append('state', params.state);
+
+      const url = `/api/v1/kb-docs${qs.toString() ? `?${qs.toString()}` : ''}`;
+      const response = await httpClient.get<KbDocsListResponse>(url, KbDocsListResponseSchema);
+      return (
+        response ?? { items: [], total: 0, page: params.page ?? 1, pageSize: params.pageSize ?? 20 }
+      );
+    },
+
+    async searchGlobal(req: GlobalKbSearchRequest): Promise<GlobalKbSearchResponse> {
+      // Phase 3 (#1737): req now optionally includes docType, gameId, language
+      // — forwarded verbatim to BE per PR #1730 (#1686) DTO shape.
+      const response = await httpClient.post<GlobalKbSearchResponse>(
+        '/api/v1/knowledge-base/search/global',
+        req,
+        GlobalKbSearchResponseSchema
+      );
+      return response ?? { results: [], hasMore: false, nextCursor: null };
+    },
+
+    async patchKbDocMetadata(
+      id: string,
+      body: PatchKbDocMetadataRequest
+    ): Promise<UserKbDocDto> {
+      const validated = PatchKbDocMetadataRequestSchema.parse(body);
+      const response = await httpClient.patch<UserKbDocDto>(
+        `/api/v1/kb-docs/${id}`,
+        validated,
+        UserKbDocDtoSchema
+      );
+      if (response == null) {
+        throw new Error('PATCH /kb-docs returned no body');
+      }
+      return response;
+    },
+  };
+}
+```
+
+NOTE: if `HttpClient` interface doesn't expose `patch`, **first** verify and extend it. The Phase 1 client used `get`/`post`. Check `apps/web/src/lib/api/core/httpClient.ts` for the `patch` method signature; if absent, add it following the existing `post` pattern. This is a pre-requisite for Step 3.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts`
+Expected: 4 PASS (new) + all pre-existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/kbDocsClient.ts \
+        apps/web/src/lib/api/clients/__tests__/kbDocsClient.test.ts
+# include httpClient.ts if patch method was added
+git commit -m "feat(kb-globale): #1737 Task 2 — kbDocsClient.searchGlobal filters + patchKbDocMetadata"
+```
+
+---
+
+## Task 3: useGlobalKbSearch — filters extension
+
+**Files:**
+- Modify: `apps/web/src/hooks/queries/useGlobalKbSearch.ts`
+- Test: `apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx` (modify)
+
+- [ ] **Step 1: Write failing tests for filter propagation**
+
+Add to `apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useGlobalKbSearch } from '../useGlobalKbSearch';
+import { api } from '@/lib/api';
+
+// Helper: wrap hook with QueryClient
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('useGlobalKbSearch — filters (Phase 3 #1737)', () => {
+  it('passes docType filter to client call', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'searchGlobal').mockResolvedValue({
+      results: [], hasMore: false, nextCursor: null,
+    });
+    renderHook(
+      () => useGlobalKbSearch({ query: 'azul', filters: { docType: ['Rulebook'] } }),
+      { wrapper }
+    );
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ docType: ['Rulebook'] }))
+    );
+    spy.mockRestore();
+  });
+
+  it('passes all filter fields to client call', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'searchGlobal').mockResolvedValue({
+      results: [], hasMore: false, nextCursor: null,
+    });
+    renderHook(
+      () =>
+        useGlobalKbSearch({
+          query: 'azul',
+          filters: {
+            docType: ['Rulebook'],
+            gameId: ['00000000-0000-0000-0000-000000000001'],
+            language: 'it',
+          },
+        }),
+      { wrapper }
+    );
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          docType: ['Rulebook'],
+          gameId: ['00000000-0000-0000-0000-000000000001'],
+          language: 'it',
+        })
+      )
+    );
+    spy.mockRestore();
+  });
+
+  it('queryKey includes filters (different filters = different cache entry)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'searchGlobal').mockResolvedValue({
+      results: [], hasMore: false, nextCursor: null,
+    });
+    const { rerender } = renderHook(
+      ({ filters }: { filters: { docType?: readonly string[] } }) =>
+        useGlobalKbSearch({ query: 'azul', filters }),
+      { wrapper, initialProps: { filters: { docType: ['Rulebook'] } } }
+    );
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+    rerender({ filters: { docType: ['Errata'] } });
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+    spy.mockRestore();
+  });
+
+  it('omitted filters are not sent (backwards-compat with Phase 1+2 callers)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'searchGlobal').mockResolvedValue({
+      results: [], hasMore: false, nextCursor: null,
+    });
+    renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const call = spy.mock.calls[0]?.[0];
+    expect(call).not.toHaveProperty('docType');
+    expect(call).not.toHaveProperty('gameId');
+    expect(call).not.toHaveProperty('language');
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx`
+Expected: 4 FAIL — `filters` prop unrecognized.
+
+- [ ] **Step 3: Extend useGlobalKbSearch**
+
+Modify `apps/web/src/hooks/queries/useGlobalKbSearch.ts` — replace `kbGlobaleSearchKeys`, `UseGlobalKbSearchOptions`, and the hook body:
+
+```ts
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { useDebounce } from '@/hooks/useDebounce';
+import { api } from '@/lib/api';
+import type {
+  GlobalKbSearchFilters,
+  GlobalKbSearchResult,
+  GlobalKbSearchResponse,
+  SearchMode,
+} from '@/lib/api/schemas/kb-globale.schemas';
+
+export const KB_GLOBALE_SEARCH_STALE_TIME_MS = 5 * 60 * 1000;
+
+/** Stable serialized form of filters for queryKey identity. */
+function serializeFilters(filters?: GlobalKbSearchFilters): string {
+  if (!filters) return '';
+  const parts: string[] = [];
+  if (filters.docType && filters.docType.length > 0) {
+    parts.push(`docType:${[...filters.docType].sort().join(',')}`);
+  }
+  if (filters.gameId && filters.gameId.length > 0) {
+    parts.push(`gameId:${[...filters.gameId].sort().join(',')}`);
+  }
+  if (filters.language) parts.push(`language:${filters.language}`);
+  return parts.join('|');
+}
+
+export const kbGlobaleSearchKeys = {
+  all: ['kb-globale', 'search'] as const,
+  byQuery: (query: string, mode: SearchMode | null, filtersKey: string) =>
+    [...kbGlobaleSearchKeys.all, { query, mode, filtersKey }] as const,
+};
+
+export interface UseGlobalKbSearchOptions {
+  query: string;
+  mode?: SearchMode;
+  debounceMs?: number;
+  enabled?: boolean;
+  /** Phase 3 (#1737): optional server-side facet filters. */
+  filters?: GlobalKbSearchFilters;
+}
+
+export interface UseGlobalKbSearchResult {
+  results: readonly GlobalKbSearchResult[];
+  hasMore: boolean;
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  error: Error | null;
+  fetchNextPage: () => void;
+}
+
+export function useGlobalKbSearch(opts: UseGlobalKbSearchOptions): UseGlobalKbSearchResult {
+  const { query, mode, debounceMs = 250, enabled, filters } = opts;
+
+  const debouncedQuery = useDebounce(query.trim(), debounceMs);
+  const effectiveEnabled = enabled ?? debouncedQuery.length >= 2;
+  const filtersKey = serializeFilters(filters);
+
+  const q = useInfiniteQuery<
+    GlobalKbSearchResponse,
+    Error,
+    { pages: GlobalKbSearchResponse[] },
+    ReturnType<typeof kbGlobaleSearchKeys.byQuery>,
+    string | null
+  >({
+    queryKey: kbGlobaleSearchKeys.byQuery(debouncedQuery, mode ?? null, filtersKey),
+    queryFn: ({ pageParam }) =>
+      api.kbDocs.searchGlobal({
+        query: debouncedQuery,
+        mode,
+        cursor: pageParam,
+        // Phase 3: only include non-empty filters to keep wire format clean.
+        ...(filters?.docType && filters.docType.length > 0
+          ? { docType: [...filters.docType] }
+          : {}),
+        ...(filters?.gameId && filters.gameId.length > 0
+          ? { gameId: [...filters.gameId] }
+          : {}),
+        ...(filters?.language ? { language: filters.language } : {}),
+      }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage: GlobalKbSearchResponse) =>
+      lastPage.hasMore ? lastPage.nextCursor : undefined,
+    enabled: effectiveEnabled,
+    staleTime: KB_GLOBALE_SEARCH_STALE_TIME_MS,
+  });
+
+  const results: readonly GlobalKbSearchResult[] = q.data?.pages.flatMap(p => p.results) ?? [];
+  const pages = q.data?.pages;
+  const hasMore =
+    pages != null && pages.length > 0 ? (pages[pages.length - 1]?.hasMore ?? false) : false;
+
+  return {
+    results,
+    hasMore,
+    isLoading: q.isLoading,
+    isFetchingNextPage: q.isFetchingNextPage,
+    error: q.error,
+    fetchNextPage: () => {
+      void q.fetchNextPage();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx`
+Expected: 4 new PASS + all pre-existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/queries/useGlobalKbSearch.ts \
+        apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx
+git commit -m "feat(kb-globale): #1737 Task 3 — useGlobalKbSearch accepts facet filters"
+```
+
+---
+
+## Task 4: useUpdateKbDocMeta — mutation hook with aggressive cache invalidation
+
+**Files:**
+- Create: `apps/web/src/hooks/mutations/useUpdateKbDocMeta.ts`
+- Create: `apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx`
+
+- [ ] **Step 1: Write failing tests for mutation + cache invalidation**
+
+Create `apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import type { JSX, ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUpdateKbDocMeta } from '../useUpdateKbDocMeta';
+import { api } from '@/lib/api';
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const DTO_FIXTURE = {
+  id: '00000000-0000-0000-0000-000000000001',
+  gameId: null,
+  gameName: null,
+  fileName: 'azul.pdf',
+  processingState: 'Ready' as const,
+  pageCount: 24,
+  processedAt: '2026-05-31T00:00:00Z',
+  uploadedAt: '2026-05-31T00:00:00Z',
+  updatedAt: '2026-05-31T00:00:00Z',
+  title: 'New Title',
+  tags: ['strategy'],
+  updatedBy: '00000000-0000-0000-0000-000000000003',
+};
+
+describe('useUpdateKbDocMeta (Phase 3 #1737)', () => {
+  it('calls api.kbDocs.patchKbDocMetadata on mutate', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DTO_FIXTURE);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: '00000000-0000-0000-0000-000000000001',
+        body: { title: 'New Title' },
+      });
+    });
+    expect(spy).toHaveBeenCalledWith(
+      '00000000-0000-0000-0000-000000000001',
+      { title: 'New Title' }
+    );
+    spy.mockRestore();
+  });
+
+  it('invalidates ["kb-docs","user"] queries on success', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DTO_FIXTURE);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: '00000000-0000-0000-0000-000000000001',
+        body: { title: 'New Title' },
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['kb-docs', 'user'] });
+    spy.mockRestore();
+  });
+
+  it('invalidates ["kb-globale","search"] queries on success (DEC-2 aggressive)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockResolvedValue(DTO_FIXTURE);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: '00000000-0000-0000-0000-000000000001',
+        body: { title: 'New Title' },
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['kb-globale', 'search'] });
+    spy.mockRestore();
+  });
+
+  it('exposes error on 404 (S5 anti-info-leak)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(new Error('HTTP 404'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          id: '00000000-0000-0000-0000-000000000001',
+          body: { title: 'X' },
+        });
+      } catch {
+        /* expected */
+      }
+    });
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error?.message).toContain('404');
+    spy.mockRestore();
+  });
+
+  it('does NOT invalidate on error (cache stays consistent)', async () => {
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(new Error('HTTP 422'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateKbDocMeta(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          id: '00000000-0000-0000-0000-000000000001',
+          body: { title: 'X' },
+        });
+      } catch {
+        /* expected */
+      }
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx`
+Expected: 5 FAIL — module not found.
+
+- [ ] **Step 3: Implement useUpdateKbDocMeta**
+
+Create `apps/web/src/hooks/mutations/useUpdateKbDocMeta.ts`:
+
+```ts
+/**
+ * useUpdateKbDocMeta — Phase 3 #1737 mutation hook for PATCH /api/v1/kb-docs/{id}.
+ *
+ * Cache invalidation (DEC-2 aggressive — issue #1737 spec-panel):
+ *   - ['kb-docs', 'user']         → KbHomeDesktop recent docs
+ *   - ['kb-globale', 'search']    → search results (title affects display)
+ *   - ['kb-docs', 'detail', id]   → per-doc detail cache (viewer hero)
+ *
+ * BE contract (PR #1732 #1687):
+ *   - 200 + extended UserKbDocDto (Title, Tags, UpdatedBy added)
+ *   - 404 = not accessible (anti-info-leak D-2, NOT 403)
+ *   - 422 = validation envelope (FluentValidation)
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+import type { PatchKbDocMetadataRequest } from '@/lib/api/schemas/kb-docs-patch.schemas';
+
+export interface UpdateKbDocMetaInput {
+  id: string;
+  body: PatchKbDocMetadataRequest;
+}
+
+export type UseUpdateKbDocMetaResult = UseMutationResult<
+  UserKbDocDto,
+  Error,
+  UpdateKbDocMetaInput
+>;
+
+export function useUpdateKbDocMeta(): UseUpdateKbDocMetaResult {
+  const qc = useQueryClient();
+  return useMutation<UserKbDocDto, Error, UpdateKbDocMetaInput>({
+    mutationFn: ({ id, body }) => api.kbDocs.patchKbDocMetadata(id, body),
+    onSuccess: (_data, vars) => {
+      // DEC-2 aggressive invalidation: any cached query whose key starts with
+      // these prefixes will refetch on next mount/observer.
+      qc.invalidateQueries({ queryKey: ['kb-docs', 'user'] });
+      qc.invalidateQueries({ queryKey: ['kb-globale', 'search'] });
+      qc.invalidateQueries({ queryKey: ['kb-docs', 'detail', vars.id] });
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx`
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/mutations/useUpdateKbDocMeta.ts \
+        apps/web/src/hooks/mutations/__tests__/useUpdateKbDocMeta.test.tsx
+git commit -m "feat(kb-globale): #1737 Task 4 — useUpdateKbDocMeta mutation hook with DEC-2 aggressive invalidation"
+```
+
+---
+
+## Task 5: FilterAccordion component
+
+**Files:**
+- Create: `apps/web/src/components/features/kb-globale/FilterAccordion.tsx`
+- Create: `apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx`
+
+- [ ] **Step 1: Write failing tests covering S1/S2/S3 + a11y**
+
+Create `apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { FilterAccordion } from '../FilterAccordion';
+
+expect.extend(toHaveNoViolations);
+
+const DEFAULT_LABELS = {
+  heading: 'Filtri',
+  docTypeLabel: 'Tipo documento',
+  gameIdLabel: 'Gioco',
+  languageLabel: 'Lingua',
+  clearAll: 'Cancella filtri',
+  docTypeOptions: {
+    Rulebook: 'Regolamento',
+    Expansion: 'Espansione',
+    Errata: 'Errata',
+    QuickStart: 'Quick Start',
+    Reference: 'Riferimento',
+    PlayerAid: 'Aiuto giocatore',
+    Other: 'Altro',
+  },
+  languageOptions: { en: 'English', it: 'Italiano', de: 'Deutsch', fr: 'Français', es: 'Español' },
+};
+
+const GAMES_FIXTURE = [
+  { id: '00000000-0000-0000-0000-000000000001', name: 'Azul' },
+  { id: '00000000-0000-0000-0000-000000000002', name: 'Wingspan' },
+];
+
+describe('FilterAccordion (Phase 3 #1737)', () => {
+  it('renders all 3 facet sections', () => {
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    expect(screen.getByText('Tipo documento')).toBeInTheDocument();
+    expect(screen.getByText('Gioco')).toBeInTheDocument();
+    expect(screen.getByText('Lingua')).toBeInTheDocument();
+  });
+
+  it('renders 7 docType options from allowlist (drops faq per DEC-7)', () => {
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    // Open the section first (assuming default-collapsed accordion behavior).
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    expect(screen.getByLabelText('Regolamento')).toBeInTheDocument();
+    expect(screen.getByLabelText('Espansione')).toBeInTheDocument();
+    expect(screen.getByLabelText('Errata')).toBeInTheDocument();
+    expect(screen.getByLabelText('Altro')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/FAQ/i)).not.toBeInTheDocument();
+  });
+
+  // S1: facet apply
+  it('S1: calls onChange with new docType selection on toggle', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    fireEvent.click(screen.getByLabelText('Regolamento'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ docType: ['Rulebook'] })
+    );
+  });
+
+  // S2: facet clear
+  it('S2: clearAll button resets all facets', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ docType: ['Rulebook'], language: 'it' }}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /cancella filtri/i }));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  // S3: URL SSOT round-trip (controlled component reflects external `selected`)
+  it('S3: pre-selects facets from controlled `selected` prop', () => {
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ docType: ['Rulebook'], language: 'it' }}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    const checkbox = screen.getByLabelText('Regolamento') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('multi-select GameId: toggle adds a uuid to the array', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ gameId: ['00000000-0000-0000-0000-000000000001'] }}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /gioco/i }));
+    fireEvent.click(screen.getByLabelText('Wingspan'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gameId: expect.arrayContaining([
+          '00000000-0000-0000-0000-000000000001',
+          '00000000-0000-0000-0000-000000000002',
+        ]),
+      })
+    );
+  });
+
+  it('single-select Language: replaces the previous value', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{ language: 'it' }}
+        onChange={onChange}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /lingua/i }));
+    fireEvent.click(screen.getByLabelText('English'));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ language: 'en' }));
+  });
+
+  it('a11y: no jest-axe violations', async () => {
+    const { container } = render(
+      <FilterAccordion
+        availableGames={GAMES_FIXTURE}
+        selected={{}}
+        onChange={vi.fn()}
+        labels={DEFAULT_LABELS}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx`
+Expected: 8 FAIL — module not found.
+
+- [ ] **Step 3: Implement FilterAccordion**
+
+Create `apps/web/src/components/features/kb-globale/FilterAccordion.tsx`:
+
+```tsx
+/**
+ * FilterAccordion — Phase 3 #1737 / Issue #1482 component #4.
+ *
+ * Three server-side facets backed by BE PR #1730 (#1686):
+ *   - DocType  : multi-select, 7-value allowlist (D-6 #1686); drops `faq` per DEC-7
+ *   - GameId   : multi-select, dropdown of accessible games (DEC-1: derived from useUserKbDocs)
+ *   - Language : single-select, 5-value ISO 639-1 allowlist (D-7 #1686)
+ *
+ * Controlled component — parent owns `selected` state (URL SSOT in KbGlobaleView)
+ * and reacts to `onChange`.
+ *
+ * Empty selection = no filter (D-3/D-5 #1686, byte-identical baseline).
+ *
+ * a11y: each facet section is a <details>+<summary> for native accordion;
+ * checkboxes/radios for inputs; visible clearAll button at top.
+ */
+'use client';
+
+import { type JSX } from 'react';
+import type { GlobalKbSearchFilters } from '@/lib/api/schemas/kb-globale.schemas';
+
+export interface FilterAccordionLabels {
+  heading: string;
+  docTypeLabel: string;
+  gameIdLabel: string;
+  languageLabel: string;
+  clearAll: string;
+  /** Map: BE enum string → display label */
+  docTypeOptions: Readonly<Record<string, string>>;
+  languageOptions: Readonly<Record<string, string>>;
+}
+
+export interface GameOption {
+  id: string;
+  name: string;
+}
+
+export interface FilterAccordionProps {
+  availableGames: readonly GameOption[];
+  selected: GlobalKbSearchFilters;
+  onChange: (next: GlobalKbSearchFilters) => void;
+  labels: FilterAccordionLabels;
+}
+
+const DOC_TYPE_ALLOWLIST = [
+  'Rulebook',
+  'Expansion',
+  'Errata',
+  'QuickStart',
+  'Reference',
+  'PlayerAid',
+  'Other',
+] as const;
+
+const LANGUAGE_ALLOWLIST = ['en', 'it', 'de', 'fr', 'es'] as const;
+
+export function FilterAccordion(props: FilterAccordionProps): JSX.Element {
+  const { availableGames, selected, onChange, labels } = props;
+  const selectedDocTypes = selected.docType ?? [];
+  const selectedGameIds = selected.gameId ?? [];
+  const selectedLanguage = selected.language ?? '';
+
+  const toggleDocType = (value: string) => {
+    const next = selectedDocTypes.includes(value)
+      ? selectedDocTypes.filter(v => v !== value)
+      : [...selectedDocTypes, value];
+    onChange({ ...selected, docType: next.length > 0 ? next : undefined });
+  };
+
+  const toggleGameId = (id: string) => {
+    const next = selectedGameIds.includes(id)
+      ? selectedGameIds.filter(v => v !== id)
+      : [...selectedGameIds, id];
+    onChange({ ...selected, gameId: next.length > 0 ? next : undefined });
+  };
+
+  const setLanguage = (lang: string) => {
+    onChange({ ...selected, language: lang || undefined });
+  };
+
+  const clearAll = () => onChange({});
+
+  const hasAnyFilter =
+    selectedDocTypes.length > 0 || selectedGameIds.length > 0 || selectedLanguage !== '';
+
+  return (
+    <aside
+      className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3"
+      aria-label={labels.heading}
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-foreground">{labels.heading}</h2>
+        {hasAnyFilter && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-sm text-muted-foreground hover:text-foreground underline"
+          >
+            {labels.clearAll}
+          </button>
+        )}
+      </div>
+
+      {/* DocType facet */}
+      <details className="border-t border-border-strong pt-2">
+        <summary className="cursor-pointer font-medium text-sm text-foreground">
+          {labels.docTypeLabel}
+          {selectedDocTypes.length > 0 && (
+            <span className="ml-2 text-muted-foreground">({selectedDocTypes.length})</span>
+          )}
+        </summary>
+        <div className="mt-2 flex flex-col gap-1">
+          {DOC_TYPE_ALLOWLIST.map(opt => (
+            <label key={opt} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={selectedDocTypes.includes(opt)}
+                onChange={() => toggleDocType(opt)}
+              />
+              <span>{labels.docTypeOptions[opt] ?? opt}</span>
+            </label>
+          ))}
+        </div>
+      </details>
+
+      {/* GameId facet */}
+      <details className="border-t border-border-strong pt-2">
+        <summary className="cursor-pointer font-medium text-sm text-foreground">
+          {labels.gameIdLabel}
+          {selectedGameIds.length > 0 && (
+            <span className="ml-2 text-muted-foreground">({selectedGameIds.length})</span>
+          )}
+        </summary>
+        <div className="mt-2 flex flex-col gap-1 max-h-60 overflow-auto">
+          {availableGames.map(g => (
+            <label key={g.id} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={selectedGameIds.includes(g.id)}
+                onChange={() => toggleGameId(g.id)}
+              />
+              <span>{g.name}</span>
+            </label>
+          ))}
+        </div>
+      </details>
+
+      {/* Language facet */}
+      <details className="border-t border-border-strong pt-2">
+        <summary className="cursor-pointer font-medium text-sm text-foreground">
+          {labels.languageLabel}
+          {selectedLanguage && (
+            <span className="ml-2 text-muted-foreground">
+              ({labels.languageOptions[selectedLanguage] ?? selectedLanguage})
+            </span>
+          )}
+        </summary>
+        <div className="mt-2 flex flex-col gap-1" role="radiogroup">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="kb-globale-language"
+              checked={selectedLanguage === ''}
+              onChange={() => setLanguage('')}
+            />
+            <span className="text-muted-foreground">—</span>
+          </label>
+          {LANGUAGE_ALLOWLIST.map(lang => (
+            <label key={lang} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="kb-globale-language"
+                checked={selectedLanguage === lang}
+                onChange={() => setLanguage(lang)}
+              />
+              <span>{labels.languageOptions[lang] ?? lang}</span>
+            </label>
+          ))}
+        </div>
+      </details>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx`
+Expected: 8 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/kb-globale/FilterAccordion.tsx \
+        apps/web/src/components/features/kb-globale/__tests__/FilterAccordion.test.tsx
+git commit -m "feat(kb-globale): #1737 Task 5 — FilterAccordion component (3 facets + a11y)"
+```
+
+---
+
+## Task 6: KbEditorDesktop component
+
+**Files:**
+- Create: `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx`
+- Create: `apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx`
+
+- [ ] **Step 1: Write failing tests covering S4/S5/S6 + a11y**
+
+Create `apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { JSX, ReactNode } from 'react';
+
+import { KbEditorDesktop } from '../KbEditorDesktop';
+import { api } from '@/lib/api';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+
+expect.extend(toHaveNoViolations);
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const DOC_FIXTURE: UserKbDocDto = {
+  id: '00000000-0000-0000-0000-000000000001',
+  gameId: null,
+  gameName: null,
+  fileName: 'azul.pdf',
+  processingState: 'Ready',
+  pageCount: 24,
+  processedAt: '2026-05-31T00:00:00Z',
+  uploadedAt: '2026-05-31T00:00:00Z',
+  updatedAt: '2026-05-31T00:00:00Z',
+  title: 'Old Title',
+  tags: ['family'],
+  updatedBy: null,
+};
+
+const LABELS = {
+  heading: 'Modifica metadati',
+  titleLabel: 'Titolo',
+  documentTypeLabel: 'Tipo documento',
+  languageLabel: 'Lingua',
+  tagsLabel: 'Tag',
+  saveLabel: 'Salva',
+  cancelLabel: 'Annulla',
+  notFoundError: 'Documento non trovato',
+  genericError: 'Errore generico, riprova.',
+  documentTypeOptions: { Rulebook: 'Regolamento' },
+  languageOptions: { it: 'Italiano', en: 'English' },
+};
+
+describe('KbEditorDesktop (Phase 3 #1737)', () => {
+  it('renders form pre-filled with doc fields', () => {
+    const qc = new QueryClient();
+    render(
+      <KbEditorDesktop
+        doc={DOC_FIXTURE}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+    expect((screen.getByLabelText('Titolo') as HTMLInputElement).value).toBe('Old Title');
+  });
+
+  // S4: PATCH success
+  it('S4: submits PATCH with changed title and closes on success', async () => {
+    const spy = vi
+      .spyOn(api.kbDocs, 'patchKbDocMetadata')
+      .mockResolvedValue({ ...DOC_FIXTURE, title: 'New Title' });
+    const onClose = vi.fn();
+    const qc = new QueryClient();
+    render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={onClose} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    const titleInput = screen.getByLabelText('Titolo') as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: 'New Title' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(spy).toHaveBeenCalledWith(DOC_FIXTURE.id, expect.objectContaining({ title: 'New Title' }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    spy.mockRestore();
+  });
+
+  // S5: PATCH 404
+  it('S5: shows generic notFoundError on 404 (anti-info-leak)', async () => {
+    const spy = vi
+      .spyOn(api.kbDocs, 'patchKbDocMetadata')
+      .mockRejectedValue(new Error('HTTP 404'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    fireEvent.change(screen.getByLabelText('Titolo'), { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(screen.getByText('Documento non trovato')).toBeInTheDocument());
+    spy.mockRestore();
+  });
+
+  // S6: PATCH 422 field errors
+  it('S6: shows inline field error on 422 (FluentValidation envelope)', async () => {
+    const validationError = Object.assign(new Error('HTTP 422'), {
+      status: 422,
+      fieldErrors: { title: 'Title must not exceed 200 characters.' },
+    });
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata').mockRejectedValue(validationError);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    fireEvent.change(screen.getByLabelText('Titolo'), { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/title must not exceed 200/i)).toBeInTheDocument()
+    );
+    // aria-describedby links input to error
+    expect(screen.getByLabelText('Titolo')).toHaveAttribute('aria-describedby');
+    spy.mockRestore();
+  });
+
+  it('omits unchanged fields from PATCH body (partial update D-4 #1687)', async () => {
+    const spy = vi
+      .spyOn(api.kbDocs, 'patchKbDocMetadata')
+      .mockResolvedValue(DOC_FIXTURE);
+    const qc = new QueryClient();
+    render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    // Don't change anything, just click Save.
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const body = spy.mock.calls[0]?.[1];
+    expect(body).toEqual({}); // no-op patch
+    spy.mockRestore();
+  });
+
+  it('cancel button calls onClose without submitting', () => {
+    const onClose = vi.fn();
+    const spy = vi.spyOn(api.kbDocs, 'patchKbDocMetadata');
+    const qc = new QueryClient();
+    render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={onClose} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    fireEvent.click(screen.getByRole('button', { name: /annulla/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('a11y: no jest-axe violations', async () => {
+    const qc = new QueryClient();
+    const { container } = render(
+      <KbEditorDesktop doc={DOC_FIXTURE} onClose={vi.fn()} labels={LABELS} />,
+      { wrapper: makeWrapper(qc) }
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx`
+Expected: 7 FAIL — module not found.
+
+- [ ] **Step 3: Implement KbEditorDesktop**
+
+Create `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx`:
+
+```tsx
+/**
+ * KbEditorDesktop — Phase 3 #1737 / Issue #1482 component #8.
+ *
+ * Metadata-edit form for owner-curated KB docs. Calls PATCH /api/v1/kb-docs/{id}
+ * (BE PR #1732 #1687) with partial update semantics (D-4): null = no-op, ""/[] = clear.
+ *
+ * Error handling:
+ *   - 404 → generic "Documento non trovato" (D-2 anti-info-leak)
+ *   - 422 → inline field errors via aria-describedby (FluentValidation envelope)
+ *   - other → generic error toast
+ *
+ * Owner-only affordance enforcement is upstream (DEC-3 — only mounted from
+ * KbHomeDesktop recent cards which are BE-filtered to owned docs).
+ *
+ * Mounted lazy via dynamic({ ssr: false }) by KbGlobaleView (DEC-5 bundle).
+ */
+'use client';
+
+import { type JSX, useState, useId } from 'react';
+
+import { useUpdateKbDocMeta } from '@/hooks/mutations/useUpdateKbDocMeta';
+import type { PatchKbDocMetadataRequest } from '@/lib/api/schemas/kb-docs-patch.schemas';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+
+export interface KbEditorDesktopLabels {
+  heading: string;
+  titleLabel: string;
+  documentTypeLabel: string;
+  languageLabel: string;
+  tagsLabel: string;
+  saveLabel: string;
+  cancelLabel: string;
+  notFoundError: string;
+  genericError: string;
+  documentTypeOptions: Readonly<Record<string, string>>;
+  languageOptions: Readonly<Record<string, string>>;
+}
+
+export interface KbEditorDesktopProps {
+  doc: UserKbDocDto;
+  onClose: () => void;
+  labels: KbEditorDesktopLabels;
+}
+
+interface FieldError {
+  title?: string;
+  documentType?: string;
+  language?: string;
+  tags?: string;
+}
+
+interface HttpFieldError extends Error {
+  status?: number;
+  fieldErrors?: Record<string, string>;
+}
+
+function isHttpFieldError(err: unknown): err is HttpFieldError {
+  return err instanceof Error && 'status' in err;
+}
+
+function buildPatchBody(
+  initial: UserKbDocDto,
+  draft: { title: string; documentType: string; language: string; tags: string[] }
+): PatchKbDocMetadataRequest {
+  const body: PatchKbDocMetadataRequest = {};
+  if (draft.title !== (initial.title ?? '')) {
+    body.title = draft.title; // empty string ⇒ clear (D-4)
+  }
+  if (draft.documentType !== ((initial as { documentType?: string }).documentType ?? '')) {
+    body.documentType = draft.documentType || undefined;
+  }
+  if (draft.language !== ((initial as { language?: string }).language ?? '')) {
+    body.language = draft.language || undefined;
+  }
+  const initialTags = initial.tags ?? [];
+  const tagsChanged =
+    draft.tags.length !== initialTags.length ||
+    draft.tags.some((t, i) => t !== initialTags[i]);
+  if (tagsChanged) {
+    body.tags = draft.tags;
+  }
+  return body;
+}
+
+export function KbEditorDesktop(props: KbEditorDesktopProps): JSX.Element {
+  const { doc, onClose, labels } = props;
+  const titleId = useId();
+  const titleErrId = useId();
+  const tagsId = useId();
+  const tagsErrId = useId();
+
+  const [title, setTitle] = useState(doc.title ?? '');
+  const [documentType, setDocumentType] = useState((doc as { documentType?: string }).documentType ?? '');
+  const [language, setLanguage] = useState((doc as { language?: string }).language ?? '');
+  const [tagsInput, setTagsInput] = useState((doc.tags ?? []).join(', '));
+  const [errors, setErrors] = useState<FieldError>({});
+  const [topError, setTopError] = useState<string | null>(null);
+
+  const mutation = useUpdateKbDocMeta();
+
+  const docTypeOptions = Object.keys(labels.documentTypeOptions);
+  const languageOptions = Object.keys(labels.languageOptions);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setTopError(null);
+
+    const tagsArray = tagsInput
+      .split(',')
+      .map(t => t.trim())
+      .filter(t => t.length > 0);
+
+    const body = buildPatchBody(doc, {
+      title,
+      documentType,
+      language,
+      tags: tagsArray,
+    });
+
+    mutation.mutate(
+      { id: doc.id, body },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: (err: unknown) => {
+          if (isHttpFieldError(err)) {
+            if (err.status === 404) {
+              setTopError(labels.notFoundError);
+              return;
+            }
+            if (err.status === 422 && err.fieldErrors) {
+              setErrors(err.fieldErrors as FieldError);
+              return;
+            }
+          }
+          setTopError(labels.genericError);
+        },
+      }
+    );
+  }
+
+  return (
+    <section
+      className="bg-card border border-border rounded-lg p-6 flex flex-col gap-4"
+      aria-label={labels.heading}
+    >
+      <h2 className="font-semibold text-foreground">{labels.heading}</h2>
+      {topError && (
+        <div role="alert" className="text-sm text-destructive">
+          {topError}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor={titleId} className="text-sm font-medium">
+            {labels.titleLabel}
+          </label>
+          <input
+            id={titleId}
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            aria-describedby={errors.title ? titleErrId : undefined}
+            aria-invalid={errors.title ? true : undefined}
+            className="border border-border rounded px-2 py-1"
+          />
+          {errors.title && (
+            <p id={titleErrId} className="text-sm text-destructive">
+              {errors.title}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium" htmlFor={`${titleId}-doctype`}>
+            {labels.documentTypeLabel}
+          </label>
+          <select
+            id={`${titleId}-doctype`}
+            value={documentType}
+            onChange={e => setDocumentType(e.target.value)}
+            className="border border-border rounded px-2 py-1"
+          >
+            <option value="">—</option>
+            {docTypeOptions.map(opt => (
+              <option key={opt} value={opt}>
+                {labels.documentTypeOptions[opt]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium" htmlFor={`${titleId}-lang`}>
+            {labels.languageLabel}
+          </label>
+          <select
+            id={`${titleId}-lang`}
+            value={language}
+            onChange={e => setLanguage(e.target.value)}
+            className="border border-border rounded px-2 py-1"
+          >
+            <option value="">—</option>
+            {languageOptions.map(opt => (
+              <option key={opt} value={opt}>
+                {labels.languageOptions[opt]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor={tagsId} className="text-sm font-medium">
+            {labels.tagsLabel}
+          </label>
+          <input
+            id={tagsId}
+            type="text"
+            value={tagsInput}
+            onChange={e => setTagsInput(e.target.value)}
+            placeholder="tag1, tag2, …"
+            aria-describedby={errors.tags ? tagsErrId : undefined}
+            aria-invalid={errors.tags ? true : undefined}
+            className="border border-border rounded px-2 py-1"
+          />
+          {errors.tags && (
+            <p id={tagsErrId} className="text-sm text-destructive">
+              {errors.tags}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 mt-2">
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="bg-primary text-primary-foreground rounded px-4 py-2 hover:opacity-90 disabled:opacity-50"
+          >
+            {labels.saveLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border border-border rounded px-4 py-2 hover:bg-muted"
+          >
+            {labels.cancelLabel}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx`
+Expected: 7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx \
+        apps/web/src/components/features/kb-globale/__tests__/KbEditorDesktop.test.tsx
+git commit -m "feat(kb-globale): #1737 Task 6 — KbEditorDesktop component (4 fields, partial update, 404/422 handling)"
+```
+
+---
+
+## Task 7: Orchestrator wiring (KbGlobaleView + KbSearchResultsDesktop)
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx`
+- Modify: `apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx`
+- Modify: `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx` (add edit-affordance per DEC-3)
+- Test: `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx` (modify, add Phase 3 unit assertions)
+
+- [ ] **Step 1: Write failing tests for orchestrator URL parsing of filters + edit param**
+
+Add to `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx`:
+
+```tsx
+describe('KbGlobaleView — Phase 3 (#1737) URL parsing', () => {
+  it('passes docType from ?docType=Rulebook,Errata to useGlobalKbSearch filters', () => {
+    // Mock useSearchParams to return ?q=azul&docType=Rulebook,Errata
+    // Assert: useGlobalKbSearch spy is called with filters: { docType: ['Rulebook','Errata'] }
+    // (Use the test pattern already established in this file for searchParams mocking.)
+  });
+
+  it('passes gameId from ?game=uuid1,uuid2 to useGlobalKbSearch filters', () => {
+    // Similar to above, for gameId.
+  });
+
+  it('passes language from ?lang=it to useGlobalKbSearch filters', () => {
+    // Similar to above, for language.
+  });
+
+  it('lazy-mounts KbEditorDesktop when ?docId=X&edit=1 present and doc is in useUserKbDocs', () => {
+    // Mock useUserKbDocs to return [{ id: X, ... }]; mock useSearchParams to return ?docId=X&edit=1
+    // Assert: KbEditorDesktop is rendered.
+  });
+
+  it('does NOT mount KbEditorDesktop when ?docId=Y&edit=1 but doc Y not in useUserKbDocs (DEC-3)', () => {
+    // Mock useUserKbDocs returning [{ id: X, ... }] (not Y); URL ?docId=Y&edit=1
+    // Assert: KbEditorDesktop is NOT rendered (no edit affordance for non-owned docs).
+  });
+});
+```
+
+NOTE: implement using the existing mocking pattern in the same test file (mock `next/navigation`'s `useSearchParams` + `useRouter`; the file already does this for Phase 1+2 tests — replicate that style for these 5 new tests).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test apps/web/src/app/\(authenticated\)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx`
+Expected: 5 new FAIL.
+
+- [ ] **Step 3: Extend KbGlobaleView**
+
+Modify `apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx`:
+
+A) **Add lazy import** near the existing Phase 2 lazy block (after `DrawerShellLazy`):
+
+```tsx
+const KbEditorDesktopLazy = dynamic(
+  () =>
+    import('@/components/features/kb-globale/KbEditorDesktop').then(m => ({
+      default: m.KbEditorDesktop,
+    })),
+  { ssr: false }
+);
+```
+
+B) **Extend LABELS** — add two new top-level sections (sketch — full content lives in i18n catalogs Task 8):
+
+```tsx
+const LABELS = {
+  // ... existing hero, home, results, viewer, drawer ...
+  filters: {
+    heading: 'Filtri',
+    docTypeLabel: 'Tipo documento',
+    gameIdLabel: 'Gioco',
+    languageLabel: 'Lingua',
+    clearAll: 'Cancella filtri',
+    docTypeOptions: {
+      Rulebook: 'Regolamento',
+      Expansion: 'Espansione',
+      Errata: 'Errata',
+      QuickStart: 'Quick Start',
+      Reference: 'Riferimento',
+      PlayerAid: 'Aiuto giocatore',
+      Other: 'Altro',
+    },
+    languageOptions: { en: 'English', it: 'Italiano', de: 'Deutsch', fr: 'Français', es: 'Español' },
+  },
+  editor: {
+    heading: 'Modifica metadati',
+    titleLabel: 'Titolo',
+    documentTypeLabel: 'Tipo documento',
+    languageLabel: 'Lingua',
+    tagsLabel: 'Tag',
+    saveLabel: 'Salva',
+    cancelLabel: 'Annulla',
+    notFoundError: 'Documento non trovato',
+    genericError: 'Errore generico, riprova.',
+    documentTypeOptions: {
+      Rulebook: 'Regolamento',
+      Expansion: 'Espansione',
+      Errata: 'Errata',
+      QuickStart: 'Quick Start',
+      Reference: 'Riferimento',
+      PlayerAid: 'Aiuto giocatore',
+      Other: 'Altro',
+    },
+    languageOptions: { en: 'English', it: 'Italiano', de: 'Deutsch', fr: 'Français', es: 'Español' },
+  },
+};
+```
+
+C) **Parse filter URL params** (inside the component body, right after the existing URL state block):
+
+```tsx
+// Phase 3 (#1737): URL SSOT for facets.
+const docTypeParam = searchParams.get('docType');
+const gameParam = searchParams.get('game');
+const langParam = searchParams.get('lang');
+const editParam = searchParams.get('edit') === '1';
+
+const filters: GlobalKbSearchFilters = useMemo(() => {
+  const f: GlobalKbSearchFilters = {};
+  if (docTypeParam) f.docType = docTypeParam.split(',').filter(Boolean);
+  if (gameParam) f.gameId = gameParam.split(',').filter(Boolean);
+  if (langParam) f.language = langParam;
+  return f;
+}, [docTypeParam, gameParam, langParam]);
+```
+
+Add `GlobalKbSearchFilters` to the existing import from `@/lib/api/schemas/kb-globale.schemas`.
+
+D) **Pass filters to useGlobalKbSearch**:
+
+```tsx
+const search = useGlobalKbSearch({
+  query: q,
+  mode,
+  enabled: !isHomeBranch,
+  filters,
+});
+```
+
+E) **Add filter URL update helper**:
+
+```tsx
+const setFilters = useCallback(
+  (next: GlobalKbSearchFilters) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.docType && next.docType.length > 0) {
+      params.set('docType', [...next.docType].join(','));
+    } else {
+      params.delete('docType');
+    }
+    if (next.gameId && next.gameId.length > 0) {
+      params.set('game', [...next.gameId].join(','));
+    } else {
+      params.delete('game');
+    }
+    if (next.language) {
+      params.set('lang', next.language);
+    } else {
+      params.delete('lang');
+    }
+    const qs = params.toString();
+    router.push(qs ? `/knowledge-base/global?${qs}` : '/knowledge-base/global');
+  },
+  [router, searchParams]
+);
+```
+
+F) **Derive available games from useUserKbDocs** (DEC-1):
+
+```tsx
+const availableGames = useMemo(() => {
+  const seen = new Set<string>();
+  const games: { id: string; name: string }[] = [];
+  for (const doc of recentDocs) {
+    if (doc.gameId && doc.gameName && !seen.has(doc.gameId)) {
+      seen.add(doc.gameId);
+      games.push({ id: doc.gameId, name: doc.gameName });
+    }
+  }
+  return games;
+}, [recentDocs]);
+```
+
+G) **Compute edit-mount safety** (DEC-3):
+
+```tsx
+// Edit affordance: only mount if doc is in useUserKbDocs (BE-filtered to owned).
+const editTargetDoc = useMemo(() => {
+  if (!editParam || !docIdParam) return null;
+  return recentDocs.find(d => d.id === docIdParam) ?? null;
+}, [editParam, docIdParam, recentDocs]);
+
+// NOTE: editTargetDoc is the KbDoc projection from useUserKbDocs (lacks title/tags
+// fields). KbEditorDesktop expects UserKbDocDto. We pass the raw DTO when available.
+const editTargetDto = useMemo<UserKbDocDto | null>(() => {
+  const raw = recent.data?.items.find((d: KbDoc) => d.id === docIdParam);
+  // recent.data.items are already KbDoc-mapped; need the source DTO.
+  // Use the raw response from useUserKbDocs if we can re-derive, otherwise refetch the detail.
+  // For simplicity, expose a `rawItems` field in useUserKbDocs (Task 7 sub-fix below).
+  return null; // placeholder — real impl below in next sub-step.
+}, [docIdParam, recent.data?.items]);
+```
+
+WAIT — there's a refactor dependency: `useUserKbDocs` currently maps to `KbDoc` which strips `title/tags/updatedBy`. KbEditorDesktop needs the full `UserKbDocDto`. Two options:
+
+- **A**: Expose `rawItems: UserKbDocDto[]` in `useUserKbDocs` result alongside `items: KbDoc[]`.
+- **B**: Fetch the full DTO via `useKbDocDetail(docId)` when entering edit mode.
+
+**Choose A** — additive, no extra fetch, and `useUserKbDocs.data.items` already has the data we need before mapping. Implementation:
+
+H) **Modify `useUserKbDocs.ts`** to expose raw items:
+
+```ts
+export interface UseUserKbDocsResult {
+  items: KbDoc[];
+  rawItems: UserKbDocDto[]; // Phase 3 (#1737) — needed by KbEditorDesktop (full DTO with title/tags)
+  total: number;
+  page: number;
+  pageSize: number;
+}
+```
+
+In the queryFn:
+
+```ts
+return {
+  items: response.items.map(toKbDoc),
+  rawItems: response.items,
+  total: response.total,
+  page: response.page,
+  pageSize: response.pageSize,
+};
+```
+
+I) **Use rawItems for editor mount**:
+
+```tsx
+const editTargetDto = useMemo<UserKbDocDto | null>(() => {
+  if (!editParam || !docIdParam) return null;
+  return recent.data?.rawItems.find(d => d.id === docIdParam) ?? null;
+}, [editParam, docIdParam, recent.data?.rawItems]);
+```
+
+J) **Render FilterAccordion in results branch + KbEditorDesktop conditionally**. Replace the render JSX block:
+
+```tsx
+{isHomeBranch ? (
+  <KbHomeDesktop
+    recentDocs={recentDocs}
+    isLoading={recent.isLoading}
+    error={(recent.error as Error | null) ?? null}
+    labels={LABELS.home}
+    onRetry={handleHomeRetry}
+    onEditClick={doc => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('docId', doc.id);
+      params.set('edit', '1');
+      router.push(`/knowledge-base/global?${params.toString()}`);
+    }}
+  />
+) : (
+  <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4">
+    <FilterAccordion
+      availableGames={availableGames}
+      selected={filters}
+      onChange={setFilters}
+      labels={LABELS.filters}
+    />
+    <KbSearchResultsDesktop
+      query={q}
+      results={search.results}
+      hasMore={search.hasMore}
+      isLoading={search.isLoading}
+      isFetchingNextPage={search.isFetchingNextPage}
+      error={search.error}
+      onLoadMore={search.fetchNextPage}
+      labels={LABELS.results}
+      onRetry={handleResultsRetry}
+      onResultClick={r => openViewer({ docId: r.docId, page: r.pageNumber ?? 1 })}
+    />
+  </div>
+)}
+
+{/* Phase 3: lazy-mount KbEditorDesktop when ?edit=1 + owned doc resolvable */}
+{editTargetDto && (
+  <KbEditorDesktopLazy
+    doc={editTargetDto}
+    labels={LABELS.editor}
+    onClose={() => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('edit');
+      router.push(`/knowledge-base/global?${params.toString()}`);
+    }}
+  />
+)}
+```
+
+K) **Import FilterAccordion + types** at top of file:
+
+```tsx
+import { FilterAccordion } from '@/components/features/kb-globale/FilterAccordion';
+import type { GlobalKbSearchFilters } from '@/lib/api/schemas/kb-globale.schemas';
+import type { UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
+```
+
+- [ ] **Step 4: Modify KbHomeDesktop to surface edit affordance**
+
+In `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx`:
+
+1. Add `onEditClick?: (doc: KbDoc) => void` to props
+2. In each recent-doc card, if `onEditClick` is provided, add an "Edit" button (icon or label)
+3. Update LABELS prop interface to include `editLabel: string`
+4. Add corresponding test in `KbHomeDesktop.test.tsx`:
+
+```tsx
+it('Phase 3 #1737: renders Edit button per recent doc when onEditClick provided', () => {
+  const onEditClick = vi.fn();
+  render(
+    <KbHomeDesktop
+      recentDocs={[/* fixture */]}
+      isLoading={false}
+      error={null}
+      labels={{ ...LABELS, editLabel: 'Modifica' }}
+      onRetry={vi.fn()}
+      onEditClick={onEditClick}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: /modifica/i }));
+  expect(onEditClick).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test apps/web/src/app/\(authenticated\)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx`
+Expected: 5 new KbGlobaleView tests PASS + 1 new KbHomeDesktop test PASS + all pre-existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/knowledge-base/global/_components/KbGlobaleView.tsx \
+        apps/web/src/app/\(authenticated\)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx \
+        apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx \
+        apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx \
+        apps/web/src/hooks/queries/useUserKbDocs.ts
+git commit -m "feat(kb-globale): #1737 Task 7 — wire FilterAccordion + KbEditorDesktop into orchestrator"
+```
+
+---
+
+## Task 8: MSW integration tests S1-S6 + i18n + matrix update
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx`
+- Modify: `apps/web/messages/it.json`
+- Modify: `apps/web/messages/en.json`
+- Modify: `docs/for-developers/frontend/v2-migration-matrix.md`
+
+- [ ] **Step 1: Write 6 MSW integration scenarios S1-S6**
+
+Create `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx`:
+
+```tsx
+/**
+ * KbGlobaleView Phase 3 integration tests (#1737)
+ * — MSW-mocked scenarios S1-S6 from spec-panel decisions
+ *
+ * S1: Facet apply — selecting docType refetches with filter, results filtered
+ * S2: Facet clear — clearAll resets URL + refetch baseline
+ * S3: URL SSOT round-trip — initial URL with filters pre-selects FilterAccordion
+ * S4: PATCH success — Edit→change title→Save → 200 → cache invalidates → UI updates
+ * S5: PATCH 404 — generic "Documento non trovato" message (anti-info-leak)
+ * S6: PATCH 422 — FluentValidation envelope → inline field error with aria-describedby
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { KbGlobaleView } from '../KbGlobaleView';
+// Import the test-only helper from existing integration test pattern if available;
+// otherwise replicate it inline (look at Phase 1+2 integration test file for the
+// pattern that mocks next/navigation searchParams/router via testing-library-vitest's
+// vi.mock helpers).
+
+// === Fixtures ===
+const DOC_FIXTURE = {
+  id: '00000000-0000-0000-0000-000000000001',
+  gameId: '00000000-0000-0000-0000-000000000010',
+  gameName: 'Azul',
+  fileName: 'azul.pdf',
+  processingState: 'Ready' as const,
+  pageCount: 24,
+  processedAt: '2026-05-31T00:00:00Z',
+  uploadedAt: '2026-05-31T00:00:00Z',
+  updatedAt: '2026-05-31T00:00:00Z',
+  title: 'Old Title',
+  tags: ['family'],
+  updatedBy: null,
+};
+
+const SEARCH_RESULT_RULEBOOK = {
+  chunkId: 'c1', docId: DOC_FIXTURE.id, docTitle: 'Azul Rules',
+  gameId: DOC_FIXTURE.gameId!, gameName: 'Azul', docType: 'Rulebook',
+  headingPath: 'Setup', snippet: 'Place tiles...', pageNumber: 3, score: 0.9,
+};
+const SEARCH_RESULT_ERRATA = {
+  ...SEARCH_RESULT_RULEBOOK, chunkId: 'c2', docType: 'Errata', snippet: 'Errata correction...',
+};
+
+const server = setupServer(
+  http.get('/api/v1/kb-docs', () =>
+    HttpResponse.json({ items: [DOC_FIXTURE], total: 1, page: 1, pageSize: 20 })
+  ),
+  http.post('/api/v1/knowledge-base/search/global', async ({ request }) => {
+    const body = (await request.json()) as { docType?: string[] };
+    if (body.docType?.includes('Rulebook') && !body.docType?.includes('Errata')) {
+      return HttpResponse.json({
+        results: [SEARCH_RESULT_RULEBOOK], hasMore: false, nextCursor: null,
+      });
+    }
+    return HttpResponse.json({
+      results: [SEARCH_RESULT_RULEBOOK, SEARCH_RESULT_ERRATA],
+      hasMore: false, nextCursor: null,
+    });
+  }),
+  http.patch('/api/v1/kb-docs/:id', async ({ params, request }) => {
+    const body = (await request.json()) as { title?: string };
+    if (body.title === 'TRIGGER_404') return new HttpResponse(null, { status: 404 });
+    if (body.title === 'TRIGGER_422') {
+      return HttpResponse.json(
+        { errors: { title: 'Title must not exceed 200 characters.' } },
+        { status: 422 }
+      );
+    }
+    return HttpResponse.json({ ...DOC_FIXTURE, title: body.title ?? DOC_FIXTURE.title });
+  })
+);
+
+beforeEach(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.close());
+
+function renderWithUrl(searchParamsString: string) {
+  // Use the test helper that mocks next/navigation per the established pattern.
+  // ... (replicate from KbGlobaleView.integration.test.tsx Phase 1+2)
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <KbGlobaleView />
+    </QueryClientProvider>
+  );
+}
+
+describe('KbGlobaleView Phase 3 — S1-S6 (#1737)', () => {
+  it('S1: docType filter applied refetches with new params', async () => {
+    renderWithUrl('?q=azul');
+    await waitFor(() => expect(screen.getByText(/Azul Rules/i)).toBeInTheDocument());
+    // Find FilterAccordion section, expand DocType, click Rulebook
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    fireEvent.click(screen.getByLabelText(/regolamento/i));
+    // After refetch, only Rulebook result visible (Errata snippet absent).
+    await waitFor(() => expect(screen.queryByText(/errata correction/i)).not.toBeInTheDocument());
+  });
+
+  it('S2: clearAll resets all facets and refetches baseline', async () => {
+    renderWithUrl('?q=azul&docType=Rulebook');
+    // Wait for filtered result.
+    await waitFor(() => expect(screen.getByText(/Azul Rules/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /cancella filtri/i }));
+    // After clear, both results visible.
+    await waitFor(() => expect(screen.getByText(/errata correction/i)).toBeInTheDocument());
+  });
+
+  it('S3: URL ?docType=Rulebook&lang=it pre-selects the FilterAccordion checkboxes', async () => {
+    renderWithUrl('?q=azul&docType=Rulebook&lang=it');
+    fireEvent.click(screen.getByRole('button', { name: /tipo documento/i }));
+    const rulebookCheckbox = screen.getByLabelText(/regolamento/i) as HTMLInputElement;
+    expect(rulebookCheckbox.checked).toBe(true);
+    fireEvent.click(screen.getByRole('button', { name: /lingua/i }));
+    const italianRadio = screen.getByLabelText(/italiano/i) as HTMLInputElement;
+    expect(italianRadio.checked).toBe(true);
+  });
+
+  it('S4: PATCH success → cache invalidates → UI shows updated title', async () => {
+    renderWithUrl('?docId=00000000-0000-0000-0000-000000000001&edit=1');
+    await waitFor(() => expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/titolo/i), { target: { value: 'Brand New Title' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    // Editor closes (onClose called); KbHomeDesktop refetches → shows new title.
+    await waitFor(() =>
+      expect(screen.queryByText(/modifica metadati/i)).not.toBeInTheDocument()
+    );
+  });
+
+  it('S5: PATCH 404 → generic notFoundError message (anti-info-leak)', async () => {
+    renderWithUrl('?docId=00000000-0000-0000-0000-000000000001&edit=1');
+    await waitFor(() => expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/titolo/i), { target: { value: 'TRIGGER_404' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/documento non trovato/i)).toBeInTheDocument()
+    );
+    // Verify NO "non autorizzato" / "forbidden" text (anti-info-leak).
+    expect(screen.queryByText(/non autorizzato|forbidden/i)).not.toBeInTheDocument();
+  });
+
+  it('S6: PATCH 422 → inline field error with aria-describedby', async () => {
+    renderWithUrl('?docId=00000000-0000-0000-0000-000000000001&edit=1');
+    await waitFor(() => expect(screen.getByLabelText(/titolo/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/titolo/i), { target: { value: 'TRIGGER_422' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/title must not exceed 200/i)).toBeInTheDocument()
+    );
+    expect(screen.getByLabelText(/titolo/i)).toHaveAttribute('aria-describedby');
+  });
+});
+```
+
+NOTE: the test uses an `errors` envelope shape `{ errors: { title: '...' } }` for 422 — the FE error parser (in `useUpdateKbDocMeta` or a shared HTTP error handler) must extract this into `HttpFieldError.fieldErrors`. If the existing httpClient doesn't do this automatically, add the extraction logic when the subagent encounters the test failure. The PR body for #1732 should document the exact 422 envelope shape.
+
+- [ ] **Step 2: Run integration tests to verify they fail**
+
+Run: `pnpm test apps/web/src/app/\(authenticated\)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx`
+Expected: 6 FAIL (mix of missing UI, missing 422 envelope parsing, etc.)
+
+- [ ] **Step 3: Add 422 envelope parsing if not already present**
+
+Verify `apps/web/src/lib/api/core/httpClient.ts` parses 422 responses into a typed error with `status` + `fieldErrors`. If not, extend the error path to convert `{ errors: Record<string, string> }` → an `HttpFieldError` with `status: 422, fieldErrors: errors`. Then the existing `isHttpFieldError` check in `KbEditorDesktop` works.
+
+- [ ] **Step 4: Run integration tests until all 6 pass**
+
+Iterate until 6 PASS.
+
+- [ ] **Step 5: Add i18n catalogs**
+
+Modify `apps/web/messages/it.json`:
+
+```json
+{
+  "kbGlobale": {
+    "filters": {
+      "heading": "Filtri",
+      "docTypeLabel": "Tipo documento",
+      "gameIdLabel": "Gioco",
+      "languageLabel": "Lingua",
+      "clearAll": "Cancella filtri",
+      "docTypeOptions": {
+        "Rulebook": "Regolamento",
+        "Expansion": "Espansione",
+        "Errata": "Errata",
+        "QuickStart": "Quick Start",
+        "Reference": "Riferimento",
+        "PlayerAid": "Aiuto giocatore",
+        "Other": "Altro"
+      },
+      "languageOptions": {
+        "en": "English",
+        "it": "Italiano",
+        "de": "Deutsch",
+        "fr": "Français",
+        "es": "Español"
+      }
+    },
+    "editor": {
+      "heading": "Modifica metadati",
+      "titleLabel": "Titolo",
+      "documentTypeLabel": "Tipo documento",
+      "languageLabel": "Lingua",
+      "tagsLabel": "Tag",
+      "saveLabel": "Salva",
+      "cancelLabel": "Annulla",
+      "notFoundError": "Documento non trovato",
+      "genericError": "Errore generico, riprova."
+    }
+  }
+}
+```
+
+Modify `apps/web/messages/en.json` with English mirror (translate each label).
+
+NOTE: KbGlobaleView LABELS const may currently hold strings inline (Phase 1+2 style "Task 10 deferred"). If the codebase has migrated to MESSAGES catalog via `useTranslations()`, update the orchestrator to read from `useTranslations('kbGlobale')` for the new sections. Inspect the existing pattern in the file before applying.
+
+- [ ] **Step 6: Update v2-migration-matrix.md**
+
+Modify `docs/for-developers/frontend/v2-migration-matrix.md`:
+
+Find the `kb-globale` section. Flip the rows for:
+- Component #4 `FilterAccordion` — `pending` → `done`, add `PR #<this-PR>` in PR column
+- Component #8 `KbEditorDesktop` — `pending` → `done`, add `PR #<this-PR>` in PR column
+
+(After PR open, replace `<this-PR>` with the actual PR number.)
+
+- [ ] **Step 7: Run full test suite + quality gates**
+
+Run all in sequence (must all pass):
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm lint:tokens
+```
+
+Expected: PASS PASS PASS PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/knowledge-base/global/_components/__tests__/KbGlobaleView.phase3.integration.test.tsx \
+        apps/web/messages/it.json \
+        apps/web/messages/en.json \
+        docs/for-developers/frontend/v2-migration-matrix.md \
+        apps/web/src/lib/api/core/httpClient.ts  # if 422 parsing was extended
+git commit -m "feat(kb-globale): #1737 Task 8 — S1-S6 MSW integration + i18n + matrix"
+```
+
+---
+
+## Final checklist (before opening PR)
+
+- [ ] All 8 tasks committed
+- [ ] `git log --oneline main-dev..HEAD` shows 8 commits prefixed `feat(kb-globale): #1737 Task N`
+- [ ] `pnpm test` PASS (~60 new tests + 0 regression in pre-existing)
+- [ ] `pnpm typecheck` exit 0
+- [ ] `pnpm lint` exit 0
+- [ ] `pnpm lint:tokens` exit 0
+- [ ] Bundle delta verified ≤ +30 KB (check `.next` analyze if needed)
+- [ ] Matrix updated with PR number after `gh pr create`
+
+## Decisions reference (in case of mid-impl ambiguity)
+
+- DEC-1: GameId facet = derived from `useUserKbDocs` (Task 7 step F)
+- DEC-2: Aggressive cache invalidation (Task 4 step 3 onSuccess)
+- DEC-3: Edit affordance only in KbHomeDesktop (Task 7 step 4 + step 3 G/I)
+- DEC-4: G/W/T scenarios S1-S6 (Task 8 step 1)
+- DEC-5: FilterAccordion eager (Task 7 import), KbEditorDesktop lazy (Task 7 step 3 A)
+- DEC-6: 6 MSW + jest-axe per component + cache invalidation test (Task 4-6-8)
+- DEC-7: `docType: z.string()` raw, drop faq labels (Task 1 + Task 5 DOC_TYPE_ALLOWLIST)


### PR DESCRIPTION
## Summary

Closes #1737 (Phase 3 of `/knowledge-base/global`). Completes the FE loop of #1482 by shipping the two components deferred from Phase 1+2 now that BE blockers cleared:

- **FilterAccordion** (component #4) — eager, 3 facets (DocType multi / GameId multi / Language single), URL SSOT `?docType=&game=&lang=`, drives `useGlobalKbSearch` refetch via filters. Consumes BE PR #1730 (#1686).
- **KbEditorDesktop** (component #8) — lazy via `dynamic({ssr:false})`, 4-field metadata form (title/documentType/language/tags), partial-update semantics (null=no-op, ""/[]=clear), 404/422 error handling. Consumes BE PR #1732 (#1687).

After this merge: #1482 is **structurally complete** (10/10 mockup components) and ready to close. Epic #1475 progresses to 25/26 (96%).

## What ships

10 commits TDD (8 task + 1 review fix + 1 plan doc):

| # | Commit | Scope |
|---|---|---|
| T1 | `3c212fa4e` | Schemas: `GlobalKbSearchRequest.{docType,gameId,language}` + `UserKbDocDto.{title,tags,updatedBy}` extension + new `PatchKbDocMetadataRequestSchema` |
| T2 | `e6c77ab6f` | `kbDocsClient.patchKbDocMetadata(id, body)` |
| T3 | `b30cc801b` | `useGlobalKbSearch` accepts `filters?: GlobalKbSearchFilters` + stable `serializeFilters` for queryKey identity |
| T4 | `a1bcbf64a` | `useUpdateKbDocMeta` mutation hook + aggressive cache invalidation (DEC-2) |
| T5 | `6c48b6a16` | `FilterAccordion` component (3 facets, jest-axe 0 violations) |
| T6 | `e2e0ff34e` | `KbEditorDesktop` form (4 fields, partial update, 404/422 handling, jest-axe 0 violations) |
| T7 | `3345d93f0` | Orchestrator wiring: `KbGlobaleView` URL parsing + `availableGames` derivation + lazy editor mount + DEC-3 anti-info-leak; `KbHomeDesktop` `onEditClick` affordance; `useUserKbDocs.rawItems` exposure |
| T8 | `c5cc6d35b` | MSW integration tests S1-S6 + i18n catalogs (`apps/web/src/locales/it.json`+`en.json`) + v2-migration-matrix update |
| Fix | `ef83b91e2` | Review M1+M2: robust 404 via `ApiError.statusCode` + client-side `PatchKbDocMetadataRequestSchema.parse` |
| Doc | `f1dae80f4` | Phase 3 implementation plan |

## Spec-panel decisions implemented (DEC-1..DEC-7, S1..S6)

See https://github.com/meepleAi-app/meepleai-monorepo/issues/1737#issuecomment-4586313755 for full discussion.

- **DEC-1** GameId facet = derived from `useUserKbDocs.rawItems` (MVP-safe; no new BE endpoint)
- **DEC-2** Cache invalidation aggressive: `['kb-docs','user']` + `['kb-globale','search']` + `['kb-docs','detail',id]`
- **DEC-3** Edit affordance ONLY in `KbHomeDesktop` recent cards (BE-filtered to owned); URL `?docId=NOT_OWNED&edit=1` → editor NOT mounted (silent NO-OP, anti-info-leak preserved)
- **DEC-4** G/W/T scenarios S1-S6 in `KbGlobaleView.phase3.integration.test.tsx`
- **DEC-5** FilterAccordion eager (<5KB); KbEditorDesktop lazy via `dynamic({ssr:false})`
- **DEC-6** 6 MSW scenarios + jest-axe per new component + cache invalidation test
- **DEC-7** docType: `z.string()` raw, dropped `faq` from labels only

## Test plan

- [x] **47 schema tests** (Task 1) — Zod safeParse coverage for all new fields
- [x] **4 client tests** (Task 2) — PATCH wire format + 404 propagation
- [x] **13 hook tests** (Tasks 3+4) — 4 new useGlobalKbSearch + 5 useUpdateKbDocMeta + 4 pre-existing preserved
- [x] **8 FilterAccordion tests + jest-axe 0 violations** (Task 5)
- [x] **7 KbEditorDesktop tests + jest-axe 0 violations** (Task 6)
- [x] **47 orchestrator tests preserved** + 5 new KbGlobaleView Phase 3 + 1 KbHomeDesktop edit affordance (Task 7)
- [x] **6 MSW integration scenarios S1-S6 all pass** (Task 8)
- [x] **Phase 1+2 integration tests still pass 10/10** (no regression)
- [x] `pnpm typecheck` exit 0
- [x] `pnpm lint` exit 0 (53 pre-existing warnings unrelated)
- [x] `pnpm lint:tokens` exit 0
- [x] DEC-3 anti-info-leak: URL `?docId=NOT_OWNED&edit=1` → editor not mounted (test covered)
- [ ] Visual review by reviewer on running app

**Total**: ~58 new tests across 8 files + 0 regression.

## Bundle impact

- FilterAccordion eager: <5 KB
- KbEditorDesktop lazy: ~10-15 KB (loaded on `?edit=1` only, separate chunk)
- Phase 3 delta: **< +20 KB** (well under +150 KB umbrella budget; Phase 1+2 already consumed ~120 KB)

## Anti-info-leak verification (DEC-3 / D-2 of #1687)

The `editTargetDto` resolver in `KbGlobaleView.tsx` derives from `recent.data?.rawItems.find(d => d.id === docIdParam)`. Since `useUserKbDocs` filters BE-side via `UploadedByUserId == request.UserId` (`ListUserKbDocsQuery.cs:92`), `rawItems` only contains docs owned by the current user. A non-owned `docId` in the URL produces `null` → `KbEditorDesktopLazy` is never mounted → BE PATCH never fires → silent NO-OP. Integration test `S5` further validates that a real BE 404 renders the generic "Documento non trovato" message, NOT "non autorizzato".

## Follow-up issues to file (from review MINORs)

1. **m1** — Remove `role="button"` from `<summary>` in `FilterAccordion.tsx` once jsdom 30+ exposes the native disclosure widget role correctly.
2. **m2** — When BE `UserKbDocDto` is extended to expose `documentType` and `language` (currently both BE-internal), add them to `UserKbDocDtoSchema` and drop the ad-hoc type assertions in `KbEditorDesktop` state initializers. Needs a small BE issue.
3. **m3** — i18n catalog namespaces (`kbGlobale.filters.*` + `kbGlobale.editor.*`) are present in `it.json`/`en.json`, but `KbGlobaleView.tsx` LABELS const stays inline for consistency with Phase 1+2; future Task 10 extraction PR consumes both.
4. **m4** — Consider always-visible `clearAll` button in FilterAccordion (disabled when no filters) for predictable AT discoverability.

## References

- Epic: #1475 (User-facing UI completion)
- Parent: #1482 (Phase 1+2 shipped via PR #1688 + #1701; this PR closes the structural loop)
- BE deps shipped: #1730 (#1686 facets) + #1732 (#1687 PATCH metadata) + #1736 (#1731 OpenTelemetry counter)
- Phase 0.5 contract: `docs/for-developers/frontend/contracts/kb-globale-hooks.md` §6 + §11
- Implementation plan: `docs/superpowers/plans/2026-05-31-kb-globale-phase3-filter-editor-fe.md` (in this PR)
- Spec-panel decisions: #1737 comment thread

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)