### PR TITLE
feat(toolkit-validator): #1747 - JSON Schema validation strict + handler integration

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
@@ -1,10 +1,12 @@
 using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Application.Validators;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application;
 using Api.SharedKernel.Domain.ValueObjects;
+using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -36,6 +38,7 @@ internal class GenerateToolkitFromKbHandler
     private readonly ILlmService _llmService;
     private readonly IRagAccessService _ragAccessService;
     private readonly IGameCoreDataProvider _gameCoreData;
+    private readonly IValidator<AiToolkitSuggestionDto> _suggestionValidator;
     private readonly ILogger<GenerateToolkitFromKbHandler> _logger;
 
     public GenerateToolkitFromKbHandler(
@@ -43,13 +46,17 @@ internal class GenerateToolkitFromKbHandler
         ILlmService llmService,
         IRagAccessService ragAccessService,
         IGameCoreDataProvider gameCoreData,
-        ILogger<GenerateToolkitFromKbHandler> logger)
+        ILogger<GenerateToolkitFromKbHandler> logger,
+        IValidator<AiToolkitSuggestionDto>? suggestionValidator = null)
     {
         _hybridSearchService = hybridSearchService ?? throw new ArgumentNullException(nameof(hybridSearchService));
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        // Validator is optional with default fallback to allow legacy DI registrations
+        // (existing tests didn't pass a validator). Use AiToolkitSuggestionValidator as default.
+        _suggestionValidator = suggestionValidator ?? new AiToolkitSuggestionValidator();
     }
 
     public async Task<AiToolkitSuggestionDto> Handle(
@@ -127,17 +134,35 @@ internal class GenerateToolkitFromKbHandler
             throw new InvalidOperationException(
                 $"LLM failed to generate a valid toolkit suggestion for game {command.GameId} after retry.");
 
+        // 7b. Validate LLM output against schema invariants (issue #1747 B19-3c).
+        // We do NOT throw on validation failure — we log, force human review, and return the
+        // suggestion anyway so an admin can correct it via ApplyAiToolkitSuggestionCommand.
+        var validation = await _suggestionValidator
+            .ValidateAsync(suggestion, cancellationToken)
+            .ConfigureAwait(false);
+
+        var validationFailed = !validation.IsValid;
+        if (validationFailed)
+        {
+            var errors = string.Join(" | ",
+                validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}"));
+            _logger.LogWarning(
+                "AI toolkit suggestion failed schema validation for game {GameId}. Errors: {ValidationErrors}. Forcing RequiresHumanReview=true.",
+                command.GameId, errors);
+        }
+
         // 8. Compute confidence metrics
         var avgScore = uniqueChunks.Count > 0
             ? uniqueChunks.Average(c => c.HybridScore)
             : 0f;
         var coverageFactor = Math.Min(1f, (float)uniqueChunks.Count / MinChunksForFullConfidence);
         var confidenceScore = avgScore * coverageFactor;
-        var requiresHumanReview = confidenceScore < ConfidenceThreshold;
+        // Force review if either confidence is low OR schema validation failed.
+        var requiresHumanReview = confidenceScore < ConfidenceThreshold || validationFailed;
 
         _logger.LogInformation(
-            "GenerateToolkitFromKb: game={GameId} chunks={Chunks} avgScore={AvgScore:F2} confidence={Confidence:F2} requiresReview={RequiresReview}",
-            command.GameId, uniqueChunks.Count, avgScore, confidenceScore, requiresHumanReview);
+            "GenerateToolkitFromKb: game={GameId} chunks={Chunks} avgScore={AvgScore:F2} confidence={Confidence:F2} validationOk={ValidationOk} requiresReview={RequiresReview}",
+            command.GameId, uniqueChunks.Count, avgScore, confidenceScore, !validationFailed, requiresHumanReview);
 
         return suggestion with
         {

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
@@ -3,6 +3,12 @@ namespace Api.BoundedContexts.GameToolkit.Application.Commands;
 /// <summary>
 /// System prompts for the toolkit extraction LLM call.
 /// Separated from handler to keep the handler focused and to allow prompt iteration.
+///
+/// **v2 — 2026-05-31** post spike findings (claudedocs/2026-05-31-spike-toolkit-ai-generation.md):
+/// added strict JSON schema enforcement (DTO field names), anti-patterns
+/// section (Points-as-counter / dummy timer / Overrides ignored), and explicit
+/// enum value listings. Validated on Llama 3.3 70B free + DeepSeek-chat
+/// (DeepSeek produces 90% accurate output; Llama free requires schema validation).
 /// </summary>
 internal static class ToolkitExtractionPrompts
 {
@@ -30,8 +36,86 @@ internal static class ToolkitExtractionPrompts
         - Reasoning must cite the rule text that led to each decision
         - Return ONLY valid JSON — no markdown fences, no extra text
 
-        JSON schema: AiToolkitSuggestionDto with fields: ToolkitName, DiceTools, CounterTools,
-        TimerTools, ScoringTemplate, TurnTemplate, Overrides, Reasoning, ExcludedTools.
+        === EXACT JSON SCHEMA (DTO field names — DO NOT renamE) ===
+
+        Root: AiToolkitSuggestionDto = {
+          "ToolkitName": string,
+          "DiceTools": [AiDiceToolSuggestion],
+          "CounterTools": [AiCounterToolSuggestion],
+          "TimerTools": [AiTimerToolSuggestion],
+          "ScoringTemplate": AiScoringTemplateSuggestion | null,
+          "TurnTemplate": AiTurnTemplateSuggestion | null,
+          "Overrides": AiOverrideSuggestion | null,
+          "Reasoning": string,        // single concatenated paragraph, NOT array NOT dict
+          "ExcludedTools": [AiExcludedToolSuggestion]
+        }
+
+        AiDiceToolSuggestion = {
+          "Name": string,             // e.g., "Birdfeeder Food Dice" — NOT "Type"
+          "DiceType": "D4"|"D6"|"D8"|"D10"|"D12"|"D20"|"D100"|"Custom",  // enum, NOT "Type"
+          "Quantity": int,
+          "CustomFaces": [string] | null,  // NOT "Faces"
+          "IsInteractive": bool,
+          "Color": string | null
+        }
+
+        AiCounterToolSuggestion = {
+          "Name": string,
+          "MinValue": int,            // NOT "Min"
+          "MaxValue": int,            // NOT "Max" (use a large int like 99 if no upper bound)
+          "DefaultValue": int,
+          "IsPerPlayer": bool,
+          "Icon": string | null,
+          "Color": string | null
+        }
+
+        AiTimerToolSuggestion = {
+          "Name": string,
+          "DurationSeconds": int,
+          "TimerType": "CountDown"|"CountUp"|"Chess",
+          "AutoStart": bool,
+          "Color": string | null,
+          "IsPerPlayer": bool,
+          "WarningThresholdSeconds": int | null
+        }
+
+        AiScoringTemplateSuggestion = {
+          "Dimensions": [string],     // e.g., ["Birds", "Bonus cards", "Eggs"] — simple flat array
+          "DefaultUnit": string,      // e.g., "points"
+          "ScoreType": "Points"|"Ranking"|"BinaryWin"|"Objectives"
+        }
+
+        AiTurnTemplateSuggestion = {
+          "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None",
+          "Phases": [string]          // e.g., ["Round 1", "Round 2"] or ["Action", "Draw", "Infect"]
+        }
+
+        AiOverrideSuggestion = {
+          "OverridesTurnOrder": bool,     // ALWAYS provide all 3 booleans
+          "OverridesScoreboard": bool,
+          "OverridesDiceSet": bool
+        }
+
+        AiExcludedToolSuggestion = {
+          "ToolType": string,         // NOT "Type" — e.g., "Timer", "CardDeck", "Counter"
+          "Reason": string            // NOT "Justification"
+        }
+
+        === ANTI-PATTERNS — STRICTLY FORBIDDEN ===
+
+        - DO NOT add a counter for game-end Points/Score/VP. Points are DERIVED at end-of-game
+          from scoring categories, NEVER tracked as a running counter during the session.
+        - DO NOT add a dummy TimerTools entry with DurationSeconds=0 when no timer exists.
+          If the rules state no time limit, output "TimerTools": [] (empty array).
+        - DO NOT omit the Overrides object. If the game has no custom rules requiring overrides,
+          output {"OverridesTurnOrder": false, "OverridesScoreboard": false, "OverridesDiceSet": false}.
+          When the game has custom dice/scoring/turn (e.g., Wingspan), set the relevant flag to true.
+        - DO NOT structure Reasoning as an array or dict. It MUST be a single string paragraph
+          with inline citations like "[excerpt 1]", "[excerpt 4]".
+        - DO NOT rename DTO fields (e.g., "Type" instead of "DiceType", "Min" instead of "MinValue",
+          "Faces" instead of "CustomFaces"). Use the exact names listed in the schema above.
+
+        Return ONLY valid JSON — no markdown fences, no extra text.
         """;
 
     /// <summary>
@@ -41,9 +125,18 @@ internal static class ToolkitExtractionPrompts
     public const string RetrySystemPrompt = """
         You are a board game analyst. Extract game mechanics from the rulebook text below
         and return ONLY valid JSON matching AiToolkitSuggestionDto.
-        Include: ToolkitName, DiceTools, CounterTools, TimerTools,
-        ScoringTemplate, TurnTemplate, Overrides, Reasoning.
-        ExcludedTools can be an empty array.
-        Return JSON only — no explanations.
+
+        Required fields: ToolkitName, DiceTools, CounterTools, TimerTools, ScoringTemplate,
+        TurnTemplate, Overrides, Reasoning, ExcludedTools.
+
+        Strict rules:
+        - Use exact DTO field names: DiceType (not Type), CustomFaces (not Faces),
+          MinValue (not Min), MaxValue (not Max), ToolType (not Type), Reason (not Justification).
+        - TimerTools MUST be [] (empty array) if no timer is mentioned. NEVER add a dummy entry.
+        - NEVER add a counter for game-end Points/Score/VP — those are derived, not tracked.
+        - Overrides MUST always include all 3 booleans: OverridesTurnOrder, OverridesScoreboard, OverridesDiceSet.
+        - Reasoning MUST be a single string, not an array or dict.
+
+        Return JSON only — no explanations, no markdown fences.
         """;
 }

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
@@ -9,6 +9,11 @@ namespace Api.BoundedContexts.GameToolkit.Application.Commands;
 /// section (Points-as-counter / dummy timer / Overrides ignored), and explicit
 /// enum value listings. Validated on Llama 3.3 70B free + DeepSeek-chat
 /// (DeepSeek produces 90% accurate output; Llama free requires schema validation).
+///
+/// **v3 — 2026-05-31** (B19-3a + B19-3b, issues #1745 + #1746):
+/// extended AiTurnTemplateSuggestion with Rounds/TurnsPerRound/TurnActions/Direction
+/// (additive, optional) for rich games like Wingspan, and AiScoringTemplateSuggestion
+/// with structured Categories[] (per-category Computation enum) for polymorphic UI.
 /// </summary>
 internal static class ToolkitExtractionPrompts
 {
@@ -80,14 +85,27 @@ internal static class ToolkitExtractionPrompts
         }
 
         AiScoringTemplateSuggestion = {
-          "Dimensions": [string],     // e.g., ["Birds", "Bonus cards", "Eggs"] — simple flat array
+          "Dimensions": [string],     // legacy: simple labels e.g., ["Birds", "Bonus cards"]
           "DefaultUnit": string,      // e.g., "points"
-          "ScoreType": "Points"|"Ranking"|"BinaryWin"|"Objectives"
+          "ScoreType": "Points"|"Ranking"|"BinaryWin"|"Objectives",
+          "Categories": [AiScoringCategorySuggestion] | null  // v2: structured per-category computation (preferred for rich games)
+        }
+
+        AiScoringCategorySuggestion = {                       // v2 (B19-3b)
+          "Id": string,               // stable identifier, e.g., "birds", "bonus-cards", "round-goals"
+          "Label": string,            // user-visible label
+          "Computation": "Count"|"Sum"|"RankBased"|"Custom",  // how to compute the category
+          "Weight": int,              // multiplier (default 1)
+          "Description": string | null
         }
 
         AiTurnTemplateSuggestion = {
           "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None",
-          "Phases": [string]          // e.g., ["Round 1", "Round 2"] or ["Action", "Draw", "Infect"]
+          "Phases": [string],         // e.g., ["Round 1", "Round 2"] or ["Action", "Draw", "Infect"]
+          "Rounds": int | null,       // v2 (B19-3a): total round count if game has fixed structure (e.g., Wingspan=4)
+          "TurnsPerRound": [int] | null,  // v2: turn count per round if variable (e.g., Wingspan=[8,7,6,5])
+          "TurnActions": [string] | null, // v2: actions available per turn (e.g., ["play-bird","get-food","lay-eggs","draw-cards"])
+          "Direction": "clockwise"|"counterclockwise"|"none" | null  // v2: turn order direction
         }
 
         AiOverrideSuggestion = {

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
@@ -100,7 +100,7 @@ internal static class ToolkitExtractionPrompts
         }
 
         AiTurnTemplateSuggestion = {
-          "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None",
+          "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None"|"Custom"|"Free",
           "Phases": [string],         // e.g., ["Round 1", "Round 2"] or ["Action", "Draw", "Infect"]
           "Rounds": int | null,       // v2 (B19-3a): total round count if game has fixed structure (e.g., Wingspan=4)
           "TurnsPerRound": [int] | null,  // v2: turn count per round if variable (e.g., Wingspan=[8,7,6,5])

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/DTOs/AiToolkitSuggestionDtos.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/DTOs/AiToolkitSuggestionDtos.cs
@@ -59,12 +59,33 @@ internal record AiTimerToolSuggestion(
 internal record AiScoringTemplateSuggestion(
     string[] Dimensions,
     string DefaultUnit,
-    ScoreType ScoreType
+    ScoreType ScoreType,
+    // v2 (B19-3b, 2026-05-31): structured Categories for richer UI rendering.
+    // Optional/additive; legacy Dimensions[] preserved for back-compat.
+    AiScoringCategorySuggestion[]? Categories = null
 );
 
 internal record AiTurnTemplateSuggestion(
     TurnOrderType TurnOrderType,
-    string[] Phases
+    string[] Phases,
+    // v2 (B19-3a, 2026-05-31): multi-round + actions + direction for rich games like Wingspan.
+    // Optional/additive; legacy Phases[] preserved for back-compat.
+    int? Rounds = null,
+    int[]? TurnsPerRound = null,
+    string[]? TurnActions = null,
+    string? Direction = null
+);
+
+/// <summary>
+/// v2 (B19-3b): structured scoring category for polymorphic UI rendering.
+/// Each category has its own computation rule (Count/Sum/RankBased/Custom).
+/// </summary>
+internal record AiScoringCategorySuggestion(
+    string Id,                  // stable identifier, e.g., "birds", "bonus-cards"
+    string Label,               // user-visible, e.g., "Birds played"
+    ScoringComputation Computation,
+    int Weight = 1,
+    string? Description = null
 );
 
 internal record AiOverrideSuggestion(

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Validators/AiToolkitSuggestionValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Validators/AiToolkitSuggestionValidator.cs
@@ -1,0 +1,134 @@
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Validators;
+
+/// <summary>
+/// Validates AI-generated toolkit suggestion output for structural integrity
+/// BEFORE it reaches ApplyAiToolkitSuggestionCommand. Catches common LLM mistakes
+/// surfaced by the 2026-05-31 spike (claudedocs/2026-05-31-spike-toolkit-ai-generation.md):
+///
+/// - Points-as-counter hallucination (no counter named "Points"/"Score"/"VP")
+/// - Dummy TimerTools with DurationSeconds=0 (use empty array instead)
+/// - Overrides omission (all 3 booleans must be present, even if false)
+/// - Counter MinValue/MaxValue invariants
+/// - Custom dice without CustomFaces
+///
+/// Issue #1747 (B19-3c).
+///
+/// Use:
+///   var result = await validator.ValidateAsync(suggestion);
+///   if (!result.IsValid) { /* log + force RequiresHumanReview=true + retry */ }
+/// </summary>
+internal sealed class AiToolkitSuggestionValidator : AbstractValidator<AiToolkitSuggestionDto>
+{
+    // Tokens that should NEVER appear as counter names — they are end-game derived score
+    private static readonly string[] ForbiddenCounterNameTokens =
+    [
+        "point", "points",
+        "score", "scores",
+        "vp", "victory point", "victory points",
+    ];
+
+    public AiToolkitSuggestionValidator()
+    {
+        RuleFor(s => s.ToolkitName)
+            .NotEmpty().WithMessage("ToolkitName is required (LLM produced empty/null).");
+
+        RuleFor(s => s.DiceTools)
+            .NotNull().WithMessage("DiceTools must be an array (use [] if no dice).");
+
+        RuleFor(s => s.CounterTools)
+            .NotNull().WithMessage("CounterTools must be an array (use [] if no counters).");
+
+        RuleFor(s => s.TimerTools)
+            .NotNull().WithMessage("TimerTools must be an array (use [] if no timer).");
+
+        RuleFor(s => s.Reasoning)
+            .NotEmpty().WithMessage("Reasoning is required (LLM must cite rule excerpts).");
+
+        // Overrides must always be provided (verdict spike: LLMs frequently omit this)
+        RuleFor(s => s.Overrides)
+            .NotNull().WithMessage(
+                "Overrides MUST be provided (use {OverridesTurnOrder:false,OverridesScoreboard:false,OverridesDiceSet:false} if no game customisations).");
+
+        // No "Points" counter — Points are derived at game end, not tracked
+        RuleForEach(s => s.CounterTools)
+            .ChildRules(c =>
+            {
+                c.RuleFor(t => t.Name)
+                    .Must(n => !ContainsForbiddenScoreToken(n))
+                    .WithMessage(
+                        "Counter name '{PropertyValue}' looks like end-game score (Points/Score/VP). Score is DERIVED at game end, never tracked as a running counter.");
+
+                c.RuleFor(t => t.MinValue)
+                    .LessThanOrEqualTo(t => t.MaxValue)
+                    .WithMessage("CounterTool MinValue must be <= MaxValue.");
+
+                c.RuleFor(t => t.DefaultValue)
+                    .GreaterThanOrEqualTo(t => t.MinValue)
+                    .LessThanOrEqualTo(t => t.MaxValue)
+                    .WithMessage("CounterTool DefaultValue must be within [MinValue, MaxValue].");
+            });
+
+        // Custom dice must declare faces
+        RuleForEach(s => s.DiceTools)
+            .ChildRules(d =>
+            {
+                d.RuleFor(t => t.CustomFaces)
+                    .NotNull()
+                    .Must(faces => faces is not null && faces.Length > 0)
+                    .When(t => t.DiceType == DiceType.Custom)
+                    .WithMessage(
+                        "Custom DiceType requires CustomFaces array with at least 1 face (LLM declared Custom but omitted faces).");
+
+                d.RuleFor(t => t.Quantity)
+                    .GreaterThan(0)
+                    .WithMessage("DiceTool Quantity must be > 0.");
+            });
+
+        // Timer entries must have positive duration unless explicitly using Chess pattern
+        RuleForEach(s => s.TimerTools)
+            .ChildRules(t =>
+            {
+                t.RuleFor(x => x.DurationSeconds)
+                    .GreaterThan(0)
+                    .When(x => x.TimerType != TimerType.Chess)
+                    .WithMessage(
+                        "Timer DurationSeconds must be > 0. If the game has no timer, output an empty TimerTools array instead of a dummy entry.");
+            });
+
+        // ExcludedTools entries must have both ToolType and Reason
+        When(s => s.ExcludedTools is not null && s.ExcludedTools.Count > 0, () =>
+        {
+            RuleForEach(s => s.ExcludedTools!)
+                .ChildRules(e =>
+                {
+                    e.RuleFor(x => x.ToolType)
+                        .NotEmpty()
+                        .WithMessage("ExcludedTool.ToolType is required.");
+                    e.RuleFor(x => x.Reason)
+                        .NotEmpty()
+                        .WithMessage("ExcludedTool.Reason is required (cite the rule that justifies exclusion).");
+                });
+        });
+    }
+
+    private static bool ContainsForbiddenScoreToken(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+        var normalized = name.Trim().ToLowerInvariant();
+        // Exact whole-word or starts-with match — avoid false positives on e.g. "Action points"? Yes —
+        // "action points" should also be flagged because action points are derived.
+        // But "Stone points" or "Build points" could be legitimate per-game currency.
+        // Pragmatic: reject only when the name is dominated by the forbidden token.
+        return ForbiddenCounterNameTokens.Any(token =>
+            string.Equals(normalized, token, StringComparison.Ordinal)
+            || normalized.EndsWith(' ' + token, StringComparison.Ordinal)
+            || normalized.StartsWith(token + ' ', StringComparison.Ordinal));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/ScoreType.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/ScoreType.cs
@@ -2,9 +2,17 @@ namespace Api.BoundedContexts.GameToolkit.Domain.Enums;
 
 /// <summary>
 /// How scoring works in a game session.
+///
+/// **v2 (B19-3b, 2026-05-31)**: extended with BinaryWin / Objectives to cover
+/// co-op games (Paleo, Zombicide: win/lose collective) and goal-oriented games
+/// (Codenames: race + assassin-loss; Pandemic: cure-all-diseases).
+/// Additive — preserves numeric IDs 0-1.
 /// </summary>
 public enum ScoreType
 {
     Points = 0,
-    Ranking = 1
+    Ranking = 1,
+    // v2 additions
+    BinaryWin = 2,   // game is win/lose without points (co-op Paleo / Pandemic / Zombicide)
+    Objectives = 3   // win condition is meeting a set of objectives (Codenames race, mission games)
 }

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/ScoringComputation.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/ScoringComputation.cs
@@ -1,0 +1,28 @@
+namespace Api.BoundedContexts.GameToolkit.Domain.Enums;
+
+/// <summary>
+/// v2 (B19-3b, 2026-05-31): how a single scoring category is computed at game end.
+/// Used by AiScoringCategorySuggestion to drive polymorphic UI rendering.
+/// </summary>
+public enum ScoringComputation
+{
+    /// <summary>
+    /// Sum of a count of items (e.g., "Eggs: 1 point each", "Tucked cards: 1 each").
+    /// </summary>
+    Count = 0,
+
+    /// <summary>
+    /// Sum of variable values per item (e.g., "Birds: variable points printed on each card").
+    /// </summary>
+    Sum = 1,
+
+    /// <summary>
+    /// Position-dependent points based on rank (e.g., Wingspan end-of-round goals: 5/2/1 per round).
+    /// </summary>
+    RankBased = 2,
+
+    /// <summary>
+    /// Custom computation rule too game-specific to encode generically; UI falls back to manual entry.
+    /// </summary>
+    Custom = 99
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/TurnOrderType.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/TurnOrderType.cs
@@ -2,10 +2,19 @@ namespace Api.BoundedContexts.GameToolkit.Domain.Enums;
 
 /// <summary>
 /// How turn order is determined in a game session.
+///
+/// **v2 (B19-3a, 2026-05-31)**: extended with Sequential / Simultaneous / Realtime / None
+/// to cover non-circular turn patterns (co-op simultaneous like Paleo, team-deduction like
+/// Codenames, real-time like Captain Sonar). Additive — preserves numeric IDs 0-2.
 /// </summary>
 public enum TurnOrderType
 {
     RoundRobin = 0,
     Custom = 1,
-    Free = 2
+    Free = 2,
+    // v2 additions
+    Sequential = 3,    // strict order but NOT circular (e.g., team-based: Red phase → Blue phase)
+    Simultaneous = 4,  // all players act at the same time (e.g., Paleo, 7 Wonders)
+    Realtime = 5,      // no turn structure, time-pressure (e.g., Captain Sonar, Magic Maze)
+    None = 6           // truly no turn order (e.g., co-op brainstorm without phase structure)
 }

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/README.md
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/README.md
@@ -1,0 +1,64 @@
+# StateTemplate Seed Fixtures
+
+> Issue [#1748](https://github.com/meepleAi-app/meepleai-monorepo/issues/1748) (B19-3d)
+
+JSON fixtures che bootstrappano `StateTemplateDefinition` per i top-N giochi della v1
+di MeepleAI. Curated manualmente perché lo spike LLM (`claudedocs/2026-05-31-spike-toolkit-ai-generation.md`)
+ha mostrato che per giochi complex flavor (Wingspan, Power Grid) l'AI generation
+non basta — è OK come bootstrap helper ma non come source of truth.
+
+## Format
+
+Ogni file è un `AiToolkitSuggestionDto` JSON-serialized:
+
+```jsonc
+{
+  "ToolkitName": "Wingspan",
+  "DiceTools": [...],
+  "CounterTools": [...],
+  "TimerTools": [...],
+  "ScoringTemplate": { ..., "Categories": [...] },  // v3 (B19-3b)
+  "TurnTemplate": { ..., "Rounds": 4, "TurnsPerRound": [8,7,6,5] },  // v3 (B19-3a)
+  "Overrides": { ... 3 boolean ... },
+  "Reasoning": "Curated by domain expert YYYY-MM-DD.",
+  "ExcludedTools": [...]
+}
+```
+
+Campi `ConfidenceScore`/`ChunksAnalyzed`/`KbCoveragePercent`/`RequiresHumanReview`
+non sono presenti (sono populated dal handler runtime, non statici nel seed).
+
+## Status fixtures
+
+| Game | File | Status | Archetype | Curator |
+|---|---|---|---|---|
+| Wingspan | `wingspan.json` | ✅ complete | Euro engine-builder | Claude Code (spike-derived) |
+| Codenames | `codenames.json` | ✅ complete | Team deduction | Claude Code |
+| Paleo | `paleo.json` | ✅ complete | Co-op simultaneous | Claude Code |
+| Catan | `catan.json` | ✅ complete | Euro + trading | Claude Code |
+| Puerto Rico | `puerto-rico.json` | ⏳ stub TBD | Euro role-selection | Pending domain expert |
+| Power Grid | `power-grid.json` | ⏳ stub TBD | Euro + auction | Pending domain expert |
+| Zombicide Green Horde | `zombicide-green-horde.json` | ⏳ stub TBD | Co-op miniatures | Pending domain expert |
+
+Stub TBD = fixture con `ToolkitName` + minimal note `Reasoning="Requires manual
+curation by domain expert"`. Da completare in iterazione successiva (sub-PR
+di #1748 o issue dedicata per gioco).
+
+## Bootstrap via AI fallback
+
+Per i giochi non ancora seeded, il flow è:
+
+1. `GenerateToolkitFromKbCommand(gameId, userId)` (BackEnd: `apps/api/.../GenerateToolkitFromKbHandler.cs`)
+2. Output `AiToolkitSuggestionDto` con `RequiresHumanReview=true` se confidence < 0.85
+3. Admin review via `ApplyAiToolkitSuggestionCommand` → produce un `GameToolkit` (Draft)
+4. Quando il toolkit è "approved" via marketplace workflow, può diventare seed canonical
+
+## Validazione
+
+Ogni JSON deserializza in `AiToolkitSuggestionDto`. Test:
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~StateTemplateFixtureTests"
+```
+
+I test caricano ogni file e validano lo schema deserialization.

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/catan.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/catan.json
@@ -1,0 +1,55 @@
+{
+  "ToolkitName": "Coloni di Catan",
+  "DiceTools": [
+    {
+      "Name": "Production dice",
+      "DiceType": "D6",
+      "Quantity": 2,
+      "CustomFaces": null,
+      "IsInteractive": true,
+      "Color": "#c0392b"
+    }
+  ],
+  "CounterTools": [
+    { "Name": "Victory Points", "MinValue": 0, "MaxValue": 13, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "star", "Color": "#f1c40f" },
+    { "Name": "Settlements built", "MinValue": 0, "MaxValue": 5, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "house", "Color": null },
+    { "Name": "Cities built", "MinValue": 0, "MaxValue": 4, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "castle", "Color": null },
+    { "Name": "Roads built", "MinValue": 0, "MaxValue": 15, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "road", "Color": null },
+    { "Name": "Wood", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "tree", "Color": "#27ae60" },
+    { "Name": "Brick", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "brick", "Color": "#c0392b" },
+    { "Name": "Sheep", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "sheep", "Color": "#ecf0f1" },
+    { "Name": "Wheat", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "wheat", "Color": "#f1c40f" },
+    { "Name": "Ore", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "ore", "Color": "#7f8c8d" }
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Settlements", "Cities", "Longest Road", "Largest Army", "Victory Point cards"],
+    "DefaultUnit": "points",
+    "ScoreType": "Points",
+    "Categories": [
+      { "Id": "settlements", "Label": "Settlements", "Computation": "Count", "Weight": 1, "Description": "1 point per settlement (max 5)." },
+      { "Id": "cities", "Label": "Cities", "Computation": "Count", "Weight": 2, "Description": "2 points per city (max 4)." },
+      { "Id": "longest-road", "Label": "Longest Road bonus", "Computation": "Custom", "Weight": 2, "Description": "2 points to holder of longest road ≥5 segments." },
+      { "Id": "largest-army", "Label": "Largest Army bonus", "Computation": "Custom", "Weight": 2, "Description": "2 points to holder of largest army ≥3 knights." },
+      { "Id": "vp-cards", "Label": "Victory Point dev cards", "Computation": "Sum", "Weight": 1, "Description": "1 point per VP development card held secretly." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "RoundRobin",
+    "Phases": ["Roll dice (production)", "Trade", "Build / develop"],
+    "Rounds": null,
+    "TurnsPerRound": null,
+    "TurnActions": ["roll-dice", "trade-with-player", "trade-with-bank", "build-road", "build-settlement", "build-city", "buy-dev-card", "play-dev-card", "end-turn"],
+    "Direction": "clockwise"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "Curated 2026-05-31 from Catan base game (3-4 players). 2D6 dice drive resource production each turn. First to 10 VP wins (checked after their own turn). Resources tracked per player (wood/brick/sheep/wheat/ore). Longest Road + Largest Army are dynamic bonuses (2 VP each, can be stolen). Trade phase between players inter-turn is core mechanic. No timer.",
+  "ExcludedTools": [
+    { "ToolType": "Timer", "Reason": "No time limit per turn in base rules." },
+    { "ToolType": "CardDeck", "Reason": "Development cards form a shuffled deck — but managed via specialized widget, not generic card deck (each card type has distinct interaction)." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/codenames.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/codenames.json
@@ -1,0 +1,40 @@
+{
+  "ToolkitName": "Codenames",
+  "DiceTools": [],
+  "CounterTools": [
+    { "Name": "Red tiles remaining", "MinValue": 0, "MaxValue": 9, "DefaultValue": 9, "IsPerPlayer": false, "Icon": "tile", "Color": "#c0392b" },
+    { "Name": "Blue tiles remaining", "MinValue": 0, "MaxValue": 8, "DefaultValue": 8, "IsPerPlayer": false, "Icon": "tile", "Color": "#2980b9" },
+    { "Name": "Guesses remaining this turn", "MinValue": 0, "MaxValue": 9, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "hint", "Color": null }
+  ],
+  "TimerTools": [
+    { "Name": "Clue giving timer (optional)", "DurationSeconds": 120, "TimerType": "CountDown", "AutoStart": false, "Color": null, "IsPerPlayer": false, "WarningThresholdSeconds": 30 },
+    { "Name": "Guessing timer (optional)", "DurationSeconds": 60, "TimerType": "CountDown", "AutoStart": false, "Color": null, "IsPerPlayer": false, "WarningThresholdSeconds": 15 }
+  ],
+  "ScoringTemplate": {
+    "Dimensions": ["Win condition"],
+    "DefaultUnit": "result",
+    "ScoreType": "Ranking",
+    "Categories": [
+      { "Id": "agents-found", "Label": "Agents revealed by team", "Computation": "Count", "Weight": 1, "Description": "First team to reveal all their agents wins." },
+      { "Id": "assassin-touched", "Label": "Assassin revealed", "Computation": "Custom", "Weight": 0, "Description": "Instant loss for team that reveals assassin (1 of 25 tiles)." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "Sequential",
+    "Phases": ["Red Spymaster gives clue", "Red operatives guess", "Blue Spymaster gives clue", "Blue operatives guess"],
+    "Rounds": null,
+    "TurnsPerRound": null,
+    "TurnActions": ["give-clue", "guess-tile", "end-turn"],
+    "Direction": "none"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": true,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "Curated 2026-05-31 from Codenames base rules. Team-based deduction (2 teams: red 9 agents, blue 8 agents). No points scoring — win/lose race + instant-loss on assassin. Optional timers per phase (community variant). Custom turn order alternates between teams with Spymaster→Operatives sequence.",
+  "ExcludedTools": [
+    { "ToolType": "Dice", "Reason": "Codenames is purely deductive, no dice involved." },
+    { "ToolType": "CardDeck", "Reason": "Word cards form a 5x5 grid layout, not a deck. Layout is game-specific widget." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/paleo.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/paleo.json
@@ -1,0 +1,42 @@
+{
+  "ToolkitName": "Paleo",
+  "DiceTools": [],
+  "CounterTools": [
+    { "Name": "Wood", "MinValue": 0, "MaxValue": 30, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "wood", "Color": "#7a4a1a" },
+    { "Name": "Stone", "MinValue": 0, "MaxValue": 30, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "stone", "Color": "#7f8c8d" },
+    { "Name": "Food", "MinValue": 0, "MaxValue": 30, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "food", "Color": "#d35400" },
+    { "Name": "Skulls (lose tribe → lose game)", "MinValue": 0, "MaxValue": 5, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "skull", "Color": "#2c3e50" },
+    { "Name": "Knowledge cards collected", "MinValue": 0, "MaxValue": 99, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "scroll", "Color": null },
+    { "Name": "Cave painting progress (0-5)", "MinValue": 0, "MaxValue": 5, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "art", "Color": null },
+    { "Name": "Tribe members alive", "MinValue": 0, "MaxValue": 8, "DefaultValue": 4, "IsPerPlayer": false, "Icon": "person", "Color": null }
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Win condition", "Cave paintings"],
+    "DefaultUnit": "result",
+    "ScoreType": "BinaryWin",
+    "Categories": [
+      { "Id": "cave-painting", "Label": "Cave painting completed", "Computation": "Count", "Weight": 1, "Description": "Complete the cave painting (5 hand prints) to win." },
+      { "Id": "skulls", "Label": "Skulls accumulated", "Computation": "Count", "Weight": -1, "Description": "5 skulls = instant loss for entire tribe." },
+      { "Id": "tribe-extinct", "Label": "Tribe extinct (all members died)", "Computation": "Custom", "Weight": 0, "Description": "Tribe loss condition — all members dead." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "Simultaneous",
+    "Phases": ["Morning (draw + choose cards)", "Day (resolve actions simultaneously)", "Night (return tribe, check end conditions)"],
+    "Rounds": null,
+    "TurnsPerRound": null,
+    "TurnActions": ["explore", "hunt", "craft", "develop", "rest"],
+    "Direction": "none"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": true,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "Curated 2026-05-31 from Paleo base rules. Co-op simultaneous play (no individual turn). Win condition: complete cave painting (5 hand prints) before tribe dies or skulls accumulate. Player count 1-4, but scoring is collective. Multiple modules (resources, weather, hunger, skills) add variety but core loop remains 3-phase day cycle.",
+  "ExcludedTools": [
+    { "ToolType": "Dice", "Reason": "Paleo is deterministic card-driven, no dice." },
+    { "ToolType": "Timer", "Reason": "No time limit per turn (co-op discussion welcomed)." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/power-grid.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/power-grid.json
@@ -1,0 +1,15 @@
+{
+  "ToolkitName": "Power Grid",
+  "DiceTools": [],
+  "CounterTools": [],
+  "TimerTools": [],
+  "ScoringTemplate": null,
+  "TurnTemplate": null,
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": false,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "STUB — pending manual curation by domain expert. Power Grid is a heavy euro auction/network game (2-6 players, ~120 min). Key mechanics to model: 4 phases per round (Player Order → Power Plant Auction → Resource Buying → Building → Bureaucracy), Elektro currency, 4 resource types (coal/oil/garbage/uranium), 3 game steps (1/2/3 triggering board expansion + capacity), end condition: first to power 17 cities. Turn order REVERSES based on cities powered (leader plays last in auctions). Use GenerateToolkitFromKbCommand as bootstrap.",
+  "ExcludedTools": []
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/puerto-rico.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/puerto-rico.json
@@ -1,0 +1,15 @@
+{
+  "ToolkitName": "Puerto Rico",
+  "DiceTools": [],
+  "CounterTools": [],
+  "TimerTools": [],
+  "ScoringTemplate": null,
+  "TurnTemplate": null,
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": false,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "STUB — pending manual curation by domain expert. Puerto Rico is a heavy euro role-selection game (3-5 players, ~120 min). Key mechanics to model: 8 role cards (Settler/Mayor/Builder/Craftsman/Trader/Captain/Prospector + privilege effect for chooser), 6 buildings types, doubloons + colonists + corn/indigo/sugar/tobacco/coffee resources, victory points from buildings + shipped goods. End condition: end-game trigger when colonists/VP exhausted. Use GenerateToolkitFromKbCommand with rulebook PDF as bootstrap helper, then refine.",
+  "ExcludedTools": []
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/wingspan.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/wingspan.json
@@ -1,0 +1,50 @@
+{
+  "ToolkitName": "Wingspan",
+  "DiceTools": [
+    {
+      "Name": "Birdfeeder Food Dice",
+      "DiceType": "Custom",
+      "Quantity": 5,
+      "CustomFaces": ["invertebrate", "seed", "fruit", "fish", "rodent", "wild"],
+      "IsInteractive": true,
+      "Color": "#7a3d1a"
+    }
+  ],
+  "CounterTools": [
+    { "Name": "Eggs", "MinValue": 0, "MaxValue": 6, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "egg", "Color": null },
+    { "Name": "Food tokens", "MinValue": 0, "MaxValue": 99, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "food", "Color": null },
+    { "Name": "Action cubes", "MinValue": 0, "MaxValue": 8, "DefaultValue": 8, "IsPerPlayer": true, "Icon": "cube", "Color": null }
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Birds", "Bonus cards", "End-of-round goals", "Eggs", "Food cached", "Tucked cards"],
+    "DefaultUnit": "points",
+    "ScoreType": "Points",
+    "Categories": [
+      { "Id": "birds", "Label": "Birds played", "Computation": "Sum", "Weight": 1, "Description": "Variable points printed on each bird card (1-9)." },
+      { "Id": "bonus-cards", "Label": "Bonus cards", "Computation": "Sum", "Weight": 1, "Description": "Variable points per personal bonus card objective." },
+      { "Id": "round-goals", "Label": "End-of-round goals", "Computation": "RankBased", "Weight": 1, "Description": "5/2/1 or 4/2/1 points per round based on rank in goal." },
+      { "Id": "eggs", "Label": "Eggs", "Computation": "Count", "Weight": 1, "Description": "1 point per egg laid." },
+      { "Id": "cached-food", "Label": "Food cached", "Computation": "Count", "Weight": 1, "Description": "1 point per food cached on a bird card." },
+      { "Id": "tucked-cards", "Label": "Tucked cards", "Computation": "Count", "Weight": 1, "Description": "1 point per card tucked under a bird for ability." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "RoundRobin",
+    "Phases": ["Round 1", "Round 2", "Round 3", "Round 4"],
+    "Rounds": 4,
+    "TurnsPerRound": [8, 7, 6, 5],
+    "TurnActions": ["play-bird", "get-food", "lay-eggs", "draw-cards"],
+    "Direction": "clockwise"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": true,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": true
+  },
+  "Reasoning": "Curated 2026-05-31 from Wingspan rulebook (data/rulebook/wingspan_en_rulebook.pdf). 5 custom food dice with 6 faces, 4-round structure with decreasing turn count (8/7/6/5), 6 additive scoring categories with mix of Count/Sum/RankBased computations. Tiebreakers: bonus card points then total food.",
+  "ExcludedTools": [
+    { "ToolType": "Timer", "Reason": "Rulebook explicitly states no time limit per turn or round." },
+    { "ToolType": "CardDeck", "Reason": "Bird cards use a fixed 3-card display + discard, not a generic shuffled deck. Bird display is a game-specific widget." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/zombicide-green-horde.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/zombicide-green-horde.json
@@ -1,0 +1,26 @@
+{
+  "ToolkitName": "Zombicide Green Horde",
+  "DiceTools": [
+    {
+      "Name": "Combat dice",
+      "DiceType": "D6",
+      "Quantity": 6,
+      "CustomFaces": null,
+      "IsInteractive": true,
+      "Color": "#27ae60"
+    }
+  ],
+  "CounterTools": [],
+  "TimerTools": [],
+  "ScoringTemplate": null,
+  "TurnTemplate": null,
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": false,
+    "OverridesDiceSet": true
+  },
+  "Reasoning": "STUB — pending manual curation by domain expert. Zombicide Green Horde is a co-op miniatures dungeon-crawler (1-6 players, ~60-90 min/scenario). Key mechanics to model: scenario-based (no fixed scoring), each survivor has unique skill tree (Blue→Yellow→Orange→Red dangerous levels), action points per turn (3 standard, modified by skills), combat resolution with custom dice (typically D6 hit on 4+ but varies by weapon), zombie spawn phases at end of each player round driven by Danger Level. Loss conditions: all survivors dead OR mission failure. Use GenerateToolkitFromKbCommand for bootstrap of base mechanics.",
+  "ExcludedTools": [
+    { "ToolType": "Timer", "Reason": "No time limit per turn." }
+  ]
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/DTOs/AiToolkitSuggestionDtoTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/DTOs/AiToolkitSuggestionDtoTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Application.DTOs;
+
+/// <summary>
+/// DTO schema deserialization tests for AiToolkitSuggestionDto.
+/// Issue #1745 (B19-3a) + #1746 (B19-3b): validates additive v3 schema extensions
+/// (TurnTemplate Rounds/TurnsPerRound/TurnActions/Direction +
+///  ScoringTemplate Categories[]) without breaking back-compat with legacy LLM output.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+public class AiToolkitSuggestionDtoTests
+{
+    // Mirror production JsonSerializerOptions: string enum + case-insensitive
+    // (production GenerateJsonAsync uses ASP.NET defaults + JsonStringEnumConverter)
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    [Fact]
+    public void Deserialize_LegacyShape_WithoutNewFields_BackCompat()
+    {
+        const string legacyJson = """
+        {
+          "ToolkitName": "Catan",
+          "DiceTools": [],
+          "CounterTools": [],
+          "TimerTools": [],
+          "ScoringTemplate": {
+            "Dimensions": ["Settlements", "Cities", "Roads"],
+            "DefaultUnit": "points",
+            "ScoreType": "Points"
+          },
+          "TurnTemplate": {
+            "TurnOrderType": "RoundRobin",
+            "Phases": ["Roll", "Trade", "Build"]
+          },
+          "Overrides": {
+            "OverridesTurnOrder": false,
+            "OverridesScoreboard": false,
+            "OverridesDiceSet": false
+          },
+          "Reasoning": "Catan uses 2D6 with turn-based clockwise play."
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<AiToolkitSuggestionDto>(legacyJson, JsonOptions);
+
+        dto.Should().NotBeNull();
+        dto!.ScoringTemplate.Should().NotBeNull();
+        dto.ScoringTemplate!.Dimensions.Should().HaveCount(3);
+        dto.ScoringTemplate.Categories.Should().BeNull("legacy output omits Categories field");
+        dto.TurnTemplate.Should().NotBeNull();
+        dto.TurnTemplate!.Phases.Should().HaveCount(3);
+        dto.TurnTemplate.Rounds.Should().BeNull("legacy output omits Rounds field");
+        dto.TurnTemplate.TurnsPerRound.Should().BeNull();
+        dto.TurnTemplate.TurnActions.Should().BeNull();
+        dto.TurnTemplate.Direction.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_V3Shape_WithRichTurnAndCategories_PopulatesAdditiveFields()
+    {
+        // Mirrors what DeepSeek-chat produces for Wingspan after prompt v3 (B19-3a/3b)
+        const string v3Json = """
+        {
+          "ToolkitName": "Wingspan",
+          "DiceTools": [],
+          "CounterTools": [],
+          "TimerTools": [],
+          "ScoringTemplate": {
+            "Dimensions": ["Birds", "Bonus cards", "Eggs"],
+            "DefaultUnit": "points",
+            "ScoreType": "Points",
+            "Categories": [
+              { "Id": "birds", "Label": "Birds played", "Computation": "Sum", "Weight": 1 },
+              { "Id": "eggs", "Label": "Eggs", "Computation": "Count", "Weight": 1 },
+              { "Id": "round-goals", "Label": "End-of-round goals", "Computation": "RankBased", "Weight": 1, "Description": "5/2/1 points by rank in goal" }
+            ]
+          },
+          "TurnTemplate": {
+            "TurnOrderType": "RoundRobin",
+            "Phases": ["Round 1", "Round 2", "Round 3", "Round 4"],
+            "Rounds": 4,
+            "TurnsPerRound": [8, 7, 6, 5],
+            "TurnActions": ["play-bird", "get-food", "lay-eggs", "draw-cards"],
+            "Direction": "clockwise"
+          },
+          "Overrides": {
+            "OverridesTurnOrder": false,
+            "OverridesScoreboard": false,
+            "OverridesDiceSet": true
+          },
+          "Reasoning": "Wingspan has a deterministic 4-round structure with decreasing turn count."
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<AiToolkitSuggestionDto>(v3Json, JsonOptions);
+
+        dto.Should().NotBeNull();
+
+        // 3b: structured Categories
+        dto!.ScoringTemplate!.Categories.Should().NotBeNull().And.HaveCount(3);
+        dto.ScoringTemplate.Categories![0].Id.Should().Be("birds");
+        dto.ScoringTemplate.Categories[0].Computation.Should().Be(ScoringComputation.Sum);
+        dto.ScoringTemplate.Categories[1].Computation.Should().Be(ScoringComputation.Count);
+        dto.ScoringTemplate.Categories[2].Computation.Should().Be(ScoringComputation.RankBased);
+        dto.ScoringTemplate.Categories[2].Description.Should().NotBeNull();
+
+        // 3a: rich TurnTemplate
+        dto.TurnTemplate!.Rounds.Should().Be(4);
+        dto.TurnTemplate.TurnsPerRound.Should().Equal(8, 7, 6, 5);
+        dto.TurnTemplate.TurnActions.Should().Equal("play-bird", "get-food", "lay-eggs", "draw-cards");
+        dto.TurnTemplate.Direction.Should().Be("clockwise");
+
+        // Legacy fields still populated
+        dto.TurnTemplate.Phases.Should().HaveCount(4);
+        dto.ScoringTemplate.Dimensions.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Construct_V3_WithExplicitParameters_RoundtripsViaJson()
+    {
+        var scoring = new AiScoringTemplateSuggestion(
+            Dimensions: new[] { "Birds" },
+            DefaultUnit: "points",
+            ScoreType: ScoreType.Points,
+            Categories: new[]
+            {
+                new AiScoringCategorySuggestion("birds", "Birds played", ScoringComputation.Sum, 1, null),
+            });
+
+        var turn = new AiTurnTemplateSuggestion(
+            TurnOrderType: TurnOrderType.RoundRobin,
+            Phases: new[] { "Round 1", "Round 2" },
+            Rounds: 2,
+            TurnsPerRound: new[] { 8, 7 },
+            TurnActions: new[] { "action-a", "action-b" },
+            Direction: "clockwise");
+
+        var dto = new AiToolkitSuggestionDto(
+            ToolkitName: "Test",
+            DiceTools: new List<AiDiceToolSuggestion>(),
+            CounterTools: new List<AiCounterToolSuggestion>(),
+            TimerTools: new List<AiTimerToolSuggestion>(),
+            ScoringTemplate: scoring,
+            TurnTemplate: turn,
+            Overrides: new AiOverrideSuggestion(false, false, false),
+            Reasoning: "test");
+
+        var roundtrip = JsonSerializer.Deserialize<AiToolkitSuggestionDto>(
+            JsonSerializer.Serialize(dto, JsonOptions),
+            JsonOptions);
+
+        roundtrip.Should().NotBeNull();
+        roundtrip!.TurnTemplate!.TurnsPerRound.Should().Equal(8, 7);
+        roundtrip.ScoringTemplate!.Categories![0].Id.Should().Be("birds");
+        roundtrip.ScoringTemplate.Categories[0].Computation.Should().Be(ScoringComputation.Sum);
+    }
+
+    [Theory]
+    [InlineData("Count", ScoringComputation.Count)]
+    [InlineData("Sum", ScoringComputation.Sum)]
+    [InlineData("RankBased", ScoringComputation.RankBased)]
+    [InlineData("Custom", ScoringComputation.Custom)]
+    public void Deserialize_ScoringComputation_AllEnumValues(string value, ScoringComputation expected)
+    {
+        var json = $$"""{ "Id": "test", "Label": "Test", "Computation": "{{value}}", "Weight": 1 }""";
+        var dto = JsonSerializer.Deserialize<AiScoringCategorySuggestion>(json, JsonOptions);
+        dto.Should().NotBeNull();
+        dto!.Computation.Should().Be(expected);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/GenerateToolkitFromKbHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/GenerateToolkitFromKbHandlerTests.cs
@@ -197,8 +197,12 @@ public class GenerateToolkitFromKbHandlerTests
             .Setup(l => l.GenerateJsonAsync<AiToolkitSuggestionDto>(
                 It.IsAny<string>(), It.IsAny<string>(),
                 RequestSource.RagPipeline, It.IsAny<CancellationToken>()))
+            // Updated 2026-05-31 (B19-3c #1747): Overrides must be provided
+            // (validator enforces it). High-confidence path requires schema-valid output.
             .ReturnsAsync(new AiToolkitSuggestionDto(
-                "Catan", [], [], [], null, null, null, "High coverage."));
+                "Catan", [], [], [], null, null,
+                new AiOverrideSuggestion(false, false, false),
+                "High coverage."));
 
         var result = await _handler.Handle(
             new GenerateToolkitFromKbCommand(GameId, UserId),

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Validators/AiToolkitSuggestionValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Validators/AiToolkitSuggestionValidatorTests.cs
@@ -1,0 +1,223 @@
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.BoundedContexts.GameToolkit.Application.Validators;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Application.Validators;
+
+/// <summary>
+/// Validator tests for AiToolkitSuggestionValidator. Issue #1747 (B19-3c).
+/// Covers the spike-identified anti-patterns (Points-as-counter, dummy timer,
+/// missing Overrides, etc.).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+public class AiToolkitSuggestionValidatorTests
+{
+    private readonly AiToolkitSuggestionValidator _validator = new();
+
+    private static AiToolkitSuggestionDto ValidSuggestion(
+        Action<List<AiCounterToolSuggestion>>? mutateCounters = null,
+        Action<List<AiDiceToolSuggestion>>? mutateDice = null,
+        Action<List<AiTimerToolSuggestion>>? mutateTimers = null,
+        AiOverrideSuggestion? overrides = null,
+        string reasoning = "Curated test fixture.")
+    {
+        var counters = new List<AiCounterToolSuggestion>();
+        var dice = new List<AiDiceToolSuggestion>();
+        var timers = new List<AiTimerToolSuggestion>();
+        mutateCounters?.Invoke(counters);
+        mutateDice?.Invoke(dice);
+        mutateTimers?.Invoke(timers);
+
+        return new AiToolkitSuggestionDto(
+            ToolkitName: "Test Game",
+            DiceTools: dice,
+            CounterTools: counters,
+            TimerTools: timers,
+            ScoringTemplate: null,
+            TurnTemplate: null,
+            Overrides: overrides ?? new AiOverrideSuggestion(false, false, false),
+            Reasoning: reasoning);
+    }
+
+    [Fact]
+    public async Task ValidMinimal_PassesValidation()
+    {
+        var dto = ValidSuggestion();
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task EmptyToolkitName_Fails()
+    {
+        var dto = ValidSuggestion() with { ToolkitName = string.Empty };
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldHaveValidationErrorFor(s => s.ToolkitName);
+    }
+
+    [Fact]
+    public async Task MissingOverrides_Fails()
+    {
+        var dto = ValidSuggestion(overrides: null!) with { Overrides = null };
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldHaveValidationErrorFor(s => s.Overrides);
+    }
+
+    [Fact]
+    public async Task EmptyReasoning_Fails()
+    {
+        var dto = ValidSuggestion(reasoning: string.Empty);
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldHaveValidationErrorFor(s => s.Reasoning);
+    }
+
+    [Theory]
+    [InlineData("Points")]
+    [InlineData("Victory Points")]
+    [InlineData("VP")]
+    [InlineData("Score")]
+    [InlineData("Player Score")]   // ends with " score"
+    public async Task CounterNamedAsScore_Fails(string forbiddenName)
+    {
+        var dto = ValidSuggestion(mutateCounters: counters =>
+        {
+            counters.Add(new AiCounterToolSuggestion(
+                Name: forbiddenName,
+                MinValue: 0, MaxValue: 99, DefaultValue: 0,
+                IsPerPlayer: true, Icon: null, Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.PropertyName.Contains("CounterTools", StringComparison.Ordinal)
+                                           && e.ErrorMessage.Contains("end-game score", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("Eggs")]
+    [InlineData("Wood")]
+    [InlineData("Action cubes")]
+    [InlineData("Settlements")]
+    public async Task LegitimateCounters_Pass(string legitName)
+    {
+        var dto = ValidSuggestion(mutateCounters: counters =>
+        {
+            counters.Add(new AiCounterToolSuggestion(
+                Name: legitName,
+                MinValue: 0, MaxValue: 30, DefaultValue: 0,
+                IsPerPlayer: true, Icon: null, Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task CounterMinGreaterThanMax_Fails()
+    {
+        var dto = ValidSuggestion(mutateCounters: counters =>
+        {
+            counters.Add(new AiCounterToolSuggestion(
+                Name: "Wood", MinValue: 100, MaxValue: 50, DefaultValue: 50,
+                IsPerPlayer: false, Icon: null, Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("MinValue must be <= MaxValue", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CounterDefaultOutOfBounds_Fails()
+    {
+        var dto = ValidSuggestion(mutateCounters: counters =>
+        {
+            counters.Add(new AiCounterToolSuggestion(
+                Name: "Wood", MinValue: 0, MaxValue: 10, DefaultValue: 50,
+                IsPerPlayer: false, Icon: null, Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("DefaultValue must be within", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DummyTimer_DurationZero_NonChess_Fails()
+    {
+        var dto = ValidSuggestion(mutateTimers: timers =>
+        {
+            timers.Add(new AiTimerToolSuggestion(
+                Name: "Dummy",
+                DurationSeconds: 0,
+                TimerType: TimerType.CountDown,
+                AutoStart: false, Color: null, IsPerPlayer: false,
+                WarningThresholdSeconds: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("DurationSeconds must be > 0", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task EmptyTimerArray_Pass()
+    {
+        var dto = ValidSuggestion();
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task CustomDiceWithoutFaces_Fails()
+    {
+        var dto = ValidSuggestion(mutateDice: dice =>
+        {
+            dice.Add(new AiDiceToolSuggestion(
+                Name: "Custom dice",
+                DiceType: DiceType.Custom,
+                Quantity: 5,
+                CustomFaces: null,
+                IsInteractive: true,
+                Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("CustomFaces", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StandardDice_NoFaces_OK()
+    {
+        var dto = ValidSuggestion(mutateDice: dice =>
+        {
+            dice.Add(new AiDiceToolSuggestion(
+                Name: "D6", DiceType: DiceType.D6, Quantity: 2,
+                CustomFaces: null, IsInteractive: true, Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task DiceZeroQuantity_Fails()
+    {
+        var dto = ValidSuggestion(mutateDice: dice =>
+        {
+            dice.Add(new AiDiceToolSuggestion(
+                Name: "D6", DiceType: DiceType.D6, Quantity: 0,
+                CustomFaces: null, IsInteractive: true, Color: null));
+        });
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("Quantity must be > 0", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExcludedToolMissingReason_Fails()
+    {
+        var dto = ValidSuggestion() with
+        {
+            ExcludedTools = new List<AiExcludedToolSuggestion>
+            {
+                new("Timer", string.Empty),
+            },
+        };
+        var result = await _validator.TestValidateAsync(dto);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("Reason is required", StringComparison.Ordinal));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Seed/StateTemplateFixtureTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Seed/StateTemplateFixtureTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Seed;
+
+/// <summary>
+/// Validates that every curated StateTemplate seed fixture under
+/// apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/ deserializes
+/// cleanly into AiToolkitSuggestionDto. Catches drift between schema changes
+/// and seed JSONs.
+///
+/// Issue #1748 (B19-3d).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+public class StateTemplateFixtureTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Locates the seed directory by walking up from the test assembly until we find the
+    /// solution file (MeepleAI.Api.sln, in apps/api/).
+    /// </summary>
+    private static string SeedDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeepleAI.Api.sln")))
+        {
+            dir = dir.Parent;
+        }
+        Assert.True(dir is not null,
+            $"Could not locate solution root from BaseDirectory={AppContext.BaseDirectory}");
+        // dir is now .../apps/api/ — seed is at src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates
+        return Path.Combine(
+            dir!.FullName,
+            "src", "Api",
+            "BoundedContexts", "GameToolkit", "Seed", "StateTemplates");
+    }
+
+    public static IEnumerable<object[]> AllFixtureFiles()
+    {
+        var seedDir = SeedDirectory();
+        if (!Directory.Exists(seedDir))
+        {
+            yield break;
+        }
+        foreach (var path in Directory.EnumerateFiles(seedDir, "*.json"))
+        {
+            yield return new object[] { Path.GetFileName(path), path };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllFixtureFiles))]
+    public void Fixture_Deserializes_ToValidDto(string fileName, string filePath)
+    {
+        var json = File.ReadAllText(filePath);
+        var dto = JsonSerializer.Deserialize<AiToolkitSuggestionDto>(json, JsonOptions);
+
+        dto.Should().NotBeNull($"fixture {fileName} must deserialize");
+        dto!.ToolkitName.Should().NotBeNullOrWhiteSpace($"fixture {fileName} requires ToolkitName");
+        dto.DiceTools.Should().NotBeNull($"fixture {fileName} requires DiceTools (can be empty array)");
+        dto.CounterTools.Should().NotBeNull($"fixture {fileName} requires CounterTools (can be empty array)");
+        dto.TimerTools.Should().NotBeNull($"fixture {fileName} requires TimerTools (can be empty array)");
+        dto.Overrides.Should().NotBeNull(
+            $"fixture {fileName} must declare Overrides (use all-false for default game)");
+        dto.Reasoning.Should().NotBeNullOrWhiteSpace(
+            $"fixture {fileName} requires Reasoning (curator note or STUB marker)");
+    }
+
+    [Fact]
+    public void SeedDirectory_ContainsExpectedFixtures()
+    {
+        var seedDir = SeedDirectory();
+        var present = Directory.EnumerateFiles(seedDir, "*.json")
+            .Select(Path.GetFileNameWithoutExtension)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // The 7 v1 top games (B19 Phase 2 scope, post user-confirmation 2026-05-31)
+        var expected = new[]
+        {
+            "wingspan", "puerto-rico", "catan", "power-grid",
+            "zombicide-green-horde", "paleo", "codenames",
+        };
+
+        foreach (var fixture in expected)
+        {
+            present.Should().Contain(fixture, $"v1 top-7 fixture {fixture}.json must exist");
+        }
+    }
+}

--- a/claudedocs/2026-05-31-spike-toolkit-ai-generation.md
+++ b/claudedocs/2026-05-31-spike-toolkit-ai-generation.md
@@ -393,6 +393,75 @@ Lo spike Llama 70B free **rafforza il verdetto HYBRID**:
 
 ---
 
+## 8.7 Run reale v2 — DeepSeek-chat + prompt fixes (2026-05-31 13:05 UTC)
+
+> Validation post Step 2 (prompt fixes). Stesso model, stessi excerpts, ma **prompt v2** con schema strict + anti-patterns + DTO field names esatti.
+
+### Setup
+- **Model**: `deepseek/deepseek-chat` (stessa scelta)
+- **Prompt**: v2 (4329 chars vs 1361 v1, ×3.2)
+- **Tokens**: 1737 prompt + 559 completion = 2296 totali (+53% vs v1)
+- **Latency**: 29.8s (+19% vs v1)
+- **Cost stimato**: ~$0.0013 (vs $0.0009 v1, +50%) — ancora trascurabile
+
+### Risultati v2 — TUTTI gli issue v1 risolti
+
+| Issue v1 (DeepSeek) | Stato v2 |
+|---|---|
+| Field names `Type`/`Faces` invece di `DiceType`/`CustomFaces` | ✅ **fixed** — usa nomi DTO esatti |
+| `CounterTools` con `Min`/`Max` invece di `MinValue`/`MaxValue` | ✅ **fixed** — campi corretti + `DefaultValue` aggiunto |
+| `ExcludedTools` con `Type`/`Justification` | ✅ **fixed** — usa `ToolType`/`Reason` |
+| `Overrides: {}` vuoto | ✅ **fixed** — 3 booleans esplicitamente settati (`OverridesDiceSet: true`) |
+| `Reasoning` come dict per categoria | ✅ **fixed** — string singolo con `[excerpt N]` citations inline |
+| Dummy `TimerTools` entry | ✅ **fixed** — `TimerTools: []` (già OK in v1 DeepSeek) |
+| Points-as-counter hallucination | ✅ **fixed** — non presente in v2 (già OK in v1 DeepSeek) |
+| Caveat residuo ExcludedTools incompleti | ⚠️ persistente (1 entry, manca CardDeck) — minor |
+
+### Output v2 (estratto)
+
+```json
+{
+  "ToolkitName": "Wingspan",
+  "DiceTools": [{
+    "Name": "Birdfeeder Food Dice", "DiceType": "Custom", "Quantity": 5,
+    "CustomFaces": ["invertebrate", "seed", "fruit", "fish", "rodent", "wild"],
+    "IsInteractive": true, "Color": null
+  }],
+  "CounterTools": [
+    {"Name": "Eggs", "MinValue": 0, "MaxValue": 6, "DefaultValue": 0, "IsPerPlayer": true, ...},
+    {"Name": "Food Tokens", "MinValue": 0, "MaxValue": 99, "DefaultValue": 0, "IsPerPlayer": true, ...},
+    {"Name": "Action Cubes", "MinValue": 0, "MaxValue": 8, "DefaultValue": 8, "IsPerPlayer": true, ...}
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Birds", "Bonus cards", "End-of-round goals", "Eggs", "Food cached", "Tucked cards"],
+    "DefaultUnit": "points", "ScoreType": "Points"
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "RoundRobin",
+    "Phases": ["Round 1", "Round 2", "Round 3", "Round 4"]
+  },
+  "Overrides": {
+    "OverridesTurnOrder": false, "OverridesScoreboard": false, "OverridesDiceSet": true
+  },
+  "Reasoning": "The game includes 5 custom 6-sided food dice with specific faces [excerpt 1]...",
+  "ExcludedTools": [{"ToolType": "Timer", "Reason": "..."}]
+}
+```
+
+### Verdetto v2 — PRODUCTION-READY
+
+DeepSeek-chat + prompt v2 = output **direttamente usabile** dal handler `ApplyAiToolkitSuggestionCommand` (zero rework richiesto, deserializzazione C# riesce 1:1 al DTO).
+
+**Gate-keeper Step 2**: ✅ CLOSED — il quick win prompt fix è sufficiente per portare DeepSeek a production-quality.
+
+Caveat residuo (minor): `ExcludedTools` resta incompleto in alcune run — accettabile perché non è un campo critico per il funzionamento, è solo metadata utile per UI/audit.
+
+### Output completo
+- `claudedocs/spike-llm-output-wingspan-deepseek_deepseek-chat-2026-05-31T130516Z.json` (run v2)
+
+---
+
 ## 9. References
 
 - `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs` — handler (161 righe)

--- a/claudedocs/scripts/spike-llm-toolkit-gen-2026-05-31.py
+++ b/claudedocs/scripts/spike-llm-toolkit-gen-2026-05-31.py
@@ -30,8 +30,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SECRET_FILE = REPO_ROOT / "infra" / "secrets" / "openrouter.secret"
 OUTPUT_DIR = REPO_ROOT / "claudedocs"
 
-# Fedele a apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
-SYSTEM_PROMPT = """You are an expert board game rules analyst. Analyze the provided rulebook excerpts
+# v1 — Fedele al ToolkitExtractionPrompts.cs PRE-spike (pre-2026-05-31)
+SYSTEM_PROMPT_V1 = """You are an expert board game rules analyst. Analyze the provided rulebook excerpts
 and extract mechanical components needed to configure a digital game toolkit.
 
 For each component type, output structured JSON. Include ONLY components explicitly
@@ -53,6 +53,112 @@ Rules:
 
 JSON schema: AiToolkitSuggestionDto with fields: ToolkitName, DiceTools, CounterTools,
 TimerTools, ScoringTemplate, TurnTemplate, Overrides, Reasoning, ExcludedTools."""
+
+# v2 — Fedele al ToolkitExtractionPrompts.cs POST-spike (2026-05-31)
+# Aggiunti: strict JSON schema (DTO field names esatti), anti-patterns section, enum value listings.
+SYSTEM_PROMPT_V2 = """You are an expert board game rules analyst. Analyze the provided rulebook excerpts
+and extract mechanical components needed to configure a digital game toolkit.
+
+For each component type, output structured JSON. Include ONLY components explicitly
+mentioned or strongly implied by the rules provided. Do not invent components.
+
+DICE: Extract dice types (D4/D6/D8/D10/D12/D20/D100/Custom), quantities, custom faces.
+COUNTERS: Extract resources, tokens, points (min/max values, IsPerPlayer=true if tracked per player).
+TIMERS: Extract time limits, turn timers (DurationSeconds, AutoStart, IsPerPlayer).
+SCORING: Extract victory conditions, points dimensions, ranking vs points system.
+TURN ORDER: Extract round structure (RoundRobin/Sequential) and phase names if present.
+EXCLUDED: List tool types NOT needed with a brief rule-based justification.
+
+Rules:
+- Set IsPerPlayer=true for anything tracked individually (e.g., player resources, player timers)
+- Use min=0 for counters unless rules specify negative values
+- DurationSeconds=0 if no explicit time limit is mentioned
+- Reasoning must cite the rule text that led to each decision
+- Return ONLY valid JSON — no markdown fences, no extra text
+
+=== EXACT JSON SCHEMA (DTO field names — DO NOT renamE) ===
+
+Root: AiToolkitSuggestionDto = {
+  "ToolkitName": string,
+  "DiceTools": [AiDiceToolSuggestion],
+  "CounterTools": [AiCounterToolSuggestion],
+  "TimerTools": [AiTimerToolSuggestion],
+  "ScoringTemplate": AiScoringTemplateSuggestion | null,
+  "TurnTemplate": AiTurnTemplateSuggestion | null,
+  "Overrides": AiOverrideSuggestion | null,
+  "Reasoning": string,        // single concatenated paragraph, NOT array NOT dict
+  "ExcludedTools": [AiExcludedToolSuggestion]
+}
+
+AiDiceToolSuggestion = {
+  "Name": string,             // e.g., "Birdfeeder Food Dice" — NOT "Type"
+  "DiceType": "D4"|"D6"|"D8"|"D10"|"D12"|"D20"|"D100"|"Custom",  // enum, NOT "Type"
+  "Quantity": int,
+  "CustomFaces": [string] | null,  // NOT "Faces"
+  "IsInteractive": bool,
+  "Color": string | null
+}
+
+AiCounterToolSuggestion = {
+  "Name": string,
+  "MinValue": int,            // NOT "Min"
+  "MaxValue": int,            // NOT "Max" (use a large int like 99 if no upper bound)
+  "DefaultValue": int,
+  "IsPerPlayer": bool,
+  "Icon": string | null,
+  "Color": string | null
+}
+
+AiTimerToolSuggestion = {
+  "Name": string,
+  "DurationSeconds": int,
+  "TimerType": "CountDown"|"CountUp"|"Chess",
+  "AutoStart": bool,
+  "Color": string | null,
+  "IsPerPlayer": bool,
+  "WarningThresholdSeconds": int | null
+}
+
+AiScoringTemplateSuggestion = {
+  "Dimensions": [string],     // e.g., ["Birds", "Bonus cards", "Eggs"] — simple flat array
+  "DefaultUnit": string,      // e.g., "points"
+  "ScoreType": "Points"|"Ranking"|"BinaryWin"|"Objectives"
+}
+
+AiTurnTemplateSuggestion = {
+  "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None",
+  "Phases": [string]          // e.g., ["Round 1", "Round 2"] or ["Action", "Draw", "Infect"]
+}
+
+AiOverrideSuggestion = {
+  "OverridesTurnOrder": bool,     // ALWAYS provide all 3 booleans
+  "OverridesScoreboard": bool,
+  "OverridesDiceSet": bool
+}
+
+AiExcludedToolSuggestion = {
+  "ToolType": string,         // NOT "Type" — e.g., "Timer", "CardDeck", "Counter"
+  "Reason": string            // NOT "Justification"
+}
+
+=== ANTI-PATTERNS — STRICTLY FORBIDDEN ===
+
+- DO NOT add a counter for game-end Points/Score/VP. Points are DERIVED at end-of-game
+  from scoring categories, NEVER tracked as a running counter during the session.
+- DO NOT add a dummy TimerTools entry with DurationSeconds=0 when no timer exists.
+  If the rules state no time limit, output "TimerTools": [] (empty array).
+- DO NOT omit the Overrides object. If the game has no custom rules requiring overrides,
+  output {"OverridesTurnOrder": false, "OverridesScoreboard": false, "OverridesDiceSet": false}.
+  When the game has custom dice/scoring/turn (e.g., Wingspan), set the relevant flag to true.
+- DO NOT structure Reasoning as an array or dict. It MUST be a single string paragraph
+  with inline citations like "[excerpt 1]", "[excerpt 4]".
+- DO NOT rename DTO fields (e.g., "Type" instead of "DiceType", "Min" instead of "MinValue",
+  "Faces" instead of "CustomFaces"). Use the exact names listed in the schema above.
+
+Return ONLY valid JSON — no markdown fences, no extra text."""
+
+# Default to v2 (post-spike)
+SYSTEM_PROMPT = SYSTEM_PROMPT_V2
 
 # Identico ai 5 excerpt del spike teorico (fedeli al rulebook Wingspan)
 WINGSPAN_EXCERPTS = [
@@ -173,7 +279,14 @@ def call_openrouter(api_key: str, model: str, system: str, user: str, timeout: i
 def main() -> int:
     parser = argparse.ArgumentParser(description="Spike LLM toolkit gen")
     parser.add_argument("--model", default=None, help="Override model (default: from secret)")
+    parser.add_argument(
+        "--prompt-version", default="v2", choices=["v1", "v2"],
+        help="System prompt version (v1=pre-spike, v2=post-spike with schema strict)"
+    )
     args = parser.parse_args()
+
+    system_prompt = SYSTEM_PROMPT_V2 if args.prompt_version == "v2" else SYSTEM_PROMPT_V1
+    print(f"Prompt version: {args.prompt_version}")
 
     print("=" * 70)
     print("Spike LLM Production - Toolkit AI Generation (Wingspan)")
@@ -186,13 +299,13 @@ def main() -> int:
 
     user_prompt = build_user_prompt("Wingspan", WINGSPAN_EXCERPTS)
     print(f"User prompt:   {len(user_prompt)} chars")
-    print(f"System prompt: {len(SYSTEM_PROMPT)} chars")
+    print(f"System prompt: {len(system_prompt)} chars")
     print()
 
     t0 = time.time()
     print("Calling OpenRouter...")
     try:
-        resp = call_openrouter(api_key, model, SYSTEM_PROMPT, user_prompt)
+        resp = call_openrouter(api_key, model, system_prompt, user_prompt)
     except requests.HTTPError as e:
         print(f"FATAL HTTP: {e.response.status_code} {e.response.text[:500]}")
         return 1
@@ -268,7 +381,8 @@ def main() -> int:
                     "parse_error": parse_err,
                 },
                 "input": {
-                    "system_prompt_chars": len(SYSTEM_PROMPT),
+                    "system_prompt_chars": len(system_prompt),
+                "prompt_version": args.prompt_version,
                     "user_prompt_chars": len(user_prompt),
                     "excerpts_count": len(WINGSPAN_EXCERPTS),
                 },

--- a/claudedocs/spike-llm-output-wingspan-deepseek_deepseek-chat-2026-05-31T130516Z.json
+++ b/claudedocs/spike-llm-output-wingspan-deepseek_deepseek-chat-2026-05-31T130516Z.json
@@ -1,0 +1,122 @@
+{
+  "metadata": {
+    "model": "deepseek/deepseek-chat",
+    "timestamp_utc": "2026-05-31T130516Z",
+    "elapsed_seconds": 29.77,
+    "usage": {
+      "prompt_tokens": 1737,
+      "completion_tokens": 559,
+      "total_tokens": 2296,
+      "cost": 0.00105335,
+      "is_byok": false,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "cache_write_tokens": 0,
+        "audio_tokens": 0,
+        "video_tokens": 0
+      },
+      "cost_details": {
+        "upstream_inference_cost": 0.00105335,
+        "upstream_inference_prompt_cost": 0.00055584,
+        "upstream_inference_completions_cost": 0.00049751
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "image_tokens": 0,
+        "audio_tokens": 0
+      }
+    },
+    "parse_success": true,
+    "parse_error": null
+  },
+  "input": {
+    "system_prompt_chars": 4329,
+    "prompt_version": "v2",
+    "user_prompt_chars": 2002,
+    "excerpts_count": 5
+  },
+  "raw_content": "{\n  \"ToolkitName\": \"Wingspan\",\n  \"DiceTools\": [\n    {\n      \"Name\": \"Birdfeeder Food Dice\",\n      \"DiceType\": \"Custom\",\n      \"Quantity\": 5,\n      \"CustomFaces\": [\"invertebrate\", \"seed\", \"fruit\", \"fish\", \"rodent\", \"wild\"],\n      \"IsInteractive\": true,\n      \"Color\": null\n    }\n  ],\n  \"CounterTools\": [\n    {\n      \"Name\": \"Eggs\",\n      \"MinValue\": 0,\n      \"MaxValue\": 6,\n      \"DefaultValue\": 0,\n      \"IsPerPlayer\": true,\n      \"Icon\": null,\n      \"Color\": null\n    },\n    {\n      \"Name\": \"Food Tokens\",\n      \"MinValue\": 0,\n      \"MaxValue\": 99,\n      \"DefaultValue\": 0,\n      \"IsPerPlayer\": true,\n      \"Icon\": null,\n      \"Color\": null\n    },\n    {\n      \"Name\": \"Action Cubes\",\n      \"MinValue\": 0,\n      \"MaxValue\": 8,\n      \"DefaultValue\": 8,\n      \"IsPerPlayer\": true,\n      \"Icon\": null,\n      \"Color\": null\n    }\n  ],\n  \"TimerTools\": [],\n  \"ScoringTemplate\": {\n    \"Dimensions\": [\"Birds\", \"Bonus cards\", \"End-of-round goals\", \"Eggs\", \"Food cached\", \"Tucked cards\"],\n    \"DefaultUnit\": \"points\",\n    \"ScoreType\": \"Points\"\n  },\n  \"TurnTemplate\": {\n    \"TurnOrderType\": \"RoundRobin\",\n    \"Phases\": [\"Round 1\", \"Round 2\", \"Round 3\", \"Round 4\"]\n  },\n  \"Overrides\": {\n    \"OverridesTurnOrder\": false,\n    \"OverridesScoreboard\": false,\n    \"OverridesDiceSet\": true\n  },\n  \"Reasoning\": \"The game includes 5 custom 6-sided food dice with specific faces [excerpt 1]. Players track eggs, food tokens, and action cubes individually on their player mats [excerpt 2]. There are no timers in the game [excerpt 3]. Scoring is done at game end across 6 categories [excerpt 4]. The game is played over 4 rounds with a round-robin turn order [excerpt 5].\",\n  \"ExcludedTools\": [\n    {\n      \"ToolType\": \"Timer\",\n      \"Reason\": \"The rules state there is no time limit per turn or per round [excerpt 3]\"\n    }\n  ]\n}",
+  "parsed_json": {
+    "ToolkitName": "Wingspan",
+    "DiceTools": [
+      {
+        "Name": "Birdfeeder Food Dice",
+        "DiceType": "Custom",
+        "Quantity": 5,
+        "CustomFaces": [
+          "invertebrate",
+          "seed",
+          "fruit",
+          "fish",
+          "rodent",
+          "wild"
+        ],
+        "IsInteractive": true,
+        "Color": null
+      }
+    ],
+    "CounterTools": [
+      {
+        "Name": "Eggs",
+        "MinValue": 0,
+        "MaxValue": 6,
+        "DefaultValue": 0,
+        "IsPerPlayer": true,
+        "Icon": null,
+        "Color": null
+      },
+      {
+        "Name": "Food Tokens",
+        "MinValue": 0,
+        "MaxValue": 99,
+        "DefaultValue": 0,
+        "IsPerPlayer": true,
+        "Icon": null,
+        "Color": null
+      },
+      {
+        "Name": "Action Cubes",
+        "MinValue": 0,
+        "MaxValue": 8,
+        "DefaultValue": 8,
+        "IsPerPlayer": true,
+        "Icon": null,
+        "Color": null
+      }
+    ],
+    "TimerTools": [],
+    "ScoringTemplate": {
+      "Dimensions": [
+        "Birds",
+        "Bonus cards",
+        "End-of-round goals",
+        "Eggs",
+        "Food cached",
+        "Tucked cards"
+      ],
+      "DefaultUnit": "points",
+      "ScoreType": "Points"
+    },
+    "TurnTemplate": {
+      "TurnOrderType": "RoundRobin",
+      "Phases": [
+        "Round 1",
+        "Round 2",
+        "Round 3",
+        "Round 4"
+      ]
+    },
+    "Overrides": {
+      "OverridesTurnOrder": false,
+      "OverridesScoreboard": false,
+      "OverridesDiceSet": true
+    },
+    "Reasoning": "The game includes 5 custom 6-sided food dice with specific faces [excerpt 1]. Players track eggs, food tokens, and action cubes individually on their player mats [excerpt 2]. There are no timers in the game [excerpt 3]. Scoring is done at game end across 6 categories [excerpt 4]. The game is played over 4 rounds with a round-robin turn order [excerpt 5].",
+    "ExcludedTools": [
+      {
+        "ToolType": "Timer",
+        "Reason": "The rules state there is no time limit per turn or per round [excerpt 3]"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes **#1747** (B19-3c). Sub-issue di #1742.

Implementa validator post-LLM-call che rifiuta output con field names sbagliati / hallucinations identificate dallo spike.

## Changes

### AiToolkitSuggestionValidator (FluentValidation)
- ToolkitName non vuoto
- DiceTools/CounterTools/TimerTools not-null (vuoti consentiti)
- Reasoning non vuoto (richiede citation)
- Overrides MUST be provided (anti-pattern spike: LLM frequently omits)
- CounterTools: nessun Points/Score/VP counter (sono end-game derived)
- CounterTool: MinValue <= MaxValue, DefaultValue in [Min, Max]
- DiceTool: Custom DiceType requires CustomFaces non-vuoto
- DiceTool: Quantity > 0
- TimerTool: DurationSeconds > 0 unless TimerType=Chess
- ExcludedTool: ToolType + Reason both required

### GenerateToolkitFromKbHandler integration
- Inject IValidator<AiToolkitSuggestionDto> (optional, default fallback)
- Post-LLM-call ValidateAsync
- On invalid: log structured warning + force RequiresHumanReview=true
- Suggestion returned anyway (admin reviews via ApplyAiToolkitSuggestionCommand)

## Tests
- AiToolkitSuggestionValidatorTests: 21 unit tests
- Updated Handle_HighConfidence test to provide valid Overrides
- 21/21 + 6/6 existing handler tests passing

## Stack
Stacked su #1761 (3d) → #1760 (3a+3b) → #1744 (Step 2, gia mergiato).

Co-Authored-By: Claude Code