### PR TITLE
feat(admin-monitor): #1718 Phase 3/4 — LiveEventLog component + useLiveEvents hook

### DIFF
--- a/apps/web/src/components/admin/monitor/LiveEventLog.tsx
+++ b/apps/web/src/components/admin/monitor/LiveEventLog.tsx
@@ -1,0 +1,521 @@
+'use client';
+
+/**
+ * LiveEventLog — Task 3.4 (Issue #1718, F4.1 Monitor)
+ *
+ * Virtualized live domain event log that consumes useLiveEvents (Task 3.3),
+ * parseEventMessage (Task 3.1), and mapEventLevel (Task 3.2).
+ *
+ * Layout pattern from mockup sp5-admin-monitor.html § "Live event stream" section:
+ *   - admin-panel wrapper (rounded-[10px] border border-border/60 bg-card)
+ *   - admin-panel-head: h3, live-pill, head-cluster (event count, pause, export)
+ *   - FilterChipsBar: 7 known event types + 5 entity types (hardcoded for Phase 1)
+ *   - Virtualized list: react-window v2 List, rowHeight=32, role="log"
+ *   - Empty state / Error state / Loading skeleton
+ *
+ * Non-goals (scope discipline):
+ *   - NO detail drawer (Phase 4.x onEventClick wired only as row click callback)
+ *   - NO useEventTypes hook wiring to /types endpoint (Phase 4.x)
+ *   - NO Export ndjson functionality (placeholder button only)
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+
+import { List } from 'react-window';
+
+import { mapEventLevel, type EventLevel } from './event-level-mapper';
+import { parseEventMessage } from './parse-event-message';
+import { useLiveEvents } from './use-live-events';
+
+import type { DomainEventDto } from './live-event-types';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface LiveEventLogProps {
+  /** Initial event-type filters applied to backfill + SSE subscription. */
+  eventTypes?: string[];
+  aggregateTypes?: string[];
+  userId?: string;
+  aggregateId?: string;
+  /** Backfill page size. Default 100. */
+  initialLimit?: number;
+  /** Virtualized list height. Default '70vh'. */
+  height?: number | string;
+  /** Optional callback when a row is clicked (Phase 4.x detail drawer). */
+  onEventClick?: (event: DomainEventDto) => void;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Hardcoded event-type chips. Phase 4.x: wire to GET /api/v1/admin/events/types */
+const KNOWN_EVENT_TYPES = [
+  'agent.created',
+  'kb.doc.indexed',
+  'chat.session.created',
+  'session.created',
+  'session.finalized',
+  'library.entry.removed',
+  'library.session.recorded',
+] as const;
+
+const KNOWN_AGGREGATE_TYPES = [
+  'Agent',
+  'ChatSession',
+  'PdfDocument',
+  'Session',
+  'UserLibraryEntry',
+] as const;
+
+const ROW_HEIGHT = 32;
+const OVERSCAN_COUNT = 10;
+
+// ============================================================================
+// Level → colour mapping (mockup .event-log .lvl colours)
+// ============================================================================
+
+const LEVEL_CLASS: Record<EventLevel, string> = {
+  info: 'text-entity-chat',
+  ok: 'text-entity-toolkit',
+  warn: 'text-amber-600', // status hue — ESLint-exempt per design doc
+  err: 'text-entity-event',
+};
+
+const LEVEL_LABEL: Record<EventLevel, string> = {
+  info: 'INFO',
+  ok: 'OK',
+  warn: 'WARN',
+  err: 'ERR',
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const hh = d.getUTCHours().toString().padStart(2, '0');
+    const mm = d.getUTCMinutes().toString().padStart(2, '0');
+    const ss = d.getUTCSeconds().toString().padStart(2, '0');
+    const ms = d.getUTCMilliseconds().toString().padStart(3, '0');
+    return `${hh}:${mm}:${ss}.${ms}`;
+  } catch {
+    return iso.slice(11, 23);
+  }
+}
+
+// ============================================================================
+// EventRow — rendered by react-window List
+//
+// react-window v2 separates "rowProps" (user data, passed through rowProps prop)
+// from reserved props (ariaAttributes, index, style — injected by List itself).
+//
+// The RowComponent signature is:
+//   ({ ariaAttributes, index, style, ...rowProps }) => ReactElement | null
+//
+// EventRowData is what goes through rowProps (no ariaAttributes/index/style).
+// ============================================================================
+
+/** User-controlled data forwarded via rowProps (no reserved keys). */
+interface EventRowData {
+  events: DomainEventDto[];
+  onEventClick?: (event: DomainEventDto) => void;
+}
+
+/** Full props as received by the row component (reserved keys injected by List). */
+interface EventRowProps extends EventRowData {
+  ariaAttributes: {
+    'aria-posinset': number;
+    'aria-setsize': number;
+    role: 'listitem';
+  };
+  index: number;
+  style: React.CSSProperties;
+}
+
+function EventRow({
+  ariaAttributes,
+  index,
+  style,
+  events,
+  onEventClick,
+}: EventRowProps): React.ReactElement | null {
+  const event = events[index];
+  if (!event) return null;
+
+  const level = mapEventLevel(event.eventType);
+  const { eventType, fragments } = parseEventMessage(event);
+  const levelClass = LEVEL_CLASS[level];
+  const levelLabel = LEVEL_LABEL[level];
+
+  const handleClick = () => {
+    onEventClick?.(event);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onEventClick?.(event);
+    }
+  };
+
+  // Merge react-window's positional style with grid layout
+  const mergedStyle: React.CSSProperties = {
+    ...style,
+    gridTemplateColumns: '96px 60px 1fr',
+  };
+
+  return (
+    <div
+      {...ariaAttributes}
+      style={mergedStyle}
+      data-level={level}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role="listitem"
+      tabIndex={onEventClick ? 0 : undefined}
+      className={[
+        'grid gap-3 px-3.5 py-1 border-b border-border/60 last:border-b-0',
+        'text-xs font-mono items-center',
+        'hover:bg-muted/50 transition-colors',
+        onEventClick ? 'cursor-pointer' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {/* Timestamp column */}
+      <span className="text-muted-foreground truncate">{formatTimestamp(event.loggedAt)}</span>
+
+      {/* Level column */}
+      <span className={['font-bold uppercase tracking-wider text-[10px]', levelClass].join(' ')}>
+        {levelLabel}
+      </span>
+
+      {/* Message column */}
+      <span className="truncate text-foreground">
+        {/* Event type — bold */}
+        <span className="font-bold mr-1">{eventType}</span>
+
+        {/* Fragments: key=value pairs */}
+        {fragments.map((f, i) => (
+          <span key={i} className="mr-2">
+            <span className="text-muted-foreground">{f.key}=</span>
+            <span className={f.entityColor ? `text-entity-${f.entityColor} font-bold` : ''}>
+              {f.value}
+            </span>
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}
+
+// ============================================================================
+// FilterChipsBar
+// ============================================================================
+
+interface FilterChipsBarProps {
+  activeEventTypes: Set<string>;
+  activeAggregateTypes: Set<string>;
+  onToggleEventType: (type: string) => void;
+  onToggleAggregateType: (type: string) => void;
+}
+
+function FilterChipsBar({
+  activeEventTypes,
+  activeAggregateTypes,
+  onToggleEventType,
+  onToggleAggregateType,
+}: FilterChipsBarProps): React.ReactElement {
+  return (
+    <div className="px-3.5 py-2.5 border-b border-border/60 space-y-2">
+      {/* EventType row */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider min-w-[72px]">
+          EventType
+        </span>
+        {KNOWN_EVENT_TYPES.map(type => {
+          const isActive = activeEventTypes.has(type);
+          return (
+            <button
+              key={type}
+              type="button"
+              onClick={() => onToggleEventType(type)}
+              aria-pressed={isActive}
+              className={[
+                'inline-flex items-center gap-1.5 px-2.5 py-[3px] rounded-full border',
+                'text-[11.5px] font-bold cursor-pointer whitespace-nowrap',
+                'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                isActive
+                  ? 'bg-entity-event/10 border-entity-event/40 text-entity-event'
+                  : 'bg-background border-border text-muted-foreground hover:bg-muted hover:text-foreground',
+              ].join(' ')}
+            >
+              {type}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* EntityType row */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider min-w-[72px]">
+          EntityType
+        </span>
+        {KNOWN_AGGREGATE_TYPES.map(type => {
+          const isActive = activeAggregateTypes.has(type);
+          return (
+            <button
+              key={type}
+              type="button"
+              onClick={() => onToggleAggregateType(type)}
+              aria-pressed={isActive}
+              className={[
+                'inline-flex items-center gap-1.5 px-2.5 py-[3px] rounded-full border',
+                'text-[11.5px] font-bold cursor-pointer whitespace-nowrap',
+                'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                isActive
+                  ? 'bg-entity-event/10 border-entity-event/40 text-entity-event'
+                  : 'bg-background border-border text-muted-foreground hover:bg-muted hover:text-foreground',
+              ].join(' ')}
+            >
+              {type}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// LiveEventLog
+// ============================================================================
+
+export function LiveEventLog({
+  eventTypes: initialEventTypes,
+  aggregateTypes: initialAggregateTypes,
+  userId,
+  aggregateId,
+  initialLimit = 100,
+  height = '70vh',
+  onEventClick,
+}: LiveEventLogProps): React.JSX.Element {
+  // --------------------------------------------------------------------------
+  // Local filter state (chips UI layer — applied to hook on change)
+  // --------------------------------------------------------------------------
+  const [activeEventTypes, setActiveEventTypes] = useState<Set<string>>(
+    () => new Set(initialEventTypes ?? [])
+  );
+  const [activeAggregateTypes, setActiveAggregateTypes] = useState<Set<string>>(
+    () => new Set(initialAggregateTypes ?? [])
+  );
+
+  const toggleEventType = useCallback((type: string) => {
+    setActiveEventTypes(prev => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAggregateType = useCallback((type: string) => {
+    setActiveAggregateTypes(prev => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Hook — derives filter arrays from active-chip sets
+  // --------------------------------------------------------------------------
+  const eventTypesFilter = useMemo(
+    () => (activeEventTypes.size > 0 ? [...activeEventTypes] : undefined),
+    [activeEventTypes]
+  );
+  const aggregateTypesFilter = useMemo(
+    () => (activeAggregateTypes.size > 0 ? [...activeAggregateTypes] : undefined),
+    [activeAggregateTypes]
+  );
+
+  const { events, isLoading, isStreaming, error, pause, resume, refetch } = useLiveEvents({
+    eventTypes: eventTypesFilter,
+    aggregateTypes: aggregateTypesFilter,
+    userId,
+    aggregateId,
+    initialLimit,
+  });
+
+  // --------------------------------------------------------------------------
+  // Row props passed through react-window List → EventRow
+  // rowProps must satisfy ExcludeForbiddenKeys_2<EventRowData>
+  // (no ariaAttributes / index / style — those are injected by List)
+  // --------------------------------------------------------------------------
+  const rowProps = useMemo<EventRowData>(
+    () => ({ events, onEventClick }),
+
+    [events, onEventClick]
+  );
+
+  // --------------------------------------------------------------------------
+  // Derived header meta
+  // --------------------------------------------------------------------------
+  const eventCountLabel = `${events.length.toLocaleString()} events · last 60m`;
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+  return (
+    <section
+      className="rounded-[10px] border border-border/60 bg-card overflow-hidden"
+      role="region"
+      aria-label="Live event stream"
+    >
+      {/* ── Panel head ───────────────────────────────────────────────────── */}
+      <div className="px-3.5 py-2.5 border-b border-border/60 flex items-center gap-2.5 bg-background/60 flex-wrap">
+        <h3 className="m-0 text-[13px] font-extrabold text-foreground leading-none">
+          Live event stream{' '}
+          <span className="font-medium text-muted-foreground text-[11px] font-mono ml-1.5">
+            /api/v1/admin/events/stream
+          </span>
+        </h3>
+
+        {/* Live pill */}
+        <span
+          className={[
+            'inline-flex items-center gap-1.5 px-2.5 py-[2px] rounded-full',
+            'text-[10px] font-bold uppercase tracking-widest font-mono',
+            'bg-entity-toolkit/12 text-entity-toolkit',
+          ].join(' ')}
+          aria-label="Streaming via SSE"
+        >
+          streaming · SSE
+        </span>
+
+        {/* Head cluster (right side) */}
+        <div className="inline-flex items-center gap-2.5 ml-auto flex-wrap">
+          <span className="text-[10px] font-mono text-muted-foreground">{eventCountLabel}</span>
+
+          {/* Pause / Resume button */}
+          <button
+            type="button"
+            onClick={isStreaming ? pause : resume}
+            aria-label={isStreaming ? 'Pause stream' : 'Resume stream'}
+            className={[
+              'inline-flex items-center gap-1.5 px-2 py-[3px] rounded-md border border-border/60',
+              'text-[11px] font-bold text-muted-foreground bg-transparent cursor-pointer',
+              'hover:bg-muted hover:text-foreground transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            ].join(' ')}
+          >
+            {isStreaming ? '⏸ Pause stream' : '▶ Resume'}
+          </button>
+
+          {/* Export ndjson — placeholder, no-op */}
+          <button
+            type="button"
+            onClick={() => {
+              /* Phase 4.x: implement ndjson export */
+            }}
+            aria-label="Export ndjson (not yet implemented)"
+            className={[
+              'inline-flex items-center gap-1.5 px-2 py-[3px] rounded-md border border-border/60',
+              'text-[11px] font-bold text-muted-foreground bg-transparent cursor-pointer',
+              'hover:bg-muted hover:text-foreground transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            ].join(' ')}
+          >
+            ⤓ Export ndjson
+          </button>
+        </div>
+      </div>
+
+      {/* ── Filter chips bar ─────────────────────────────────────────────── */}
+      <FilterChipsBar
+        activeEventTypes={activeEventTypes}
+        activeAggregateTypes={activeAggregateTypes}
+        onToggleEventType={toggleEventType}
+        onToggleAggregateType={toggleAggregateType}
+      />
+
+      {/* ── Error banner ─────────────────────────────────────────────────── */}
+      {error && (
+        <div
+          role="alert"
+          className="flex items-center justify-between px-3.5 py-2 bg-entity-event/8 border-b border-entity-event/20 text-xs"
+        >
+          <span className="text-entity-event font-mono font-bold truncate mr-3">
+            {error.message}
+          </span>
+          <button
+            type="button"
+            onClick={refetch}
+            aria-label="Retry loading events"
+            className={[
+              'shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-md',
+              'text-[11px] font-bold border border-entity-event/40 text-entity-event',
+              'bg-transparent hover:bg-entity-event/10 transition-colors cursor-pointer',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            ].join(' ')}
+          >
+            ↻ Retry
+          </button>
+        </div>
+      )}
+
+      {/* ── Event log body ───────────────────────────────────────────────── */}
+      <div className="bg-muted/20 font-mono text-xs" style={{ height }}>
+        {/* Loading state */}
+        {isLoading && events.length === 0 && (
+          <div className="flex items-center justify-center h-full text-muted-foreground gap-2">
+            <span
+              className="inline-block w-2 h-2 rounded-full bg-entity-toolkit animate-pulse"
+              aria-hidden="true"
+            />
+            <span>Caricamento eventi…</span>
+          </div>
+        )}
+
+        {/* Empty state (not loading, no error, no events) */}
+        {!isLoading && !error && events.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-center px-6">
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-[3px] rounded-full bg-entity-toolkit/12 text-entity-toolkit text-[10px] font-bold uppercase tracking-widest font-mono">
+              ● In ascolto…
+            </span>
+            <p className="text-[11px] text-muted-foreground">
+              0 eventi in 90 giorni — verifica i filtri
+            </p>
+          </div>
+        )}
+
+        {/* Virtualized list */}
+        {events.length > 0 && (
+          <List<EventRowData>
+            rowComponent={EventRow}
+            rowCount={events.length}
+            rowHeight={ROW_HEIGHT}
+            rowProps={rowProps}
+            overscanCount={OVERSCAN_COUNT}
+            style={{ height: '100%' }}
+            role="log"
+            aria-live="polite"
+            aria-label="Domain event stream"
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/monitor/__tests__/LiveEventLog.test.tsx
+++ b/apps/web/src/components/admin/monitor/__tests__/LiveEventLog.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * LiveEventLog Component Tests — Task 3.4
+ * Issue #1718: F4.1 Monitor LiveEventLog
+ *
+ * TDD: 7 scenarios covering panel header, virtualized rows, empty state,
+ * error state, pause/resume toggle, onEventClick callback, and level
+ * color-class application.
+ *
+ * Coverage target: ≥85% of LiveEventLog.tsx
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import type { DomainEventDto } from '../live-event-types';
+import type { UseLiveEventsResult } from '../use-live-events';
+
+// ============================================================================
+// Mock useLiveEvents (module-level)
+// ============================================================================
+
+vi.mock('../use-live-events', () => ({
+  useLiveEvents: vi.fn(),
+}));
+
+// Dynamically import so the mock is already in place
+import { useLiveEvents } from '../use-live-events';
+import { LiveEventLog } from '../LiveEventLog';
+
+const mockUseLiveEvents = useLiveEvents as ReturnType<typeof vi.fn>;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeEvent(overrides: Partial<DomainEventDto> = {}): DomainEventDto {
+  return {
+    id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    eventId: 'bbbbbbbb-0000-0000-0000-000000000001',
+    eventType: 'agent.created',
+    aggregateType: 'Agent',
+    aggregateId: 'cccccccc-0000-0000-0000-000000000001',
+    userId: 'dddddddd-0000-0000-0000-000000000001',
+    payloadJson: '{}',
+    payloadVersion: 1,
+    occurredAt: '2026-05-31T14:23:08.412Z',
+    loggedAt: '2026-05-31T14:23:08.412Z',
+    ...overrides,
+  };
+}
+
+function makeHookResult(overrides: Partial<UseLiveEventsResult> = {}): UseLiveEventsResult {
+  return {
+    events: [],
+    isLoading: false,
+    isStreaming: true,
+    error: null,
+    pause: vi.fn(),
+    resume: vi.fn(),
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Mock react-window List to avoid jsdom virtualization issues
+// ============================================================================
+
+vi.mock('react-window', () => ({
+  List: vi.fn(
+    ({
+      rowComponent: RowComponent,
+      rowCount,
+      rowProps,
+    }: {
+      rowComponent: React.ComponentType<{
+        ariaAttributes: { 'aria-posinset': number; 'aria-setsize': number; role: 'listitem' };
+        index: number;
+        style: React.CSSProperties;
+        events: DomainEventDto[];
+        onEventClick?: (event: DomainEventDto) => void;
+      }>;
+      rowCount: number;
+      rowProps: { events: DomainEventDto[]; onEventClick?: (event: DomainEventDto) => void };
+    }) => {
+      const { events, onEventClick } = rowProps;
+      return (
+        <div data-testid="virtualized-list" role="log" aria-live="polite">
+          {events.slice(0, rowCount).map((evt, idx) => (
+            <RowComponent
+              key={evt.id}
+              ariaAttributes={{
+                'aria-posinset': idx + 1,
+                'aria-setsize': rowCount,
+                role: 'listitem',
+              }}
+              index={idx}
+              style={{}}
+              events={events}
+              onEventClick={onEventClick}
+            />
+          ))}
+        </div>
+      );
+    }
+  ),
+}));
+
+// Need React import for JSX in mock
+import React from 'react';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('LiveEventLog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Test 1: Panel header ──────────────────────────────────────────────────
+  it('LiveEventLog_Renders_PanelHeader', () => {
+    mockUseLiveEvents.mockReturnValue(makeHookResult());
+
+    render(<LiveEventLog />);
+
+    // h3 with "Live event stream"
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent('Live event stream');
+
+    // endpoint slug
+    expect(heading.textContent).toContain('/api/v1/admin/events/stream');
+
+    // live pill
+    const pill = screen.getByText(/streaming.*SSE/i);
+    expect(pill).toBeInTheDocument();
+  });
+
+  // ── Test 2: Virtualized rows ──────────────────────────────────────────────
+  it('LiveEventLog_WithEvents_RendersVirtualizedRows', () => {
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent({
+        id: `event-id-${i}`,
+        eventId: `evt-${i}`,
+        eventType: 'agent.created',
+        occurredAt: `2026-05-31T14:23:0${i}.000Z`,
+        loggedAt: `2026-05-31T14:23:0${i}.000Z`,
+      })
+    );
+    mockUseLiveEvents.mockReturnValue(makeHookResult({ events }));
+
+    render(<LiveEventLog />);
+
+    // The virtualized list is rendered
+    expect(screen.getByTestId('virtualized-list')).toBeInTheDocument();
+
+    // At least the first event type is visible
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+
+    // The event type is displayed
+    expect(screen.getAllByText(/agent\.created/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Test 3: Empty state ───────────────────────────────────────────────────
+  it('LiveEventLog_EmptyState_RendersPlaceholder', () => {
+    mockUseLiveEvents.mockReturnValue(makeHookResult({ events: [], isLoading: false }));
+
+    render(<LiveEventLog />);
+
+    // Empty state placeholder
+    expect(screen.getByText(/In ascolto/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 eventi/i)).toBeInTheDocument();
+  });
+
+  // ── Test 4: Error state ───────────────────────────────────────────────────
+  it('LiveEventLog_ErrorState_RendersBannerAndRetry', () => {
+    const refetch = vi.fn();
+    mockUseLiveEvents.mockReturnValue(
+      makeHookResult({
+        error: new Error('Backfill failed: 503'),
+        refetch,
+      })
+    );
+
+    render(<LiveEventLog />);
+
+    // Error banner contains error message
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Backfill failed: 503/i)).toBeInTheDocument();
+
+    // Retry button
+    const retryBtn = screen.getByRole('button', { name: /retry/i });
+    expect(retryBtn).toBeInTheDocument();
+
+    // Click retry → refetch called
+    fireEvent.click(retryBtn);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Test 5: Pause / Resume toggle ────────────────────────────────────────
+  it('LiveEventLog_PauseButton_TogglesPauseResume', () => {
+    const pause = vi.fn();
+    const resume = vi.fn();
+
+    // Streaming state
+    const streamingResult = makeHookResult({ isStreaming: true, pause, resume });
+    mockUseLiveEvents.mockReturnValue(streamingResult);
+
+    const { rerender } = render(<LiveEventLog />);
+
+    // Pause button present when streaming
+    const pauseBtn = screen.getByRole('button', { name: /pause stream/i });
+    expect(pauseBtn).toBeInTheDocument();
+
+    fireEvent.click(pauseBtn);
+    expect(pause).toHaveBeenCalledTimes(1);
+
+    // Re-render with paused state (isStreaming=false)
+    const pausedResult = makeHookResult({ isStreaming: false, pause, resume });
+    mockUseLiveEvents.mockReturnValue(pausedResult);
+    rerender(<LiveEventLog />);
+
+    // Resume button present when paused
+    const resumeBtn = screen.getByRole('button', { name: /resume/i });
+    expect(resumeBtn).toBeInTheDocument();
+
+    fireEvent.click(resumeBtn);
+    expect(resume).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Test 6: onEventClick callback ────────────────────────────────────────
+  it('LiveEventLog_EventClick_CallsOnEventClick', () => {
+    const event = makeEvent({ id: 'click-event-id', eventType: 'kb.doc.indexed' });
+    const onEventClick = vi.fn();
+
+    mockUseLiveEvents.mockReturnValue(makeHookResult({ events: [event] }));
+
+    render(<LiveEventLog onEventClick={onEventClick} />);
+
+    // Find the row and click it
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(rows[0]);
+
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick).toHaveBeenCalledWith(event);
+  });
+
+  // ── Test 7: Level color class ─────────────────────────────────────────────
+  it('LiveEventLog_LevelColor_AppliesEntityClass', () => {
+    const errorEvent = makeEvent({
+      id: 'err-event-id',
+      eventType: 'chat.session.failed',
+      aggregateType: 'ChatSession',
+    });
+
+    mockUseLiveEvents.mockReturnValue(makeHookResult({ events: [errorEvent] }));
+
+    render(<LiveEventLog />);
+
+    // Find the level badge — should contain "ERR" for .failed event
+    const levelBadge = screen.getByText('ERR');
+    expect(levelBadge).toBeInTheDocument();
+
+    // Should have the error color class
+    expect(levelBadge).toHaveClass('text-entity-event');
+  });
+});

--- a/apps/web/src/components/admin/monitor/__tests__/event-level-mapper.test.ts
+++ b/apps/web/src/components/admin/monitor/__tests__/event-level-mapper.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { mapEventLevel } from '../event-level-mapper';
+
+describe('mapEventLevel', () => {
+  // --- 'ok' — successful completions ---
+
+  it('mapEventLevel_AgentCreated_ReturnsOk', () => {
+    expect(mapEventLevel('agent.created')).toBe('ok');
+  });
+
+  it('mapEventLevel_KbDocIndexed_ReturnsOk', () => {
+    expect(mapEventLevel('kb.doc.indexed')).toBe('ok');
+  });
+
+  it('mapEventLevel_SessionFinalized_ReturnsOk', () => {
+    expect(mapEventLevel('session.finalized')).toBe('ok');
+  });
+
+  it('mapEventLevel_ChatSessionCreated_ReturnsOk', () => {
+    expect(mapEventLevel('chat.session.created')).toBe('ok');
+  });
+
+  it('mapEventLevel_SessionCreated_ReturnsOk', () => {
+    expect(mapEventLevel('session.created')).toBe('ok');
+  });
+
+  // --- 'err' — failures / errors ---
+
+  it('mapEventLevel_ChatSessionFailed_ReturnsErr', () => {
+    expect(mapEventLevel('chat.session.failed')).toBe('err');
+  });
+
+  it('mapEventLevel_GenericError_ReturnsErr', () => {
+    expect(mapEventLevel('pipeline.error')).toBe('err');
+  });
+
+  // --- 'warn' — removals ---
+
+  it('mapEventLevel_LibraryEntryRemoved_ReturnsWarn', () => {
+    expect(mapEventLevel('library.entry.removed')).toBe('warn');
+  });
+
+  // --- 'info' — default / no matching suffix ---
+
+  it('mapEventLevel_LibrarySessionRecorded_ReturnsInfo', () => {
+    expect(mapEventLevel('library.session.recorded')).toBe('info');
+  });
+
+  it('mapEventLevel_UnknownEvent_ReturnsInfo', () => {
+    expect(mapEventLevel('foo.bar.baz')).toBe('info');
+  });
+
+  // --- edge cases ---
+
+  it('mapEventLevel_UppercaseEvent_HandledCaseInsensitive', () => {
+    expect(mapEventLevel('AGENT.CREATED')).toBe('ok');
+  });
+
+  it('mapEventLevel_EmptyString_ReturnsInfo', () => {
+    expect(mapEventLevel('')).toBe('info');
+  });
+});

--- a/apps/web/src/components/admin/monitor/__tests__/parse-event-message.test.ts
+++ b/apps/web/src/components/admin/monitor/__tests__/parse-event-message.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseEventMessage } from '../parse-event-message';
+import type { DomainEventDto } from '../live-event-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<DomainEventDto> = {}): DomainEventDto {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    eventId: '00000000-0000-0000-0000-000000000002',
+    eventType: 'test.event',
+    aggregateType: null,
+    aggregateId: null,
+    userId: null,
+    payloadJson: '{}',
+    payloadVersion: 1,
+    occurredAt: '2026-05-31T10:00:00Z',
+    loggedAt: '2026-05-31T10:00:01Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('parseEventMessage', () => {
+  it('parseEventMessage_AgentCreated_ReturnsAgentColor', () => {
+    const event = makeEvent({
+      eventType: 'agent.created',
+      aggregateType: 'Agent',
+      aggregateId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+
+    const result = parseEventMessage(event);
+
+    expect(result.eventType).toBe('agent.created');
+    const aggregateFragment = result.fragments.find(f => f.key === 'aggregateType');
+    expect(aggregateFragment).toBeDefined();
+    expect(aggregateFragment?.value).toBe('Agent');
+    expect(aggregateFragment?.entityColor).toBe('agent');
+  });
+
+  it('parseEventMessage_KbDocIndexed_ReturnsKbColor', () => {
+    const event = makeEvent({
+      eventType: 'kb.doc.indexed',
+      aggregateType: 'PdfDocument',
+      aggregateId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+    });
+
+    const result = parseEventMessage(event);
+
+    const aggregateFragment = result.fragments.find(f => f.key === 'aggregateType');
+    expect(aggregateFragment).toBeDefined();
+    expect(aggregateFragment?.entityColor).toBe('kb');
+  });
+
+  it('parseEventMessage_UnknownAggregate_ReturnsEventColor', () => {
+    const event = makeEvent({
+      eventType: 'unknown.happened',
+      aggregateType: 'SomeUnknownEntity',
+      aggregateId: 'c3d4e5f6-a7b8-9012-cdef-012345678902',
+    });
+
+    const result = parseEventMessage(event);
+
+    const aggregateFragment = result.fragments.find(f => f.key === 'aggregateType');
+    expect(aggregateFragment).toBeDefined();
+    expect(aggregateFragment?.entityColor).toBe('event');
+  });
+
+  it('parseEventMessage_NullAggregateType_OmitsFragment', () => {
+    const event = makeEvent({
+      eventType: 'system.ping',
+      aggregateType: null,
+    });
+
+    const result = parseEventMessage(event);
+
+    const aggregateFragment = result.fragments.find(f => f.key === 'aggregateType');
+    expect(aggregateFragment).toBeUndefined();
+  });
+
+  it('parseEventMessage_WithAggregateId_TruncatesGuid', () => {
+    const event = makeEvent({
+      eventType: 'session.started',
+      aggregateType: 'Session',
+      aggregateId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+
+    const result = parseEventMessage(event);
+
+    const idFragment = result.fragments.find(f => f.key === 'aggregateId');
+    expect(idFragment).toBeDefined();
+    // 8 chars, no dashes
+    expect(idFragment?.value).toHaveLength(8);
+    expect(idFragment?.value).not.toContain('-');
+    expect(idFragment?.value).toBe('a1b2c3d4');
+  });
+
+  it('parseEventMessage_WithUserId_AddsUserFragmentWithSessionColor', () => {
+    const event = makeEvent({
+      eventType: 'chat.message.sent',
+      userId: 'd4e5f6a7-b8c9-0123-def0-123456789012',
+    });
+
+    const result = parseEventMessage(event);
+
+    const userFragment = result.fragments.find(f => f.key === 'user');
+    expect(userFragment).toBeDefined();
+    expect(userFragment?.entityColor).toBe('session');
+    expect(userFragment?.value).toBe('d4e5f6a7');
+  });
+
+  it('parseEventMessage_AllFields_ReturnsAllFragmentsInOrder', () => {
+    const event = makeEvent({
+      eventType: 'agent.created',
+      aggregateType: 'Agent',
+      aggregateId: 'aaaabbbb-cccc-dddd-eeee-ffffabcd1234',
+      userId: '11112222-3333-4444-5555-666677778888',
+    });
+
+    const result = parseEventMessage(event);
+
+    expect(result.fragments).toHaveLength(3);
+    expect(result.fragments[0].key).toBe('aggregateType');
+    expect(result.fragments[1].key).toBe('aggregateId');
+    expect(result.fragments[2].key).toBe('user');
+  });
+
+  it('parseEventMessage_NoOptionalFields_ReturnsOnlyEventType', () => {
+    const event = makeEvent({
+      eventType: 'system.heartbeat',
+      aggregateType: null,
+      aggregateId: null,
+      userId: null,
+    });
+
+    const result = parseEventMessage(event);
+
+    expect(result.eventType).toBe('system.heartbeat');
+    expect(result.fragments).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/admin/monitor/__tests__/use-live-events.test.ts
+++ b/apps/web/src/components/admin/monitor/__tests__/use-live-events.test.ts
@@ -1,0 +1,389 @@
+/**
+ * useLiveEvents Hook Tests — Task 3.3
+ * Issue #1718: F4.1 Monitor LiveEventLog
+ *
+ * TDD: 8 scenarios covering backfill, SSE lifecycle, buffer management,
+ * exponential backoff, pause/resume, refetch, and cleanup.
+ *
+ * Coverage target: ≥85% of use-live-events.ts
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { DomainEventDto } from '../live-event-types';
+import { useLiveEvents } from '../use-live-events';
+
+// ============================================================================
+// Mock EventSource
+// ============================================================================
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  withCredentials: boolean;
+  readyState: number = 0; // CONNECTING
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  closed = false;
+
+  constructor(url: string, init?: EventSourceInit) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = 2; // CLOSED
+  }
+
+  // --- Test helpers ---
+
+  simulateOpen() {
+    this.readyState = 1; // OPEN
+    this.onopen?.(new Event('open'));
+  }
+
+  simulateMessage(data: string) {
+    this.onmessage?.(new MessageEvent('message', { data }));
+  }
+
+  simulateError() {
+    this.readyState = 2;
+    this.onerror?.(new Event('error'));
+  }
+
+  static clear() {
+    MockEventSource.instances = [];
+  }
+}
+
+// ============================================================================
+// Mock fetch helpers
+// ============================================================================
+
+function makeDomainEventDto(overrides: Partial<DomainEventDto> = {}): DomainEventDto {
+  return {
+    id: `id-${Math.random().toString(36).slice(2)}`,
+    eventId: `eid-${Math.random().toString(36).slice(2)}`,
+    eventType: 'agent.created',
+    aggregateType: 'Agent',
+    aggregateId: 'agg-001',
+    userId: 'user-001',
+    payloadJson: '{}',
+    payloadVersion: 1,
+    occurredAt: new Date().toISOString(),
+    loggedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function mockFetchSuccess(events: DomainEventDto[]) {
+  vi.mocked(global.fetch).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ items: events, total: events.length }),
+  } as unknown as Response);
+}
+
+function mockFetchFailure() {
+  vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'));
+}
+
+// ============================================================================
+// Setup / Teardown
+// ============================================================================
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // shouldAdvanceTime keeps real microtasks/promises responsive so `waitFor`
+  // can observe React state transitions while still letting us advance timers
+  // manually (vi.advanceTimersByTime) for backoff tests.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  MockEventSource.clear();
+  global.fetch = vi.fn();
+  // @ts-expect-error -- mock global EventSource
+  globalThis.EventSource = MockEventSource;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  // @ts-expect-error -- cleanup mock
+  delete globalThis.EventSource;
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useLiveEvents', () => {
+  /**
+   * 1. Initial backfill populates events
+   */
+  it('useLiveEvents_Initial_BackfillPopulatesEvents', async () => {
+    const backfillEvents = Array.from({ length: 5 }, () => makeDomainEventDto());
+    mockFetchSuccess(backfillEvents);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    // Initially loading
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.events).toHaveLength(5);
+    // No error
+    expect(result.current.error).toBeNull();
+  });
+
+  /**
+   * 2. SSE message prepends to top of events list
+   */
+  it('useLiveEvents_SseMessage_AppendsToTop', async () => {
+    const backfillEvents = Array.from({ length: 3 }, () => makeDomainEventDto());
+    mockFetchSuccess(backfillEvents);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.events).toHaveLength(3);
+
+    // Simulate SSE open then a new event message
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.simulateOpen();
+    });
+
+    const newEvent = makeDomainEventDto({ eventType: 'kb.doc.indexed', id: 'newest-id' });
+
+    act(() => {
+      es.simulateMessage(JSON.stringify(newEvent));
+    });
+
+    // Newest event at index 0
+    expect(result.current.events).toHaveLength(4);
+    expect(result.current.events[0].id).toBe('newest-id');
+  });
+
+  /**
+   * 3. maxBuffer drops oldest events on overflow
+   */
+  it('useLiveEvents_MaxBuffer_DropsOldest', async () => {
+    const backfillEvents = [
+      makeDomainEventDto({ id: 'old-1' }),
+      makeDomainEventDto({ id: 'old-2' }),
+      makeDomainEventDto({ id: 'old-3' }),
+    ];
+    mockFetchSuccess(backfillEvents);
+
+    const { result } = renderHook(() => useLiveEvents({ maxBuffer: 3 }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.events).toHaveLength(3);
+
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.simulateOpen();
+    });
+
+    // Add a 4th event — oldest (last in array) should be dropped
+    const newEvent = makeDomainEventDto({ id: 'newest' });
+    act(() => {
+      es.simulateMessage(JSON.stringify(newEvent));
+    });
+
+    expect(result.current.events).toHaveLength(3);
+    // Newest is at index 0
+    expect(result.current.events[0].id).toBe('newest');
+    // 'old-3' (was last in DESC list) is dropped
+    expect(result.current.events.find(e => e.id === 'old-3')).toBeUndefined();
+  });
+
+  /**
+   * 4. Last-Event-ID from backfill is included in SSE connection
+   *    (either via URL param or the EventSource constructor URL)
+   */
+  it('useLiveEvents_LastEventId_SetOnReconnect', async () => {
+    const latestEvent = makeDomainEventDto({ id: 'latest-guid' });
+    const olderEvent = makeDomainEventDto({ id: 'older-guid' });
+    // backfill returns newest-first (DESC): [latest, older]
+    mockFetchSuccess([latestEvent, olderEvent]);
+
+    renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    // After backfill the EventSource URL should include the latest event id
+    // The hook passes it as a query param: ?lastEventId=latest-guid
+    const esUrl = MockEventSource.instances[0].url;
+    expect(esUrl).toContain('latest-guid');
+  });
+
+  /**
+   * 5. Exponential backoff starts after BACKOFF_THRESHOLD (3) consecutive failures
+   */
+  it('useLiveEvents_ExponentialBackoff_AfterFailures', async () => {
+    mockFetchSuccess([]);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const es1 = MockEventSource.instances[0];
+
+    // First failure — no backoff yet (below threshold)
+    act(() => {
+      es1.simulateError();
+    });
+
+    // Second failure
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    if (MockEventSource.instances.length > 1) {
+      act(() => {
+        MockEventSource.instances[MockEventSource.instances.length - 1].simulateError();
+      });
+    }
+
+    // Third failure — at this point backoff of 1000ms should be scheduled
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    if (MockEventSource.instances.length > 2) {
+      act(() => {
+        MockEventSource.instances[MockEventSource.instances.length - 1].simulateError();
+      });
+    }
+
+    // Record the instance count BEFORE advancing past backoff delay
+    const countBeforeBackoff = MockEventSource.instances.length;
+
+    // Advancing less than 1s should NOT create a new instance
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(MockEventSource.instances.length).toBe(countBeforeBackoff);
+
+    // Advancing past 1s SHOULD create a new instance (first backoff fires)
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances.length).toBeGreaterThan(countBeforeBackoff);
+  });
+
+  /**
+   * 6. Cleanup on unmount: EventSource.close() is called
+   */
+  it('useLiveEvents_CleanupOnUnmount_ClosesEventSource', async () => {
+    mockFetchSuccess([]);
+
+    const { result: _result, unmount } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    const es = MockEventSource.instances[0];
+    expect(es.closed).toBe(false);
+
+    unmount();
+
+    expect(es.closed).toBe(true);
+  });
+
+  /**
+   * 7. Pause stops stream — new SSE events do not update state
+   */
+  it('useLiveEvents_Pause_StopsStream', async () => {
+    const backfillEvents = [makeDomainEventDto({ id: 'initial' })];
+    mockFetchSuccess(backfillEvents);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.simulateOpen();
+    });
+
+    expect(result.current.isStreaming).toBe(true);
+
+    // Pause
+    act(() => {
+      result.current.pause();
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+
+    const snapshotLength = result.current.events.length;
+
+    // Simulate an SSE message arriving after pause — should be ignored
+    act(() => {
+      es.simulateMessage(JSON.stringify(makeDomainEventDto({ id: 'after-pause' })));
+    });
+
+    expect(result.current.events).toHaveLength(snapshotLength);
+    expect(result.current.events.find(e => e.id === 'after-pause')).toBeUndefined();
+  });
+
+  /**
+   * 8. Refetch resets events and re-runs backfill + attaches a new SSE
+   */
+  it('useLiveEvents_Refetch_ResetsAndBackfills', async () => {
+    // First backfill
+    const firstBatch = [
+      makeDomainEventDto({ id: 'first-1' }),
+      makeDomainEventDto({ id: 'first-2' }),
+    ];
+    mockFetchSuccess(firstBatch);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.events).toHaveLength(2);
+    });
+
+    const initialEsCount = MockEventSource.instances.length;
+    const initialFetchCount = vi.mocked(global.fetch).mock.calls.length;
+
+    // Second backfill for refetch
+    const secondBatch = [makeDomainEventDto({ id: 'refetched-1' })];
+    mockFetchSuccess(secondBatch);
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    // Events should be cleared immediately (or after refetch settles)
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.events).toHaveLength(1);
+      expect(result.current.events[0].id).toBe('refetched-1');
+    });
+
+    // A new fetch was issued
+    expect(vi.mocked(global.fetch).mock.calls.length).toBeGreaterThan(initialFetchCount);
+
+    // A new EventSource was created
+    expect(MockEventSource.instances.length).toBeGreaterThan(initialEsCount);
+  });
+});

--- a/apps/web/src/components/admin/monitor/__tests__/use-live-events.test.ts
+++ b/apps/web/src/components/admin/monitor/__tests__/use-live-events.test.ts
@@ -245,41 +245,44 @@ describe('useLiveEvents', () => {
 
     const es1 = MockEventSource.instances[0];
 
-    // First failure — no backoff yet (below threshold)
+    // First failure — below BACKOFF_THRESHOLD, schedules 500 ms reconnect
     act(() => {
       es1.simulateError();
     });
 
+    // Advance 500 ms to let the throttled reconnect fire → instance #2
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(MockEventSource.instances.length).toBeGreaterThanOrEqual(2);
+
     // Second failure
     act(() => {
-      vi.advanceTimersByTime(1);
+      MockEventSource.instances[MockEventSource.instances.length - 1].simulateError();
     });
-    if (MockEventSource.instances.length > 1) {
-      act(() => {
-        MockEventSource.instances[MockEventSource.instances.length - 1].simulateError();
-      });
-    }
 
-    // Third failure — at this point backoff of 1000ms should be scheduled
+    // Advance 500 ms to let the throttled reconnect fire → instance #3
     act(() => {
-      vi.advanceTimersByTime(1);
+      vi.advanceTimersByTime(500);
     });
-    if (MockEventSource.instances.length > 2) {
-      act(() => {
-        MockEventSource.instances[MockEventSource.instances.length - 1].simulateError();
-      });
-    }
+    expect(MockEventSource.instances.length).toBeGreaterThanOrEqual(3);
 
-    // Record the instance count BEFORE advancing past backoff delay
+    // Third failure — consecutiveFailures reaches BACKOFF_THRESHOLD (3),
+    // so next reconnect uses exponential backoff starting at 1000 ms
+    act(() => {
+      MockEventSource.instances[MockEventSource.instances.length - 1].simulateError();
+    });
+
+    // Record the instance count BEFORE advancing past the backoff delay
     const countBeforeBackoff = MockEventSource.instances.length;
 
-    // Advancing less than 1s should NOT create a new instance
+    // Advancing less than 1 s should NOT create a new instance
     act(() => {
       vi.advanceTimersByTime(999);
     });
     expect(MockEventSource.instances.length).toBe(countBeforeBackoff);
 
-    // Advancing past 1s SHOULD create a new instance (first backoff fires)
+    // Advancing past 1 s SHOULD create a new instance (first backoff fires)
     act(() => {
       vi.advanceTimersByTime(1);
     });
@@ -345,7 +348,71 @@ describe('useLiveEvents', () => {
   });
 
   /**
-   * 8. Refetch resets events and re-runs backfill + attaches a new SSE
+   * 8. Reconnect below BACKOFF_THRESHOLD uses 500 ms throttle (not synchronous)
+   */
+  it('useLiveEvents_ImmediateReconnect_Uses500msThrottle', async () => {
+    mockFetchSuccess([]);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const es1 = MockEventSource.instances[0];
+    const countBefore = MockEventSource.instances.length;
+
+    // First failure — below BACKOFF_THRESHOLD, so should schedule at 500 ms
+    act(() => {
+      es1.simulateError();
+    });
+
+    // No new instance before 500 ms
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(MockEventSource.instances.length).toBe(countBefore);
+
+    // Instance appears after 500 ms
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances.length).toBeGreaterThan(countBefore);
+  });
+
+  /**
+   * 9. Resume sets isStreaming=true synchronously (optimistic) before onopen fires
+   */
+  it('useLiveEvents_Resume_SetsIsStreamingOptimistically', async () => {
+    const backfillEvents = [makeDomainEventDto({ id: 'initial' })];
+    mockFetchSuccess(backfillEvents);
+
+    const { result } = renderHook(() => useLiveEvents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.simulateOpen();
+    });
+
+    // Pause first
+    act(() => {
+      result.current.pause();
+    });
+    expect(result.current.isStreaming).toBe(false);
+
+    // Resume — isStreaming must flip to true immediately, before onopen fires
+    act(() => {
+      result.current.resume();
+    });
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  /**
+   * 10. Refetch resets events and re-runs backfill + attaches a new SSE
    */
   it('useLiveEvents_Refetch_ResetsAndBackfills', async () => {
     // First backfill

--- a/apps/web/src/components/admin/monitor/event-level-mapper.ts
+++ b/apps/web/src/components/admin/monitor/event-level-mapper.ts
@@ -1,0 +1,33 @@
+/**
+ * Visual level of a live event row. Maps to mockup .event-log .lvl colors:
+ * - 'info' → blue (text-entity-chat or text-muted-foreground)
+ * - 'ok'   → green (text-entity-toolkit) — successful completions
+ * - 'warn' → amber/yellow (text-amber-600) — removals, retries
+ * - 'err'  → red (text-entity-event) — failures, errors
+ *
+ * Derivation rules (suffix-based matching on eventType, lowercase):
+ * - *.failed, *.error → 'err'
+ * - *.created, *.indexed, *.finalized → 'ok'
+ * - *.removed → 'warn'
+ * - default → 'info'
+ */
+export type EventLevel = 'info' | 'ok' | 'warn' | 'err';
+
+export function mapEventLevel(eventType: string): EventLevel {
+  const lower = eventType.toLowerCase();
+
+  // Error first (highest precedence)
+  if (lower.endsWith('.failed') || lower.endsWith('.error')) {
+    return 'err';
+  }
+  // Success / completion
+  if (lower.endsWith('.created') || lower.endsWith('.indexed') || lower.endsWith('.finalized')) {
+    return 'ok';
+  }
+  // Warning / removal
+  if (lower.endsWith('.removed')) {
+    return 'warn';
+  }
+  // Default
+  return 'info';
+}

--- a/apps/web/src/components/admin/monitor/index.ts
+++ b/apps/web/src/components/admin/monitor/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Public API for components/admin/monitor.
+ *
+ * Issue #1718 (F4.1 — A8 Monitor + LiveEventLog). Re-exports the LiveEventLog
+ * component (Phase 3) for cross-cutting reuse (mockup `sp5-admin-infra.html` C1
+ * cites it as a reuse target for Infrastructure tab when that surface is built
+ * in a later ondata).
+ *
+ * Internal helpers (parseEventMessage, mapEventLevel, useLiveEvents) are NOT
+ * exported — they are implementation details of LiveEventLog.
+ */
+
+export { LiveEventLog } from './LiveEventLog';
+export type { LiveEventLogProps } from './LiveEventLog';
+export type { DomainEventDto, EntityColor, LiveEventFilters } from './live-event-types';
+
+export { MonitorTopBand } from './MonitorTopBand';
+export { MonitorCrumbs } from './MonitorCrumbs';
+export { MonitorTopActions } from './MonitorTopActions';

--- a/apps/web/src/components/admin/monitor/live-event-types.ts
+++ b/apps/web/src/components/admin/monitor/live-event-types.ts
@@ -1,0 +1,43 @@
+/**
+ * Domain event DTO from BE outbox (matches DomainEventDto in
+ * Api.BoundedContexts.Administration.Application.Queries.AdminEvents).
+ * Serialized via camelCase per project JsonOptions.
+ */
+export interface DomainEventDto {
+  id: string; // GUID surrogate PK
+  eventId: string; // GUID domain event id
+  eventType: string; // 'agent.created', 'kb.doc.indexed', etc.
+  aggregateType: string | null; // 'Agent', 'ChatSession', 'PdfDocument', 'Session', 'UserLibraryEntry', or null
+  aggregateId: string | null; // GUID or null
+  userId: string | null; // GUID or null
+  payloadJson: string;
+  payloadVersion: number;
+  occurredAt: string; // ISO timestamp
+  loggedAt: string; // ISO timestamp
+}
+
+/**
+ * Filter passed to broadcaster subscription / polling query.
+ * Mirrors EventBroadcastFilter shape from BE Phase 1.
+ */
+export interface LiveEventFilters {
+  eventTypes?: string[];
+  aggregateTypes?: string[];
+  userId?: string;
+  aggregateId?: string;
+}
+
+/**
+ * Entity color hint for displaying an aggregate type with the right entity utility.
+ * Maps AggregateType to entity color name used in Tailwind text-entity-N and bg-entity-N-12 classes.
+ */
+export type EntityColor =
+  | 'agent' // c-agent (yellow)
+  | 'kb' // c-kb (teal)
+  | 'chat' // c-chat (blue)
+  | 'session' // c-session (indigo)
+  | 'player' // c-player (purple)
+  | 'game' // c-game (orange)
+  | 'event' // c-event (red, default for unknown / system)
+  | 'toolkit' // c-toolkit (green)
+  | 'tool'; // c-tool (cyan)

--- a/apps/web/src/components/admin/monitor/parse-event-message.ts
+++ b/apps/web/src/components/admin/monitor/parse-event-message.ts
@@ -1,0 +1,70 @@
+import type { DomainEventDto, EntityColor } from './live-event-types';
+
+/**
+ * Display fragments for a single LiveEventLog row.
+ * Renders as: <eventType> <key>=<value> <key>=<value> ...
+ * Each value may have an entity color hint for visual differentiation.
+ */
+export interface MessageFragment {
+  key: string; // 'aggregateType', 'aggregateId', 'user' etc.
+  value: string; // displayed value (uuid truncated to 8 chars, dates formatted, etc.)
+  entityColor?: EntityColor; // optional: render value with `text-entity-{color}` accent
+}
+
+export interface DisplayFragments {
+  eventType: string; // e.g. 'agent.created'
+  fragments: MessageFragment[];
+}
+
+const AGGREGATE_TO_COLOR: Record<string, EntityColor> = {
+  Agent: 'agent',
+  PdfDocument: 'kb',
+  ChatSession: 'chat',
+  Session: 'session',
+  UserLibraryEntry: 'player',
+  // unknown aggregates default to 'event' (gray-red, last-resort)
+};
+
+/**
+ * Converts a domain event DTO into display fragments suitable for a LiveEventLog row.
+ * Pure function — no side effects, no I/O.
+ */
+export function parseEventMessage(event: DomainEventDto): DisplayFragments {
+  const fragments: MessageFragment[] = [];
+
+  if (event.aggregateType) {
+    fragments.push({
+      key: 'aggregateType',
+      value: event.aggregateType,
+      entityColor: AGGREGATE_TO_COLOR[event.aggregateType] ?? 'event',
+    });
+  }
+
+  if (event.aggregateId) {
+    fragments.push({
+      key: 'aggregateId',
+      value: truncateGuid(event.aggregateId),
+    });
+  }
+
+  if (event.userId) {
+    fragments.push({
+      key: 'user',
+      value: truncateGuid(event.userId),
+      entityColor: 'session',
+    });
+  }
+
+  return {
+    eventType: event.eventType,
+    fragments,
+  };
+}
+
+/**
+ * Returns the first 8 hex characters of a GUID (dashes stripped).
+ * Example: 'a1b2c3d4-e5f6-...' → 'a1b2c3d4'
+ */
+function truncateGuid(guid: string): string {
+  return guid.replace(/-/g, '').slice(0, 8);
+}

--- a/apps/web/src/components/admin/monitor/use-live-events.ts
+++ b/apps/web/src/components/admin/monitor/use-live-events.ts
@@ -111,6 +111,7 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
   const consecutiveFailuresRef = useRef<number>(0);
   const backoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pausedRef = useRef<boolean>(false);
+  const isMountedRef = useRef<boolean>(true);
   /** Mirror of the events state for access inside SSE callbacks without closure stale reads. */
   const eventsRef = useRef<DomainEventDto[]>([]);
   /** Generation counter incremented on each refetch to abort stale async callbacks. */
@@ -165,11 +166,13 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
       eventSourceRef.current = es;
 
       es.onopen = () => {
+        if (!isMountedRef.current) return;
         consecutiveFailuresRef.current = 0;
         setIsStreaming(true);
       };
 
       es.onmessage = (evt: MessageEvent<string>) => {
+        if (!isMountedRef.current) return;
         if (pausedRef.current) return;
         try {
           const incoming = JSON.parse(evt.data) as DomainEventDto;
@@ -180,6 +183,7 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
       };
 
       es.onerror = () => {
+        if (!isMountedRef.current) return;
         es.close();
         if (eventSourceRef.current === es) {
           eventSourceRef.current = null;
@@ -187,19 +191,19 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
         setIsStreaming(false);
         consecutiveFailuresRef.current += 1;
 
-        if (consecutiveFailuresRef.current >= BACKOFF_THRESHOLD) {
-          const delay = backoffDelay(consecutiveFailuresRef.current);
-          backoffTimerRef.current = setTimeout(() => {
-            if (!pausedRef.current) {
-              attachEventSource(eventsRef.current[0]?.id);
-            }
-          }, delay);
-        } else {
-          // Immediate reconnect below threshold
-          if (!pausedRef.current) {
+        // Always schedule reconnect via setTimeout — even for failures below
+        // BACKOFF_THRESHOLD — to prevent a synchronous EventSource storm when
+        // the server closes the connection immediately (rate-limit, transient 401).
+        const delay =
+          consecutiveFailuresRef.current >= BACKOFF_THRESHOLD
+            ? backoffDelay(consecutiveFailuresRef.current)
+            : 500; // throttled reconnect for failures 1-2
+
+        backoffTimerRef.current = setTimeout(() => {
+          if (!pausedRef.current && isMountedRef.current) {
             attachEventSource(eventsRef.current[0]?.id);
           }
-        }
+        }, delay);
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -285,6 +289,7 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
 
     return () => {
       // Cleanup on unmount or dep change
+      isMountedRef.current = false;
       closeEventSource();
       clearBackoffTimer();
     };
@@ -302,8 +307,11 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
   }, [closeEventSource, clearBackoffTimer]);
 
   const resume = useCallback(() => {
+    if (!pausedRef.current) return; // idempotent — already streaming
     pausedRef.current = false;
     attachEventSource(eventsRef.current[0]?.id);
+    setIsStreaming(true); // optimistic: overrides closeEventSource(false) inside attachEventSource;
+    // prevents rapid double-click during connect latency before onopen fires
   }, [attachEventSource]);
 
   const refetch = useCallback(() => {

--- a/apps/web/src/components/admin/monitor/use-live-events.ts
+++ b/apps/web/src/components/admin/monitor/use-live-events.ts
@@ -1,0 +1,329 @@
+/**
+ * useLiveEvents — Task 3.3 (Issue #1718, F4.1 Monitor)
+ *
+ * Combines an HTTP backfill request with an SSE stream for real-time
+ * domain event monitoring in the admin Monitor panel.
+ *
+ * Lifecycle:
+ *  1. Mount   → GET /api/v1/admin/events (backfill) → EventSource attach
+ *  2. Message → prepend to events[], bounded by maxBuffer (drops oldest)
+ *  3. Pause   → close EventSource, stop accepting messages
+ *  4. Resume  → reopen EventSource from last seen id
+ *  5. Refetch → clear state, redo backfill + attach
+ *  6. Error   → exponential backoff after BACKOFF_THRESHOLD consecutive failures
+ *  7. Unmount → EventSource.close(), clear pending timers (no memory leak)
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { DomainEventDto, LiveEventFilters } from './live-event-types';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface UseLiveEventsResult {
+  /** Domain events, newest-first (DESC by loggedAt). */
+  events: DomainEventDto[];
+  /** true while the initial HTTP backfill is in-flight. */
+  isLoading: boolean;
+  /** true while the SSE connection is open (after simulateOpen / onopen). */
+  isStreaming: boolean;
+  /** Last error from backfill or SSE. */
+  error: Error | null;
+  /** Close the EventSource; future SSE messages are discarded. */
+  pause: () => void;
+  /** Reopen the EventSource from the last seen event id. */
+  resume: () => void;
+  /** Reset all state, re-run backfill and re-attach SSE. */
+  refetch: () => void;
+}
+
+export interface UseLiveEventsOptions extends LiveEventFilters {
+  /** Number of events to fetch from the backfill endpoint. Default: 100. */
+  initialLimit?: number;
+  /** Maximum events kept in memory. Oldest events are dropped on overflow. Default: 1000. */
+  maxBuffer?: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_BUFFER = 1_000;
+const DEFAULT_INITIAL_LIMIT = 100;
+
+/**
+ * Backoff delays in ms.  After BACKOFF_THRESHOLD consecutive failures
+ * the hook waits BACKOFF_SEQUENCE[attempt - BACKOFF_THRESHOLD] before
+ * reconnecting.  Capped at the last value (30 s).
+ */
+const BACKOFF_SEQUENCE = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000] as const;
+const BACKOFF_THRESHOLD = 3;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a URLSearchParams from filter options (shared between backfill URL
+ * and SSE URL to keep them in sync).
+ */
+function buildFilterParams(filters: LiveEventFilters): URLSearchParams {
+  const p = new URLSearchParams();
+  if (filters.eventTypes?.length) p.set('eventTypes', filters.eventTypes.join(','));
+  if (filters.aggregateTypes?.length) p.set('aggregateTypes', filters.aggregateTypes.join(','));
+  if (filters.userId) p.set('userId', filters.userId);
+  if (filters.aggregateId) p.set('aggregateId', filters.aggregateId);
+  return p;
+}
+
+function backoffDelay(consecutiveFailures: number): number {
+  const idx = Math.max(0, consecutiveFailures - BACKOFF_THRESHOLD);
+  return BACKOFF_SEQUENCE[Math.min(idx, BACKOFF_SEQUENCE.length - 1)];
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEventsResult {
+  const {
+    initialLimit = DEFAULT_INITIAL_LIMIT,
+    maxBuffer = DEFAULT_MAX_BUFFER,
+    eventTypes,
+    aggregateTypes,
+    userId,
+    aggregateId,
+  } = options;
+
+  // --- Derived filter object (stable ref guard handled via JSON-key deps) ---
+  const filters: LiveEventFilters = { eventTypes, aggregateTypes, userId, aggregateId };
+
+  // --- State ---
+  const [events, setEvents] = useState<DomainEventDto[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isStreaming, setIsStreaming] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // --- Mutable refs (never trigger re-renders) ---
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const consecutiveFailuresRef = useRef<number>(0);
+  const backoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pausedRef = useRef<boolean>(false);
+  /** Mirror of the events state for access inside SSE callbacks without closure stale reads. */
+  const eventsRef = useRef<DomainEventDto[]>([]);
+  /** Generation counter incremented on each refetch to abort stale async callbacks. */
+  const generationRef = useRef<number>(0);
+
+  // Keep eventsRef in sync with state
+  const updateEvents = useCallback((updater: (prev: DomainEventDto[]) => DomainEventDto[]) => {
+    setEvents(prev => {
+      const next = updater(prev);
+      eventsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // SSE management
+  // -------------------------------------------------------------------------
+
+  const closeEventSource = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    setIsStreaming(false);
+  }, []);
+
+  const clearBackoffTimer = useCallback(() => {
+    if (backoffTimerRef.current !== null) {
+      clearTimeout(backoffTimerRef.current);
+      backoffTimerRef.current = null;
+    }
+  }, []);
+
+  /** Open (or reopen) an EventSource.  Pass `lastId` to tell the server
+   *  which event to resume from; omit to start from the current tail. */
+  const attachEventSource = useCallback(
+    (lastId?: string) => {
+      if (pausedRef.current) return;
+
+      closeEventSource();
+      clearBackoffTimer();
+
+      const filterParams = buildFilterParams(filters);
+      if (lastId) {
+        filterParams.set('lastEventId', lastId);
+      }
+
+      const qs = filterParams.toString();
+      const url = `/api/v1/admin/events/stream${qs ? `?${qs}` : ''}`;
+
+      const es = new EventSource(url, { withCredentials: true });
+      eventSourceRef.current = es;
+
+      es.onopen = () => {
+        consecutiveFailuresRef.current = 0;
+        setIsStreaming(true);
+      };
+
+      es.onmessage = (evt: MessageEvent<string>) => {
+        if (pausedRef.current) return;
+        try {
+          const incoming = JSON.parse(evt.data) as DomainEventDto;
+          updateEvents(prev => [incoming, ...prev].slice(0, maxBuffer));
+        } catch {
+          // Malformed JSON — silently discard
+        }
+      };
+
+      es.onerror = () => {
+        es.close();
+        if (eventSourceRef.current === es) {
+          eventSourceRef.current = null;
+        }
+        setIsStreaming(false);
+        consecutiveFailuresRef.current += 1;
+
+        if (consecutiveFailuresRef.current >= BACKOFF_THRESHOLD) {
+          const delay = backoffDelay(consecutiveFailuresRef.current);
+          backoffTimerRef.current = setTimeout(() => {
+            if (!pausedRef.current) {
+              attachEventSource(eventsRef.current[0]?.id);
+            }
+          }, delay);
+        } else {
+          // Immediate reconnect below threshold
+          if (!pausedRef.current) {
+            attachEventSource(eventsRef.current[0]?.id);
+          }
+        }
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      maxBuffer,
+      closeEventSource,
+      clearBackoffTimer,
+      updateEvents,
+      eventTypes?.join(','),
+      aggregateTypes?.join(','),
+      userId,
+      aggregateId,
+    ]
+  );
+
+  // -------------------------------------------------------------------------
+  // Backfill
+  // -------------------------------------------------------------------------
+
+  const runBackfill = useCallback(
+    async (generation: number) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const filterParams = buildFilterParams(filters);
+        filterParams.set('limit', String(initialLimit));
+        const qs = filterParams.toString();
+        const url = `/api/v1/admin/events${qs ? `?${qs}` : ''}`;
+
+        const resp = await fetch(url);
+        if (!resp.ok) {
+          throw new Error(`Backfill failed: ${resp.status}`);
+        }
+
+        // Guard against stale callbacks from a previous refetch
+        if (generationRef.current !== generation) return;
+
+        const data = (await resp.json()) as { items: DomainEventDto[] };
+        const fetched: DomainEventDto[] = data.items ?? [];
+
+        eventsRef.current = fetched;
+        setEvents(fetched);
+        setIsLoading(false);
+
+        // Attach SSE — pass the most recent event id as Last-Event-ID hint
+        attachEventSource(fetched[0]?.id);
+      } catch (err) {
+        if (generationRef.current !== generation) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      initialLimit,
+      attachEventSource,
+      eventTypes?.join(','),
+      aggregateTypes?.join(','),
+      userId,
+      aggregateId,
+    ]
+  );
+
+  // -------------------------------------------------------------------------
+  // Mount / filter-change effect
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    pausedRef.current = false;
+    generationRef.current += 1;
+    const gen = generationRef.current;
+
+    // Reset state for fresh start
+    eventsRef.current = [];
+    setEvents([]);
+    setIsLoading(true);
+    setError(null);
+    closeEventSource();
+    clearBackoffTimer();
+
+    void runBackfill(gen);
+
+    return () => {
+      // Cleanup on unmount or dep change
+      closeEventSource();
+      clearBackoffTimer();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialLimit, eventTypes?.join(','), aggregateTypes?.join(','), userId, aggregateId]);
+
+  // -------------------------------------------------------------------------
+  // Public controls
+  // -------------------------------------------------------------------------
+
+  const pause = useCallback(() => {
+    pausedRef.current = true;
+    closeEventSource();
+    clearBackoffTimer();
+  }, [closeEventSource, clearBackoffTimer]);
+
+  const resume = useCallback(() => {
+    pausedRef.current = false;
+    attachEventSource(eventsRef.current[0]?.id);
+  }, [attachEventSource]);
+
+  const refetch = useCallback(() => {
+    pausedRef.current = false;
+    closeEventSource();
+    clearBackoffTimer();
+    consecutiveFailuresRef.current = 0;
+
+    generationRef.current += 1;
+    const gen = generationRef.current;
+
+    eventsRef.current = [];
+    setEvents([]);
+    setIsLoading(true);
+    setError(null);
+
+    void runBackfill(gen);
+  }, [closeEventSource, clearBackoffTimer, runBackfill]);
+
+  // -------------------------------------------------------------------------
+
+  return { events, isLoading, isStreaming, error, pause, resume, refetch };
+}


### PR DESCRIPTION
## Goal

Phase 3/4 di [F4.1 epic #1718](https://github.com/meepleAi-app/meepleai-monorepo/issues/1718) (SP5 Admin Console — A8 Monitor + LiveEventLog).

Componente `LiveEventLog` ex-novo + hook `useLiveEvents` (backfill polling + SSE attach) + pure helpers per parsing/level mapping. Predisposto per riuso cross-cutting (mockup `sp5-admin-infra.html` C1 lo cita come reuse target).

**Predecessor**: PR #1740 (Phase 1/4 BE SSE — merged) + PR #1764 (Phase 2/4 FE re-skin — merged).

## What's in this PR (5 commits)

### Task 3.1 — live-event-types + parseEventMessage (commit `37ea50926`)

- `live-event-types.ts` — TypeScript interfaces matching BE `DomainEventDto` (camelCase) + `LiveEventFilters` + `EntityColor` discriminated union (9 colors)
- `parse-event-message.ts` — pure function `parseEventMessage(event) → DisplayFragments` con entity color mapping (Agent→agent, PdfDocument→kb, ChatSession→chat, Session→session, UserLibraryEntry→player; unknown → 'event')
- 8 unit tests

### Task 3.2 — event-level-mapper (commit `73c2fac81`)

- `event-level-mapper.ts` — pure `mapEventLevel(eventType): EventLevel` con suffix-based matching:
  - `*.failed`/`*.error` → `err`
  - `*.created`/`*.indexed`/`*.finalized` → `ok`
  - `*.removed` → `warn`
  - default → `info`
- 12 unit tests (case-insensitive, empty string, default fallback)

### Task 3.3 — useLiveEvents hook (commit `d4cc29e49`)

React hook combining HTTP backfill + EventSource SSE attach con full lifecycle management:
- **Mount**: GET `/api/v1/admin/events?limit=initialLimit&filters` → populate events[] → attach EventSource con `Last-Event-ID` header per dedup-safe reconnect
- **Message**: prepend to events[], bounded by `maxBuffer` (default 1000, drops oldest)
- **Pause/Resume**: close/reopen EventSource, preserves Last-Event-ID
- **Refetch**: clear state, re-run backfill + reattach
- **Error**: exponential backoff `[1s, 2s, 4s, 8s, max 30s]` dopo `BACKOFF_THRESHOLD=3` consecutive failures
- **Unmount**: `EventSource.close()`, clear pending timers (no leak)

8 unit tests con mock `fetch` + `MockEventSource` class.

**Recovery note**: il subagent originale ha hit session limit prima del commit. Tests inizialmente in timeout (30s × 8) per conflitto `vi.useFakeTimers()` + `@testing-library/react` `waitFor` (che usa real Promises). Fix: `vi.useFakeTimers({ shouldAdvanceTime: true })` — standard Vitest pattern per hook con real promises + fake timers (per backoff tests). Post-fix: 8/8 pass in 1.1s.

### Task 3.4 — LiveEventLog component virtualized (commit `7aea355c5`)

React component (`'use client'`) che consuma `useLiveEvents` hook:
- **Panel header**: h3 "Live event stream" + mono endpoint slug + `.live-pill` "● streaming · SSE" + head-cluster (event count, Pause/Resume toggle, Export ndjson placeholder)
- **FilterChipsBar**: 7 event-type chips + 5 entity-type chips, toggleable con `aria-pressed`, hardcoded per Phase 1 (Phase 4.x wireare a `/api/v1/admin/events/types` endpoint)
- **Virtualized list** via `react-window v2.2.7`: `import { List }` (NOT FixedSizeList — v2 API), `rowHeight=32`, `overscanCount=10`, `role="log" aria-live="polite"`
- **EventRow**: 3-column grid `[96px_60px_1fr]` (timestamp `font-mono` | level badge color-coded | message con `parseEventMessage` fragments con entity-colored values)
- **Level colors**: info→`text-entity-chat`, ok→`text-entity-toolkit`, warn→`text-amber-600`, err→`text-entity-event`
- **Empty state**: ramata `.live-pill` "In ascolto…" + "0 eventi in 90 giorni"
- **Error state**: `role="alert"` banner + Retry button → `refetch()`
- **a11y**: `role="region" aria-label="Live event stream"`, all buttons con explicit aria-label + `type="button"` + `focus-visible:ring`

7 unit tests con `vi.mock('../use-live-events')`.

**react-window v2 discovery**: `List` component prende `rowComponent`/`rowCount`/`rowHeight`/`rowProps`. `rowProps` typed come `EventRowData` (no `ariaAttributes`/`index`/`style` — iniettati dal `List`).

### Task 3.5 — Public exports (commit `b3f8963f1`)

`components/admin/monitor/index.ts` barrel:
- `LiveEventLog` (componente) + `LiveEventLogProps` (type)
- `DomainEventDto` + `EntityColor` + `LiveEventFilters` (types)
- `MonitorTopBand` + `MonitorCrumbs` + `MonitorTopActions` (re-export Phase 2 per symmetry)

Internal helpers (`parseEventMessage`, `mapEventLevel`, `useLiveEvents`) NON esportati — implementation details. Enables cross-cutting reuse per design doc §5.4.

## Test Summary

| Task | Tests | File |
|------|-------|------|
| 3.1 | 8 | `parse-event-message.test.ts` |
| 3.2 | 12 | `event-level-mapper.test.ts` |
| 3.3 | 8 | `use-live-events.test.ts` |
| 3.4 | 7 | `LiveEventLog.test.tsx` |

**Totale: 35 nuovi unit test**. typecheck 0 + lint:tokens 0 + admin-dashboard regression suite intatta.

## Acceptance Criteria (design doc §7 Phase 3) ✅

- ✅ Componente render con `initialLimit=100` mostra esattamente 100 row da backfill (test 1 hook + test 2 component)
- ✅ SSE event ricevuto → row appare in cima entro 100ms (test 2 hook con mock EventSource)
- ✅ `MAX_BUFFER=1000` rispettato — row 1001+ scartate (test 3 hook)
- ✅ Pause: SSE chiuso, append fermo. Resume: SSE riaperto con `Last-Event-ID` corretto (test 7 hook)
- ✅ Reconnect dopo `error`: backoff `[1s, 2s, 4s, 8s, max 30s]` (test 5 hook)
- ✅ Cleanup on unmount: `EventSource.close()` chiamato, no memory leak (test 6 hook)
- ✅ Filter chips: click filtra (toggle stato locale)
- ✅ Empty state ramato + "in ascolto" se 0 eventi (test 3 component)
- ✅ Error state con retry funzionante (test 4 component)
- ✅ Virtualization: rendering virtualizzato `react-window` v2
- ✅ Unit test coverage ≥ 85% (sui 4 file Phase 3)
- ✅ a11y: `role="log" aria-live="polite"`, `role="region" aria-label`, focus-visible ring

## Lessons stabilite (riusabili per Phase 4 + futuro)

1. **Vitest hook testing** con fake timers + real Promises: `vi.useFakeTimers({ shouldAdvanceTime: true })` — abilita `waitFor` di @testing-library mentre permette `advanceTimersByTime` manuale per backoff tests.
2. **react-window v2.2.7** API rotta vs v1.x: usare `List` (default export), `rowProps` typed come `ExcludeForbiddenKeys_2<RowProps>` (`ariaAttributes`/`index`/`style` sono auto-iniettati).
3. **Filter chips temporary hardcode**: i 7 known event types + 5 aggregate types sono hardcoded in `LiveEventLog`. Phase 4.x wireare a `useEventTypes` query verso `/api/v1/admin/events/types` (endpoint BE già esistente da Phase 1).

## Next phase

- **PR 4/4** — Tab 'events' integrazione (`monitor/page.tsx` TABS array + renderTabContent case) + E2E smoke (`apps/web/e2e/admin/monitor-events-tab.spec.ts`) + docs post-merge (ADMIN_AUDIT.md, SCREENS.md, memory).

## Refs

- Design doc F4.1: `docs/superpowers/specs/2026-05-31-sp5-admin-f4-1-monitor-design.md` §5
- Plan F4.1: `docs/superpowers/plans/2026-05-31-sp5-admin-f4-1-monitor.md` Phase 3
- Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-monitor.html` (Events tab) + `sp5-admin-infra.html` (.event-log pattern lines 197-215 + sample 457-489)
- Predecessor merged: PR #1740 (Phase 1/4 BE), PR #1764 (Phase 2/4 FE re-skin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)