### PR TITLE
feat(translate-viewer): #1557 Loading 4-step skeleton + abort CTA + 20s timeout

### DIFF
--- a/apps/web/src/components/features/gamebook/AbortButton.tsx
+++ b/apps/web/src/components/features/gamebook/AbortButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { LABELS } from './TranslateViewer.steps';
+
+export interface AbortButtonProps {
+  /**
+   * Callback fired when user clicks the abort button.
+   * Caller should handle FSM rollback (phase change, sse.stop(), etc.)
+   * per DEC-3.
+   */
+  onClick: () => void;
+}
+
+/**
+ * AbortButton component
+ *
+ * Single button rendered conditionally by the parent (TranslateViewer) when
+ * uiStep is abortable (ocr, translating, glossary-check).
+ *
+ * Per DEC-6: Responsive Tailwind layout
+ * - Mobile (default): fixed bottom-4 right-4, rounded-full (FAB style)
+ * - Desktop (lg:): static position, rounded-md, no shadow
+ *
+ * Uses semantic button with aria-label for accessibility.
+ * Focus ring uses --c-game color variable (game entity color).
+ */
+export function AbortButton({ onClick }: AbortButtonProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid="translate-abort-button"
+      aria-label={LABELS.abortAriaLabel}
+      className="
+        fixed bottom-4 right-4 z-50 rounded-full shadow-lg px-4 py-3
+        bg-background border border-border text-foreground
+        lg:static lg:inline-flex lg:rounded-md lg:shadow-none lg:px-3 lg:py-1.5
+        hover:bg-muted focus-visible:ring-2 focus-visible:ring-[var(--c-game)]
+      "
+    >
+      {LABELS.abort}
+    </button>
+  );
+}

--- a/apps/web/src/components/features/gamebook/LoadingSkeleton.tsx
+++ b/apps/web/src/components/features/gamebook/LoadingSkeleton.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { LABELS } from './TranslateViewer.steps';
+
+import type { UiStep } from './TranslateViewer.steps';
+
+export interface LoadingSkeletonProps {
+  /**
+   * Current UI step from deriveUiStep().
+   * Determines the displayed label and test ID.
+   */
+  uiStep: UiStep;
+}
+
+/**
+ * LoadingSkeleton component
+ *
+ * Renders a 4-line skeleton animation (label + 3 bars) with accessibility attributes.
+ * Per DEC-5: Uses Tailwind motion-safe:animate-pulse for reduced-motion fallback.
+ *
+ * Structure:
+ * - Container: role="status" + aria-busy="true" + aria-live="polite" for SR announcement
+ * - Label: text-sm text-muted-foreground with step label from LABELS[uiStep]
+ * - 3 skeleton bars: h-4 rounded bg-muted/50 motion-safe:animate-pulse
+ *   - Bar 1: w-full (100%)
+ *   - Bar 2: w-[92%]
+ *   - Bar 3: w-[78%]
+ */
+export function LoadingSkeleton({ uiStep }: LoadingSkeletonProps): ReactElement {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="space-y-2 max-w-[65ch]"
+      data-testid={`translate-skeleton-${uiStep}`}
+    >
+      <p className="text-sm text-muted-foreground" data-testid="translate-step-label">
+        {LABELS[uiStep]}
+      </p>
+      <div className="h-4 w-full rounded bg-muted/50 motion-safe:animate-pulse" />
+      <div className="h-4 w-[92%] rounded bg-muted/50 motion-safe:animate-pulse" />
+      <div className="h-4 w-[78%] rounded bg-muted/50 motion-safe:animate-pulse" />
+    </div>
+  );
+}

--- a/apps/web/src/components/features/gamebook/TranslateViewer.steps.ts
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.steps.ts
@@ -1,0 +1,79 @@
+/**
+ * TranslateViewer.steps.ts
+ *
+ * UI step mapping and labels for the 4-step loading skeleton.
+ * Decoupled from the internal FSM `Phase` enum to allow independent evolution.
+ *
+ * DEC-1 (Fowler SRP): `UiStep` type projects the internal `Phase` enum
+ * onto user-facing steps (uploading, ocr, translating, glossary-check).
+ * DEC-2 (Crispin testability): Glossary-check signal is `appliedTerms.length > 0`.
+ */
+
+import type { Phase } from './TranslateViewer';
+
+/**
+ * User-facing UI step names for the 4-step skeleton + labels.
+ * Independent of the internal Phase FSM.
+ */
+export type UiStep = 'uploading' | 'ocr' | 'translating' | 'glossary-check';
+
+/**
+ * Internationalized labels (IT) for UI steps and controls.
+ * Per DEC-7: Hardcoded IT, extracted into const for reuse across LoadingSkeleton, AbortButton.
+ */
+export const LABELS = {
+  uploading: 'Caricamento foto…',
+  ocr: 'Sto leggendo il libro…',
+  translating: 'Sto traducendo…',
+  'glossary-check': 'Cerco parole nel glossario…',
+  abort: 'Annulla',
+  abortAriaLabel: 'Annulla la traduzione in corso',
+  timeoutError: 'Traduzione interrotta: superato il limite di 20 secondi. Riprova.',
+} as const;
+
+/**
+ * Maps internal FSM Phase to user-facing UiStep.
+ *
+ * DEC-1: `uploading` phase → `uploading` step (no change).
+ * DEC-1: `segmenting` phase → `ocr` step.
+ * DEC-1: `translating` phase → either `translating` or `glossary-check` based on glossary signal.
+ * DEC-2: Glossary-check is triggered when `appliedTerms.length > 0` during `translating`.
+ *
+ * Returns `null` for idle, segments_ready, translated phases (no skeleton shown).
+ *
+ * @param phase - Internal FSM phase
+ * @param sse - SSE hook state containing appliedTerms and isComplete signals
+ * @returns UiStep or null if no skeleton should be shown
+ */
+export function deriveUiStep(
+  phase: Phase,
+  sse: { readonly appliedTerms: readonly string[]; readonly isComplete: boolean }
+): UiStep | null {
+  switch (phase) {
+    case 'uploading':
+      return 'uploading';
+    case 'segmenting':
+      return 'ocr';
+    case 'translating':
+      // Glossary-check is shown when appliedTerms have been populated.
+      // If appliedTerms is empty, we're still translating without glossary lookups.
+      return sse.appliedTerms.length > 0 ? 'glossary-check' : 'translating';
+    case 'idle':
+    case 'segments_ready':
+    case 'translated':
+      return null;
+  }
+}
+
+/**
+ * Determines if the given UiStep should show the abort button.
+ *
+ * DEC-3: Abort is visible from step 2+ (ocr, translating, glossary-check).
+ * Abort is hidden during `uploading` (step 1) because it's too fast to abort usefully.
+ *
+ * @param uiStep - Current UI step or null if no skeleton
+ * @returns true if abort button should be visible
+ */
+export function isAbortableStep(uiStep: UiStep | null): boolean {
+  return uiStep === 'ocr' || uiStep === 'translating' || uiStep === 'glossary-check';
+}

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -109,12 +109,14 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
   useEffect(() => {
     if (phase !== 'uploading' && phase !== 'segmenting' && phase !== 'translating') return;
     const timerId = window.setTimeout(() => {
+      // M2 review fix: skip rollback if SSE already completed in the same tick (race guard)
+      if (sse.isComplete) return;
       sse.stop();
       setTimeoutError(LABELS.timeoutError);
       setPhase(prev => (prev === 'translating' ? 'segments_ready' : 'idle'));
     }, HARD_TIMEOUT_MS);
     return () => window.clearTimeout(timerId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only re-arm on phase change
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sse.stop is stable (useCallback); deliberate phase-only arm
   }, [phase]);
 
   const handlePickSegment = (paragraphNumber: number) => {

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -173,6 +173,7 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
           type="file"
           accept="image/*"
           capture="environment"
+          aria-label="Seleziona foto da tradurre"
           onChange={e => {
             const f = e.target.files?.[0];
             if (f) void handleFile(f);

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import { useMemo, useRef, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 
+import { AbortButton } from '@/components/features/gamebook/AbortButton';
 import { BookPicker } from '@/components/features/gamebook/BookPicker';
+import { LoadingSkeleton } from '@/components/features/gamebook/LoadingSkeleton';
 import { SegmentPicker } from '@/components/features/gamebook/SegmentPicker';
+import {
+  deriveUiStep,
+  isAbortableStep,
+  LABELS,
+} from '@/components/features/gamebook/TranslateViewer.steps';
 import { TranslationPane } from '@/components/features/gamebook/TranslationPane';
 import { useGameBooks } from '@/hooks/useGameBooks';
 import { GameBookRole, hasRole, type GameRef } from '@/lib/api/gamebook';
@@ -25,7 +32,13 @@ export interface TranslateViewerProps {
   gameRef: GameRef;
 }
 
-type Phase = 'idle' | 'uploading' | 'segmenting' | 'segments_ready' | 'translating' | 'translated';
+export type Phase =
+  | 'idle'
+  | 'uploading'
+  | 'segmenting'
+  | 'segments_ready'
+  | 'translating'
+  | 'translated';
 
 export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): ReactElement {
   const [phase, setPhase] = useState<Phase>('idle');
@@ -53,11 +66,18 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
   const segment = useSegmentPhoto(campaignId);
   const sse = useTranslateSegmentSSE();
 
+  // T5 — DEC-4: Hard timeout state. Merged into errorMessage below.
+  const [timeoutError, setTimeoutError] = useState<string | null>(null);
+
+  // DEC-1: Derive user-facing UI step from internal FSM phase + SSE signals.
+  const uiStep = deriveUiStep(phase, sse);
+
   const handleFile = async (file: File) => {
     if (!effectiveBookId) {
       // Defensive: button should be disabled when no book selectable.
       return;
     }
+    setTimeoutError(null); // Clear timeout error on new operation start.
     setPhase('uploading');
     setArtifact(null);
     setActiveSegment(null);
@@ -73,6 +93,30 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
     }
   };
 
+  // T4 — DEC-3: Abort handler. Rolls back FSM per phase:
+  //   uploading   → idle          (photo discarded, camera available)
+  //   segmenting  → idle          (photo + OCR discarded, camera available)
+  //   translating → segments_ready (artifact preserved, user can pick another segment)
+  const handleAbort = useCallback(() => {
+    sse.stop();
+    setTimeoutError(null);
+    setPhase(prev => (prev === 'translating' ? 'segments_ready' : 'idle'));
+  }, [sse]);
+
+  // T5 — DEC-4: Hard timeout 20s. Soft target 17s (Aaron CORE §1b lines 122-123 — no UI feedback).
+  const HARD_TIMEOUT_MS = 20_000;
+
+  useEffect(() => {
+    if (phase !== 'uploading' && phase !== 'segmenting' && phase !== 'translating') return;
+    const timerId = window.setTimeout(() => {
+      sse.stop();
+      setTimeoutError(LABELS.timeoutError);
+      setPhase(prev => (prev === 'translating' ? 'segments_ready' : 'idle'));
+    }, HARD_TIMEOUT_MS);
+    return () => window.clearTimeout(timerId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only re-arm on phase change
+  }, [phase]);
+
   const handlePickSegment = (paragraphNumber: number) => {
     if (!artifact || !effectiveBookId) return;
     const seg = artifact.segments.find(s => s.paragraphNumber === paragraphNumber);
@@ -87,7 +131,8 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
     setPhase('translated');
   }
 
-  const errorMessage = upload.error?.message ?? segment.error?.message ?? sse.error;
+  const errorMessage =
+    upload.error?.message ?? segment.error?.message ?? sse.error ?? timeoutError ?? undefined;
 
   const isBusy = phase === 'uploading' || phase === 'segmenting' || phase === 'translating';
   const cameraDisabled = isBusy || !effectiveBookId;
@@ -144,10 +189,8 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
         >
           {phase === 'idle' || phase === 'translated' ? 'Scatta o scegli foto' : 'In corso…'}
         </button>
-        {phase === 'uploading' && <p className="text-sm text-muted-foreground">Upload in corso…</p>}
-        {phase === 'segmenting' && (
-          <p className="text-sm text-muted-foreground">OCR in corso (estrazione paragrafi)…</p>
-        )}
+        {uiStep && <LoadingSkeleton uiStep={uiStep} />}
+        {isAbortableStep(uiStep) && <AbortButton onClick={handleAbort} />}
         {errorMessage && (
           <p className="text-sm text-destructive" role="alert" data-testid="translate-viewer-error">
             {errorMessage}

--- a/apps/web/src/components/features/gamebook/__tests__/AbortButton.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/AbortButton.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AbortButton } from '../AbortButton';
+import { LABELS } from '../TranslateViewer.steps';
+
+describe('AbortButton', () => {
+  it('renders with data-testid="translate-abort-button"', () => {
+    render(<AbortButton onClick={vi.fn()} />);
+    expect(screen.getByTestId('translate-abort-button')).toBeInTheDocument();
+  });
+
+  it('displays the abort label text', () => {
+    render(<AbortButton onClick={vi.fn()} />);
+    expect(screen.getByText(LABELS.abort)).toBeInTheDocument();
+  });
+
+  it('has correct aria-label for accessibility', () => {
+    render(<AbortButton onClick={vi.fn()} />);
+    const button = screen.getByTestId('translate-abort-button');
+    expect(button).toHaveAttribute('aria-label', LABELS.abortAriaLabel);
+  });
+
+  it('calls onClick handler when clicked', async () => {
+    const handleClick = vi.fn();
+    render(<AbortButton onClick={handleClick} />);
+
+    const button = screen.getByTestId('translate-abort-button');
+    const user = userEvent.setup();
+    await user.click(button);
+
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it('has type="button" to avoid form submission', () => {
+    render(<AbortButton onClick={vi.fn()} />);
+    const button = screen.getByTestId('translate-abort-button') as HTMLButtonElement;
+    expect(button.type).toBe('button');
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LoadingSkeleton } from '../LoadingSkeleton';
+import { LABELS, type UiStep } from '../TranslateViewer.steps';
+
+describe('LoadingSkeleton', () => {
+  const uiSteps: UiStep[] = ['uploading', 'ocr', 'translating', 'glossary-check'];
+
+  uiSteps.forEach(uiStep => {
+    describe(`when uiStep = "${uiStep}"`, () => {
+      it('renders with correct data-testid', () => {
+        render(<LoadingSkeleton uiStep={uiStep} />);
+        expect(screen.getByTestId(`translate-skeleton-${uiStep}`)).toBeInTheDocument();
+      });
+
+      it('displays the step label from LABELS', () => {
+        render(<LoadingSkeleton uiStep={uiStep} />);
+        const label = screen.getByTestId('translate-step-label');
+        expect(label).toHaveTextContent(LABELS[uiStep]);
+      });
+
+      it('has aria-busy="true" for accessibility', () => {
+        render(<LoadingSkeleton uiStep={uiStep} />);
+        const container = screen.getByTestId(`translate-skeleton-${uiStep}`);
+        expect(container).toHaveAttribute('aria-busy', 'true');
+      });
+
+      it('has aria-live="polite" for SR announcement', () => {
+        render(<LoadingSkeleton uiStep={uiStep} />);
+        const container = screen.getByTestId(`translate-skeleton-${uiStep}`);
+        expect(container).toHaveAttribute('aria-live', 'polite');
+      });
+    });
+  });
+
+  it('renders 3 skeleton bars with correct widths', () => {
+    render(<LoadingSkeleton uiStep="ocr" />);
+    const bars = screen
+      .getByTestId('translate-skeleton-ocr')
+      .querySelectorAll('div[class*="bg-muted"]');
+    expect(bars).toHaveLength(3);
+
+    // Verify width classes are present in DOM
+    const container = screen.getByTestId('translate-skeleton-ocr');
+    const barElements = Array.from(container.querySelectorAll('div.motion-safe\\:animate-pulse'));
+    expect(barElements).toHaveLength(3);
+  });
+
+  it('has role="status" for semantic meaning', () => {
+    render(<LoadingSkeleton uiStep="translating" />);
+    const container = screen.getByTestId('translate-skeleton-translating');
+    expect(container).toHaveAttribute('role', 'status');
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.steps.test.ts
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.steps.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { type UiStep, LABELS, deriveUiStep, isAbortableStep } from '../TranslateViewer.steps';
+
+describe('TranslateViewer.steps', () => {
+  describe('deriveUiStep', () => {
+    it('returns "uploading" when phase is uploading', () => {
+      const uiStep = deriveUiStep('uploading', { appliedTerms: [], isComplete: false });
+      expect(uiStep).toBe('uploading');
+    });
+
+    it('returns "ocr" when phase is segmenting', () => {
+      const uiStep = deriveUiStep('segmenting', { appliedTerms: [], isComplete: false });
+      expect(uiStep).toBe('ocr');
+    });
+
+    it('returns "translating" when phase is translating with empty appliedTerms', () => {
+      const uiStep = deriveUiStep('translating', { appliedTerms: [], isComplete: false });
+      expect(uiStep).toBe('translating');
+    });
+
+    it('returns "glossary-check" when phase is translating with appliedTerms present', () => {
+      const uiStep = deriveUiStep('translating', {
+        appliedTerms: ['sentinel', 'gold'],
+        isComplete: false,
+      });
+      expect(uiStep).toBe('glossary-check');
+    });
+
+    it('returns "glossary-check" when appliedTerms has even one entry', () => {
+      const uiStep = deriveUiStep('translating', {
+        appliedTerms: ['single-term'],
+        isComplete: false,
+      });
+      expect(uiStep).toBe('glossary-check');
+    });
+
+    it('returns null when phase is idle', () => {
+      const uiStep = deriveUiStep('idle', { appliedTerms: [], isComplete: false });
+      expect(uiStep).toBeNull();
+    });
+
+    it('returns null when phase is segments_ready', () => {
+      const uiStep = deriveUiStep('segments_ready', { appliedTerms: [], isComplete: false });
+      expect(uiStep).toBeNull();
+    });
+
+    it('returns null when phase is translated', () => {
+      const uiStep = deriveUiStep('translated', { appliedTerms: [], isComplete: false });
+      expect(uiStep).toBeNull();
+    });
+
+    it('handles appliedTerms and isComplete state independently', () => {
+      // isComplete=true should not affect glossary-check trigger
+      const uiStep = deriveUiStep('translating', {
+        appliedTerms: ['word1'],
+        isComplete: true,
+      });
+      expect(uiStep).toBe('glossary-check');
+    });
+  });
+
+  describe('isAbortableStep', () => {
+    it('returns true for "ocr" step', () => {
+      expect(isAbortableStep('ocr')).toBe(true);
+    });
+
+    it('returns true for "translating" step', () => {
+      expect(isAbortableStep('translating')).toBe(true);
+    });
+
+    it('returns true for "glossary-check" step', () => {
+      expect(isAbortableStep('glossary-check')).toBe(true);
+    });
+
+    it('returns false for "uploading" step (DEC-3: abort hidden in step 1)', () => {
+      expect(isAbortableStep('uploading')).toBe(false);
+    });
+
+    it('returns false when uiStep is null', () => {
+      expect(isAbortableStep(null)).toBe(false);
+    });
+  });
+
+  describe('LABELS', () => {
+    it('has entry for all UiStep values', () => {
+      const uiSteps: UiStep[] = ['uploading', 'ocr', 'translating', 'glossary-check'];
+      uiSteps.forEach(step => {
+        expect(LABELS[step]).toBeDefined();
+        expect(typeof LABELS[step]).toBe('string');
+        expect(LABELS[step].length).toBeGreaterThan(0);
+      });
+    });
+
+    it('has abort control labels', () => {
+      expect(LABELS.abort).toBe('Annulla');
+      expect(LABELS.abortAriaLabel).toBe('Annulla la traduzione in corso');
+    });
+
+    it('has timeoutError label', () => {
+      expect(LABELS.timeoutError).toContain('20 secondi');
+    });
+
+    it('all labels are non-empty strings', () => {
+      Object.values(LABELS).forEach(label => {
+        expect(typeof label).toBe('string');
+        expect(label.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
@@ -21,7 +22,55 @@ const CAMPAIGN_ID = '11111111-1111-4111-a111-111111111111';
 const GAME_ID = '99999999-9999-4999-a999-999999999999';
 const BOOK_STORY_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
 const BOOK_ENCOUNTER_ID = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
+const PHOTO_ID = 'cccccccc-cccc-4ccc-accc-cccccccccccc';
+const ARTIFACT_ID = 'dddddddd-dddd-4ddd-addd-dddddddddddd';
 const GAME_REF: GameRef = { id: GAME_ID, kind: GameRefKind.Shared };
+
+/** A fake artifact with 1 segment (para §1) for segment-pick tests */
+const FAKE_ARTIFACT = {
+  id: ARTIFACT_ID,
+  campaignId: CAMPAIGN_ID,
+  photoId: PHOTO_ID,
+  segments: [
+    {
+      paragraphNumber: 1,
+      sourceText: 'You wake up in a dungeon.',
+    },
+  ],
+};
+
+/** Mock the books hook with a single narrative book so camera is auto-enabled */
+function makeOneBookMock() {
+  vi.mocked(booksHook.useGameBooks).mockReturnValue({
+    data: [
+      {
+        id: BOOK_STORY_ID,
+        gameRefId: GAME_ID,
+        gameRefKind: GameRefKind.Shared,
+        ownerUserId: null,
+        displayName: 'Solo Storybook',
+        roles: 4,
+        paragraphScheme: 1,
+        language: 'en',
+        sequentialRead: true,
+        kbSourceDocId: null,
+        physicalOnly: true,
+        createdAt: '2026-05-07T10:00:00Z',
+      },
+    ],
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as never);
+}
+
+/** Fire a file-change event on the hidden photo input to kick off handleFile() */
+function firePhotoInput() {
+  const input = screen.getByTestId('photo-input');
+  fireEvent.change(input, {
+    target: { files: [new File(['x'], 'photo.png', { type: 'image/png' })] },
+  });
+}
 
 function wrap(ui: ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -215,5 +264,470 @@ describe('TranslateViewer', () => {
     expect(screen.queryByTestId('translate-viewer-book-picker-section')).not.toBeInTheDocument();
     // Camera is enabled because we auto-selected the single book.
     expect(screen.getByTestId('open-camera-button')).not.toBeDisabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // S1 — Uploading shows skeleton + label (T6)
+  // ---------------------------------------------------------------------------
+  it('S1: uploading phase shows translate-skeleton-uploading + correct label + aria-busy', async () => {
+    makeOneBookMock();
+
+    // Hold upload unresolved so component stays in 'uploading' phase
+    let resolveUpload!: (v: unknown) => void;
+    const uploadPromise = new Promise(r => {
+      resolveUpload = r;
+    });
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockReturnValue(uploadPromise),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-uploading')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('translate-step-label')).toHaveTextContent('Caricamento foto…');
+    expect(screen.getByTestId('translate-skeleton-uploading')).toHaveAttribute('aria-busy', 'true');
+
+    // Resolve upload to avoid dangling promise in cleanup
+    await act(async () => {
+      resolveUpload({ id: PHOTO_ID, segments: [] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // S2 — OCR step shows (T6)
+  // ---------------------------------------------------------------------------
+  it('S2: segmenting phase shows translate-skeleton-ocr + correct label', async () => {
+    makeOneBookMock();
+
+    // Upload resolves immediately; hold segment unresolved
+    let resolveSegment!: (v: unknown) => void;
+    const segmentPromise = new Promise(r => {
+      resolveSegment = r;
+    });
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockReturnValue(segmentPromise),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-ocr')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('translate-step-label')).toHaveTextContent('Sto leggendo il libro…');
+
+    // Resolve segment to avoid dangling promise
+    await act(async () => {
+      resolveSegment(FAKE_ARTIFACT);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // S3 — Translating step shows (no appliedTerms) (T6)
+  // ---------------------------------------------------------------------------
+  it('S3: translating phase with empty appliedTerms shows translate-skeleton-translating', async () => {
+    makeOneBookMock();
+
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue(FAKE_ARTIFACT),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    // SSE stays incomplete with no appliedTerms → 'translating' uiStep
+    vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+      partialText: '',
+      isComplete: false,
+      appliedTerms: [],
+      error: undefined,
+      start: vi.fn(),
+      stop: vi.fn(),
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    // Wait for segments_ready phase (SegmentPicker visible)
+    await waitFor(() => {
+      expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+    });
+
+    // Click translate on §1
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('segment-picker-translate-1'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-translating')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('translate-step-label')).toHaveTextContent('Sto traducendo…');
+  });
+
+  // ---------------------------------------------------------------------------
+  // S4 — Glossary-check step on appliedTerms signal (T7)
+  // ---------------------------------------------------------------------------
+  it('S4: translating phase with appliedTerms shows translate-skeleton-glossary-check', async () => {
+    makeOneBookMock();
+
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue(FAKE_ARTIFACT),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    // SSE returns appliedTerms → glossary-check uiStep
+    vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+      partialText: 'partial…',
+      isComplete: false,
+      appliedTerms: ['sentinel', 'gold'],
+      error: undefined,
+      start: vi.fn(),
+      stop: vi.fn(),
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('segment-picker-translate-1'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-glossary-check')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('translate-step-label')).toHaveTextContent(
+      'Cerco parole nel glossario…'
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // S5 — Abort hidden during uploading (T6)
+  // ---------------------------------------------------------------------------
+  it('S5: abort button is NOT visible during uploading (step 1)', async () => {
+    makeOneBookMock();
+
+    let resolveUpload!: (v: unknown) => void;
+    const uploadPromise = new Promise(r => {
+      resolveUpload = r;
+    });
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockReturnValue(uploadPromise),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-uploading')).toBeInTheDocument();
+    });
+
+    // Abort button must NOT appear during uploading (DEC-6 / DEC-3)
+    expect(screen.queryByTestId('translate-abort-button')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveUpload({ id: PHOTO_ID, segments: [] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // S6 — Abort visible from step 2+ (segmenting) (T6)
+  // ---------------------------------------------------------------------------
+  it('S6: abort button IS visible during segmenting (step 2+)', async () => {
+    makeOneBookMock();
+
+    let resolveSegment!: (v: unknown) => void;
+    const segmentPromise = new Promise(r => {
+      resolveSegment = r;
+    });
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockReturnValue(segmentPromise),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-ocr')).toBeInTheDocument();
+    });
+
+    // Abort button MUST appear from step 2 (DEC-6)
+    expect(screen.getByTestId('translate-abort-button')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSegment(FAKE_ARTIFACT);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // S7 — Abort during translating reverts to segments_ready (T7)
+  // ---------------------------------------------------------------------------
+  it('S7: clicking abort during translating calls sse.stop() and reverts to segments_ready', async () => {
+    makeOneBookMock();
+
+    const stopMock = vi.fn();
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue(FAKE_ARTIFACT),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+      partialText: '',
+      isComplete: false,
+      appliedTerms: [],
+      error: undefined,
+      start: vi.fn(),
+      stop: stopMock,
+    } as never);
+
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('segment-picker-translate-1'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-abort-button')).toBeInTheDocument();
+    });
+
+    // Click abort
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('translate-abort-button'));
+    });
+
+    // sse.stop() must have been called
+    expect(stopMock).toHaveBeenCalledOnce();
+
+    // Phase rolls back to segments_ready: SegmentPicker still visible,
+    // no skeleton, no abort button
+    await waitFor(() => {
+      expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('translate-abort-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('translate-skeleton-translating')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // S8 — Hard timeout 20s fires (T7)
+  // ---------------------------------------------------------------------------
+  it('S8: 20s hard timeout calls sse.stop() and surfaces timeout error', async () => {
+    makeOneBookMock();
+
+    const stopMock = vi.fn();
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue(FAKE_ARTIFACT),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+      partialText: '',
+      isComplete: false,
+      appliedTerms: [],
+      error: undefined,
+      start: vi.fn(),
+      stop: stopMock,
+    } as never);
+
+    // Use fake timers with shouldAdvanceTime so that promise microtasks still
+    // flush (required for waitFor / act to work alongside advanceTimersByTime)
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      // Flush all pending microtasks so upload+segment promises resolve
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // Confirm we reached segments_ready (SegmentPicker visible)
+      expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+
+      // Click translate to enter translating phase
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('segment-picker-translate-1'));
+      });
+
+      expect(screen.getByTestId('translate-skeleton-translating')).toBeInTheDocument();
+
+      // Advance timers past 20s to fire the hard timeout
+      await act(async () => {
+        vi.advanceTimersByTime(20_001);
+      });
+
+      // sse.stop() must have been called by the timeout handler
+      expect(stopMock).toHaveBeenCalled();
+
+      // Error message must reference '20 secondi'
+      expect(screen.getByTestId('translate-viewer-error')).toHaveTextContent('20 secondi');
+
+      // Phase rolls back: SegmentPicker still visible (segments_ready), no active skeleton
+      expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      expect(screen.queryByTestId('translate-skeleton-translating')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 60_000); // generous timeout for fake-timer test
+
+  // ---------------------------------------------------------------------------
+  // S9 — jest-axe scan (T8)
+  // ---------------------------------------------------------------------------
+  it('S9: idle state has no axe accessibility violations', async () => {
+    // Use default mocks (2-book state, idle phase)
+    const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('S9b: uploading skeleton state has no axe accessibility violations', async () => {
+    makeOneBookMock();
+
+    let resolveUpload!: (v: unknown) => void;
+    const uploadPromise = new Promise(r => {
+      resolveUpload = r;
+    });
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockReturnValue(uploadPromise),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-uploading')).toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+
+    await act(async () => {
+      resolveUpload({ id: PHOTO_ID, segments: [] });
+    });
   });
 });

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -730,4 +730,49 @@ describe('TranslateViewer', () => {
       resolveUpload({ id: PHOTO_ID, segments: [] });
     });
   });
+
+  it('S9c: ocr skeleton + AbortButton state has no axe accessibility violations', async () => {
+    // Review fix M1: cover ocr state where AbortButton becomes visible (fixed-position element)
+    makeOneBookMock();
+
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    let resolveSegment!: (v: unknown) => void;
+    const segmentPromise = new Promise(r => {
+      resolveSegment = r;
+    });
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockReturnValue(segmentPromise),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+
+    await act(async () => {
+      firePhotoInput();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('translate-skeleton-ocr')).toBeInTheDocument();
+      expect(screen.getByTestId('translate-abort-button')).toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+
+    await act(async () => {
+      resolveSegment({ id: PHOTO_ID, segments: [] });
+    });
+  });
 });

--- a/docs/superpowers/plans/2026-05-31-issue-1557-loading-skeleton-abort.md
+++ b/docs/superpowers/plans/2026-05-31-issue-1557-loading-skeleton-abort.md
@@ -1,0 +1,207 @@
+# Plan — #1557 Loading 4-step skeleton + abort CTA
+
+> **Source**: issue [#1557](https://github.com/meepleAi-app/meepleai-monorepo/issues/1557), audit [`translate-gap-report.md §2 row G`](../../../admin-mockups/design_handoff/translate-gap-report.md), Aaron CORE spec [`§1b lines 103-141`](../specs/2026-05-23-mockup-refinement-aaron-core-design.md).
+>
+> **Branch**: `feature/issue-1557-loading-skeleton-abort-cta` (parent: `main-dev`)
+>
+> **Effort**: L ~3-4h, FE-only, P1.
+
+## Decisions locked (spec-panel critique sintetizzato)
+
+### DEC-1 — Phase enum strategy (Fowler SRP)
+
+**MANTENERE** `Phase` enum esistente (`idle|uploading|segmenting|segments_ready|translating|translated`) — non rompere FSM SSE/upload/segment. **AGGIUNGERE** `UiStep` type 4-valori per la rendering label:
+
+```ts
+type UiStep = 'uploading' | 'ocr' | 'translating' | 'glossary-check';
+
+function deriveUiStep(phase: Phase, sse: { appliedTerms: string[]; isComplete: boolean }): UiStep | null {
+  if (phase === 'uploading') return 'uploading';
+  if (phase === 'segmenting') return 'ocr';
+  if (phase === 'translating') {
+    return sse.appliedTerms.length > 0 ? 'glossary-check' : 'translating';
+  }
+  return null;
+}
+```
+
+**Rationale**: La spec parla di "4 step nominati" (UI concept), il codice FSM è una proiezione tecnica orthogonal. Non touch ai contratti dei hook.
+
+### DEC-2 — Glossary-check signal (Crispin testability)
+
+Usa `sse.appliedTerms.length > 0` come trigger del 4° step. Se appliedTerms vuoto → skip diretto `translating → translated` (acceptable: no glossary check happened).
+
+**Edge case coperto in S5**: rendering switch da "translating" a "glossary-check" quando arriva il primo applied term, anche se `partialText` continua a streamare.
+
+### DEC-3 — Abort rollback (Cockburn primary actor goal)
+
+| Phase corrente | Click abort → | Effetto |
+|---|---|---|
+| `uploading` | `idle` | Foto descartata, camera disponibile |
+| `segmenting` | `idle` | Foto + OCR descartati, camera disponibile |
+| `translating` | `segments_ready` | Artifact preserved, può scegliere altro paragrafo |
+
+Tutti i casi → `sse.stop()` chiamato + `setError(null)` + clearTimeout. **Abort NON visibile in `uploading`** (step 1 troppo veloce per essere abortable utilmente, Aaron CORE §1b: "visibile dal step 2 in poi").
+
+### DEC-4 — Hard timeout 20s (Nygard failure mode)
+
+```ts
+useEffect(() => {
+  if (phase !== 'uploading' && phase !== 'segmenting' && phase !== 'translating') return;
+  const TIMEOUT_MS = 20_000;
+  const timerId = window.setTimeout(() => {
+    sse.stop();
+    setError('Traduzione interrotta: superato il limite di 20 secondi. Riprova.');
+    // Rollback come DEC-3
+    setPhase(prev => prev === 'translating' ? 'segments_ready' : 'idle');
+  }, TIMEOUT_MS);
+  return () => window.clearTimeout(timerId);
+}, [phase]);
+```
+
+**Soft target 17s** = solo commento JSDoc sopra `TIMEOUT_MS` (no UI per ora).
+
+### DEC-5 — Skeleton + reduced-motion fallback (Tailwind built-in)
+
+```tsx
+<div
+  role="status"
+  aria-busy="true"
+  aria-live="polite"
+  className="space-y-2 max-w-[65ch]"
+  data-testid={`translate-skeleton-${uiStep}`}
+>
+  <p className="text-sm text-muted-foreground" data-testid="translate-step-label">{LABELS[uiStep]}</p>
+  <div className="h-4 w-full rounded bg-muted/50 motion-safe:animate-pulse" />
+  <div className="h-4 w-[92%] rounded bg-muted/50 motion-safe:animate-pulse" />
+  <div className="h-4 w-[78%] rounded bg-muted/50 motion-safe:animate-pulse" />
+</div>
+```
+
+- `motion-safe:animate-pulse` = Tailwind built-in, zero-config; user con `prefers-reduced-motion: reduce` vede solo background statico
+- `role="status" + aria-busy + aria-live="polite"` = SR announce phase change senza interruzione
+- `max-w-65ch` = allineamento Aaron CORE J (AAA contrast width)
+
+**Shimmer-sweep gradient**: deferred (Tailwind pulse soddisfa "animated + reduced-motion fallback" AC; mockup nice-to-have).
+
+### DEC-6 — Abort button responsive (Fowler single component)
+
+```tsx
+{(uiStep === 'ocr' || uiStep === 'translating' || uiStep === 'glossary-check') && (
+  <button
+    type="button"
+    onClick={handleAbort}
+    data-testid="translate-abort-button"
+    aria-label={LABELS.abortAriaLabel}
+    className="
+      fixed bottom-4 right-4 z-50 rounded-full shadow-lg px-4 py-3
+      bg-background border border-border text-foreground
+      lg:static lg:inline-flex lg:rounded-md lg:shadow-none lg:px-3 lg:py-1.5
+      hover:bg-muted focus-visible:ring-2 focus-visible:ring-[var(--c-game)]
+    "
+  >
+    {LABELS.abort}
+  </button>
+)}
+```
+
+Una sola istanza nel DOM. Test assertion via `data-testid`, position-test via class snapshot acceptable.
+
+### DEC-7 — i18n (Wiegers no-scope-creep)
+
+Hardcoded IT, estratti in const `LABELS`:
+
+```ts
+const LABELS: Record<UiStep | 'abort' | 'abortAriaLabel' | 'timeoutError', string> = {
+  uploading: 'Caricamento foto…',
+  ocr: 'Sto leggendo il libro…',
+  translating: 'Sto traducendo…',
+  'glossary-check': 'Cerco parole nel glossario…',
+  abort: 'Annulla',
+  abortAriaLabel: 'Annulla la traduzione in corso',
+  timeoutError: 'Traduzione interrotta: superato il limite di 20 secondi. Riprova.',
+};
+```
+
+Coerente con `'Traduci pagina libro game'` hardcoded esistente. Migration i18n out-of-scope (#1557 non lo cita).
+
+## Given/When/Then scenarios
+
+### S1 — Uploading shows skeleton + label
+GIVEN `phase === 'uploading'` WHEN render THEN `[data-testid="translate-skeleton-uploading"]` visible AND `[data-testid="translate-step-label"]` text === `'Caricamento foto…'` AND container has `aria-busy="true"`.
+
+### S2 — OCR step shows
+GIVEN `phase === 'segmenting'` WHEN render THEN `[data-testid="translate-skeleton-ocr"]` visible AND label === `'Sto leggendo il libro…'`.
+
+### S3 — Translating step shows
+GIVEN `phase === 'translating'` AND `sse.appliedTerms === []` WHEN render THEN `[data-testid="translate-skeleton-translating"]` visible AND label === `'Sto traducendo…'`.
+
+### S4 — Glossary-check step on appliedTerms signal
+GIVEN `phase === 'translating'` AND `sse.appliedTerms === ['sentinel', 'gold']` AND `!sse.isComplete` WHEN render THEN `[data-testid="translate-skeleton-glossary-check"]` visible AND label === `'Cerco parole nel glossario…'`.
+
+### S5 — Abort hidden during uploading
+GIVEN `phase === 'uploading'` WHEN render THEN `[data-testid="translate-abort-button"]` NOT in document.
+
+### S6 — Abort visible from step 2+
+GIVEN `phase === 'segmenting'` WHEN render THEN `[data-testid="translate-abort-button"]` visible.
+
+### S7 — Abort during translating reverts to segments_ready
+GIVEN `phase === 'translating'` AND artifact present WHEN user clicks abort THEN `sse.stop()` called AND phase becomes `segments_ready`.
+
+### S8 — Hard timeout 20s fires
+GIVEN `phase === 'translating'` AND `vi.useFakeTimers()` AND 20_001ms advance THEN `sse.stop()` called AND error contains `'20 secondi'` AND phase becomes `segments_ready`.
+
+### S9 — jest-axe scan
+GIVEN skeleton rendered in any of the 4 uiSteps WHEN axe runs THEN `violations.length === 0`.
+
+## Tasks (TDD, mix-model P120)
+
+| # | Task | Model | Effort | Deps |
+|---|---|---|---|---|
+| T1 | Add `UiStep` type, `LABELS` const, `deriveUiStep()` helper in new module `TranslateViewer.steps.ts` + unit tests for deriveUiStep (covers DEC-1 + DEC-2 mapping logic) | haiku | 20m | — |
+| T2 | Build `LoadingSkeleton` component (3-line skeleton + label + aria-busy/live) in new file `LoadingSkeleton.tsx` + unit test (snapshot + a11y attrs per uiStep) | haiku | 20m | T1 |
+| T3 | Build `AbortButton` component (responsive FAB/inline) in new file `AbortButton.tsx` + unit test (data-testid, aria-label) | haiku | 15m | — |
+| T4 | Wire `LoadingSkeleton` + `AbortButton` into `TranslateViewer.tsx`: replace text labels at lines 147-149, add `handleAbort` callback (FSM rollback per DEC-3), integrate `deriveUiStep` | sonnet | 30m | T1, T2, T3 |
+| T5 | Implement 20s hard timeout `useEffect` per DEC-4 in `TranslateViewer.tsx` (setTimeout + clearTimeout on phase change/unmount, JSDoc soft target 17s) | haiku | 15m | T4 |
+| T6 | Update `TranslateViewer.test.tsx`: add tests for S1, S2, S3, S5, S6 (rendering-level, mock-driven phase via `act` or test helper exposing internal setter via re-render — NB: existing tests use mock-only, so need helper or refactor to accept controlled phase prop OR test via DOM interaction triggering phase change) | sonnet | 30m | T4, T5 |
+| T7 | Add advanced tests for S4 (appliedTerms→glossary), S7 (abort flow), S8 (timeout fake timers) via integration-level setup driving real state transitions through mocked hooks side-effects | sonnet | 30m | T6 |
+| T8 | Add S9 (jest-axe scan) in `TranslateViewer.test.tsx` covering 4 uiStep states (mirror `EncounterCheatsheetView.test.tsx:3` pattern) | sonnet | 15m | T7 |
+
+**Total**: ~3h25m. Mix-model breakdown: 4 haiku (mechanical schemas/components/timer), 4 sonnet (integration/judgment/a11y).
+
+## P74 risks identified
+
+- **R1**: Existing test pattern uses `vi.mock` only → no internal state controllability. T6/T7 may need a controlled-prop refactor on `TranslateViewer` OR test-helper. Decision punted to subagent: prefer NOT mutating the public API; use real DOM interactions (file upload → triggers `handleFile` → real phase change) to drive transitions.
+- **R2**: `_content.tsx` at `apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx` consumes `TranslateViewer` — verify no breakage. Component public API unchanged in this plan.
+- **R3**: `useTranslateSegmentSSE.stop()` signature already exists — verified line 6 of hook. ✅
+- **R4**: Shimmer-sweep gradient deferred (Tailwind pulse soddisfa AC; Aaron CORE nice-to-have). Document in PR body as MINOR follow-up if reviewer flags.
+
+## Verification gates
+
+- `pnpm typecheck` (project)
+- `pnpm test src/components/features/gamebook/__tests__/TranslateViewer.test.tsx` (focused)
+- `pnpm lint:tokens` (DS-15 compliance: NO hardcoded `bg-white`/`text-gray-*`)
+- jest-axe 0 violations in all 4 uiStep states
+
+## PR body
+
+```
+Closes #1557.
+
+## Summary
+- Implement loading 4-step skeleton (uploading/ocr/translating/glossary-check) replacing text labels
+- Add abort CTA (FAB mobile, inline desktop) visible from step 2+, rolls back FSM
+- Hard timeout 20s with error message + state rollback
+- Reduced-motion fallback via Tailwind motion-safe:animate-pulse
+- jest-axe scan covers 4 uiStep states
+
+## Tests
+- 9 new scenarios (S1-S9) in TranslateViewer.test.tsx
+- deriveUiStep unit tests in TranslateViewer.steps.test.ts
+- LoadingSkeleton + AbortButton unit tests
+
+## Deferred (acceptable per AC)
+- Shimmer-sweep gradient (Tailwind pulse satisfies "animated + reduced-motion fallback" AC; mockup nice-to-have)
+- Soft 17s target UI feedback (JSDoc only per DEC-4)
+- Foto retake CTA on abort during uploading/segmenting (Aaron CORE §1b mentions but #1557 AC doesn't require)
+```


### PR DESCRIPTION
Closes #1557.

## Summary

Implementa il **Loading 4-step skeleton + abort CTA + 20s hard timeout** sulla route `/library/[gameId]/play/[campaignId]/translate`, chiudendo l'ultimo gap user-facing **P1** del cluster #1487 follow-up Aaron CORE (G state).

- **FSM 4-step labels**: `uploading → ocr → translating → glossary-check` (signal-driven via `sse.appliedTerms.length > 0`)
- **LoadingSkeleton** componente nuovo: 3 barre + label IT + `motion-safe:animate-pulse` + `aria-busy="true"` + `aria-live="polite"`
- **AbortButton** componente nuovo: responsive (FAB mobile `fixed bottom-4 right-4`, inline desktop top-right) visibile dal step 2+; click → `sse.stop()` + FSM rollback (uploading/segmenting → idle; translating → segments_ready)
- **Hard timeout 20s** (DEC-4): `useEffect` + `setTimeout` + cleanup; race guard `if (sse.isComplete) return;` per evitare rollback erroneo quando SSE completa al limite
- **Reduced-motion fallback**: `motion-safe:` variant Tailwind built-in (zero JS hook)
- **jest-axe 0 violations** in 3 stati (`idle`, `uploading`, `ocr+AbortButton`) — fix bonus: aggiunto `aria-label` al hidden file input (pre-existing a11y gap scoperto da axe scan)

## Tests — 18/18 ✅ (was 7/7)

- **TranslateViewer.steps.test.ts** — 18 unit test su `deriveUiStep` + `isAbortableStep` + `LABELS`
- **LoadingSkeleton.test.tsx** — 9 unit test su 4 uiStep × rendering+a11y
- **AbortButton.test.tsx** — 5 unit test su data-testid/aria-label/click
- **TranslateViewer.test.tsx** — 18 test (7 esistenti + 11 nuovi):
  - S1: uploading skeleton + label
  - S2: ocr skeleton
  - S3: translating skeleton (no appliedTerms)
  - S4: glossary-check on `sse.appliedTerms.length > 0` signal
  - S5: abort hidden during uploading
  - S6: abort visible from step 2+
  - S7: abort during translating → `sse.stop()` + rollback to segments_ready
  - S8: hard timeout 20s (fake timers + `vi.advanceTimersByTime(20_001)`)
  - S9: idle state axe scan
  - S9b: uploading skeleton axe scan
  - S9c: ocr + AbortButton axe scan (M1 review fix)

## Pattern decisions locked (spec-panel)

- **DEC-1 (Fowler SRP)**: `Phase` enum FSM resta intatto; `UiStep` 4-valori è proiezione UI orthogonal
- **DEC-2 (Crispin)**: glossary-check trigger = `sse.appliedTerms.length > 0` (signal-driven, no timing)
- **DEC-3 (Cockburn)**: rollback granulare per phase corrente (uploading/segmenting→idle, translating→segments_ready)
- **DEC-4 (Nygard)**: hard 20s con race guard + soft 17s solo JSDoc
- **DEC-5**: Tailwind `motion-safe:animate-pulse` zero-config (shimmer-sweep gradient deferred — pulse soddisfa AC)
- **DEC-6 (Fowler)**: single AbortButton, due layout via Tailwind responsive classes
- **DEC-7 (Wiegers)**: IT hardcoded coerente con esistente, no i18n integration (out-of-scope)

## Plan + spec-panel

- Plan TDD: `docs/superpowers/plans/2026-05-31-issue-1557-loading-skeleton-abort.md` (7 DEC + S1-S9 G/W/T)
- Audit fonte: `admin-mockups/design_handoff/translate-gap-report.md §2 row G`
- Aaron CORE spec: `docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md §1b lines 103-141`
- Code reviewer: `feature-dev:code-reviewer` → APPROVED_WITH_NOTES (0 CRITICAL · 2 MAJOR fixati inline · 3 MINOR deferred)

## Deferred / Known limitations

- **Shimmer-sweep gradient** (DEC-5): `motion-safe:animate-pulse` soddisfa AC \"animated + reduced-motion fallback\"; mockup nice-to-have, follow-up.
- **`handleAbort` deps** (review m1): `useCallback([sse])` recreates ogni render; dovrebbe usare `[sse.stop]` (no impact funzionale, `AbortButton` non `React.memo`-wrapped).
- **`HARD_TIMEOUT_MS` in body** (review m2): style; potrebbe essere module-level constant. Non correctness issue.
- **errorMessage priority** (review m3): `sse.error` shadows `timeoutError` se entrambi presenti — UX edge case.
- **Soft 17s UI feedback** (DEC-4): JSDoc only, intentional per plan.
- **Foto retake CTA su abort** (Aaron CORE §1b): non richiesto da #1557 AC.

## Risorse follow-up

Restano nel cluster #1487 follow-up: #1558 (Reader-mode toggle H), #1559 (Multi-language K/L), #1560 (Manual-mode M), #1561 (AAA contrast J).

🤖 Generated with [Claude Code](https://claude.com/claude-code)