### PR TITLE
feat(mockup): #1742 B19 premium #3/7 - Catan (euro + trading + hex board)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -89,6 +89,13 @@
 | `sp4-play-records-stats.html` | page-mock | `/play-records/stats` |
 | `sp4-player-detail.html` | page-mock | `/players/[id]`, `/players/[id]/{achievements,games,sessions,stats}` |
 | `sp4-players-index.html` | page-mock | `/players` |
+| `sp4-session-catan-data.jsx` | component-mock | Catan-specific dataset (hex board 19-tiles, resources, settlements/cities/roads, dev cards). Premium #3/7. |
+| `sp4-session-catan-flavor.jsx` | component-mock | Catan flavor components — `HexBoard`, `RobberOverlay`, `DiceDisplay`, `TradePanel`, `DevCardsPanel`, `ResourceHandBar`. |
+| `sp4-session-catan-live.html` | page-mock | `/sessions/[id]/live` Catan demo (medium euro + trading, 3-4 players, ~75-90 min). Extends skeleton with Catan-specific panels. |
+| `sp4-session-catan-live.jsx` | component-mock | Root component for `sp4-session-catan-live.html` — wires skeleton + hex board + RightColumnTabs (Scoring, Trade, Dev, Build, Chat). |
+| `sp4-session-catan-parts.jsx` | component-mock | Shared parts for Catan — player rail with hand counts + dev cards + pieces remaining. |
+| `sp4-session-catan-summary.html` | page-mock | `/sessions/[id]` Catan post-game (final VP: settlements + cities + Longest Road + Largest Army + VP dev cards). Premium #3/7. |
+| `sp4-session-catan-summary.jsx` | component-mock | Root component for Catan summary — hero + tabs (Scoreboard / Final Board / Stats). |
 | `sp4-session-puerto-rico-data.jsx` | component-mock | Puerto Rico-specific dataset (role-selection state, 5 goods, plantations + buildings grids). Premium #2/7. |
 | `sp4-session-puerto-rico-flavor.jsx` | component-mock | Puerto Rico flavor components — `RoleSelectionBoard`, `PlantationGrid`, `BuildingGrid`, `GalleonsShipping`, `TradingHouseSlots`, `ColonistShip`. |
 | `sp4-session-puerto-rico-live.html` | page-mock | `/sessions/[id]/live` Puerto Rico demo (heavy euro role-selection, 3-5 players, ~120min). Extends skeleton (mockup #1) with PR-specific panels. |
@@ -175,10 +182,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 59 |
-| component-mock | 30 |
+| page-mock | 61 |
+| component-mock | 35 |
 | dev-fixture | 12 |
-| **Total** | **101** |
+| **Total** | **108** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/sp4-session-catan-data.jsx
+++ b/admin-mockups/design_files/sp4-session-catan-data.jsx
@@ -1,0 +1,324 @@
+/* MeepleAI SP4 · Coloni di Catan — DATASET  (window.CATAN)
+   Game-specific data for the Catan extension of the universal session skeleton.
+
+   Also provides a SHIM for window.SkeletonData.STATES so the skeleton parts
+   (sp4-session-skeleton-parts.jsx) can resolve the canonical-state selector
+   without loading the full skeleton dataset (skeleton-data is built for the
+   generic demo). Load AFTER sp4-parts-common.jsx / skeleton-renderers and
+   BEFORE skeleton-parts.
+
+   Source of truth for the toolkit shape: catan.json (Coloni di Catan, base game,
+   3-4 players). Resource colors are taken verbatim from catan.json — the ONLY
+   non-token colors allowed by the brief. Everything else uses tokens.css vars. */
+
+(function () {
+  // ─── canonical-state selector shim (5 stati) ──────────────────────────────
+  if (!window.SkeletonData) window.SkeletonData = {};
+  if (!window.SkeletonData.STATES) {
+    window.SkeletonData.STATES = [
+      { id: 'default', lb: 'Default' },
+      { id: 'empty',   lb: 'Empty' },
+      { id: 'loading', lb: 'Loading' },
+      { id: 'error',   lb: 'Error' },
+      { id: 'sse',     lb: 'SSE-disc' },
+    ];
+  }
+
+  // ─── resource / terrain palette (verbatim from catan.json) ────────────────
+  // each: label, board terrain name, tile color, number-token text color,
+  //       a darker stripe for the light terrain "texture" pattern.
+  const RES = {
+    wood:  { id: 'wood',  lb: 'Legno',  res: 'Legno',  terrain: 'Foresta',  letter: 'L', icon: '🌲', color: '#3f8f56', stripe: '#36794a', ink: '#ffffff' },
+    brick: { id: 'brick', lb: 'Argilla',res: 'Argilla',terrain: 'Collina',  letter: 'A', icon: '🧱', color: '#c0584a', stripe: '#a8493d', ink: '#ffffff' },
+    sheep: { id: 'sheep', lb: 'Lana',   res: 'Lana',   terrain: 'Pascolo',  letter: 'P', icon: '🐑', color: '#a3c95e', stripe: '#92b850', ink: '#1f2a0e' },
+    wheat: { id: 'wheat', lb: 'Grano',  res: 'Grano',  terrain: 'Campo',    letter: 'G', icon: '🌾', color: '#e7b53d', stripe: '#d4a32c', ink: '#3a2a06' },
+    ore:   { id: 'ore',   lb: 'Minerale',res:'Minerale',terrain:'Montagna', letter: 'M', icon: '⛰️', color: '#8a93a0', stripe: '#79828f', ink: '#ffffff' },
+    desert:{ id: 'desert',lb: 'Deserto',res: '—',      terrain: 'Deserto',  letter: '·', icon: '🏜️', color: '#d9c08a', stripe: '#cbae73', ink: '#5a4423' },
+  };
+  // ordered list of the 5 producing resources (bank / hand / trade order)
+  const RES_ORDER = ['wood', 'brick', 'sheep', 'wheat', 'ore'];
+
+  // ─── players (4) — Catan piece colors + avatar hue ────────────────────────
+  // pc = piece color (settlements/cities/roads); pcInk = outline ink.
+  const PLAYERS = [
+    { id: 'marco', name: 'Marco', hue: 4,   pc: '#cf4036', pcInk: '#fff', vp: 8, turnDelta: 1, current: true,
+      hand: { wood: 2, brick: 1, sheep: 0, wheat: 3, ore: 2 },
+      pieces: { settlements: 3, cities: 2, roads: 8 },     // BUILT
+      dev: { held: 2, knightsPlayed: 1, vpCards: 1 },
+      badges: { longestRoad: true, largestArmy: false }, longestRoadLen: 6, knights: 1 },
+    { id: 'anna', name: 'Anna', hue: 212, pc: '#2f72c4', pcInk: '#fff', vp: 7, turnDelta: 0,
+      hand: { wood: 1, brick: 2, sheep: 3, wheat: 0, ore: 1 },
+      pieces: { settlements: 3, cities: 1, roads: 5 },
+      dev: { held: 1, knightsPlayed: 3, vpCards: 0 },
+      badges: { longestRoad: false, largestArmy: true }, longestRoadLen: 4, knights: 3 },
+    { id: 'luca', name: 'Luca', hue: 32,  pc: '#e0902a', pcInk: '#3a2606', vp: 5, turnDelta: 0,
+      hand: { wood: 0, brick: 1, sheep: 1, wheat: 1, ore: 0 },
+      pieces: { settlements: 3, cities: 1, roads: 6 },
+      dev: { held: 0, knightsPlayed: 1, vpCards: 0 },
+      badges: { longestRoad: false, largestArmy: false }, longestRoadLen: 5, knights: 1 },
+    { id: 'sara', name: 'Sara', hue: 45,  pc: '#e9e3d4', pcInk: '#4a3a1e', vp: 4, turnDelta: 0,
+      hand: { wood: 3, brick: 0, sheep: 2, wheat: 1, ore: 1 },
+      pieces: { settlements: 4, cities: 0, roads: 4 },
+      dev: { held: 1, knightsPlayed: 0, vpCards: 0 },
+      badges: { longestRoad: false, largestArmy: false }, longestRoadLen: 3, knights: 0 },
+  ];
+  // derived "score" field used by the skeleton ScoringPanelRenderer (public VP)
+  PLAYERS.forEach(p => { p.score = p.vp; });
+
+  const TOTAL_PIECES = { settlements: 5, cities: 4, roads: 15 };
+
+  // ─── hex board (19 tiles, flat-top, columns 3·4·5·4·3) ────────────────────
+  // col 0..4 (left→right); rowInCol top→bottom. terrain + number token.
+  // Distribution: 4 wood · 4 sheep · 4 wheat · 3 brick · 3 ore · 1 desert.
+  // Numbers: full standard set 2·3·3·4·4·5·5·6·6·8·8·9·9·10·10·11·11·12.
+  const HEXES = [
+    // col 0
+    { id: 'h0',  col: 0, row: 0, t: 'ore',   n: 10 },
+    { id: 'h1',  col: 0, row: 1, t: 'sheep', n: 2 },
+    { id: 'h2',  col: 0, row: 2, t: 'wood',  n: 9 },
+    // col 1
+    { id: 'h3',  col: 1, row: 0, t: 'wheat', n: 12 },
+    { id: 'h4',  col: 1, row: 1, t: 'brick', n: 6 },
+    { id: 'h5',  col: 1, row: 2, t: 'sheep', n: 4 },
+    { id: 'h6',  col: 1, row: 3, t: 'brick', n: 10 },
+    // col 2 (center)
+    { id: 'h7',  col: 2, row: 0, t: 'wheat', n: 9 },
+    { id: 'h8',  col: 2, row: 1, t: 'wood',  n: 11 },
+    { id: 'h9',  col: 2, row: 2, t: 'desert', n: null },
+    { id: 'h10', col: 2, row: 3, t: 'ore',   n: 3 },
+    { id: 'h11', col: 2, row: 4, t: 'wheat', n: 8 },
+    // col 3
+    { id: 'h12', col: 3, row: 0, t: 'wood',  n: 8 },
+    { id: 'h13', col: 3, row: 1, t: 'sheep', n: 3 },
+    { id: 'h14', col: 3, row: 2, t: 'brick', n: 4 },
+    { id: 'h15', col: 3, row: 3, t: 'wheat', n: 5 },
+    // col 4
+    { id: 'h16', col: 4, row: 0, t: 'wood',  n: 5 },
+    { id: 'h17', col: 4, row: 1, t: 'ore',   n: 6 },
+    { id: 'h18', col: 4, row: 2, t: 'sheep', n: 11 },
+  ];
+  const COL_HEIGHTS = [3, 4, 5, 4, 3];
+
+  // robber position (moved off the desert after a 7 earlier in the game)
+  const ROBBER_HEX = 'h6';
+
+  // ─── pieces on the board ──────────────────────────────────────────────────
+  // settlements/cities reference a hex + corner index (0=E, going clockwise in
+  // screen space: 0 E, 1 SE, 2 SW, 3 W, 4 NW, 5 NE). roads reference hex + edge
+  // index (0 SE-edge … rotating). Curated for a believable network; exact graph
+  // connectivity is illustrative.
+  const SETTLEMENTS = [
+    { p: 'marco', hex: 'h2',  corner: 5 },
+    { p: 'marco', hex: 'h8',  corner: 4 },
+    { p: 'marco', hex: 'h12', corner: 5 },
+    { p: 'anna',  hex: 'h7',  corner: 0 },
+    { p: 'anna',  hex: 'h11', corner: 1 },
+    { p: 'anna',  hex: 'h18', corner: 4 },
+    { p: 'luca',  hex: 'h5',  corner: 2 },
+    { p: 'luca',  hex: 'h13', corner: 0 },
+    { p: 'luca',  hex: 'h10', corner: 2 },
+    { p: 'sara',  hex: 'h1',  corner: 4 },
+    { p: 'sara',  hex: 'h3',  corner: 5 },
+    { p: 'sara',  hex: 'h16', corner: 5 },
+    { p: 'sara',  hex: 'h14', corner: 1 },
+  ];
+  const CITIES = [
+    { p: 'marco', hex: 'h4',  corner: 0 },
+    { p: 'marco', hex: 'h0',  corner: 1 },
+    { p: 'anna',  hex: 'h15', corner: 2 },
+    { p: 'luca',  hex: 'h17', corner: 3 },
+  ];
+  // roads: hex + edge (0..5 starting at NE edge going clockwise)
+  const ROADS = [
+    // Marco — the longest road (top arc)
+    { p: 'marco', hex: 'h2', edge: 5 }, { p: 'marco', hex: 'h2', edge: 0 },
+    { p: 'marco', hex: 'h8', edge: 4 }, { p: 'marco', hex: 'h8', edge: 5 },
+    { p: 'marco', hex: 'h4', edge: 0 }, { p: 'marco', hex: 'h4', edge: 1 },
+    { p: 'marco', hex: 'h0', edge: 1 }, { p: 'marco', hex: 'h12', edge: 5 },
+    // Anna
+    { p: 'anna', hex: 'h7', edge: 0 }, { p: 'anna', hex: 'h11', edge: 1 },
+    { p: 'anna', hex: 'h11', edge: 0 }, { p: 'anna', hex: 'h15', edge: 2 },
+    { p: 'anna', hex: 'h18', edge: 4 },
+    // Luca
+    { p: 'luca', hex: 'h5', edge: 2 }, { p: 'luca', hex: 'h10', edge: 2 },
+    { p: 'luca', hex: 'h13', edge: 0 }, { p: 'luca', hex: 'h17', edge: 3 },
+    { p: 'luca', hex: 'h13', edge: 3 }, { p: 'luca', hex: 'h14', edge: 4 },
+    // Sara
+    { p: 'sara', hex: 'h1', edge: 4 }, { p: 'sara', hex: 'h3', edge: 5 },
+    { p: 'sara', hex: 'h16', edge: 5 }, { p: 'sara', hex: 'h14', edge: 1 },
+  ];
+
+  // ─── ports (harbors) on the coastline ─────────────────────────────────────
+  // type: 'generic' (3:1) or a resource id (2:1). anchored to a hex edge.
+  const PORTS = [
+    { type: 'generic', hex: 'h0',  edge: 4, ratio: '3:1' },
+    { type: 'wheat',   hex: 'h3',  edge: 5, ratio: '2:1' },
+    { type: 'ore',     hex: 'h16', edge: 0, ratio: '2:1' },
+    { type: 'generic', hex: 'h18', edge: 1, ratio: '3:1' },
+    { type: 'wood',    hex: 'h2',  edge: 2, ratio: '2:1' },
+    { type: 'brick',   hex: 'h10', edge: 3, ratio: '2:1' },
+    { type: 'sheep',   hex: 'h11', edge: 2, ratio: '2:1' },
+    { type: 'generic', hex: 'h15', edge: 1, ratio: '3:1' },
+  ];
+  // ports actually owned/usable by each player (settlement on a port vertex)
+  const PLAYER_PORTS = {
+    marco: [{ type: 'generic', ratio: '3:1' }, { type: 'wood', ratio: '2:1' }],
+    anna:  [{ type: 'wheat', ratio: '2:1' }],
+    luca:  [{ type: 'brick', ratio: '2:1' }],
+    sara:  [{ type: 'generic', ratio: '3:1' }],
+  };
+
+  // ─── dice ─────────────────────────────────────────────────────────────────
+  // last roll = 8 → highlights producing hexes (h11 wheat, h12 wood); robber on
+  // h6 blocks nothing for an 8. History newest-first.
+  const DICE = {
+    last: [5, 3],            // sum 8
+    history: [8, 6, 11, 4, 9, 7, 5, 8, 10, 3, 6, 9],
+  };
+
+  // ─── shared bank ──────────────────────────────────────────────────────────
+  const BANK = { wood: 11, brick: 13, sheep: 14, wheat: 9, ore: 12 };  // /19 each
+  const DEV_DECK = { remaining: 18, total: 25 };
+  // dev card breakdown of the full deck (for Build/Dev reference)
+  const DEV_TYPES = [
+    { id: 'knight',     lb: 'Cavaliere',       icon: '⚔️', total: 14, e: 'event',   desc: 'Sposta il ladro e ruba 1 carta. 3 cavalieri = Armata più grande.' },
+    { id: 'vp',         lb: 'Punto Vittoria',  icon: '⭐', total: 5,  e: 'toolkit', desc: '+1 PV, tenuta segreta fino alla vittoria.' },
+    { id: 'road',       lb: 'Costruzione strade', icon: '🛤️', total: 2, e: 'session', desc: 'Costruisci 2 strade gratis.' },
+    { id: 'plenty',     lb: 'Anno dell\u2019abbondanza', icon: '🎁', total: 2, e: 'kb', desc: 'Prendi 2 risorse a scelta dalla banca.' },
+    { id: 'monopoly',   lb: 'Monopolio',       icon: '💰', total: 2,  e: 'agent',   desc: 'Tutti ti danno tutte le carte di una risorsa.' },
+  ];
+
+  // ─── build costs reference ────────────────────────────────────────────────
+  const BUILD_COSTS = [
+    { id: 'road',       lb: 'Strada',       icon: '🛤️', cost: { wood: 1, brick: 1 }, vp: 0, e: 'session', note: 'Connette i tuoi insediamenti. 5+ = Strada più lunga.' },
+    { id: 'settlement', lb: 'Insediamento', icon: '🏠', cost: { wood: 1, brick: 1, sheep: 1, wheat: 1 }, vp: 1, e: 'game', note: '1 PV. Produce su 1 risorsa per vertice.' },
+    { id: 'city',       lb: 'Città',        icon: '🏛️', cost: { wheat: 2, ore: 3 }, vp: 2, e: 'player', note: '2 PV. Sostituisce un insediamento, doppia produzione.' },
+    { id: 'dev',        lb: 'Carta sviluppo', icon: '🃏', cost: { sheep: 1, wheat: 1, ore: 1 }, vp: 0, e: 'toolkit', note: 'Pesca dal mazzo: cavaliere, PV, progresso.' },
+  ];
+
+  // ─── scoring template (from catan.json ScoringTemplate) ───────────────────
+  const SCORING = {
+    scoreType: 'Points',
+    defaultUnit: 'points',
+    categories: [
+      { id: 'settlements',  label: 'Insediamenti',     computation: 'Count',  weight: 1, description: '1 PV per insediamento (max 5).' },
+      { id: 'cities',       label: 'Città',            computation: 'Count',  weight: 2, description: '2 PV per città (max 4).' },
+      { id: 'longest-road', label: 'Strada più lunga', computation: 'Custom', weight: 2, description: '2 PV a chi ha la strada più lunga ≥5 segmenti.' },
+      { id: 'largest-army', label: 'Armata più grande', computation: 'Custom', weight: 2, description: '2 PV a chi ha l\u2019armata più grande ≥3 cavalieri.' },
+      { id: 'vp-cards',     label: 'Carte PV',         computation: 'Sum',    weight: 1, description: '1 PV per carta sviluppo Punto Vittoria (segreta).' },
+    ],
+    target: 10,
+  };
+  // breakdown = VP contributed per category (sums to public VP). vp-cards kept
+  // secret in live view → shown as hidden; revealed in summary.
+  const BREAKDOWN = {
+    marco: { settlements: 2, cities: 4, 'longest-road': 2, 'largest-army': 0, 'vp-cards': 1 },
+    anna:  { settlements: 3, cities: 2, 'longest-road': 0, 'largest-army': 2, 'vp-cards': 0 },
+    luca:  { settlements: 3, cities: 2, 'longest-road': 0, 'largest-army': 0, 'vp-cards': 0 },
+    sara:  { settlements: 4, cities: 0, 'longest-road': 0, 'largest-army': 0, 'vp-cards': 0 },
+  };
+
+  // ─── turn template (from catan.json TurnTemplate) ─────────────────────────
+  const TURN = {
+    turnOrderType: 'RoundRobin',
+    phases: ['Tira i dadi', 'Commercio', 'Costruisci / sviluppa'],
+    turnActions: ['roll-dice', 'trade-with-player', 'trade-with-bank', 'build-road', 'build-settlement', 'build-city', 'buy-dev-card', 'play-dev-card', 'end-turn'],
+    direction: 'clockwise',
+    rounds: '\u221e',          // open-ended: first to 10 VP
+    turnsPerRound: null,
+  };
+  const TURN_STATE = {
+    activePlayerId: 'marco',
+    round: 8,
+    turnInRound: 1,
+    phaseIndex: 2,             // currently in Build / develop
+    actionIndex: 5,           // build-city
+  };
+
+  // ─── trade panel ──────────────────────────────────────────────────────────
+  const TRADE = {
+    // incoming offers from other players to the active player (Marco)
+    incoming: [
+      { id: 'o1', from: 'anna', give: { sheep: 2 }, want: { ore: 1 }, note: 'Mi serve minerale per la città' },
+      { id: 'o2', from: 'luca', give: { brick: 1, sheep: 1 }, want: { wheat: 1 }, note: '' },
+    ],
+    // outgoing offer drafted by the active player
+    outgoing: { give: { wheat: 1 }, want: { brick: 1 }, to: 'all', status: 'open' },
+  };
+
+  // ─── action log (events) — newest first ───────────────────────────────────
+  const EVENTS = [
+    { kind: 'score-update', who: 'marco', t: '19:42', text: '<strong>Marco</strong> costruisce una <strong>città</strong> su Foresta-9 → <strong>8 PV</strong>' },
+    { kind: 'custom',       who: 'marco', t: '19:41', text: 'Banca: <strong>2 grano + 3 minerale</strong> spesi per la città' },
+    { kind: 'turn-change',  who: 'marco', t: '19:40', text: 'Inizia il turno di <strong>Marco</strong> · Round 8' },
+    { kind: 'custom',       who: 'anna',  t: '19:38', text: '<strong>Anna</strong> gioca un <strong>Cavaliere</strong> → Armata più grande (3) 🛡️' },
+    { kind: 'custom',       who: 'anna',  t: '19:38', text: 'Ladro spostato su <strong>Collina-10</strong>, ruba 1 carta a Luca' },
+    { kind: 'custom',       who: 'sara',  t: '19:35', text: 'Scambio <strong>Sara → Luca</strong>: 1 legno ⇄ 1 minerale' },
+    { kind: 'custom',       who: 'luca',  t: '19:33', text: '<strong>Luca</strong> tira <strong>7</strong> · scarto carte > 7 · sposta il ladro' },
+    { kind: 'score-update', who: 'luca',  t: '19:32', text: '<strong>Luca</strong> costruisce un <strong>insediamento</strong> → 5 PV' },
+    { kind: 'turn-change',  who: 'luca',  t: '19:30', text: 'Inizia il turno di <strong>Luca</strong>' },
+    { kind: 'game-start',   who: null,    t: '18:18', text: 'Partita avviata · 4 giocatori · disposizione iniziale completata' },
+  ];
+
+  // ─── chat with the agent (reused ChatAgentPanel shape) ────────────────────
+  const CHAT = [
+    { id: 'c1', from: 'user',  t: '19:36', text: 'Se costruisco la città su Foresta-9, perdo la strada più lunga?' },
+    { id: 'c2', from: 'agent', t: '19:36', text: 'No: costruire una città non rimuove strade. Mantieni i tuoi 6 segmenti consecutivi, quindi conservi il bonus Strada più lunga (+2 PV).', citations: ['Catan §Costruzione', 'FAQ #7'] },
+    { id: 'c3', from: 'user',  t: '19:41', text: 'Con la città arrivo a 8 PV?' },
+    { id: 'c4', from: 'agent', t: '19:41', text: '2 insediamenti (2) + 2 città (4) + Strada più lunga (2) = 8 PV pubblici. Con la tua carta PV segreta saresti a 9 — ti manca 1 punto per vincere.', citations: ['Catan §Punteggio'] },
+  ];
+  const SUGGESTIONS = ['Costo della città?', 'Chi ha l\u2019Armata più grande?', 'Probabilità del 6 e 8'];
+
+  // ─── session / game header (TopBar reads ds.game / ds.session) ────────────
+  const GAME = {
+    id: 'catan', title: 'Coloni di Catan', emoji: '🎲',
+    cover: 'linear-gradient(135deg, hsl(28,70%,52%), hsl(150,45%,40%))',
+    meta: 'Euro · trading · 3-4 giocatori · ~80 min',
+  };
+  const SESSION = { id: 'catan-7', elapsed: '1h 24min', startedAt: '18:18', turn: 29, round: 8 };
+
+  const AGENT = { id: 'a-catan', name: 'Esperto Catan', emoji: '🤖', latency: '~0.7s' };
+
+  const PHOTOS = [
+    { lb: 'tavolo', g: 'linear-gradient(135deg,#3f8f56,#e7b53d)' },
+    { lb: 'plance', g: 'linear-gradient(135deg,#2f72c4,#8a93a0)' },
+    { lb: 'dadi',   g: 'linear-gradient(135deg,#cf4036,#e0902a)' },
+  ];
+
+  // ─── stats (for the summary) ──────────────────────────────────────────────
+  const STATS = {
+    totalTurns: 29, totalRounds: 8, duration: '1h 24min',
+    diceCounts: { 2: 3, 3: 8, 4: 9, 5: 11, 6: 14, 7: 13, 8: 15, 9: 10, 10: 8, 11: 6, 12: 2 },
+    diceTotal: 99,
+    trades: { marco: 7, anna: 9, luca: 6, sara: 4 },
+    longestProductionRun: { number: 8, count: 5, hint: '5 volte di fila ha prodotto l\u20198' },
+    robberMoves: 13,
+    biggestHand: { player: 'sara', n: 9, hint: 'mano più grande mai tenuta' },
+  };
+
+  // ─── assembled "ds" object — shape consumed by skeleton parts/renderers ───
+  const ds = {
+    game: GAME,
+    session: SESSION,
+    agent: AGENT,
+    players: PLAYERS,
+    scoring: SCORING,
+    breakdown: BREAKDOWN,
+    turn: TURN,
+    turnState: TURN_STATE,
+    chat: CHAT,
+    suggestions: SUGGESTIONS,
+    events: EVENTS,
+    notes: 'Setup: Marco rosso (alto/sx), Anna blu (dx), Luca arancio (centro/basso), Sara bianco (sx). Porto 2:1 legno conteso. Occhio al 7 di Luca.',
+    photos: PHOTOS,
+  };
+
+  window.CATAN = {
+    RES, RES_ORDER, PLAYERS, TOTAL_PIECES,
+    HEXES, COL_HEIGHTS, ROBBER_HEX, SETTLEMENTS, CITIES, ROADS, PORTS, PLAYER_PORTS,
+    DICE, BANK, DEV_DECK, DEV_TYPES, BUILD_COSTS,
+    SCORING, BREAKDOWN, TURN, TURN_STATE, TRADE,
+    EVENTS, CHAT, SUGGESTIONS, GAME, SESSION, AGENT, PHOTOS, STATS,
+    ds,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-catan-flavor.jsx
+++ b/admin-mockups/design_files/sp4-session-catan-flavor.jsx
@@ -1,0 +1,345 @@
+/* MeepleAI SP4 · Coloni di Catan — FLAVOR ATOMS  (window.CatanFlavor)
+   Game-specific visual primitives shared by live + summary:
+     hexGeom · HexTile · NumberToken · RobberToken · PortMarker ·
+     Settlement · City · Road · HexBoard ·
+     ResourceToken · ResourceCount · ResourceHandBar ·
+     Die · DiceDisplay · VPBadge · LongestRoadBadge · LargestArmyBadge · PlayerDot
+
+   Resource/terrain colors come from window.CATAN.RES (verbatim from catan.json).
+   All spacing / radius / surface / text colors are tokens.css vars.
+   Reads window.MAI for entityHsl. */
+
+(function () {
+  const M = window.MAI;
+  const C = window.CATAN;
+  const eHsl = M.entityHsl;
+  const { RES } = C;
+  const mono = (s, w, c) => ({ fontFamily: 'var(--f-mono)', fontSize: s, fontWeight: w, color: c });
+  const disp = (s, w, c) => ({ fontFamily: 'var(--f-display)', fontSize: s, fontWeight: w, color: c });
+  const SQRT3 = Math.sqrt(3);
+
+  const playerOf = (id) => C.PLAYERS.find(p => p.id === id) || C.PLAYERS[0];
+
+  // ─── hex geometry (flat-top, columns 3·4·5·4·3) ───────────────────────────
+  // R = circumradius (center→vertex). width 2R, height √3 R.
+  const hexGeom = (R) => {
+    const h = SQRT3 * R;
+    const maxCol = Math.max(...C.COL_HEIGHTS);
+    const centers = {};
+    C.HEXES.forEach(hx => {
+      const cx = R + hx.col * 1.5 * R;
+      const n = C.COL_HEIGHTS[hx.col];
+      const colTop = (maxCol - n) / 2 * h;
+      const cy = colTop + h / 2 + hx.row * h;
+      centers[hx.id] = { cx, cy };
+    });
+    const width = R + (C.COL_HEIGHTS.length - 1) * 1.5 * R + R;
+    const height = maxCol * h;
+    // corner k: angle 60k° ; 0 E,1 SE,2 SW,3 W,4 NW,5 NE
+    const corner = (hexId, k) => {
+      const { cx, cy } = centers[hexId];
+      const a = (Math.PI / 180) * (60 * k);
+      return { x: cx + R * Math.cos(a), y: cy + R * Math.sin(a) };
+    };
+    // edge k midpoint: angle 30+60k° ; rotation = that + 90
+    const edge = (hexId, k) => {
+      const { cx, cy } = centers[hexId];
+      const deg = 30 + 60 * k;
+      const a = (Math.PI / 180) * deg;
+      const ap = (SQRT3 / 2) * R;
+      return { x: cx + ap * Math.cos(a), y: cy + ap * Math.sin(a), rot: deg + 90 };
+    };
+    return { R, h, width, height, centers, corner, edge };
+  };
+
+  // ─── NumberToken — production chit with probability pips ───────────────────
+  const NumberToken = ({ n, R, hot }) => {
+    if (n == null) return null;
+    const d = Math.round(R * 0.82);
+    const red = n === 6 || n === 8;
+    const pips = 6 - Math.abs(7 - n);
+    return (
+      <div aria-hidden="true" style={{
+        width: d, height: d, borderRadius: '50%',
+        background: 'radial-gradient(circle at 38% 32%, #fbf3df, #ecdcb8)',
+        border: `1.5px solid ${hot ? eHsl('event') : 'rgba(70,45,15,.45)'}`,
+        boxShadow: hot ? `0 0 0 3px ${eHsl('event', 0.4)}, inset 0 1px 2px rgba(255,255,255,.7)` : 'inset 0 1px 2px rgba(255,255,255,.6), 0 1px 3px rgba(0,0,0,.25)',
+        display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', lineHeight: 1,
+      }}>
+        <span style={{ ...disp(R * 0.42, 800, red ? '#b4271c' : '#42301a'), fontVariantNumeric: 'tabular-nums' }}>{n}</span>
+        <span style={{ display: 'flex', gap: 1.5, marginTop: 1 }}>
+          {Array.from({ length: pips }).map((_, i) => (
+            <span key={i} style={{ width: Math.max(2, R * 0.045), height: Math.max(2, R * 0.045), borderRadius: '50%', background: red ? '#b4271c' : '#6a4e2a' }} />
+          ))}
+        </span>
+      </div>
+    );
+  };
+
+  // ─── RobberToken ──────────────────────────────────────────────────────────
+  const RobberToken = ({ R, size }) => {
+    const d = size || Math.round(R * 0.62);
+    return (
+      <div aria-label="Ladro" title="Ladro" style={{
+        width: d * 0.74, height: d, borderRadius: `${d}px ${d}px ${d * 0.4}px ${d * 0.4}px`,
+        background: 'linear-gradient(160deg, #4a4a52, #232327)',
+        border: '1.5px solid #16161a', boxShadow: '0 2px 5px rgba(0,0,0,.5), inset 0 1px 1px rgba(255,255,255,.18)',
+        position: 'relative',
+      }}>
+        <span style={{ position: 'absolute', top: d * 0.12, left: '50%', transform: 'translateX(-50%)', width: d * 0.34, height: d * 0.34, borderRadius: '50%', background: 'linear-gradient(160deg,#52525a,#2c2c31)', border: '1.5px solid #16161a' }} />
+      </div>
+    );
+  };
+
+  // ─── pieces: Settlement · City · Road ─────────────────────────────────────
+  const Settlement = ({ p, R, atGeom }) => {
+    const s = Math.round(R * 0.46);
+    return (
+      <div title={`Insediamento · ${p.name}`} aria-label={`Insediamento di ${p.name}`} style={{
+        position: 'absolute', left: atGeom.x, top: atGeom.y, transform: 'translate(-50%,-50%)',
+        width: s, height: s * 0.92, background: p.pc,
+        clipPath: 'polygon(50% 0, 100% 40%, 100% 100%, 0 100%, 0 40%)',
+        border: `1px solid ${p.pcInk === '#fff' ? 'rgba(0,0,0,.35)' : p.pcInk}`,
+        boxShadow: '0 1px 3px rgba(0,0,0,.4)', zIndex: 6,
+        outline: p.pc === '#e9e3d4' ? '1px solid rgba(74,58,30,.6)' : 'none',
+      }} />
+    );
+  };
+  const City = ({ p, R, atGeom }) => {
+    const s = Math.round(R * 0.66);
+    return (
+      <div title={`Città · ${p.name}`} aria-label={`Città di ${p.name}`} style={{
+        position: 'absolute', left: atGeom.x, top: atGeom.y, transform: 'translate(-50%,-50%)',
+        width: s, height: s * 0.74, background: p.pc,
+        clipPath: 'polygon(0 45%, 34% 45%, 34% 0, 64% 0, 64% 45%, 100% 45%, 100% 100%, 0 100%)',
+        border: `1px solid ${p.pcInk === '#fff' ? 'rgba(0,0,0,.4)' : p.pcInk}`,
+        boxShadow: '0 1px 4px rgba(0,0,0,.45)', zIndex: 7,
+        outline: p.pc === '#e9e3d4' ? '1px solid rgba(74,58,30,.6)' : 'none',
+      }} />
+    );
+  };
+  const Road = ({ p, R, atGeom }) => {
+    const len = R * 0.86, th = Math.max(4, R * 0.2);
+    return (
+      <div aria-label={`Strada di ${p.name}`} style={{
+        position: 'absolute', left: atGeom.x, top: atGeom.y,
+        width: len, height: th, borderRadius: th,
+        transform: `translate(-50%,-50%) rotate(${atGeom.rot}deg)`,
+        background: p.pc, border: `1px solid ${p.pcInk === '#fff' ? 'rgba(0,0,0,.3)' : 'rgba(58,38,6,.5)'}`,
+        boxShadow: '0 1px 2px rgba(0,0,0,.35)', zIndex: 5,
+      }} />
+    );
+  };
+
+  // ─── PortMarker ───────────────────────────────────────────────────────────
+  const PortMarker = ({ port, atGeom, R }) => {
+    const generic = port.type === 'generic';
+    const r = RES[port.type];
+    const d = Math.round(R * 0.5);
+    return (
+      <div title={`Porto ${port.ratio}${generic ? '' : ' · ' + r.lb}`} aria-label={`Porto ${port.ratio}${generic ? '' : ' ' + r.lb}`} style={{
+        position: 'absolute', left: atGeom.x, top: atGeom.y, transform: 'translate(-50%,-50%)',
+        display: 'flex', alignItems: 'center', gap: 2, padding: '1px 4px 1px 1px',
+        borderRadius: 'var(--r-pill)', background: 'rgba(20,26,40,.82)', border: '1px solid rgba(120,160,220,.5)',
+        boxShadow: '0 1px 3px rgba(0,0,0,.4)', zIndex: 4,
+      }}>
+        <span style={{ width: d, height: d, borderRadius: '50%', background: generic ? '#5b7fb0' : r.color, border: '1px solid rgba(0,0,0,.3)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...mono(d * 0.5, 800, generic ? '#fff' : r.ink) }}>{generic ? '?' : r.letter}</span>
+        <span style={{ ...mono(R * 0.2, 800, '#cfe0f5') }}>{port.ratio}</span>
+      </div>
+    );
+  };
+
+  // ─── HexTile — terrain hexagon (flat-top) with texture + number ───────────
+  const HexTile = ({ hx, geom, robber, hot }) => {
+    const r = RES[hx.t];
+    const { cx, cy } = geom.centers[hx.id];
+    const w = 2 * geom.R, h = geom.h;
+    const label = `${r.terrain}${hx.n ? `, produce ${r.res}, numero ${hx.n}` : ', deserto, nessuna risorsa'}${robber ? ', con il ladro' : ''}${hot ? ', in produzione' : ''}`;
+    return (
+      <div role="img" aria-label={label} className={hot ? 'catan-hot' : undefined} style={{
+        position: 'absolute', left: cx - geom.R, top: cy - h / 2, width: w, height: h,
+        clipPath: 'polygon(100% 50%, 75% 100%, 25% 100%, 0% 50%, 25% 0%, 75% 0%)',
+        background: hot
+          ? `repeating-linear-gradient(48deg, ${r.color}, ${r.color} 7px, ${r.stripe} 7px, ${r.stripe} 10px), radial-gradient(circle at 50% 50%, rgba(255,235,170,.55), transparent 70%)`
+          : `repeating-linear-gradient(48deg, ${r.color}, ${r.color} 7px, ${r.stripe} 7px, ${r.stripe} 10px)`,
+        boxShadow: hot ? `inset 0 0 0 4px ${eHsl('event')}` : 'inset 0 0 0 1px rgba(0,0,0,.18)',
+        filter: hot ? `drop-shadow(0 0 5px ${eHsl('event', 0.9)}) drop-shadow(0 0 11px ${eHsl('event', 0.6)})` : 'none',
+        zIndex: hot ? 3 : 1,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        transition: 'box-shadow var(--dur-md) var(--ease-out)',
+      }}>
+        <span style={{ position: 'absolute', top: 4, left: 0, right: 0, textAlign: 'center', ...mono(geom.R * 0.2, 700, r.ink), opacity: 0.65, textTransform: 'uppercase', letterSpacing: '.04em', pointerEvents: 'none' }}>{r.icon}</span>
+        {hx.n != null
+          ? <NumberToken n={hx.n} R={geom.R} hot={hot} />
+          : <span style={{ ...disp(geom.R * 0.26, 800, r.ink), opacity: 0.8, marginTop: 6 }}>Deserto</span>}
+      </div>
+    );
+  };
+
+  // ─── HexBoard — full 19-hex board + pieces + ports + robber + highlight ───
+  const HexBoard = ({ R = 44, highlightNumber = null, robberHex = C.ROBBER_HEX, showPorts = true, showPieces = true, pad = 16 }) => {
+    const geom = hexGeom(R);
+    const hotIds = highlightNumber != null
+      ? C.HEXES.filter(h => h.n === highlightNumber && h.id !== robberHex).map(h => h.id)
+      : [];
+    return (
+      <div role="group" aria-label="Tabellone di Catan, 19 esagoni" style={{
+        position: 'relative', width: geom.width + pad * 2, height: geom.height + pad * 2,
+        margin: '0 auto', flexShrink: 0,
+        background: 'radial-gradient(ellipse at 50% 42%, hsl(205,55%,42%), hsl(212,60%,28%))',
+        borderRadius: 'var(--r-2xl)', padding: pad,
+        boxShadow: 'inset 0 2px 12px rgba(0,0,0,.4), var(--shadow-md)',
+        overflow: 'hidden',
+      }}>
+        <div style={{ position: 'absolute', inset: pad, width: geom.width, height: geom.height }}>
+          {C.HEXES.map(hx => (
+            <HexTile key={hx.id} hx={hx} geom={geom} robber={hx.id === robberHex} hot={hotIds.includes(hx.id)} />
+          ))}
+          {showPorts && C.PORTS.map((pt, i) => <PortMarker key={i} port={pt} R={R} atGeom={geom.edge(pt.hex, pt.edge)} />)}
+          {showPieces && C.ROADS.map((rd, i) => <Road key={`r${i}`} p={playerOf(rd.p)} R={R} atGeom={geom.edge(rd.hex, rd.edge)} />)}
+          {showPieces && C.SETTLEMENTS.map((st, i) => <Settlement key={`s${i}`} p={playerOf(st.p)} R={R} atGeom={geom.corner(st.hex, st.corner)} />)}
+          {showPieces && C.CITIES.map((ct, i) => <City key={`c${i}`} p={playerOf(ct.p)} R={R} atGeom={geom.corner(ct.hex, ct.corner)} />)}
+          {robberHex && (() => { const g = geom.centers[robberHex]; return (
+            <div style={{ position: 'absolute', left: g.cx, top: g.cy - R * 0.05, transform: 'translate(-50%,-50%)', zIndex: 9 }}><RobberToken R={R} /></div>
+          ); })()}
+        </div>
+      </div>
+    );
+  };
+
+  // ─── ResourceToken / ResourceCount / ResourceHandBar ──────────────────────
+  const ResourceToken = ({ id, size = 18, title }) => {
+    const r = RES[id];
+    return (
+      <span title={title || r.lb} aria-label={r.lb} style={{
+        width: size, height: size, borderRadius: '50%', flexShrink: 0,
+        background: `radial-gradient(circle at 36% 30%, ${r.color}, ${r.stripe})`,
+        color: r.ink, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        ...mono(size * 0.5, 800), border: '1px solid rgba(0,0,0,.25)',
+        boxShadow: 'inset 0 1px 1px rgba(255,255,255,.4), inset 0 -1px 2px rgba(0,0,0,.18)',
+      }}>{r.letter}</span>
+    );
+  };
+  const ResourceCount = ({ id, n, dim, max }) => (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 8px 2px 3px',
+      borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)',
+      opacity: dim && !n ? 0.42 : 1,
+    }}>
+      <ResourceToken id={id} size={16} />
+      <span style={{ ...mono(11.5, 800, n ? 'var(--text)' : 'var(--text-muted)'), fontVariantNumeric: 'tabular-nums', minWidth: 8, textAlign: 'center' }}>{n}{max ? <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>/{max}</span> : null}</span>
+    </span>
+  );
+  // hidden-count variant: shows total cards as a fanned back (opponent hand)
+  const HiddenHand = ({ n }) => (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }} title={`${n} carte in mano (segrete)`}>
+      <span style={{ display: 'inline-flex' }} aria-hidden="true">
+        {Array.from({ length: Math.min(n, 5) }).map((_, i) => (
+          <span key={i} style={{ width: 11, height: 15, borderRadius: 2, marginLeft: i ? -6 : 0, background: 'linear-gradient(150deg, hsl(28,55%,46%), hsl(28,60%,34%))', border: '1px solid rgba(0,0,0,.35)', boxShadow: '0 1px 2px rgba(0,0,0,.3)' }} />
+        ))}
+      </span>
+      <span style={{ ...mono(12, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{n}</span>
+    </span>
+  );
+  const ResourceHandBar = ({ hand, hidden, label = 'Mano' }) => {
+    const total = C.RES_ORDER.reduce((s, k) => s + (hand[k] || 0), 0);
+    return (
+      <div>
+        {label && <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 5 }}>
+          <span style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</span>
+          <span style={{ ...mono(9, 800, eHsl('session')) }}>{total} carte</span>
+        </div>}
+        {hidden
+          ? <HiddenHand n={total} />
+          : <div aria-live="polite" style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+              {C.RES_ORDER.map(k => <ResourceCount key={k} id={k} n={hand[k] || 0} dim />)}
+            </div>}
+      </div>
+    );
+  };
+
+  // ─── Die · DiceDisplay ────────────────────────────────────────────────────
+  // pip layout per face value
+  const PIPS = {
+    1: [4], 2: [0, 8], 3: [0, 4, 8], 4: [0, 2, 6, 8], 5: [0, 2, 4, 6, 8], 6: [0, 2, 3, 5, 6, 8],
+  };
+  const Die = ({ v, size = 34, accent }) => (
+    <div aria-label={`Dado: ${v}`} style={{
+      width: size, height: size, borderRadius: size * 0.22, flexShrink: 0,
+      background: accent ? 'linear-gradient(150deg,#fff,#f1e6d6)' : 'linear-gradient(150deg,#fbf6ec,#ede0cb)',
+      border: '1px solid rgba(70,45,15,.4)', boxShadow: '0 2px 5px rgba(0,0,0,.3), inset 0 1px 2px rgba(255,255,255,.7)',
+      display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gridTemplateRows: 'repeat(3,1fr)', padding: size * 0.16, gap: size * 0.04,
+    }}>
+      {Array.from({ length: 9 }).map((_, i) => (
+        <span key={i} style={{ borderRadius: '50%', background: (PIPS[v] || []).includes(i) ? '#9a2b1f' : 'transparent', alignSelf: 'center', justifySelf: 'center', width: size * 0.17, height: size * 0.17 }} />
+      ))}
+    </div>
+  );
+  const DiceDisplay = ({ dice = C.DICE, compact, onRoll }) => {
+    const sum = dice.last[0] + dice.last[1];
+    const hot = sum === 6 || sum === 8;
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 8 : 12 }}>
+        <div style={{ display: 'flex', gap: 6 }} aria-live="polite" aria-label={`Ultimo lancio: ${dice.last[0]} e ${dice.last[1]}, totale ${sum}`}>
+          <Die v={dice.last[0]} size={compact ? 30 : 38} />
+          <Die v={dice.last[1]} size={compact ? 30 : 38} />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1 }}>
+          <span style={{ ...disp(compact ? 22 : 28, 800, sum === 7 ? eHsl('event') : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{sum}</span>
+          <span style={{ ...mono(8.5, 800, hot ? '#b4271c' : 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>{sum === 7 ? 'ladro!' : hot ? 'numero caldo' : 'totale'}</span>
+        </div>
+      </div>
+    );
+  };
+  const DiceHistory = ({ history = C.DICE.history }) => (
+    <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap' }} aria-label="Cronologia dei lanci">
+      {history.map((n, i) => (
+        <span key={i} style={{
+          width: 20, height: 20, borderRadius: 'var(--r-sm)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          ...mono(10, 800, n === 7 ? '#fff' : (n === 6 || n === 8) ? '#b4271c' : 'var(--text-sec)'),
+          background: n === 7 ? eHsl('event') : i === 0 ? 'var(--bg-card)' : 'var(--bg-muted)',
+          border: i === 0 ? `1.5px solid ${eHsl('session', 0.6)}` : '1px solid var(--border-light)',
+          fontVariantNumeric: 'tabular-nums',
+        }}>{n}</span>
+      ))}
+    </div>
+  );
+
+  // ─── badges ───────────────────────────────────────────────────────────────
+  const Badge = ({ e, icon, lb, sub, on }) => (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 9px', borderRadius: 'var(--r-pill)',
+      background: on ? eHsl(e, 0.14) : 'var(--bg-muted)', color: on ? eHsl(e) : 'var(--text-muted)',
+      border: `1px solid ${on ? eHsl(e, 0.4) : 'var(--border-light)'}`,
+      ...mono(9, 800), textTransform: 'uppercase', letterSpacing: '.04em', whiteSpace: 'nowrap',
+      opacity: on ? 1 : 0.7,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 11 }}>{icon}</span>{lb}{sub != null && <span style={{ opacity: 0.8 }}>{sub}</span>}
+    </span>
+  );
+  const LongestRoadBadge = ({ on, len }) => <Badge e="session" icon="🛤️" lb="Strada+" sub={len ? ` ${len}` : null} on={on} />;
+  const LargestArmyBadge = ({ on, n }) => <Badge e="event" icon="⚔️" lb="Armata+" sub={n ? ` ${n}` : null} on={on} />;
+
+  const VPBadge = ({ vp, target = 10, leader, size = 'md' }) => {
+    const big = size === 'lg';
+    return (
+      <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+        <span aria-hidden="true" style={{ fontSize: big ? 18 : 14, color: eHsl('toolkit') }}>⭐</span>
+        <span style={{ ...disp(big ? 30 : 22, 800, leader ? eHsl('toolkit') : 'var(--text)'), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{vp}</span>
+        <span style={{ ...mono(big ? 11 : 9.5, 700, 'var(--text-muted)') }}>/{target} PV</span>
+      </div>
+    );
+  };
+
+  const PlayerDot = ({ p, size = 12 }) => (
+    <span title={p.name} style={{ width: size, height: size, borderRadius: '50%', background: p.pc, border: `1.5px solid ${p.pc === '#e9e3d4' ? 'rgba(74,58,30,.6)' : 'rgba(0,0,0,.3)'}`, flexShrink: 0, display: 'inline-block', boxShadow: 'inset 0 1px 1px rgba(255,255,255,.3)' }} />
+  );
+
+  window.CatanFlavor = {
+    hexGeom, playerOf, mono, disp,
+    NumberToken, RobberToken, Settlement, City, Road, PortMarker, HexTile, HexBoard,
+    ResourceToken, ResourceCount, HiddenHand, ResourceHandBar,
+    Die, DiceDisplay, DiceHistory,
+    LongestRoadBadge, LargestArmyBadge, VPBadge, PlayerDot, Badge,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-catan-live.html
+++ b/admin-mockups/design_files/sp4-session-catan-live.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Coloni di Catan · Live — /sessions/[id]/live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-catan-live.jsx
+++ b/admin-mockups/design_files/sp4-session-catan-live.jsx
@@ -1,0 +1,183 @@
+/* MeepleAI SP4 · Coloni di Catan — SESSION LIVE  (App)
+   /sessions/[id]/live — Catan extension of the universal session skeleton.
+
+   The skeleton (mockup #1) supplies the polymorphic renderers + universal chrome
+   (TopBar · ChatAgentPanel · ActionLog · ScoringPanelRenderer · TurnIndicator ·
+   ToolkitRenderer). THIS layer adds the Catan board: the 19-hex flat-top map with
+   color-coded settlements / cities / roads, the robber, ports, the 2D6 dice + roll
+   history, per-player state cards, the resource bank / dev deck, and a 5-tab right
+   column (Punti · Scambi · Sviluppo · Costruisci · Agente).
+
+   Reused verbatim from the skeleton: TopBar · ChatAgentPanel · ActionLogTimeline ·
+   ScoringPanelRenderer (Points) · TurnIndicatorRenderer (RoundRobin clockwise) ·
+   ToolkitRenderer (CounterTools dal JSON). Dark = primary mode.
+
+   Loads: sp4-parts-common · skeleton-renderers · catan-data(+SkeletonData shim) ·
+          skeleton-parts · catan-flavor · catan-parts · catan-live
+   DEMO-NAV-HINTS: sp4-session-catan-summary.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const S = window.SkeletonParts;
+const C = window.CATAN;
+const F = window.CatanFlavor;
+const P = window.CatanParts;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+const Intro = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+    {[
+      { e: 'session', h: 'Estende lo skeleton', b: 'Riusa TopBar · ChatAgent · ActionLog e i 3 renderer polimorfici. Aggiunge sopra il tabellone esagonale e lo stato dei giocatori.' },
+      { e: 'game',    h: 'Tabellone a 19 esagomi', b: '4 legno · 4 lana · 4 grano · 3 argilla · 3 minerale · 1 deserto. Token di produzione 2-12, ladro, insediamenti/città/strade color-coded, porti.' },
+      { e: 'player',  h: 'Stato per giocatore', b: 'Mano (visibile per il giocatore attivo, segreta per gli altri) · pezzi rimasti · carte sviluppo · PV pubblici · badge Strada+ / Armata+.' },
+      { e: 'toolkit', h: '5 stati canonici', b: 'default · empty · loading · error · sse-disconnect per ogni pannello (punti, scambi, sviluppo, costruisci).' },
+    ].map(c => (
+      <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+        <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: eHsl(c.e), marginBottom: 4 }}>{c.h}</div>
+        <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+      </div>
+    ))}
+  </div>
+);
+
+// states-gallery helper
+const StatesRow = ({ title, sub, entity, render, h = 480 }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHsl(entity) }}>{title}</span>
+      {sub && <span style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)', fontWeight: 700 }}>{sub}</span>}
+    </div>
+    <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>
+      {P.STATES.map(s => (
+        <S.PanelFrame key={s.id} label={s.lb} entity={entity} dark={s.id === 'sse'} h={h}>
+          {render(s.id)}
+        </S.PanelFrame>
+      ))}
+    </div>
+  </div>
+);
+
+// toolkit widgets derived from catan.json CounterTools (for the reused ToolkitRenderer)
+const COUNTER_WIDGETS = [
+  { id: 'w-res', type: 'ResourceManager', isEnabled: true, displayOrder: 0, config: { shared: true, resources: [
+    { label: 'Legno', value: C.BANK.wood, max: 19 }, { label: 'Argilla', value: C.BANK.brick, max: 19 },
+    { label: 'Lana', value: C.BANK.sheep, max: 19 }, { label: 'Grano', value: C.BANK.wheat, max: 19, danger: C.BANK.wheat <= 9 },
+    { label: 'Minerale', value: C.BANK.ore, max: 19 },
+  ] } },
+  { id: 'w-score', type: 'ScoreTracker', isEnabled: true, displayOrder: 1, config: {} },
+  { id: 'w-dice', type: 'RandomGenerator', isEnabled: true, displayOrder: 2, config: { name: 'Dadi di produzione', last: C.DICE.last[0] + C.DICE.last[1], quantity: 2, faces: ['1', '2', '3', '4', '5', '6'] } },
+  { id: 'w-turn', type: 'TurnManager', isEnabled: false, displayOrder: 3, config: { phaseBased: false } },
+];
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Coloni di Catan · Live ⚡ · estensione skeleton</div>
+        <h1>Session live — Coloni di Catan</h1>
+        <p className="lead">
+          Estensione game-specific dello <strong>skeleton universale</strong> applicata a <strong>Coloni di Catan</strong>
+          (euro medium con trading, 3-4 giocatori, ~80 min). Lo skeleton fornisce i renderer polimorfici e la chrome;
+          questo layer aggiunge il <strong>tabellone esagonale a 19 caselle</strong>, il <strong>ladro</strong>, i
+          <strong> 2D6</strong> con cronologia, lo <strong>stato per giocatore</strong> e una colonna destra a 5 tab
+          <strong> Punti · Scambi · Sviluppo · Costruisci · Agente</strong>. Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        {/* INTERACTIVE — desktop */}
+        <div className="section-label">Interattivo · Desktop 1280 — rail giocatori · tabellone + dadi + banca · colonna tab</div>
+        <S.DesktopFrame ds={C.ds} dark label="Desktop · live · Coloni di Catan" url="meepleai.app/sessions/catan-7/live?tab=scores" height={780}
+          desc="3 regioni + tab: SINISTRA stato dei giocatori (Marco attivo, mano visibile; avversari con mano segreta) · CENTRO turno + 2D6 con cronologia · tabellone 19 esagoni con produzione evidenziata (8) · banca + mazzo sviluppo · registro azioni · DESTRA tab Punti/Scambi/Sviluppo/Costruisci/Agente con selettore stato.">
+          <S.TopBar ds={C.ds} connection="connected" />
+          <P.DesktopBody ds={C.ds} initialTab="scoring" initialState="default" />
+        </S.DesktopFrame>
+
+        {/* INTERACTIVE — mobile */}
+        <div className="section-label">Mobile 375 — tabellone scrollabile · rail giocatori collassabile · sezioni in bottom-sheet</div>
+        <div className="phones-grid">
+          <P.PhoneShell label="01 · base · sheet chiuso" desc="Tabellone + dadi sempre visibili. In basso: rail giocatori collassabile + strip tab scrollabile." />
+          <P.PhoneShell label="02 · sheet Scambi" initialTab="trade" desc="Tap su una tab apre il bottom-sheet: offerte player-to-player + banca/porti, con selettore stato." />
+          <P.PhoneShell label="03 · sheet Punti · dark" dark initialTab="scoring" desc="ScoringPanelRenderer riusato: classifica live + breakdown 5 categorie (insediamenti/città/strada+/armata+/carte PV)." />
+        </div>
+
+        {/* STATES — reused polymorphic renderers fed by catan.json */}
+        <div className="section-label">Gallery stati · renderer polimorfici riusati — alimentati dal toolkit Catan</div>
+        <StatesRow title="ScoringPanelRenderer" sub="scoreType · Points — 5 categorie dal JSON (Count · Custom · Sum)" entity="session"
+          render={(st) => <R.ScoringPanelRenderer data={C.ds} state={st} />} />
+        <StatesRow title="TurnIndicatorRenderer" sub="turnOrderType · RoundRobin — giocatore attivo + ordine orario" entity="player"
+          render={(st) => <R.TurnIndicatorRenderer data={C.ds} state={st} />} />
+        <StatesRow title="ToolkitRenderer" sub="dispatch widgets[] — CounterTools del JSON (risorse · punti · dadi)" entity="toolkit"
+          render={(st) => <R.ToolkitRenderer widgets={COUNTER_WIDGETS} players={C.PLAYERS} state={st} />} />
+
+        {/* STATES — Catan-specific panels */}
+        <div className="section-label">Gallery stati · pannelli specifici Catan × 5 stati canonici</div>
+        <StatesRow title="TradePanel" sub="offerte player-to-player + banca 4:1 / porti 3:1 · 2:1" entity="chat"
+          render={(st) => <P.TradePanel state={st} />} />
+        <StatesRow title="DevCardsPanel" sub="mano segreta + cavalieri giocati + tipi nel mazzo" entity="toolkit"
+          render={(st) => <P.DevCardsPanel state={st} />} />
+        <StatesRow title="BuildPanel" sub="costi di costruzione + pezzi rimasti" entity="game"
+          render={(st) => <P.BuildPanel state={st} />} />
+
+        {/* COMPONENT SHOWCASE */}
+        <div className="section-label">Componenti Catan · tabellone · dadi · ladro · stato giocatore</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 18, alignItems: 'start' }}>
+          <div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 800, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>HexBoard · produzione 8 evidenziata</div>
+            <P.SectionCard title="Tabellone · 19 esagoni" entity="session" accent icon="🗺️" pad={10}>
+              <F.HexBoard R={40} highlightNumber={8} />
+            </P.SectionCard>
+          </div>
+          <div data-theme="dark">
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 800, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>RobberBanner · 7 sui dadi · dark</div>
+            <div style={{ background: 'var(--bg)', padding: 12, borderRadius: 'var(--r-lg)', display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <P.RobberBanner mode="discard" />
+              <P.RobberBanner mode="move" />
+              <P.SectionCard title="Stato giocatore · attivo" entity="session" accent>
+                <P.PlayerStateCard p={C.PLAYERS[0]} active />
+              </P.SectionCard>
+            </div>
+          </div>
+        </div>
+        <div style={{ marginTop: 18 }}>
+          <P.SectionCard title="Stato giocatori · 4 plance (Marco attivo)" entity="session" accent>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: 12 }}>
+              {C.PLAYERS.map(p => <P.PlayerStateCard key={p.id} p={p} active={p.current} />)}
+            </div>
+          </P.SectionCard>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        @keyframes catan-hot-anim { 0%,100% { filter: drop-shadow(0 0 5px hsl(var(--c-event)/.9)) drop-shadow(0 0 11px hsl(var(--c-event)/.55)); } 50% { filter: drop-shadow(0 0 8px hsl(var(--c-event)/1)) drop-shadow(0 0 20px hsl(var(--c-event)/.8)); } }
+        .catan-hot { animation: catan-hot-anim 1.7s ease-in-out infinite; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer, .catan-hot { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-catan-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-catan-parts.jsx
@@ -1,0 +1,528 @@
+/* MeepleAI SP4 · Coloni di Catan — PARTS  (window.CatanParts)
+   Game-specific panels + layout that sit ON TOP of the universal skeleton.
+
+   Reused verbatim from the skeleton (window.SkeletonParts):
+     TopBar · ChatAgentPanel · ActionLogTimeline · StateSwitch
+   Reused renderers (window.SkeletonRenderers):
+     ScoringPanelRenderer (Points) · StateScaffold
+   Adds (Catan-specific):
+     SectionCard · PlayerStateCard · PlayerRail · ResourceBank · DevDeck ·
+     TurnPhaseBar · RobberBanner · BoardPanel · TradePanel · DevCardsPanel ·
+     BuildPanel · CatanRightTabs · DesktopBody · MobileBody · PhoneShell
+
+   Reads window.CATAN (data) · window.CatanFlavor (atoms) · window.MAI (eHsl). */
+
+(function () {
+  const M = window.MAI;
+  const C = window.CATAN;
+  const F = window.CatanFlavor;
+  const S = window.SkeletonParts;
+  const R = window.SkeletonRenderers;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const { mono, disp, playerOf } = F;
+
+  const STATES = window.SkeletonData.STATES;
+
+  // ─── SectionCard — titled container ───────────────────────────────────────
+  const SectionCard = ({ title, entity = 'session', accent, icon, right, children, pad = 12, scroll }) => (
+    <section style={{ background: 'var(--bg-card)', border: `1px solid ${accent ? eHsl(entity, 0.3) : 'var(--border)'}`, borderRadius: 'var(--r-lg)', overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      {title && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '8px 11px', background: accent ? eHsl(entity, 0.06) : 'transparent', borderBottom: '1px solid var(--border-light)', borderLeft: accent ? `2px solid ${eHsl(entity)}` : 'none', flexShrink: 0 }}>
+          {icon && <span aria-hidden="true" style={{ fontSize: 13 }}>{icon}</span>}
+          <span style={{ ...mono(10, 800, accent ? eHsl(entity) : 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', flex: 1, minWidth: 0 }}>{title}</span>
+          {right}
+        </div>
+      )}
+      <div style={{ padding: pad, ...(scroll ? { overflowY: 'auto', minHeight: 0 } : {}) }}>{children}</div>
+    </section>
+  );
+
+  // ─── PieceCounter — remaining pieces glyph ────────────────────────────────
+  const PieceCounter = ({ icon, lb, remaining, total }) => (
+    <div title={`${lb}: ${remaining} su ${total} disponibili`} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, flex: 1, padding: '5px 2px', borderRadius: 'var(--r-sm)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+      <span aria-hidden="true" style={{ fontSize: 13 }}>{icon}</span>
+      <span style={{ ...mono(11, 800, remaining === 0 ? eHsl('event') : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{remaining}<span style={{ color: 'var(--text-muted)', fontWeight: 600, fontSize: 9 }}>/{total}</span></span>
+      <span style={{ ...mono(7.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.04em' }}>{lb}</span>
+    </div>
+  );
+
+  // ─── PlayerStateCard — one player in the left rail ────────────────────────
+  const PlayerStateCard = ({ p, active, compact }) => {
+    const T = C.TOTAL_PIECES;
+    const rem = { settlements: T.settlements - p.pieces.settlements, cities: T.cities - p.pieces.cities, roads: T.roads - p.pieces.roads };
+    return (
+      <div style={{
+        borderRadius: 'var(--r-lg)', overflow: 'hidden', flexShrink: 0,
+        background: active ? eHsl('session', 0.06) : 'var(--bg-card)',
+        border: `1px solid ${active ? eHsl('session', 0.45) : 'var(--border)'}`,
+        boxShadow: active ? `0 3px 14px ${eHsl('session', 0.18)}` : 'var(--shadow-xs)',
+      }}>
+        {/* header: piece-color stripe + avatar + name + VP */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderBottom: '1px solid var(--border-light)', borderTop: `3px solid ${p.pc}` }}>
+          <div aria-hidden="true" style={{ width: 30, height: 30, borderRadius: '50%', flexShrink: 0, background: `linear-gradient(135deg, hsl(${p.hue},70%,64%), hsl(${p.hue},58%,44%))`, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...disp(14, 800, '#fff'), border: active ? `2px solid ${eHsl('session')}` : '2px solid var(--bg-card)' }}>{p.name[0]}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+              <span style={{ ...disp(13.5, 800, 'var(--text)') }}>{p.name}</span>
+              <F.PlayerDot p={p} size={9} />
+              {active && <span className="mai-pulse-dot-host" style={{ ...mono(7.5, 800, eHsl('session')), textTransform: 'uppercase', letterSpacing: '.05em', padding: '1px 5px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.14), border: `1px solid ${eHsl('session', 0.35)}` }}>turno</span>}
+            </div>
+            <div style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{p.pieces.settlements} ins · {p.pieces.cities} città · {p.pieces.roads} strade</div>
+          </div>
+          <F.VPBadge vp={p.vp} leader={active} />
+        </div>
+        <div style={{ padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {/* hand */}
+          <F.ResourceHandBar hand={p.hand} hidden={!active} label={active ? 'Mano (visibile)' : 'Mano avversario'} />
+          {/* pieces remaining */}
+          <div>
+            <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 4 }}>Pezzi rimasti</div>
+            <div style={{ display: 'flex', gap: 5 }}>
+              <PieceCounter icon="🏠" lb="ins." remaining={rem.settlements} total={T.settlements} />
+              <PieceCounter icon="🏛️" lb="città" remaining={rem.cities} total={T.cities} />
+              <PieceCounter icon="🛤️" lb="strade" remaining={rem.roads} total={T.roads} />
+            </div>
+          </div>
+          {/* dev + badges */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '3px 8px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.1), border: `1px solid ${eHsl('toolkit', 0.28)}`, ...mono(9.5, 800, eHsl('toolkit')) }}>
+              <span aria-hidden="true">🃏</span>{p.dev.held}<span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>sviluppo</span>
+            </span>
+            <span title="Cavalieri giocati" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '3px 8px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', ...mono(9.5, 800, 'var(--text-sec)') }}>
+              <span aria-hidden="true">⚔️</span>{p.dev.knightsPlayed}
+            </span>
+          </div>
+          {(p.badges.longestRoad || p.badges.largestArmy) && (
+            <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+              {p.badges.longestRoad && <F.LongestRoadBadge on len={p.longestRoadLen} />}
+              {p.badges.largestArmy && <F.LargestArmyBadge on n={p.knights} />}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const PlayerRail = ({ players = C.PLAYERS }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>Giocatori · {players.length}</div>
+      {players.map(p => <PlayerStateCard key={p.id} p={p} active={p.current} />)}
+    </div>
+  );
+
+  // ─── ResourceBank · DevDeck (shared) ──────────────────────────────────────
+  const ResourceBank = ({ bank = C.BANK }) => (
+    <SectionCard title="Banca risorse" entity="kb" accent icon="🏦">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+        {C.RES_ORDER.map(k => {
+          const v = bank[k], low = v <= 8;
+          return (
+            <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <F.ResourceToken id={k} size={18} />
+              <span style={{ flex: 1, ...disp(12, 700, 'var(--text)') }}>{C.RES[k].lb}</span>
+              <div style={{ flex: 1.4, height: 7, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+                <div style={{ width: `${(v / 19) * 100}%`, height: '100%', borderRadius: 'var(--r-pill)', background: low ? eHsl('event') : eHsl('kb') }} />
+              </div>
+              <span style={{ ...mono(11, 800, low ? eHsl('event') : 'var(--text)'), minWidth: 30, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{v}<span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>/19</span></span>
+            </div>
+          );
+        })}
+      </div>
+    </SectionCard>
+  );
+
+  const DevDeck = ({ deck = C.DEV_DECK }) => (
+    <SectionCard title="Mazzo sviluppo" entity="toolkit" accent icon="🃏">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div style={{ position: 'relative', width: 44, height: 60, flexShrink: 0 }} aria-hidden="true">
+          {[0, 1, 2].map(i => (
+            <div key={i} style={{ position: 'absolute', inset: 0, transform: `translate(${i * 3}px, ${-i * 3}px)`, borderRadius: 'var(--r-sm)', background: 'linear-gradient(150deg, hsl(150,30%,30%), hsl(150,35%,20%))', border: '1.5px solid hsl(150,30%,16%)', boxShadow: '0 2px 5px rgba(0,0,0,.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>{i === 2 ? '🃏' : ''}</div>
+          ))}
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ ...disp(22, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{deck.remaining}<span style={{ ...mono(11, 700, 'var(--text-muted)') }}> / {deck.total}</span></div>
+          <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', marginTop: 2 }}>carte nel mazzo</div>
+          <div style={{ height: 6, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden', marginTop: 6 }}>
+            <div style={{ width: `${(deck.remaining / deck.total) * 100}%`, height: '100%', background: eHsl('toolkit') }} />
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
+
+  // ─── TurnPhaseBar — active player + 3 phases + dice ───────────────────────
+  const TurnPhaseBar = ({ ds = C.ds, dice = C.DICE, onRoll }) => {
+    const ts = ds.turnState, t = ds.turn;
+    const active = ds.players.find(p => p.id === ts.activePlayerId) || ds.players[0];
+    return (
+      <div style={{ display: 'flex', gap: 12, alignItems: 'stretch', flexWrap: 'wrap' }}>
+        {/* active player + phases */}
+        <div style={{ flex: '1 1 320px', minWidth: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: 12, borderRadius: 'var(--r-lg)', background: eHsl('player', 0.06), border: `1px solid ${eHsl('player', 0.28)}` }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }} aria-live="polite">
+            <div aria-hidden="true" style={{ width: 38, height: 38, borderRadius: '50%', flexShrink: 0, background: `linear-gradient(135deg, hsl(${active.hue},70%,64%), hsl(${active.hue},58%,44%))`, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...disp(16, 800, '#fff'), border: `2px solid ${active.pc}` }}>{active.name[0]}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ ...mono(8.5, 800, eHsl('player')), textTransform: 'uppercase', letterSpacing: '.06em' }}>Turno di · round {ts.round}</div>
+              <div style={{ ...disp(16, 800, 'var(--text)') }}>{active.name}</div>
+            </div>
+            <span style={{ ...mono(9, 800, eHsl('player')), textTransform: 'uppercase', letterSpacing: '.05em', padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('player', 0.12), border: `1px solid ${eHsl('player', 0.3)}` }}>↻ {t.direction === 'clockwise' ? 'orario' : t.direction}</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {t.phases.map((ph, i) => {
+              const on = i === ts.phaseIndex, past = i < ts.phaseIndex;
+              return (
+                <div key={ph} aria-current={on ? 'step' : undefined} style={{ flex: 1, padding: '6px 6px', borderRadius: 'var(--r-md)', textAlign: 'center', background: on ? eHsl('player', 0.16) : past ? eHsl('player', 0.06) : 'var(--bg-muted)', border: `1px solid ${on ? eHsl('player', 0.45) : 'var(--border-light)'}`, color: on ? eHsl('player') : past ? 'var(--text-sec)' : 'var(--text-muted)' }}>
+                  <div style={{ ...mono(8, 800), opacity: 0.7 }}>{past ? '✓' : i + 1}</div>
+                  <div style={{ ...disp(10.5, 800), lineHeight: 1.1, marginTop: 1 }}>{ph}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        {/* dice */}
+        <div style={{ flex: '0 1 230px', display: 'flex', flexDirection: 'column', gap: 8, padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+            <F.DiceDisplay dice={dice} />
+            <button type="button" onClick={onRoll} style={{ padding: '8px 13px', borderRadius: 'var(--r-md)', background: eHsl('tool'), color: '#06222b', border: 'none', ...disp(12, 800, '#06222b'), cursor: 'pointer', flexShrink: 0, boxShadow: `0 3px 10px ${eHsl('tool', 0.4)}` }}>🎲 Tira</button>
+          </div>
+          <F.DiceHistory dice={dice} history={dice.history} />
+        </div>
+      </div>
+    );
+  };
+
+  // ─── RobberBanner — alert when a 7 is rolled ──────────────────────────────
+  const RobberBanner = ({ mode }) => {
+    if (!mode) return null;
+    const isDiscard = mode === 'discard';
+    return (
+      <div role="alert" aria-live="assertive" style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '11px 14px', borderRadius: 'var(--r-lg)', background: eHsl('event', 0.1), border: `1px solid ${eHsl('event', 0.4)}`, boxShadow: `0 3px 14px ${eHsl('event', 0.2)}` }}>
+        <span aria-hidden="true" style={{ width: 34, height: 34, borderRadius: '50%', flexShrink: 0, background: eHsl('event', 0.16), display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>🦹</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ ...disp(13.5, 800, eHsl('event')) }}>È uscito un 7 — il Ladro!</div>
+          <div style={{ ...mono(10, 700, 'var(--text-sec)') }}>{isDiscard ? 'Chi ha più di 7 carte ne scarta metà' : 'Sposta il ladro e ruba una carta'}</div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+          <span style={{ ...mono(9, 800, isDiscard ? eHsl('event') : 'var(--text-muted)'), padding: '4px 9px', borderRadius: 'var(--r-pill)', background: isDiscard ? eHsl('event', 0.14) : 'var(--bg-muted)', border: `1px solid ${isDiscard ? eHsl('event', 0.4) : 'var(--border-light)'}` }}>1 · scarta</span>
+          <span style={{ ...mono(9, 800, !isDiscard ? eHsl('event') : 'var(--text-muted)'), padding: '4px 9px', borderRadius: 'var(--r-pill)', background: !isDiscard ? eHsl('event', 0.14) : 'var(--bg-muted)', border: `1px solid ${!isDiscard ? eHsl('event', 0.4) : 'var(--border-light)'}` }}>2 · sposta</span>
+        </div>
+      </div>
+    );
+  };
+
+  // ─── BoardPanel — center column board + dice + log ────────────────────────
+  const BoardPanel = ({ ds = C.ds, R: hexR = 44, rolled7, robberMode, embedded }) => {
+    const dice = C.DICE;
+    const sum = dice.last[0] + dice.last[1];
+    const robberHex = C.ROBBER_HEX;
+    const rob = C.HEXES.find(h => h.id === robberHex);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, minHeight: 0 }}>
+        <TurnPhaseBar ds={ds} dice={dice} />
+        {robberMode && <RobberBanner mode={robberMode} />}
+        <SectionCard title={`Tabellone · ultimo lancio ${sum}`} entity="session" accent icon="🗺️"
+          right={<span style={{ ...mono(9, 700, 'var(--text-muted)') }}>ladro su {C.RES[rob.t].terrain}-{rob.n}</span>} pad={10}>
+          <F.HexBoard R={hexR} highlightNumber={sum === 7 ? null : sum} robberHex={robberHex} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, flexWrap: 'wrap', justifyContent: 'center' }}>
+            {C.PLAYERS.map(p => (
+              <span key={p.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, ...mono(9.5, 700, 'var(--text-sec)') }}>
+                <F.PlayerDot p={p} size={10} />{p.name}
+              </span>
+            ))}
+            <span style={{ ...mono(9, 700, 'var(--text-muted)'), marginLeft: 4 }}>· i numeri 6 e 8 (rossi) sono i più probabili</span>
+          </div>
+        </SectionCard>
+        <div style={{ display: 'grid', gridTemplateColumns: embedded ? '1fr' : '1.3fr 1fr', gap: 12 }}>
+          <ResourceBank />
+          <DevDeck />
+        </div>
+        <S.ActionLogTimeline ds={ds} />
+      </div>
+    );
+  };
+
+  // ─── state wrapper ────────────────────────────────────────────────────────
+  const withStates = (state, opts, children) => (
+    <R.StateScaffold state={state} sseWhere={opts.sseWhere} empty={opts.empty} error={opts.error}>{children}</R.StateScaffold>
+  );
+  const SubLabel = ({ children, mt }) => (
+    <div style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginTop: mt }}>{children}</div>
+  );
+  const ResSet = ({ set, sign }) => (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+      {Object.entries(set).map(([k, n]) => (
+        <span key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+          <F.ResourceToken id={k} size={16} />
+          <span style={{ ...mono(11, 800, 'var(--text)') }}>{sign}{n}</span>
+        </span>
+      ))}
+    </span>
+  );
+
+  // ─── TradePanel ───────────────────────────────────────────────────────────
+  const OfferCard = ({ offer, kind }) => {
+    const other = kind === 'in' ? playerOf(offer.from) : null;
+    return (
+      <div style={{ padding: 11, borderRadius: 'var(--r-md)', background: 'var(--bg-card)', border: `1px solid ${kind === 'in' ? eHsl('chat', 0.3) : eHsl('session', 0.3)}` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 8 }}>
+          {other && <F.PlayerDot p={other} size={11} />}
+          <span style={{ ...disp(12.5, 800, 'var(--text)') }}>{kind === 'in' ? `${other.name} propone` : 'La tua proposta'}</span>
+          <div style={{ flex: 1 }} />
+          <span style={{ ...mono(8, 800, kind === 'in' ? eHsl('chat') : eHsl('session')), textTransform: 'uppercase', letterSpacing: '.05em', padding: '2px 7px', borderRadius: 'var(--r-pill)', background: kind === 'in' ? eHsl('chat', 0.12) : eHsl('session', 0.12) }}>{kind === 'in' ? 'in arrivo' : 'aperta'}</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 'var(--r-sm)', background: 'var(--bg-muted)' }}>
+          <div><div style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase', marginBottom: 3 }}>{kind === 'in' ? 'ti danno' : 'tu dai'}</div><ResSet set={kind === 'in' ? offer.give : offer.give} /></div>
+          <span style={{ color: 'var(--text-muted)', fontSize: 16 }} aria-hidden="true">⇄</span>
+          <div><div style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase', marginBottom: 3 }}>{kind === 'in' ? 'vogliono' : 'tu vuoi'}</div><ResSet set={kind === 'in' ? offer.want : offer.want} /></div>
+        </div>
+        {offer.note ? <div style={{ ...mono(9.5, 600, 'var(--text-muted)'), marginTop: 6, fontStyle: 'italic' }}>“{offer.note}”</div> : null}
+        {kind === 'in' && (
+          <div style={{ display: 'flex', gap: 6, marginTop: 9 }}>
+            <button type="button" style={{ flex: 1, padding: '7px', borderRadius: 'var(--r-md)', background: eHsl('toolkit'), color: '#fff', border: 'none', ...disp(11.5, 800, '#fff'), cursor: 'pointer' }}>Accetta</button>
+            <button type="button" style={{ flex: 1, padding: '7px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', color: 'var(--text-sec)', border: '1px solid var(--border)', ...disp(11.5, 800), cursor: 'pointer' }}>Rifiuta</button>
+            <button type="button" style={{ padding: '7px 11px', borderRadius: 'var(--r-md)', background: 'transparent', color: eHsl('chat'), border: `1px solid ${eHsl('chat', 0.4)}`, ...disp(11.5, 800), cursor: 'pointer' }}>Contro</button>
+          </div>
+        )}
+      </div>
+    );
+  };
+  const BankTradeRow = ({ ratio, lb, e, ports }) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+      <span style={{ width: 34, ...disp(14, 800, eHsl(e)), textAlign: 'center', fontVariantNumeric: 'tabular-nums' }}>{ratio}</span>
+      <span style={{ flex: 1, ...mono(10, 700, 'var(--text-sec)') }}>{lb}</span>
+      {ports && <span style={{ display: 'inline-flex', gap: 3 }}>{ports.map((pt, i) => pt.type === 'generic' ? <span key={i} style={{ ...mono(9, 800, 'var(--text-muted)') }}>3:1</span> : <F.ResourceToken key={i} id={pt.type} size={15} />)}</span>}
+    </div>
+  );
+  const TradePanel = ({ state = 'default', ds = C.ds }) => withStates(state, {
+    sseWhere: 'scambi',
+    empty: { icon: '🤝', title: 'Nessuna proposta', body: 'Le offerte di scambio compariranno qui durante la fase di commercio.' },
+    error: { title: 'Scambi non disponibili', body: 'Impossibile sincronizzare le proposte di scambio.' },
+  }, (
+    <R.Panel gap={11}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <SubLabel>Offerte in arrivo · {C.TRADE.incoming.length}</SubLabel><div style={{ flex: 1 }} />
+        <span style={{ ...mono(9, 800, eHsl('chat')), textTransform: 'uppercase', letterSpacing: '.05em', padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('chat', 0.12), border: `1px solid ${eHsl('chat', 0.3)}` }}>player-to-player</span>
+      </div>
+      {C.TRADE.incoming.map(o => <OfferCard key={o.id} offer={o} kind="in" />)}
+      <SubLabel mt={4}>La tua proposta</SubLabel>
+      <OfferCard offer={C.TRADE.outgoing} kind="out" />
+      <SubLabel mt={4}>Commercio con la banca / porti</SubLabel>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <BankTradeRow ratio="4:1" lb="Banca · qualsiasi risorsa" e="kb" />
+        <BankTradeRow ratio="3:1" lb="Porto generico" e="session" ports={C.PLAYER_PORTS[ds.turnState.activePlayerId]?.filter(p => p.type === 'generic')} />
+        <BankTradeRow ratio="2:1" lb="Porto specifico (tuoi)" e="toolkit" ports={C.PLAYER_PORTS[ds.turnState.activePlayerId]?.filter(p => p.type !== 'generic')} />
+      </div>
+    </R.Panel>
+  ));
+
+  // ─── DevCardsPanel ────────────────────────────────────────────────────────
+  const DevCardsPanel = ({ state = 'default', ds = C.ds }) => {
+    const me = ds.players.find(p => p.id === ds.turnState.activePlayerId) || ds.players[0];
+    return withStates(state, {
+      sseWhere: 'carte sviluppo',
+      empty: { icon: '🃏', title: 'Nessuna carta sviluppo', body: 'Compra carte con 1 lana + 1 grano + 1 minerale.' },
+      error: { title: 'Carte non disponibili', body: 'Impossibile caricare le carte sviluppo.' },
+    }, (
+      <R.Panel gap={11}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <SubLabel>La tua mano · {me.name}</SubLabel><div style={{ flex: 1 }} />
+          <span style={{ ...mono(9, 800, eHsl('toolkit')), padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.12), border: `1px solid ${eHsl('toolkit', 0.3)}` }}>segreta</span>
+        </div>
+        <div style={{ display: 'flex', gap: 7 }}>
+          <div style={{ flex: 1, padding: '10px 12px', borderRadius: 'var(--r-md)', background: eHsl('toolkit', 0.07), border: `1px solid ${eHsl('toolkit', 0.3)}`, textAlign: 'center' }}>
+            <div style={{ ...disp(22, 800, 'var(--text)') }}>{me.dev.held}</div>
+            <div style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase' }}>in mano</div>
+          </div>
+          <div style={{ flex: 1, padding: '10px 12px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', textAlign: 'center' }}>
+            <div style={{ ...disp(22, 800, eHsl('event')) }}>{me.dev.knightsPlayed}</div>
+            <div style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase' }}>cavalieri giocati</div>
+          </div>
+          <div style={{ flex: 1, padding: '10px 12px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', textAlign: 'center' }}>
+            <div style={{ ...disp(22, 800, eHsl('toolkit')) }}>{me.dev.vpCards}</div>
+            <div style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase' }}>carte PV</div>
+          </div>
+        </div>
+        <SubLabel mt={4}>Tipi nel mazzo · {C.DEV_DECK.remaining} rimaste</SubLabel>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {C.DEV_TYPES.map(d => (
+            <div key={d.id} title={d.desc} style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+              <span aria-hidden="true" style={{ width: 26, height: 26, borderRadius: 'var(--r-sm)', background: eHsl(d.e, 0.14), border: `1px solid ${eHsl(d.e, 0.3)}`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, flexShrink: 0 }}>{d.icon}</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ ...disp(12, 800, 'var(--text)') }}>{d.lb}</div>
+                <div style={{ ...mono(9, 600, 'var(--text-muted)'), whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{d.desc}</div>
+              </div>
+              <span style={{ ...mono(10, 800, 'var(--text-sec)'), flexShrink: 0 }}>×{d.total}</span>
+            </div>
+          ))}
+        </div>
+      </R.Panel>
+    ));
+  };
+
+  // ─── BuildPanel ───────────────────────────────────────────────────────────
+  const BuildPanel = ({ state = 'default', ds = C.ds }) => {
+    const me = ds.players.find(p => p.id === ds.turnState.activePlayerId) || ds.players[0];
+    const T = C.TOTAL_PIECES;
+    const canAfford = (cost) => C.RES_ORDER.every(k => (me.hand[k] || 0) >= (cost[k] || 0));
+    return withStates(state, {
+      sseWhere: 'costruzione',
+      empty: { icon: '🧱', title: 'Niente da costruire', body: 'Raccogli risorse per costruire strade, insediamenti e città.' },
+      error: { title: 'Costruzione non disponibile', body: 'Impossibile caricare i costi di costruzione.' },
+    }, (
+      <R.Panel gap={11}>
+        <SubLabel>Costi di costruzione</SubLabel>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          {C.BUILD_COSTS.map(b => {
+            const ok = canAfford(b.cost);
+            return (
+              <div key={b.id} style={{ padding: '9px 11px', borderRadius: 'var(--r-md)', background: ok ? eHsl(b.e, 0.06) : 'var(--bg-card)', border: `1px solid ${ok ? eHsl(b.e, 0.3) : 'var(--border)'}` }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span aria-hidden="true" style={{ fontSize: 16 }}>{b.icon}</span>
+                  <span style={{ ...disp(13, 800, 'var(--text)') }}>{b.lb}</span>
+                  {b.vp > 0 && <span style={{ ...mono(8.5, 800, eHsl('toolkit')), padding: '1px 6px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.12) }}>+{b.vp} PV</span>}
+                  <div style={{ flex: 1 }} />
+                  <ResSet set={b.cost} />
+                  <button type="button" disabled={!ok} style={{ marginLeft: 6, padding: '5px 11px', borderRadius: 'var(--r-md)', background: ok ? eHsl(b.e) : 'var(--bg-muted)', color: ok ? '#fff' : 'var(--text-muted)', border: ok ? 'none' : '1px solid var(--border)', ...disp(11, 800), cursor: ok ? 'pointer' : 'not-allowed', opacity: ok ? 1 : 0.7 }}>{ok ? 'Costruisci' : 'manca'}</button>
+                </div>
+                <div style={{ ...mono(9, 600, 'var(--text-muted)'), marginTop: 5 }}>{b.note}</div>
+              </div>
+            );
+          })}
+        </div>
+        <SubLabel mt={4}>Pezzi rimasti · {me.name}</SubLabel>
+        <div style={{ display: 'flex', gap: 7 }}>
+          <PieceCounter icon="🏠" lb="insediamenti" remaining={T.settlements - me.pieces.settlements} total={T.settlements} />
+          <PieceCounter icon="🏛️" lb="città" remaining={T.cities - me.pieces.cities} total={T.cities} />
+          <PieceCounter icon="🛤️" lb="strade" remaining={T.roads - me.pieces.roads} total={T.roads} />
+        </div>
+      </R.Panel>
+    ));
+  };
+
+  // ─── CatanRightTabs — Scoring · Trade · Dev · Build · Chat ─────────────────
+  const CAT_TABS = [
+    { id: 'scoring', icon: '🎯', label: 'Punti', entity: 'session', render: (ds, st) => <R.ScoringPanelRenderer data={ds} state={st} /> },
+    { id: 'trade',   icon: '🤝', label: 'Scambi', entity: 'chat',    render: (ds, st) => <TradePanel ds={ds} state={st} /> },
+    { id: 'dev',     icon: '🃏', label: 'Sviluppo', entity: 'toolkit', render: (ds, st) => <DevCardsPanel ds={ds} state={st} /> },
+    { id: 'build',   icon: '🧱', label: 'Costruisci', entity: 'game', render: (ds, st) => <BuildPanel ds={ds} state={st} /> },
+    { id: 'chat',    icon: '🤖', label: 'Agente', entity: 'agent',   render: (ds, st) => <div style={{ flex: 1, minHeight: 0, display: 'flex', padding: 10 }}><S.ChatAgentPanel ds={ds} /></div> },
+  ];
+
+  const CatanRightTabs = ({ ds = C.ds, initial = 'scoring', initialState = 'default', embedded, width = 372 }) => {
+    const [tab, setTab] = useState(initial);
+    const [st, setSt] = useState(initialState);
+    const active = CAT_TABS.find(t => t.id === tab) || CAT_TABS[0];
+    return (
+      <aside aria-label="Pannello sessione Catan" style={{ width: embedded ? '100%' : width, minWidth: embedded ? 0 : 320, flexShrink: 0, height: '100%', background: 'var(--bg-card)', borderLeft: embedded ? 'none' : '1px solid var(--border)', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <div role="tablist" aria-label="Sezioni" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0 }}>
+          {CAT_TABS.map(t => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} onClick={() => setTab(t.id)} style={{ flex: 1, padding: '9px 4px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(11, 800), cursor: 'pointer', display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+                <span aria-hidden="true" style={{ fontSize: 15 }}>{t.icon}</span><span>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        {tab !== 'chat' && <S.StateSwitch value={st} onChange={setSt} />}
+        <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(ds, tab === 'chat' ? 'default' : st)}</div>
+      </aside>
+    );
+  };
+
+  // ─── DesktopBody — LEFT rail · CENTER board · RIGHT tabs ──────────────────
+  const DesktopBody = ({ ds = C.ds, initialTab = 'scoring', initialState = 'default' }) => (
+    <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+      <div style={{ width: 244, flexShrink: 0, borderRight: '1px solid var(--border)', overflowY: 'auto', padding: 12, background: 'var(--bg)' }}>
+        <PlayerRail players={ds.players} />
+      </div>
+      <main style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: 14, background: 'var(--bg)' }}>
+        <BoardPanel ds={ds} R={44} />
+      </main>
+      <CatanRightTabs ds={ds} initial={initialTab} initialState={initialState} />
+    </div>
+  );
+
+  // ─── MOBILE body ──────────────────────────────────────────────────────────
+  const MobileSheet = ({ ds, open, tab, st, setSt, onClose }) => {
+    const active = CAT_TABS.find(t => t.id === tab) || CAT_TABS[0];
+    return (
+      <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+        <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,12,30,.5)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+        <div role="dialog" aria-modal="true" aria-label={active.label} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '86%', background: 'var(--bg-card)', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl(active.entity)}`, boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 8, flexShrink: 0 }}>
+            <div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px 10px', flexShrink: 0 }}>
+            <span aria-hidden="true" style={{ fontSize: 16 }}>{active.icon}</span>
+            <span style={{ ...disp(15, 800, eHsl(active.entity)) }}>{active.label}</span>
+            <div style={{ flex: 1 }} />
+            <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+          </div>
+          {tab !== 'chat' && <S.StateSwitch value={st} onChange={setSt} />}
+          <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(ds, tab === 'chat' ? 'default' : st)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const MobileBody = ({ ds = C.ds, initialTab }) => {
+    const [sheet, setSheet] = useState(initialTab || null);
+    const [st, setSt] = useState('default');
+    const [railOpen, setRailOpen] = useState(false);
+    const active = ds.players.find(p => p.id === ds.turnState.activePlayerId) || ds.players[0];
+    return (
+      <>
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, background: 'var(--bg)' }}>
+          <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <BoardPanel ds={ds} R={32} embedded />
+          </div>
+        </div>
+        {/* collapsible player rail */}
+        <div style={{ flexShrink: 0, borderTop: '1px solid var(--border)', background: 'var(--bg-card)' }}>
+          <button type="button" onClick={() => setRailOpen(o => !o)} aria-expanded={railOpen} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: 'transparent', border: 'none', cursor: 'pointer' }}>
+            <span style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Giocatori</span>
+            <div style={{ display: 'flex', marginLeft: 2 }}>{ds.players.map((p, i) => <span key={p.id} style={{ marginLeft: i ? -6 : 0 }}><F.PlayerDot p={p} size={16} /></span>)}</div>
+            <div style={{ flex: 1 }} />
+            <span style={{ ...mono(9, 700, eHsl('session')) }}>turno: {active.name}</span>
+            <span aria-hidden="true" style={{ ...mono(11, 800, 'var(--text-muted)'), transform: railOpen ? 'none' : 'rotate(-90deg)', transition: 'transform var(--dur-sm)' }}>▾</span>
+          </button>
+          {railOpen && <div style={{ padding: '0 12px 12px', display: 'flex', flexDirection: 'column', gap: 10, maxHeight: 320, overflowY: 'auto' }}>{ds.players.map(p => <PlayerStateCard key={p.id} p={p} active={p.current} />)}</div>}
+        </div>
+        {/* tab strip */}
+        <nav className="mai-cb-scroll" aria-label="Sezioni" style={{ display: 'flex', gap: 6, overflowX: 'auto', flexShrink: 0, padding: '8px 10px', background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderTop: '1px solid var(--border)' }}>
+          {CAT_TABS.map(t => (
+            <button key={t.id} type="button" onClick={() => { setSt('default'); setSheet(t.id); }} style={{ flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 5, padding: '7px 13px', borderRadius: 'var(--r-pill)', background: eHsl(t.entity, 0.1), border: `1px solid ${eHsl(t.entity, 0.28)}`, color: eHsl(t.entity), ...disp(12, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true">{t.icon}</span>{t.label}
+            </button>
+          ))}
+        </nav>
+        <MobileSheet ds={ds} open={!!sheet} tab={sheet} st={st} setSt={setSt} onClose={() => setSheet(null)} />
+      </>
+    );
+  };
+
+  // ─── PhoneShell ───────────────────────────────────────────────────────────
+  const PhoneShell = ({ ds = C.ds, label, desc, dark, initialTab }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+      <div className="phone" data-theme={dark ? 'dark' : undefined}>
+        <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+          <span style={{ fontFamily: 'var(--f-mono)' }}>19:42</span>
+          <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">82%</span></div>
+        </div>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <S.TopBar ds={ds} compact />
+          <MobileBody ds={ds} initialTab={initialTab} />
+        </div>
+      </div>
+      {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 340, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  window.CatanParts = {
+    SectionCard, PieceCounter, PlayerStateCard, PlayerRail, ResourceBank, DevDeck,
+    TurnPhaseBar, RobberBanner, BoardPanel, TradePanel, DevCardsPanel, BuildPanel,
+    CatanRightTabs, DesktopBody, MobileBody, MobileSheet, PhoneShell, CAT_TABS, STATES,
+    SubLabel, ResSet, OfferCard,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-catan-summary.html
+++ b/admin-mockups/design_files/sp4-session-catan-summary.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Coloni di Catan · Summary — /sessions/[id]/summary</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-catan-summary.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-catan-summary.jsx
+++ b/admin-mockups/design_files/sp4-session-catan-summary.jsx
@@ -1,0 +1,368 @@
+/* MeepleAI SP4 · Coloni di Catan — SESSION SUMMARY  (App)
+   /sessions/[id]/summary — post-game recap for a finished Catan session.
+
+   Reuses the universal chrome + atoms; adds the Catan post-game surfaces:
+     Hero (winner banner + final VP) · Scoreboard (per-player VP breakdown by the
+     5 catan.json categories) · Final Board (board snapshot) · Stats (turns, 2D6
+     distribution chart, trades per player, longest production run).
+
+   Reused: OutcomeBadge (window.MAI) · HexBoard / VPBadge / badges (CatanFlavor) ·
+   SectionCard / PlayerDot (CatanParts). Dark = primary mode.
+
+   Loads: sp4-parts-common · skeleton-renderers · catan-data(+SkeletonData shim) ·
+          skeleton-parts · catan-flavor · catan-parts · catan-summary
+   DEMO-NAV-HINTS: sp4-session-catan-live.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const S = window.SkeletonParts;
+const C = window.CATAN;
+const F = window.CatanFlavor;
+const P = window.CatanParts;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+const { mono, disp } = F;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+// ─── final standings (game over — Marco reaches 10 VP) ──────────────────────
+// counts per category; VP computed from C.SCORING category weights.
+const FINAL = {
+  winner: 'marco',
+  longestRoadHolder: 'marco',
+  largestArmyHolder: 'anna',
+  rows: [
+    { id: 'marco', counts: { settlements: 2, cities: 2, 'longest-road': 1, 'largest-army': 0, 'vp-cards': 2 }, knights: 1, roadLen: 7 },
+    { id: 'anna',  counts: { settlements: 2, cities: 2, 'longest-road': 0, 'largest-army': 1, 'vp-cards': 0 }, knights: 4, roadLen: 5 },
+    { id: 'luca',  counts: { settlements: 3, cities: 1, 'longest-road': 0, 'largest-army': 0, 'vp-cards': 1 }, knights: 2, roadLen: 5 },
+    { id: 'sara',  counts: { settlements: 4, cities: 0, 'longest-road': 0, 'largest-army': 0, 'vp-cards': 1 }, knights: 0, roadLen: 3 },
+  ],
+};
+const CAT = C.SCORING.categories;
+const catVP = (catId, count) => {
+  const cat = CAT.find(c => c.id === catId);
+  return count * cat.weight;
+};
+const rowTotal = (row) => CAT.reduce((s, c) => s + catVP(c.id, row.counts[c.id]), 0);
+FINAL.rows.forEach(r => { r.total = rowTotal(r); r.player = C.PLAYERS.find(p => p.id === r.id); });
+FINAL.standings = [...FINAL.rows].sort((a, b) => b.total - a.total);
+
+// ─── Hero ────────────────────────────────────────────────────────────────────
+const Hero = () => {
+  const win = FINAL.standings[0];
+  return (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'stretch', flexWrap: 'wrap', padding: 16, borderBottom: '1px solid var(--border)', background: `linear-gradient(135deg, ${eHsl('toolkit', 0.1)}, ${eHsl('session', 0.06)})` }}>
+      <div style={{ flex: '1 1 320px', minWidth: 0, display: 'flex', gap: 14, alignItems: 'center' }}>
+        <div style={{ position: 'relative', flexShrink: 0 }}>
+          <div aria-hidden="true" style={{ width: 64, height: 64, borderRadius: '50%', background: `linear-gradient(135deg, hsl(${win.player.hue},70%,64%), hsl(${win.player.hue},58%,44%))`, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...disp(28, 800, '#fff'), border: `3px solid ${eHsl('toolkit')}`, boxShadow: `0 4px 18px ${eHsl('toolkit', 0.35)}` }}>{win.player.name[0]}</div>
+          <span aria-hidden="true" style={{ position: 'absolute', top: -10, right: -6, fontSize: 26, transform: 'rotate(18deg)' }}>👑</span>
+        </div>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 3 }}>
+            <M.OutcomeBadge status="win" />
+            <span style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{C.GAME.title} · {C.STATS.duration} · {C.STATS.totalTurns} turni</span>
+          </div>
+          <h2 style={{ fontFamily: 'var(--f-display)', fontSize: 26, fontWeight: 800, color: 'var(--text)', margin: 0 }}>{win.player.name} vince!</h2>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 5 }}>
+            <F.VPBadge vp={win.total} leader size="lg" />
+            <span style={{ ...mono(10, 700, 'var(--text-sec)') }}>· primo a {C.SCORING.target} PV</span>
+          </div>
+        </div>
+      </div>
+      {/* final standings strip */}
+      <div style={{ flex: '1 1 360px', display: 'flex', flexDirection: 'column', gap: 6, justifyContent: 'center' }}>
+        {FINAL.standings.map((r, i) => (
+          <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '6px 10px', borderRadius: 'var(--r-md)', background: i === 0 ? eHsl('toolkit', 0.1) : 'var(--bg-card)', border: `1px solid ${i === 0 ? eHsl('toolkit', 0.3) : 'var(--border)'}` }}>
+            <span style={{ ...mono(11, 800, i === 0 ? eHsl('toolkit') : 'var(--text-muted)'), width: 16 }}>{i + 1}°</span>
+            <F.PlayerDot p={r.player} size={12} />
+            <span style={{ flex: 1, ...disp(13, 800, 'var(--text)') }}>{r.player.name}</span>
+            {FINAL.longestRoadHolder === r.id && <F.LongestRoadBadge on len={r.roadLen} />}
+            {FINAL.largestArmyHolder === r.id && <F.LargestArmyBadge on n={r.knights} />}
+            <div style={{ height: 7, width: 90, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+              <div style={{ width: `${(r.total / C.SCORING.target) * 100}%`, height: '100%', background: i === 0 ? eHsl('toolkit') : `hsl(${r.player.hue},58%,55%)` }} />
+            </div>
+            <span style={{ ...disp(18, 800, i === 0 ? eHsl('toolkit') : 'var(--text)'), fontVariantNumeric: 'tabular-nums', minWidth: 22, textAlign: 'right' }}>{r.total}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// ─── Scoreboard tab ──────────────────────────────────────────────────────────
+const ScoreboardTab = () => (
+  <div style={{ padding: 16, overflowX: 'auto' }}>
+    <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 10 }}>Punteggio finale · breakdown per categoria (catan.json scoringTemplate)</div>
+    <table style={{ width: '100%', minWidth: 640, borderCollapse: 'separate', borderSpacing: 0 }}>
+      <thead>
+        <tr>
+          <th style={{ textAlign: 'left', padding: '8px 10px', ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', borderBottom: '1px solid var(--border)' }}>Giocatore</th>
+          {CAT.map(c => (
+            <th key={c.id} title={c.description} style={{ textAlign: 'center', padding: '8px 6px', ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.03em', borderBottom: '1px solid var(--border)', whiteSpace: 'nowrap' }}>
+              {c.label}<div style={{ ...mono(8, 700, 'var(--text-muted)'), opacity: 0.7 }}>×{c.weight} · {c.computation}</div>
+            </th>
+          ))}
+          <th style={{ textAlign: 'right', padding: '8px 10px', ...mono(9, 800, eHsl('toolkit')), textTransform: 'uppercase', letterSpacing: '.05em', borderBottom: '1px solid var(--border)' }}>Totale</th>
+        </tr>
+      </thead>
+      <tbody>
+        {FINAL.standings.map((r, i) => (
+          <tr key={r.id} style={{ background: i === 0 ? eHsl('toolkit', 0.06) : 'transparent' }}>
+            <td style={{ padding: '9px 10px', borderBottom: '1px solid var(--border-light)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ ...mono(10, 800, i === 0 ? eHsl('toolkit') : 'var(--text-muted)') }}>{i + 1}°</span>
+                <F.PlayerDot p={r.player} size={11} />
+                <span style={{ ...disp(13, 800, 'var(--text)') }}>{r.player.name}</span>
+                {i === 0 && <span aria-hidden="true">👑</span>}
+              </div>
+            </td>
+            {CAT.map(c => {
+              const cnt = r.counts[c.id];
+              const vp = catVP(c.id, cnt);
+              const isBonus = c.id === 'longest-road' || c.id === 'largest-army';
+              const held = isBonus && cnt > 0;
+              return (
+                <td key={c.id} style={{ textAlign: 'center', padding: '9px 6px', borderBottom: '1px solid var(--border-light)' }}>
+                  {isBonus
+                    ? (held
+                        ? <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}><span aria-hidden="true">{c.id === 'longest-road' ? '🛤️' : '⚔️'}</span><span style={{ ...mono(10, 800, eHsl('toolkit')) }}>+{vp}</span></span>
+                        : <span style={{ ...mono(11, 700, 'var(--text-muted)') }}>—</span>)
+                    : <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', lineHeight: 1.1 }}>
+                        <span style={{ ...disp(14, 800, vp ? 'var(--text)' : 'var(--text-muted)'), fontVariantNumeric: 'tabular-nums' }}>{vp}</span>
+                        <span style={{ ...mono(8, 700, 'var(--text-muted)') }}>{c.id === 'vp-cards' ? `${cnt} carte` : `${cnt}×`}</span>
+                      </span>}
+                </td>
+              );
+            })}
+            <td style={{ textAlign: 'right', padding: '9px 10px', borderBottom: '1px solid var(--border-light)' }}>
+              <span style={{ ...disp(20, 800, i === 0 ? eHsl('toolkit') : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{r.total}</span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 14 }}>
+      {CAT.map(c => (
+        <div key={c.id} style={{ display: 'flex', alignItems: 'center', gap: 6, ...mono(9.5, 700, 'var(--text-muted)') }}>
+          <R.ComputationBadge c={c.computation} size={16} />{c.label} — {c.description}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// ─── Final Board tab ─────────────────────────────────────────────────────────
+const FinalBoardTab = () => (
+  <div style={{ padding: 16, display: 'flex', gap: 18, flexWrap: 'wrap', alignItems: 'flex-start', justifyContent: 'center' }}>
+    <F.HexBoard R={46} highlightNumber={null} robberHex={C.ROBBER_HEX} />
+    <div style={{ flex: '0 1 280px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Snapshot finale del tavolo</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {FINAL.standings.map(r => {
+          const pc = C.PLAYERS.find(p => p.id === r.id);
+          return (
+            <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+              <F.PlayerDot p={pc} size={14} />
+              <span style={{ flex: 1, ...disp(12.5, 800, 'var(--text)') }}>{pc.name}</span>
+              <span style={{ ...mono(9.5, 700, 'var(--text-sec)') }}>{pc.pieces.settlements}🏠 · {pc.pieces.cities}🏛️ · {pc.pieces.roads}🛤️</span>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ padding: '10px 12px', borderRadius: 'var(--r-md)', background: eHsl('event', 0.07), border: `1px solid ${eHsl('event', 0.28)}`, display: 'flex', alignItems: 'center', gap: 9 }}>
+        <span aria-hidden="true" style={{ fontSize: 18 }}>🦹</span>
+        <div style={{ ...mono(9.5, 700, 'var(--text-sec)') }}>Ladro fermo su <strong>{C.RES[C.HEXES.find(h => h.id === C.ROBBER_HEX).t].terrain}-{C.HEXES.find(h => h.id === C.ROBBER_HEX).n}</strong> a fine partita · {C.STATS.robberMoves} spostamenti totali</div>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── Stats tab ───────────────────────────────────────────────────────────────
+const DiceChart = () => {
+  const counts = C.STATS.diceCounts;
+  const max = Math.max(...Object.values(counts));
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 6, height: 150, padding: '0 4px' }}>
+        {Object.keys(counts).map(k => {
+          const n = +k, v = counts[k];
+          const hot = n === 6 || n === 8, seven = n === 7;
+          return (
+            <div key={k} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4, height: '100%', justifyContent: 'flex-end' }}>
+              <span style={{ ...mono(9.5, 800, seven ? eHsl('event') : hot ? '#d9694f' : 'var(--text-sec)'), fontVariantNumeric: 'tabular-nums' }}>{v}</span>
+              <div title={`${n}: ${v} volte`} style={{ width: '100%', maxWidth: 30, height: `${(v / max) * 100}%`, borderRadius: '4px 4px 0 0', background: seven ? eHsl('event') : hot ? 'linear-gradient(180deg,#e07a5f,#c0584a)' : `hsl(${210},45%,55%)`, minHeight: 4, transition: 'height var(--dur-md) var(--ease-out)' }} />
+              <span style={{ ...mono(10, 800, seven ? eHsl('event') : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{n}</span>
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ ...mono(9, 700, 'var(--text-muted)'), marginTop: 8, textAlign: 'center' }}>{C.STATS.diceTotal} lanci totali · 7 (ladro) il più frequente · 6 e 8 i numeri di produzione più caldi</div>
+    </div>
+  );
+};
+const TradeBars = () => {
+  const t = C.STATS.trades;
+  const max = Math.max(...Object.values(t));
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {C.PLAYERS.map(p => (
+        <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <F.PlayerDot p={p} size={11} />
+          <span style={{ width: 48, ...disp(12, 700, 'var(--text)') }}>{p.name}</span>
+          <div style={{ flex: 1, height: 14, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+            <div style={{ width: `${(t[p.id] / max) * 100}%`, height: '100%', borderRadius: 'var(--r-pill)', background: `hsl(${p.hue},58%,55%)` }} />
+          </div>
+          <span style={{ ...mono(11, 800, 'var(--text)'), minWidth: 16, textAlign: 'right' }}>{t[p.id]}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+const StatTile = ({ icon, value, label, e = 'session' }) => (
+  <div style={{ flex: 1, minWidth: 120, padding: '12px 14px', borderRadius: 'var(--r-lg)', background: eHsl(e, 0.06), border: `1px solid ${eHsl(e, 0.25)}` }}>
+    <div style={{ fontSize: 18, marginBottom: 3 }} aria-hidden="true">{icon}</div>
+    <div style={{ ...disp(22, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{value}</div>
+    <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', marginTop: 3 }}>{label}</div>
+  </div>
+);
+const StatsTab = () => (
+  <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+      <StatTile icon="🔄" value={C.STATS.totalTurns} label="turni totali" e="player" />
+      <StatTile icon="🗓️" value={C.STATS.totalRounds} label="round" e="session" />
+      <StatTile icon="⏱️" value={C.STATS.duration} label="durata" e="game" />
+      <StatTile icon="🤝" value={Object.values(C.STATS.trades).reduce((a, b) => a + b, 0)} label="scambi" e="chat" />
+      <StatTile icon="🦹" value={C.STATS.robberMoves} label="mosse del ladro" e="event" />
+    </div>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 14 }}>
+      <P.SectionCard title="Distribuzione dei 2D6" entity="tool" accent icon="🎲"><DiceChart /></P.SectionCard>
+      <P.SectionCard title="Scambi per giocatore" entity="chat" accent icon="🤝"><TradeBars /></P.SectionCard>
+    </div>
+    <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+      <div style={{ flex: '1 1 280px', display: 'flex', alignItems: 'center', gap: 12, padding: 14, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: `1px solid ${eHsl('toolkit', 0.3)}` }}>
+        <span aria-hidden="true" style={{ fontSize: 26 }}>🌾</span>
+        <div><div style={{ ...disp(14, 800, 'var(--text)') }}>Serie di produzione più lunga</div><div style={{ ...mono(10, 700, 'var(--text-sec)') }}>{C.STATS.longestProductionRun.hint} (numero {C.STATS.longestProductionRun.number})</div></div>
+        <div style={{ flex: 1 }} /><span style={{ ...disp(28, 800, eHsl('toolkit')) }}>×{C.STATS.longestProductionRun.count}</span>
+      </div>
+      <div style={{ flex: '1 1 280px', display: 'flex', alignItems: 'center', gap: 12, padding: 14, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: `1px solid ${eHsl('player', 0.3)}` }}>
+        <span aria-hidden="true" style={{ fontSize: 26 }}>🃏</span>
+        <div><div style={{ ...disp(14, 800, 'var(--text)') }}>Mano più grande</div><div style={{ ...mono(10, 700, 'var(--text-sec)') }}>{C.PLAYERS.find(p => p.id === C.STATS.biggestHand.player).name} · {C.STATS.biggestHand.hint}</div></div>
+        <div style={{ flex: 1 }} /><span style={{ ...disp(28, 800, eHsl('player')) }}>{C.STATS.biggestHand.n}</span>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── tab shell ───────────────────────────────────────────────────────────────
+const SUM_TABS = [
+  { id: 'scoreboard', icon: '🏆', label: 'Scoreboard', entity: 'toolkit', render: () => <ScoreboardTab /> },
+  { id: 'board',      icon: '🗺️', label: 'Tabellone finale', entity: 'session', render: () => <FinalBoardTab /> },
+  { id: 'stats',      icon: '📊', label: 'Statistiche', entity: 'player', render: () => <StatsTab /> },
+];
+const SummaryBody = ({ initial = 'scoreboard' }) => {
+  const [tab, setTab] = useState(initial);
+  const active = SUM_TABS.find(t => t.id === tab) || SUM_TABS[0];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      <Hero />
+      <div role="tablist" aria-label="Sezioni recap" style={{ display: 'flex', borderBottom: '1px solid var(--border)', flexShrink: 0, background: 'var(--bg-card)' }}>
+        {SUM_TABS.map(t => {
+          const on = tab === t.id;
+          return (
+            <button key={t.id} type="button" role="tab" aria-selected={on} onClick={() => setTab(t.id)} style={{ padding: '11px 16px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(12.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+              <span aria-hidden="true" style={{ fontSize: 15 }}>{t.icon}</span>{t.label}
+            </button>
+          );
+        })}
+      </div>
+      <div role="tabpanel" style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--bg)' }}>{active.render()}</div>
+    </div>
+  );
+};
+
+// ─── mobile phone ────────────────────────────────────────────────────────────
+const PhoneSummary = ({ label, dark, initial }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+    <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+    <div className="phone" data-theme={dark ? 'dark' : undefined}>
+      <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+        <span style={{ fontFamily: 'var(--f-mono)' }}>20:11</span>
+        <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">78%</span></div>
+      </div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', minHeight: 0, overflow: 'hidden' }}>
+        <SummaryBody initial={initial} />
+      </div>
+    </div>
+  </div>
+);
+
+const Intro = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+    {[
+      { e: 'toolkit', h: 'Hero · vincitore', b: 'Banner con OutcomeBadge riusato, PV finali e classifica completa con barre verso il traguardo dei 10 PV.' },
+      { e: 'session', h: 'Scoreboard', b: 'Breakdown per le 5 categorie del catan.json: insediamenti ×1, città ×2, Strada+ 2PV, Armata+ 2PV, carte PV ×1.' },
+      { e: 'game',    h: 'Tabellone finale', b: 'Snapshot del tavolo a fine partita — esagoni, pezzi color-coded, posizione finale del ladro.' },
+      { e: 'player',  h: 'Statistiche', b: 'Turni, distribuzione dei 2D6 (chart), scambi per giocatore, serie di produzione più lunga.' },
+    ].map(c => (
+      <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+        <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: eHsl(c.e), marginBottom: 4 }}>{c.h}</div>
+        <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+      </div>
+    ))}
+  </div>
+);
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Coloni di Catan · Summary 🏆 · estensione skeleton</div>
+        <h1>Recap partita — Coloni di Catan</h1>
+        <p className="lead">
+          Schermata post-partita per <code>/sessions/[id]/summary</code>. Hero con il vincitore e i PV finali, poi tre tab:
+          <strong> Scoreboard</strong> (breakdown per le 5 categorie del toolkit), <strong>Tabellone finale</strong> (snapshot del tavolo)
+          e <strong>Statistiche</strong> (turni · distribuzione dei dadi · scambi). Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        <div className="section-label">Desktop 1280 — hero + tab Scoreboard / Tabellone finale / Statistiche</div>
+        <S.DesktopFrame dark label="Desktop · summary · Coloni di Catan" url="meepleai.app/sessions/catan-7/summary" height={760}
+          desc="Hero: Marco vince con 10 PV. Tab Scoreboard: breakdown per categoria con badge computation. Tab Tabellone: snapshot finale. Tab Statistiche: chart dei 2D6, scambi, record di partita.">
+          <SummaryBody initial="scoreboard" />
+        </S.DesktopFrame>
+
+        <div className="section-label">Mobile 375 — recap a tab impilate</div>
+        <div className="phones-grid">
+          <PhoneSummary label="01 · Scoreboard" initial="scoreboard" />
+          <PhoneSummary label="02 · Tabellone finale" initial="board" />
+          <PhoneSummary label="03 · Statistiche · dark" dark initial="stats" />
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

Mockup **#3 di 7** della pipeline B19. Estensione game-specific dello skeleton applicata a **Coloni di Catan** (medium euro + trading, 3-4 players, ~75-90 min).

## Files (7 in admin-mockups/design_files/)

- sp4-session-catan-live.html / .jsx
- sp4-session-catan-summary.html / .jsx
- sp4-session-catan-data.jsx (hex board, resources, pieces)
- sp4-session-catan-flavor.jsx (6 component: HexBoard, RobberOverlay, DiceDisplay, TradePanel, DevCardsPanel, ResourceHandBar)
- sp4-session-catan-parts.jsx

## Validation

- 0 cross-game contamination
- Baseline files NOT touched

## Mechanics modellate

Hex board 19-tile + numbered hexes 2-12 + robber + settlements/cities/roads color-coded + resource hand (5 types) + dev cards + 2D6 + Longest Road/Largest Army badges + trade panel (bank/port/player) + RightColumnTabs estese (Scoring polimorfico + Trade + Dev + Build + Chat).

## Docs sync

MOCKUPS_INDEX: +2 page-mock +5 component-mock, total 101 -> 108

## Pipeline progress

| # | Game | Stato |
|---|---|---|
| 1 | Skeleton | ✅ MERGED #1766 |
| 2 | Puerto Rico | ✅ MERGED #1769 |
| 3 | **Catan** | 🟡 **questo PR** |
| 4-7 | Power Grid / Zombicide / Paleo / Codenames | ⏸️ pending |

Co-Authored-By: Claude Code