### PR TITLE
feat(toolkit-fe): #1749 - polymorphic ScoringPanelRenderer + TurnIndicatorRenderer

### DIFF
--- a/apps/web/src/components/toolkit/ScoringPanelRenderer.tsx
+++ b/apps/web/src/components/toolkit/ScoringPanelRenderer.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import React from 'react';
+
+import { Trophy, Hash, ListOrdered, CheckSquare, Target } from 'lucide-react';
+
+import type {
+  AiScoringTemplateSuggestion,
+  AiScoringCategorySuggestion,
+} from '@/lib/api/schemas/toolkit.schemas';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ScoringPanelRendererProps {
+  /** ScoringTemplate from the toolkit. Null if no scoring is configured. */
+  template: AiScoringTemplateSuggestion | null;
+  /** Optional per-player score values (id → score). When provided, renders read-only mini-scoreboard inline. */
+  scores?: Record<string, number>;
+  /** Optional player metadata for inline scoreboard. */
+  players?: ReadonlyArray<{ id: string; name: string }>;
+  /** Test id passthrough. */
+  'data-testid'?: string;
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+function ScoringEmpty({ testId }: { testId?: string }) {
+  return (
+    <div
+      className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-muted/30 p-4 text-muted-foreground"
+      data-testid={testId ?? 'scoring-panel-empty'}
+    >
+      <Trophy className="h-8 w-8 opacity-30" aria-hidden="true" />
+      <p className="text-sm">No scoring template configured for this game.</p>
+    </div>
+  );
+}
+
+// ── Per-category computation icon ─────────────────────────────────────────────
+
+function CategoryIcon({
+  computation,
+}: {
+  computation: AiScoringCategorySuggestion['computation'];
+}) {
+  const className = 'h-4 w-4';
+  switch (computation) {
+    case 'Count':
+      return <Hash className={className} aria-hidden="true" />;
+    case 'Sum':
+      return <ListOrdered className={className} aria-hidden="true" />;
+    case 'RankBased':
+      return <Trophy className={className} aria-hidden="true" />;
+    case 'Custom':
+      return <CheckSquare className={className} aria-hidden="true" />;
+    default:
+      return <Target className={className} aria-hidden="true" />;
+  }
+}
+
+// ── ScoreType-specific layouts ────────────────────────────────────────────────
+
+function CategoryRow({ category }: { category: AiScoringCategorySuggestion }) {
+  return (
+    <div
+      className="flex items-start gap-3 rounded-md border border-border bg-card p-3"
+      data-testid={`scoring-category-${category.id}`}
+      data-computation={category.computation}
+    >
+      <div className="mt-0.5 shrink-0 text-muted-foreground">
+        <CategoryIcon computation={category.computation} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate font-medium text-foreground">{category.label}</p>
+          {category.weight !== 1 && (
+            <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              ×{category.weight}
+            </span>
+          )}
+        </div>
+        {category.description && (
+          <p className="mt-1 text-xs text-muted-foreground">{category.description}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PointsLayout({
+  template,
+  scores,
+  players,
+}: {
+  template: AiScoringTemplateSuggestion;
+  scores?: Record<string, number>;
+  players?: ReadonlyArray<{ id: string; name: string }>;
+}) {
+  const categories = template.categories ?? null;
+  return (
+    <div className="space-y-3">
+      {categories && categories.length > 0 ? (
+        <div className="space-y-2" data-testid="scoring-categories">
+          {categories.map(c => (
+            <CategoryRow key={c.id} category={c} />
+          ))}
+        </div>
+      ) : (
+        <ul
+          className="flex flex-wrap gap-2"
+          data-testid="scoring-dimensions-legacy"
+          aria-label="Scoring dimensions"
+        >
+          {template.dimensions.map(dim => (
+            <li key={dim} className="rounded-full bg-muted px-3 py-1 text-sm text-foreground">
+              {dim}
+            </li>
+          ))}
+        </ul>
+      )}
+      {scores && players && players.length > 0 && (
+        <InlineScoreboard scores={scores} players={players} unit={template.defaultUnit} />
+      )}
+    </div>
+  );
+}
+
+function RankingLayout({
+  template,
+  scores,
+  players,
+}: {
+  template: AiScoringTemplateSuggestion;
+  scores?: Record<string, number>;
+  players?: ReadonlyArray<{ id: string; name: string }>;
+}) {
+  // Ranking: prefer scores when provided, sort descending
+  if (scores && players && players.length > 0) {
+    const ranked = players
+      .map(p => ({ ...p, score: scores[p.id] ?? 0 }))
+      .sort((a, b) => b.score - a.score);
+    return (
+      <ol className="space-y-1" data-testid="scoring-ranking">
+        {ranked.map((p, i) => (
+          <li
+            key={p.id}
+            className="flex items-center justify-between gap-2 rounded-md border border-border bg-card px-3 py-2"
+          >
+            <span className="flex items-center gap-2">
+              <span
+                className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ${
+                  i === 0 ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+                }`}
+              >
+                {i + 1}
+              </span>
+              <span className="text-foreground">{p.name}</span>
+            </span>
+            <span className="font-mono text-sm text-muted-foreground">
+              {p.score} {template.defaultUnit}
+            </span>
+          </li>
+        ))}
+      </ol>
+    );
+  }
+  return (
+    <p className="text-sm text-muted-foreground" data-testid="scoring-ranking-empty">
+      Ranking will appear once scores are recorded.
+    </p>
+  );
+}
+
+function BinaryWinLayout({ scores }: { scores?: Record<string, number> }) {
+  // BinaryWin: no points, just win/lose collective. Show generic indicator.
+  const hasScore = scores && Object.keys(scores).length > 0;
+  return (
+    <div
+      className="flex flex-col items-center gap-2 rounded-md border border-border bg-card p-4 text-center"
+      data-testid="scoring-binary-win"
+    >
+      <Target className="h-8 w-8 text-primary" aria-hidden="true" />
+      <p className="text-sm font-medium text-foreground">
+        {hasScore ? 'Outcome recorded — see session summary.' : 'Win/lose tracked at game end.'}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        This game has no continuous scoring; the result is collective.
+      </p>
+    </div>
+  );
+}
+
+function ObjectivesLayout({
+  template,
+  scores,
+}: {
+  template: AiScoringTemplateSuggestion;
+  scores?: Record<string, number>;
+}) {
+  // Objectives: list of dimensions as checkboxes (read-only, requires controlled state for interaction)
+  return (
+    <div className="space-y-2" data-testid="scoring-objectives">
+      {template.dimensions.map(dim => (
+        <div
+          key={dim}
+          className="flex items-center gap-3 rounded-md border border-border bg-card p-3"
+        >
+          <CheckSquare className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          <span className="flex-1 text-sm text-foreground">{dim}</span>
+          {scores?.[dim] !== undefined && (
+            <span className="font-mono text-xs text-muted-foreground">{scores[dim]}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function InlineScoreboard({
+  scores,
+  players,
+  unit,
+}: {
+  scores: Record<string, number>;
+  players: ReadonlyArray<{ id: string; name: string }>;
+  unit: string;
+}) {
+  return (
+    <div
+      className="rounded-md border border-border bg-muted/30 p-3"
+      data-testid="scoring-inline-scoreboard"
+    >
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Live scoreboard
+      </p>
+      <ul className="space-y-1">
+        {players.map(p => (
+          <li key={p.id} className="flex items-center justify-between text-sm">
+            <span className="text-foreground">{p.name}</span>
+            <span className="font-mono text-muted-foreground">
+              {scores[p.id] ?? 0} {unit}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ── Main dispatcher ───────────────────────────────────────────────────────────
+
+/**
+ * ScoringPanelRenderer — polymorphic UI for the ScoringTemplate of a toolkit.
+ *
+ * Issue #1749 (B19-4a). Switches on ScoreType to render the most appropriate
+ * UI for each scoring model:
+ *
+ * - **Points**: list of scoring categories (when v3 Categories[] provided)
+ *   or flat list of dimensions (legacy); optional inline scoreboard.
+ * - **Ranking**: live ordered list with rank pills; falls back to placeholder
+ *   when no scores recorded yet.
+ * - **BinaryWin**: collective outcome indicator (co-op games like Paleo).
+ * - **Objectives**: checklist of objectives (goal-oriented games like Codenames).
+ *
+ * Unknown ScoreType falls back to Points layout for graceful degradation.
+ */
+export function ScoringPanelRenderer({
+  template,
+  scores,
+  players,
+  'data-testid': testId,
+}: ScoringPanelRendererProps) {
+  if (!template) {
+    return <ScoringEmpty testId={testId} />;
+  }
+
+  const scoreType = template.scoreType;
+  let body: React.ReactNode;
+  switch (scoreType) {
+    case 'Points':
+      body = <PointsLayout template={template} scores={scores} players={players} />;
+      break;
+    case 'Ranking':
+      body = <RankingLayout template={template} scores={scores} players={players} />;
+      break;
+    case 'BinaryWin':
+      body = <BinaryWinLayout scores={scores} />;
+      break;
+    case 'Objectives':
+      body = <ObjectivesLayout template={template} scores={scores} />;
+      break;
+    default:
+      // Graceful degradation: unknown ScoreType → render as Points
+      body = <PointsLayout template={template} scores={scores} players={players} />;
+      break;
+  }
+
+  return (
+    <section
+      className="flex flex-col gap-3"
+      data-testid={testId ?? 'scoring-panel'}
+      data-score-type={scoreType}
+      aria-label="Scoring panel"
+    >
+      {body}
+    </section>
+  );
+}

--- a/apps/web/src/components/toolkit/TurnIndicatorRenderer.tsx
+++ b/apps/web/src/components/toolkit/TurnIndicatorRenderer.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import React from 'react';
+
+import { ArrowRight, Users, Zap, Activity, Infinity as InfinityIcon, RotateCw } from 'lucide-react';
+
+import type { AiTurnTemplateSuggestion } from '@/lib/api/schemas/toolkit.schemas';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface TurnIndicatorRendererProps {
+  /** TurnTemplate from the toolkit. Null if no turn structure is configured. */
+  template: AiTurnTemplateSuggestion | null;
+  /** Current round (1-indexed). Optional. */
+  currentRound?: number;
+  /** Current turn within the round (1-indexed). Optional. */
+  currentTurn?: number;
+  /** Current phase id (when game uses phases). Optional. */
+  currentPhaseIndex?: number;
+  /** Active player id/name for sequential modes. */
+  activePlayer?: { id: string; name: string } | null;
+  /** All players, used to highlight everyone in Simultaneous mode. */
+  players?: ReadonlyArray<{ id: string; name: string }>;
+  'data-testid'?: string;
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+function TurnEmpty({ testId }: { testId?: string }) {
+  return (
+    <div
+      className="flex min-h-24 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-muted/30 p-4 text-muted-foreground"
+      data-testid={testId ?? 'turn-indicator-empty'}
+    >
+      <RotateCw className="h-6 w-6 opacity-30" aria-hidden="true" />
+      <p className="text-sm">No turn structure configured for this game.</p>
+    </div>
+  );
+}
+
+// ── Subcomponents ─────────────────────────────────────────────────────────────
+
+function RoundProgress({
+  rounds,
+  currentRound,
+  turnsPerRound,
+  currentTurn,
+}: {
+  rounds: number;
+  currentRound?: number;
+  turnsPerRound?: number[] | null;
+  currentTurn?: number;
+}) {
+  const round = currentRound ?? 1;
+  const turn = currentTurn ?? 1;
+  const totalTurns = turnsPerRound?.[round - 1];
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md bg-muted px-3 py-1 text-xs font-mono"
+      data-testid="turn-round-progress"
+    >
+      <span className="font-semibold text-foreground">
+        Round {round}/{rounds}
+      </span>
+      {totalTurns !== undefined && (
+        <>
+          <span className="text-muted-foreground">·</span>
+          <span className="text-muted-foreground">
+            Turn {turn}/{totalTurns}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PhaseStepper({
+  phases,
+  currentPhaseIndex,
+}: {
+  phases: string[];
+  currentPhaseIndex?: number;
+}) {
+  const idx = currentPhaseIndex ?? 0;
+  return (
+    <ol
+      className="flex flex-wrap items-center gap-1 text-xs"
+      data-testid="turn-phase-stepper"
+      aria-label="Phases"
+    >
+      {phases.map((phase, i) => (
+        <React.Fragment key={`${i}-${phase}`}>
+          <li
+            className={`rounded-full px-2 py-1 ${
+              i === idx
+                ? 'bg-primary text-primary-foreground font-medium'
+                : i < idx
+                  ? 'bg-muted text-muted-foreground line-through opacity-60'
+                  : 'bg-muted text-foreground'
+            }`}
+            aria-current={i === idx ? 'step' : undefined}
+          >
+            {phase}
+          </li>
+          {i < phases.length - 1 && (
+            <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+          )}
+        </React.Fragment>
+      ))}
+    </ol>
+  );
+}
+
+function ActivePlayerBadge({
+  player,
+  direction,
+}: {
+  player: { id: string; name: string } | null | undefined;
+  direction?: string | null;
+}) {
+  if (!player) {
+    return (
+      <span
+        className="rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground"
+        data-testid="turn-active-player-empty"
+      >
+        Waiting for active player…
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary"
+      data-testid="turn-active-player"
+    >
+      <ArrowRight className="h-3 w-3" aria-hidden="true" />
+      {player.name}
+      {direction && direction !== 'none' && (
+        <span className="ml-1 text-[10px] uppercase tracking-wide opacity-70">{direction}</span>
+      )}
+    </span>
+  );
+}
+
+function SimultaneousPlayersBadge({
+  players,
+}: {
+  players: ReadonlyArray<{ id: string; name: string }>;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs" data-testid="turn-simultaneous-players">
+      <Users className="h-4 w-4 text-primary" aria-hidden="true" />
+      <span className="text-muted-foreground">All players act simultaneously:</span>
+      <span className="flex flex-wrap gap-1">
+        {players.map(p => (
+          <span key={p.id} className="rounded-full bg-primary/10 px-2 py-0.5 text-primary">
+            {p.name}
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}
+
+function RealtimeBanner() {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md bg-warning/10 px-3 py-2 text-xs"
+      data-testid="turn-realtime-banner"
+    >
+      <Zap className="h-4 w-4 text-warning" aria-hidden="true" />
+      <span className="font-medium text-warning">Real-time play</span>
+      <span className="text-muted-foreground">— no turns, react fast.</span>
+    </div>
+  );
+}
+
+function NoneBanner() {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground"
+      data-testid="turn-none-banner"
+    >
+      <InfinityIcon className="h-4 w-4" aria-hidden="true" />
+      <span>No turn order — open play.</span>
+    </div>
+  );
+}
+
+// ── Per-TurnOrderType layouts ─────────────────────────────────────────────────
+
+interface LayoutContext {
+  template: AiTurnTemplateSuggestion;
+  currentRound?: number;
+  currentTurn?: number;
+  currentPhaseIndex?: number;
+  activePlayer?: { id: string; name: string } | null;
+  players?: ReadonlyArray<{ id: string; name: string }>;
+}
+
+function RoundRobinLayout(ctx: LayoutContext) {
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ActivePlayerBadge player={ctx.activePlayer} direction={ctx.template.direction} />
+        {ctx.template.rounds && (
+          <RoundProgress
+            rounds={ctx.template.rounds}
+            currentRound={ctx.currentRound}
+            turnsPerRound={ctx.template.turnsPerRound}
+            currentTurn={ctx.currentTurn}
+          />
+        )}
+      </div>
+      {ctx.template.phases.length > 0 && (
+        <PhaseStepper phases={ctx.template.phases} currentPhaseIndex={ctx.currentPhaseIndex} />
+      )}
+    </div>
+  );
+}
+
+function SequentialLayout(ctx: LayoutContext) {
+  // Sequential (team-based, e.g. Codenames): same as RoundRobin but phases drive flow more than active player.
+  return (
+    <div className="space-y-2">
+      {ctx.template.phases.length > 0 && (
+        <PhaseStepper phases={ctx.template.phases} currentPhaseIndex={ctx.currentPhaseIndex} />
+      )}
+      {ctx.activePlayer && (
+        <ActivePlayerBadge player={ctx.activePlayer} direction={ctx.template.direction} />
+      )}
+    </div>
+  );
+}
+
+function SimultaneousLayout(ctx: LayoutContext) {
+  return (
+    <div className="space-y-2">
+      {ctx.players && ctx.players.length > 0 && <SimultaneousPlayersBadge players={ctx.players} />}
+      {ctx.template.phases.length > 0 && (
+        <PhaseStepper phases={ctx.template.phases} currentPhaseIndex={ctx.currentPhaseIndex} />
+      )}
+    </div>
+  );
+}
+
+function RealtimeLayout(ctx: LayoutContext) {
+  return (
+    <div className="space-y-2">
+      <RealtimeBanner />
+      {ctx.template.phases.length > 0 && (
+        <PhaseStepper phases={ctx.template.phases} currentPhaseIndex={ctx.currentPhaseIndex} />
+      )}
+    </div>
+  );
+}
+
+function NoneLayout(_ctx: LayoutContext) {
+  return <NoneBanner />;
+}
+
+function CustomLayout(ctx: LayoutContext) {
+  // Custom/Free: render whatever info we have without strong assumptions
+  return (
+    <div className="space-y-2">
+      <span
+        className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground"
+        data-testid="turn-custom-indicator"
+      >
+        <Activity className="h-3 w-3" aria-hidden="true" />
+        Custom turn order
+      </span>
+      {ctx.template.phases.length > 0 && (
+        <PhaseStepper phases={ctx.template.phases} currentPhaseIndex={ctx.currentPhaseIndex} />
+      )}
+      {ctx.activePlayer && (
+        <ActivePlayerBadge player={ctx.activePlayer} direction={ctx.template.direction} />
+      )}
+    </div>
+  );
+}
+
+// ── Lookup table for dispatch ─────────────────────────────────────────────────
+
+type LayoutFn = (ctx: LayoutContext) => React.ReactElement;
+
+const LAYOUT_REGISTRY: Readonly<Record<string, LayoutFn>> = Object.freeze({
+  RoundRobin: RoundRobinLayout,
+  Sequential: SequentialLayout,
+  Simultaneous: SimultaneousLayout,
+  Realtime: RealtimeLayout,
+  None: NoneLayout,
+  Custom: CustomLayout,
+  Free: CustomLayout,
+});
+
+// ── Main dispatcher ───────────────────────────────────────────────────────────
+
+/**
+ * TurnIndicatorRenderer — polymorphic UI for the TurnTemplate of a toolkit.
+ *
+ * Issue #1749 (B19-4a). Switches on TurnOrderType to render the appropriate
+ * indicator for each turn pattern:
+ *
+ * - **RoundRobin**: active player badge + round progress (Round X/Y · Turn N/M)
+ *   when v3 Rounds/TurnsPerRound are provided. Phase stepper if Phases present.
+ * - **Sequential** (team-based): phase stepper takes precedence over active player.
+ * - **Simultaneous**: shows all players highlighted together (co-op like Paleo).
+ * - **Realtime**: warning banner — no turns, time-pressure play.
+ * - **None**: open-play indicator.
+ * - **Custom / Free**: generic custom-turn indicator + phases if any.
+ *
+ * Unknown TurnOrderType falls back to Custom layout.
+ */
+export function TurnIndicatorRenderer({
+  template,
+  currentRound,
+  currentTurn,
+  currentPhaseIndex,
+  activePlayer,
+  players,
+  'data-testid': testId,
+}: TurnIndicatorRendererProps) {
+  if (!template) {
+    return <TurnEmpty testId={testId} />;
+  }
+
+  const ctx: LayoutContext = {
+    template,
+    currentRound,
+    currentTurn,
+    currentPhaseIndex,
+    activePlayer,
+    players,
+  };
+
+  const layout = LAYOUT_REGISTRY[template.turnOrderType] ?? CustomLayout;
+
+  return (
+    <section
+      className="flex flex-col gap-2"
+      data-testid={testId ?? 'turn-indicator'}
+      data-turn-order-type={template.turnOrderType}
+      aria-label="Turn indicator"
+    >
+      {layout(ctx)}
+    </section>
+  );
+}

--- a/apps/web/src/components/toolkit/__tests__/ScoringPanelRenderer.test.tsx
+++ b/apps/web/src/components/toolkit/__tests__/ScoringPanelRenderer.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * ScoringPanelRenderer tests (issue #1749 B19-4a).
+ *
+ * Covers all 4 ScoreType variants + null template + Categories[] vs legacy
+ * Dimensions[] back-compat + inline scoreboard rendering.
+ */
+
+import React from 'react';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ScoringPanelRenderer } from '../ScoringPanelRenderer';
+import type {
+  AiScoringTemplateSuggestion,
+  AiScoringCategorySuggestion,
+} from '@/lib/api/schemas/toolkit.schemas';
+
+const PLAYERS = [
+  { id: 'p1', name: 'Alice' },
+  { id: 'p2', name: 'Bob' },
+  { id: 'p3', name: 'Carol' },
+] as const;
+
+const WINGSPAN_CATEGORIES: AiScoringCategorySuggestion[] = [
+  { id: 'birds', label: 'Birds played', computation: 'Sum', weight: 1 },
+  { id: 'bonus', label: 'Bonus cards', computation: 'Sum', weight: 1 },
+  { id: 'eggs', label: 'Eggs', computation: 'Count', weight: 1 },
+  {
+    id: 'round-goals',
+    label: 'End-of-round goals',
+    computation: 'RankBased',
+    weight: 1,
+    description: '5/2/1',
+  },
+];
+
+const WINGSPAN_TEMPLATE: AiScoringTemplateSuggestion = {
+  dimensions: ['Birds', 'Bonus cards', 'Eggs', 'End-of-round goals'],
+  defaultUnit: 'points',
+  scoreType: 'Points',
+  categories: WINGSPAN_CATEGORIES,
+};
+
+const LEGACY_TEMPLATE: AiScoringTemplateSuggestion = {
+  dimensions: ['Victory Points', 'Settlements'],
+  defaultUnit: 'points',
+  scoreType: 'Points',
+  // No categories — legacy shape
+};
+
+const CATAN_RANKING: AiScoringTemplateSuggestion = {
+  dimensions: ['Total VP'],
+  defaultUnit: 'points',
+  scoreType: 'Ranking',
+};
+
+const PALEO_BINARY: AiScoringTemplateSuggestion = {
+  dimensions: ['Win condition'],
+  defaultUnit: 'result',
+  scoreType: 'BinaryWin',
+};
+
+const CODENAMES_OBJECTIVES: AiScoringTemplateSuggestion = {
+  dimensions: ['Red agents revealed', 'Blue agents revealed', 'Assassin avoided'],
+  defaultUnit: 'tiles',
+  scoreType: 'Objectives',
+};
+
+describe('ScoringPanelRenderer', () => {
+  describe('empty / null template', () => {
+    it('renders empty state when template is null', () => {
+      render(<ScoringPanelRenderer template={null} />);
+      expect(screen.getByTestId('scoring-panel-empty')).toBeInTheDocument();
+      expect(screen.getByText(/no scoring template/i)).toBeInTheDocument();
+    });
+
+    it('respects custom data-testid in empty state', () => {
+      render(<ScoringPanelRenderer template={null} data-testid="custom-id" />);
+      expect(screen.getByTestId('custom-id')).toBeInTheDocument();
+    });
+  });
+
+  describe('Points layout (Wingspan v3 categories)', () => {
+    it('renders all 4 categories with their computation icons', () => {
+      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} />);
+      expect(screen.getByTestId('scoring-categories')).toBeInTheDocument();
+      WINGSPAN_CATEGORIES.forEach(c => {
+        expect(screen.getByTestId(`scoring-category-${c.id}`)).toBeInTheDocument();
+        expect(screen.getByText(c.label)).toBeInTheDocument();
+      });
+    });
+
+    it('exposes computation type via data attribute for testability', () => {
+      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} />);
+      expect(screen.getByTestId('scoring-category-birds')).toHaveAttribute(
+        'data-computation',
+        'Sum'
+      );
+      expect(screen.getByTestId('scoring-category-eggs')).toHaveAttribute(
+        'data-computation',
+        'Count'
+      );
+      expect(screen.getByTestId('scoring-category-round-goals')).toHaveAttribute(
+        'data-computation',
+        'RankBased'
+      );
+    });
+
+    it('shows description when category has one', () => {
+      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} />);
+      expect(screen.getByText('5/2/1')).toBeInTheDocument();
+    });
+
+    it('shows weight badge only when weight !== 1', () => {
+      const customWeight: AiScoringTemplateSuggestion = {
+        ...WINGSPAN_TEMPLATE,
+        categories: [
+          { id: 'doubled', label: 'Doubled cat', computation: 'Sum', weight: 2 },
+          { id: 'normal', label: 'Normal cat', computation: 'Sum', weight: 1 },
+        ],
+      };
+      render(<ScoringPanelRenderer template={customWeight} />);
+      expect(screen.getByText('×2')).toBeInTheDocument();
+      expect(screen.queryByText('×1')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Points layout (legacy dimensions only)', () => {
+    it('falls back to legacy dimensions chip list when no categories', () => {
+      render(<ScoringPanelRenderer template={LEGACY_TEMPLATE} />);
+      expect(screen.getByTestId('scoring-dimensions-legacy')).toBeInTheDocument();
+      expect(screen.queryByTestId('scoring-categories')).not.toBeInTheDocument();
+      LEGACY_TEMPLATE.dimensions.forEach(d => {
+        expect(screen.getByText(d)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Ranking layout', () => {
+    it('renders ranked list with rank pills when scores provided', () => {
+      const scores = { p1: 12, p2: 8, p3: 15 };
+      render(
+        <ScoringPanelRenderer template={CATAN_RANKING} scores={scores} players={PLAYERS as never} />
+      );
+      const ranking = screen.getByTestId('scoring-ranking');
+      expect(ranking).toBeInTheDocument();
+      const items = ranking.querySelectorAll('li');
+      expect(items).toHaveLength(3);
+      // Carol (15) > Alice (12) > Bob (8)
+      expect(items[0]).toHaveTextContent('Carol');
+      expect(items[1]).toHaveTextContent('Alice');
+      expect(items[2]).toHaveTextContent('Bob');
+    });
+
+    it('shows placeholder when no scores recorded yet', () => {
+      render(<ScoringPanelRenderer template={CATAN_RANKING} players={PLAYERS as never} />);
+      expect(screen.getByTestId('scoring-ranking-empty')).toBeInTheDocument();
+    });
+
+    it('handles missing player scores as 0', () => {
+      const scores = { p1: 10 };
+      render(
+        <ScoringPanelRenderer template={CATAN_RANKING} scores={scores} players={PLAYERS as never} />
+      );
+      const ranking = screen.getByTestId('scoring-ranking');
+      // p2 and p3 missing → both 0, p1 wins
+      expect(ranking.querySelectorAll('li')[0]).toHaveTextContent('Alice');
+    });
+  });
+
+  describe('BinaryWin layout', () => {
+    it('renders collective outcome indicator', () => {
+      render(<ScoringPanelRenderer template={PALEO_BINARY} />);
+      expect(screen.getByTestId('scoring-binary-win')).toBeInTheDocument();
+      expect(screen.getByText(/win\/lose tracked at game end/i)).toBeInTheDocument();
+    });
+
+    it('changes message when scores present', () => {
+      render(<ScoringPanelRenderer template={PALEO_BINARY} scores={{ result: 1 }} />);
+      expect(screen.getByText(/outcome recorded/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Objectives layout', () => {
+    it('renders each dimension as a checkable row', () => {
+      render(<ScoringPanelRenderer template={CODENAMES_OBJECTIVES} />);
+      expect(screen.getByTestId('scoring-objectives')).toBeInTheDocument();
+      CODENAMES_OBJECTIVES.dimensions.forEach(d => {
+        expect(screen.getByText(d)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('inline scoreboard (Points mode)', () => {
+    it('renders inline scoreboard when scores+players provided', () => {
+      const scores = { p1: 25, p2: 18, p3: 22 };
+      render(
+        <ScoringPanelRenderer
+          template={WINGSPAN_TEMPLATE}
+          scores={scores}
+          players={PLAYERS as never}
+        />
+      );
+      const board = screen.getByTestId('scoring-inline-scoreboard');
+      expect(board).toBeInTheDocument();
+      // Verify it renders 3 players with their scores
+      expect(board).toHaveTextContent('Alice');
+      expect(board).toHaveTextContent('25');
+      expect(board).toHaveTextContent('Bob');
+      expect(board).toHaveTextContent('18');
+    });
+
+    it('skips inline scoreboard when only players provided without scores', () => {
+      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} players={PLAYERS as never} />);
+      expect(screen.queryByTestId('scoring-inline-scoreboard')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('unknown scoreType', () => {
+    it('falls back to Points layout for unknown scoreType', () => {
+      const unknown: AiScoringTemplateSuggestion = {
+        ...LEGACY_TEMPLATE,
+        scoreType: 'TotallyMadeUp',
+      };
+      const { container } = render(<ScoringPanelRenderer template={unknown} />);
+      // Should not crash, should render legacy dimensions
+      expect(screen.getByTestId('scoring-dimensions-legacy')).toBeInTheDocument();
+      // Section data attribute reflects the (unknown) score type for debugging
+      const section = container.querySelector('[data-score-type]');
+      expect(section).toHaveAttribute('data-score-type', 'TotallyMadeUp');
+    });
+  });
+});

--- a/apps/web/src/components/toolkit/__tests__/TurnIndicatorRenderer.test.tsx
+++ b/apps/web/src/components/toolkit/__tests__/TurnIndicatorRenderer.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * TurnIndicatorRenderer tests (issue #1749 B19-4a).
+ *
+ * Covers all 7 TurnOrderType variants + null template + Rounds/TurnsPerRound +
+ * phase stepper + active player + simultaneous players.
+ */
+
+import React from 'react';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { TurnIndicatorRenderer } from '../TurnIndicatorRenderer';
+import type { AiTurnTemplateSuggestion } from '@/lib/api/schemas/toolkit.schemas';
+
+const PLAYERS = [
+  { id: 'p1', name: 'Alice' },
+  { id: 'p2', name: 'Bob' },
+] as const;
+
+const WINGSPAN_TURN: AiTurnTemplateSuggestion = {
+  turnOrderType: 'RoundRobin',
+  phases: ['Round 1', 'Round 2', 'Round 3', 'Round 4'],
+  rounds: 4,
+  turnsPerRound: [8, 7, 6, 5],
+  turnActions: ['play-bird', 'get-food', 'lay-eggs', 'draw-cards'],
+  direction: 'clockwise',
+};
+
+const CODENAMES_TURN: AiTurnTemplateSuggestion = {
+  turnOrderType: 'Sequential',
+  phases: ['Red Spymaster clue', 'Red guess', 'Blue Spymaster clue', 'Blue guess'],
+};
+
+const PALEO_TURN: AiTurnTemplateSuggestion = {
+  turnOrderType: 'Simultaneous',
+  phases: ['Morning', 'Day', 'Night'],
+};
+
+const CAPTAIN_SONAR_TURN: AiTurnTemplateSuggestion = {
+  turnOrderType: 'Realtime',
+  phases: ['Mission'],
+};
+
+const NONE_TURN: AiTurnTemplateSuggestion = {
+  turnOrderType: 'None',
+  phases: [],
+};
+
+const CUSTOM_TURN: AiTurnTemplateSuggestion = {
+  turnOrderType: 'Custom',
+  phases: ['Setup', 'Play', 'Cleanup'],
+};
+
+describe('TurnIndicatorRenderer', () => {
+  describe('empty / null template', () => {
+    it('renders empty state when template is null', () => {
+      render(<TurnIndicatorRenderer template={null} />);
+      expect(screen.getByTestId('turn-indicator-empty')).toBeInTheDocument();
+    });
+
+    it('respects custom data-testid in empty state', () => {
+      render(<TurnIndicatorRenderer template={null} data-testid="custom-turn-id" />);
+      expect(screen.getByTestId('custom-turn-id')).toBeInTheDocument();
+    });
+  });
+
+  describe('RoundRobin (Wingspan-like)', () => {
+    it('renders round progress with TurnsPerRound', () => {
+      render(
+        <TurnIndicatorRenderer
+          template={WINGSPAN_TURN}
+          currentRound={2}
+          currentTurn={3}
+          activePlayer={PLAYERS[0]}
+        />
+      );
+      const progress = screen.getByTestId('turn-round-progress');
+      expect(progress).toHaveTextContent('Round 2/4');
+      expect(progress).toHaveTextContent('Turn 3/7'); // round 2 has 7 turns
+    });
+
+    it('shows active player with direction', () => {
+      render(<TurnIndicatorRenderer template={WINGSPAN_TURN} activePlayer={PLAYERS[1]} />);
+      const badge = screen.getByTestId('turn-active-player');
+      expect(badge).toHaveTextContent('Bob');
+      expect(badge).toHaveTextContent('clockwise');
+    });
+
+    it('renders phase stepper with currentPhaseIndex highlight', () => {
+      render(
+        <TurnIndicatorRenderer
+          template={WINGSPAN_TURN}
+          currentPhaseIndex={1}
+          activePlayer={PLAYERS[0]}
+        />
+      );
+      const stepper = screen.getByTestId('turn-phase-stepper');
+      expect(stepper).toBeInTheDocument();
+      // The currently active phase has aria-current="step"
+      const currentStep = stepper.querySelector('[aria-current="step"]');
+      expect(currentStep).toHaveTextContent('Round 2');
+    });
+
+    it('shows waiting state when no active player', () => {
+      render(<TurnIndicatorRenderer template={WINGSPAN_TURN} />);
+      expect(screen.getByTestId('turn-active-player-empty')).toBeInTheDocument();
+    });
+
+    it('exposes turn order type via data attribute', () => {
+      const { container } = render(
+        <TurnIndicatorRenderer template={WINGSPAN_TURN} activePlayer={PLAYERS[0]} />
+      );
+      expect(container.querySelector('[data-turn-order-type]')).toHaveAttribute(
+        'data-turn-order-type',
+        'RoundRobin'
+      );
+    });
+  });
+
+  describe('Sequential (Codenames-like team)', () => {
+    it('renders phase stepper as primary indicator', () => {
+      render(<TurnIndicatorRenderer template={CODENAMES_TURN} currentPhaseIndex={0} />);
+      const stepper = screen.getByTestId('turn-phase-stepper');
+      expect(stepper).toBeInTheDocument();
+      const currentStep = stepper.querySelector('[aria-current="step"]');
+      expect(currentStep).toHaveTextContent('Red Spymaster clue');
+    });
+
+    it('omits active player badge when not provided', () => {
+      render(<TurnIndicatorRenderer template={CODENAMES_TURN} />);
+      expect(screen.queryByTestId('turn-active-player')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('turn-active-player-empty')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Simultaneous (Paleo-like co-op)', () => {
+    it('renders all-players badge', () => {
+      render(<TurnIndicatorRenderer template={PALEO_TURN} players={PLAYERS as never} />);
+      const badge = screen.getByTestId('turn-simultaneous-players');
+      expect(badge).toHaveTextContent('Alice');
+      expect(badge).toHaveTextContent('Bob');
+      expect(badge).toHaveTextContent(/all players act simultaneously/i);
+    });
+
+    it('renders phase stepper alongside simultaneous indicator', () => {
+      render(
+        <TurnIndicatorRenderer
+          template={PALEO_TURN}
+          players={PLAYERS as never}
+          currentPhaseIndex={1}
+        />
+      );
+      expect(screen.getByTestId('turn-simultaneous-players')).toBeInTheDocument();
+      const stepper = screen.getByTestId('turn-phase-stepper');
+      const currentStep = stepper.querySelector('[aria-current="step"]');
+      expect(currentStep).toHaveTextContent('Day');
+    });
+
+    it('handles no players gracefully', () => {
+      render(<TurnIndicatorRenderer template={PALEO_TURN} />);
+      expect(screen.queryByTestId('turn-simultaneous-players')).not.toBeInTheDocument();
+      // But the section still renders
+      expect(screen.getByTestId('turn-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('Realtime (Captain Sonar-like)', () => {
+    it('renders warning banner', () => {
+      render(<TurnIndicatorRenderer template={CAPTAIN_SONAR_TURN} />);
+      const banner = screen.getByTestId('turn-realtime-banner');
+      expect(banner).toBeInTheDocument();
+      expect(banner).toHaveTextContent(/real-time play/i);
+    });
+  });
+
+  describe('None (no turn structure)', () => {
+    it('renders open-play banner', () => {
+      render(<TurnIndicatorRenderer template={NONE_TURN} />);
+      expect(screen.getByTestId('turn-none-banner')).toBeInTheDocument();
+      expect(screen.getByText(/no turn order/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Custom / Free', () => {
+    it('renders Custom indicator', () => {
+      render(<TurnIndicatorRenderer template={CUSTOM_TURN} currentPhaseIndex={1} />);
+      expect(screen.getByTestId('turn-custom-indicator')).toBeInTheDocument();
+      const stepper = screen.getByTestId('turn-phase-stepper');
+      expect(stepper.querySelector('[aria-current="step"]')).toHaveTextContent('Play');
+    });
+
+    it('Free aliases to Custom layout', () => {
+      const free: AiTurnTemplateSuggestion = { ...CUSTOM_TURN, turnOrderType: 'Free' };
+      render(<TurnIndicatorRenderer template={free} />);
+      expect(screen.getByTestId('turn-custom-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('unknown turnOrderType', () => {
+    it('falls back to Custom layout gracefully', () => {
+      const unknown: AiTurnTemplateSuggestion = {
+        turnOrderType: 'TotallyInvented',
+        phases: ['Phase A'],
+      };
+      render(<TurnIndicatorRenderer template={unknown} />);
+      // Custom layout renders custom indicator
+      expect(screen.getByTestId('turn-custom-indicator')).toBeInTheDocument();
+    });
+  });
+
+  describe('phase stepper edge cases', () => {
+    it('hides phase stepper when phases array is empty', () => {
+      const noPhases: AiTurnTemplateSuggestion = {
+        turnOrderType: 'RoundRobin',
+        phases: [],
+        rounds: 4,
+        turnsPerRound: [8, 7, 6, 5],
+      };
+      render(<TurnIndicatorRenderer template={noPhases} activePlayer={PLAYERS[0]} />);
+      expect(screen.queryByTestId('turn-phase-stepper')).not.toBeInTheDocument();
+    });
+
+    it('handles currentPhaseIndex past end gracefully (no aria-current set)', () => {
+      render(<TurnIndicatorRenderer template={CUSTOM_TURN} currentPhaseIndex={99} />);
+      const stepper = screen.getByTestId('turn-phase-stepper');
+      // No phase is at index 99 → no aria-current
+      expect(stepper.querySelector('[aria-current="step"]')).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/toolkit/index.ts
+++ b/apps/web/src/components/toolkit/index.ts
@@ -15,3 +15,8 @@ export { NoteManagerWidget } from './NoteManagerWidget';
 export { WhiteboardWidget } from './WhiteboardWidget';
 export { CardDeckTool } from './CardDeckTool';
 export { CounterTool } from './CounterTool';
+// Polymorphic renderers (B19-4a, issue #1749)
+export { ScoringPanelRenderer } from './ScoringPanelRenderer';
+export type { ScoringPanelRendererProps } from './ScoringPanelRenderer';
+export { TurnIndicatorRenderer } from './TurnIndicatorRenderer';
+export type { TurnIndicatorRendererProps } from './TurnIndicatorRenderer';

--- a/apps/web/src/lib/api/schemas/toolkit.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit.schemas.ts
@@ -114,15 +114,60 @@ export const AiTimerToolSuggestionSchema = z.object({
   warningThresholdSeconds: z.number().nullable().optional(),
 });
 
+/**
+ * v3 (B19-3b, 2026-05-31): structured scoring category for polymorphic UI rendering.
+ * Computation enum drives the per-category UI variant (Count counter,
+ * Sum input, RankBased pills, Custom manual entry).
+ */
+export const ScoringComputationSchema = z.enum(['Count', 'Sum', 'RankBased', 'Custom']);
+export type ScoringComputation = z.infer<typeof ScoringComputationSchema>;
+
+export const AiScoringCategorySuggestionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  computation: ScoringComputationSchema,
+  weight: z.number().int().default(1),
+  description: z.string().nullable().optional(),
+});
+export type AiScoringCategorySuggestion = z.infer<typeof AiScoringCategorySuggestionSchema>;
+
+/**
+ * ScoreType enum extended v2 (B19-3b): BinaryWin + Objectives for co-op + goal-oriented games.
+ */
+export const ScoreTypeSchema = z.enum(['Points', 'Ranking', 'BinaryWin', 'Objectives']);
+export type ScoreType = z.infer<typeof ScoreTypeSchema>;
+
+/**
+ * TurnOrderType enum extended v2 (B19-3a): Sequential/Simultaneous/Realtime/None for
+ * non-circular turn patterns (Codenames, Paleo, Captain Sonar).
+ */
+export const TurnOrderTypeSchema = z.enum([
+  'RoundRobin',
+  'Custom',
+  'Free',
+  'Sequential',
+  'Simultaneous',
+  'Realtime',
+  'None',
+]);
+export type TurnOrderType = z.infer<typeof TurnOrderTypeSchema>;
+
 export const AiScoringTemplateSuggestionSchema = z.object({
   dimensions: z.array(z.string()),
   defaultUnit: z.string(),
-  scoreType: z.string(),
+  scoreType: z.string(), // legacy: kept as string for back-compat; new code should use ScoreTypeSchema
+  // v3 (B19-3b, additive): structured per-category computation
+  categories: z.array(AiScoringCategorySuggestionSchema).nullable().optional(),
 });
 
 export const AiTurnTemplateSuggestionSchema = z.object({
-  turnOrderType: z.string(),
+  turnOrderType: z.string(), // legacy: kept as string for back-compat
   phases: z.array(z.string()),
+  // v3 (B19-3a, additive): rich turn structure for Wingspan-like games
+  rounds: z.number().int().nullable().optional(),
+  turnsPerRound: z.array(z.number().int()).nullable().optional(),
+  turnActions: z.array(z.string()).nullable().optional(),
+  direction: z.string().nullable().optional(),
 });
 
 export const AiOverrideSuggestionSchema = z.object({


### PR DESCRIPTION
## Summary

Closes **#1749** (B19-4a). Sub-issue di #1742 B19 game-agnostic session.

**Discovery**: ToolkitDashboard.tsx esiste gia ed e gia il dispatcher polimorfico per i 6 WidgetType. Il vero gap 4a era quindi limitato a 2 renderer: ScoringPanelRenderer + TurnIndicatorRenderer.

## Changes

### TypeScript schemas (additive, mirror C# v3 di PR #1760)

- `ScoringComputationSchema` + `AiScoringCategorySuggestionSchema` (nuovi)
- `ScoreTypeSchema` enum (Points/Ranking/BinaryWin/Objectives)
- `TurnOrderTypeSchema` enum (7 valori incl. Sequential/Simultaneous/Realtime/None)
- `AiScoringTemplateSuggestion` esteso con `categories[]` opzionale
- `AiTurnTemplateSuggestion` esteso con `rounds`/`turnsPerRound`/`turnActions`/`direction` opzionali

### ScoringPanelRenderer (`apps/web/src/components/toolkit/`)

- Dispatcher switch su ScoreType (Points/Ranking/BinaryWin/Objectives)
- **Points**: Categories[] (v3, structured con Computation icon) o Dimensions[] legacy
- **Ranking**: live ordered list con rank pills (sort by score desc)
- **BinaryWin**: collective outcome indicator (co-op games)
- **Objectives**: checklist di dimensions (goal-oriented games)
- Inline scoreboard opzionale (scores + players props)
- Fallback graceful per unknown ScoreType
- Token-compliant (CSS vars semantici, no hardcoded colors)

### TurnIndicatorRenderer

- Lookup table dispatcher su TurnOrderType (7 valori)
- **RoundRobin**: active player + round progress (X/Y - Turn N/M) + phase stepper
- **Sequential**: phase stepper come primary indicator (team-based)
- **Simultaneous**: all-players badge + phase stepper (co-op)
- **Realtime**: warning banner
- **None**: open-play banner
- **Custom / Free**: generic indicator
- Phase stepper con `aria-current="step"` per a11y
- TurnsPerRound supportato (Wingspan-like 8/7/6/5)

## Tests Vitest

- `ScoringPanelRenderer.test.tsx`: **16 tests** (4 ScoreType + null + categories vs dimensions + scores+players + unknown fallback + weight badges)
- `TurnIndicatorRenderer.test.tsx`: **19 tests** (7 TurnOrderType + null + Rounds/TurnsPerRound + phase stepper edge cases + unknown fallback)
- **35/35 passing** in 4.4s

## Validation
- [x] `pnpm typecheck` OK (zero TS errors)
- [x] `pnpm vitest run` 35/35 passed
- [x] Component index.ts updated con exports + types
- [x] Token compliance (CSS vars semantici)
- [x] A11y attributes (aria-label, aria-current, aria-hidden)

## Stack
PR puo essere mergiato indipendentemente da #1760/#1761/#1762 (TS schemas extension additive — back-compat con shape legacy). Quando #1760 mergia, gli schema C# coincidono con i schema FE qui definiti.

## Out of scope (deferred)

- **4b** Skeleton mockup HTML/JSX (richiede Claude Design Web esterno) → issue #1750
- Storybook stories (non urgenti — i Vitest test coprono i variant)
- Integration con `ToolkitDashboard` esistente (lascia ai consumers integrare i renderer)

🤖 Generated with Claude Code