### PR TITLE
feat(translate-viewer): #1558 H Reader-mode + #1561 J AAA contrast bundle

### DIFF
--- a/apps/web/src/components/features/gamebook/LoadingSkeleton.tsx
+++ b/apps/web/src/components/features/gamebook/LoadingSkeleton.tsx
@@ -34,7 +34,7 @@ export function LoadingSkeleton({ uiStep }: LoadingSkeletonProps): ReactElement 
       role="status"
       aria-busy="true"
       aria-live="polite"
-      className="space-y-2 max-w-[65ch]"
+      className="space-y-2 max-w-[65ch] reader-mode-content"
       data-testid={`translate-skeleton-${uiStep}`}
     >
       <p className="text-sm text-muted-foreground" data-testid="translate-step-label">

--- a/apps/web/src/components/features/gamebook/ReaderModeToggle.tsx
+++ b/apps/web/src/components/features/gamebook/ReaderModeToggle.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+export interface ReaderModeToggleProps {
+  isReaderMode: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Reader-mode toggle button per mockup §1b lines 1697-1727.
+ * Toggles between default (16pt) and reader-mode (24pt + 1.7 line-height + 65ch).
+ *
+ * #1558 H · Aaron CORE spec 2026-05-23.
+ */
+export function ReaderModeToggle({ isReaderMode, onToggle }: ReaderModeToggleProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={isReaderMode}
+      aria-label={isReaderMode ? 'Disattiva Reader Mode' : 'Attiva Reader Mode'}
+      className={`reader-mode-toggle${isReaderMode ? ' active' : ''}`}
+    >
+      <span className="ico" aria-hidden="true">
+        📖
+      </span>
+      <span>{isReaderMode ? 'Reader ✓' : 'Reader'}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { AbortButton } from '@/components/features/gamebook/AbortButton';
 import { BookPicker } from '@/components/features/gamebook/BookPicker';
 import { LoadingSkeleton } from '@/components/features/gamebook/LoadingSkeleton';
+import { ReaderModeToggle } from '@/components/features/gamebook/ReaderModeToggle';
 import { SegmentPicker } from '@/components/features/gamebook/SegmentPicker';
 import {
   deriveUiStep,
@@ -16,6 +17,7 @@ import { useGameBooks } from '@/hooks/useGameBooks';
 import { GameBookRole, hasRole, type GameRef } from '@/lib/api/gamebook';
 import type { GamebookPhotoArtifact, GamebookSegment } from '@/lib/api/gamebook-photos';
 import { usePhotoUpload } from '@/lib/gamebook/hooks/usePhotoUpload';
+import { useReaderMode } from '@/lib/gamebook/hooks/useReaderMode';
 import { useSegmentPhoto } from '@/lib/gamebook/hooks/useSegmentPhoto';
 import { useTranslateSegmentSSE } from '@/lib/gamebook/hooks/useTranslateSegmentSSE';
 
@@ -45,6 +47,8 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
   const [artifact, setArtifact] = useState<GamebookPhotoArtifact | null>(null);
   const [activeSegment, setActiveSegment] = useState<GamebookSegment | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { isReaderMode, toggle: toggleReaderMode } = useReaderMode();
 
   // C4/C5 (multi-book generalization 2026-05-19): book selection replaces the
   // legacy Storybook/Encounter `pageType` dropdown.
@@ -140,9 +144,12 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
   const cameraDisabled = isBusy || !effectiveBookId;
 
   return (
-    <div className="grid gap-4 px-4 py-6 sm:px-6">
+    <div className="grid gap-4 px-4 py-6 sm:px-6" data-reader-mode={String(isReaderMode)}>
       <header className="flex flex-wrap items-center gap-3">
-        <h1 className="text-xl font-semibold text-[var(--c-game)]">Traduci pagina libro game</h1>
+        <div className="flex flex-1 items-center justify-between gap-2">
+          <h1 className="text-xl font-semibold text-[var(--c-game)]">Traduci pagina libro game</h1>
+          <ReaderModeToggle isReaderMode={isReaderMode} onToggle={toggleReaderMode} />
+        </div>
       </header>
 
       {narrativeBooks.length > 1 && (

--- a/apps/web/src/components/features/gamebook/TranslationPane.tsx
+++ b/apps/web/src/components/features/gamebook/TranslationPane.tsx
@@ -42,7 +42,10 @@ export function TranslationPane({
           </span>
           {isComplete && <span className="text-xs text-muted-foreground">&#10003; completata</span>}
         </div>
-        <p className="text-sm whitespace-pre-wrap">
+        <p
+          className="text-sm whitespace-pre-wrap reader-mode-content"
+          style={{ color: 'hsl(var(--c-text-high-contrast))' }}
+        >
           {partialText || (isComplete ? '(traduzione vuota)' : 'Traduzione in corso…')}
         </p>
         {highlightTerms.length > 0 && (

--- a/apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx
@@ -51,4 +51,13 @@ describe('LoadingSkeleton', () => {
     const container = screen.getByTestId('translate-skeleton-translating');
     expect(container).toHaveAttribute('role', 'status');
   });
+
+  describe('reader-mode cascade (#1558 H · DEC-5)', () => {
+    it('root element has .reader-mode-content class for parent data-attr cascading', () => {
+      const { container } = render(<LoadingSkeleton uiStep="ocr" />);
+      // Root element should expose the cascade hook
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveClass('reader-mode-content');
+    });
+  });
 });

--- a/apps/web/src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { ReaderModeToggle } from '../ReaderModeToggle';
+
+expect.extend(toHaveNoViolations);
+
+describe('ReaderModeToggle', () => {
+  it('renders with aria-pressed=false when isReaderMode is false', () => {
+    render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    const button = screen.getByRole('button', { name: /attiva reader mode/i });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders with aria-pressed=true when isReaderMode is true', () => {
+    render(<ReaderModeToggle isReaderMode={true} onToggle={vi.fn()} />);
+    const button = screen.getByRole('button', { name: /disattiva reader mode/i });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows "Reader" label when off and "Reader ✓" when on (mockup parity)', () => {
+    const { rerender } = render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    expect(screen.getByText('Reader')).toBeInTheDocument();
+    rerender(<ReaderModeToggle isReaderMode={true} onToggle={vi.fn()} />);
+    expect(screen.getByText('Reader ✓')).toBeInTheDocument();
+  });
+
+  it('calls onToggle when clicked', async () => {
+    const onToggle = vi.fn();
+    render(<ReaderModeToggle isReaderMode={false} onToggle={onToggle} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('renders the book emoji icon with aria-hidden', () => {
+    render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    const icon = screen.getByText('📖');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has no a11y violations (S6)', async () => {
+    const { container } = render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -773,6 +774,68 @@ describe('TranslateViewer', () => {
 
     await act(async () => {
       resolveSegment({ id: PHOTO_ID, segments: [] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // reader-mode integration (#1558 H)
+  // ---------------------------------------------------------------------------
+  describe('reader-mode integration (#1558 H)', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    afterEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('renders the ReaderModeToggle in the header', () => {
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      expect(screen.getByRole('button', { name: /reader mode/i })).toBeInTheDocument();
+    });
+
+    it('root wrapper has data-reader-mode="false" by default (S1)', () => {
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      const root = container.querySelector('[data-reader-mode]');
+      expect(root).toHaveAttribute('data-reader-mode', 'false');
+    });
+
+    it('clicking toggle sets data-reader-mode="true" + writes localStorage (S1)', async () => {
+      const user = userEvent.setup();
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await user.click(screen.getByRole('button', { name: /attiva reader mode/i }));
+      expect(container.querySelector('[data-reader-mode]')).toHaveAttribute(
+        'data-reader-mode',
+        'true'
+      );
+      expect(window.localStorage.getItem('reader-mode-enabled')).toBe('true');
+    });
+
+    it('applies reader-mode from localStorage on mount (S2 persistence)', async () => {
+      window.localStorage.setItem('reader-mode-enabled', 'true');
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      // useReaderMode reads localStorage in a useEffect (SSR-safe), so we wait for it
+      await waitFor(() => {
+        expect(container.querySelector('[data-reader-mode]')).toHaveAttribute(
+          'data-reader-mode',
+          'true'
+        );
+      });
+    });
+
+    it('reader-mode wrapper contains the camera section (S3 cascade scope)', () => {
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      const wrapper = container.querySelector('[data-reader-mode]');
+      expect(wrapper).toBeInTheDocument();
+      // The camera button lives inside the data-reader-mode wrapper
+      const cameraBtn = screen.getByTestId('open-camera-button');
+      expect(wrapper).toContainElement(cameraBtn);
+    });
+
+    it('has zero a11y violations with reader-mode toggle rendered (S6)', async () => {
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
     });
   });
 });

--- a/apps/web/src/components/features/gamebook/__tests__/TranslationPane.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslationPane.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 
 import { TranslationPane } from '../TranslationPane';
+
+expect.extend(toHaveNoViolations);
 
 describe('TranslationPane', () => {
   it('renders error alert when error prop is provided', () => {
@@ -84,5 +87,63 @@ describe('TranslationPane', () => {
       />
     );
     expect(screen.getByText('You stand at the crossroads.')).toBeInTheDocument();
+  });
+
+  describe('AAA contrast + reader-mode (#1561 J + #1558 H)', () => {
+    it('body <p> uses var(--c-text-high-contrast) via inline style or class (S9)', () => {
+      render(
+        <TranslationPane
+          partialText="Test paragraph"
+          isComplete={true}
+          appliedTerms={[]}
+          sourceTextEn=""
+        />
+      );
+      const para = screen.getByText('Test paragraph');
+      // Either inline style OR via class with custom property
+      const computed = window.getComputedStyle(para);
+      // jsdom returns the literal style value; the cascade resolves at runtime in browser
+      expect(para.getAttribute('style')).toContain('var(--c-text-high-contrast)');
+    });
+
+    it('body <p> has .reader-mode-content class for parent data-attr cascading', () => {
+      render(
+        <TranslationPane partialText="Test" isComplete={true} appliedTerms={[]} sourceTextEn="" />
+      );
+      const para = screen.getByText('Test');
+      expect(para).toHaveClass('reader-mode-content');
+    });
+
+    it('has zero AAA color-contrast violations on :root (light theme) (S7)', async () => {
+      const { container } = render(
+        <TranslationPane
+          partialText="Lorem ipsum dolor sit amet"
+          isComplete={true}
+          appliedTerms={[]}
+          sourceTextEn=""
+        />
+      );
+      const results = await axe(container, {
+        rules: { 'color-contrast-enhanced': { enabled: true } },
+      });
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has zero AAA color-contrast violations on [data-theme="dark"] (S8)', async () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      const { container } = render(
+        <TranslationPane
+          partialText="Lorem ipsum dolor sit amet"
+          isComplete={true}
+          appliedTerms={[]}
+          sourceTextEn=""
+        />
+      );
+      const results = await axe(container, {
+        rules: { 'color-contrast-enhanced': { enabled: true } },
+      });
+      expect(results).toHaveNoViolations();
+      document.documentElement.removeAttribute('data-theme');
+    });
   });
 });

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useReaderMode } from '../useReaderMode';
+
+describe('useReaderMode', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns false initially when localStorage is empty (S1 default)', () => {
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(false);
+  });
+
+  it('returns true when localStorage has reader-mode-enabled=true (S2 persistence)', () => {
+    window.localStorage.setItem('reader-mode-enabled', 'true');
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(true);
+  });
+
+  it('toggle() flips state and writes to localStorage', () => {
+    const { result } = renderHook(() => useReaderMode());
+    act(() => result.current.toggle());
+    expect(result.current.isReaderMode).toBe(true);
+    expect(window.localStorage.getItem('reader-mode-enabled')).toBe('true');
+    act(() => result.current.toggle());
+    expect(result.current.isReaderMode).toBe(false);
+    expect(window.localStorage.getItem('reader-mode-enabled')).toBe('false');
+  });
+
+  it('preserves state across remount via localStorage (S4)', () => {
+    const { result: r1, unmount } = renderHook(() => useReaderMode());
+    act(() => r1.current.toggle());
+    unmount();
+    const { result: r2 } = renderHook(() => useReaderMode());
+    expect(r2.current.isReaderMode).toBe(true);
+  });
+
+  it('falls back to in-memory state when localStorage.setItem throws (S5)', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    const { result } = renderHook(() => useReaderMode());
+    act(() => result.current.toggle());
+    expect(result.current.isReaderMode).toBe(true); // in-memory still works
+    expect(consoleError).not.toHaveBeenCalled(); // silent
+  });
+
+  it('falls back to false when localStorage.getItem throws on mount', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(false);
+  });
+
+  it('ignores invalid localStorage values (not "true"/"false")', () => {
+    window.localStorage.setItem('reader-mode-enabled', 'garbage');
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(false);
+  });
+
+  it('toggle() is stable across renders (referential equality)', () => {
+    const { result, rerender } = renderHook(() => useReaderMode());
+    const firstToggle = result.current.toggle;
+    rerender();
+    expect(result.current.toggle).toBe(firstToggle);
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/useReaderMode.ts
+++ b/apps/web/src/lib/gamebook/hooks/useReaderMode.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'reader-mode-enabled';
+
+export interface UseReaderModeResult {
+  /** Current reader-mode state (true = active, larger font + line-height + max-width). */
+  isReaderMode: boolean;
+  /** Flip reader-mode state. Stable reference across renders. */
+  toggle: () => void;
+}
+
+/**
+ * SSR-safe reader-mode hook backed by localStorage (key: `reader-mode-enabled`).
+ *
+ * Per DEC-3 + DEC-9: gracefully degrades to in-memory state if localStorage
+ * is unavailable (private mode, quota exceeded). Returns false on SSR; reads
+ * actual value after hydration to avoid mismatch warnings.
+ *
+ * #1558 H · Aaron CORE spec 2026-05-23 §1b.
+ */
+export function useReaderMode(): UseReaderModeResult {
+  const [isReaderMode, setIsReaderMode] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === 'true') setIsReaderMode(true);
+    } catch {
+      // localStorage unavailable (private mode / SecurityError) — keep default false
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsReaderMode(prev => {
+      const next = !prev;
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem(STORAGE_KEY, String(next));
+        } catch {
+          // localStorage write blocked — in-memory state still flips correctly
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  return { isReaderMode, toggle };
+}

--- a/apps/web/src/styles/__tests__/entity-tokens.test.ts
+++ b/apps/web/src/styles/__tests__/entity-tokens.test.ts
@@ -24,3 +24,15 @@ describe('entity tokens alignment (post-#807 AA, post DS-16)', () => {
     expect(css).toMatch(/--c-toolkit:\s*142\s+70%\s+30%/);
   });
 });
+
+describe('--c-text-high-contrast (AAA contrast)', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../design-tokens-canonical.css'), 'utf8');
+
+  it('exists in :root (light theme) with HSL 32 36% 4% (#0f0a05 ≈15:1 on cream)', () => {
+    expect(css).toMatch(/:root\s*\{[\s\S]*--c-text-high-contrast:\s*32\s+36%\s+4%/);
+  });
+
+  it('exists in [data-theme="dark"] with HSL 0 0% 100% (#ffffff ≈18:1 on dark)', () => {
+    expect(css).toMatch(/\[data-theme="dark"\]\s*\{[\s\S]*--c-text-high-contrast:\s*0\s+0%\s+100%/);
+  });
+});

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -47,6 +47,13 @@
   --c-toolkit-text: 142 70% 24%; /* Real-C-E gamebook: hsl(142 70% 24%) ≈ #0f5d2b vs #e3f0e8 = ~5.6:1 ✅ — replaces text-entity-toolkit (4.16:1 fail on toolkit/12 bg) */
   --c-session-text: 240 60% 35%; /* PR #1721 follow-up: light theme value = same as --c-session (already 12.22:1 AA on cream). Defined as a token so callers can use --c-session-text consistently across themes; dark theme overrides this to 235 85% 85% for AA on dark surfaces. */
 
+  /* AAA contrast token (#1561 J — Aaron CORE spec 2026-05-23 §1b)
+   * Light: hsl(32 36% 4%) ≈ #0f0a05 vs cream #f7f3ee = 15.1:1 (AAA-large + AAA-normal)
+   * Dark:  hsl(0 0% 100%) = #ffffff vs dark bg #14100a = 18.4:1 (AAA-large + AAA-normal)
+   * Use via: color: hsl(var(--c-text-high-contrast))
+   */
+  --c-text-high-contrast: 32 36% 4%;
+
   /* ─── Semantic Colors ─── */
   --c-success: 142 70% 45%;
   --c-warning: 38 92% 50%;
@@ -213,6 +220,9 @@
   --c-kb-text:   174 60% 55%;
   --c-toolkit-text: 142 60% 72%; /* Real-C-E gamebook dark: lighter variant for AA on dark bg */
   --c-session-text: 235 85% 85%; /* PR #1721 follow-up: lighter variant — hsl(235 85% 85%) ≈ #cdd1f9 hits AA ≥ 4.5:1 on dark `--card` + `--c-session/14` overlay (was --c-session 235 70% 70% ≈ #7d86e8 → 3.85:1 fail). Used by SessionShareCard theme toggle (line 189) and other components rendering text-entity-session text on dark surfaces. */
+
+  /* AAA contrast dark — see :root docblock */
+  --c-text-high-contrast: 0 0% 100%;
 
   color-scheme: dark;
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -806,3 +806,49 @@
     opacity: 1;
   }
 }
+
+/* ============================================================================
+ * Translate-Viewer reader-mode (#1558 H · Aaron CORE spec 2026-05-23 §1b)
+ * ============================================================================
+ *
+ * Toggle (.reader-mode-toggle) and content scaling (.reader-mode-content)
+ * scoped via [data-reader-mode="true"] attribute on TranslateViewer root.
+ *
+ * Default (toggle off): font-size inherits (16px base), line-height 1.55,
+ * max-width 60ch, padding var(--s-4).
+ *
+ * Active (toggle on): 24px / 1.7 / 65ch / var(--s-6) padding.
+ * ============================================================================ */
+
+.reader-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-1) var(--s-3);
+  border-radius: var(--r-pill);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--f-mono);
+  font-size: var(--fs-xs);
+  cursor: pointer;
+}
+
+.reader-mode-toggle.active {
+  background: hsl(var(--c-kb) / 0.15);
+  border-color: hsl(var(--c-kb));
+  color: hsl(var(--c-kb));
+  font-weight: var(--fw-bold);
+}
+
+.reader-mode-toggle .ico {
+  font-size: 14px;
+}
+
+[data-reader-mode="true"] .reader-mode-content {
+  font-size: 24px;
+  line-height: 1.7;
+  padding: var(--s-6);
+  max-width: 65ch;
+  margin-inline: auto;
+}

--- a/docs/superpowers/plans/2026-05-31-translate-reader-mode-aaa-bundle.md
+++ b/docs/superpowers/plans/2026-05-31-translate-reader-mode-aaa-bundle.md
@@ -1,0 +1,855 @@
+# Translate-Viewer Reader-Mode + AAA Contrast Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reader-mode toggle (#1558 H) and AAA contrast text (#1561 J) to `TranslateViewer` per Aaron CORE refinement spec 2026-05-23, closing 2 Cluster #1487 follow-up issues in a single PR.
+
+**Architecture:** Two FE-only additions sharing the `TranslationPane.tsx` surface:
+1. **Reader-mode**: SSR-safe localStorage-backed hook + toggle button in viewer header + CSS-var cascade via `data-reader-mode` wrapper attribute scoping the viewer subtree (toggle + skeleton + body all scale).
+2. **AAA contrast**: New `--c-text-high-contrast` design token (light `#0f0a05` ≈15:1, dark `#ffffff` ≈18:1) applied to TranslationPane body `<p>`; jest-axe AAA assertion both themes.
+
+Both additions are additive (no FSM touch, zero risk to #1557 G shipped 24h ago in PR #1765).
+
+**Tech Stack:** React 19 · Next.js 16 App Router · Tailwind 4 · CSS vars · `data-theme` next-themes · Vitest + jest-axe + Testing Library
+
+---
+
+## Locked Decisions (from /sc:spec-panel critique)
+
+- **DEC-1 (scope)**: CSS vars applied via `data-reader-mode="true|false"` attribute on TranslateViewer root `<div>`, NOT globally. Scoping selector: `[data-reader-mode="true"] .reader-mode-content`. Zero leak (Fowler ✅).
+- **DEC-2 (CSS naming)**: Reuse mockup class names `.reader-mode-content` + `.reader-mode-toggle` 1:1 (NOT inferred `--tv-*`). Default off: 16px/1.55/60ch. Active: 24px/1.7/65ch + `padding: var(--s-6)`.
+- **DEC-3 (localStorage)**: Key `'reader-mode-enabled'`, value `'true'|'false'` (string). No namespacing — user-preference globale (cross-page sticky). SSR-safe: `useEffect` mount + `typeof window !== 'undefined'` guard.
+- **DEC-4 (toggle UI)**: Placed in TranslateViewer header (after `<h1>`). `aria-pressed={isReaderMode}`, `aria-label` dynamic ("Attiva Reader Mode" / "Disattiva Reader Mode"). Icon 📖 + label "Reader" (off) / "Reader ✓" (on) per mockup line 1697-1727.
+- **DEC-5 (skeleton apply)**: Reader-mode CSS must cascade to `LoadingSkeleton` for visual coherence during OCR. Implement via `data-reader-mode` on the viewer wrapper that includes both skeleton and TranslationPane as children.
+- **DEC-6 (AAA token)**: Add to `design-tokens-canonical.css`: `:root { --c-text-high-contrast: 32 36% 4%; }` (≈ `#0f0a05` HSL, 15:1 on cream `#f7f3ee`) and `[data-theme="dark"] { --c-text-high-contrast: 0 0% 100%; }` (≈ `#ffffff`, 18:1 on dark bg). Use HSL triplet format consistent with existing token convention.
+- **DEC-7 (AAA scope)**: Apply `var(--c-text-high-contrast)` ONLY to body `<p>` in TranslationPane.tsx:45. `<em>` opacity-0.92 variant deferred (TranslationPane renders flat text via `whitespace-pre-wrap`, no `<em>` nodes today). Document as MINOR follow-up in PR body.
+- **DEC-8 (jest-axe AAA)**: Use `axe.configure({ rules: [{ id: 'color-contrast-enhanced', enabled: true }] })` for AAA test on TranslationPane (NOT global). The `color-contrast-enhanced` axe rule enforces 7:1 ratio (AAA). Keep default `color-contrast` (AA 4.5:1) elsewhere.
+- **DEC-9 (graceful degrade)**: If `localStorage` is unavailable (private mode, SSR), hook falls back to in-memory state without throwing. `try/catch` wrapper around `localStorage.getItem/setItem`. No telemetry (silent).
+
+---
+
+## Given/When/Then Scenarios
+
+**Reader-mode**:
+- **S1**: GIVEN localStorage['reader-mode-enabled']='false' AND viewer mounts, WHEN user clicks 📖 toggle, THEN TranslationPane body font scales 16→24px AND line-height to 1.7 AND max-width 65ch AND localStorage updated to 'true' AND `aria-pressed='true'`.
+- **S2**: GIVEN localStorage['reader-mode-enabled']='true' (prev session), WHEN TranslateViewer mounts, THEN reader-mode applies after hydration AND toggle `aria-pressed='true'` AND no hydration mismatch warning.
+- **S3**: GIVEN reader-mode is active AND uploading phase, WHEN LoadingSkeleton renders, THEN skeleton text/blocks reflect scaled font (data attr cascades).
+- **S4**: GIVEN reader-mode active, WHEN user unmounts+remounts viewer, THEN reader-mode is restored from localStorage on remount.
+- **S5**: GIVEN localStorage.setItem throws (private mode), WHEN user clicks toggle, THEN UI updates (in-memory state) AND no error thrown AND no console.error.
+- **S6**: GIVEN toggle is rendered, WHEN axe runs, THEN zero violations on `aria-pressed`, `aria-label`, button role.
+
+**AAA contrast**:
+- **S7**: GIVEN TranslationPane renders body text on `:root` (light theme), WHEN axe runs with `color-contrast-enhanced` rule, THEN zero violations (≥7:1 ratio).
+- **S8**: GIVEN TranslationPane renders body text on `[data-theme="dark"]`, WHEN axe runs with `color-contrast-enhanced` rule, THEN zero violations (≥7:1 ratio).
+- **S9**: GIVEN `--c-text-high-contrast` token is added to design-tokens-canonical.css, WHEN we read computed style of TranslationPane body `<p>`, THEN `color` resolves to the token's HSL value.
+
+---
+
+## File Structure
+
+**Modify**:
+- `apps/web/src/styles/design-tokens-canonical.css` — add `--c-text-high-contrast` light+dark
+- `apps/web/src/styles/globals.css` — add `.reader-mode-content` + `.reader-mode-toggle` styles + `[data-reader-mode="true"]` selectors
+- `apps/web/src/styles/__tests__/entity-tokens.test.ts` — add test for new token presence
+- `apps/web/src/components/features/gamebook/TranslateViewer.tsx` — wire ReaderModeToggle + `data-reader-mode` wrapper
+- `apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx` — add S2/S3/S4 integration tests
+- `apps/web/src/components/features/gamebook/TranslationPane.tsx` — apply AAA contrast class + `.reader-mode-content` className
+- `apps/web/src/components/features/gamebook/__tests__/TranslationPane.test.tsx` — add S7/S8/S9 + reader-mode scaling tests
+- `apps/web/src/components/features/gamebook/LoadingSkeleton.tsx` — add `.reader-mode-content` className (cascades from parent data attr)
+- `apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx` — add reader-mode cascade test
+
+**Create**:
+- `apps/web/src/lib/gamebook/hooks/useReaderMode.ts` — SSR-safe localStorage hook
+- `apps/web/src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts` — 8 tests (S1, S2, S4, S5)
+- `apps/web/src/components/features/gamebook/ReaderModeToggle.tsx` — toggle component
+- `apps/web/src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx` — 6 tests (toggle + S6)
+
+---
+
+### Task 1: Add `--c-text-high-contrast` token (AAA #1561)
+
+**Files:**
+- Modify: `apps/web/src/styles/design-tokens-canonical.css` (`:root` + `[data-theme="dark"]` blocks)
+- Modify: `apps/web/src/styles/__tests__/entity-tokens.test.ts` (add token assertion)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `apps/web/src/styles/__tests__/entity-tokens.test.ts` (after the existing `--c-kb` test):
+
+```typescript
+describe('--c-text-high-contrast (AAA contrast)', () => {
+  it('exists in :root (light theme) with HSL 32 36% 4% (#0f0a05 ≈15:1 on cream)', () => {
+    expect(css).toMatch(/:root\s*\{[\s\S]*--c-text-high-contrast:\s*32\s+36%\s+4%/);
+  });
+
+  it('exists in [data-theme="dark"] with HSL 0 0% 100% (#ffffff ≈18:1 on dark)', () => {
+    expect(css).toMatch(/\[data-theme="dark"\]\s*\{[\s\S]*--c-text-high-contrast:\s*0\s+0%\s+100%/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/styles/__tests__/entity-tokens.test.ts`
+Expected: 2 FAIL with "expected '...' to match /.../"
+
+- [ ] **Step 3: Add token to design-tokens-canonical.css**
+
+In `:root` block (around line 26-46, after `--c-kb-text`):
+
+```css
+  /* AAA contrast token (#1561 J — Aaron CORE spec 2026-05-23 §1b)
+   * Light: hsl(32 36% 4%) ≈ #0f0a05 vs cream #f7f3ee = 15.1:1 (AAA-large + AAA-normal)
+   * Dark:  hsl(0 0% 100%) = #ffffff vs dark bg #14100a = 18.4:1 (AAA-large + AAA-normal)
+   * Use via: color: hsl(var(--c-text-high-contrast))
+   */
+  --c-text-high-contrast: 32 36% 4%;
+```
+
+In `[data-theme="dark"]` block (around line 199-213, after `--c-kb-text` dark variant):
+
+```css
+  /* AAA contrast dark — see :root docblock */
+  --c-text-high-contrast: 0 0% 100%;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/styles/__tests__/entity-tokens.test.ts`
+Expected: PASS (all tests including the 2 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/styles/design-tokens-canonical.css apps/web/src/styles/__tests__/entity-tokens.test.ts
+git commit -m "feat(tokens): #1561 J - add --c-text-high-contrast AAA token (15:1 light, 18:1 dark)"
+```
+
+---
+
+### Task 2: Create `useReaderMode` hook (SSR-safe localStorage)
+
+**Files:**
+- Create: `apps/web/src/lib/gamebook/hooks/useReaderMode.ts`
+- Create: `apps/web/src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `apps/web/src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts`:
+
+```typescript
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useReaderMode } from '../useReaderMode';
+
+describe('useReaderMode', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns false initially when localStorage is empty (S1 default)', () => {
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(false);
+  });
+
+  it('returns true when localStorage has reader-mode-enabled=true (S2 persistence)', () => {
+    window.localStorage.setItem('reader-mode-enabled', 'true');
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(true);
+  });
+
+  it('toggle() flips state and writes to localStorage', () => {
+    const { result } = renderHook(() => useReaderMode());
+    act(() => result.current.toggle());
+    expect(result.current.isReaderMode).toBe(true);
+    expect(window.localStorage.getItem('reader-mode-enabled')).toBe('true');
+    act(() => result.current.toggle());
+    expect(result.current.isReaderMode).toBe(false);
+    expect(window.localStorage.getItem('reader-mode-enabled')).toBe('false');
+  });
+
+  it('preserves state across remount via localStorage (S4)', () => {
+    const { result: r1, unmount } = renderHook(() => useReaderMode());
+    act(() => r1.current.toggle());
+    unmount();
+    const { result: r2 } = renderHook(() => useReaderMode());
+    expect(r2.current.isReaderMode).toBe(true);
+  });
+
+  it('falls back to in-memory state when localStorage.setItem throws (S5)', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    const { result } = renderHook(() => useReaderMode());
+    act(() => result.current.toggle());
+    expect(result.current.isReaderMode).toBe(true); // in-memory still works
+    expect(consoleError).not.toHaveBeenCalled(); // silent
+  });
+
+  it('falls back to false when localStorage.getItem throws on mount', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(false);
+  });
+
+  it('ignores invalid localStorage values (not "true"/"false")', () => {
+    window.localStorage.setItem('reader-mode-enabled', 'garbage');
+    const { result } = renderHook(() => useReaderMode());
+    expect(result.current.isReaderMode).toBe(false);
+  });
+
+  it('toggle() is stable across renders (referential equality)', () => {
+    const { result, rerender } = renderHook(() => useReaderMode());
+    const firstToggle = result.current.toggle;
+    rerender();
+    expect(result.current.toggle).toBe(firstToggle);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts`
+Expected: 8 FAIL with "Cannot find module '../useReaderMode'"
+
+- [ ] **Step 3: Implement hook**
+
+Create `apps/web/src/lib/gamebook/hooks/useReaderMode.ts`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'reader-mode-enabled';
+
+export interface UseReaderModeResult {
+  /** Current reader-mode state (true = active, larger font + line-height + max-width). */
+  isReaderMode: boolean;
+  /** Flip reader-mode state. Stable reference across renders. */
+  toggle: () => void;
+}
+
+/**
+ * SSR-safe reader-mode hook backed by localStorage (key: `reader-mode-enabled`).
+ *
+ * Per DEC-3 + DEC-9: gracefully degrades to in-memory state if localStorage
+ * is unavailable (private mode, quota exceeded). Returns false on SSR; reads
+ * actual value after hydration to avoid mismatch warnings.
+ *
+ * #1558 H · Aaron CORE spec 2026-05-23 §1b.
+ */
+export function useReaderMode(): UseReaderModeResult {
+  const [isReaderMode, setIsReaderMode] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === 'true') setIsReaderMode(true);
+    } catch {
+      // localStorage unavailable (private mode / SecurityError) — keep default false
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsReaderMode((prev) => {
+      const next = !prev;
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem(STORAGE_KEY, String(next));
+        } catch {
+          // localStorage write blocked — in-memory state still flips correctly
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  return { isReaderMode, toggle };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts`
+Expected: 8/8 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/gamebook/hooks/useReaderMode.ts apps/web/src/lib/gamebook/hooks/__tests__/useReaderMode.test.ts
+git commit -m "feat(translate-viewer): #1558 H - useReaderMode SSR-safe localStorage hook"
+```
+
+---
+
+### Task 3: Create `ReaderModeToggle` component
+
+**Files:**
+- Create: `apps/web/src/components/features/gamebook/ReaderModeToggle.tsx`
+- Create: `apps/web/src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `apps/web/src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { ReaderModeToggle } from '../ReaderModeToggle';
+
+expect.extend(toHaveNoViolations);
+
+describe('ReaderModeToggle', () => {
+  it('renders with aria-pressed=false when isReaderMode is false', () => {
+    render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    const button = screen.getByRole('button', { name: /attiva reader mode/i });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders with aria-pressed=true when isReaderMode is true', () => {
+    render(<ReaderModeToggle isReaderMode={true} onToggle={vi.fn()} />);
+    const button = screen.getByRole('button', { name: /disattiva reader mode/i });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows "Reader" label when off and "Reader ✓" when on (mockup parity)', () => {
+    const { rerender } = render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    expect(screen.getByText('Reader')).toBeInTheDocument();
+    rerender(<ReaderModeToggle isReaderMode={true} onToggle={vi.fn()} />);
+    expect(screen.getByText('Reader ✓')).toBeInTheDocument();
+  });
+
+  it('calls onToggle when clicked', async () => {
+    const onToggle = vi.fn();
+    render(<ReaderModeToggle isReaderMode={false} onToggle={onToggle} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('renders the book emoji icon with aria-hidden', () => {
+    render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    const icon = screen.getByText('📖');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has no a11y violations (S6)', async () => {
+    const { container } = render(<ReaderModeToggle isReaderMode={false} onToggle={vi.fn()} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx`
+Expected: 6 FAIL with "Cannot find module '../ReaderModeToggle'"
+
+- [ ] **Step 3: Implement component**
+
+Create `apps/web/src/components/features/gamebook/ReaderModeToggle.tsx`:
+
+```typescript
+'use client';
+
+import type { ReactElement } from 'react';
+
+export interface ReaderModeToggleProps {
+  isReaderMode: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Reader-mode toggle button per mockup §1b lines 1697-1727.
+ * Toggles between default (16pt) and reader-mode (24pt + 1.7 line-height + 65ch).
+ *
+ * #1558 H · Aaron CORE spec 2026-05-23.
+ */
+export function ReaderModeToggle({ isReaderMode, onToggle }: ReaderModeToggleProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={isReaderMode}
+      aria-label={isReaderMode ? 'Disattiva Reader Mode' : 'Attiva Reader Mode'}
+      className={`reader-mode-toggle${isReaderMode ? ' active' : ''}`}
+    >
+      <span className="ico" aria-hidden="true">📖</span>
+      <span>{isReaderMode ? 'Reader ✓' : 'Reader'}</span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx`
+Expected: 6/6 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/ReaderModeToggle.tsx apps/web/src/components/features/gamebook/__tests__/ReaderModeToggle.test.tsx
+git commit -m "feat(translate-viewer): #1558 H - ReaderModeToggle component (aria-pressed + i18n labels)"
+```
+
+---
+
+### Task 4: Add CSS styles for `.reader-mode-toggle` + `.reader-mode-content`
+
+**Files:**
+- Modify: `apps/web/src/styles/globals.css` (append at end of file)
+
+- [ ] **Step 1: Add CSS styles**
+
+Append to `apps/web/src/styles/globals.css` (at the end of the file):
+
+```css
+/* ============================================================================
+ * Translate-Viewer reader-mode (#1558 H · Aaron CORE spec 2026-05-23 §1b)
+ * ============================================================================
+ *
+ * Toggle (.reader-mode-toggle) and content scaling (.reader-mode-content)
+ * scoped via [data-reader-mode="true"] attribute on TranslateViewer root.
+ *
+ * Default (toggle off): font-size inherits (16px base), line-height 1.55,
+ * max-width 60ch, padding var(--s-4).
+ *
+ * Active (toggle on): 24px / 1.7 / 65ch / var(--s-6) padding.
+ * ============================================================================ */
+
+.reader-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-1) var(--s-3);
+  border-radius: var(--r-pill);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--f-mono);
+  font-size: var(--fs-xs);
+  cursor: pointer;
+}
+
+.reader-mode-toggle.active {
+  background: hsl(var(--c-kb) / 0.15);
+  border-color: hsl(var(--c-kb));
+  color: hsl(var(--c-kb));
+  font-weight: var(--fw-bold);
+}
+
+.reader-mode-toggle .ico {
+  font-size: 14px;
+}
+
+[data-reader-mode="true"] .reader-mode-content {
+  font-size: 24px;
+  line-height: 1.7;
+  padding: var(--s-6);
+  max-width: 65ch;
+  margin-inline: auto;
+}
+```
+
+- [ ] **Step 2: Verify CSS does not break existing styles**
+
+Run: `cd apps/web && pnpm lint:tokens 2>&1 | head -20`
+Expected: no new violations (or "0 errors" if clean). The new selectors do not use forbidden Tailwind color utilities.
+
+Run: `cd apps/web && pnpm vitest run src/styles/__tests__/`
+Expected: existing token tests still PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/styles/globals.css
+git commit -m "feat(translate-viewer): #1558 H - reader-mode CSS (.reader-mode-toggle + .reader-mode-content scoped via data-reader-mode)"
+```
+
+---
+
+### Task 5: Modify TranslationPane.tsx — apply AAA + reader-mode className
+
+**Files:**
+- Modify: `apps/web/src/components/features/gamebook/TranslationPane.tsx`
+- Modify: `apps/web/src/components/features/gamebook/__tests__/TranslationPane.test.tsx`
+
+- [ ] **Step 1: Read TranslationPane.tsx current state**
+
+Run: `cat apps/web/src/components/features/gamebook/TranslationPane.tsx`
+
+Locate line ~45 where `<p className="text-sm whitespace-pre-wrap">` renders the body text.
+
+- [ ] **Step 2: Write failing tests**
+
+Add to `apps/web/src/components/features/gamebook/__tests__/TranslationPane.test.tsx` (inside the main `describe` block):
+
+```typescript
+describe('AAA contrast + reader-mode (#1561 J + #1558 H)', () => {
+  it('body <p> uses var(--c-text-high-contrast) via inline style or class (S9)', () => {
+    render(<TranslationPane partialText="Test paragraph" isComplete={true} appliedTerms={[]} />);
+    const para = screen.getByText('Test paragraph');
+    // Either inline style OR via class with custom property
+    const computed = window.getComputedStyle(para);
+    // jsdom returns the literal style value; the cascade resolves at runtime in browser
+    expect(para.getAttribute('style')).toContain('var(--c-text-high-contrast)');
+  });
+
+  it('body <p> has .reader-mode-content class for parent data-attr cascading', () => {
+    render(<TranslationPane partialText="Test" isComplete={true} appliedTerms={[]} />);
+    const para = screen.getByText('Test');
+    expect(para).toHaveClass('reader-mode-content');
+  });
+
+  it('has zero AAA color-contrast violations on :root (light theme) (S7)', async () => {
+    const { container } = render(
+      <TranslationPane partialText="Lorem ipsum dolor sit amet" isComplete={true} appliedTerms={[]} />
+    );
+    const results = await axe(container, {
+      rules: { 'color-contrast-enhanced': { enabled: true } },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has zero AAA color-contrast violations on [data-theme="dark"] (S8)', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { container } = render(
+      <TranslationPane partialText="Lorem ipsum dolor sit amet" isComplete={true} appliedTerms={[]} />
+    );
+    const results = await axe(container, {
+      rules: { 'color-contrast-enhanced': { enabled: true } },
+    });
+    expect(results).toHaveNoViolations();
+    document.documentElement.removeAttribute('data-theme');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/TranslationPane.test.tsx`
+Expected: 4 FAIL (missing style attr, missing class, axe violations).
+
+- [ ] **Step 4: Modify TranslationPane.tsx**
+
+Replace the body `<p>` element (around line 45). Change:
+
+```tsx
+<p className="text-sm whitespace-pre-wrap">{partialText}</p>
+```
+
+to:
+
+```tsx
+<p
+  className="text-sm whitespace-pre-wrap reader-mode-content"
+  style={{ color: 'hsl(var(--c-text-high-contrast))' }}
+>
+  {partialText}
+</p>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/TranslationPane.test.tsx`
+Expected: All tests PASS (including the 4 new).
+
+If a pre-existing test now fails because the `<p>` class string changed, update its assertion to match the new className.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/TranslationPane.tsx apps/web/src/components/features/gamebook/__tests__/TranslationPane.test.tsx
+git commit -m "feat(translate-viewer): #1561 J + #1558 H - TranslationPane AAA contrast + reader-mode-content class"
+```
+
+---
+
+### Task 6: Modify LoadingSkeleton.tsx — cascade reader-mode
+
+**Files:**
+- Modify: `apps/web/src/components/features/gamebook/LoadingSkeleton.tsx`
+- Modify: `apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx`
+
+- [ ] **Step 1: Read LoadingSkeleton.tsx current state**
+
+Run: `cat apps/web/src/components/features/gamebook/LoadingSkeleton.tsx`
+
+Identify the root element + any text-bearing child elements that should scale with reader-mode.
+
+- [ ] **Step 2: Write failing test**
+
+Add to `apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx` (inside the main `describe` block):
+
+```typescript
+describe('reader-mode cascade (#1558 H · DEC-5)', () => {
+  it('root element has .reader-mode-content class for parent data-attr cascading', () => {
+    const { container } = render(<LoadingSkeleton uiStep="ocr" />);
+    // Root element should expose the cascade hook
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('reader-mode-content');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx`
+Expected: 1 FAIL (missing class).
+
+- [ ] **Step 4: Modify LoadingSkeleton.tsx**
+
+In `apps/web/src/components/features/gamebook/LoadingSkeleton.tsx`, append `reader-mode-content` to the root element's `className`. Example: if the root is `<div className="space-y-2 ...">`, change to `<div className="space-y-2 ... reader-mode-content">`.
+
+If `className` is built dynamically, append via template literal or `cn()` utility.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/LoadingSkeleton.tsx apps/web/src/components/features/gamebook/__tests__/LoadingSkeleton.test.tsx
+git commit -m "feat(translate-viewer): #1558 H DEC-5 - LoadingSkeleton cascades reader-mode via .reader-mode-content"
+```
+
+---
+
+### Task 7: Modify TranslateViewer.tsx — wire ReaderModeToggle + data-reader-mode wrapper
+
+**Files:**
+- Modify: `apps/web/src/components/features/gamebook/TranslateViewer.tsx`
+- Modify: `apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx` (inside the main `describe` block; adapt prop setup to match existing test patterns):
+
+```typescript
+describe('reader-mode integration (#1558 H)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the ReaderModeToggle in the header', () => {
+    render(/* existing TranslateViewer setup */);
+    expect(screen.getByRole('button', { name: /reader mode/i })).toBeInTheDocument();
+  });
+
+  it('root wrapper has data-reader-mode="false" by default (S1)', () => {
+    const { container } = render(/* existing TranslateViewer setup */);
+    const root = container.querySelector('[data-reader-mode]');
+    expect(root).toHaveAttribute('data-reader-mode', 'false');
+  });
+
+  it('clicking the toggle sets data-reader-mode="true" + writes localStorage (S1)', async () => {
+    const { container } = render(/* existing TranslateViewer setup */);
+    await userEvent.click(screen.getByRole('button', { name: /attiva reader mode/i }));
+    expect(container.querySelector('[data-reader-mode]')).toHaveAttribute('data-reader-mode', 'true');
+    expect(window.localStorage.getItem('reader-mode-enabled')).toBe('true');
+  });
+
+  it('applies reader-mode from localStorage on mount (S2 persistence)', () => {
+    window.localStorage.setItem('reader-mode-enabled', 'true');
+    const { container } = render(/* existing TranslateViewer setup */);
+    expect(container.querySelector('[data-reader-mode]')).toHaveAttribute('data-reader-mode', 'true');
+  });
+
+  it('reader-mode wrapper contains both LoadingSkeleton and TranslationPane (S3 cascade)', () => {
+    window.localStorage.setItem('reader-mode-enabled', 'true');
+    const { container } = render(/* existing TranslateViewer setup, force phase to a state where skeleton renders */);
+    const wrapper = container.querySelector('[data-reader-mode="true"]');
+    expect(wrapper).toBeInTheDocument();
+    // Skeleton (if rendered) AND TranslationPane (if rendered) are inside this wrapper.
+  });
+
+  it('has zero a11y violations with reader-mode toggle rendered (S6)', async () => {
+    const { container } = render(/* existing TranslateViewer setup */);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+NOTE for implementer: the existing test file likely has a helper for setting up `<TranslateViewer />` props (e.g., `defaultProps`, `setup()`). Reuse it. If unsure, copy the prop setup from the first existing test in the file. Place `useEvent` / `axe` imports at top with other imports if missing.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/TranslateViewer.test.tsx -t "reader-mode integration"`
+Expected: 6 FAIL with missing toggle / missing data-reader-mode attr.
+
+- [ ] **Step 3: Modify TranslateViewer.tsx**
+
+Add imports at top of `apps/web/src/components/features/gamebook/TranslateViewer.tsx`:
+
+```typescript
+import { ReaderModeToggle } from '@/components/features/gamebook/ReaderModeToggle';
+import { useReaderMode } from '@/lib/gamebook/hooks/useReaderMode';
+```
+
+Inside the component function, after existing `useState` hooks (around line 44-70):
+
+```typescript
+const { isReaderMode, toggle: toggleReaderMode } = useReaderMode();
+```
+
+Wrap the existing root return JSX with `data-reader-mode` attribute. Locate the outermost element returned (around line 143). If it's currently:
+
+```tsx
+return (
+  <div className="...">
+    <h1>Traduci pagina libro game</h1>
+    {/* ... rest ... */}
+  </div>
+);
+```
+
+Change to:
+
+```tsx
+return (
+  <div className="..." data-reader-mode={isReaderMode}>
+    <div className="flex items-center justify-between gap-2">
+      <h1>Traduci pagina libro game</h1>
+      <ReaderModeToggle isReaderMode={isReaderMode} onToggle={toggleReaderMode} />
+    </div>
+    {/* ... rest (unchanged: BookPicker, camera section, SegmentPicker, TranslationPane) ... */}
+  </div>
+);
+```
+
+Important: `data-reader-mode={isReaderMode}` renders as `data-reader-mode="true"` or `data-reader-mode="false"` (React serializes boolean attributes as string when the attribute name doesn't match a known boolean HTML attr).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/__tests__/TranslateViewer.test.tsx`
+Expected: All tests PASS (existing + 6 new).
+
+If pre-existing tests fail because the header structure changed (e.g., they used `screen.getByText('Traduci pagina libro game')` and now there's a wrapper `<div>`), update them to use `getByRole('heading', { name: /Traduci pagina libro game/i })` instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/TranslateViewer.tsx apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+git commit -m "feat(translate-viewer): #1558 H - wire ReaderModeToggle + data-reader-mode wrapper in viewer header"
+```
+
+---
+
+### Task 8: Verification + final commit (orchestration)
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run full gamebook test scope**
+
+Run: `cd apps/web && pnpm vitest run src/components/features/gamebook/ src/lib/gamebook/ src/styles/`
+Expected: All tests PASS (existing + ~25 new from tasks 1-7).
+
+If any failure: investigate, fix inline (do NOT skip tests), re-run. Report root cause in commit message.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: 0 errors.
+
+If errors: fix inline. Common pitfalls:
+- `data-reader-mode={isReaderMode}` may produce TS error if React types are strict — use `data-reader-mode={String(isReaderMode)}` as workaround.
+- `style={{ color: 'hsl(var(--c-text-high-contrast))' }}` — CSSProperties accepts strings, no issue expected.
+
+- [ ] **Step 3: Run lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: 0 errors, 0 warnings (CLAUDE.md baseline 0).
+
+If `local/no-hardcoded-color-utility` flags new code: review — we used only CSS vars + Tailwind tokens, should pass. If false-positive, add line-level disable with `// eslint-disable-next-line local/no-hardcoded-color-utility — reason: <why>`.
+
+- [ ] **Step 4: Run lint:tokens**
+
+Run: `cd apps/web && pnpm lint:tokens`
+Expected: no new violations in `audits/2026-05-12-token-violations.md` diff.
+
+- [ ] **Step 5: Final integration sanity check**
+
+Run: `cd apps/web && pnpm vitest run --reporter=verbose 2>&1 | tail -50`
+Expected: full suite PASS, no skips on new tests, no console.error in test output.
+
+- [ ] **Step 6: Final commit (if any fixup needed)**
+
+If the verification surfaced fixup commits needed (typecheck/lint), commit them:
+
+```bash
+git add -A
+git commit -m "chore(translate-viewer): #1558 + #1561 - typecheck/lint fixup"
+```
+
+If nothing to commit, skip this step.
+
+- [ ] **Step 7: Push branch**
+
+```bash
+git push -u origin feature/issue-1558-reader-mode-aaa-bundle
+```
+
+---
+
+## Post-Plan Steps (handled by main session, NOT subagent)
+
+After the plan is fully implemented, the main session will:
+
+1. Run final code-reviewer agent (superpowers:requesting-code-review)
+2. Fix any MAJOR findings inline, defer MINOR in PR body
+3. Open PR base `main-dev` with `Closes #1558` + `Closes #1561` in body
+4. Verify CI green (P67: rerun flaky if AdminSideDrawer or similar baseline)
+5. Merge squash normale (post-P75 resolution via #1526, no --admin needed for clean FE PRs)
+6. Verify auto-close of #1558 + #1561
+7. Update memory with session log
+
+---
+
+## Spec Coverage Self-Review
+
+| Spec requirement | Task |
+|---|---|
+| #1558 AC: 📖 button in header w/ aria-pressed | Task 3 (component) + Task 7 (wire) |
+| #1558 AC: localStorage 'reader-mode-enabled' read+write | Task 2 (hook) |
+| #1558 AC: CSS vars 16↔24px, line-height +30%, max-width 65ch | Task 4 (CSS) |
+| #1558 AC: applies to BOTH skeleton AND TranslationPane | Task 5 (pane) + Task 6 (skeleton) + Task 7 (wrapper) |
+| #1558 AC: SSR-safe | Task 2 (hook useEffect mount) |
+| #1558 AC: jest-axe `aria-pressed` | Task 3 (S6) |
+| #1561 AC: `--c-text-high-contrast` on TranslationPane body | Task 1 (token) + Task 5 (apply) |
+| #1561 AC: jest-axe color-contrast assertion | Task 5 (S7+S8) |
+| #1561 AC: AAA both themes | Task 5 (S7+S8) |
+| DEC-9 graceful degrade localStorage failure | Task 2 (S5) |
+| #1561 deferred: `<em>` opacity 0.92 | Document in PR body as MINOR |
+
+All AC covered. No placeholders detected. Type names consistent: `UseReaderModeResult`, `ReaderModeToggleProps`, `isReaderMode`, `toggle` used uniformly across tasks 2/3/7.
+
+---
+
+## Implementation Notes for Subagent
+
+- **Stack reminder**: Vitest (not Jest), Testing Library, jest-axe, Tailwind 4, Next.js 16 App Router. Mock-free DOM via jsdom.
+- **Path discipline**: Components in `apps/web/src/components/features/gamebook/`, hooks in `apps/web/src/lib/gamebook/hooks/`, styles in `apps/web/src/styles/`. Tests adjacent in `__tests__/` folders.
+- **Existing patterns**: `LoadingSkeleton`, `AbortButton`, `TranslationPane` all follow `export function Name(props): ReactElement` pattern with named `export interface Props`. Reuse.
+- **i18n state**: TranslateViewer is currently Italian-only hardcoded (per audit). Use IT strings consistently with existing LABELS const in `TranslateViewer.steps.ts:24-32`.
+- **No FSM touch**: Reader-mode is purely visual; do NOT modify `phase` state, `useTranslateSegmentSSE` hook, or any abort/timeout logic. These belong to #1557 G shipped 24h ago.
+- **CSS file choice**: Append to `globals.css` (not `design-tokens-canonical.css`). Tokens go in canonical; component CSS in globals.
+- **TranslateViewer test setup**: Existing tests likely use a helper like `renderTranslateViewer(props)` or inline `render(<TranslateViewer {...defaultProps} />)`. Locate and reuse, do NOT reinvent the setup.
+- **Run subagent prompts with absolute paths** under `D:\Repositories\meepleai-monorepo-frontend\`.


### PR DESCRIPTION
## Summary

Cluster #1487 follow-up Aaron CORE bundle (2 issues, single PR, FE-only, additive — zero risk to #1557 G shipped 24h ago).

- **Closes #1558** — `H` Reader-mode toggle: 📖 button in `TranslateViewer` header scales body from 16pt → 24pt + line-height +30% + max-width 65ch + padding `var(--s-6)`. SSR-safe `useReaderMode` hook backed by `localStorage['reader-mode-enabled']` with graceful degrade (private mode safe). Cascade via `data-reader-mode` attribute scopes both `LoadingSkeleton` and `TranslationPane` for visual coherence during all 4 UiSteps.
- **Closes #1561** — `J` AAA contrast: new design token `--c-text-high-contrast` (light HSL `32 36% 4%` ≈ `#0f0a05` = 15:1 on cream; dark HSL `0 0% 100%` ≈ `#ffffff` = 18:1 on dark) applied to `TranslationPane` body `<p>`. AAA target ≥7:1 both themes via jest-axe `color-contrast-enhanced` rule.

## Architecture / Decisions

9 DEC locked in [plan](docs/superpowers/plans/2026-05-31-translate-reader-mode-aaa-bundle.md) post `/sc:spec-panel` critique (Wiegers, Cockburn, Adzic, Crispin, Nygard, Fowler, Doumont):

- **DEC-1** scope via `data-reader-mode` attr (NOT global) — Fowler isolation
- **DEC-2** CSS class names `.reader-mode-toggle` / `.reader-mode-content` 1:1 from mockup (NOT inferred `--tv-*`)
- **DEC-3** localStorage key `reader-mode-enabled`, string `'true'|'false'`, no namespace (user-pref globale)
- **DEC-4** Toggle UI in header w/ dynamic `aria-label` IT (Wiegers AC measurability)
- **DEC-5** Skeleton must cascade reader-mode (mockup §1b explicit)
- **DEC-6** AAA token HSL triplet convention (file pattern fidelity)
- **DEC-7** AAA scope only body `<p>` — `<em>` deferred (TranslationPane renders flat `whitespace-pre-wrap`, no em nodes today)
- **DEC-8** jest-axe `color-contrast-enhanced` (AAA 7:1 rule) — known jsdom CSS-var limitation acknowledged; tests serve regression guard for `style` attr removal
- **DEC-9** Graceful degrade silent on localStorage errors (private mode no console.error)

## Files

- **NEW**: `apps/web/src/lib/gamebook/hooks/useReaderMode.ts` (+test 8 cases)
- **NEW**: `apps/web/src/components/features/gamebook/ReaderModeToggle.tsx` (+test 6 cases incl. jest-axe)
- **MOD**: `TranslateViewer.tsx` (wire toggle + `data-reader-mode` wrapper, +6 integration tests)
- **MOD**: `TranslationPane.tsx` (apply AAA color + `.reader-mode-content`, +4 tests)
- **MOD**: `LoadingSkeleton.tsx` (append `.reader-mode-content` cascade, +1 test)
- **MOD**: `design-tokens-canonical.css` (token light+dark, +2 unit tests)
- **MOD**: `globals.css` (component CSS `.reader-mode-toggle` + `[data-reader-mode]` scoping)
- **DOC**: implementation plan committed

**Total**: 25 new test, 0 pre-existing test changed. Verified locally: 555 tests PASS in `gamebook/ + lib/gamebook/ + styles/` scope; typecheck 0; lint 0 new; lint:tokens 0 violations. Pre-push hook full Next.js + backend build ✅.

## Test plan

- [x] Vitest unit `useReaderMode` (8 cases: default false, persistence, toggle, remount restore, graceful degrade setItem throw, graceful degrade getItem throw, invalid value fallback, toggle stable ref)
- [x] Vitest unit `ReaderModeToggle` (6 cases: aria-pressed off/on, IT label dynamic, click handler, emoji aria-hidden, jest-axe 0 violations)
- [x] Vitest unit `TranslationPane` AAA + reader-mode (4 cases: `var(--c-text-high-contrast)` inline style, `.reader-mode-content` class, axe color-contrast-enhanced light, axe dark)
- [x] Vitest unit `LoadingSkeleton` cascade (1 case)
- [x] Vitest integration `TranslateViewer` reader-mode (6 cases: toggle render, default data-attr false, click toggle persists + writes localStorage, mount reads localStorage, wrapper contains skeleton+pane, jest-axe 0 violations)
- [x] Vitest unit `entity-tokens.test.ts` (2 cases: light + dark token presence)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 new errors
- [x] `pnpm lint:tokens` 0 new violations
- [x] Pre-push hook: full Next.js build + backend build ✅
- [ ] CI green (post-PR-open verify)

## Deferred MINOR (final review APPROVED_WITH_NOTES)

- **M1** — `LoadingSkeleton.tsx:37` already has pre-existing `max-w-[65ch]` Tailwind utility (independent of reader-mode); the new `.reader-mode-content` is additive cascade hook with no own styling. Pre-existing constraint, not regression. Confidence 45 — below threshold, observation only.
- **M2** — `TranslateViewer.test.tsx` S3 cascade test verifies wrapper exists with `data-reader-mode` but doesn't drive component to `uploading` phase to assert skeleton containment. Test coverage gap, not implementation bug (wrapper is root `<div>`, both skeleton + pane are inside structurally). Defer to follow-up.
- **#1561 `<em>` AAA opacity 0.92** (DEC-7): TranslationPane renders `whitespace-pre-wrap` flat text, no `<em>` nodes today. When/if italic emphasis is re-introduced, apply `var(--c-text-high-contrast)` + `opacity: 0.92` per mockup.

## Out of scope (Cluster #1487 follow-up still OPEN)

- **#1559 K/L** Multi-lang detection + override modal — BE+FE coordinated, requires BE prereq (OCR LLM prompt + SSE shape backward-compat + cache strategy + observability). Not shippable in FE-only PR per `/sc:spec-panel` critique.
- **#1560 M** Manual-mode textarea entry — FE-only L 4-5h+, surface larga 3 entry points + FSM extension. Risk medium for #1557 G regression; AC reinforcement needed before writing-plans.

## References

- Aaron CORE spec: `docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md` §1b
- Mockup: `admin-mockups/design_files/librogame-runthrough-translate-viewer.html` (states H, J)
- Gap report: `admin-mockups/design_handoff/translate-gap-report.md` § 2 row H + § 3 row J
- Cluster umbrella: #1487 (closed 2026-05-26)
- Predecessor: PR #1765 (#1557 G — loading skeleton + abort + timeout, shipped 24h ago)

🤖 Generated with [Claude Code](https://claude.com/claude-code)