### PR TITLE
feat(mockup): #1750 B19-4b - generic session skeleton (game-agnostic)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -89,6 +89,13 @@
 | `sp4-play-records-stats.html` | page-mock | `/play-records/stats` |
 | `sp4-player-detail.html` | page-mock | `/players/[id]`, `/players/[id]/{achievements,games,sessions,stats}` |
 | `sp4-players-index.html` | page-mock | `/players` |
+| `sp4-session-skeleton-data.jsx` | component-mock | Demo datasets (Wingspan + Paleo) for the generic session skeleton — `window.SkelData`. Used only inside `sp4-session-skeleton-*` mockup to validate polymorphic rendering side-by-side. |
+| `sp4-session-skeleton-live.html` | page-mock | `/sessions/[id]/live` **generic skeleton** (universal renderer for any game). Consumes `AiToolkitSuggestionDto` polymorphically. Demo shows side-by-side Wingspan (Points+RoundRobin) vs Paleo (BinaryWin+Simultaneous). Closes #1750 (B19-4b). |
+| `sp4-session-skeleton-live.jsx` | component-mock | Root component for `sp4-session-skeleton-live.html` — wires top-bar + ChatAgent + `RightColumnTabs` polymorphic. |
+| `sp4-session-skeleton-parts.jsx` | component-mock | Shared building blocks for the skeleton (TopBar, ChatAgentPanel, ActionLog, RightColumnTabs container, DesktopFrame, PhoneShell side-by-side wrapper). Game-agnostic. |
+| `sp4-session-skeleton-renderers.jsx` | component-mock | **Polymorphic renderers** — `ScoringPanelRenderer` (switch on ScoreType: Points/Ranking/BinaryWin/Objectives), `TurnIndicatorRenderer` (switch on TurnOrderType: 7 variants), `WidgetRenderer` (6 WidgetType dispatch). Zero game-specific code. Mirrors FE renderers shipped in PR #1763 (B19-4a). |
+| `sp4-session-summary-skeleton.html` | page-mock | `/sessions/[id]` **generic post-game skeleton** (universal summary). Demo shows side-by-side Wingspan vs Paleo. Closes #1750 (B19-4b). |
+| `sp4-session-summary-skeleton.jsx` | component-mock | Root component for `sp4-session-summary-skeleton.html` — hero result + tabbed review (scoreboard / diary / photos / chat highlights / stats). Game-agnostic. |
 | `sp4-session-wingspan-live-parts.jsx` | component-mock | Sub-components of `/sessions/[id]/live` Wingspan demo — `window.LiveSessionParts1`. **Wingspan-specific** (scoring categories hard-coded). Generic skeleton tracked in B19. |
 | `sp4-session-wingspan-live-tabs.jsx` | component-mock | `window.LiveTabs` — 4 new consolidated tabs (scores · photos · agent · players) × 5 stati each (default · empty · loading · error · sse). **Wingspan-flavored content**. See consolidation ADR `claudedocs/2026-05-31-sessions-consolidation-adr.md` + spike `claudedocs/2026-05-31-spike-toolkit-ai-generation.md`. |
 | `sp4-session-wingspan-live.html` | page-mock | `/sessions/[id]/live` Wingspan demo + consolidated tabs `?tab=scores\|photos\|agent\|players\|chat\|tools\|notes` (was 4 separate sub-routes pre-2026-05-31, see ADR). Also reuses for `/sessions/live/[sessionId]/*`. **Wingspan-specific** — generic session skeleton in B19. |
@@ -161,10 +168,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 55 |
-| component-mock | 20 |
+| page-mock | 57 |
+| component-mock | 25 |
 | dev-fixture | 12 |
-| **Total** | **87** |
+| **Total** | **94** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/sp4-session-skeleton-data.jsx
+++ b/admin-mockups/design_files/sp4-session-skeleton-data.jsx
@@ -1,0 +1,252 @@
+/* MeepleAI SP4 — Generic Session Skeleton · DATA
+   Game-AGNOSTIC runtime fixtures. Nothing here is hard-wired into the
+   renderers — every value is shaped like what the Toolkit/Toolbox API would
+   return (see toolkit.schemas.ts): AiScoringTemplateSuggestion,
+   AiTurnTemplateSuggestion, ToolkitDashboardDto.widgets[].
+
+   Two live datasets prove the same skeleton adapts to opposite genres:
+     A · Wingspan  — engine builder · Points · RoundRobin · 4 round
+     B · Paleo     — co-op         · BinaryWin · Simultaneous · no score
+
+   Plus GALLERY fixtures that exercise every other switch branch the two
+   datasets don't hit (Ranking/Objectives · Sequential/Realtime/None/Custom).
+
+   Exposes window.SkeletonData. */
+
+(function () {
+  // ─── DATASET A · WINGSPAN (engine builder) ───────────────────────────────
+  const wingspan = {
+    game: {
+      id: 'wingspan', title: 'Wingspan', emoji: '🦜',
+      cover: 'linear-gradient(135deg, hsl(165,55%,42%), hsl(205,60%,38%))',
+      meta: '1–5 giocatori · ~70 min', complexity: 2.4,
+    },
+    session: { id: 'wing-3', elapsed: '1:24:06', startedAt: '23 apr · 20:41' },
+    agent: { name: 'Wingspan Coach', emoji: '🦜', latency: 'Risponde in 1–2s' },
+    players: [
+      { id: 'p-marco', name: 'Marco', hue: 262, score: 87, turnDelta: 16, presence: 'host' },
+      { id: 'p-anna',  name: 'Anna',  hue: 350, score: 82, turnDelta: 0,  presence: 'online' },
+      { id: 'p-luca',  name: 'Luca',  hue: 174, score: 74, turnDelta: 0,  presence: 'online' },
+      { id: 'p-sara',  name: 'Sara',  hue: 38,  score: 61, turnDelta: 0,  presence: 'away' },
+    ],
+    // AiScoringTemplateSuggestion → scoreType "Points"
+    scoring: {
+      scoreType: 'Points', defaultUnit: 'punti',
+      dimensions: ['Uccelli', 'Carte bonus', 'Obiettivi round', 'Uova', 'Cibo', 'Carte infilate'],
+      categories: [
+        { id: 'birds',  label: 'Uccelli',         computation: 'Sum',       weight: 1, description: 'Punti variabili stampati su ogni carta uccello (1–9).' },
+        { id: 'bonus',  label: 'Carte bonus',      computation: 'Sum',       weight: 1, description: 'Punti variabili per obiettivo bonus personale.' },
+        { id: 'goals',  label: 'Obiettivi round',  computation: 'RankBased', weight: 1, description: '5/2/1 o 4/2/1 punti per round in base al rank.' },
+        { id: 'eggs',   label: 'Uova',             computation: 'Count',     weight: 1, description: '1 punto per uovo deposto.' },
+        { id: 'cached', label: 'Cibo',             computation: 'Count',     weight: 1, description: '1 punto per cibo accumulato su una carta.' },
+        { id: 'tucked', label: 'Carte infilate',   computation: 'Count',     weight: 1, description: '1 punto per carta infilata sotto un uccello.' },
+      ],
+    },
+    breakdown: {
+      'p-marco': { birds: 31, bonus: 16, goals: 11, eggs: 18, cached: 6, tucked: 5 },
+      'p-anna':  { birds: 34, bonus: 9,  goals: 13, eggs: 14, cached: 7, tucked: 5 },
+      'p-luca':  { birds: 28, bonus: 7,  goals: 9,  eggs: 16, cached: 9, tucked: 5 },
+      'p-sara':  { birds: 22, bonus: 5,  goals: 8,  eggs: 13, cached: 8, tucked: 5 },
+    },
+    // AiTurnTemplateSuggestion → turnOrderType "RoundRobin"
+    turn: {
+      turnOrderType: 'RoundRobin',
+      phases: ['Round 1', 'Round 2', 'Round 3', 'Round 4'],
+      rounds: 4, turnsPerRound: [8, 7, 6, 5],
+      turnActions: ['Gioca uccello', 'Cerca cibo', 'Deponi uova', 'Pesca carte'],
+      direction: 'clockwise',
+    },
+    turnState: { round: 2, turnInRound: 3, activePlayerId: 'p-marco', actionIndex: 1 },
+    // ToolkitDashboardDto.widgets[]
+    widgets: [
+      { id: 'w1', type: 'RandomGenerator', isEnabled: true,  displayOrder: 0, config: { name: 'Dadi mangiatoia', faces: ['🐛', '🌱', '🍒', '🐟', '🐭', '✦'], quantity: 5, last: '🌱 🐛 🐟 ✦ 🌱' } },
+      { id: 'w2', type: 'ResourceManager', isEnabled: true,  displayOrder: 1, config: { perPlayer: true, resources: [{ label: 'Uova', value: 3, max: 6 }, { label: 'Cibo', value: 5, max: 99 }, { label: 'Cubi azione', value: 6, max: 8 }] } },
+      { id: 'w3', type: 'ScoreTracker',    isEnabled: true,  displayOrder: 2, config: {} },
+      { id: 'w4', type: 'NoteManager',     isEnabled: true,  displayOrder: 3, config: { text: 'Marco apertura aggressiva sul forest.\nWetland con 3 uccelli a turno 8.' } },
+      { id: 'w5', type: 'TurnManager',     isEnabled: false, displayOrder: 4, config: {} },
+      { id: 'w6', type: 'Whiteboard',      isEnabled: false, displayOrder: 5, config: {} },
+    ],
+    events: [
+      { t: '14:51', who: 'p-marco', kind: 'score-update', text: 'gioca <b>Aquila reale</b> nel forest · +9 punti' },
+      { t: '14:49', who: 'p-anna',  kind: 'turn-change',   text: 'completa l\u2019obiettivo di round <b>uova in nido</b>' },
+      { t: '14:45', who: 'p-luca',  kind: 'custom',        text: 'attiva potere a catena · pesca 3 carte' },
+      { t: '14:41', who: 'p-sara',  kind: 'score-update',  text: 'deposita <b>4 uova</b> sulla wetland' },
+      { t: '14:32', who: null,      kind: 'game-start',    text: 'inizio <b>Round 2</b> · 7 turni rimasti' },
+    ],
+    chat: [
+      { id: 'c1', from: 'user',  t: '14:51', text: 'Quanto vale la wetland a fine partita?' },
+      { id: 'c2', from: 'agent', t: '14:51', text: 'La wetland dà punti tramite gli uccelli giocati e le uova deposte sopra — non ha un bonus di colonna proprio.', citations: ['Wingspan §4.2'] },
+      { id: 'c3', from: 'user',  t: '14:58', text: 'I bird con uova multiple come si contano?' },
+      { id: 'c4', from: 'agent', t: '14:58', text: 'Ogni uovo deposto vale 1 punto a fine partita, indipendentemente dal massimo del bird.', citations: ['Wingspan §6', 'FAQ #12'] },
+    ],
+    suggestions: ['Punteggio bonus card?', 'Regola wetland', 'Tucked cards'],
+    notes: 'Marco apertura aggressiva sul forest.\nWetland con 3 uccelli a turno 8.\n→ Valutare bonus card "Eggs in nest" a fine partita.',
+    photos: [
+      { lb: 'Tableau T8', g: 'linear-gradient(135deg, hsl(85,60%,55%), hsl(180,50%,40%))' },
+      { lb: 'Wetland',    g: 'linear-gradient(135deg, hsl(200,60%,55%), hsl(230,50%,40%))' },
+    ],
+    connections: [
+      { type: 'game', label: 'Wingspan' }, { type: 'player', label: '4 giocatori' },
+      { type: 'agent', label: 'Coach' }, { type: 'kb', label: '2 doc' },
+      { type: 'chat', label: '8 msg' }, { type: 'event', label: '12 eventi' },
+    ],
+    // ── summary-only ──
+    summary: {
+      outcome: 'win',
+      result: { kind: 'winner', playerId: 'p-marco', headline: 'Marco vince', sub: '87 punti · margine +5' },
+      duration: '1h 24min', date: '23 apr 2026', rounds: '4 round · 26 turni',
+    },
+  };
+
+  // ─── DATASET B · PALEO (co-op, simultaneous, BinaryWin) ───────────────────
+  const paleo = {
+    game: {
+      id: 'paleo', title: 'Paleo', emoji: '🦣',
+      cover: 'linear-gradient(135deg, hsl(28,48%,40%), hsl(8,42%,26%))',
+      meta: '1–4 giocatori · co-op · ~60 min', complexity: 3.2,
+    },
+    session: { id: 'paleo-1', elapsed: '0:47:12', startedAt: '30 mag · 21:10' },
+    agent: { name: 'Paleo Guida', emoji: '🦣', latency: 'Risponde in 1–2s' },
+    players: [
+      { id: 'p-giulia', name: 'Giulia', hue: 142, current: true, presence: 'host' },
+      { id: 'p-davide', name: 'Davide', hue: 200, current: true, presence: 'online' },
+      { id: 'p-elena',  name: 'Elena',  hue: 320, current: true, presence: 'online' },
+    ],
+    // scoreType "BinaryWin" — collective, no points
+    scoring: {
+      scoreType: 'BinaryWin', defaultUnit: 'esito',
+      dimensions: ['Condizione di vittoria', 'Pitture rupestri'],
+      collective: {
+        goalLabel: 'Pittura rupestre', goalValue: 3, goalMax: 5, goalHint: 'impronte',
+        failLabel: 'Teschi', failValue: 2, failMax: 5, failHint: 'su 5 = sconfitta',
+      },
+      categories: [
+        { id: 'cave',    label: 'Pittura rupestre completata', computation: 'Count',  weight: 1,  description: 'Completa la pittura (5 impronte) per vincere.' },
+        { id: 'skulls',  label: 'Teschi accumulati',           computation: 'Count',  weight: -1, description: '5 teschi = sconfitta immediata per la tribù.' },
+        { id: 'extinct', label: 'Tribù estinta',               computation: 'Custom', weight: 0,  description: 'Tutti i membri morti = sconfitta collettiva.' },
+      ],
+    },
+    breakdown: null,
+    // turnOrderType "Simultaneous"
+    turn: {
+      turnOrderType: 'Simultaneous',
+      phases: ['Mattina', 'Giorno', 'Notte'],
+      rounds: null, turnsPerRound: null,
+      turnActions: ['Esplora', 'Caccia', 'Costruisci', 'Sviluppa', 'Riposa'],
+      direction: 'none',
+    },
+    turnState: { phaseIndex: 1 },
+    widgets: [
+      { id: 'w1', type: 'ResourceManager', isEnabled: true,  displayOrder: 0, config: { shared: true, resources: [{ label: 'Legno', value: 6, max: 30 }, { label: 'Pietra', value: 4, max: 30 }, { label: 'Cibo', value: 8, max: 30 }, { label: 'Teschi', value: 2, max: 5, danger: true }, { label: 'Membri tribù', value: 4, max: 8 }] } },
+      { id: 'w2', type: 'TurnManager',     isEnabled: true,  displayOrder: 1, config: { phaseBased: true } },
+      { id: 'w3', type: 'NoteManager',     isEnabled: true,  displayOrder: 2, config: { text: 'Non spendere cibo prima della Notte.\nElena tiene la carta "fuoco".' } },
+      { id: 'w4', type: 'Whiteboard',      isEnabled: true,  displayOrder: 3, config: {} },
+      { id: 'w5', type: 'RandomGenerator', isEnabled: false, displayOrder: 4, config: {} },
+      { id: 'w6', type: 'ScoreTracker',    isEnabled: false, displayOrder: 5, config: {} },
+    ],
+    events: [
+      { t: '21:54', who: null,      kind: 'custom',       text: 'la tribù aggiunge la <b>3ª impronta</b> alla pittura' },
+      { t: '21:50', who: 'p-elena', kind: 'score-update', text: 'subisce un <b>teschio</b> dalla carta notte · 2/5' },
+      { t: '21:46', who: 'p-davide',kind: 'turn-change',  text: 'caccia il mammut · +3 cibo condiviso' },
+      { t: '21:40', who: 'p-giulia',kind: 'custom',       text: 'sblocca abilità <b>lancia</b> per la tribù' },
+      { t: '21:10', who: null,      kind: 'game-start',   text: 'inizio partita · fase <b>Mattina</b>' },
+    ],
+    chat: [
+      { id: 'c1', from: 'user',  t: '21:48', text: 'Se finiamo le carte del mazzo notte cosa succede?' },
+      { id: 'c2', from: 'agent', t: '21:48', text: 'Esaurire il mazzo notte non è una sconfitta diretta: si risolve la fine del giorno e si controllano le condizioni di fine partita.', citations: ['Paleo §Notte'] },
+      { id: 'c3', from: 'user',  t: '21:52', text: 'Il teschio si può rimuovere?' },
+      { id: 'c4', from: 'agent', t: '21:52', text: 'No, i teschi sono permanenti. Al 5° teschio la tribù perde immediatamente, qualunque sia lo stato della pittura.', citations: ['Paleo §Sconfitta'] },
+    ],
+    suggestions: ['Condizioni di fine?', 'Carte missione', 'Gestione fame'],
+    notes: 'Non spendere cibo prima della Notte.\nElena tiene la carta "fuoco".\n→ Servono 2 impronte ancora, attenzione ai teschi.',
+    photos: [
+      { lb: 'Pittura', g: 'linear-gradient(135deg, hsl(28,50%,45%), hsl(8,45%,30%))' },
+    ],
+    connections: [
+      { type: 'game', label: 'Paleo' }, { type: 'player', label: '3 · co-op' },
+      { type: 'agent', label: 'Guida' }, { type: 'kb', label: '1 doc' },
+      { type: 'chat', label: '6 msg' }, { type: 'event', label: '9 eventi' },
+    ],
+    summary: {
+      outcome: 'win',
+      result: { kind: 'collective', won: true, headline: 'Tribù sopravvissuta', sub: 'Pittura completata · 5/5 impronte · 3 teschi' },
+      duration: '1h 02min', date: '30 mag 2026', rounds: 'Co-op · 11 giorni',
+    },
+  };
+
+  // ─── GALLERY FIXTURES — branches the 2 datasets don't exercise ────────────
+  // Scoring: Ranking + Objectives (Points/BinaryWin already covered above).
+  const scoringFixtures = {
+    Ranking: {
+      scoring: { scoreType: 'Ranking', defaultUnit: 'posizione', categories: [] },
+      players: [
+        { id: 'r1', name: 'Bea',   hue: 25,  score: 0 },
+        { id: 'r2', name: 'Tariq', hue: 195, score: 0 },
+        { id: 'r3', name: 'Noa',   hue: 262, score: 0 },
+        { id: 'r4', name: 'Kai',   hue: 142, score: 0 },
+      ],
+      ranking: [
+        { id: 'r2', name: 'Tariq', hue: 195, rank: 1, sub: 'in testa di 2 case' },
+        { id: 'r1', name: 'Bea',   hue: 25,  rank: 2, sub: 'a –2' },
+        { id: 'r4', name: 'Kai',   hue: 142, rank: 3, sub: 'a –5' },
+        { id: 'r3', name: 'Noa',   hue: 262, rank: 4, sub: 'ultimo' },
+      ],
+      meta: 'Gara · giro 3 / 5',
+    },
+    Objectives: {
+      scoring: { scoreType: 'Objectives', defaultUnit: 'obiettivo', categories: [] },
+      objectives: [
+        { id: 'o1', label: 'Costruisci 3 avamposti',     done: true },
+        { id: 'o2', label: 'Esplora la regione nord',     done: true },
+        { id: 'o3', label: 'Recupera l\u2019artefatto',   done: false, progress: '2 / 3 frammenti' },
+        { id: 'o4', label: 'Nessun membro perso',         done: false, progress: 'a rischio' },
+        { id: 'o5', label: 'Completa entro il giorno 12', done: false, progress: 'giorno 9' },
+      ],
+      meta: 'Campagna · capitolo 4',
+    },
+  };
+
+  // Turn: Sequential / Realtime / None / Custom (RoundRobin+Simultaneous covered).
+  const turnFixtures = {
+    Sequential: {
+      turn: { turnOrderType: 'Sequential', phases: ['Spirito', 'Crescita', 'Veloce', 'Invasori', 'Lento'], turnActions: [], direction: 'team' },
+      turnState: { phaseIndex: 2 },
+      meta: 'Fasi a squadra · turno 5',
+    },
+    Realtime: {
+      turn: { turnOrderType: 'Realtime', phases: ['Tempo reale'], turnActions: [], direction: 'none' },
+      turnState: {},
+      meta: 'Nessun turno · simultaneo continuo',
+    },
+    None: {
+      turn: { turnOrderType: 'None', phases: [], turnActions: [], direction: 'none' },
+      turnState: {},
+      meta: 'Gioco libero',
+    },
+    Custom: {
+      turn: { turnOrderType: 'Custom', phases: ['Setup', 'Azioni', 'Mercato', 'Pulizia'], turnActions: [], direction: 'free' },
+      turnState: { phaseIndex: 1 },
+      meta: 'Sequenza custom dal toolkit',
+    },
+  };
+
+  // Widget: one representative config per type for the dispatcher gallery.
+  const widgetFixtures = [
+    { id: 'g-rng', type: 'RandomGenerator', isEnabled: true, displayOrder: 0, config: { name: 'Dado d20', faces: ['1','2','…','20'], quantity: 1, last: '🎲 14' } },
+    { id: 'g-trn', type: 'TurnManager',     isEnabled: true, displayOrder: 1, config: {} },
+    { id: 'g-sco', type: 'ScoreTracker',    isEnabled: true, displayOrder: 2, config: {} },
+    { id: 'g-res', type: 'ResourceManager', isEnabled: true, displayOrder: 3, config: { shared: true, resources: [{ label: 'Oro', value: 7, max: 20 }, { label: 'Legno', value: 3, max: 20 }] } },
+    { id: 'g-not', type: 'NoteManager',     isEnabled: true, displayOrder: 4, config: { text: 'Promemoria di partita…' } },
+    { id: 'g-whb', type: 'Whiteboard',      isEnabled: true, displayOrder: 5, config: {} },
+  ];
+
+  window.SkeletonData = {
+    DATASETS: { wingspan, paleo },
+    ORDER: ['wingspan', 'paleo'],
+    scoringFixtures, turnFixtures, widgetFixtures,
+    STATES: [
+      { id: 'default', lb: 'Default' }, { id: 'empty', lb: 'Empty' },
+      { id: 'loading', lb: 'Loading' }, { id: 'error', lb: 'Error' }, { id: 'sse', lb: 'SSE-off' },
+    ],
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-skeleton-live.html
+++ b/admin-mockups/design_files/sp4-session-skeleton-live.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Generic Session Skeleton · Live — /sessions/[id]/live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-skeleton-live.jsx
+++ b/admin-mockups/design_files/sp4-session-skeleton-live.jsx
@@ -1,0 +1,180 @@
+/* MeepleAI SP4 — Generic Session Skeleton · LIVE
+   /sessions/[id]/live  — game-AGNOSTIC template.
+
+   The SAME skeleton renders any game by reading the Toolkit JSON. To prove it,
+   two opposite datasets are rendered SIDE-BY-SIDE, live & interactive:
+     A · Wingspan — Points · RoundRobin · 4 round · 6 categorie
+     B · Paleo    — BinaryWin · Simultaneous · co-op · no punteggio
+
+   Layout (desktop): LEFT 60% = ChatAgent (sempre visibile) + action log ·
+   RIGHT 40% = RightColumnTabs polimorfico (Score/Turni/Widget/Note).
+   Mobile 375: main full-width, side → bottom-sheet drawer.
+
+   Below: full states gallery — ogni renderer polimorfico × 5 stati canonici
+   (default · empty · loading · error · sse-disconnect).
+
+   Loads: sp4-parts-common.jsx · sp4-session-skeleton-data.jsx ·
+          sp4-session-skeleton-renderers.jsx · sp4-session-skeleton-parts.jsx
+   DEMO-NAV-HINTS: sp4-session-summary-skeleton.html
+*/
+
+const D = window.SkeletonData;
+const S = window.SkeletonParts;
+const R = window.SkeletonRenderers;
+const M = window.MAI;
+const eHsl = M.entityHsl;
+const WING = D.DATASETS.wingspan;
+const PALEO = D.DATASETS.paleo;
+const STATES = D.STATES;
+
+// ─── gallery building blocks ───────────────────────────────────────────────
+const GalleryRow = ({ title, sub, entity, children }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHsl(entity) }}>{title}</span>
+      {sub && <span style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)', fontWeight: 700 }}>{sub}</span>}
+    </div>
+    <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>{children}</div>
+  </div>
+);
+
+const StatesOf = ({ entity, data, Renderer, h = 470 }) =>
+  STATES.map(s => (
+    <S.PanelFrame key={s.id} label={s.lb} entity={entity} h={h}>
+      <Renderer data={data} state={s.id} players={data.players} />
+    </S.PanelFrame>
+  ));
+
+// scoring branches: Points(Wing) · Ranking(fix) · BinaryWin(Paleo) · Objectives(fix)
+const SCORING_BRANCHES = [
+  { key: 'Points',     title: 'Points',     sub: 'scoreType · lista categorie + computation', data: WING },
+  { key: 'Ranking',    title: 'Ranking',    sub: 'scoreType · classifica con rank pill',      data: D.scoringFixtures.Ranking },
+  { key: 'BinaryWin',  title: 'BinaryWin',  sub: 'scoreType · esito collettivo (no punti)',   data: PALEO },
+  { key: 'Objectives', title: 'Objectives', sub: 'scoreType · checklist obiettivi',           data: D.scoringFixtures.Objectives },
+];
+
+// turn branches: all 6
+const TURN_BRANCHES = [
+  { key: 'RoundRobin',   title: 'RoundRobin',   sub: 'active player + Round X/Y',        data: WING },
+  { key: 'Sequential',   title: 'Sequential',   sub: 'phase stepper a squadra',          data: { ...D.turnFixtures.Sequential, players: [] } },
+  { key: 'Simultaneous', title: 'Simultaneous', sub: 'tutti evidenziati (co-op)',        data: PALEO },
+  { key: 'Realtime',     title: 'Realtime',     sub: 'warning banner · nessun turno',    data: { ...D.turnFixtures.Realtime, players: [] } },
+  { key: 'None',         title: 'None',         sub: 'banner gioco libero',              data: { ...D.turnFixtures.None, players: [] } },
+  { key: 'Custom',       title: 'Custom / Free', sub: 'phase stepper generico',          data: { ...D.turnFixtures.Custom, players: [] } },
+];
+
+// widget dispatcher fixture (all 6 types enabled)
+const WIDGET_ALL = { widgets: D.widgetFixtures, players: WING.players };
+
+function Intro() {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+      {[
+        { e: 'session', h: 'Skeleton universale', b: 'Un solo template renderizza qualsiasi gioco del catalogo leggendo la struttura dal Toolkit/Toolbox API. Zero dati hard-coded.' },
+        { e: 'toolkit', h: '3 renderer polimorfici', b: 'ScoringPanel (switch scoreType) · TurnIndicator (switch turnOrderType) · ToolkitRenderer (dispatch widgets[]).' },
+        { e: 'agent', h: 'ChatAgent come magnete', b: 'La chat con l\u2019agente è sempre visibile nella colonna principale — non un toggle secondario.' },
+        { e: 'event', h: '5 stati canonici', b: 'default · empty · loading · error · sse-disconnect per ogni componente principale.' },
+      ].map(c => (
+        <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+          <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: eHsl(c.e), marginBottom: 4 }}>{c.h}</div>
+          <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <S.ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Generic Session Skeleton · Live ⚡</div>
+        <h1>Session live — skeleton generico (qualsiasi gioco)</h1>
+        <p className="lead">
+          Template universale per <code>/sessions/[id]/live</code>. La struttura della sessione è letta dal
+          <strong> Toolkit JSON</strong> (scoring · turn · widgets) — nessun dato specifico del gioco nel codice.
+          Sotto, lo <strong>stesso skeleton</strong> è applicato a due dataset opposti, affiancati: <strong>Wingspan</strong> (engine builder)
+          e <strong>Paleo</strong> (co-op simultaneo). Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        {/* SIDE-BY-SIDE — both datasets, interactive */}
+        <div className="section-label">Side-by-side · Desktop 1280 — stesso skeleton, 2 giochi · cambia tab e stato dai selettori</div>
+        <div className="sk-sxs">
+          <S.DesktopFrame ds={WING} label="Dataset A · Wingspan — Points · RoundRobin" url="meepleai.app/sessions/wing-3/live?tab=scores" height={660}
+            desc="Engine builder: tab Score → breakdown 6 categorie con icona computation; tab Turni → giocatore attivo + Round 2/4; tab Widget → dadi mangiatoia, risorse, score tracker.">
+            <S.TopBar ds={WING} connection="connected" />
+            <S.DesktopSessionBody ds={WING} initialTab="scoring" initialState="default" />
+          </S.DesktopFrame>
+          <S.DesktopFrame ds={PALEO} label="Dataset B · Paleo — BinaryWin · Simultaneous" url="meepleai.app/sessions/paleo-1/live?tab=scores" height={660}
+            desc="Co-op simultaneo: tab Score → esito collettivo (pittura vs teschi, niente punti); tab Turni → tutti evidenziati + fasi Mattina/Giorno/Notte; tab Widget → risorse condivise, lavagna.">
+            <S.TopBar ds={PALEO} connection="connected" />
+            <S.DesktopSessionBody ds={PALEO} initialTab="scoring" initialState="default" />
+          </S.DesktopFrame>
+        </div>
+
+        {/* MOBILE — both datasets */}
+        <div className="section-label">Mobile 375 — main full-width · side → bottom-sheet drawer</div>
+        <div className="phones-grid">
+          <S.PhoneShell ds={WING} label="A · Wingspan · base" desc="ChatAgent + action log sempre visibili. Strip tab in basso, scrollabile." />
+          <S.PhoneShell ds={WING} label="A · Wingspan · sheet Score" initialTab="scoring" desc="Tap su una tab apre il bottom-sheet con handle, header entity-color, selettore stato e renderer." />
+          <S.PhoneShell ds={PALEO} label="B · Paleo · sheet Turni · dark" dark initialTab="turn" desc="Stesso drawer, dataset co-op: TurnIndicator rende il ramo Simultaneous." />
+        </div>
+
+        {/* STATES GALLERY — SCORING */}
+        <div className="section-label">Gallery stati · ScoringPanelRenderer — switch su scoreType × 5 stati canonici</div>
+        {SCORING_BRANCHES.map(b => (
+          <GalleryRow key={b.key} title={b.title} sub={b.sub} entity="session">
+            <StatesOf entity="session" data={b.data} Renderer={R.ScoringPanelRenderer} />
+          </GalleryRow>
+        ))}
+
+        {/* STATES GALLERY — TURN */}
+        <div className="section-label">Gallery stati · TurnIndicatorRenderer — switch su turnOrderType (tutti e 6) × 5 stati</div>
+        {TURN_BRANCHES.map(b => (
+          <GalleryRow key={b.key} title={b.title} sub={b.sub} entity="player">
+            <StatesOf entity="player" data={b.data} Renderer={R.TurnIndicatorRenderer} />
+          </GalleryRow>
+        ))}
+
+        {/* STATES GALLERY — WIDGET */}
+        <div className="section-label">Gallery stati · ToolkitRenderer — dispatch widgets[] × 5 stati</div>
+        <GalleryRow title="ToolkitRenderer" sub="dispatcher · 6 widget enabled" entity="toolkit">
+          {STATES.map(s => (
+            <S.PanelFrame key={s.id} label={s.lb} entity="toolkit" h={470}>
+              <R.ToolkitRenderer widgets={WIDGET_ALL.widgets} players={WIDGET_ALL.players} state={s.id} />
+            </S.PanelFrame>
+          ))}
+        </GalleryRow>
+        <div className="section-label" style={{ marginTop: 4 }}>I 6 widget types del dispatcher — RandomGenerator · TurnManager · ScoreTracker · ResourceManager · NoteManager · Whiteboard</div>
+        <div className="mai-cb-scroll" style={{ display: 'flex', gap: 14, overflowX: 'auto', paddingBottom: 10 }}>
+          {D.widgetFixtures.map(w => (
+            <div key={w.id} style={{ width: 280, flexShrink: 0 }}>
+              <R.WidgetBlock widget={w} players={WING.players} />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .sk-sxs { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px; align-items: start; }
+        @media (max-width: 1100px) { .sk-sxs { grid-template-columns: 1fr; } }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-skeleton-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-skeleton-parts.jsx
@@ -1,0 +1,372 @@
+/* MeepleAI SP4 — Generic Session Skeleton · SHARED PARTS
+   Game-agnostic chrome that wraps the polymorphic renderers:
+     TopBar · ConnectionChip · ChatAgentPanel · ActionLogTimeline ·
+     NotesPanel · RightColumnTabs (Scoring/Turn/Widget/Notes) · StateSwitch ·
+     ThemeToggle · DesktopFrame · PhoneShell · PanelFrame
+
+   Reads window.MAI (primitives) + window.SkeletonRenderers (polymorphic tabs).
+   Exposes window.SkeletonParts. */
+
+(function () {
+  const M = window.MAI;
+  const R = window.SkeletonRenderers;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const mono = R.mono;
+
+  // ─── connection chip (SSE status) ────────────────────────────────────────
+  const CONN = {
+    connected:    { e: 'toolkit', dot: '●', lb: 'Connesso',       pulse: true },
+    reconnecting: { e: 'agent',   dot: '◐', lb: 'Riconnessione…', pulse: true },
+    offline:      { e: 'event',   dot: '○', lb: 'Offline' },
+  };
+  const ConnectionChip = ({ status = 'connected' }) => {
+    const c = CONN[status] || CONN.connected;
+    return (
+      <span role="status" aria-label={`Stato connessione: ${c.lb}`} style={{
+        display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 9px', borderRadius: 'var(--r-pill)',
+        background: eHsl(c.e, 0.1), color: eHsl(c.e), border: `1px solid ${eHsl(c.e, 0.3)}`,
+        ...mono(9.5, 800), textTransform: 'uppercase', letterSpacing: '.05em', whiteSpace: 'nowrap',
+      }}>
+        <span aria-hidden="true" className={c.pulse ? 'mai-pulse-dot' : undefined}>{c.dot}</span>{c.lb}
+      </span>
+    );
+  };
+
+  // ─── TopBar (identical chrome for every game) ────────────────────────────
+  const PlayerStrip = ({ players, max = 4 }) => {
+    const shown = players.slice(0, max);
+    const extra = players.length - shown.length;
+    return (
+      <div style={{ display: 'flex', alignItems: 'center' }} aria-label={`${players.length} giocatori`}>
+        {shown.map((p, i) => (
+          <div key={p.id} title={p.name} style={{
+            width: 26, height: 26, borderRadius: '50%', marginLeft: i === 0 ? 0 : -8,
+            background: `linear-gradient(135deg, hsl(${p.hue},70%,64%), hsl(${p.hue},58%,44%))`,
+            color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            ...mono(11, 800), border: '2px solid var(--bg-card)', zIndex: max - i,
+          }} aria-hidden="true">{p.name[0]}</div>
+        ))}
+        {extra > 0 && <span style={{ ...mono(10, 800, 'var(--text-muted)'), marginLeft: 6 }}>+{extra}</span>}
+      </div>
+    );
+  };
+
+  const TopBar = ({ ds, connection = 'connected', compact }) => (
+    <header aria-label="Barra sessione" style={{
+      display: 'flex', alignItems: 'center', gap: compact ? 8 : 12, rowGap: 8, flexWrap: compact ? 'nowrap' : 'wrap',
+      padding: compact ? '8px 12px' : '10px 16px', flexShrink: 0,
+      background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderBottom: '1px solid var(--border)',
+    }}>
+      <div style={{ width: compact ? 30 : 38, height: compact ? 38 : 48, borderRadius: 'var(--r-md)', background: ds.game.cover, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: compact ? 16 : 20, boxShadow: 'var(--shadow-xs)' }} aria-hidden="true">{ds.game.emoji}</div>
+      <div style={{ minWidth: compact ? 0 : 120, flex: compact ? 1 : '1 1 auto' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+          <span style={{ fontFamily: 'var(--f-display)', fontSize: compact ? 14 : 16, fontWeight: 800, color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{ds.game.title}</span>
+          <span style={{ ...mono(9, 800, eHsl('session')), padding: '1px 6px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.12), border: `1px solid ${eHsl('session', 0.3)}`, textTransform: 'uppercase', letterSpacing: '.05em' }} className="mai-pulse-dot-host">live</span>
+        </div>
+        {!compact && <div style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{ds.game.meta}</div>}
+      </div>
+      {compact && <ConnectionChip status={connection} />}
+      {compact && (
+        <span style={{ ...mono(11, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums', display: 'inline-flex', alignItems: 'center', gap: 4 }} aria-label={`Tempo trascorso ${ds.session.elapsed}`}>
+          <span aria-hidden="true" style={{ color: 'var(--text-muted)' }}>⏱</span>{ds.session.elapsed}
+        </span>
+      )}
+      {compact && <button type="button" aria-label="Pausa" style={{ width: 30, height: 30, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 12, flexShrink: 0 }}>⏸</button>}
+      {!compact && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginLeft: 'auto', flexShrink: 0 }}>
+          <PlayerStrip players={ds.players} />
+          <ConnectionChip status={connection} />
+          <span style={{ ...mono(12.5, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums', display: 'inline-flex', alignItems: 'center', gap: 4 }} aria-label={`Tempo trascorso ${ds.session.elapsed}`}>
+            <span aria-hidden="true" style={{ color: 'var(--text-muted)' }}>⏱</span>{ds.session.elapsed}
+          </span>
+          <button type="button" aria-label="Pausa" style={{ width: 34, height: 34, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13, flexShrink: 0 }}>⏸</button>
+          <button type="button" style={{ padding: '7px 14px', borderRadius: 'var(--r-md)', background: eHsl('session'), color: '#fff', border: 'none', fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, cursor: 'pointer', flexShrink: 0, boxShadow: `0 3px 10px ${eHsl('session', 0.35)}` }}>Salva</button>
+        </div>
+      )}
+    </header>
+  );
+
+  // ─── ChatAgent panel (the magnet — always visible, no toggle) ────────────
+  const ChatAgentPanel = ({ ds, compact, collapsed, onHeaderClick }) => (
+    <section aria-label="Chat con l'agente AI" style={{ display: 'flex', flexDirection: 'column', flex: collapsed ? '0 0 auto' : 1, minHeight: 0, background: 'var(--bg-card)', border: `1px solid ${collapsed ? 'var(--border)' : eHsl('agent', 0.3)}`, borderRadius: 'var(--r-lg)', overflow: 'hidden' }}>
+      <button type="button" onClick={onHeaderClick} aria-expanded={!collapsed} style={{ width: '100%', textAlign: 'left', border: 'none', padding: '9px 12px', background: eHsl('agent', collapsed ? 0.04 : 0.06), borderBottom: collapsed ? 'none' : `1px solid ${eHsl('agent', 0.2)}`, display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0, cursor: onHeaderClick ? 'pointer' : 'default' }}>
+        <div style={{ width: 34, height: 34, borderRadius: '50%', position: 'relative', background: `linear-gradient(135deg, ${eHsl('agent')}, ${eHsl('agent', 0.6)})`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16, flexShrink: 0 }} aria-hidden="true">
+          {ds.agent.emoji}
+          <span className="mai-pulse-dot" style={{ position: 'absolute', bottom: -1, right: -1, width: 11, height: 11, borderRadius: '50%', background: 'hsl(140,60%,45%)', border: '2px solid var(--bg-card)' }} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: 'var(--text)' }}>{ds.agent.name}</div>
+          <div style={{ ...mono(9.5, 700, 'hsl(140,50%,40%)') }}>● Online · {ds.agent.latency}</div>
+        </div>
+        <span style={{ ...mono(8.5, 800, eHsl('agent')), textTransform: 'uppercase', letterSpacing: '.05em', padding: '2px 7px', borderRadius: 'var(--r-pill)', background: eHsl('agent', 0.1), border: `1px solid ${eHsl('agent', 0.28)}` }}>ChatAgent</span>
+        {onHeaderClick && <span aria-hidden="true" style={{ ...mono(11, 800, eHsl('agent')), flexShrink: 0, transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span>}
+      </button>
+      {!collapsed && (<>
+      <div style={{ flex: 1, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 10, minHeight: compact ? 180 : 0 }}>
+        {ds.chat.map(m => {
+          const isAgent = m.from === 'agent';
+          return (
+            <div key={m.id} style={{ alignSelf: isAgent ? 'flex-start' : 'flex-end', maxWidth: '86%', display: 'flex', flexDirection: 'column', gap: 3 }}>
+              <div style={{ padding: '8px 11px', borderRadius: 'var(--r-lg)', background: isAgent ? eHsl('agent', 0.1) : eHsl('chat', 0.12), border: `1px solid ${isAgent ? eHsl('agent', 0.25) : eHsl('chat', 0.25)}`, borderTopLeftRadius: isAgent ? 4 : 'var(--r-lg)', borderTopRightRadius: isAgent ? 'var(--r-lg)' : 4, fontFamily: 'var(--f-body)', fontSize: 12.5, fontWeight: 500, color: 'var(--text)', lineHeight: 1.45 }}>{m.text}</div>
+              <div style={{ ...mono(9, 700, 'var(--text-muted)'), alignSelf: isAgent ? 'flex-start' : 'flex-end', padding: '0 4px' }}>{m.t}</div>
+              {m.citations && (
+                <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', marginTop: 2 }}>
+                  {m.citations.map((c, i) => (
+                    <span key={i} style={{ display: 'inline-flex', alignItems: 'center', gap: 3, padding: '2px 6px', borderRadius: 'var(--r-pill)', background: eHsl('kb', 0.1), border: `1px solid ${eHsl('kb', 0.25)}`, color: eHsl('kb'), ...mono(9, 700) }}><span aria-hidden="true">📄</span>{c}</span>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ padding: '8px 12px', borderTop: '1px solid var(--border-light)', display: 'flex', gap: 5, flexWrap: 'wrap', flexShrink: 0 }}>
+        {ds.suggestions.map(s => (
+          <button key={s} type="button" style={{ padding: '5px 10px', borderRadius: 'var(--r-pill)', background: eHsl('chat', 0.08), border: `1px solid ${eHsl('chat', 0.25)}`, color: eHsl('chat'), fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700, cursor: 'pointer' }}>{s}</button>
+        ))}
+      </div>
+      <div style={{ padding: '10px 12px', borderTop: '1px solid var(--border)', display: 'flex', gap: 6, alignItems: 'flex-end', flexShrink: 0 }}>
+        <textarea placeholder="Chiedi all'agente…" rows={1} aria-label="Messaggio all'agente" style={{ flex: 1, padding: '8px 11px', borderRadius: 'var(--r-md)', border: '1px solid var(--border)', background: 'var(--bg)', color: 'var(--text)', fontFamily: 'var(--f-body)', fontSize: 12.5, resize: 'none', minHeight: 34 }} />
+        <button type="button" aria-label="Invia" style={{ width: 36, height: 36, borderRadius: 'var(--r-md)', background: eHsl('chat'), color: '#fff', border: 'none', fontSize: 14, cursor: 'pointer', flexShrink: 0, boxShadow: `0 3px 10px ${eHsl('chat', 0.4)}` }}>↑</button>
+      </div>
+      </>)}
+    </section>
+  );
+
+  // ─── Action log timeline ─────────────────────────────────────────────────
+  const KIND_E = { 'game-start': 'session', 'turn-change': 'player', 'score-update': 'toolkit', custom: 'event' };
+  const ActionLogTimeline = ({ ds, compact, state = 'default', collapsed, onHeaderClick }) => {
+    const inner = (
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        {ds.events.map((ev, i) => {
+          const e = KIND_E[ev.kind] || 'session';
+          const who = ds.players.find(p => p.id === ev.who);
+          return (
+            <div key={i} style={{ display: 'flex', gap: 10, padding: '7px 0' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0 }}>
+                <span style={{ width: 10, height: 10, borderRadius: '50%', background: eHsl(e), border: `2px solid var(--bg-card)`, boxShadow: `0 0 0 2px ${eHsl(e, 0.25)}` }} aria-hidden="true" />
+                {i < ds.events.length - 1 && <span style={{ width: 2, flex: 1, minHeight: 14, background: 'var(--border)', marginTop: 2 }} />}
+              </div>
+              <div style={{ flex: 1, minWidth: 0, paddingBottom: 2 }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                  {who && <span style={{ fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, color: `hsl(${who.hue},60%,52%)` }}>{who.name}</span>}
+                  <span style={{ ...mono(8.5, 800, eHsl(e)), textTransform: 'uppercase', letterSpacing: '.05em' }}>{ev.kind}</span>
+                  <div style={{ flex: 1 }} />
+                  <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>{ev.t}</span>
+                </div>
+                <div style={{ fontFamily: 'var(--f-body)', fontSize: 12.5, color: 'var(--text-sec)', lineHeight: 1.45 }} dangerouslySetInnerHTML={{ __html: ev.text }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+    return (
+      <section aria-label="Registro azioni" style={{ background: 'var(--bg-card)', border: `1px solid ${onHeaderClick && !collapsed ? eHsl('event', 0.3) : 'var(--border)'}`, borderRadius: 'var(--r-lg)', overflow: 'hidden', display: 'flex', flexDirection: 'column', ...(onHeaderClick ? { flex: collapsed ? '0 0 auto' : 1, minHeight: 0 } : { flexShrink: 0, maxHeight: compact ? 'none' : 260 }) }}>
+        <button type="button" onClick={onHeaderClick} aria-expanded={onHeaderClick ? !collapsed : undefined} style={{ width: '100%', textAlign: 'left', border: 'none', background: onHeaderClick && !collapsed ? eHsl('event', 0.06) : 'transparent', padding: '9px 12px', borderBottom: collapsed ? 'none' : '1px solid var(--border-light)', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, cursor: onHeaderClick ? 'pointer' : 'default' }}>
+          <span style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>Registro azioni</span>
+          <span style={{ ...mono(9, 800, eHsl('event')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.1), border: `1px solid ${eHsl('event', 0.28)}` }}>{ds.events.length}</span>
+          {onHeaderClick && <><div style={{ flex: 1 }} /><span aria-hidden="true" style={{ ...mono(11, 800, eHsl('event')), transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span></>}
+        </button>
+        {!collapsed && <div style={{ padding: '4px 12px 10px', overflowY: 'auto', flex: 1, minHeight: 0 }}>
+          <R.StateScaffold state={state} sseWhere="eventi"
+            empty={{ icon: '🎉', title: 'Nessun evento', body: 'Gli eventi della partita compariranno qui in tempo reale.' }}
+            error={{ title: 'Registro non disponibile', body: 'Impossibile caricare gli eventi della sessione.' }}>
+            {inner}
+          </R.StateScaffold>
+        </div>}
+      </section>
+    );
+  };
+
+  // ─── Notes panel (private notes + photos) ────────────────────────────────
+  const NotesPanel = ({ ds, state = 'default' }) => (
+    <R.StateScaffold state={state} sseWhere="note"
+      empty={{ icon: '📋', title: 'Nessuna nota', body: 'Aggiungi note private condivise con il tavolo.' }}
+      error={{ title: 'Note non disponibili', body: 'Impossibile sincronizzare le note della sessione.' }}>
+      <R.Panel gap={12}>
+        <R.Label>Note private · condivise</R.Label>
+        <textarea defaultValue={ds.notes} rows={5} aria-label="Note sessione" style={{ width: '100%', padding: '10px 12px', borderRadius: 'var(--r-md)', border: '1px solid var(--border)', background: 'var(--bg-card)', color: 'var(--text)', fontFamily: 'var(--f-mono)', fontSize: 12, lineHeight: 1.55, resize: 'vertical', minHeight: 100 }} />
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <R.Label>Foto · {ds.photos.length}</R.Label>
+          <button type="button" style={{ padding: '3px 8px', borderRadius: 'var(--r-pill)', background: eHsl('kb', 0.1), color: eHsl('kb'), border: `1px solid ${eHsl('kb', 0.3)}`, ...mono(9.5, 800), cursor: 'pointer', textTransform: 'uppercase', letterSpacing: '.04em' }}>+ Foto</button>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 6 }}>
+          {ds.photos.map((p, i) => (
+            <div key={i} style={{ aspectRatio: '1', borderRadius: 'var(--r-sm)', background: p.g, display: 'flex', alignItems: 'flex-end', padding: 4 }}>
+              <span style={{ ...mono(9, 800, '#fff'), background: 'rgba(0,0,0,.4)', padding: '1px 5px', borderRadius: 'var(--r-pill)' }}>{p.lb}</span>
+            </div>
+          ))}
+          <button type="button" aria-label="Aggiungi foto" style={{ aspectRatio: '1', borderRadius: 'var(--r-sm)', background: 'transparent', border: '1px dashed var(--border-strong)', color: 'var(--text-muted)', fontSize: 20, cursor: 'pointer' }}>+</button>
+        </div>
+      </R.Panel>
+    </R.StateScaffold>
+  );
+
+  // ─── state selector (segmented) ──────────────────────────────────────────
+  const STATES = window.SkeletonData.STATES;
+  const StateSwitch = ({ value, onChange }) => (
+    <div className="mai-cb-scroll" role="group" aria-label="Stato del componente" style={{ display: 'flex', gap: 4, overflowX: 'auto', padding: '7px 10px', borderBottom: '1px solid var(--border-light)', background: 'var(--bg)', flexShrink: 0 }}>
+      <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', alignSelf: 'center', flexShrink: 0, marginRight: 2 }}>Stato</span>
+      {STATES.map(s => {
+        const active = value === s.id;
+        return (
+          <button key={s.id} type="button" onClick={() => onChange(s.id)} aria-pressed={active} style={{ padding: '3px 9px', borderRadius: 'var(--r-pill)', flexShrink: 0, background: active ? eHsl('session', 0.14) : 'var(--bg-card)', border: active ? `1px solid ${eHsl('session', 0.4)}` : '1px solid var(--border)', color: active ? eHsl('session') : 'var(--text-sec)', ...mono(9.5, 800), cursor: 'pointer' }}>{s.lb}</button>
+        );
+      })}
+    </div>
+  );
+
+  // ─── RightColumnTabs (polymorphic: Scoring · Turn · Widget · Notes) ──────
+  const TABS = [
+    { id: 'scoring', icon: '🎯', label: 'Score',  entity: 'session', render: (ds, st) => <R.ScoringPanelRenderer data={ds} state={st} /> },
+    { id: 'turn',    icon: '🔄', label: 'Turni',  entity: 'player',  render: (ds, st) => <R.TurnIndicatorRenderer data={ds} state={st} /> },
+    { id: 'widget',  icon: '🧰', label: 'Widget', entity: 'toolkit', render: (ds, st) => <R.ToolkitRenderer data={ds} players={ds.players} state={st} /> },
+    { id: 'notes',   icon: '📋', label: 'Note',   entity: 'kb',      render: (ds, st) => <NotesPanel ds={ds} state={st} /> },
+  ];
+
+  const RightColumnTabs = ({ ds, initial = 'scoring', initialState = 'default', embedded }) => {
+    const [tab, setTab] = useState(initial);
+    const [st, setSt] = useState(initialState);
+    const active = TABS.find(t => t.id === tab) || TABS[0];
+    return (
+      <aside aria-label="Pannello polimorfico" style={{ width: embedded ? '100%' : '40%', minWidth: embedded ? 0 : 300, flexShrink: 0, height: '100%', background: 'var(--bg-card)', borderLeft: embedded ? 'none' : '1px solid var(--border)', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <div role="tablist" aria-label="Sezioni" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0 }}>
+          {TABS.map(t => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} onClick={() => setTab(t.id)} style={{ flex: 1, padding: '10px 6px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5, whiteSpace: 'nowrap' }}>
+                <span aria-hidden="true" style={{ fontSize: 14 }}>{t.icon}</span><span>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        <StateSwitch value={st} onChange={setSt} />
+        <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(ds, st)}</div>
+      </aside>
+    );
+  };
+
+  // ─── DESKTOP session body (LEFT 60% chat+log · RIGHT 40% tabs) ───────────
+  const DesktopSessionBody = ({ ds, initialTab, initialState }) => {
+    const [expanded, setExpanded] = useState('chat'); // 'chat' | 'log'
+    return (
+      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        <main style={{ flex: 3, minWidth: 0, padding: 14, display: 'flex', flexDirection: 'column', gap: 12, overflow: 'hidden' }}>
+          <ChatAgentPanel ds={ds} collapsed={expanded !== 'chat'} onHeaderClick={() => setExpanded('chat')} />
+          <ActionLogTimeline ds={ds} collapsed={expanded !== 'log'} onHeaderClick={() => setExpanded('log')} />
+        </main>
+        <RightColumnTabs ds={ds} initial={initialTab} initialState={initialState} />
+      </div>
+    );
+  };
+
+  // ─── MOBILE session body (full-width main · bottom-sheet drawer) ─────────
+  const MobileTabSheet = ({ ds, open, tab, st, setSt, onClose }) => {
+    const active = TABS.find(t => t.id === tab) || TABS[0];
+    return (
+      <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+        <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,12,30,.5)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+        <div role="dialog" aria-modal="true" aria-label={active.label} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '84%', background: 'var(--bg-card)', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl(active.entity)}`, boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 8, flexShrink: 0 }}>
+            <div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px 10px', flexShrink: 0 }}>
+            <span aria-hidden="true" style={{ fontSize: 16 }}>{active.icon}</span>
+            <span style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHsl(active.entity) }}>{active.label}</span>
+            <div style={{ flex: 1 }} />
+            <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+          </div>
+          <StateSwitch value={st} onChange={setSt} />
+          <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(ds, st)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const MobileSessionBody = ({ ds, initialTab }) => {
+    const [sheet, setSheet] = useState(initialTab || null);
+    const [st, setSt] = useState('default');
+    const [expanded, setExpanded] = useState('chat'); // 'chat' | 'log'
+    return (
+      <>
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, background: 'var(--bg)' }}>
+          <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12, height: '100%', minHeight: 0 }}>
+            <ChatAgentPanel ds={ds} compact collapsed={expanded !== 'chat'} onHeaderClick={() => setExpanded('chat')} />
+            <ActionLogTimeline ds={ds} compact collapsed={expanded !== 'log'} onHeaderClick={() => setExpanded('log')} />
+          </div>
+        </div>
+        <nav className="mai-cb-scroll" aria-label="Sezioni sessione" style={{ display: 'flex', gap: 6, overflowX: 'auto', flexShrink: 0, padding: '8px 10px', background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderTop: '1px solid var(--border)' }}>
+          {TABS.map(t => (
+            <button key={t.id} type="button" onClick={() => { setSt('default'); setSheet(t.id); }} style={{ flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 5, padding: '7px 13px', borderRadius: 'var(--r-pill)', background: eHsl(t.entity, 0.1), border: `1px solid ${eHsl(t.entity, 0.28)}`, color: eHsl(t.entity), fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer', whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true">{t.icon}</span>{t.label}
+            </button>
+          ))}
+        </nav>
+        <MobileTabSheet ds={ds} open={!!sheet} tab={sheet} st={st} setSt={setSt} onClose={() => setSheet(null)} />
+      </>
+    );
+  };
+
+  // ─── Frames ──────────────────────────────────────────────────────────────
+  const PhoneSbar = () => (
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>14:32</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+  );
+  const PhoneShell = ({ ds, label, desc, dark, initialTab }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+      <div className="phone" data-theme={dark ? 'dark' : undefined}>
+        <PhoneSbar />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <TopBar ds={ds} compact />
+          <MobileSessionBody ds={ds} initialTab={initialTab} />
+        </div>
+      </div>
+      {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 340, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  const DesktopFrame = ({ ds, label, desc, dark, url, children, height = 720 }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%' }} data-theme={dark ? 'dark' : undefined}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}</div>
+      <div style={{ width: '100%', borderRadius: 'var(--r-xl)', border: '1px solid var(--border)', background: 'var(--bg)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px', background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)', ...mono(11, 600, 'var(--text-muted)') }}>
+          <span style={{ width: 11, height: 11, borderRadius: '50%', background: 'hsl(var(--c-event))' }} />
+          <span style={{ width: 11, height: 11, borderRadius: '50%', background: 'hsl(var(--c-warning))' }} />
+          <span style={{ width: 11, height: 11, borderRadius: '50%', background: 'hsl(var(--c-toolkit))' }} />
+          <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.03em' }}>{url}</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', height, background: 'var(--bg)', overflow: 'hidden' }}>{children}</div>
+      </div>
+      {desc && <div style={{ fontSize: 11.5, color: 'var(--text-muted)', maxWidth: 720, lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  // panel frame for the states gallery (rail-sized)
+  const PanelFrame = ({ label, entity, dark, children, w = 300, h = 460 }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} data-theme={dark ? 'dark' : undefined}>
+      <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</div>
+      <div style={{ width: w, height: h, borderRadius: 'var(--r-lg)', border: `1px solid ${eHsl(entity, 0.3)}`, background: 'var(--bg-card)', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: 'var(--shadow-sm)' }}>{children}</div>
+    </div>
+  );
+
+  function ThemeToggle() {
+    const [dark, setDark] = useState(true);
+    React.useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+    return (
+      <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+        <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+      </button>
+    );
+  }
+
+  window.SkeletonParts = {
+    TopBar, ConnectionChip, ChatAgentPanel, ActionLogTimeline, NotesPanel,
+    RightColumnTabs, StateSwitch, DesktopSessionBody, MobileSessionBody,
+    PhoneShell, DesktopFrame, PanelFrame, ThemeToggle, TABS, PlayerStrip,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-skeleton-renderers.jsx
+++ b/admin-mockups/design_files/sp4-session-skeleton-renderers.jsx
@@ -1,0 +1,622 @@
+/* MeepleAI SP4 — Generic Session Skeleton · POLYMORPHIC RENDERERS
+   The heart of the skeleton. Nothing game-specific: every branch reads from
+   the Toolkit JSON shape (toolkit.schemas.ts) passed in as `data`.
+
+     ScoringPanelRenderer  → switch on scoring.scoreType
+                             Points · Ranking · BinaryWin · Objectives
+     TurnIndicatorRenderer → switch on turn.turnOrderType
+                             RoundRobin · Sequential · Simultaneous ·
+                             Realtime · None · Custom/Free
+     ToolkitRenderer       → dispatch widgets[] → WidgetBlock
+                             RandomGenerator · TurnManager · ScoreTracker ·
+                             ResourceManager · NoteManager · Whiteboard
+
+   Each renderer honours the 5 canonical states:
+     default · empty · loading · error · sse-disconnect
+   reusing MAI primitives (StateBlock · Shimmer · SseBanner) — not reinvented.
+
+   Exposes window.SkeletonRenderers. */
+
+(function () {
+  const M = window.MAI;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+
+  // ─── tiny shared atoms ───────────────────────────────────────────────────
+  const mono = (size, weight, color) => ({
+    fontFamily: 'var(--f-mono)', fontSize: size, fontWeight: weight, color,
+  });
+  const Label = ({ children, mt }) => (
+    <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', marginTop: mt }}>{children}</div>
+  );
+  const Avatar = ({ p, size = 26, ring }) => (
+    <div aria-hidden="true" style={{
+      width: size, height: size, borderRadius: '50%', flexShrink: 0,
+      background: `linear-gradient(135deg, hsl(${p.hue},70%,64%), hsl(${p.hue},58%,44%))`,
+      color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: 'var(--f-display)', fontSize: size * 0.46, fontWeight: 800,
+      border: ring ? `2px solid ${eHsl('toolkit')}` : 'none',
+    }}>{p.name[0]}</div>
+  );
+  const RetryBtn = ({ children = '↻ Riprova' }) => (
+    <button type="button" style={{
+      marginTop: 4, padding: '5px 12px', borderRadius: 'var(--r-pill)',
+      background: eHsl('event', 0.12), color: eHsl('event'),
+      border: `1px solid ${eHsl('event', 0.35)}`, cursor: 'pointer',
+      ...mono(10, 800), textTransform: 'uppercase', letterSpacing: '.05em',
+    }}>{children}</button>
+  );
+
+  // computation → icon + tint (drives the per-category UI variant)
+  const COMPUTATION = {
+    Count:     { g: '#', e: 'tool',    lb: 'Conteggio' },
+    Sum:       { g: 'Σ', e: 'session', lb: 'Somma' },
+    RankBased: { g: '①', e: 'toolkit', lb: 'Per rank' },
+    Custom:    { g: '✎', e: 'agent',   lb: 'Manuale' },
+  };
+  const ComputationBadge = ({ c, size = 18 }) => {
+    const m = COMPUTATION[c] || COMPUTATION.Custom;
+    return (
+      <span title={m.lb} aria-label={m.lb} style={{
+        width: size, height: size, borderRadius: 'var(--r-sm)', flexShrink: 0,
+        background: eHsl(m.e, 0.14), color: eHsl(m.e), border: `1px solid ${eHsl(m.e, 0.3)}`,
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        ...mono(size * 0.55, 800),
+      }}>{m.g}</span>
+    );
+  };
+
+  // ─── state scaffold: wraps any default render with the other 4 states ─────
+  const Loading = ({ rows = 4, h = 30, pad = 14 }) => (
+    <div style={{ padding: pad, display: 'flex', flexDirection: 'column', gap: 10 }} aria-busy="true" aria-label="Caricamento">
+      {Array.from({ length: rows }).map((_, i) => <M.Shimmer key={i} h={h} />)}
+    </div>
+  );
+  const Centered = ({ children }) => (
+    <div style={{ flex: 1, minHeight: 160, display: 'flex', padding: 16 }}>{children}</div>
+  );
+  const StateScaffold = ({ state, empty, error, sseWhere, loading, children }) => {
+    if (state === 'loading') return loading || <Loading />;
+    if (state === 'empty') return <Centered><M.StateBlock {...empty} /></Centered>;
+    if (state === 'error') return <Centered><M.StateBlock tone="error" icon="⚠️" action={<RetryBtn />} {...error} /></Centered>;
+    if (state === 'sse') return (
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <M.SseBanner where={sseWhere} />
+        <div aria-live="off" style={{ opacity: 0.5, pointerEvents: 'none', filter: 'saturate(.7)', flex: 1, minHeight: 0, overflow: 'hidden' }}>{children}</div>
+      </div>
+    );
+    return children;
+  };
+
+  const Panel = ({ children, gap = 12, pad = 14 }) => (
+    <div style={{ padding: pad, display: 'flex', flexDirection: 'column', gap, overflowY: 'auto', flex: 1, minHeight: 0 }}>{children}</div>
+  );
+  const Meter = ({ value, max, e, danger }) => (
+    <div style={{ height: 8, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+      <div style={{ width: `${Math.min(100, (value / max) * 100)}%`, height: '100%', borderRadius: 'var(--r-pill)', background: eHsl(danger ? 'event' : (e || 'toolkit')) }} />
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ScoringPanelRenderer — switch on scoreType
+  // ══════════════════════════════════════════════════════════════════════════
+  const ScoreTypePill = ({ type }) => (
+    <span style={{
+      ...mono(9, 800), textTransform: 'uppercase', letterSpacing: '.06em',
+      padding: '2px 8px', borderRadius: 'var(--r-pill)',
+      background: eHsl('session', 0.12), color: eHsl('session'), border: `1px solid ${eHsl('session', 0.3)}`,
+    }}>scoreType · {type}</span>
+  );
+
+  // — Points: leaderboard + per-category computation breakdown —
+  const PointsScoring = ({ data }) => {
+    const ranked = [...data.players].sort((a, b) => b.score - a.score);
+    const lead = ranked[0];
+    return (
+      <Panel>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Label>Classifica live</Label><div style={{ flex: 1 }} /><ScoreTypePill type="Points" />
+        </div>
+        <div role="list" aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {ranked.map((p, i) => {
+            const leader = p.id === lead.id;
+            return (
+              <div key={p.id} role="listitem" style={{
+                display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 'var(--r-md)',
+                background: leader ? eHsl('toolkit', 0.08) : 'var(--bg-card)',
+                border: `1px solid ${leader ? eHsl('toolkit', 0.3) : 'var(--border)'}`,
+              }}>
+                <span style={{ ...mono(11, 800, leader ? eHsl('toolkit') : 'var(--text-muted)'), width: 16 }}>{i + 1}°</span>
+                <Avatar p={p} ring={leader} />
+                <span style={{ flex: 1, fontFamily: 'var(--f-display)', fontSize: 13.5, fontWeight: 800, color: 'var(--text)' }}>{p.name}</span>
+                {p.turnDelta ? <span style={{ ...mono(10, 800, eHsl('toolkit')) }}>+{p.turnDelta}</span> : null}
+                <span style={{ fontFamily: 'var(--f-display)', fontSize: 20, fontWeight: 800, color: leader ? eHsl('toolkit') : 'var(--text)', fontVariantNumeric: 'tabular-nums' }}>{p.score}</span>
+              </div>
+            );
+          })}
+        </div>
+        <Label mt={4}>Dettaglio categorie · {data.scoring.categories.length}</Label>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {data.scoring.categories.map(cat => (
+            <div key={cat.id} title={cat.description} style={{
+              display: 'flex', alignItems: 'center', gap: 8, padding: '7px 9px', borderRadius: 'var(--r-md)',
+              background: 'var(--bg-muted)', border: '1px solid var(--border-light)',
+            }}>
+              <ComputationBadge c={cat.computation} />
+              <span style={{ flex: 1, minWidth: 0, fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700, color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{cat.label}</span>
+              <div style={{ display: 'flex', gap: 4 }}>
+                {ranked.map(p => (
+                  <span key={p.id} title={p.name} style={{ ...mono(10.5, 700, 'var(--text-sec)'), minWidth: 18, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                    {data.breakdown?.[p.id]?.[cat.id] ?? '–'}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Panel>
+    );
+  };
+
+  // — Ranking: live ordered list with rank pills —
+  const RankingScoring = ({ data }) => (
+    <Panel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <Label>{data.meta || 'Classifica'}</Label><div style={{ flex: 1 }} /><ScoreTypePill type="Ranking" />
+      </div>
+      <div role="list" aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+        {data.ranking.map(p => {
+          const leader = p.rank === 1;
+          return (
+            <div key={p.id} role="listitem" style={{
+              display: 'flex', alignItems: 'center', gap: 11, padding: '9px 11px', borderRadius: 'var(--r-md)',
+              background: leader ? eHsl('toolkit', 0.08) : 'var(--bg-card)',
+              border: `1px solid ${leader ? eHsl('toolkit', 0.3) : 'var(--border)'}`,
+            }}>
+              <span style={{
+                width: 26, height: 26, borderRadius: 'var(--r-pill)', flexShrink: 0,
+                background: leader ? eHsl('toolkit') : eHsl('session', 0.12),
+                color: leader ? '#fff' : eHsl('session'),
+                display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(12, 800),
+              }}>{p.rank}</span>
+              <Avatar p={p} ring={leader} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontFamily: 'var(--f-display)', fontSize: 13.5, fontWeight: 800, color: 'var(--text)' }}>{p.name}</div>
+                <div style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{p.sub}</div>
+              </div>
+              {leader && <span style={{ fontSize: 16 }} aria-hidden="true">🏆</span>}
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+
+  // — BinaryWin: collective outcome (no points) —
+  const BinaryWinScoring = ({ data }) => {
+    const c = data.scoring.collective || {};
+    return (
+      <Panel>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Label>Esito collettivo</Label><div style={{ flex: 1 }} /><ScoreTypePill type="BinaryWin" />
+        </div>
+        <div style={{ padding: 14, borderRadius: 'var(--r-lg)', background: eHsl('session', 0.06), border: `1px solid ${eHsl('session', 0.25)}`, textAlign: 'center' }} aria-live="polite">
+          <div style={{ fontSize: 26, marginBottom: 2 }} aria-hidden="true">🤝</div>
+          <div style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: 'var(--text)' }}>Partita in corso</div>
+          <div style={{ ...mono(10, 700, 'var(--text-muted)'), marginTop: 2 }}>nessun punteggio · vittoria/sconfitta condivisa</div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <span style={{ fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: eHsl('toolkit') }}>{c.goalLabel}</span>
+            <span style={{ ...mono(11, 800, 'var(--text)') }}>{c.goalValue}/{c.goalMax} {c.goalHint}</span>
+          </div>
+          <Meter value={c.goalValue} max={c.goalMax} e="toolkit" />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <span style={{ fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: eHsl('event') }}>{c.failLabel}</span>
+            <span style={{ ...mono(11, 800, 'var(--text)') }}>{c.failValue}/{c.failMax} · {c.failHint}</span>
+          </div>
+          <Meter value={c.failValue} max={c.failMax} danger />
+        </div>
+        <Label mt={4}>Condizioni</Label>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {data.scoring.categories.map(cat => (
+            <div key={cat.id} title={cat.description} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 9px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+              <ComputationBadge c={cat.computation} />
+              <span style={{ flex: 1, minWidth: 0, fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700, color: 'var(--text)' }}>{cat.label}</span>
+              <span style={{ ...mono(10, 800, cat.weight > 0 ? eHsl('toolkit') : cat.weight < 0 ? eHsl('event') : 'var(--text-muted)') }}>
+                {cat.weight > 0 ? 'vince' : cat.weight < 0 ? 'perde' : 'neutro'}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Panel>
+    );
+  };
+
+  // — Objectives: checklist —
+  const ObjectivesScoring = ({ data }) => {
+    const done = data.objectives.filter(o => o.done).length;
+    return (
+      <Panel>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Label>{data.meta || 'Obiettivi'}</Label><div style={{ flex: 1 }} /><ScoreTypePill type="Objectives" />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <span style={{ fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: 'var(--text)' }}>Completati</span>
+            <span style={{ ...mono(11, 800, eHsl('toolkit')) }}>{done}/{data.objectives.length}</span>
+          </div>
+          <Meter value={done} max={data.objectives.length} e="toolkit" />
+        </div>
+        <div role="list" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {data.objectives.map(o => (
+            <div key={o.id} role="listitem" style={{
+              display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 'var(--r-md)',
+              background: o.done ? eHsl('toolkit', 0.07) : 'var(--bg-card)',
+              border: `1px solid ${o.done ? eHsl('toolkit', 0.28) : 'var(--border)'}`,
+            }}>
+              <span aria-hidden="true" style={{
+                width: 20, height: 20, borderRadius: 'var(--r-sm)', flexShrink: 0,
+                background: o.done ? eHsl('toolkit') : 'transparent',
+                border: o.done ? 'none' : `2px solid ${eHsl('session', 0.4)}`,
+                color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 800,
+              }}>{o.done ? '✓' : ''}</span>
+              <span style={{ flex: 1, fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 700, color: 'var(--text)', textDecoration: o.done ? 'line-through' : 'none', opacity: o.done ? 0.65 : 1 }}>{o.label}</span>
+              {o.progress && <span style={{ ...mono(9.5, 700, 'var(--text-muted)'), flexShrink: 0 }}>{o.progress}</span>}
+            </div>
+          ))}
+        </div>
+      </Panel>
+    );
+  };
+
+  const SCORING_BRANCH = { Points: PointsScoring, Ranking: RankingScoring, BinaryWin: BinaryWinScoring, Objectives: ObjectivesScoring };
+  const ScoringPanelRenderer = ({ data, state = 'default' }) => {
+    const type = data?.scoring?.scoreType;
+    const Branch = SCORING_BRANCH[type];
+    return (
+      <StateScaffold state={state} sseWhere="punteggio"
+        empty={{ icon: '🎯', title: 'Nessun punteggio', body: 'Il punteggio comparirà appena la prima azione viene registrata.' }}
+        error={{ title: 'Punteggio non disponibile', body: 'Impossibile caricare il template di scoring dal toolkit.' }}>
+        {Branch ? <Branch data={data} /> : <Centered><M.StateBlock icon="❔" title={`scoreType "${type}" sconosciuto`} body="Nessun renderer registrato per questo tipo." /></Centered>}
+      </StateScaffold>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // TurnIndicatorRenderer — switch on turnOrderType
+  // ══════════════════════════════════════════════════════════════════════════
+  const TurnTypePill = ({ type }) => (
+    <span style={{
+      ...mono(9, 800), textTransform: 'uppercase', letterSpacing: '.06em',
+      padding: '2px 8px', borderRadius: 'var(--r-pill)',
+      background: eHsl('player', 0.12), color: eHsl('player'), border: `1px solid ${eHsl('player', 0.3)}`,
+    }}>turnOrder · {type}</span>
+  );
+
+  // generic phase stepper (Sequential / Simultaneous / Custom)
+  const PhaseStepper = ({ phases, activeIndex }) => (
+    <ol style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 0 }}>
+      {phases.map((ph, i) => {
+        const on = i === activeIndex, past = i < activeIndex;
+        return (
+          <li key={ph} aria-current={on ? 'step' : undefined} style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '4px 0' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', alignSelf: 'stretch' }}>
+              <span style={{
+                width: 24, height: 24, borderRadius: '50%', flexShrink: 0,
+                background: on ? eHsl('player') : past ? eHsl('player', 0.2) : 'var(--bg-muted)',
+                color: on ? '#fff' : past ? eHsl('player') : 'var(--text-muted)',
+                border: on ? 'none' : `1px solid var(--border)`,
+                display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(11, 800),
+              }}>{past ? '✓' : i + 1}</span>
+              {i < phases.length - 1 && <span style={{ width: 2, flex: 1, minHeight: 12, background: past ? eHsl('player', 0.3) : 'var(--border)' }} />}
+            </div>
+            <span style={{
+              fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: on ? 800 : 600,
+              color: on ? eHsl('player') : past ? 'var(--text-sec)' : 'var(--text-muted)', padding: '2px 0',
+            }}>{ph}{on && <span style={{ ...mono(9, 800, eHsl('player')), marginLeft: 8 }}>◀ attuale</span>}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+
+  const Banner = ({ e, icon, title, body }) => (
+    <div role="status" style={{
+      margin: 14, padding: 16, borderRadius: 'var(--r-lg)', textAlign: 'center',
+      background: eHsl(e, 0.08), border: `1px solid ${eHsl(e, 0.3)}`,
+    }}>
+      <div style={{ fontSize: 30, marginBottom: 4 }} aria-hidden="true">{icon}</div>
+      <div style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHsl(e) }}>{title}</div>
+      <div style={{ ...mono(10.5, 700, 'var(--text-sec)'), marginTop: 4, lineHeight: 1.5 }}>{body}</div>
+    </div>
+  );
+
+  const RoundRobinTurn = ({ data }) => {
+    const t = data.turn, ts = data.turnState;
+    const active = data.players.find(p => p.id === ts.activePlayerId) || data.players[0];
+    const order = data.players;
+    const totalTurns = t.turnsPerRound?.[ts.round - 1];
+    return (
+      <Panel>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <Label>Turno attivo</Label><div style={{ flex: 1 }} /><TurnTypePill type="RoundRobin" />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 12, borderRadius: 'var(--r-lg)', background: eHsl('player', 0.07), border: `1px solid ${eHsl('player', 0.28)}` }} aria-live="polite">
+          <Avatar p={active} size={44} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ ...mono(9.5, 800, eHsl('player')), textTransform: 'uppercase', letterSpacing: '.06em' }}>Sta giocando</div>
+            <div style={{ fontFamily: 'var(--f-display)', fontSize: 17, fontWeight: 800, color: 'var(--text)' }}>{active.name}</div>
+            {t.turnActions?.[ts.actionIndex] && <div style={{ ...mono(10, 700, 'var(--text-muted)') }}>azione: {t.turnActions[ts.actionIndex]}</div>}
+          </div>
+        </div>
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
+            <Label>Round {ts.round} / {t.rounds}</Label>
+            <span style={{ ...mono(10, 800, 'var(--text-sec)') }}>turno {ts.turnInRound} / {totalTurns}</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {t.phases.map((ph, i) => {
+              const on = i === ts.round - 1, past = i < ts.round - 1;
+              return (
+                <div key={ph} aria-current={on ? 'step' : undefined} style={{
+                  flex: 1, textAlign: 'center', padding: '6px 2px', borderRadius: 'var(--r-md)',
+                  background: on ? eHsl('player', 0.14) : past ? eHsl('player', 0.06) : 'var(--bg-muted)',
+                  border: `1px solid ${on ? eHsl('player', 0.4) : 'var(--border-light)'}`,
+                  color: on ? eHsl('player') : 'var(--text-muted)', ...mono(10, 800),
+                }}>{i + 1}{on && t.turnsPerRound && <div style={{ ...mono(8, 700), opacity: 0.8 }}>{t.turnsPerRound[i]}t</div>}</div>
+              );
+            })}
+          </div>
+        </div>
+        <Label mt={4}>Ordine di gioco · {t.direction}</Label>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+          {order.map((p, i) => (
+            <React.Fragment key={p.id}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 8px 4px 4px', borderRadius: 'var(--r-pill)', background: p.id === active.id ? eHsl('player', 0.12) : 'var(--bg-muted)', border: `1px solid ${p.id === active.id ? eHsl('player', 0.35) : 'var(--border-light)'}` }}>
+                <Avatar p={p} size={20} />
+                <span style={{ fontFamily: 'var(--f-display)', fontSize: 11, fontWeight: 700, color: 'var(--text)' }}>{p.name}</span>
+              </div>
+              {i < order.length - 1 && <span style={{ color: 'var(--text-muted)' }} aria-hidden="true">→</span>}
+            </React.Fragment>
+          ))}
+        </div>
+      </Panel>
+    );
+  };
+
+  const SequentialTurn = ({ data }) => (
+    <Panel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <Label>{data.meta || 'Fasi'}</Label><div style={{ flex: 1 }} /><TurnTypePill type="Sequential" />
+      </div>
+      <div style={{ ...mono(10, 700, 'var(--text-muted)') }}>Sequenza di fasi a squadra — risolte in ordine fisso, non per giocatore.</div>
+      <div style={{ padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+        <PhaseStepper phases={data.turn.phases} activeIndex={data.turnState.phaseIndex} />
+      </div>
+    </Panel>
+  );
+
+  const SimultaneousTurn = ({ data }) => (
+    <Panel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <Label>Gioco simultaneo</Label><div style={{ flex: 1 }} /><TurnTypePill type="Simultaneous" />
+      </div>
+      <Banner e="toolkit" icon="⚡" title="Tutti giocano insieme" body="Co-op simultaneo · nessun ordine di turno individuale" />
+      <Label>Giocatori attivi · tutti</Label>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 7 }}>
+        {data.players.map(p => (
+          <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 'var(--r-md)', background: eHsl('toolkit', 0.08), border: `1px solid ${eHsl('toolkit', 0.3)}` }}>
+            <Avatar p={p} size={26} ring />
+            <span style={{ fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: 'var(--text)' }}>{p.name}</span>
+          </div>
+        ))}
+      </div>
+      {data.turn.phases?.length > 0 && (<>
+        <Label mt={4}>Fase del giorno</Label>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {data.turn.phases.map((ph, i) => {
+            const on = i === data.turnState.phaseIndex;
+            return <div key={ph} aria-current={on ? 'step' : undefined} style={{ flex: 1, textAlign: 'center', padding: '8px 4px', borderRadius: 'var(--r-md)', background: on ? eHsl('player', 0.14) : 'var(--bg-muted)', border: `1px solid ${on ? eHsl('player', 0.4) : 'var(--border-light)'}`, color: on ? eHsl('player') : 'var(--text-muted)', fontFamily: 'var(--f-display)', fontSize: 11.5, fontWeight: 800 }}>{ph}</div>;
+          })}
+        </div>
+      </>)}
+    </Panel>
+  );
+
+  const RealtimeTurn = ({ data }) => (
+    <Panel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <Label>Tempo reale</Label><div style={{ flex: 1 }} /><TurnTypePill type="Realtime" />
+      </div>
+      <Banner e="warning" icon="⏱" title="Nessun turno" body="Partita in tempo reale e simultanea · l'indicatore di turno non si applica" />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', borderRadius: 'var(--r-md)', background: eHsl('agent', 0.08), border: `1px solid ${eHsl('agent', 0.3)}` }}>
+        <span className="mai-pulse-dot" aria-hidden="true" style={{ color: eHsl('agent') }}>●</span>
+        <span style={{ ...mono(10.5, 700, 'var(--text-sec)') }}>Tutti i giocatori agiscono in parallelo, senza attendere.</span>
+      </div>
+    </Panel>
+  );
+
+  const NoneTurn = ({ data }) => (
+    <Panel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <Label>Gioco libero</Label><div style={{ flex: 1 }} /><TurnTypePill type="None" />
+      </div>
+      <Banner e="session" icon="🎲" title="Nessun ordine di turno" body="Gioco a struttura libera · i giocatori procedono senza turni definiti" />
+    </Panel>
+  );
+
+  const CustomTurn = ({ data }) => (
+    <Panel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <Label>{data.meta || 'Sequenza custom'}</Label><div style={{ flex: 1 }} /><TurnTypePill type={data.turn.turnOrderType} />
+      </div>
+      <div style={{ ...mono(10, 700, 'var(--text-muted)') }}>Fasi definite dal toolkit, ripetute ogni round.</div>
+      <div style={{ padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+        <PhaseStepper phases={data.turn.phases} activeIndex={data.turnState.phaseIndex || 0} />
+      </div>
+    </Panel>
+  );
+
+  const TURN_BRANCH = {
+    RoundRobin: RoundRobinTurn, Sequential: SequentialTurn, Simultaneous: SimultaneousTurn,
+    Realtime: RealtimeTurn, None: NoneTurn, Custom: CustomTurn, Free: CustomTurn,
+  };
+  const TurnIndicatorRenderer = ({ data, state = 'default' }) => {
+    const type = data?.turn?.turnOrderType;
+    const Branch = TURN_BRANCH[type];
+    return (
+      <StateScaffold state={state} sseWhere="turni"
+        empty={{ icon: '🎯', title: 'Turno non avviato', body: 'L\u2019indicatore comparirà all\u2019avvio della partita.' }}
+        error={{ title: 'Turno non disponibile', body: 'Impossibile leggere il template dei turni dal toolkit.' }}>
+        {Branch ? <Branch data={data} /> : <Centered><M.StateBlock icon="❔" title={`turnOrderType "${type}" sconosciuto`} body="Nessun renderer registrato." /></Centered>}
+      </StateScaffold>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ToolkitRenderer — dispatch widgets[] → WidgetBlock (6 types)
+  // ══════════════════════════════════════════════════════════════════════════
+  const WidgetShell = ({ icon, title, type, children, accent = 'tool', collapsed, onHeaderClick }) => (
+    <div style={{ borderRadius: 'var(--r-md)', background: 'var(--bg-card)', border: `1px solid ${collapsed ? 'var(--border)' : eHsl(accent, 0.3)}`, overflow: 'hidden', flexShrink: 0 }}>
+      <button type="button" onClick={onHeaderClick} aria-expanded={!collapsed} style={{ width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: eHsl(accent, collapsed ? 0.04 : 0.08), borderBottom: collapsed ? 'none' : `1px solid ${eHsl(accent, 0.18)}`, border: 'none', borderLeft: collapsed ? 'none' : `2px solid ${eHsl(accent)}`, cursor: onHeaderClick ? 'pointer' : 'default' }}>
+        <span style={{ width: 24, height: 24, borderRadius: 'var(--r-sm)', background: eHsl(accent, 0.14), display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, flexShrink: 0 }} aria-hidden="true">{icon}</span>
+        <span style={{ flex: 1, minWidth: 0, fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{title}</span>
+        <span style={{ ...mono(8, 800, eHsl(accent)), textTransform: 'uppercase', letterSpacing: '.05em', padding: '1px 6px', borderRadius: 'var(--r-pill)', background: eHsl(accent, 0.1), flexShrink: 0 }}>{type}</span>
+        {onHeaderClick && <span aria-hidden="true" style={{ ...mono(11, 800, eHsl(accent)), flexShrink: 0, transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span>}
+      </button>
+      {!collapsed && <div style={{ padding: 10 }}>{children}</div>}
+    </div>
+  );
+  const Stepper = ({ value, color = 'tool', wide }) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <button type="button" aria-label="meno" style={{ width: 24, height: 24, borderRadius: 'var(--r-sm)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontWeight: 800 }}>–</button>
+      <span style={{ ...mono(14, 800, 'var(--text)'), minWidth: wide ? 34 : 20, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }}>{value}</span>
+      <button type="button" aria-label="più" style={{ width: 24, height: 24, borderRadius: 'var(--r-sm)', background: eHsl(color, 0.12), border: `1px solid ${eHsl(color, 0.3)}`, color: eHsl(color), cursor: 'pointer', fontWeight: 800 }}>+</button>
+    </div>
+  );
+
+  const RandomGeneratorBlock = ({ w, shell }) => (
+    <WidgetShell icon="🎲" title={w.config.name || 'Generatore'} type="RandomGenerator" accent="tool" {...shell}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ flex: 1, padding: '10px 12px', borderRadius: 'var(--r-md)', background: eHsl('tool', 0.06), border: `1px dashed ${eHsl('tool', 0.3)}` }}>
+          <div style={{ ...mono(8.5, 800, eHsl('tool')), textTransform: 'uppercase', letterSpacing: '.06em' }}>Ultimo</div>
+          <div style={{ ...mono(16, 800, 'var(--text)'), marginTop: 2 }}>{w.config.last || '—'}</div>
+        </div>
+        <button type="button" style={{ padding: '10px 14px', borderRadius: 'var(--r-md)', background: eHsl('tool'), color: '#06222b', border: 'none', fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, cursor: 'pointer', flexShrink: 0 }}>Genera</button>
+      </div>
+      {w.config.faces && <div style={{ ...mono(9.5, 700, 'var(--text-muted)'), marginTop: 8 }}>{w.config.quantity}× · facce: {w.config.faces.join(' ')}</div>}
+    </WidgetShell>
+  );
+  const TurnManagerBlock = ({ w, shell }) => (
+    <WidgetShell icon="🔄" title="Gestore turni" type="TurnManager" accent="player" {...shell}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button type="button" style={{ padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontWeight: 800 }}>‹ Prec</button>
+        <div style={{ flex: 1, textAlign: 'center' }}>
+          <div style={{ ...mono(8.5, 800, eHsl('player')), textTransform: 'uppercase' }}>{w.config.phaseBased ? 'Fase' : 'Turno di'}</div>
+          <div style={{ fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 800, color: 'var(--text)' }}>{w.config.phaseBased ? 'Giorno' : '—'}</div>
+        </div>
+        <button type="button" style={{ padding: '8px 10px', borderRadius: 'var(--r-md)', background: eHsl('player', 0.12), border: `1px solid ${eHsl('player', 0.3)}`, color: eHsl('player'), cursor: 'pointer', fontWeight: 800 }}>Pross ›</button>
+      </div>
+    </WidgetShell>
+  );
+  const ScoreTrackerBlock = ({ w, players = [], shell }) => (
+    <WidgetShell icon="🧮" title="Segna punti" type="ScoreTracker" accent="session" {...shell}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+        {(players.length ? players : [{ id: 'x', name: 'Giocatore', hue: 240, score: 0 }]).slice(0, 4).map(p => (
+          <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Avatar p={p} size={22} />
+            <span style={{ flex: 1, fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700, color: 'var(--text)' }}>{p.name}</span>
+            <Stepper value={p.score ?? 0} color="session" wide />
+          </div>
+        ))}
+      </div>
+    </WidgetShell>
+  );
+  const ResourceManagerBlock = ({ w, shell }) => (
+    <WidgetShell icon="📦" title={w.config.shared ? 'Risorse condivise' : 'Risorse'} type="ResourceManager" accent="kb" {...shell}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {(w.config.resources || []).map(r => (
+          <div key={r.label} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 6px', borderRadius: 'var(--r-sm)', background: r.danger ? eHsl('event', 0.07) : 'transparent', border: r.danger ? `1px solid ${eHsl('event', 0.25)}` : '1px solid transparent' }}>
+            <span style={{ flex: 1, fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 700, color: r.danger ? eHsl('event') : 'var(--text)' }}>{r.label}</span>
+            <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>/{r.max}</span>
+            <Stepper value={r.value} color={r.danger ? 'event' : 'kb'} />
+          </div>
+        ))}
+      </div>
+    </WidgetShell>
+  );
+  const NoteManagerBlock = ({ w, shell }) => (
+    <WidgetShell icon="📝" title="Note" type="NoteManager" accent="kb" {...shell}>
+      <textarea defaultValue={w.config.text || ''} rows={3} placeholder="Scrivi una nota condivisa…" style={{ width: '100%', padding: '8px 10px', borderRadius: 'var(--r-sm)', border: '1px solid var(--border)', background: 'var(--bg-sunken)', color: 'var(--text)', fontFamily: 'var(--f-mono)', fontSize: 11.5, lineHeight: 1.5, resize: 'vertical' }} />
+    </WidgetShell>
+  );
+  const WhiteboardBlock = ({ w, shell }) => (
+    <WidgetShell icon="🖊" title="Lavagna" type="Whiteboard" accent="chat" {...shell}>
+      <div style={{ display: 'flex', gap: 5, marginBottom: 8 }}>
+        {['✏️', '⬛', '⭕', '🩹'].map((t, i) => <button key={i} type="button" aria-label={`strumento ${i + 1}`} style={{ width: 28, height: 28, borderRadius: 'var(--r-sm)', background: i === 0 ? eHsl('chat', 0.14) : 'var(--bg-muted)', border: `1px solid ${i === 0 ? eHsl('chat', 0.3) : 'var(--border)'}`, cursor: 'pointer', fontSize: 13 }}>{t}</button>)}
+      </div>
+      <div style={{ height: 86, borderRadius: 'var(--r-sm)', border: `1px dashed ${eHsl('chat', 0.3)}`, background: 'repeating-linear-gradient(45deg, var(--bg-sunken), var(--bg-sunken) 9px, var(--bg-muted) 9px, var(--bg-muted) 18px)', display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(9.5, 700, 'var(--text-muted)') }}>area disegno condivisa</div>
+    </WidgetShell>
+  );
+
+  const WIDGET_BRANCH = {
+    RandomGenerator: RandomGeneratorBlock, TurnManager: TurnManagerBlock, ScoreTracker: ScoreTrackerBlock,
+    ResourceManager: ResourceManagerBlock, NoteManager: NoteManagerBlock, Whiteboard: WhiteboardBlock,
+  };
+  const WIDGET_META = {
+    RandomGenerator: { icon: '🎲', lb: 'Random' }, TurnManager: { icon: '🔄', lb: 'Turni' },
+    ScoreTracker: { icon: '🧮', lb: 'Punti' }, ResourceManager: { icon: '📦', lb: 'Risorse' },
+    NoteManager: { icon: '📝', lb: 'Note' }, Whiteboard: { icon: '🖊', lb: 'Lavagna' },
+  };
+  const WidgetBlock = ({ widget, players, collapsed, onHeaderClick }) => {
+    const Branch = WIDGET_BRANCH[widget.type];
+    if (!Branch) return <Centered><M.StateBlock icon="❔" title={`widget "${widget.type}"`} body="Tipo non riconosciuto dal dispatcher." /></Centered>;
+    const shell = onHeaderClick != null ? { collapsed, onHeaderClick } : undefined;
+    return <Branch w={widget} players={players} shell={shell} />;
+  };
+
+  const ToolkitRenderer = ({ data, widgets, players, state = 'default', accordion = true }) => {
+    const list = (widgets || data?.widgets || []);
+    const enabled = list.filter(w => w.isEnabled).sort((a, b) => a.displayOrder - b.displayOrder);
+    const disabled = list.filter(w => !w.isEnabled);
+    const [open, setOpen] = useState(null);
+    const openId = open || enabled[0]?.id;
+    return (
+      <StateScaffold state={state} sseWhere="widget"
+        empty={{ icon: '🧰', title: 'Nessun widget attivo', body: 'Abilita i widget dal toolkit per usarli durante la sessione.', action: <button type="button" style={{ marginTop: 4, padding: '6px 12px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.12), color: eHsl('toolkit'), border: `1px solid ${eHsl('toolkit', 0.35)}`, cursor: 'pointer', ...mono(10, 800) }}>Apri toolkit</button> }}
+        error={{ title: 'Toolkit non disponibile', body: 'Impossibile caricare la dashboard dei widget.' }}>
+        <Panel gap={10}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Label>Widget attivi · {enabled.length}</Label>
+            <div style={{ flex: 1 }} />
+            <span style={{ ...mono(9, 800, eHsl('toolkit')), textTransform: 'uppercase', letterSpacing: '.06em', padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.12), border: `1px solid ${eHsl('toolkit', 0.3)}` }}>ToolkitDashboard</span>
+          </div>
+          {enabled.length === 0
+            ? <Centered><M.StateBlock icon="🧰" title="Tutti i widget disattivati" body="Nessun widget abilitato in questa sessione." /></Centered>
+            : enabled.map(w => accordion
+                ? <WidgetBlock key={w.id} widget={w} players={players} collapsed={w.id !== openId} onHeaderClick={() => setOpen(w.id)} />
+                : <WidgetBlock key={w.id} widget={w} players={players} />)}
+          {disabled.length > 0 && (
+            <div style={{ marginTop: 2 }}>
+              <Label>Disattivati · {disabled.length}</Label>
+              <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 6 }}>
+                {disabled.map(w => {
+                  const m = WIDGET_META[w.type] || { icon: '❔', lb: w.type };
+                  return <span key={w.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 9px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', ...mono(10, 700, 'var(--text-muted)') }}><span aria-hidden="true">{m.icon}</span>{m.lb}</span>;
+                })}
+              </div>
+            </div>
+          )}
+        </Panel>
+      </StateScaffold>
+    );
+  };
+
+  window.SkeletonRenderers = {
+    ScoringPanelRenderer, TurnIndicatorRenderer, ToolkitRenderer, WidgetBlock,
+    ComputationBadge, COMPUTATION, WIDGET_META, Avatar, Label, mono, Panel, StateScaffold, Centered,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-summary-skeleton.html
+++ b/admin-mockups/design_files/sp4-session-summary-skeleton.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Generic Session Skeleton · Summary — /sessions/[id]</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-summary-skeleton.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-summary-skeleton.jsx
+++ b/admin-mockups/design_files/sp4-session-summary-skeleton.jsx
@@ -1,0 +1,311 @@
+/* MeepleAI SP4 — Generic Session Skeleton · SUMMARY
+   /sessions/[id]  — post-game review, game-AGNOSTIC.
+
+   Hero post-game (vincitore / esito collettivo / obiettivi) + 5 tab:
+     Scoreboard (ScoringPanelRenderer) · Diario · Foto · ChatHighlights · Stat.
+   Rendered SIDE-BY-SIDE per due dataset opposti:
+     A · Wingspan — Points, c'è un vincitore
+     B · Paleo    — BinaryWin, esito collettivo (tribù salva)
+
+   Loads: sp4-parts-common.jsx · sp4-session-skeleton-data.jsx ·
+          sp4-session-skeleton-renderers.jsx · sp4-session-skeleton-parts.jsx
+   DEMO-NAV-HINTS: sp4-session-skeleton-live.html
+*/
+
+const { useState: useStateS } = React;
+const Ds = window.SkeletonData;
+const Sp = window.SkeletonParts;
+const Rs = window.SkeletonRenderers;
+const Ms = window.MAI;
+const eHslS = Ms.entityHsl;
+const monoS = Rs.mono;
+const WINGs = Ds.DATASETS.wingspan;
+const PALEOs = Ds.DATASETS.paleo;
+const STATESs = Ds.STATES;
+const AvatarS = Rs.Avatar;
+const LabelS = Rs.Label;
+
+// ─── HERO ──────────────────────────────────────────────────────────────────
+const HeroSummary = ({ ds }) => {
+  const sm = ds.summary;
+  const res = sm.result;
+  const winner = res.kind === 'winner' ? ds.players.find(p => p.id === res.playerId) : null;
+  return (
+    <header aria-label="Esito partita" style={{ position: 'relative', padding: '22px 22px 20px', background: ds.game.cover, overflow: 'hidden', flexShrink: 0 }}>
+      <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(0,0,0,.12), rgba(0,0,0,.55))' }} aria-hidden="true" />
+      <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 26 }} aria-hidden="true">{ds.game.emoji}</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: 'var(--f-display)', fontSize: 20, fontWeight: 800, color: '#fff', textShadow: '0 2px 8px rgba(0,0,0,.4)' }}>{ds.game.title}</div>
+            <div style={{ ...monoS(10, 700, 'rgba(255,255,255,.85)') }}>{sm.date} · {sm.duration} · {sm.rounds}</div>
+          </div>
+          <Ms.OutcomeBadge status={sm.outcome} />
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: 14, borderRadius: 'var(--r-lg)', background: 'rgba(0,0,0,.32)', backdropFilter: 'blur(6px)', border: '1px solid rgba(255,255,255,.16)' }}>
+          {winner
+            ? <AvatarS p={winner} size={52} ring />
+            : <div style={{ width: 52, height: 52, borderRadius: 'var(--r-md)', background: eHslS(res.won ? 'toolkit' : 'event', 0.9), display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 26 }} aria-hidden="true">{res.won ? '🏆' : '💀'}</div>}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ ...monoS(9.5, 800, 'rgba(255,255,255,.8)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>{res.kind === 'winner' ? 'Vincitore' : res.kind === 'collective' ? 'Esito collettivo' : 'Obiettivi'}</div>
+            <div style={{ fontFamily: 'var(--f-display)', fontSize: 19, fontWeight: 800, color: '#fff' }}>{res.headline}</div>
+            <div style={{ ...monoS(10.5, 700, 'rgba(255,255,255,.85)') }}>{res.sub}</div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+// ─── TAB BODIES ────────────────────────────────────────────────────────────
+const DiaryTab = ({ ds, state = 'default' }) => {
+  const KIND_E = { 'game-start': 'session', 'turn-change': 'player', 'score-update': 'toolkit', custom: 'event' };
+  return (
+    <Rs.StateScaffold state={state} sseWhere="diario"
+      empty={{ icon: '📓', title: 'Diario vuoto', body: 'Nessun evento rilevante registrato in questa partita.' }}
+      error={{ title: 'Diario non disponibile', body: 'Impossibile caricare la timeline della partita.' }}>
+      <Rs.Panel>
+        <LabelS>Diario · {ds.events.length} eventi</LabelS>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {ds.events.map((ev, i) => {
+            const e = KIND_E[ev.kind] || 'session';
+            const who = ds.players.find(p => p.id === ev.who);
+            return (
+              <div key={i} style={{ display: 'flex', gap: 11, padding: '8px 0' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0 }}>
+                  <span style={{ width: 11, height: 11, borderRadius: '50%', background: eHslS(e), boxShadow: `0 0 0 3px ${eHslS(e, 0.2)}` }} aria-hidden="true" />
+                  {i < ds.events.length - 1 && <span style={{ width: 2, flex: 1, minHeight: 16, background: 'var(--border)', marginTop: 3 }} />}
+                </div>
+                <div style={{ flex: 1, minWidth: 0, paddingBottom: 4 }}>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                    {who && <span style={{ fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: `hsl(${who.hue},60%,52%)` }}>{who.name}</span>}
+                    <span style={{ ...monoS(8.5, 800, eHslS(e)), textTransform: 'uppercase', letterSpacing: '.05em' }}>{ev.kind}</span>
+                    <div style={{ flex: 1 }} />
+                    <span style={{ ...monoS(9, 700, 'var(--text-muted)') }}>{ev.t}</span>
+                  </div>
+                  <div style={{ fontFamily: 'var(--f-body)', fontSize: 13, color: 'var(--text-sec)', lineHeight: 1.45 }} dangerouslySetInnerHTML={{ __html: ev.text }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Rs.Panel>
+    </Rs.StateScaffold>
+  );
+};
+
+const PhotosTab = ({ ds, state = 'default' }) => (
+  <Rs.StateScaffold state={state} sseWhere="foto"
+    empty={{ icon: '📷', title: 'Nessuna foto', body: 'Aggiungi foto del tavolo durante o dopo la partita.', action: <button type="button" style={{ marginTop: 4, padding: '6px 12px', borderRadius: 'var(--r-pill)', background: eHslS('kb', 0.12), color: eHslS('kb'), border: `1px solid ${eHslS('kb', 0.35)}`, cursor: 'pointer', ...monoS(10, 800) }}>+ Carica foto</button> }}
+    error={{ title: 'Foto non disponibili', body: 'Impossibile caricare la galleria.' }}>
+    <Rs.Panel>
+      <LabelS>Galleria · {ds.photos.length}</LabelS>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
+        {ds.photos.map((p, i) => (
+          <div key={i} style={{ aspectRatio: '4/3', borderRadius: 'var(--r-md)', background: p.g, display: 'flex', alignItems: 'flex-end', padding: 8, boxShadow: 'var(--shadow-xs)' }}>
+            <span style={{ ...monoS(9.5, 800, '#fff'), background: 'rgba(0,0,0,.42)', padding: '2px 7px', borderRadius: 'var(--r-pill)' }}>{p.lb}</span>
+          </div>
+        ))}
+        <button type="button" aria-label="Aggiungi foto" style={{ aspectRatio: '4/3', borderRadius: 'var(--r-md)', background: 'transparent', border: '1px dashed var(--border-strong)', color: 'var(--text-muted)', fontSize: 22, cursor: 'pointer' }}>+</button>
+      </div>
+    </Rs.Panel>
+  </Rs.StateScaffold>
+);
+
+const ChatHighlightsTab = ({ ds, state = 'default' }) => {
+  const highlights = ds.chat.filter(m => m.from === 'agent');
+  return (
+    <Rs.StateScaffold state={state} sseWhere="chat"
+      empty={{ icon: '💬', title: 'Nessun highlight', body: 'Le risposte salienti dell\u2019agente compariranno qui.' }}
+      error={{ title: 'Chat non disponibile', body: 'Impossibile caricare gli estratti chat.' }}>
+      <Rs.Panel>
+        <LabelS>Estratti chat AI · {highlights.length}</LabelS>
+        {highlights.map((m, i) => {
+          const q = ds.chat[ds.chat.indexOf(m) - 1];
+          return (
+            <div key={m.id} style={{ borderRadius: 'var(--r-md)', background: 'var(--bg-card)', border: '1px solid var(--border)', overflow: 'hidden' }}>
+              {q && q.from === 'user' && <div style={{ padding: '7px 11px', background: eHslS('chat', 0.06), borderBottom: `1px solid ${eHslS('chat', 0.18)}`, ...monoS(10.5, 700, eHslS('chat')) }}>“{q.text}”</div>}
+              <div style={{ padding: '9px 11px', display: 'flex', gap: 8 }}>
+                <span style={{ fontSize: 15 }} aria-hidden="true">{ds.agent.emoji}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontFamily: 'var(--f-body)', fontSize: 12.5, color: 'var(--text)', lineHeight: 1.45, fontWeight: 500 }}>{m.text}</div>
+                  {m.citations && <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 6 }}>
+                    {m.citations.map((c, j) => <span key={j} style={{ display: 'inline-flex', alignItems: 'center', gap: 3, padding: '2px 7px', borderRadius: 'var(--r-pill)', background: eHslS('kb', 0.1), border: `1px solid ${eHslS('kb', 0.25)}`, color: eHslS('kb'), ...monoS(9, 700) }}><span aria-hidden="true">📄</span>{c}</span>)}
+                  </div>}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </Rs.Panel>
+    </Rs.StateScaffold>
+  );
+};
+
+const PlayersStatsTab = ({ ds, state = 'default' }) => {
+  const hasScore = ds.scoring.scoreType === 'Points';
+  const rows = [...ds.players].sort((a, b) => (b.score || 0) - (a.score || 0));
+  const topCat = (pid) => {
+    if (!ds.breakdown?.[pid]) return null;
+    const entries = Object.entries(ds.breakdown[pid]);
+    const top = entries.sort((a, b) => b[1] - a[1])[0];
+    const cat = ds.scoring.categories.find(c => c.id === top[0]);
+    return cat ? `${cat.label} (${top[1]})` : null;
+  };
+  return (
+    <Rs.StateScaffold state={state} sseWhere="statistiche"
+      empty={{ icon: '👥', title: 'Nessuna statistica', body: 'Le statistiche post-partita non sono disponibili.' }}
+      error={{ title: 'Statistiche non disponibili', body: 'Impossibile calcolare le statistiche dei giocatori.' }}>
+      <Rs.Panel>
+        <LabelS>{hasScore ? 'Statistiche giocatori' : 'Contributo · co-op'}</LabelS>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          {rows.map((p, i) => (
+            <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 'var(--r-md)', background: i === 0 && hasScore ? eHslS('toolkit', 0.07) : 'var(--bg-card)', border: `1px solid ${i === 0 && hasScore ? eHslS('toolkit', 0.28) : 'var(--border)'}` }}>
+              <AvatarS p={p} size={32} ring={i === 0 && hasScore} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: 'var(--text)' }}>{p.name}{p.presence === 'host' && <span style={{ ...monoS(8.5, 800, eHslS('session')), marginLeft: 6, padding: '1px 5px', borderRadius: 'var(--r-pill)', background: eHslS('session', 0.12) }}>HOST</span>}</div>
+                <div style={{ ...monoS(9.5, 700, 'var(--text-muted)') }}>{hasScore ? (topCat(p.id) ? `Top: ${topCat(p.id)}` : 'partita completata') : 'membro tribù · attivo'}</div>
+              </div>
+              {hasScore
+                ? <div style={{ textAlign: 'right' }}><div style={{ fontFamily: 'var(--f-display)', fontSize: 18, fontWeight: 800, color: i === 0 ? eHslS('toolkit') : 'var(--text)', fontVariantNumeric: 'tabular-nums' }}>{p.score}</div><div style={{ ...monoS(8.5, 700, 'var(--text-muted)') }}>{i + 1}° posto</div></div>
+                : <span style={{ ...monoS(10, 800, eHslS('toolkit')) }}>✓</span>}
+            </div>
+          ))}
+        </div>
+      </Rs.Panel>
+    </Rs.StateScaffold>
+  );
+};
+
+// ─── TABS ──────────────────────────────────────────────────────────────────
+const SUMMARY_TABS = [
+  { id: 'score',   icon: '🏆', label: 'Risultato', entity: 'session', render: (ds, st) => <Rs.ScoringPanelRenderer data={ds} state={st} /> },
+  { id: 'diary',   icon: '📓', label: 'Diario',    entity: 'event',   render: (ds, st) => <DiaryTab ds={ds} state={st} /> },
+  { id: 'photos',  icon: '📷', label: 'Foto',      entity: 'kb',      render: (ds, st) => <PhotosTab ds={ds} state={st} /> },
+  { id: 'chat',    icon: '💬', label: 'Chat',      entity: 'chat',    render: (ds, st) => <ChatHighlightsTab ds={ds} state={st} /> },
+  { id: 'stats',   icon: '👥', label: 'Stat',      entity: 'player',  render: (ds, st) => <PlayersStatsTab ds={ds} state={st} /> },
+];
+
+const SummaryTabs = ({ ds, initial = 'score', initialState = 'default', mobile }) => {
+  const [tab, setTab] = useStateS(initial);
+  const [st, setSt] = useStateS(initialState);
+  const active = SUMMARY_TABS.find(t => t.id === tab) || SUMMARY_TABS[0];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, background: 'var(--bg-card)' }}>
+      <div role="tablist" aria-label="Sezioni recap" className="mai-cb-scroll" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0, overflowX: 'auto' }}>
+        {SUMMARY_TABS.map(t => {
+          const on = tab === t.id;
+          return (
+            <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} onClick={() => setTab(t.id)} style={{ flex: mobile ? '0 0 auto' : 1, padding: '10px 12px', background: on ? eHslS(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHslS(t.entity)}` : '2px solid transparent', color: on ? eHslS(t.entity) : 'var(--text-sec)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5, whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true" style={{ fontSize: 14 }}>{t.icon}</span><span>{t.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <Sp.StateSwitch value={st} onChange={setSt} />
+      <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(ds, st)}</div>
+    </div>
+  );
+};
+
+const SummaryDesktopBody = ({ ds, initialTab, initialState }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+    <HeroSummary ds={ds} />
+    <SummaryTabs ds={ds} initial={initialTab} initialState={initialState} />
+  </div>
+);
+
+const SummaryPhone = ({ ds, label, desc, dark, initialTab }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+    <div style={{ ...monoS(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHslS('session'), marginLeft: 6 }}>· dark</span>}</div>
+    <div className="phone" data-theme={dark ? 'dark' : undefined}>
+      <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+        <span style={{ fontFamily: 'var(--f-mono)' }}>22:40</span>
+        <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+      </div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', overflow: 'hidden', minHeight: 0 }}>
+        <HeroSummary ds={ds} />
+        <SummaryTabs ds={ds} initial={initialTab || 'score'} mobile />
+      </div>
+    </div>
+    {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 340, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+  </div>
+);
+
+// ─── APP ───────────────────────────────────────────────────────────────────
+function AppSummary() {
+  return (
+    <div className="stage">
+      <Sp.ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Generic Session Skeleton · Summary 🏁</div>
+        <h1>Session summary — recap post-game generico</h1>
+        <p className="lead">
+          Template universale per <code>/sessions/[id]</code>. Hero post-game (vincitore · esito collettivo · obiettivi) +
+          5 tab: <strong>Risultato</strong> (ScoringPanelRenderer) · Diario · Foto · ChatHighlights · Statistiche.
+          Stesso skeleton applicato a due esiti opposti, affiancati: <strong>Wingspan</strong> (c'è un vincitore) e
+          <strong> Paleo</strong> (esito collettivo co-op). Dark = primario.
+        </p>
+
+        {/* SIDE-BY-SIDE */}
+        <div className="section-label">Side-by-side · Desktop — stesso recap, 2 esiti · cambia tab e stato dai selettori</div>
+        <div className="sk-sxs">
+          <Sp.DesktopFrame ds={WINGs} label="Dataset A · Wingspan — vincitore + Points" url="meepleai.app/sessions/wing-3" height={680}
+            desc="Hero con vincitore (Marco, 87). Tab Risultato → leaderboard + breakdown 6 categorie; Diario → eventi chiave; Stat → punteggi e categoria migliore per giocatore.">
+            <SummaryDesktopBody ds={WINGs} initialTab="score" initialState="default" />
+          </Sp.DesktopFrame>
+          <Sp.DesktopFrame ds={PALEOs} label="Dataset B · Paleo — esito collettivo + BinaryWin" url="meepleai.app/sessions/paleo-1" height={680}
+            desc="Hero con esito collettivo (tribù salva, no vincitore singolo). Tab Risultato → indicatore BinaryWin; Stat → contributo co-op invece di punteggi.">
+            <SummaryDesktopBody ds={PALEOs} initialTab="score" initialState="default" />
+          </Sp.DesktopFrame>
+        </div>
+
+        {/* MOBILE */}
+        <div className="section-label">Mobile 375 — hero + tab scrollabili</div>
+        <div className="phones-grid">
+          <SummaryPhone ds={WINGs} label="A · Wingspan · Risultato" desc="Hero vincitore + leaderboard. Tab strip scrollabile, selettore stato sotto." />
+          <SummaryPhone ds={WINGs} label="A · Wingspan · Diario" initialTab="diary" desc="Timeline degli eventi salienti della partita." />
+          <SummaryPhone ds={PALEOs} label="B · Paleo · Risultato · dark" dark initialTab="score" desc="Esito collettivo BinaryWin: stesso hero, nessun punteggio individuale." />
+        </div>
+
+        {/* STATES GALLERY for the 5 summary tabs */}
+        <div className="section-label">Gallery stati · ogni tab del recap × 5 stati canonici (su Wingspan)</div>
+        {SUMMARY_TABS.map(t => (
+          <div key={t.id} style={{ marginBottom: 26 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10 }}>
+              <span style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHslS(t.entity), display: 'inline-flex', alignItems: 'center', gap: 7 }}><span aria-hidden="true">{t.icon}</span>{t.label}</span>
+              <span style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)', fontWeight: 700 }}>/sessions/[id] · tab {t.id}</span>
+            </div>
+            <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>
+              {STATESs.map(s => (
+                <Sp.PanelFrame key={s.id} label={s.lb} entity={t.entity} h={460}>
+                  {t.render(WINGs, s.id)}
+                </Sp.PanelFrame>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .sk-sxs { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px; align-items: start; }
+        @media (max-width: 1100px) { .sk-sxs { grid-template-columns: 1fr; } }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<AppSummary />);

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -61,6 +61,18 @@ ambiguity. Each route is also classified by **Tier** (S/M/L) to gate dispatch st
 > photo-upload +manual-mode entry). Spec:
 > `docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`.
 
+> **Updated 2026-05-31 #3** (B19-4b skeleton mockup delivery): generic
+> session skeleton consegnato via Claude Design Web — 7 file in
+> `admin-mockups/design_files/` (`sp4-session-skeleton-{live,renderers,parts,data}.jsx`
+> + `sp4-session-skeleton-live.html` + `sp4-session-summary-skeleton.{html,jsx}`).
+> Renderizza dinamicamente qualsiasi gioco consumando `AiToolkitSuggestionDto`
+> polimorficamente (mirror dei FE renderers `ScoringPanelRenderer` +
+> `TurnIndicatorRenderer` di PR #1763). Demo side-by-side Wingspan
+> (Points + RoundRobin) vs Paleo (BinaryWin + Simultaneous). Hybrid strategy
+> confermata: skeleton copre i 13-14 giochi non-premium, i 6 premium
+> (Wingspan done, Puerto Rico + Catan + Power Grid + Zombicide GH + Paleo
+> + Codenames pending) restano ad-hoc. Closes issue #1750.
+
 > **Updated 2026-05-31 #2** (Sessions sub-routes consolidation via tabs,
 > closes gap N7 audit 2026-05-22): Option B+ hybrid consolidation accettata
 > e shipped — 7 sub-route Sessions confluiscono in `?tab=` deep-link


### PR DESCRIPTION
## Summary

Closes **#1750** (B19-4b). Mockup #1 di 7 della pipeline B19 game-agnostic sessions.

Delivery via Claude Design Web. Skeleton universale che renderizza una sessione (live + post-game) per **qualsiasi gioco**, consumando dinamicamente `AiToolkitSuggestionDto` via renderer polimorfici (mirror dei FE renderers di PR #1763).

## Files shipped (7 in admin-mockups/design_files/)

**Page-mock (2)**:
- `sp4-session-skeleton-live.html` → `/sessions/[id]/live` (universal)
- `sp4-session-summary-skeleton.html` → `/sessions/[id]` (post-game universal)

**Component-mock (5)**:
- `sp4-session-skeleton-data.jsx` → demo datasets (Wingspan + Paleo)
- `sp4-session-skeleton-live.jsx` → root component live
- `sp4-session-skeleton-parts.jsx` → shared building blocks (TopBar, ChatAgent, RightColumnTabs, DesktopFrame, PhoneShell)
- `sp4-session-skeleton-renderers.jsx` → polymorphic renderers (mirror PR #1763)
- `sp4-session-summary-skeleton.jsx` → root component summary

## Polymorphic dispatchers (mirror PR #1763)

- **ScoringPanelRenderer**: switch on ScoreType (Points/Ranking/BinaryWin/Objectives)
- **TurnIndicatorRenderer**: switch on TurnOrderType (RoundRobin/Sequential/Simultaneous/Realtime/None/Custom/Free)
- **WidgetRenderer**: dispatch on 6 WidgetType

## Game-agnostic validation

| File | Wingspan mentions | Note |
|---|---|---|
| `sp4-session-skeleton-renderers.jsx` | 0 | ✅ Zero game-specific code |
| `sp4-session-skeleton-live.jsx` | 6 | Solo in demo labels (commented context) |
| `sp4-session-skeleton-data.jsx` | 16 | ✅ Solo nel dataset demo come da brief |

Demo side-by-side: **Wingspan** (Points + RoundRobin + 4-round + 6 categories) vs **Paleo** (BinaryWin + Simultaneous + co-op) — valida polimorfismo su 2 archetypi opposti.

## Skipped (identici a canonical)

- `components.css`, `tokens.css`, `sp4-parts-common.jsx`

## Docs sync

- `MOCKUPS_INDEX.md`: +2 page-mock +5 component-mock, total 87 → 94
- `v2-migration-matrix.md`: added `Updated 2026-05-31 #3` preamble

## Strategia confermata (HYBRID)

- **Skeleton** copre i 13-14 giochi non-premium (AI bootstrap + skeleton)
- **6 premium** restano ad-hoc: Wingspan ✅ done · Puerto Rico / Catan / Power Grid / Zombicide GH / Paleo / Codenames pending

## Stack

PR indipendente da #1760/#1761/#1762 (Step 3). Può essere mergiato direttamente.

🤖 Generated with Claude Code