### PR TITLE
feat(admin-monitor): #1718 Phase 2/4 — Monitor hub re-skin + section band

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/AlertHistoryTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/AlertHistoryTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useState } from 'react';
@@ -125,7 +124,7 @@ export function AlertHistoryTab() {
       <div
         className={cn(
           'overflow-hidden rounded-xl border border-border/60',
-          'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
+          'bg-card/70 backdrop-blur-md'
         )}
       >
         {filtered.length === 0 ? (

--- a/apps/web/src/app/admin/(dashboard)/monitor/BulkExportTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/BulkExportTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useState } from 'react';
@@ -178,7 +177,7 @@ export function BulkExportTab() {
           return (
             <div
               key={card.id}
-              className="rounded-2xl border border-border/60 dark:border-zinc-700/40 bg-card/70 dark:bg-zinc-800/50 backdrop-blur-sm p-5"
+              className="rounded-2xl border border-border/60 bg-card/70 backdrop-blur-sm p-5"
             >
               <div className="flex items-center gap-3 mb-3">
                 <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100/80 dark:bg-amber-900/30">
@@ -193,7 +192,7 @@ export function BulkExportTab() {
               </div>
 
               <div className="flex items-center justify-between">
-                <span className="rounded-md bg-muted dark:bg-zinc-700/50 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                <span className="rounded-md bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
                   {card.format}
                 </span>
                 <Button

--- a/apps/web/src/app/admin/(dashboard)/monitor/CacheTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/CacheTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
@@ -27,12 +26,7 @@ function MetricCard({
   unit?: string;
 }) {
   return (
-    <div
-      className={cn(
-        'rounded-xl border border-border/60 p-5',
-        'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-      )}
-    >
+    <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
       <p className="text-sm text-muted-foreground">{label}</p>
       <p className="mt-1 font-quicksand text-2xl font-bold tracking-tight text-foreground">
         {value}

--- a/apps/web/src/app/admin/(dashboard)/monitor/EmailManagementTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/EmailManagementTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useState } from 'react';
@@ -34,7 +33,7 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="rounded-2xl border border-border/60 dark:border-zinc-700/40 bg-card/70 dark:bg-zinc-800/50 backdrop-blur-sm p-5">
+    <div className="rounded-2xl border border-border/60 bg-card/70 backdrop-blur-sm p-5">
       <div className="flex items-center gap-3">
         <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${color}`}>
           <Icon className="h-5 w-5" />
@@ -186,7 +185,7 @@ export function EmailManagementTab() {
       </div>
 
       {/* Send Test Email */}
-      <div className="rounded-2xl border border-border/60 dark:border-zinc-700/40 bg-card/70 dark:bg-zinc-800/50 backdrop-blur-sm p-5">
+      <div className="rounded-2xl border border-border/60 bg-card/70 backdrop-blur-sm p-5">
         <h2 className="font-quicksand text-sm font-semibold text-foreground mb-3">
           Send Test Email
         </h2>
@@ -196,7 +195,7 @@ export function EmailManagementTab() {
             value={testEmailTo}
             onChange={e => setTestEmailTo(e.target.value)}
             placeholder="recipient@example.com"
-            className="flex-1 rounded-lg border border-border/60 dark:border-zinc-700/40 bg-card/50 dark:bg-zinc-900/50 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+            className="flex-1 rounded-lg border border-border/60 bg-card/50 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-400/40"
           />
           <button
             onClick={() => testEmailTo && sendTestMutation.mutate(testEmailTo)}
@@ -234,11 +233,11 @@ export function EmailManagementTab() {
             </button>
           )}
         </div>
-        <div className="rounded-2xl border border-border/60 dark:border-zinc-700/40 bg-card/70 dark:bg-zinc-800/50 backdrop-blur-sm overflow-hidden">
+        <div className="rounded-2xl border border-border/60 bg-card/70 backdrop-blur-sm overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-border/60 dark:border-zinc-700/40">
+                <tr className="border-b border-border/60">
                   <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
                     Recipient
                   </th>
@@ -270,10 +269,7 @@ export function EmailManagementTab() {
                 {deadLetters.map((email: EmailQueueItem) => {
                   const isRetrying = retryingId === email.id;
                   return (
-                    <tr
-                      key={email.id}
-                      className="border-b border-border/60 dark:border-zinc-800/40 last:border-0"
-                    >
+                    <tr key={email.id} className="border-b border-border/60 last:border-0">
                       <td className="px-4 py-3 font-medium text-foreground">{email.to}</td>
                       <td className="px-4 py-3 text-muted-foreground max-w-[200px] truncate">
                         {email.subject}
@@ -324,15 +320,15 @@ export function EmailManagementTab() {
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
               placeholder="Search by email or subject..."
-              className="w-full rounded-lg border border-border/60 dark:border-zinc-700/40 bg-card/50 dark:bg-zinc-900/50 pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+              className="w-full rounded-lg border border-border/60 bg-card/50 pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-400/40"
             />
           </div>
         </div>
-        <div className="rounded-2xl border border-border/60 dark:border-zinc-700/40 bg-card/70 dark:bg-zinc-800/50 backdrop-blur-sm overflow-hidden">
+        <div className="rounded-2xl border border-border/60 bg-card/70 backdrop-blur-sm overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-border/60 dark:border-zinc-700/40">
+                <tr className="border-b border-border/60">
                   <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
                     Recipient
                   </th>
@@ -359,10 +355,7 @@ export function EmailManagementTab() {
                   </tr>
                 )}
                 {history.map((email: EmailQueueItem) => (
-                  <tr
-                    key={email.id}
-                    className="border-b border-border/60 dark:border-zinc-800/40 last:border-0"
-                  >
+                  <tr key={email.id} className="border-b border-border/60 last:border-0">
                     <td className="px-4 py-3 font-medium text-foreground">{email.to}</td>
                     <td className="px-4 py-3 text-muted-foreground max-w-[250px] truncate">
                       {email.subject}

--- a/apps/web/src/app/admin/(dashboard)/monitor/TestingTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/TestingTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useState, useEffect } from 'react';
@@ -38,12 +37,7 @@ function MetricValue({
 function AccessibilitySection({ data }: { data: AccessibilityMetrics | null }) {
   if (!data) {
     return (
-      <div
-        className={cn(
-          'rounded-xl border border-border/60 p-5',
-          'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-        )}
-      >
+      <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
         <h3 className="font-quicksand text-sm font-semibold text-foreground">Accessibility</h3>
         <p className="mt-2 text-sm text-muted-foreground">No data available.</p>
       </div>
@@ -51,12 +45,7 @@ function AccessibilitySection({ data }: { data: AccessibilityMetrics | null }) {
   }
 
   return (
-    <div
-      className={cn(
-        'rounded-xl border border-border/60 p-5',
-        'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-      )}
-    >
+    <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
       <h3 className="font-quicksand text-sm font-semibold text-foreground">Accessibility</h3>
       <div className="mt-3 space-y-1">
         <MetricValue label="Lighthouse Score" value={data.lighthouseScore} />
@@ -72,12 +61,7 @@ function AccessibilitySection({ data }: { data: AccessibilityMetrics | null }) {
 function PerformanceSection({ data }: { data: PerformanceMetrics | null }) {
   if (!data) {
     return (
-      <div
-        className={cn(
-          'rounded-xl border border-border/60 p-5',
-          'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-        )}
-      >
+      <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
         <h3 className="font-quicksand text-sm font-semibold text-foreground">Performance</h3>
         <p className="mt-2 text-sm text-muted-foreground">No data available.</p>
       </div>
@@ -85,12 +69,7 @@ function PerformanceSection({ data }: { data: PerformanceMetrics | null }) {
   }
 
   return (
-    <div
-      className={cn(
-        'rounded-xl border border-border/60 p-5',
-        'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-      )}
-    >
+    <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
       <h3 className="font-quicksand text-sm font-semibold text-foreground">Performance</h3>
       <div className="mt-3 space-y-1">
         <MetricValue label="Lighthouse Score" value={data.lighthouseScore} />
@@ -110,12 +89,7 @@ function PerformanceSection({ data }: { data: PerformanceMetrics | null }) {
 function E2ESection({ data }: { data: E2EMetrics | null }) {
   if (!data) {
     return (
-      <div
-        className={cn(
-          'rounded-xl border border-border/60 p-5',
-          'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-        )}
-      >
+      <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
         <h3 className="font-quicksand text-sm font-semibold text-foreground">E2E</h3>
         <p className="mt-2 text-sm text-muted-foreground">No data available.</p>
       </div>
@@ -123,12 +97,7 @@ function E2ESection({ data }: { data: E2EMetrics | null }) {
   }
 
   return (
-    <div
-      className={cn(
-        'rounded-xl border border-border/60 p-5',
-        'bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md'
-      )}
-    >
+    <div className={cn('rounded-xl border border-border/60 p-5', 'bg-card/70 backdrop-blur-md')}>
       <h3 className="font-quicksand text-sm font-semibold text-foreground">E2E</h3>
       <div className="mt-3 space-y-1">
         <MetricValue label="Coverage" value={`${data.coverage}%`} />

--- a/apps/web/src/app/admin/(dashboard)/monitor/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/__tests__/page.test.tsx
@@ -66,12 +66,6 @@ describe('AdminMonitorPage', () => {
     expect(screen.getByTestId('testing-tab')).toBeInTheDocument();
   });
 
-  it('renders heading', async () => {
-    const page = await AdminMonitorPage({ searchParams: Promise.resolve({}) });
-    render(page);
-    expect(screen.getByText('Monitoraggio')).toBeInTheDocument();
-  });
-
   it('renders export tab content', async () => {
     const page = await AdminMonitorPage({
       searchParams: Promise.resolve({ tab: 'export' }),

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -67,7 +66,7 @@ function ContainerCard({ container }: ContainerCardProps) {
   return (
     <div
       data-testid={`container-card-${container.id}`}
-      className="rounded-xl border bg-card/70 p-4 backdrop-blur-md transition-shadow hover:shadow-md dark:bg-zinc-900/70"
+      className="rounded-xl border bg-card/70 p-4 backdrop-blur-md transition-shadow hover:shadow-md"
     >
       {/* Header */}
       <div className="mb-3 flex items-start justify-between">
@@ -116,15 +115,15 @@ function StatusSummary({ containers }: { containers: ContainerInfo[] }) {
 
   return (
     <div className="grid grid-cols-3 gap-3" data-testid="status-summary">
-      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md dark:bg-zinc-900/70">
+      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md">
         <p className="text-xs text-muted-foreground">Total</p>
         <p className="text-lg font-semibold font-mono">{total}</p>
       </div>
-      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md dark:bg-zinc-900/70">
+      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md">
         <p className="text-xs text-green-600">Running</p>
         <p className="text-lg font-semibold font-mono text-green-600">{running}</p>
       </div>
-      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md dark:bg-zinc-900/70">
+      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md">
         <p className="text-xs text-red-600">Stopped</p>
         <p className="text-lg font-semibold font-mono text-red-600">{stopped}</p>
       </div>
@@ -255,7 +254,7 @@ export function ContainerDashboard() {
       ) : containers.length === 0 ? (
         <div
           data-testid="container-empty"
-          className="rounded-xl border bg-card/70 p-8 text-center backdrop-blur-md dark:bg-zinc-900/70"
+          className="rounded-xl border bg-card/70 p-8 text-center backdrop-blur-md"
         >
           <Box className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
           <p className="text-muted-foreground">

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -175,7 +174,7 @@ export function RestartAllPanel() {
   return (
     <section
       data-testid="restart-all-panel"
-      className="rounded-xl border bg-card/70 p-6 backdrop-blur-md dark:bg-zinc-900/70"
+      className="rounded-xl border bg-card/70 p-6 backdrop-blur-md"
     >
       {/* Header */}
       <div className="mb-5 flex items-center gap-3">

--- a/apps/web/src/app/admin/(dashboard)/monitor/grafana/GrafanaDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/grafana/GrafanaDashboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -155,7 +154,7 @@ function DashboardCard({
         'hover:border-primary/40 hover:shadow-sm',
         isSelected
           ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
-          : 'border-border bg-card/50 dark:bg-zinc-900/50'
+          : 'border-border bg-card/50'
       )}
       onClick={onSelect}
       data-testid={`dashboard-card-${dashboard.id}`}
@@ -216,7 +215,7 @@ function CategorySection({
 function GrafanaNotConfigured() {
   return (
     <div
-      className="rounded-xl border border-dashed border-muted-foreground/30 bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-8 text-center"
+      className="rounded-xl border border-dashed border-muted-foreground/30 bg-card/70 backdrop-blur-md p-8 text-center"
       data-testid="grafana-not-configured"
     >
       <BarChart3 className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
@@ -296,7 +295,7 @@ export function GrafanaDashboard() {
   return (
     <div className="space-y-5" data-testid="grafana-dashboard">
       {/* Dashboard Selector */}
-      <div className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-4 space-y-4">
+      <div className="rounded-xl border bg-card/70 backdrop-blur-md p-4 space-y-4">
         <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-foreground">Select Dashboard</p>
           {selectedDashboard && (
@@ -322,7 +321,7 @@ export function GrafanaDashboard() {
       {/* Controls bar — shown only when a dashboard is selected */}
       {selectedId && (
         <div
-          className="flex flex-wrap items-center gap-3 rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md px-4 py-3"
+          className="flex flex-wrap items-center gap-3 rounded-xl border bg-card/70 backdrop-blur-md px-4 py-3"
           data-testid="grafana-controls"
         >
           {/* Time range */}
@@ -372,7 +371,7 @@ export function GrafanaDashboard() {
       {/* Iframe / Placeholder */}
       {selectedId ? (
         <div
-          className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden"
+          className="rounded-xl border bg-card/70 backdrop-blur-md overflow-hidden"
           data-testid="grafana-iframe-container"
         >
           <iframe
@@ -387,7 +386,7 @@ export function GrafanaDashboard() {
         </div>
       ) : (
         <div
-          className="rounded-xl border border-dashed border-muted-foreground/20 bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-10 text-center"
+          className="rounded-xl border border-dashed border-muted-foreground/20 bg-card/70 backdrop-blur-md p-10 text-center"
           data-testid="grafana-empty-state"
         >
           <BarChart3 className="mx-auto h-8 w-8 text-muted-foreground/40 mb-2" />

--- a/apps/web/src/app/admin/(dashboard)/monitor/layout.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+import { MonitorTopBand } from '@/components/admin/monitor/MonitorTopBand';
+
+export default function MonitorLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="space-y-6 px-6">
+      <MonitorTopBand />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/AppLogViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/AppLogViewer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -42,9 +41,9 @@ function levelBadgeClass(level: string): string {
     case 'debug':
       return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300';
     case 'verbose':
-      return 'bg-zinc-100 text-muted-foreground dark:bg-zinc-800 dark:text-muted-foreground';
+      return 'bg-muted text-muted-foreground';
     default:
-      return 'bg-zinc-100 text-muted-foreground dark:bg-zinc-800 dark:text-muted-foreground';
+      return 'bg-muted text-muted-foreground';
   }
 }
 
@@ -205,10 +204,7 @@ export function AppLogViewer() {
   const remainingCount = data?.remainingCount ?? 0;
 
   return (
-    <div
-      className="rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70"
-      data-testid="app-log-viewer"
-    >
+    <div className="rounded-xl border bg-card/70 backdrop-blur-md" data-testid="app-log-viewer">
       {/* Filter bar */}
       <div className="flex flex-wrap items-end gap-2 border-b px-4 py-3">
         <div className="relative min-w-[180px] flex-1">

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LogViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LogViewer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -78,7 +77,7 @@ export function LogViewer() {
     return (
       <div
         data-testid="log-viewer-empty"
-        className="rounded-xl border bg-card/70 p-8 text-center backdrop-blur-md dark:bg-zinc-900/70"
+        className="rounded-xl border bg-card/70 p-8 text-center backdrop-blur-md"
       >
         <p className="text-muted-foreground">
           No containers found. Make sure Docker Socket Proxy is running.
@@ -101,7 +100,7 @@ export function LogViewer() {
         {/* Container sidebar */}
         <div
           data-testid="container-list"
-          className="w-64 shrink-0 space-y-2 rounded-xl border bg-card/70 p-4 backdrop-blur-md dark:bg-zinc-900/70"
+          className="w-64 shrink-0 space-y-2 rounded-xl border bg-card/70 p-4 backdrop-blur-md"
         >
           <h3 className="mb-3 text-sm font-semibold text-muted-foreground">Containers</h3>
           {containers.map(container => (
@@ -128,7 +127,7 @@ export function LogViewer() {
         </div>
 
         {/* Log output panel */}
-        <div className="min-w-0 flex-1 rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70">
+        <div className="min-w-0 flex-1 rounded-xl border bg-card/70 backdrop-blur-md">
           {logs ? (
             <div className="flex h-full flex-col">
               <div className="flex items-center justify-between border-b px-4 py-3">

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LokiErrorViewer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useCallback } from 'react';
@@ -19,7 +18,7 @@ function levelBadgeClass(level: LokiLogEntry['level']): string {
     case 'info':
       return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300';
     default:
-      return 'bg-zinc-100 text-muted-foreground dark:bg-zinc-800 dark:text-muted-foreground';
+      return 'bg-muted text-muted-foreground';
   }
 }
 
@@ -92,10 +91,7 @@ export function LokiErrorViewer() {
   const entries = data?.entries ?? [];
 
   return (
-    <div
-      className="rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70"
-      data-testid="loki-viewer"
-    >
+    <div className="rounded-xl border bg-card/70 backdrop-blur-md" data-testid="loki-viewer">
       {/* Header */}
       <div className="flex items-center justify-between border-b px-4 py-3">
         <span className="text-xs text-muted-foreground">Last 100 errors/warnings · last 24h</span>

--- a/apps/web/src/app/admin/(dashboard)/monitor/mau/MauDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/mau/MauDashboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 /**
  * MAU Monitoring Dashboard
  *
@@ -58,7 +57,7 @@ export function MauDashboard() {
 
   if (error) {
     return (
-      <Card className="rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70">
+      <Card className="rounded-xl border bg-card/70 backdrop-blur-md">
         <CardContent className="p-6">
           <p className="text-red-600">{error}</p>
           <Button className="mt-2" variant="outline" onClick={() => fetchData(period)}>
@@ -122,7 +121,7 @@ export function MauDashboard() {
 
       {/* Daily Trend */}
       {data && data.dailyBreakdown.length > 0 && (
-        <Card className="rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70">
+        <Card className="rounded-xl border bg-card/70 backdrop-blur-md">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Activity className="h-5 w-5" />
@@ -184,14 +183,14 @@ function KpiCard({
   isLoading: boolean;
 }) {
   return (
-    <Card className="rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70">
+    <Card className="rounded-xl border bg-card/70 backdrop-blur-md">
       <CardContent className="p-4">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs text-muted-foreground">{title}</p>
             <p className="mt-1 text-2xl font-bold">
               {isLoading ? (
-                <span className="inline-block h-7 w-12 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+                <span className="inline-block h-7 w-12 animate-pulse rounded bg-muted" />
               ) : (
                 (value ?? 0).toLocaleString()
               )}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/AuditTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/AuditTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -219,7 +218,7 @@ export function AuditTab() {
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       ) : (
-        <div className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-x-auto">
+        <div className="rounded-xl border bg-card/70 backdrop-blur-md overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b text-xs text-muted-foreground">
@@ -298,9 +297,7 @@ function AuditRow({
   return (
     <>
       <tr
-        className={cn(
-          'border-b last:border-0 cursor-pointer hover:bg-muted/50 dark:hover:bg-zinc-800/30'
-        )}
+        className={cn('border-b last:border-0 cursor-pointer hover:bg-muted/50')}
         onClick={onToggle}
       >
         <td className="py-3 px-2">
@@ -335,7 +332,7 @@ function AuditRow({
         </td>
       </tr>
       {expanded && (
-        <tr className="bg-muted/30 dark:bg-zinc-800/20">
+        <tr className="bg-muted/30">
           <td colSpan={6} className="px-6 py-3">
             <div className="grid gap-2 text-xs sm:grid-cols-2">
               <div>
@@ -365,7 +362,7 @@ function AuditDetailValue({ value }: { value: string }) {
   try {
     const parsed = JSON.parse(value);
     return (
-      <pre className="mt-1 p-2 rounded bg-muted dark:bg-zinc-800 overflow-x-auto text-xs font-mono whitespace-pre-wrap">
+      <pre className="mt-1 p-2 rounded bg-muted overflow-x-auto text-xs font-mono whitespace-pre-wrap">
         {JSON.stringify(parsed, null, 2)}
       </pre>
     );

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/EmergencyTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/EmergencyTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -179,7 +178,7 @@ export function EmergencyTab() {
           )}
 
           {/* Activate New Override */}
-          <div className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-4">
+          <div className="rounded-xl border bg-card/70 backdrop-blur-md p-4">
             <div className="flex items-center gap-2 mb-4">
               <AlertTriangle className="h-4 w-4 text-amber-600" />
               <h3 className="font-quicksand font-semibold text-sm">Activate Emergency Override</h3>

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/QueueTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/QueueTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -259,7 +258,7 @@ export function QueueTab() {
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       ) : (
-        <div className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-x-auto">
+        <div className="rounded-xl border bg-card/70 backdrop-blur-md overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b text-xs text-muted-foreground">

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/ResourcesTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/ResourcesTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -43,12 +42,7 @@ interface MetricCardProps {
 
 function MetricCard({ title, icon, children, loading }: MetricCardProps) {
   return (
-    <div
-      className={cn(
-        'rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-4',
-        'shadow-sm'
-      )}
-    >
+    <div className={cn('rounded-xl border bg-card/70 backdrop-blur-md p-4', 'shadow-sm')}>
       <div className="flex items-center gap-2 mb-3">
         {icon}
         <h3 className="font-quicksand font-semibold text-sm">{title}</h3>
@@ -265,7 +259,7 @@ export function ResourcesTab() {
 
       {/* Top Tables (Sortable DataTable) */}
       {tables.length > 0 && (
-        <div className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-4">
+        <div className="rounded-xl border bg-card/70 backdrop-blur-md p-4">
           <h3 className="font-quicksand font-semibold text-sm mb-3">Top Tables by Size</h3>
           <DataTable
             columns={tableColumns}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 /**
  * Admin Operations Console
  * Issue #126 — Domain Operations Console page
@@ -55,10 +54,10 @@ type TabId = (typeof TABS)[number]['id'];
 function TabSkeleton() {
   return (
     <div className="space-y-3 pt-2">
-      <div className="h-10 w-48 rounded-lg bg-card/40 dark:bg-zinc-800/40 animate-pulse" />
+      <div className="h-10 w-48 rounded-lg bg-card/40 animate-pulse" />
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {[1, 2, 3].map(i => (
-          <div key={i} className="h-24 rounded-xl bg-card/40 dark:bg-zinc-800/40 animate-pulse" />
+          <div key={i} className="h-24 rounded-xl bg-card/40 animate-pulse" />
         ))}
       </div>
     </div>

--- a/apps/web/src/app/admin/(dashboard)/monitor/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/page.tsx
@@ -165,15 +165,6 @@ export default async function AdminMonitorPage({ searchParams }: AdminMonitorPag
 
   return (
     <div className="space-y-5">
-      <div>
-        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
-          Monitoraggio
-        </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Stato del sistema, alert, cache, infrastruttura e operazioni.
-        </p>
-      </div>
-
       <AdminHubTabBar tabs={TABS} activeTab={tab} />
       <AdminTabPersistence hubName="monitor" defaultTab="alerts" />
 

--- a/apps/web/src/app/admin/(dashboard)/monitor/service-calls/ServiceCallHistory.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/service-calls/ServiceCallHistory.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -83,7 +82,7 @@ function methodBadgeClass(method: string): string {
     case 'DELETE':
       return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300';
     default:
-      return 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-muted-foreground';
+      return 'bg-muted text-muted-foreground';
   }
 }
 
@@ -207,7 +206,7 @@ export function ServiceCallHistory() {
 
   return (
     <div
-      className="rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70"
+      className="rounded-xl border bg-card/70 backdrop-blur-md"
       data-testid="service-call-history"
     >
       {/* Filter bar */}

--- a/apps/web/src/app/admin/(dashboard)/monitor/service-calls/ServiceSummaryCards.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/service-calls/ServiceSummaryCards.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -77,7 +76,7 @@ function ServiceCard({ summary, colorClass }: ServiceCardProps) {
 
   return (
     <div
-      className={`rounded-xl border bg-card/70 backdrop-blur-md dark:bg-zinc-900/70 border-l-4 ${colorClass} p-4 space-y-3`}
+      className={`rounded-xl border bg-card/70 backdrop-blur-md border-l-4 ${colorClass} p-4 space-y-3`}
       data-testid={`service-card-${summary.serviceName}`}
     >
       <div className="flex items-center justify-between gap-2">

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/CircuitBreakerPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/CircuitBreakerPanel.tsx
@@ -43,7 +43,7 @@ export function CircuitBreakerPanel() {
           >
             <div className="flex items-center justify-between mb-2">
               <span className="font-medium text-sm">{cb.serviceName}</span>
-              <Badge className={STATE_COLORS[cb.state] ?? 'bg-gray-100 text-gray-700'}>
+              <Badge className={STATE_COLORS[cb.state] ?? 'bg-muted text-muted-foreground'}>
                 {cb.state}
               </Badge>
             </div>

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/DbStatsPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/DbStatsPanel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -87,7 +86,7 @@ function ConnectionBar({ active, max }: { active: number; max: number }) {
         </span>
       </div>
       <div
-        className="h-1.5 w-full rounded-full bg-muted dark:bg-zinc-700 overflow-hidden"
+        className="h-1.5 w-full rounded-full bg-muted overflow-hidden"
         data-testid="db-connections-bar"
       >
         <div
@@ -105,11 +104,11 @@ function TopTablesTable({ tables }: { tables: TableSize[] }) {
 
   return (
     <div
-      className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden"
+      className="rounded-xl border bg-card/70 backdrop-blur-md overflow-hidden"
       data-testid="db-top-tables"
     >
       <button
-        className="w-full flex items-center justify-between px-4 py-3 hover:bg-muted/50 dark:hover:bg-zinc-800/30 transition-colors"
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors"
         onClick={() => setOpen(!open)}
         data-testid="db-top-tables-toggle"
       >
@@ -314,7 +313,7 @@ export function DbStatsPanel() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3" data-testid="db-kpi-row">
         {/* Total Size */}
         <div
-          className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          className="rounded-xl border bg-card/70 backdrop-blur-md p-3"
           data-testid="db-kpi-size"
         >
           <div className="flex items-center gap-1.5 mb-1">
@@ -331,7 +330,7 @@ export function DbStatsPanel() {
 
         {/* Active Connections */}
         <div
-          className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          className="rounded-xl border bg-card/70 backdrop-blur-md p-3"
           data-testid="db-kpi-connections"
         >
           <p className="text-xs text-muted-foreground mb-1">Active Connections</p>
@@ -340,7 +339,7 @@ export function DbStatsPanel() {
 
         {/* Transactions */}
         <div
-          className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          className="rounded-xl border bg-card/70 backdrop-blur-md p-3"
           data-testid="db-kpi-transactions"
         >
           <p className="text-xs text-muted-foreground mb-1">Transactions</p>
@@ -362,7 +361,7 @@ export function DbStatsPanel() {
 
         {/* Last Measured */}
         <div
-          className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          className="rounded-xl border bg-card/70 backdrop-blur-md p-3"
           data-testid="db-kpi-measured"
         >
           <p className="text-xs text-muted-foreground mb-1">Last Measured</p>

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/RestartServicePanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/RestartServicePanel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -202,7 +201,7 @@ function ServiceRow({ service, cooldown, onRestart }: ServiceRowProps) {
   return (
     <div
       data-testid={`service-row-${service.id}`}
-      className="rounded-lg border border-border/40 bg-card/50 p-4 transition-colors dark:bg-zinc-800/50"
+      className="rounded-lg border border-border/40 bg-card/50 p-4 transition-colors"
     >
       <div className="flex items-center justify-between">
         <div className="min-w-0 flex-1">
@@ -343,7 +342,7 @@ export function RestartServicePanel() {
   return (
     <section
       data-testid="restart-service-panel"
-      className="rounded-xl border bg-card/70 p-6 backdrop-blur-md dark:bg-zinc-900/70"
+      className="rounded-xl border bg-card/70 p-6 backdrop-blur-md"
     >
       {/* Header */}
       <div className="mb-5 flex items-center gap-3">

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -232,9 +231,9 @@ function CategoryGroup({
   const unhealthyCount = services.filter(s => s.state !== 'Healthy').length;
 
   return (
-    <div className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden">
+    <div className="rounded-xl border bg-card/70 backdrop-blur-md overflow-hidden">
       <button
-        className="w-full flex items-center justify-between px-4 py-3 hover:bg-muted/50 dark:hover:bg-zinc-800/30 transition-colors"
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors"
         onClick={() => setOpen(!open)}
         data-testid={`category-toggle-${category.replace(/\s+/g, '-').toLowerCase()}`}
       >
@@ -313,7 +312,7 @@ function MetricsKpiRow({ metrics }: { metrics: PrometheusMetricsSummary }) {
       {kpis.map(kpi => (
         <div
           key={kpi.testId}
-          className="rounded-xl border bg-card/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          className="rounded-xl border bg-card/70 backdrop-blur-md p-3"
           data-testid={kpi.testId}
         >
           <p className="text-xs text-muted-foreground">{kpi.label}</p>

--- a/apps/web/src/components/admin/command-center/CommandCenterDashboard.tsx
+++ b/apps/web/src/components/admin/command-center/CommandCenterDashboard.tsx
@@ -295,7 +295,7 @@ function ServiceCard({ service }: { service: ServiceData }) {
           <StatusIndicator status={service.status} />
         </div>
 
-        <h3 className="font-mono text-sm font-medium text-slate-200 mb-1">{service.name}</h3>
+        <h3 className="font-mono text-sm font-medium text-foreground mb-1">{service.name}</h3>
 
         <div className="flex items-center justify-between text-xs">
           <span className={cn('font-mono uppercase tracking-wider', colors.text)}>
@@ -373,8 +373,10 @@ function MetricCard({ metric, index }: { metric: SystemMetric; index: number }) 
       </p>
 
       <div className="flex items-baseline gap-2">
-        <span className="text-2xl font-bold text-slate-100 font-mono">{metric.value}</span>
-        {metric.unit && <span className="text-sm text-muted-foreground font-mono">{metric.unit}</span>}
+        <span className="text-2xl font-bold text-foreground font-mono">{metric.value}</span>
+        {metric.unit && (
+          <span className="text-sm text-muted-foreground font-mono">{metric.unit}</span>
+        )}
       </div>
 
       {metric.trend !== undefined && (
@@ -402,7 +404,7 @@ function AlertItem({ alert, index }: { alert: AlertData; index: number }) {
     >
       <Icon className={cn('w-5 h-5 mt-0.5 flex-shrink-0', styles.text)} />
       <div className="flex-1 min-w-0">
-        <p className="text-sm text-slate-300">{alert.message}</p>
+        <p className="text-sm text-foreground">{alert.message}</p>
         <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground font-mono">
           <span>{alert.source}</span>
           <span>•</span>
@@ -439,7 +441,7 @@ function PendingActionCard({ action }: { action: PendingAction }) {
             <Icon className={cn('w-5 h-5', style.color)} />
           </div>
           <div>
-            <p className="text-sm font-medium text-slate-200">{action.title}</p>
+            <p className="text-sm font-medium text-foreground">{action.title}</p>
             <p className="text-xs text-muted-foreground font-mono uppercase tracking-wider">
               {action.type}
             </p>
@@ -570,7 +572,7 @@ export function CommandCenterDashboard({ className }: CommandCenterDashboardProp
   };
 
   return (
-    <div className={cn('min-h-screen bg-card text-slate-100', 'font-sans', className)}>
+    <div className={cn('min-h-screen bg-card text-foreground', 'font-sans', className)}>
       {/* Subtle grid background */}
       <div
         className="fixed inset-0 opacity-[0.02] pointer-events-none"
@@ -594,7 +596,9 @@ export function CommandCenterDashboard({ className }: CommandCenterDashboardProp
                 </div>
                 <div>
                   <h1 className="text-2xl font-bold tracking-tight">Command Center</h1>
-                  <p className="text-sm text-muted-foreground font-mono">MeepleAI Admin Dashboard</p>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    MeepleAI Admin Dashboard
+                  </p>
                 </div>
               </div>
             </div>
@@ -623,7 +627,7 @@ export function CommandCenterDashboard({ className }: CommandCenterDashboardProp
               {mounted && currentTime && (
                 <div className="hidden md:flex items-center gap-2 px-4 py-2 rounded-lg bg-card border border-border/50">
                   <Clock className="w-4 h-4 text-muted-foreground" />
-                  <span className="font-mono text-sm text-slate-300">
+                  <span className="font-mono text-sm text-muted-foreground">
                     {currentTime.toLocaleDateString('it-IT')}
                   </span>
                   <span className="font-mono text-sm text-cyan-400 font-bold">
@@ -660,7 +664,7 @@ export function CommandCenterDashboard({ className }: CommandCenterDashboardProp
             </h2>
             <Link
               href="/admin/infrastructure"
-              className="text-sm text-muted-foreground hover:text-slate-300 transition-colors flex items-center gap-1"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
             >
               View Details <ChevronRight className="w-4 h-4" />
             </Link>
@@ -708,7 +712,7 @@ export function CommandCenterDashboard({ className }: CommandCenterDashboardProp
               </h2>
               <Link
                 href="/admin/alerts"
-                className="text-sm text-muted-foreground hover:text-slate-300 transition-colors flex items-center gap-1"
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
               >
                 View All <ChevronRight className="w-4 h-4" />
               </Link>

--- a/apps/web/src/components/admin/monitor/MonitorCrumbs.tsx
+++ b/apps/web/src/components/admin/monitor/MonitorCrumbs.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+
+const MONITOR_BASE = '/admin/monitor';
+
+/** Maps ?tab= query param values to display labels. */
+const TAB_LABELS: ReadonlyArray<readonly [string, string]> = [
+  ['alerts', 'Alerts'],
+  ['cache', 'Metrics'],
+  ['infra', 'Infrastructure'],
+  ['command', 'Command Center'],
+  ['testing', 'Testing'],
+  ['mau', 'MAU'],
+  ['containers', 'Containers'],
+  ['logs', 'Logs'],
+  ['grafana', 'Grafana'],
+  ['export', 'Bulk Export'],
+  ['email', 'Email'],
+  ['history', 'History'],
+  ['events', 'Events'],
+];
+
+/** Maps sub-route path segments to display labels. */
+const SUBROUTE_LABELS: ReadonlyArray<readonly [string, string]> = [
+  [`${MONITOR_BASE}/containers`, 'Containers'],
+  [`${MONITOR_BASE}/logs`, 'Logs'],
+  [`${MONITOR_BASE}/grafana`, 'Grafana'],
+  [`${MONITOR_BASE}/operations`, 'Infrastructure'],
+  [`${MONITOR_BASE}/services`, 'Infrastructure'],
+  [`${MONITOR_BASE}/service-calls`, 'Infrastructure'],
+  [`${MONITOR_BASE}/mau`, 'MAU'],
+];
+
+function labelFor(pathname: string, tab: string | null): string {
+  // Sub-route match takes precedence over query param
+  if (pathname !== MONITOR_BASE) {
+    const hit = SUBROUTE_LABELS.find(
+      ([href]) => pathname === href || pathname.startsWith(`${href}/`)
+    );
+    if (hit) return hit[1];
+  }
+
+  // Query param match
+  if (tab) {
+    const hit = TAB_LABELS.find(([id]) => id === tab);
+    if (hit) return hit[1];
+  }
+
+  // Default: first tab = Alerts
+  return 'Alerts';
+}
+
+export function MonitorCrumbs() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab');
+  const label = labelFor(pathname, tab);
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+        Admin · Monitor · {label}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/admin/monitor/MonitorTopActions.tsx
+++ b/apps/web/src/components/admin/monitor/MonitorTopActions.tsx
@@ -1,0 +1,44 @@
+import { PauseCircle, Download } from 'lucide-react';
+
+export function MonitorTopActions() {
+  return (
+    <div className="flex items-center gap-2">
+      {/* Search ⌘K visual — read-only placeholder, functional binding deferred to Task 4.x */}
+      <div className="hidden md:flex items-center gap-2 rounded-lg border border-border/60 bg-card px-3 py-1.5 text-sm text-muted-foreground w-[280px]">
+        <span aria-hidden>🔍</span>
+        <input
+          className="flex-1 bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
+          placeholder="Search events, containers, logs…"
+          aria-label="Search monitor"
+          readOnly
+          tabIndex={-1}
+        />
+        <kbd className="rounded border border-border/60 bg-muted px-1.5 font-mono text-[10px]">
+          ⌘K
+        </kbd>
+      </div>
+
+      {/* Pause stream — ghost button, non-functional placeholder (transport wiring: Task 4.x) */}
+      <button
+        type="button"
+        aria-label="Pause stream"
+        className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-3 py-1.5 text-sm font-semibold font-quicksand text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        onClick={() => {}}
+      >
+        <PauseCircle className="h-3.5 w-3.5" aria-hidden />
+        Pause stream
+      </button>
+
+      {/* Export ndjson — ghost button, non-functional placeholder (transport wiring: Task 4.x) */}
+      <button
+        type="button"
+        aria-label="Export ndjson"
+        className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-3 py-1.5 text-sm font-semibold font-quicksand text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        onClick={() => {}}
+      >
+        <Download className="h-3.5 w-3.5" aria-hidden />
+        Export ndjson
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/monitor/MonitorTopActions.tsx
+++ b/apps/web/src/components/admin/monitor/MonitorTopActions.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { PauseCircle, Download } from 'lucide-react';
 
 export function MonitorTopActions() {

--- a/apps/web/src/components/admin/monitor/MonitorTopBand.tsx
+++ b/apps/web/src/components/admin/monitor/MonitorTopBand.tsx
@@ -1,0 +1,20 @@
+import { MonitorCrumbs } from './MonitorCrumbs';
+import { MonitorTopActions } from './MonitorTopActions';
+
+export function MonitorTopBand() {
+  return (
+    <header
+      aria-label="Monitor section"
+      className="sticky top-0 z-40 -mx-6 flex items-center gap-4 border-b border-border/60 bg-background/80 px-6 py-3 backdrop-blur-md"
+    >
+      <div>
+        <h1 className="font-quicksand text-xl font-extrabold tracking-tight text-foreground">
+          Monitor
+        </h1>
+        <MonitorCrumbs />
+      </div>
+      <div className="flex-1" />
+      <MonitorTopActions />
+    </header>
+  );
+}

--- a/apps/web/src/components/admin/monitor/__tests__/MonitorCrumbs.test.tsx
+++ b/apps/web/src/components/admin/monitor/__tests__/MonitorCrumbs.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { MonitorCrumbs } from '../MonitorCrumbs';
+
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+const mockUsePathname = usePathname as ReturnType<typeof vi.fn>;
+const mockUseSearchParams = useSearchParams as ReturnType<typeof vi.fn>;
+
+function mockNav(pathname: string, tab?: string) {
+  mockUsePathname.mockReturnValue(pathname);
+  mockUseSearchParams.mockReturnValue({
+    get: (key: string) => (key === 'tab' ? (tab ?? null) : null),
+  });
+}
+
+describe('MonitorCrumbs', () => {
+  it('renders Alerts label at monitor root with no tab param', () => {
+    mockNav('/admin/monitor');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Alerts/)).toBeInTheDocument();
+  });
+
+  it('renders Alerts label when tab=alerts', () => {
+    mockNav('/admin/monitor', 'alerts');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Alerts/)).toBeInTheDocument();
+  });
+
+  it('renders Metrics label when tab=cache', () => {
+    mockNav('/admin/monitor', 'cache');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Metrics/)).toBeInTheDocument();
+  });
+
+  it('renders Infrastructure label when tab=infra', () => {
+    mockNav('/admin/monitor', 'infra');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Infrastructure/)).toBeInTheDocument();
+  });
+
+  it('renders Command Center label when tab=command', () => {
+    mockNav('/admin/monitor', 'command');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Command Center/)).toBeInTheDocument();
+  });
+
+  it('renders Testing label when tab=testing', () => {
+    mockNav('/admin/monitor', 'testing');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Testing/)).toBeInTheDocument();
+  });
+
+  it('renders MAU label when tab=mau', () => {
+    mockNav('/admin/monitor', 'mau');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/MAU/)).toBeInTheDocument();
+  });
+
+  it('renders Containers label when tab=containers', () => {
+    mockNav('/admin/monitor', 'containers');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Containers/)).toBeInTheDocument();
+  });
+
+  it('renders Logs label when tab=logs', () => {
+    mockNav('/admin/monitor', 'logs');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Logs/)).toBeInTheDocument();
+  });
+
+  it('renders Grafana label when tab=grafana', () => {
+    mockNav('/admin/monitor', 'grafana');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Grafana/)).toBeInTheDocument();
+  });
+
+  it('renders Bulk Export label when tab=export', () => {
+    mockNav('/admin/monitor', 'export');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Bulk Export/)).toBeInTheDocument();
+  });
+
+  it('renders Email label when tab=email', () => {
+    mockNav('/admin/monitor', 'email');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Email/)).toBeInTheDocument();
+  });
+
+  it('renders History label when tab=history', () => {
+    mockNav('/admin/monitor', 'history');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/History/)).toBeInTheDocument();
+  });
+
+  it('renders Events label when tab=events', () => {
+    mockNav('/admin/monitor', 'events');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Events/)).toBeInTheDocument();
+  });
+
+  it('renders Containers label for /admin/monitor/containers sub-route', () => {
+    mockNav('/admin/monitor/containers');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Containers/)).toBeInTheDocument();
+  });
+
+  it('renders Logs label for /admin/monitor/logs sub-route', () => {
+    mockNav('/admin/monitor/logs');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Logs/)).toBeInTheDocument();
+  });
+
+  it('renders Grafana label for /admin/monitor/grafana sub-route', () => {
+    mockNav('/admin/monitor/grafana');
+    render(<MonitorCrumbs />);
+    expect(screen.getByText(/Grafana/)).toBeInTheDocument();
+  });
+
+  it('renders breadcrumb nav with aria-label', () => {
+    mockNav('/admin/monitor');
+    render(<MonitorCrumbs />);
+    expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/monitor/__tests__/MonitorTopBand.test.tsx
+++ b/apps/web/src/components/admin/monitor/__tests__/MonitorTopBand.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { MonitorTopBand } from '../MonitorTopBand';
+
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+const mockUsePathname = usePathname as ReturnType<typeof vi.fn>;
+const mockUseSearchParams = useSearchParams as ReturnType<typeof vi.fn>;
+
+function mockNav(pathname = '/admin/monitor', tab?: string) {
+  mockUsePathname.mockReturnValue(pathname);
+  mockUseSearchParams.mockReturnValue({
+    get: (key: string) => (key === 'tab' ? (tab ?? null) : null),
+  });
+}
+
+describe('MonitorTopBand', () => {
+  it('renders a single h1 with text "Monitor"', () => {
+    mockNav();
+    render(<MonitorTopBand />);
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent('Monitor');
+  });
+
+  it('renders the breadcrumb navigation (MonitorCrumbs slot)', () => {
+    mockNav();
+    render(<MonitorTopBand />);
+    expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toBeInTheDocument();
+  });
+
+  it('renders the Pause stream action button', () => {
+    mockNav();
+    render(<MonitorTopBand />);
+    expect(screen.getByRole('button', { name: /pause stream/i })).toBeInTheDocument();
+  });
+
+  it('renders the Export ndjson action button', () => {
+    mockNav();
+    render(<MonitorTopBand />);
+    expect(screen.getByRole('button', { name: /export ndjson/i })).toBeInTheDocument();
+  });
+
+  it('renders the search input with ⌘K hint', () => {
+    mockNav();
+    render(<MonitorTopBand />);
+    expect(screen.getByRole('textbox', { name: /search monitor/i })).toBeInTheDocument();
+    expect(screen.getByText('⌘K')).toBeInTheDocument();
+  });
+
+  it('renders with correct section aria-label', () => {
+    mockNav('/admin/monitor', 'alerts');
+    render(<MonitorTopBand />);
+    expect(screen.getByRole('banner', { name: /monitor section/i })).toBeInTheDocument();
+  });
+
+  it('reflects active tab label in crumbs when tab=cache', () => {
+    mockNav('/admin/monitor', 'cache');
+    render(<MonitorTopBand />);
+    expect(screen.getByText(/Metrics/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Goal

Phase 2/4 di [F4.1 epic #1718](https://github.com/meepleAi-app/meepleai-monorepo/issues/1718) (SP5 Admin Console — A8 Monitor + LiveEventLog).

Re-skin **className/Tailwind-only** di `/admin/monitor` per allinearlo al design system SP5: banda di sezione condivisa via layout + conversione palette neutrale → token semantici/entity. Zero refactor di logica.

**Predecessor**: PR #1740 (Phase 1/4 BE SSE — MERGED `56dd9ef4e`).

## What's in this PR (5 commits)

### Task 2.1 — MonitorTopBand + Crumbs + Actions (commit `3ab7730a0`)

3 nuovi componenti (server `MonitorTopBand` + client `MonitorCrumbs` + `MonitorTopActions`) + 2 test files (25/25 pass). Pattern 1:1 con F3-FU-3 KB (PR #1664):
- `MonitorTopBand`: sticky band `top-0 z-40 -mx-6` con `<h1>Monitor</h1>`
- `MonitorCrumbs`: deriva da `usePathname()` + `useSearchParams().get('tab')` → label per 13 tab (12 esistenti + nuovo 'events') + 7 sub-route
- `MonitorTopActions`: search ⌘K visual + Pause stream + Export ndjson buttons (placeholder, integrazione transport-level Phase 4)

### Task 2.2 — monitor/layout.tsx wrapping (commit `4c99b5589`)

NEW `monitor/layout.tsx` che wrappa `<MonitorTopBand /> + {children}` in `<div className="space-y-6 px-6">` (mirror KbLayout). Rimosso `<h1>Monitoraggio</h1>` locale + descriptive `<p>` da `monitor/page.tsx` (assorbiti dalla banda). Rimosso test stale `renders heading` (`page.test.tsx`).

### Task 2.3 — Re-skin AlertsTab + CacheTab + InfrastructureTab (commit `e4ca9a7d6`)

- CacheTab: `bg-card/70 dark:bg-zinc-800/70` → `bg-card/70` (semantic handles dark mode natively) — lesson stabilita per il resto del PR
- AlertsTab: amber warning banner passa ESLint in context, nessun cambio netto post pre-commit hook
- InfrastructureTab: già clean

### Task 2.4 — Re-skin Containers/Logs/Grafana/MAU tabs (no-op)

I 4 tab sono **delegation stub 5-line** (`return <SubComponent />;`). Nessun commit. Re-skin reale dei sub-components shiftato a Task 2.6.

### Task 2.5 — Re-skin Command/Testing/BulkExport/Email/AlertHistory (commit `683b43163`)

5 tab batch: CommandCenterTab stub (no-op), gli altri 4 con content rimosso `dark:bg-zinc-*` e `dark:border-zinc-*` (semantic tokens già supportano dark mode):
- TestingTab: 6 section cards
- BulkExportTab: export cards + format badge
- EmailManagementTab: 3 panel containers + table wrappers + inputs (status hues emerald/amber/blue/red/orange retained)
- AlertHistoryTab: table container

Net -40 LOC (Prettier inlined cn() calls).

### Task 2.6 — Re-skin sub-routes (commit `532aabe2f`)

19 file modificati: 7 sub-route + Dashboard/Viewer/Tab/Panel sub-components:
- `containers/`: ContainerDashboard, RestartAllPanel
- `grafana/`: GrafanaDashboard
- `logs/`: AppLogViewer, LogViewer, LokiErrorViewer
- `mau/`: MauDashboard
- `operations/`: AuditTab, EmergencyTab, QueueTab, ResourcesTab + page.tsx
- `service-calls/`: ServiceCallHistory, ServiceSummaryCards
- `services/`: CircuitBreakerPanel, DbStatsPanel, RestartServicePanel, ServicesDashboard
- `components/admin/command-center/CommandCenterDashboard.tsx` (text-slate-* → semantic)

Pattern: rimosso `dark:bg-zinc-*` / `dark:border-zinc-*` ridondanti, `bg-zinc-100 dark:bg-zinc-800` badges → `bg-muted`. Recharts SVG color props out-of-scope (ESLint rule applies solo a className).

## Test Summary

| Checkpoint | Result |
|------------|--------|
| `pnpm typecheck` | 0 errors |
| `pnpm lint:tokens` | 0 violations |
| `pnpm test:admin-dashboard` | 558/558 pass |
| Visual regression gate | Rimosso 2026-05-20 (CLAUDE.md). Sostituto: manual designer review (Sara) |

**0 regressions** in tutta la Fase 2. Behavior SSE/refetch/hooks/state byte-identici (Nygard discipline).

## Acceptance Criteria (design doc §7 Fase 2 FE re-skin) ✅

- ✅ `pnpm typecheck` 0 errors
- ✅ `pnpm lint:tokens` 0 violations
- ✅ ESLint `local/no-hardcoded-color-utility` 0 errori sui file modificati
- ✅ `pnpm test:admin-dashboard` 558/558 verdi
- ✅ 0 file con neutral palette hardcoded nelle 12 tab + sub-routes
- ✅ Banda `MonitorTopBand` presente in `monitor/layout.tsx` con h1 unico "Monitor"
- ✅ Tab che avevano h1 locale ora lo perdono (assorbito dalla banda)
- ✅ Behavior SSE/refetch byte-identico (test esistenti verdi gate)
- ⏳ Manual designer review approvata (richiesta a Sara)

## Lessons stabilite (riusabili per F3-FU-7)

1. **Tab Hub admin sono delegation stub** (`return <SubComponent />;`) — re-skin lavoro reale è nei sub-components. Survey/grep PRIMA di task atomici per evitare no-op cycles.
2. **`dark:bg-zinc-*` / `dark:border-zinc-*` ridondanti**: i token semantici (`bg-card`, `bg-background`, `border-border/60`) gestiscono nativamente light/dark mode. Pattern `bg-card/70 dark:bg-zinc-800/70` → `bg-card/70`.
3. **Status hues** (amber/red/emerald/rose/blue/orange) passano ESLint `local/no-hardcoded-color-utility` in context — nessun `eslint-disable` necessario per status badges.
4. **Recharts SVG color props** (`fill`, `stroke`, `color`) out-of-scope per ESLint className rule.

## Next phases (separate PRs sullo stesso branch parent main-dev)

- **PR 3/4** — `LiveEventLog` component virtualized (react-window) + `useLiveEvents` hook (backfill polling + SSE attach) + filter chips
- **PR 4/4** — Tab 'events' integrazione in Monitor hub + E2E smoke + docs post-merge

## Refs

- Design doc F4.1: `docs/superpowers/specs/2026-05-31-sp5-admin-f4-1-monitor-design.md` §3-§7
- Plan F4.1: `docs/superpowers/plans/2026-05-31-sp5-admin-f4-1-monitor.md` Phase 2
- Predecessor merged: PR #1740 (Phase 1/4 BE SSE), PR #1664 (F3-FU-3 KB re-skin pattern)
- Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-monitor.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)