### PR TITLE
feat(mockup): #1742 B19 premium #2/7 - Puerto Rico (role-selection euro)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -89,6 +89,13 @@
 | `sp4-play-records-stats.html` | page-mock | `/play-records/stats` |
 | `sp4-player-detail.html` | page-mock | `/players/[id]`, `/players/[id]/{achievements,games,sessions,stats}` |
 | `sp4-players-index.html` | page-mock | `/players` |
+| `sp4-session-puerto-rico-data.jsx` | component-mock | Puerto Rico-specific dataset (role-selection state, 5 goods, plantations + buildings grids). Premium #2/7. |
+| `sp4-session-puerto-rico-flavor.jsx` | component-mock | Puerto Rico flavor components — `RoleSelectionBoard`, `PlantationGrid`, `BuildingGrid`, `GalleonsShipping`, `TradingHouseSlots`, `ColonistShip`. |
+| `sp4-session-puerto-rico-live.html` | page-mock | `/sessions/[id]/live` Puerto Rico demo (heavy euro role-selection, 3-5 players, ~120min). Extends skeleton (mockup #1) with PR-specific panels. |
+| `sp4-session-puerto-rico-live.jsx` | component-mock | Root component for `sp4-session-puerto-rico-live.html` — wires skeleton + PR flavor + RightColumnTabs (Scoring, Roles, Trade, Ship, Chat). |
+| `sp4-session-puerto-rico-parts.jsx` | component-mock | Shared parts for Puerto Rico — player mat, role cards, role action flow. |
+| `sp4-session-puerto-rico-summary.html` | page-mock | `/sessions/[id]` Puerto Rico post-game (final VP breakdown: buildings + shipped goods + large building bonuses). Premium #2/7. |
+| `sp4-session-puerto-rico-summary.jsx` | component-mock | Root component for PR summary — hero + tabs (Scoreboard / Final Board / Round Recap / Stats). |
 | `sp4-session-skeleton-data.jsx` | component-mock | Demo datasets (Wingspan + Paleo) for the generic session skeleton — `window.SkelData`. Used only inside `sp4-session-skeleton-*` mockup to validate polymorphic rendering side-by-side. |
 | `sp4-session-skeleton-live.html` | page-mock | `/sessions/[id]/live` **generic skeleton** (universal renderer for any game). Consumes `AiToolkitSuggestionDto` polymorphically. Demo shows side-by-side Wingspan (Points+RoundRobin) vs Paleo (BinaryWin+Simultaneous). Closes #1750 (B19-4b). |
 | `sp4-session-skeleton-live.jsx` | component-mock | Root component for `sp4-session-skeleton-live.html` — wires top-bar + ChatAgent + `RightColumnTabs` polymorphic. |
@@ -168,10 +175,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 57 |
-| component-mock | 25 |
+| page-mock | 59 |
+| component-mock | 30 |
 | dev-fixture | 12 |
-| **Total** | **94** |
+| **Total** | **101** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/sp4-session-puerto-rico-data.jsx
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-data.jsx
@@ -1,0 +1,329 @@
+/* MeepleAI SP4 · Puerto Rico — DATASET  (window.PR)
+   Game-specific data layer for the Puerto Rico extension of the universal
+   session skeleton. Pure static fixtures — no game simulation.
+
+   ── What this feeds ────────────────────────────────────────────────────────
+   • Skeleton reuse  : PR.ds drives the reused TopBar · ChatAgentPanel ·
+                       ActionLogTimeline (same prop shape as the skeleton).
+   • Polymorphic     : PR.scoring (scoreType=Points) + PR.breakdown feed the
+     renderers          reused ScoringPanelRenderer; PR.turn/PR.turnState feed
+                       TurnIndicatorRenderer (Sequential branch / phase stepper
+                       over the role sequence); PR.counterWidgets feed
+                       ToolkitRenderer (the JSON CounterTools, mapped).
+   • PR-specific UI  : PR.roster (per-player mats) · PR.roles · PR.shared
+                       (galleons / trading house / plantations / colonist ship)
+                       · PR.summary (post-game breakdown).
+
+   ── Assumptions (flagged per _common.md) ───────────────────────────────────
+   • Default variant = 4 players (3-5 supported; Prospector 2 shown disabled,
+     it only exists at 5p). Round 4, current role-phase = Captain.
+   • Goods colors are the raw hex values from puerto-rico.json — the ONE
+     sanctioned exception to "tokens-only", per the brief.
+   • Numbers are believable, not a faithful rules engine.                       */
+
+(function () {
+  // ─── Goods (colors verbatim from puerto-rico.json CounterTools) ───────────
+  const GOODS = [
+    { id: 'corn',    lb: 'Mais',     color: '#f4d03f', dark: '#1a1407' },
+    { id: 'indigo',  lb: 'Indaco',   color: '#2980b9', dark: '#fff'    },
+    { id: 'sugar',   lb: 'Zucchero', color: '#ecf0f1', dark: '#2b1f12' },
+    { id: 'tobacco', lb: 'Tabacco',  color: '#7d6608', dark: '#fff'    },
+    { id: 'coffee',  lb: 'Caffè',    color: '#6e2c00', dark: '#fff'    },
+  ];
+  const GOOD = Object.fromEntries(GOODS.map(g => [g.id, g]));
+  const SUPPLY = { // non-goods counters from JSON
+    doubloon: { lb: 'Dobloni',  color: '#f1c40f', dark: '#1a1407' },
+    colonist: { lb: 'Colono',   color: '#8b6914', dark: '#fff'    },
+    vp:       { lb: 'PV',       color: '#9b59b6', dark: '#fff'    },
+    quarry:   { lb: 'Cava',     color: '#8a8d8f', dark: '#fff'    },
+  };
+
+  // ─── Role cards (8; Prospector 2 only at 5 players) ───────────────────────
+  const ROLES = [
+    { id: 'settler',   lb: 'Colono',      icon: '🌱', effect: 'Prendi 1 tessera piantagione', priv: 'Privilegio: può prendere una cava', e: 'toolkit' },
+    { id: 'mayor',     lb: 'Sindaco',     icon: '🏛️', effect: 'Distribuisci i nuovi coloni', priv: 'Privilegio: +1 colono dalla nave', e: 'player' },
+    { id: 'builder',   lb: 'Costruttore', icon: '🔨', effect: 'Costruisci 1 edificio',        priv: 'Privilegio: sconto di 1 doblone',  e: 'game' },
+    { id: 'craftsman', lb: 'Artigiano',   icon: '⚒️', effect: 'Tutti producono merci',         priv: 'Privilegio: +1 merce extra',       e: 'kb' },
+    { id: 'trader',    lb: 'Mercante',    icon: '⚖️', effect: 'Vendi 1 merce alla casa',       priv: 'Privilegio: +1 doblone sul prezzo', e: 'chat' },
+    { id: 'captain',   lb: 'Capitano',    icon: '⛵', effect: 'Spedisci merci sui galeoni',    priv: 'Privilegio: +1 PV alla 1ª spedizione', e: 'session' },
+    { id: 'prospector1', lb: 'Cercatore I', icon: '💰', effect: 'Prendi 1 doblone (solo tu)',   priv: 'Nessuna azione per gli altri',     e: 'agent' },
+    { id: 'prospector2', lb: 'Cercatore II', icon: '💰', effect: 'Prendi 1 doblone (solo tu)',  priv: 'Solo nella partita a 5 giocatori', e: 'agent', fivePlayerOnly: true },
+  ];
+
+  // ─── Plantation / building factories ──────────────────────────────────────
+  const pl = (t, c = false) => ({ t, c });                 // tile type + colonist?
+  // building: name, kind small|prod|large, printed VP, colonist slots, filled
+  const bd = (n, kind, vp, slots, filled) => ({ n, kind, vp, slots, filled });
+
+  // ─── Roster — 4 players, full mats ────────────────────────────────────────
+  // hue drives avatar; entity-aligned hues reused from the palette.
+  const roster = [
+    {
+      id: 'p-marco', name: 'Marco', hue: 262, governor: true, current: true,
+      score: 34, turnDelta: 4, role: 'captain',
+      mat: {
+        doubloons: 4, colonistsAvail: 1, vp: 34,
+        storehouse: { corn: 1, indigo: 0, sugar: 2, tobacco: 1, coffee: 0 },
+        plantations: [
+          pl('corn', true), pl('corn', true), pl('indigo', true), pl('indigo', false),
+          pl('sugar', true), pl('tobacco', true), pl('quarry', true), pl('quarry', false),
+          pl('coffee', false),
+        ],
+        buildings: [
+          bd('Indaco (pic.)', 'prod', 1, 1, 1), bd('Zuccherificio', 'prod', 2, 3, 2),
+          bd('Tabacco', 'prod', 3, 3, 2), bd('Mercato grande', 'small', 2, 1, 1),
+          bd('Ospizio', 'small', 2, 1, 0), bd('Guild Hall', 'large', 4, 1, 1),
+          bd('Fortezza', 'large', 4, 1, 1),
+        ],
+      },
+    },
+    {
+      id: 'p-anna', name: 'Anna', hue: 350, role: 'settler',
+      score: 30, turnDelta: 0,
+      mat: {
+        doubloons: 2, colonistsAvail: 0, vp: 30,
+        storehouse: { corn: 0, indigo: 3, sugar: 1, tobacco: 0, coffee: 1 },
+        plantations: [
+          pl('indigo', true), pl('indigo', true), pl('indigo', true), pl('sugar', true),
+          pl('sugar', false), pl('corn', true), pl('coffee', true), pl('quarry', false),
+        ],
+        buildings: [
+          bd('Indaco', 'prod', 2, 3, 3), bd('Zucchero (pic.)', 'prod', 1, 1, 1),
+          bd('Caffè', 'prod', 3, 2, 1), bd('Magazzino piccolo', 'small', 1, 1, 1),
+          bd('Porto', 'small', 3, 1, 1), bd('Residence', 'large', 4, 1, 1),
+        ],
+      },
+    },
+    {
+      id: 'p-luca', name: 'Luca', hue: 174, role: 'craftsman',
+      score: 27, turnDelta: 0,
+      mat: {
+        doubloons: 5, colonistsAvail: 2, vp: 27,
+        storehouse: { corn: 2, indigo: 0, sugar: 0, tobacco: 3, coffee: 1 },
+        plantations: [
+          pl('tobacco', true), pl('tobacco', true), pl('corn', true), pl('corn', false),
+          pl('coffee', true), pl('quarry', true), pl('quarry', true),
+        ],
+        buildings: [
+          bd('Tabacco', 'prod', 3, 3, 3), bd('Caffè', 'prod', 3, 2, 2),
+          bd('Fabbrica', 'small', 3, 1, 1), bd('Università', 'small', 3, 1, 0),
+          bd('City Hall', 'large', 4, 1, 1),
+        ],
+      },
+    },
+    {
+      id: 'p-sara', name: 'Sara', hue: 38, role: 'builder',
+      score: 22, turnDelta: 0,
+      mat: {
+        doubloons: 3, colonistsAvail: 0, vp: 22,
+        storehouse: { corn: 1, indigo: 1, sugar: 2, tobacco: 0, coffee: 0 },
+        plantations: [
+          pl('corn', true), pl('sugar', true), pl('sugar', true), pl('indigo', true),
+          pl('corn', false), pl('quarry', false),
+        ],
+        buildings: [
+          bd('Zuccherificio', 'prod', 2, 3, 2), bd('Indaco (pic.)', 'prod', 1, 1, 1),
+          bd('Mercato piccolo', 'small', 1, 1, 1), bd('Ufficio', 'small', 2, 1, 0),
+        ],
+      },
+    },
+  ];
+
+  // ─── Scoring (feeds reused ScoringPanelRenderer · Points branch) ──────────
+  // categories mapped 1:1 from puerto-rico.json ScoringTemplate.Categories,
+  // computation values (Sum/Count/Custom) preserved so ComputationBadge renders.
+  const scoring = {
+    scoreType: 'Points',
+    categories: [
+      { id: 'buildings-vp',        label: 'Edifici (PV stampati)', computation: 'Sum',    weight: 1, description: 'PV stampati su ogni edificio posseduto (1-4 per edificio).' },
+      { id: 'shipped-goods-vp',    label: 'Merci spedite',          computation: 'Count',  weight: 1, description: '1 chip PV per merce spedita su un galeone in fase Capitano.' },
+      { id: 'large-building-bonus',label: 'Bonus edifici grandi',   computation: 'Custom', weight: 1, description: 'Bonus di fine partita degli edifici viola (Guild Hall, City Hall, Residence, Fortezza, Custom House…).' },
+    ],
+  };
+  // live breakdown (sums == roster.score)
+  const breakdown = {
+    'p-marco': { 'buildings-vp': 14, 'shipped-goods-vp': 12, 'large-building-bonus': 8 },
+    'p-anna':  { 'buildings-vp': 13, 'shipped-goods-vp': 12, 'large-building-bonus': 5 },
+    'p-luca':  { 'buildings-vp': 12, 'shipped-goods-vp': 9,  'large-building-bonus': 6 },
+    'p-sara':  { 'buildings-vp': 11, 'shipped-goods-vp': 9,  'large-building-bonus': 2 },
+  };
+
+  // ─── Turn (feeds reused TurnIndicatorRenderer · Sequential) ───────────────
+  // phase stepper walks the role sequence of the round; activeIndex = role
+  // currently being executed (Captain).
+  const rolePhases = ROLES.filter(r => !r.fivePlayerOnly).map(r => r.lb);
+  const turn = {
+    turnOrderType: 'Sequential',
+    phases: rolePhases,
+    direction: 'clockwise',
+    turnActions: ['choose-role', 'execute-role-action', 'all-others-clockwise', 'take-privilege', 'pass-governor'],
+  };
+  const turnState = { phaseIndex: 5 /* Captain */ };
+
+  // this round's role selections (governor Marco first, clockwise)
+  // chosen roles carry the chooser; unchosen roles accrue doubloons.
+  const roleState = {
+    round: 4,
+    activeRole: 'captain',
+    chosenBy: { captain: 'p-marco', settler: 'p-anna', craftsman: 'p-luca', builder: 'p-sara' },
+    doubloonsOn: { mayor: 2, trader: 1, prospector1: 3, prospector2: 0 },
+  };
+
+  // ─── Shared state (PR-specific board) ─────────────────────────────────────
+  const shared = {
+    galleons: [
+      { id: 'g1', cap: 4, good: 'corn',   loaded: 4 },        // full
+      { id: 'g2', cap: 6, good: 'coffee', loaded: 3 },        // partial
+      { id: 'g3', cap: 7, good: null,     loaded: 0 },        // empty
+    ],
+    tradingHouse: {
+      slots: [
+        { good: 'indigo', price: 1 },
+        { good: 'sugar',  price: 2 },
+        null, null,
+      ],
+      basePrice: { corn: 0, indigo: 1, sugar: 2, tobacco: 3, coffee: 4 },
+    },
+    plantations: { // available face-up tiles + 1 face-down + quarry stack
+      faceUp: ['corn', 'indigo', 'indigo', 'sugar', 'tobacco'],
+      faceDown: 1,
+      quarryStack: 4,
+    },
+    buildingSupply: [
+      { n: 'Caffè',          kind: 'prod',  vp: 3, cost: 6, left: 2 },
+      { n: 'Università',     kind: 'small', vp: 3, cost: 8, left: 1 },
+      { n: 'Porto',          kind: 'small', vp: 3, cost: 8, left: 2 },
+      { n: 'Custom House',   kind: 'large', vp: 4, cost: 10, left: 1 },
+      { n: 'Wharf',          kind: 'small', vp: 3, cost: 9, left: 2 },
+    ],
+    colonistShip: { incoming: 4, supply: 17, onShip: 4 },
+  };
+
+  // counter widgets — JSON CounterTools mapped to a ResourceManager widget so
+  // the reused ToolkitRenderer can render PR's per-player counters in galleries.
+  const counterWidgets = [
+    {
+      id: 'w-goods', type: 'ResourceManager', isEnabled: true, displayOrder: 0,
+      config: {
+        shared: false,
+        resources: [
+          { label: 'Dobloni', value: 4, max: 54 },
+          { label: 'Coloni',  value: 1, max: 30 },
+          { label: 'PV chip', value: 34, max: 75 },
+          { label: 'Mais',    value: 1, max: 20 },
+          { label: 'Indaco',  value: 0, max: 20 },
+        ],
+      },
+    },
+    {
+      id: 'w-score', type: 'ScoreTracker', isEnabled: true, displayOrder: 1,
+      config: {},
+    },
+    {
+      id: 'w-turn', type: 'TurnManager', isEnabled: true, displayOrder: 2,
+      config: { phaseBased: true },
+    },
+    // disabled — PR excludes dice + timer (per JSON ExcludedTools)
+    { id: 'w-dice',  type: 'RandomGenerator', isEnabled: false, displayOrder: 3, config: { name: 'Dadi (esclusi)' } },
+    { id: 'w-note',  type: 'NoteManager', isEnabled: false, displayOrder: 4, config: {} },
+    { id: 'w-board', type: 'Whiteboard', isEnabled: false, displayOrder: 5, config: {} },
+  ];
+
+  // ─── ds — drives reused skeleton chrome (TopBar / ChatAgent / ActionLog) ──
+  const ds = {
+    game: {
+      title: 'Puerto Rico', emoji: '🏝️',
+      cover: 'linear-gradient(135deg, hsl(28,80%,52%), hsl(190,55%,42%))',
+      meta: '3-5 giocatori · ~120 min · Round 4',
+    },
+    agent: { name: 'Esperto Puerto Rico', emoji: '🤖', latency: 'Risponde in 1-2s' },
+    session: { elapsed: '1h 02m' },
+    players: roster, // carries name/hue/score/turnDelta + .mat
+    // scoring + breakdown + turn so the polymorphic renderers can read `ds`
+    scoring, breakdown, turn, turnState, meta: 'Sequenza ruoli · Round 4',
+    chat: [
+      { id: 'c1', from: 'user',  t: '15:18', text: 'Posso spedire merci di tipi diversi sullo stesso galeone?' },
+      { id: 'c2', from: 'agent', t: '15:18', text: 'No — ogni galeone trasporta un solo tipo di merce. Una nave già caricata con caffè accetta solo altro caffè finché non viene svuotata a fine fase.', citations: ['Puerto Rico §Capitano'] },
+      { id: 'c3', from: 'user',  t: '15:24', text: 'Il Cercatore d’oro fa agire anche gli altri giocatori?' },
+      { id: 'c4', from: 'agent', t: '15:24', text: 'No: il Cercatore è l’unico ruolo senza azione condivisa. Solo chi lo sceglie prende 1 doblone dalla banca.', citations: ['Puerto Rico §Ruoli', 'FAQ #4'] },
+    ],
+    suggestions: ['Bonus Guild Hall?', 'Prezzi casa commerciale', 'Quando finisce la partita?'],
+    events: [
+      { kind: 'game-start', who: null,      t: '14:16', text: 'Partita avviata · <strong>4 giocatori</strong> · governatore <strong>Marco</strong>' },
+      { kind: 'turn-change', who: 'p-anna', t: '15:05', text: 'sceglie <strong>Colono</strong> · prende una piantagione di indaco' },
+      { kind: 'turn-change', who: 'p-luca', t: '15:09', text: 'sceglie <strong>Artigiano</strong> · tutti producono merci' },
+      { kind: 'score-update',who: 'p-luca', t: '15:10', text: 'produce <strong>3 tabacco</strong> + 1 caffè (privilegio)' },
+      { kind: 'turn-change', who: 'p-sara', t: '15:13', text: 'sceglie <strong>Costruttore</strong> · costruisce <strong>Ufficio</strong> (–2 dobloni)' },
+      { kind: 'turn-change', who: 'p-marco',t: '15:17', text: 'sceglie <strong>Capitano</strong> · apre la fase di spedizione' },
+      { kind: 'custom',      who: 'p-marco',t: '15:18', text: 'spedisce <strong>4 mais</strong> sul galeone da 4 · <strong>+4 PV</strong>' },
+    ],
+    notes: 'Marco controlla 2 cave → costruzioni scontate.\nAnna engine indaco (3 tessere + edificio pieno).\nLuca siede su 5 dobloni: occhio al Costruttore prossimo round.',
+    photos: [
+      { lb: 'Plancia T20', g: 'linear-gradient(135deg, hsl(30,55%,55%), hsl(150,45%,40%))' },
+      { lb: 'Casa comm.',  g: 'linear-gradient(135deg, hsl(200,55%,55%), hsl(255,45%,45%))' },
+    ],
+  };
+
+  // ─── Summary (post-game) ──────────────────────────────────────────────────
+  // shipped goods counts per player (sum == shippedVP)
+  const shipped = {
+    'p-marco': { corn: 6, coffee: 4, sugar: 3, tobacco: 2, indigo: 1 }, // 16
+    'p-anna':  { indigo: 6, sugar: 5, corn: 4, coffee: 2, tobacco: 1 }, // 18
+    'p-luca':  { coffee: 5, tobacco: 4, corn: 3, sugar: 2, indigo: 0 }, // 14
+    'p-sara':  { corn: 5, sugar: 4, indigo: 3, tobacco: 2, coffee: 2 }, // 16
+  };
+  // building VP lists (sum == buildingVP)
+  const buildingVP = {
+    'p-marco': [['Indaco (pic.)', 1], ['Zuccherificio', 2], ['Tabacco', 3], ['Mercato grande', 2], ['Ospizio', 2], ['Guild Hall', 4], ['Fortezza', 4]], // 18
+    'p-anna':  [['Indaco', 2], ['Zucchero (pic.)', 1], ['Caffè', 3], ['Magazzino piccolo', 1], ['Porto', 3], ['Università', 3], ['Residence', 4]],         // 17
+    'p-luca':  [['Tabacco', 3], ['Caffè', 3], ['Fabbrica', 3], ['Università', 3], ['City Hall', 4]],                                                        // 16
+    'p-sara':  [['Zuccherificio', 2], ['Indaco (pic.)', 1], ['Mercato grande', 2], ['Ufficio', 2], ['Fabbrica', 3], ['Custom House', 4]],                   // 14 -> bump
+  };
+  // large building end-game bonuses (sum == largeBonus)
+  const largeBonus = {
+    'p-marco': [
+      { n: 'Guild Hall', rule: '+1 PV per edificio di produzione (×2 se grande)', value: 9 },
+      { n: 'Fortezza',   rule: '+1 PV ogni 3 coloni piazzati', value: 5 },
+    ], // 14
+    'p-anna': [
+      { n: 'Residence', rule: '+PV per spazi piantagione occupati (9→4, 10→5, 11→6, 12→7)', value: 10 },
+    ], // 10
+    'p-luca': [
+      { n: 'City Hall', rule: '+1 PV per edificio viola (non di produzione)', value: 11 },
+    ], // 11
+    'p-sara': [
+      { n: 'Custom House', rule: '+1 PV ogni 4 chip PV da spedizione', value: 7 },
+    ], // 7
+  };
+  // round-by-round role recap (governor rotates clockwise)
+  const recap = [
+    { round: 1, governor: 'p-marco', picks: [['p-marco', 'settler'], ['p-anna', 'builder'], ['p-luca', 'craftsman'], ['p-sara', 'mayor']] },
+    { round: 2, governor: 'p-anna',  picks: [['p-anna', 'craftsman'], ['p-luca', 'builder'], ['p-sara', 'trader'], ['p-marco', 'captain']] },
+    { round: 3, governor: 'p-luca',  picks: [['p-luca', 'settler'], ['p-sara', 'craftsman'], ['p-marco', 'builder'], ['p-anna', 'captain']] },
+    { round: 4, governor: 'p-sara',  picks: [['p-sara', 'mayor'], ['p-marco', 'craftsman'], ['p-anna', 'trader'], ['p-luca', 'captain']] },
+    { round: 5, governor: 'p-marco', picks: [['p-marco', 'captain'], ['p-anna', 'settler'], ['p-luca', 'builder'], ['p-sara', 'prospector1']] },
+  ];
+  // per-player stats
+  const stats = {
+    'p-marco': { vpPerMin: 0.45, topRole: 'builder', topRoleCount: 3, shippedTot: 16, builtTot: 7, colonists: 11 },
+    'p-anna':  { vpPerMin: 0.42, topRole: 'captain', topRoleCount: 3, shippedTot: 18, builtTot: 7, colonists: 10 },
+    'p-luca':  { vpPerMin: 0.38, topRole: 'craftsman', topRoleCount: 4, shippedTot: 14, builtTot: 5, colonists: 9 },
+    'p-sara':  { vpPerMin: 0.35, topRole: 'craftsman', topRoleCount: 3, shippedTot: 16, builtTot: 6, colonists: 8 },
+  };
+  // final totals (building + shipped + large)
+  const finalScore = {};
+  roster.forEach(p => {
+    const b = buildingVP[p.id].reduce((s, x) => s + x[1], 0);
+    const sh = Object.values(shipped[p.id]).reduce((s, x) => s + x, 0);
+    const lg = largeBonus[p.id].reduce((s, x) => s + x.value, 0);
+    finalScore[p.id] = { building: b, shipped: sh, large: lg, total: b + sh + lg };
+  });
+  const endTrigger = 'Esaurimento dei chip PV durante la fase Capitano (round 5).';
+
+  const summary = { shipped, buildingVP, largeBonus, recap, stats, finalScore, endTrigger, durationMin: 108 };
+
+  window.PR = {
+    GOODS, GOOD, SUPPLY, ROLES, roster, scoring, breakdown,
+    turn, turnState, roleState, rolePhases, shared, counterWidgets, ds, summary,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-puerto-rico-flavor.jsx
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-flavor.jsx
@@ -1,0 +1,255 @@
+/* MeepleAI SP4 · Puerto Rico — FLAVOR ATOMS  (window.PRFlavor)
+   Small game-specific visual primitives shared by live + summary:
+     GoodToken · GoodCount · StorehouseRow · SupplyCounter ·
+     PlantationTile · PlantationGrid · BuildingTile · BuildingGrid ·
+     ColonistPip · RoleCard · GovernorToken · MiniAvatar
+
+   Goods colors come from window.PR (verbatim from puerto-rico.json). All other
+   color/space/radius values are tokens.css vars. Reads window.MAI for eHsl. */
+
+(function () {
+  const M = window.MAI;
+  const PR = window.PR;
+  const eHsl = M.entityHsl;
+  const { GOOD, SUPPLY } = PR;
+  const mono = (s, w, c) => ({ fontFamily: 'var(--f-mono)', fontSize: s, fontWeight: w, color: c });
+  const disp = (s, w, c) => ({ fontFamily: 'var(--f-display)', fontSize: s, fontWeight: w, color: c });
+
+  const goodOf = (id) => GOOD[id] || SUPPLY[id] || { lb: id, color: '#888', dark: '#fff' };
+
+  // ─── MiniAvatar ───────────────────────────────────────────────────────────
+  const MiniAvatar = ({ p, size = 22, ring }) => (
+    <div aria-hidden="true" style={{
+      width: size, height: size, borderRadius: '50%', flexShrink: 0,
+      background: `linear-gradient(135deg, hsl(${p.hue},70%,64%), hsl(${p.hue},58%,44%))`,
+      color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      ...disp(size * 0.46, 800, '#fff'),
+      border: ring ? `2px solid ${eHsl('toolkit')}` : '2px solid var(--bg-card)',
+    }}>{p.name[0]}</div>
+  );
+
+  // ─── GoodToken — colored barrel/disc with 1-letter label ──────────────────
+  const GoodToken = ({ id, size = 18, title }) => {
+    const g = goodOf(id);
+    const quarry = id === 'quarry';
+    return (
+      <span title={title || g.lb} aria-label={g.lb} style={{
+        width: size, height: size, borderRadius: quarry ? 'var(--r-xs)' : '50%', flexShrink: 0,
+        background: quarry ? 'repeating-linear-gradient(135deg, #9a9d9f, #9a9d9f 3px, #7f8284 3px, #7f8284 6px)' : g.color,
+        color: g.dark, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        ...mono(size * 0.5, 800), border: '1px solid rgba(0,0,0,.22)',
+        boxShadow: 'inset 0 1px 1px rgba(255,255,255,.35), inset 0 -1px 2px rgba(0,0,0,.18)',
+      }}>{quarry ? '◇' : g.lb[0]}</span>
+    );
+  };
+
+  // ─── GoodCount — token + count (storehouse / shipped) ─────────────────────
+  const GoodCount = ({ id, n, dim }) => (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 7px 2px 3px',
+      borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)',
+      opacity: dim && !n ? 0.45 : 1,
+    }}>
+      <GoodToken id={id} size={16} />
+      <span style={{ ...mono(11, 800, n ? 'var(--text)' : 'var(--text-muted)'), fontVariantNumeric: 'tabular-nums', minWidth: 8, textAlign: 'center' }}>{n}</span>
+    </span>
+  );
+
+  // storehouse = the 5 goods counters, aria-live for updates
+  const StorehouseRow = ({ store, label = 'Magazzino' }) => (
+    <div>
+      {label && <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 5 }}>{label}</div>}
+      <div aria-live="polite" style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+        {PR.GOODS.map(g => <GoodCount key={g.id} id={g.id} n={store[g.id] || 0} dim />)}
+      </div>
+    </div>
+  );
+
+  // ─── SupplyCounter — doubloons / colonists / VP big display ───────────────
+  const SupplyCounter = ({ kind, value, sub, big }) => {
+    const s = SUPPLY[kind];
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8, padding: big ? '8px 12px' : '6px 9px',
+        borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', flex: 1, minWidth: 0,
+      }}>
+        <span aria-hidden="true" style={{
+          width: big ? 26 : 22, height: big ? 26 : 22, borderRadius: '50%', flexShrink: 0,
+          background: s.color, color: s.dark, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          ...mono(big ? 12 : 10, 800), border: '1px solid rgba(0,0,0,.25)',
+          boxShadow: 'inset 0 1px 1px rgba(255,255,255,.4), inset 0 -1px 2px rgba(0,0,0,.2)',
+        }}>{s.lb[0]}</span>
+        <div style={{ minWidth: 0 }}>
+          <div aria-live="polite" style={{ ...disp(big ? 20 : 16, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{value}</div>
+          <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', whiteSpace: 'nowrap' }}>{sub || s.lb}</div>
+        </div>
+      </div>
+    );
+  };
+
+  // ─── ColonistPip — the brown worker token ─────────────────────────────────
+  const ColonistPip = ({ size = 10, empty }) => (
+    <span aria-hidden="true" style={{
+      width: size, height: size, borderRadius: '50%', flexShrink: 0,
+      background: empty ? 'transparent' : SUPPLY.colonist.color,
+      border: empty ? `1.5px dashed ${eHsl('game', 0.5)}` : '1px solid rgba(0,0,0,.3)',
+      boxShadow: empty ? 'none' : 'inset 0 1px 1px rgba(255,255,255,.3)',
+    }} />
+  );
+
+  // ─── PlantationTile — colored field with colonist slot ────────────────────
+  const PlantationTile = ({ tile, size = 30 }) => {
+    const g = goodOf(tile.t);
+    const quarry = tile.t === 'quarry';
+    return (
+      <div title={`${g.lb}${tile.c ? ' · colono' : ' · vuoto'}`} style={{
+        width: size, height: size, borderRadius: 'var(--r-sm)', position: 'relative', flexShrink: 0,
+        background: quarry ? 'repeating-linear-gradient(135deg, #9a9d9f, #9a9d9f 4px, #7f8284 4px, #7f8284 8px)' : g.color,
+        border: '1px solid rgba(0,0,0,.25)',
+        boxShadow: 'inset 0 1px 2px rgba(255,255,255,.3), inset 0 -2px 3px rgba(0,0,0,.18)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <span style={{ ...mono(size * 0.34, 800, g.dark), opacity: 0.85 }} aria-hidden="true">{quarry ? '◇' : g.lb[0]}</span>
+        <span style={{ position: 'absolute', bottom: 2, right: 2 }}><ColonistPip size={Math.round(size * 0.3)} empty={!tile.c} /></span>
+      </div>
+    );
+  };
+
+  // PlantationGrid — up to 12 tiles, fills empty plots with dashed slots
+  const PlantationGrid = ({ tiles, max = 12, cols = 4, size = 30, label = 'Piantagioni · cave' }) => {
+    const slots = [...tiles];
+    while (slots.length < max) slots.push(null);
+    return (
+      <div>
+        {label && (
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 5 }}>
+            <span style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</span>
+            <span style={{ ...mono(9, 800, eHsl('session')) }}>{tiles.length}/{max}</span>
+          </div>
+        )}
+        <div role="group" aria-label={label} style={{ display: 'grid', gridTemplateColumns: `repeat(${cols}, ${size}px)`, gap: 5 }}>
+          {slots.map((t, i) => t
+            ? <PlantationTile key={i} tile={t} size={size} />
+            : <div key={i} aria-hidden="true" style={{ width: size, height: size, borderRadius: 'var(--r-sm)', border: '1.5px dashed var(--border-strong)', background: 'var(--bg-sunken)', opacity: 0.5 }} />)}
+        </div>
+      </div>
+    );
+  };
+
+  // ─── BuildingTile — plot with printed VP + colonist slots ─────────────────
+  const KIND_STYLE = {
+    prod:  { e: 'kb',      lb: 'Produzione' },
+    small: { e: 'game',    lb: 'Cittadino' },
+    large: { e: 'player',  lb: 'Grande (viola)' }, // purple → player entity
+  };
+  const BuildingTile = ({ b, w = 78 }) => {
+    const ks = KIND_STYLE[b.kind] || KIND_STYLE.small;
+    const filled = b.filled || 0;
+    return (
+      <div title={`${b.n} · ${ks.lb} · ${b.vp} PV · coloni ${filled}/${b.slots}`} style={{
+        width: w, minHeight: 56, borderRadius: 'var(--r-sm)', position: 'relative', flexShrink: 0,
+        background: b.kind === 'large' ? eHsl('player', 0.14) : 'var(--bg-card)',
+        border: `1px solid ${b.kind === 'large' ? eHsl('player', 0.45) : eHsl(ks.e, 0.3)}`,
+        padding: '6px 6px 5px', display: 'flex', flexDirection: 'column', gap: 4, justifyContent: 'space-between',
+        boxShadow: 'var(--shadow-xs)',
+      }}>
+        <div style={{ ...disp(10.5, 800, 'var(--text)'), lineHeight: 1.12, paddingRight: 14 }}>{b.n}</div>
+        <span style={{ position: 'absolute', top: 4, right: 4, width: 14, height: 14, borderRadius: 'var(--r-xs)', background: SUPPLY.vp.color, color: '#fff', ...mono(9, 800), display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }} aria-hidden="true">{b.vp}</span>
+        <div style={{ display: 'flex', gap: 3, alignItems: 'center' }} aria-label={`coloni ${filled} su ${b.slots}`}>
+          {Array.from({ length: b.slots }).map((_, i) => <ColonistPip key={i} size={9} empty={i >= filled} />)}
+        </div>
+      </div>
+    );
+  };
+
+  const BuildingGrid = ({ buildings, max = 12, cols = 4, w = 78, label = 'Edifici' }) => {
+    const filled = buildings.length;
+    return (
+      <div>
+        {label && (
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 5 }}>
+            <span style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</span>
+            <span style={{ ...mono(9, 800, eHsl('session')) }}>{filled}/{max}</span>
+          </div>
+        )}
+        <div role="group" aria-label={label} style={{ display: 'grid', gridTemplateColumns: `repeat(${cols}, ${w}px)`, gap: 5 }}>
+          {buildings.map((b, i) => <BuildingTile key={i} b={b} w={w} />)}
+          {Array.from({ length: Math.max(0, max - filled) }).map((_, i) => (
+            <div key={`e${i}`} aria-hidden="true" style={{ width: w, minHeight: 56, borderRadius: 'var(--r-sm)', border: '1.5px dashed var(--border-strong)', background: 'var(--bg-sunken)', opacity: 0.5, display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(9, 700, 'var(--text-muted)') }}>libero</div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  // ─── GovernorToken ────────────────────────────────────────────────────────
+  const GovernorToken = ({ size = 'md' }) => {
+    const sm = size === 'sm';
+    return (
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 5, padding: sm ? '2px 8px' : '3px 10px',
+        borderRadius: 'var(--r-pill)', background: eHsl('game', 0.14), color: eHsl('game'),
+        border: `1px solid ${eHsl('game', 0.4)}`, ...mono(sm ? 9 : 10, 800), textTransform: 'uppercase', letterSpacing: '.05em',
+      }}>
+        <span aria-hidden="true" style={{ width: sm ? 12 : 14, height: sm ? 12 : 14, borderRadius: '50%', background: 'radial-gradient(circle at 35% 30%, #ffe9a8, #d4a017)', border: '1px solid #b8860b', boxShadow: 'inset 0 -1px 2px rgba(0,0,0,.3)' }} />
+        Governatore
+      </span>
+    );
+  };
+
+  // ─── RoleCard — accessible role-selection button ──────────────────────────
+  // shows: role identity · effect/privilege · chooser avatar (or doubloons
+  // accrued if unchosen) · active highlight (session entity color).
+  const RoleCard = ({ role, chosenBy, doubloons = 0, active, disabled, compact, onClick }) => {
+    const e = active ? 'session' : role.e;
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-current={active ? 'true' : undefined}
+        aria-label={`Ruolo ${role.lb}${active ? ', fase attuale' : ''}${chosenBy ? ', scelto' : doubloons ? `, ${doubloons} dobloni` : ''}`}
+        style={{
+          position: 'relative', textAlign: 'left', cursor: disabled ? 'not-allowed' : 'pointer',
+          width: compact ? 132 : '100%', minHeight: compact ? 96 : 78,
+          padding: compact ? '10px 10px 9px' : '10px 12px',
+          borderRadius: 'var(--r-md)', flexShrink: 0,
+          background: active ? eHsl('session', 0.1) : disabled ? 'var(--bg-sunken)' : 'var(--bg-card)',
+          border: active ? `2px solid ${eHsl('session')}` : `1px solid ${eHsl(e, 0.28)}`,
+          boxShadow: active ? `0 4px 16px ${eHsl('session', 0.28)}` : 'var(--shadow-xs)',
+          opacity: disabled ? 0.5 : 1,
+          display: 'flex', flexDirection: 'column', gap: 5,
+        }}
+      >
+        {active && <span style={{ position: 'absolute', top: 8, right: 9, ...mono(8, 800, eHsl('session')), textTransform: 'uppercase', letterSpacing: '.06em' }} className="mai-pulse-dot-host">● fase</span>}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+          <span aria-hidden="true" style={{ width: 26, height: 26, borderRadius: 'var(--r-sm)', background: eHsl(e, 0.14), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, flexShrink: 0 }}>{role.icon}</span>
+          <span style={{ ...disp(13, 800, active ? eHsl('session') : 'var(--text)') }}>{role.lb}</span>
+        </div>
+        <div style={{ ...mono(9.5, 600, 'var(--text-sec)'), lineHeight: 1.35 }}>{role.effect}</div>
+        {!compact && <div style={{ ...mono(8.5, 700, eHsl(role.e)), lineHeight: 1.3 }}>{role.priv}</div>}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 'auto' }}>
+          {chosenBy
+            ? <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+                <MiniAvatar p={chosenBy} size={18} />
+                <span style={{ ...mono(8.5, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>scelto</span>
+              </span>
+            : disabled
+              ? <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>solo 5 giocatori</span>
+              : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }} aria-label={`${doubloons} dobloni accumulati`}>
+                  {Array.from({ length: Math.min(doubloons, 4) }).map((_, i) => (
+                    <span key={i} aria-hidden="true" style={{ width: 13, height: 13, borderRadius: '50%', background: SUPPLY.doubloon.color, border: '1px solid #b8860b', marginLeft: i ? -5 : 0, boxShadow: 'inset 0 -1px 1px rgba(0,0,0,.3)' }} />
+                  ))}
+                  <span style={{ ...mono(10, 800, doubloons ? 'var(--text)' : 'var(--text-muted)'), marginLeft: 3 }}>{doubloons ? `+${doubloons}` : 'libero'}</span>
+                </span>}
+        </div>
+      </button>
+    );
+  };
+
+  window.PRFlavor = {
+    goodOf, MiniAvatar, GoodToken, GoodCount, StorehouseRow, SupplyCounter,
+    ColonistPip, PlantationTile, PlantationGrid, BuildingTile, BuildingGrid,
+    GovernorToken, RoleCard, KIND_STYLE, mono, disp,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-puerto-rico-live.html
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-live.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Puerto Rico · Live — /sessions/[id]/live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-data.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-puerto-rico-live.jsx
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-live.jsx
@@ -1,0 +1,166 @@
+/* MeepleAI SP4 · Puerto Rico — SESSION LIVE  (App)
+   /sessions/[id]/live  — Puerto Rico extension of the universal session skeleton.
+
+   PREMIUM mockup #? of pipeline B19. The skeleton (mockup #1) supplies the
+   polymorphic renderers + universal chrome; THIS layer adds the Puerto Rico
+   board: per-player mats, the 8-card role-selection board, galleons/trading
+   house/colonist ship shared state, and a 5-tab right column
+   (Scoring · Roles · Trade · Ship · Chat).
+
+   Reused verbatim from the skeleton: TopBar · ChatAgentPanel · ActionLog ·
+   ScoringPanelRenderer (Points) · TurnIndicatorRenderer (Sequential) ·
+   ToolkitRenderer. Dark = primary mode. Default variant = 4 players, Round 4,
+   current phase = Captain.
+
+   Loads: sp4-parts-common · skeleton-renderers · skeleton-data(shim) ·
+          skeleton-parts · puerto-rico-data · puerto-rico-flavor · puerto-rico-parts
+   DEMO-NAV-HINTS: sp4-session-puerto-rico-summary.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const S = window.SkeletonParts;
+const F = window.PRFlavor;
+const P = window.PRParts;
+const PR = window.PR;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+const Intro = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+    {[
+      { e: 'session', h: 'Estende lo skeleton', b: 'Riusa TopBar · ChatAgent · ActionLog e i 3 renderer polimorfici. Aggiunge sopra le plance e il tavolo di Puerto Rico.' },
+      { e: 'game',    h: 'Selezione ruoli', b: '8 carte ruolo (Prospector 2 solo a 5 giocatori). Il ruolo della fase corrente è evidenziato; i ruoli non scelti accumulano dobloni.' },
+      { e: 'player',  h: 'Plance per giocatore', b: 'Plancia del giocatore attivo sempre visibile; le altre in drawer. Dobloni · coloni · PV · 5 magazzini · piantagioni · edifici.' },
+      { e: 'toolkit', h: '5 stati canonici', b: 'default · empty · loading · error · sse-disconnect per ogni pannello (galeoni, casa commerciale, scoring, ruoli).' },
+    ].map(c => (
+      <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+        <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: eHsl(c.e), marginBottom: 4 }}>{c.h}</div>
+        <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+      </div>
+    ))}
+  </div>
+);
+
+// states-gallery helper
+const StatesRow = ({ title, sub, entity, render }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHsl(entity) }}>{title}</span>
+      {sub && <span style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)', fontWeight: 700 }}>{sub}</span>}
+    </div>
+    <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>
+      {P.STATES.map(s => (
+        <P.PanelFrame key={s.id} label={s.lb} entity={entity} dark={s.id === 'sse'}>
+          {render(s.id)}
+        </P.PanelFrame>
+      ))}
+    </div>
+  </div>
+);
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Puerto Rico · Live ⚡ · estensione skeleton</div>
+        <h1>Session live — Puerto Rico</h1>
+        <p className="lead">
+          Estensione game-specific dello <strong>skeleton universale</strong> applicata a <strong>Puerto Rico</strong>
+          (euro a selezione ruoli, 3-5 giocatori, ~120 min). Lo skeleton fornisce i renderer polimorfici e la chrome;
+          questo layer aggiunge <strong>plance per giocatore</strong>, il <strong>tavolo di selezione ruoli</strong>,
+          lo stato condiviso (galeoni · casa commerciale · nave coloni) e una colonna destra a 5 tab
+          <strong> Scoring · Roles · Trade · Ship · Chat</strong>. Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        {/* INTERACTIVE — desktop */}
+        <div className="section-label">Interattivo · Desktop 1280 — plancia attiva · tavolo ruoli + stato condiviso · colonna tab</div>
+        <S.DesktopFrame ds={PR.ds} dark label="Desktop · live · Puerto Rico" url="meepleai.app/sessions/pr-7/live?tab=ship" height={760}
+          desc="3 regioni + tab: SINISTRA plancia del giocatore attivo (Marco) + plance altrui in drawer · CENTRO selezione ruoli (Capitano evidenziato) + galeoni/rifornimenti/coloni/edifici + registro · DESTRA tab Scoring/Roles/Trade/Ship/Chat con selettore stato.">
+          <S.TopBar ds={PR.ds} connection="connected" />
+          <P.DesktopBody initialTab="ship" initialState="default" />
+        </S.DesktopFrame>
+
+        {/* INTERACTIVE — mobile */}
+        <div className="section-label">Mobile 375 — tavolo full-width · plance e sezioni in bottom-sheet</div>
+        <div className="phones-grid">
+          <P.PhoneShell label="01 · base · sheet chiuso" desc="Tavolo sempre visibile (ruoli + galeoni + rifornimenti + log). In basso: barra plance + strip tab." />
+          <P.PhoneShell label="02 · sheet Ship" initialTab="ship" desc="Tap su una tab apre il bottom-sheet: galeoni con obbligo di spedizione e selettore stato." />
+          <P.PhoneShell label="03 · sheet Scoring · dark" dark initialTab="scoring" desc="ScoringPanelRenderer riusato: classifica live + breakdown 3 categorie con badge computation." />
+        </div>
+
+        {/* STATES — reused polymorphic renderers */}
+        <div className="section-label">Gallery stati · renderer polimorfici riusati — alimentati dal toolkit Puerto Rico</div>
+        <StatesRow title="ScoringPanelRenderer" sub="scoreType · Points — 3 categorie dal JSON (Sum · Count · Custom)" entity="session"
+          render={(st) => <R.ScoringPanelRenderer data={PR.ds} state={st} />} />
+        <StatesRow title="TurnIndicatorRenderer" sub="turnOrderType · Sequential — phase stepper sui ruoli del round" entity="player"
+          render={(st) => <R.TurnIndicatorRenderer data={PR.ds} state={st} />} />
+        <StatesRow title="ToolkitRenderer" sub="dispatch widgets[] — CounterTools del JSON (dadi/timer esclusi)" entity="toolkit"
+          render={(st) => <R.ToolkitRenderer widgets={PR.counterWidgets} players={PR.roster} state={st} />} />
+
+        {/* STATES — PR-specific panels */}
+        <div className="section-label">Gallery stati · pannelli specifici Puerto Rico × 5 stati canonici</div>
+        <StatesRow title="GalleonsShipping" sub="fase Capitano · galeoni mono-merce + obbligo" entity="toolkit"
+          render={(st) => <P.GalleonsShipping state={st} />} />
+        <StatesRow title="TradingHouseSlots" sub="fase Mercante · 4 slot + prezzi" entity="chat"
+          render={(st) => <P.TradingHouseSlots state={st} />} />
+        <StatesRow title="RolesTab" sub="board compatto + sequenza fasi (TurnIndicator)" entity="player"
+          render={(st) => <P.RolesTab state={st} />} />
+
+        {/* PR component showcase (default state, light + dark) */}
+        <div className="section-label">Componenti Puerto Rico · plancia giocatore · board ruoli</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 18, alignItems: 'start' }}>
+          <div>
+            <div style={{ ...F.mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>PlayerMat · attivo</div>
+            <P.SectionCard title="Plancia · Marco" entity="session" accent>
+              <P.PlayerMat player={PR.roster[0]} active tileSize={28} bw={80} />
+            </P.SectionCard>
+          </div>
+          <div data-theme="dark">
+            <div style={{ ...F.mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>PlayerMat · dark</div>
+            <div style={{ background: 'var(--bg)', padding: 12, borderRadius: 'var(--r-lg)' }}>
+              <P.SectionCard title="Plancia · Anna" entity="session" accent>
+                <P.PlayerMat player={PR.roster[1]} tileSize={28} bw={80} />
+              </P.SectionCard>
+            </div>
+          </div>
+        </div>
+        <div style={{ marginTop: 18 }}>
+          <P.SectionCard title="Tavolo · selezione ruoli (8 carte · 4 giocatori)" entity="session" accent>
+            <P.RoleSelectionBoard />
+          </P.SectionCard>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot, .mai-pulse-dot-host::before { }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-puerto-rico-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-parts.jsx
@@ -1,0 +1,540 @@
+/* MeepleAI SP4 · Puerto Rico — PARTS  (window.PRParts)
+   Game-specific composed components layered ON the universal skeleton.
+
+   Reuses directly from the skeleton:
+     window.MAI               · primitives (StateBlock, Shimmer, eHsl…)
+     window.SkeletonRenderers · ScoringPanelRenderer · TurnIndicatorRenderer ·
+                                ToolkitRenderer · StateScaffold · Panel · Label
+     window.SkeletonParts     · TopBar · ChatAgentPanel · ActionLogTimeline
+     window.PRFlavor          · goods/tiles/role-card atoms
+     window.PR                · dataset
+
+   Adds (Puerto-Rico specific):
+     PlayerMat · OtherPlayersBar · PlayerMatDrawer · RoleSelectionBoard ·
+     GalleonsShipping · TradingHouseSlots · ColonistShip · AvailablePlantations ·
+     BuildingSupplyBoard · SharedStateBoard · RightColumnTabs (Scoring/Roles/
+     Trade/Ship/Chat) · DesktopBody · MobileBody · frames.
+
+   Right column = the brief's 5 tabs. Captain phase ⇒ Ship tab is contextual. */
+
+(function () {
+  const M = window.MAI;
+  const R = window.SkeletonRenderers;
+  const S = window.SkeletonParts;
+  const F = window.PRFlavor;
+  const PR = window.PR;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const mono = F.mono, disp = F.disp;
+  const playerById = (id) => PR.roster.find(p => p.id === id);
+
+  const STATES = [
+    { id: 'default', lb: 'Default' }, { id: 'empty', lb: 'Empty' }, { id: 'loading', lb: 'Loading' },
+    { id: 'error', lb: 'Error' }, { id: 'sse', lb: 'SSE-off' },
+  ];
+
+  // ─── SectionCard — labelled block used across the board ────────────────────
+  const SectionCard = ({ title, entity = 'session', badge, right, children, pad = 12, accent }) => (
+    <section style={{
+      background: 'var(--bg-card)', border: `1px solid ${accent ? eHsl(entity, 0.35) : 'var(--border)'}`,
+      borderRadius: 'var(--r-lg)', overflow: 'hidden', boxShadow: 'var(--shadow-sm)', flexShrink: 0,
+    }}>
+      {title && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: accent ? eHsl(entity, 0.06) : 'var(--bg-muted)', borderBottom: '1px solid var(--border-light)' }}>
+          <span style={{ ...mono(10, 800, accent ? eHsl(entity) : 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{title}</span>
+          {badge != null && <span style={{ ...mono(9, 800, eHsl(entity)), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl(entity, 0.12), border: `1px solid ${eHsl(entity, 0.28)}` }}>{badge}</span>}
+          <div style={{ flex: 1 }} />
+          {right}
+        </div>
+      )}
+      <div style={{ padding: pad }}>{children}</div>
+    </section>
+  );
+
+  // ═══ PLAYER MAT (per-player state) ════════════════════════════════════════
+  const RoleChip = ({ roleId }) => {
+    const role = PR.ROLES.find(r => r.id === roleId);
+    if (!role) return null;
+    return (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl(role.e, 0.12), color: eHsl(role.e), border: `1px solid ${eHsl(role.e, 0.3)}`, ...mono(9, 800), textTransform: 'uppercase', letterSpacing: '.04em' }}>
+        <span aria-hidden="true">{role.icon}</span>{role.lb}
+      </span>
+    );
+  };
+
+  const PlayerMat = ({ player, active, compact, tileSize = 30, bw = 78 }) => {
+    const m = player.mat;
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 11 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <F.MiniAvatar p={player} size={34} ring={active} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ ...disp(15, 800, 'var(--text)') }}>{player.name}</span>
+              {player.governor && <F.GovernorToken size="sm" />}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+              <RoleChip roleId={player.role} />
+              {active && <span style={{ ...mono(8.5, 800, eHsl('session')), textTransform: 'uppercase', letterSpacing: '.05em' }}>● sta giocando</span>}
+            </div>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ ...disp(22, 800, eHsl('toolkit')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{m.vp}</div>
+            <div style={{ ...mono(8, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>PV chip</div>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 6 }}>
+          <F.SupplyCounter kind="doubloon" value={m.doubloons} sub="Dobloni" />
+          <F.SupplyCounter kind="colonist" value={m.colonistsAvail} sub="Coloni liberi" />
+        </div>
+
+        <F.StorehouseRow store={m.storehouse} />
+        <F.PlantationGrid tiles={m.plantations} size={tileSize} cols={compact ? 6 : 4} />
+        <F.BuildingGrid buildings={m.buildings} w={bw} cols={compact ? 4 : 3} />
+      </div>
+    );
+  };
+
+  // collapsed strip of the OTHER players → open drawer
+  const OtherPlayersBar = ({ players, activeId, onOpen }) => (
+    <div>
+      <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Altri giocatori · plance</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {players.filter(p => p.id !== activeId).map(p => (
+          <button key={p.id} type="button" onClick={() => onOpen(p.id)} aria-label={`Apri plancia di ${p.name}`} style={{
+            display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 'var(--r-md)',
+            background: 'var(--bg-card)', border: '1px solid var(--border)', cursor: 'pointer', textAlign: 'left', width: '100%',
+          }}>
+            <F.MiniAvatar p={p} size={26} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ ...disp(12.5, 800, 'var(--text)') }}>{p.name}</span>
+                {p.governor && <span aria-hidden="true" style={{ width: 11, height: 11, borderRadius: '50%', background: 'radial-gradient(circle at 35% 30%, #ffe9a8, #d4a017)', border: '1px solid #b8860b' }} title="Governatore" />}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 3 }}>
+                {PR.GOODS.map(g => p.mat.storehouse[g.id] ? <F.GoodToken key={g.id} id={g.id} size={13} /> : null)}
+                <span style={{ ...mono(9, 700, 'var(--text-muted)'), marginLeft: 2 }}>· {p.mat.doubloons}🪙</span>
+              </div>
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ ...disp(15, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{p.mat.vp}</div>
+              <span style={{ ...mono(8.5, 800, eHsl('session')) }}>apri ›</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  const PlayerMatDrawer = ({ player, open, onClose, side }) => (
+    <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+      <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,12,30,.5)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+      <div role="dialog" aria-modal="true" aria-label={player ? `Plancia di ${player.name}` : 'Plancia'} style={{
+        position: 'absolute', background: 'var(--bg-card)', boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0,
+        ...(side === 'right'
+          ? { top: 0, bottom: 0, right: 0, width: 'min(380px, 86%)', borderLeft: `3px solid ${eHsl('player')}`, transform: open ? 'translateX(0)' : 'translateX(101%)', transition: 'transform var(--dur-md) var(--ease-spring)' }
+          : { left: 0, right: 0, bottom: 0, height: '86%', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl('player')}`, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }),
+      }}>
+        {side !== 'right' && <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}><div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} /></div>}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', borderBottom: '1px solid var(--border-light)', flexShrink: 0 }}>
+          <span style={{ ...mono(10, 800, eHsl('player')), textTransform: 'uppercase', letterSpacing: '.06em' }}>Plancia giocatore</span>
+          <div style={{ flex: 1 }} />
+          <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+        </div>
+        <div style={{ flex: 1, overflowY: 'auto', padding: 14, minHeight: 0 }}>
+          {player && <PlayerMat player={player} active={player.current} tileSize={28} bw={74} />}
+        </div>
+      </div>
+    </div>
+  );
+
+  // ═══ ROLE SELECTION BOARD ═════════════════════════════════════════════════
+  const RoleSelectionBoard = ({ compact, rows }) => {
+    const rs = PR.roleState;
+    const fivePlayer = PR.roster.length >= 5;
+    const roles = PR.ROLES.filter(r => !r.fivePlayerOnly || fivePlayer);
+    const showProsp2 = PR.ROLES.find(r => r.id === 'prospector2');
+    const list = fivePlayer ? roles : [...roles, showProsp2];
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 9, flexWrap: 'wrap' }}>
+          <span style={{ ...disp(14, 800, 'var(--text)') }}>Selezione ruoli</span>
+          <span style={{ ...mono(9.5, 800, eHsl('session')), padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.12), border: `1px solid ${eHsl('session', 0.3)}` }}>Round {rs.round}</span>
+          <div style={{ flex: 1 }} />
+          <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>governatore</span>
+          <F.MiniAvatar p={playerById(rs.chosenBy.captain) ? PR.roster.find(p => p.governor) : PR.roster[0]} size={20} />
+        </div>
+        <div style={{
+          display: compact ? 'flex' : 'grid', gap: 8,
+          ...(compact
+            ? { overflowX: 'auto', paddingBottom: 6 }
+            : { gridTemplateColumns: `repeat(${rows || 4}, minmax(0, 1fr))` }),
+        }} className={compact ? 'mai-cb-scroll' : undefined}>
+          {list.map(role => {
+            const disabled = role.fivePlayerOnly && !fivePlayer;
+            return (
+              <F.RoleCard
+                key={role.id}
+                role={role}
+                active={rs.activeRole === role.id}
+                chosenBy={rs.chosenBy[role.id] ? playerById(rs.chosenBy[role.id]) : null}
+                doubloons={rs.doubloonsOn[role.id] || 0}
+                disabled={disabled}
+                compact={compact}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  // ═══ SHARED STATE PIECES ══════════════════════════════════════════════════
+  // — Galleons (Captain phase) — stateful —
+  const ShipRow = ({ ship }) => {
+    const g = ship.good;
+    const full = ship.loaded >= ship.cap;
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: `1px solid ${full ? eHsl('toolkit', 0.4) : 'var(--border-light)'}` }}>
+        <span aria-hidden="true" style={{ fontSize: 18, flexShrink: 0 }}>⛵</span>
+        <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', flex: 1 }} aria-label={g ? `${ship.loaded} ${F.goodOf(g).lb} su ${ship.cap}` : `galeone vuoto, capacità ${ship.cap}`}>
+          {Array.from({ length: ship.cap }).map((_, i) => i < ship.loaded
+            ? <F.GoodToken key={i} id={g} size={17} />
+            : <span key={i} aria-hidden="true" style={{ width: 17, height: 17, borderRadius: '50%', border: '1.5px dashed var(--border-strong)', background: 'var(--bg-sunken)' }} />)}
+        </div>
+        <div style={{ textAlign: 'right', flexShrink: 0 }}>
+          <div style={{ ...mono(11, 800, full ? eHsl('toolkit') : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{ship.loaded}/{ship.cap}</div>
+          <div style={{ ...mono(8, 700, 'var(--text-muted)') }}>{full ? 'pieno' : g ? F.goodOf(g).lb : 'libero'}</div>
+        </div>
+      </div>
+    );
+  };
+  const GalleonsShipping = ({ state = 'default', compact }) => (
+    <R.StateScaffold state={state} sseWhere="spedizioni"
+      empty={{ icon: '⛵', title: 'Nessun galeone in uso', body: 'I galeoni compaiono all’avvio della fase Capitano.' }}
+      error={{ title: 'Galeoni non disponibili', body: 'Impossibile leggere lo stato di spedizione.' }}>
+      <R.Panel gap={9}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <R.Label>Galeoni · fase Capitano</R.Label>
+          <div style={{ flex: 1 }} />
+          <span style={{ ...mono(9, 800, eHsl('event')), padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.1), border: `1px solid ${eHsl('event', 0.28)}` }}>obbligo</span>
+        </div>
+        <div style={{ ...mono(9.5, 700, 'var(--text-muted)'), lineHeight: 1.4 }}>Ogni nave porta <strong>un solo tipo</strong> di merce. Devi spedire se puoi.</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          {PR.shared.galleons.map(s => <ShipRow key={s.id} ship={s} />)}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 'var(--r-md)', background: eHsl('session', 0.07), border: `1px solid ${eHsl('session', 0.28)}` }}>
+          <F.MiniAvatar p={playerById('p-marco')} size={22} />
+          <span style={{ ...mono(10, 700, 'var(--text-sec)'), flex: 1 }}>Tocca a <strong style={{ color: 'var(--text)' }}>Marco</strong> — spedisce <strong>mais</strong> · +1 PV privilegio</span>
+        </div>
+      </R.Panel>
+    </R.StateScaffold>
+  );
+
+  // — Trading house (Trader phase) — stateful —
+  const TradingHouseSlots = ({ state = 'default' }) => {
+    const th = PR.shared.tradingHouse;
+    return (
+      <R.StateScaffold state={state} sseWhere="commercio"
+        empty={{ icon: '⚖️', title: 'Casa commerciale vuota', body: 'Gli slot si riempiono quando un mercante vende una merce.' }}
+        error={{ title: 'Commercio non disponibile', body: 'Impossibile leggere la casa commerciale.' }}>
+        <R.Panel gap={10}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <R.Label>Casa commerciale · 4 slot</R.Label>
+            <div style={{ flex: 1 }} />
+            <span style={{ ...mono(9, 800, eHsl('chat')), padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('chat', 0.1), border: `1px solid ${eHsl('chat', 0.28)}` }}>{th.slots.filter(Boolean).length}/4</span>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 7 }}>
+            {th.slots.map((s, i) => (
+              <div key={i} style={{ aspectRatio: '1', borderRadius: 'var(--r-md)', border: s ? `1px solid ${eHsl('chat', 0.35)}` : '1.5px dashed var(--border-strong)', background: s ? eHsl('chat', 0.06) : 'var(--bg-sunken)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
+                {s ? (<>
+                  <F.GoodToken id={s.good} size={24} />
+                  <span style={{ ...mono(9, 800, eHsl('chat')) }}>+{s.price}🪙</span>
+                </>) : <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>vuoto</span>}
+              </div>
+            ))}
+          </div>
+          <R.Label>Prezzo base per merce</R.Label>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {PR.GOODS.map(g => (
+              <span key={g.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 8px 3px 4px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+                <F.GoodToken id={g.id} size={15} />
+                <span style={{ ...mono(10, 800, 'var(--text)') }}>{th.basePrice[g.id]}</span>
+                <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>🪙</span>
+              </span>
+            ))}
+          </div>
+          <div style={{ ...mono(9, 700, 'var(--text-muted)'), lineHeight: 1.4 }}>Max 1 merce per tipo (salvo Ufficio). Si svuota quando i 4 slot sono pieni.</div>
+        </R.Panel>
+      </R.StateScaffold>
+    );
+  };
+
+  // — Colonist ship —
+  const ColonistShip = ({ compact }) => {
+    const c = PR.shared.colonistShip;
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span aria-hidden="true" style={{ fontSize: 18 }}>🚢</span>
+          <span style={{ ...disp(12.5, 800, 'var(--text)') }}>Nave coloni</span>
+          <div style={{ flex: 1 }} />
+          <span style={{ ...mono(9, 800, eHsl('game')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('game', 0.12), border: `1px solid ${eHsl('game', 0.28)}` }}>+{c.incoming} in arrivo</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', flexWrap: 'wrap' }} aria-label={`${c.onShip} coloni sulla nave`}>
+          {Array.from({ length: c.onShip }).map((_, i) => <F.ColonistPip key={i} size={14} />)}
+          <span style={{ ...mono(9.5, 700, 'var(--text-muted)'), marginLeft: 4 }}>sulla nave</span>
+        </div>
+        <div style={{ ...mono(9, 700, 'var(--text-muted)') }}>Riserva coloni: <strong style={{ color: 'var(--text)' }}>{c.supply}</strong> · fine partita se si esaurisce</div>
+      </div>
+    );
+  };
+
+  // — Available plantations + quarry stack —
+  const AvailablePlantations = () => {
+    const p = PR.shared.plantations;
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+          <span style={{ ...disp(12.5, 800, 'var(--text)') }}>Piantagioni disponibili</span>
+          <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>scoperte {p.faceUp.length} · +{p.faceDown} coperta</span>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+          {p.faceUp.map((t, i) => <F.PlantationTile key={i} tile={{ t, c: false }} size={32} />)}
+          <div aria-label="tessera coperta" style={{ width: 32, height: 32, borderRadius: 'var(--r-sm)', background: 'repeating-linear-gradient(45deg, var(--bg-sunken), var(--bg-sunken) 4px, var(--bg-muted) 4px, var(--bg-muted) 8px)', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(13, 800, 'var(--text-muted)') }}>?</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginLeft: 4, paddingLeft: 8, borderLeft: '1px solid var(--border)' }}>
+            <F.GoodToken id="quarry" size={28} />
+            <div>
+              <div style={{ ...disp(14, 800, 'var(--text)'), lineHeight: 1 }}>{p.quarryStack}</div>
+              <div style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase' }}>cave</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // — Building supply offer —
+  const BuildingSupplyBoard = () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <span style={{ ...disp(12.5, 800, 'var(--text)') }}>Offerta edifici</span>
+      <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap' }}>
+        {PR.shared.buildingSupply.map((b, i) => {
+          const ks = F.KIND_STYLE[b.kind];
+          return (
+            <div key={i} style={{ width: 96, padding: '7px 8px', borderRadius: 'var(--r-sm)', background: b.kind === 'large' ? eHsl('player', 0.1) : 'var(--bg-card)', border: `1px solid ${b.kind === 'large' ? eHsl('player', 0.4) : eHsl(ks.e, 0.3)}`, position: 'relative' }}>
+              <span style={{ position: 'absolute', top: 5, right: 5, width: 14, height: 14, borderRadius: 'var(--r-xs)', background: PR.SUPPLY.vp.color, color: '#fff', ...mono(9, 800), display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>{b.vp}</span>
+              <div style={{ ...disp(11, 800, 'var(--text)'), paddingRight: 16, lineHeight: 1.15 }}>{b.n}</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 5 }}>
+                <span style={{ ...mono(10, 800, eHsl('game')) }}>{b.cost}🪙</span>
+                <div style={{ flex: 1 }} />
+                <span style={{ ...mono(8.5, 700, b.left ? 'var(--text-muted)' : eHsl('event')) }}>×{b.left}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  // — Composed shared board for the center column —
+  const SharedStateBoard = ({ compact }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <SectionCard title="Stato condiviso · spedizione" entity="session" accent badge="Capitano">
+        <GalleonsShipping />
+      </SectionCard>
+      <div style={{ display: 'grid', gridTemplateColumns: compact ? '1fr' : '1fr 1fr', gap: 12 }}>
+        <SectionCard title="Rifornimenti"><AvailablePlantations /></SectionCard>
+        <SectionCard title="Coloni"><ColonistShip /></SectionCard>
+      </div>
+      <SectionCard title="Edifici acquistabili"><BuildingSupplyBoard /></SectionCard>
+    </div>
+  );
+
+  // ═══ RIGHT COLUMN TABS (Scoring · Roles · Trade · Ship · Chat) ════════════
+  const RolesTab = ({ state = 'default' }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflowY: 'auto' }}>
+      <div style={{ padding: 12, borderBottom: '1px solid var(--border-light)' }}>
+        <RoleSelectionBoard compact />
+      </div>
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <R.TurnIndicatorRenderer data={PR.ds} state={state} />
+      </div>
+    </div>
+  );
+
+  const StateSwitch = ({ value, onChange }) => (
+    <div className="mai-cb-scroll" role="group" aria-label="Stato del componente" style={{ display: 'flex', gap: 4, overflowX: 'auto', padding: '7px 10px', borderBottom: '1px solid var(--border-light)', background: 'var(--bg)', flexShrink: 0 }}>
+      <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', alignSelf: 'center', flexShrink: 0, marginRight: 2 }}>Stato</span>
+      {STATES.map(s => {
+        const active = value === s.id;
+        return (
+          <button key={s.id} type="button" onClick={() => onChange(s.id)} aria-pressed={active} style={{ padding: '3px 9px', borderRadius: 'var(--r-pill)', flexShrink: 0, background: active ? eHsl('session', 0.14) : 'var(--bg-card)', border: active ? `1px solid ${eHsl('session', 0.4)}` : '1px solid var(--border)', color: active ? eHsl('session') : 'var(--text-sec)', ...mono(9.5, 800), cursor: 'pointer' }}>{s.lb}</button>
+        );
+      })}
+    </div>
+  );
+
+  const TABS = [
+    { id: 'scoring', icon: '🎯', label: 'Scoring', entity: 'session', stateful: true,  render: (st) => <R.ScoringPanelRenderer data={PR.ds} state={st} /> },
+    { id: 'roles',   icon: '🗳️', label: 'Roles',   entity: 'player',  stateful: true,  render: (st) => <RolesTab state={st} /> },
+    { id: 'trade',   icon: '⚖️', label: 'Trade',   entity: 'chat',    stateful: true,  render: (st) => <TradingHouseSlots state={st} /> },
+    { id: 'ship',    icon: '⛵', label: 'Ship',    entity: 'toolkit', stateful: true,  render: (st) => <GalleonsShipping state={st} /> },
+    { id: 'chat',    icon: '💬', label: 'Chat',    entity: 'agent',   stateful: false, render: () => <div style={{ flex: 1, minHeight: 0, display: 'flex', padding: 10 }}><S.ChatAgentPanel ds={PR.ds} /></div> },
+  ];
+
+  const RightColumnTabs = ({ initial = 'ship', initialState = 'default', width = 360, embedded }) => {
+    const [tab, setTab] = useState(initial);
+    const [st, setSt] = useState(initialState);
+    const active = TABS.find(t => t.id === tab) || TABS[0];
+    return (
+      <aside aria-label="Pannelli sessione Puerto Rico" style={{ width: embedded ? '100%' : width, flexShrink: 0, height: '100%', background: 'var(--bg-card)', borderLeft: embedded ? 'none' : '1px solid var(--border)', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <div role="tablist" aria-label="Sezioni" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0 }}>
+          {TABS.map(t => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} title={t.label} onClick={() => setTab(t.id)} style={{ flex: 1, minWidth: 0, padding: '10px 4px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(11.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, whiteSpace: 'nowrap' }}>
+                <span aria-hidden="true" style={{ fontSize: 14 }}>{t.icon}</span><span>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        {active.stateful && <StateSwitch value={st} onChange={setSt} />}
+        <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+      </aside>
+    );
+  };
+
+  // ═══ DESKTOP BODY (3 regions + right tabs) ════════════════════════════════
+  const DesktopBody = ({ initialTab = 'ship', initialState = 'default' }) => {
+    const active = PR.roster.find(p => p.current) || PR.roster[0];
+    const [drawer, setDrawer] = useState(null);
+    return (
+      <div style={{ display: 'flex', flex: 1, minHeight: 0, position: 'relative' }}>
+        {/* LEFT — active mat + other players */}
+        <div style={{ width: 312, flexShrink: 0, borderRight: '1px solid var(--border)', overflowY: 'auto', padding: 14, display: 'flex', flexDirection: 'column', gap: 14, background: 'var(--bg-card)' }}>
+          <SectionCard title="Plancia · giocatore attivo" entity="session" accent pad={12}>
+            <PlayerMat player={active} active tileSize={30} bw={84} />
+          </SectionCard>
+          <OtherPlayersBar players={PR.roster} activeId={active.id} onOpen={setDrawer} />
+        </div>
+        {/* CENTER — role board + shared state + log */}
+        <main style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: 16, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <SectionCard title="Tavolo · selezione ruoli" entity="session" accent pad={14}>
+            <RoleSelectionBoard />
+          </SectionCard>
+          <SharedStateBoard />
+          <S.ActionLogTimeline ds={PR.ds} />
+        </main>
+        {/* RIGHT — tabs */}
+        <RightColumnTabs initial={initialTab} initialState={initialState} />
+        <PlayerMatDrawer player={drawer ? playerById(drawer) : null} open={!!drawer} side="right" onClose={() => setDrawer(null)} />
+      </div>
+    );
+  };
+
+  // ═══ MOBILE BODY ══════════════════════════════════════════════════════════
+  const MobileTabSheet = ({ open, tab, st, setSt, onClose }) => {
+    const active = TABS.find(t => t.id === tab) || TABS[0];
+    return (
+      <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+        <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,12,30,.5)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+        <div role="dialog" aria-modal="true" aria-label={active.label} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '84%', background: 'var(--bg-card)', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl(active.entity)}`, boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }}>
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}><div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} /></div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px 10px', flexShrink: 0 }}>
+            <span aria-hidden="true" style={{ fontSize: 16 }}>{active.icon}</span>
+            <span style={{ ...disp(15, 800, eHsl(active.entity)) }}>{active.label}</span>
+            <div style={{ flex: 1 }} />
+            <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+          </div>
+          {active.stateful && <StateSwitch value={st} onChange={setSt} />}
+          <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const MobileBody = ({ initialTab }) => {
+    const active = PR.roster.find(p => p.current) || PR.roster[0];
+    const [sheet, setSheet] = useState(initialTab || null);
+    const [st, setSt] = useState('default');
+    const [matDrawer, setMatDrawer] = useState(null);
+    return (
+      <>
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, background: 'var(--bg)' }}>
+          <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <SectionCard title="Selezione ruoli" entity="session" accent pad={12}>
+              <RoleSelectionBoard compact />
+            </SectionCard>
+            <SectionCard title="Spedizione · Capitano" entity="session" accent badge="obbligo" pad={0}>
+              <GalleonsShipping />
+            </SectionCard>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
+              <SectionCard title="Rifornimenti"><AvailablePlantations /></SectionCard>
+            </div>
+            <S.ActionLogTimeline ds={PR.ds} compact />
+          </div>
+        </div>
+        {/* mat access bar */}
+        <div className="mai-cb-scroll" style={{ display: 'flex', gap: 6, overflowX: 'auto', flexShrink: 0, padding: '7px 10px', background: 'var(--bg-muted)', borderTop: '1px solid var(--border-light)' }}>
+          <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', alignSelf: 'center', flexShrink: 0 }}>Plance</span>
+          {PR.roster.map(p => (
+            <button key={p.id} type="button" onClick={() => setMatDrawer(p.id)} style={{ flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px 4px 4px', borderRadius: 'var(--r-pill)', background: p.current ? eHsl('session', 0.12) : 'var(--bg-card)', border: `1px solid ${p.current ? eHsl('session', 0.35) : 'var(--border)'}`, cursor: 'pointer' }}>
+              <F.MiniAvatar p={p} size={18} ring={p.current} />
+              <span style={{ ...disp(11, 800, 'var(--text)') }}>{p.name}</span>
+              <span style={{ ...mono(10, 800, eHsl('toolkit')) }}>{p.mat.vp}</span>
+            </button>
+          ))}
+        </div>
+        {/* tab strip */}
+        <nav className="mai-cb-scroll" aria-label="Sezioni sessione" style={{ display: 'flex', gap: 6, overflowX: 'auto', flexShrink: 0, padding: '8px 10px', background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderTop: '1px solid var(--border)' }}>
+          {TABS.map(t => (
+            <button key={t.id} type="button" onClick={() => { setSt('default'); setSheet(t.id); }} style={{ flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 5, padding: '7px 13px', borderRadius: 'var(--r-pill)', background: eHsl(t.entity, 0.1), border: `1px solid ${eHsl(t.entity, 0.28)}`, color: eHsl(t.entity), ...disp(12, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true">{t.icon}</span>{t.label}
+            </button>
+          ))}
+        </nav>
+        <MobileTabSheet open={!!sheet} tab={sheet} st={st} setSt={setSt} onClose={() => setSheet(null)} />
+        <PlayerMatDrawer player={matDrawer ? playerById(matDrawer) : null} open={!!matDrawer} onClose={() => setMatDrawer(null)} />
+      </>
+    );
+  };
+
+  // ═══ FRAMES ═══════════════════════════════════════════════════════════════
+  const PhoneSbar = () => (
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>15:18</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+  );
+  const PhoneShell = ({ label, desc, dark, initialTab }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+      <div className="phone" data-theme={dark ? 'dark' : undefined}>
+        <PhoneSbar />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <S.TopBar ds={PR.ds} compact />
+          <MobileBody initialTab={initialTab} />
+        </div>
+      </div>
+      {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 340, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  // states-gallery rail frame
+  const PanelFrame = ({ label, entity, dark, children, w = 320, h = 480 }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} data-theme={dark ? 'dark' : undefined}>
+      <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</div>
+      <div style={{ width: w, height: h, borderRadius: 'var(--r-lg)', border: `1px solid ${eHsl(entity, 0.3)}`, background: 'var(--bg-card)', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: 'var(--shadow-sm)' }}>{children}</div>
+    </div>
+  );
+
+  window.PRParts = {
+    SectionCard, RoleChip, PlayerMat, OtherPlayersBar, PlayerMatDrawer,
+    RoleSelectionBoard, GalleonsShipping, TradingHouseSlots, ColonistShip,
+    AvailablePlantations, BuildingSupplyBoard, SharedStateBoard,
+    RolesTab, RightColumnTabs, StateSwitch, TABS, STATES,
+    DesktopBody, MobileBody, PhoneShell, PanelFrame,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-puerto-rico-summary.html
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-summary.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Puerto Rico · Summary — /sessions/[id]/summary</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-data.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-puerto-rico-summary.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-puerto-rico-summary.jsx
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-summary.jsx
@@ -1,0 +1,346 @@
+/* MeepleAI SP4 · Puerto Rico — SESSION SUMMARY  (App)
+   /sessions/[id]/summary — post-game recap for a finished Puerto Rico session.
+
+   Tabs:
+     Hero (always-on)  · final VP totals + winner banner + stacked breakdown bar
+     Scoreboard        · analytic per-player breakdown:
+                         buildings VP (per building) · shipped goods (per type) ·
+                         large building bonuses (per building, custom computation)
+     Final Board       · snapshot of every player's mat (plantations+buildings+coloni)
+     Round Recap       · who picked which role each round (governor rotation)
+     Stats             · per-player averages / maxima (VP/min, top role, totals)
+
+   Reuses: window.PRFlavor (goods/avatars) · window.PRParts (PlayerMat ·
+   SectionCard · RoleChip) · window.PR (dataset + PR.summary). Dark = primary.
+
+   Loads: sp4-parts-common · skeleton-renderers · skeleton-data(shim) ·
+          skeleton-parts · puerto-rico-data · puerto-rico-flavor · puerto-rico-parts
+   DEMO-NAV-HINTS: sp4-session-puerto-rico-live.html
+*/
+
+const M = window.MAI;
+const F = window.PRFlavor;
+const P = window.PRParts;
+const PR = window.PR;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+const mono = F.mono, disp = F.disp;
+const sum = window.PR.summary;
+const byId = (id) => PR.roster.find(p => p.id === id);
+
+// final ranking (desc by total)
+const RANKED = [...PR.roster].map(p => ({ ...p, fin: sum.finalScore[p.id] }))
+  .sort((a, b) => b.fin.total - a.fin.total);
+const WINNER = RANKED[0];
+const MAXTOTAL = WINNER.fin.total;
+
+// breakdown segment palette (consistent everywhere)
+const SEG = [
+  { key: 'building', e: 'kb',      lb: 'Edifici' },
+  { key: 'shipped',  e: 'session', lb: 'Spedizioni' },
+  { key: 'large',    e: 'player',  lb: 'Bonus grandi' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+// stacked breakdown bar (building / shipped / large)
+const StackBar = ({ fin, max, h = 12 }) => (
+  <div style={{ display: 'flex', height: h, borderRadius: 'var(--r-pill)', overflow: 'hidden', background: 'var(--bg-sunken)', width: '100%' }} aria-hidden="true">
+    {SEG.map(s => (
+      <div key={s.key} title={`${s.lb}: ${fin[s.key]}`} style={{ width: `${(fin[s.key] / max) * 100}%`, background: eHsl(s.e), height: '100%' }} />
+    ))}
+  </div>
+);
+
+// ═══ HERO ═════════════════════════════════════════════════════════════════
+const WinnerHero = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1.1fr) minmax(0,1fr)', gap: 18, alignItems: 'stretch' }} className="pr-hero-grid">
+    {/* winner banner */}
+    <div style={{ position: 'relative', overflow: 'hidden', borderRadius: 'var(--r-2xl)', border: `1px solid ${eHsl('toolkit', 0.4)}`, background: `linear-gradient(135deg, ${eHsl('toolkit', 0.16)}, ${eHsl('session', 0.12)})`, padding: 22, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', minHeight: 230 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ ...mono(10, 800, eHsl('toolkit')), padding: '3px 10px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.16), border: `1px solid ${eHsl('toolkit', 0.4)}`, textTransform: 'uppercase', letterSpacing: '.06em' }}>🏆 Vincitore</span>
+        <span style={{ ...mono(10, 700, 'var(--text-sec)') }}>Partita conclusa · {sum.durationMin} min</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        <F.MiniAvatar p={WINNER} size={72} ring />
+        <div>
+          <div style={{ ...disp(30, 800, 'var(--text)'), lineHeight: 1 }}>{WINNER.name}</div>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginTop: 4 }}>
+            <span style={{ ...disp(42, 800, eHsl('toolkit')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{WINNER.fin.total}</span>
+            <span style={{ ...mono(12, 800, 'var(--text-sec)') }}>PV totali</span>
+          </div>
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {SEG.map(s => (
+          <span key={s.key} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, ...mono(10, 800, eHsl(s.e)), padding: '3px 9px', borderRadius: 'var(--r-pill)', background: eHsl(s.e, 0.12), border: `1px solid ${eHsl(s.e, 0.3)}` }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: eHsl(s.e) }} aria-hidden="true" />{s.lb} {WINNER.fin[s.key]}
+          </span>
+        ))}
+      </div>
+    </div>
+    {/* podium / standings */}
+    <div style={{ borderRadius: 'var(--r-2xl)', border: '1px solid var(--border)', background: 'var(--bg-card)', padding: 16, display: 'flex', flexDirection: 'column', gap: 9 }}>
+      <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Classifica finale</div>
+      {RANKED.map((p, i) => (
+        <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '7px 9px', borderRadius: 'var(--r-md)', background: i === 0 ? eHsl('toolkit', 0.08) : 'var(--bg-muted)', border: `1px solid ${i === 0 ? eHsl('toolkit', 0.3) : 'var(--border-light)'}` }}>
+          <span style={{ ...mono(12, 800, i === 0 ? eHsl('toolkit') : 'var(--text-muted)'), width: 18 }}>{i + 1}°</span>
+          <F.MiniAvatar p={p} size={28} ring={i === 0} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ ...disp(13.5, 800, 'var(--text)') }}>{p.name}</div>
+            <div style={{ marginTop: 4 }}><StackBar fin={p.fin} max={MAXTOTAL} h={8} /></div>
+          </div>
+          <span style={{ ...disp(20, 800, i === 0 ? eHsl('toolkit') : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{p.fin.total}</span>
+        </div>
+      ))}
+      <div style={{ ...mono(9.5, 700, 'var(--text-muted)'), marginTop: 2, lineHeight: 1.4 }}>Fine partita: {sum.endTrigger}</div>
+    </div>
+  </div>
+);
+
+// ═══ SCOREBOARD TAB ═══════════════════════════════════════════════════════
+const ScoreboardTab = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+    {/* totals matrix */}
+    <P.SectionCard title="Matrice punteggi" entity="session" accent>
+      <div style={{ overflowX: 'auto' }} className="mai-cb-scroll">
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 460 }}>
+          <thead>
+            <tr>
+              <th style={thStyle('left')}>Giocatore</th>
+              {SEG.map(s => <th key={s.key} style={thStyle('right', eHsl(s.e))}>{s.lb}</th>)}
+              <th style={thStyle('right')}>Totale</th>
+            </tr>
+          </thead>
+          <tbody>
+            {RANKED.map((p, i) => (
+              <tr key={p.id} style={{ background: i === 0 ? eHsl('toolkit', 0.06) : 'transparent' }}>
+                <td style={tdStyle('left')}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+                    <F.MiniAvatar p={p} size={22} ring={i === 0} />
+                    <span style={{ ...disp(12.5, 800, 'var(--text)') }}>{p.name}</span>
+                  </span>
+                </td>
+                {SEG.map(s => <td key={s.key} style={tdStyle('right')}><span style={{ ...mono(12, 800, eHsl(s.e)) }}>{p.fin[s.key]}</span></td>)}
+                <td style={tdStyle('right')}><span style={{ ...disp(16, 800, i === 0 ? eHsl('toolkit') : 'var(--text)') }}>{p.fin.total}</span></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </P.SectionCard>
+
+    {/* per-player breakdown cards */}
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(290px, 1fr))', gap: 14 }}>
+      {RANKED.map((p, i) => (
+        <P.SectionCard key={p.id} title={`${p.name} · ${p.fin.total} PV`} entity={i === 0 ? 'toolkit' : 'session'} accent={i === 0}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {/* buildings VP */}
+            <div>
+              <BreakHead e="kb" lb="Edifici · PV stampati" total={p.fin.building} />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3, marginTop: 6 }}>
+                {sum.buildingVP[p.id].map((b, k) => (
+                  <div key={k} style={rowStyle}>
+                    <span style={{ ...disp(11.5, 700, 'var(--text)'), flex: 1 }}>{b[0]}</span>
+                    <span style={{ width: 16, height: 16, borderRadius: 'var(--r-xs)', background: PR.SUPPLY.vp.color, color: '#fff', ...mono(9, 800), display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>{b[1]}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            {/* shipped goods */}
+            <div>
+              <BreakHead e="session" lb="Merci spedite · 1 PV/merce" total={p.fin.shipped} />
+              <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 6 }}>
+                {PR.GOODS.map(g => <F.GoodCount key={g.id} id={g.id} n={sum.shipped[p.id][g.id] || 0} dim />)}
+              </div>
+            </div>
+            {/* large bonuses */}
+            <div>
+              <BreakHead e="player" lb="Bonus edifici grandi" total={p.fin.large} />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5, marginTop: 6 }}>
+                {sum.largeBonus[p.id].map((b, k) => (
+                  <div key={k} style={{ padding: '7px 9px', borderRadius: 'var(--r-sm)', background: eHsl('player', 0.08), border: `1px solid ${eHsl('player', 0.28)}` }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <span style={{ ...disp(12, 800, eHsl('player')), flex: 1 }}>{b.n}</span>
+                      <span style={{ ...mono(11, 800, eHsl('player')) }}>+{b.value}</span>
+                    </div>
+                    <div style={{ ...mono(8.5, 600, 'var(--text-muted)'), marginTop: 2, lineHeight: 1.35 }}>{b.rule}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </P.SectionCard>
+      ))}
+    </div>
+  </div>
+);
+const BreakHead = ({ e, lb, total }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 7, paddingBottom: 5, borderBottom: `1px solid ${eHsl(e, 0.25)}` }}>
+    <span style={{ width: 8, height: 8, borderRadius: 2, background: eHsl(e) }} aria-hidden="true" />
+    <span style={{ ...mono(9.5, 800, eHsl(e)), textTransform: 'uppercase', letterSpacing: '.05em', flex: 1 }}>{lb}</span>
+    <span style={{ ...disp(14, 800, 'var(--text)') }}>{total}</span>
+  </div>
+);
+const rowStyle = { display: 'flex', alignItems: 'center', gap: 8, padding: '4px 8px', borderRadius: 'var(--r-sm)', background: 'var(--bg-muted)' };
+const thStyle = (align, color) => ({ textAlign: align, padding: '6px 10px', ...mono(9, 800, color || 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', borderBottom: '1px solid var(--border)', whiteSpace: 'nowrap' });
+const tdStyle = (align) => ({ textAlign: align, padding: '8px 10px', borderBottom: '1px solid var(--border-light)' });
+
+// ═══ FINAL BOARD TAB ══════════════════════════════════════════════════════
+const FinalBoardTab = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(330px, 1fr))', gap: 14 }}>
+    {RANKED.map((p, i) => (
+      <P.SectionCard key={p.id} title={`Plancia finale · ${p.name}`} entity={i === 0 ? 'toolkit' : 'session'} accent={i === 0}
+        right={<span style={{ ...disp(14, 800, eHsl('toolkit')) }}>{p.fin.total} PV</span>}>
+        <P.PlayerMat player={p} active={false} tileSize={26} bw={72} compact />
+      </P.SectionCard>
+    ))}
+  </div>
+);
+
+// ═══ ROUND RECAP TAB ══════════════════════════════════════════════════════
+const RoundRecapTab = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    {sum.recap.map(r => (
+      <P.SectionCard key={r.round} title={`Round ${r.round}`} entity="player"
+        right={<span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}><span style={{ ...mono(9, 700, 'var(--text-muted)') }}>governatore</span><F.MiniAvatar p={byId(r.governor)} size={18} /></span>}>
+        <div className="mai-cb-scroll" style={{ display: 'flex', gap: 10, overflowX: 'auto', paddingBottom: 4, alignItems: 'stretch' }}>
+          {r.picks.map((pk, i) => {
+            const pl = byId(pk[0]);
+            return (
+              <React.Fragment key={i}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, minWidth: 130, flexShrink: 0, padding: '9px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <F.MiniAvatar p={pl} size={20} />
+                    <span style={{ ...disp(12, 800, 'var(--text)') }}>{pl.name}</span>
+                  </div>
+                  <P.RoleChip roleId={pk[1]} />
+                </div>
+                {i < r.picks.length - 1 && <span aria-hidden="true" style={{ alignSelf: 'center', color: 'var(--text-muted)', ...mono(13, 800) }}>→</span>}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      </P.SectionCard>
+    ))}
+  </div>
+);
+
+// ═══ STATS TAB ════════════════════════════════════════════════════════════
+const StatTile = ({ lb, value, e = 'session', sub }) => (
+  <div style={{ padding: '10px 12px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', flex: 1, minWidth: 0 }}>
+    <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>{lb}</div>
+    <div style={{ ...disp(18, 800, eHsl(e)), fontVariantNumeric: 'tabular-nums', marginTop: 2 }}>{value}</div>
+    {sub && <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), marginTop: 1 }}>{sub}</div>}
+  </div>
+);
+const StatsTab = () => {
+  const maxShip = Math.max(...PR.roster.map(p => sum.stats[p.id].shippedTot));
+  const maxVpm = Math.max(...PR.roster.map(p => sum.stats[p.id].vpPerMin));
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px,1fr))', gap: 12 }}>
+        <P.SectionCard title="Durata" entity="session"><div style={{ ...disp(24, 800, 'var(--text)') }}>{sum.durationMin}<span style={{ ...mono(11, 700, 'var(--text-muted)'), marginLeft: 4 }}>min</span></div></P.SectionCard>
+        <P.SectionCard title="Round giocati" entity="player"><div style={{ ...disp(24, 800, 'var(--text)') }}>{sum.recap.length}</div></P.SectionCard>
+        <P.SectionCard title="Merci spedite (tot)" entity="toolkit"><div style={{ ...disp(24, 800, 'var(--text)') }}>{PR.roster.reduce((s, p) => s + sum.stats[p.id].shippedTot, 0)}</div></P.SectionCard>
+        <P.SectionCard title="Edifici costruiti" entity="kb"><div style={{ ...disp(24, 800, 'var(--text)') }}>{PR.roster.reduce((s, p) => s + sum.stats[p.id].builtTot, 0)}</div></P.SectionCard>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px,1fr))', gap: 14 }}>
+        {RANKED.map((p, i) => {
+          const st = sum.stats[p.id];
+          return (
+            <P.SectionCard key={p.id} title={p.name} entity={i === 0 ? 'toolkit' : 'session'} accent={i === 0}
+              right={st.shippedTot === maxShip ? <span style={{ ...mono(8.5, 800, eHsl('event')), padding: '1px 6px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.12) }}>top spedizioni</span> : null}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <StatTile lb="PV / min" value={st.vpPerMin.toFixed(2)} e={st.vpPerMin === maxVpm ? 'toolkit' : 'session'} sub={st.vpPerMin === maxVpm ? 'più efficiente' : null} />
+                  <StatTile lb="Coloni piazzati" value={st.colonists} e="game" />
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <StatTile lb="Merci spedite" value={st.shippedTot} e="session" />
+                  <StatTile lb="Edifici" value={st.builtTot} e="kb" />
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+                  <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>Ruolo più scelto</span>
+                  <div style={{ flex: 1 }} />
+                  <P.RoleChip roleId={st.topRole} />
+                  <span style={{ ...mono(10, 800, 'var(--text)') }}>×{st.topRoleCount}</span>
+                </div>
+              </div>
+            </P.SectionCard>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ═══ TABS SHELL ═══════════════════════════════════════════════════════════
+const TABS = [
+  { id: 'scoreboard', icon: '📊', label: 'Scoreboard', entity: 'session', render: () => <ScoreboardTab /> },
+  { id: 'board',      icon: '🗺️', label: 'Final Board', entity: 'game',    render: () => <FinalBoardTab /> },
+  { id: 'recap',      icon: '🔄', label: 'Round Recap', entity: 'player',  render: () => <RoundRecapTab /> },
+  { id: 'stats',      icon: '📈', label: 'Stats',       entity: 'toolkit', render: () => <StatsTab /> },
+];
+
+function App() {
+  const [tab, setTab] = useState('scoreboard');
+  const active = TABS.find(t => t.id === tab);
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Puerto Rico · Summary 🏁</div>
+        <h1>Riepilogo partita — Puerto Rico</h1>
+        <p className="lead">
+          Recap post-partita per <code>/sessions/[id]/summary</code>. Hero con totali finali e vincitore;
+          tab analitici: <strong>Scoreboard</strong> (breakdown edifici · merci spedite · bonus grandi),
+          <strong> Final Board</strong> (snapshot di ogni plancia), <strong>Round Recap</strong> (chi ha scelto
+          quale ruolo), <strong>Stats</strong> (medie e massimi). Dark = modalità primaria.
+        </p>
+
+        <WinnerHero />
+
+        <div role="tablist" aria-label="Sezioni riepilogo" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', margin: '22px 0 16px', borderBottom: '1px solid var(--border)', paddingBottom: 2 }}>
+          {TABS.map(t => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} onClick={() => setTab(t.id)} style={{
+                display: 'inline-flex', alignItems: 'center', gap: 6, padding: '9px 15px', borderRadius: 'var(--r-md) var(--r-md) 0 0',
+                background: on ? eHsl(t.entity, 0.1) : 'transparent', border: 'none',
+                borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent',
+                color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(13, 800), cursor: 'pointer', whiteSpace: 'nowrap',
+              }}>
+                <span aria-hidden="true" style={{ fontSize: 15 }}>{t.icon}</span>{t.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div role="tabpanel">{active.render()}</div>
+      </div>
+
+      <style>{`
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (max-width: 760px) { .pr-hero-grid { grid-template-columns: 1fr !important; } }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot { animation: none !important; } }
+        button:focus-visible, a:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

Mockup **#2 di 7** della pipeline B19. Estensione game-specific dello skeleton (mockup #1, PR #1766 mergiato) applicata a **Puerto Rico** (heavy euro role-selection, 3-5 players, ~120 min).

## Files (7 in admin-mockups/design_files/)

- sp4-session-puerto-rico-live.html / .jsx
- sp4-session-puerto-rico-summary.html / .jsx
- sp4-session-puerto-rico-data.jsx (dataset PR-specific)
- sp4-session-puerto-rico-flavor.jsx (6 nuovi component: RoleSelectionBoard, PlantationGrid, BuildingGrid, GalleonsShipping, TradingHouseSlots, ColonistShip)
- sp4-session-puerto-rico-parts.jsx

## Validation

- 0 cross-game contamination (no Wingspan/Paleo/Catan/Codenames/Zombicide/Power Grid)
- Baseline files NOT touched (tokens/components/sp4-parts-common/skeleton-* verificati identici)

## Mechanics modellate

8 role cards + 5 goods + plantation/building grids + galleons + trading house + colonist ship. RightColumnTabs estese (Scoring polimorfico + Roles + Trade + Ship + Chat).

## Docs sync

MOCKUPS_INDEX: +2 page-mock +5 component-mock, total 94 -> 101

## Pipeline progress

#1 Skeleton MERGED #1766 | #2 PR rico (questo PR) | #3-7 pending

Co-Authored-By: Claude Code