### PR TITLE
feat(mockup): #1742 B19 premium #4/7 - Power Grid (auction + network + accordion-extended)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -89,6 +89,13 @@
 | `sp4-play-records-stats.html` | page-mock | `/play-records/stats` |
 | `sp4-player-detail.html` | page-mock | `/players/[id]`, `/players/[id]/{achievements,games,sessions,stats}` |
 | `sp4-players-index.html` | page-mock | `/players` |
+| `sp4-session-power-grid-data.jsx` | component-mock | Power Grid-specific dataset (Elektro, 4 resources market, 8 plants, 5 phases, 3 game steps). Premium #4/7. |
+| `sp4-session-power-grid-flavor.jsx` | component-mock | Power Grid flavor components — `PhaseTimeline`, `PowerPlantMarket`, `ResourceMarket`, `AuctionOverlay`, `NetworkMap`, `PlantsRail`, `TurnOrderStrip` (reverse-aware). |
+| `sp4-session-power-grid-live.html` | page-mock | `/sessions/[id]/live` Power Grid demo (heavy euro auction + network, 2-6 players, ~120 min). Extends skeleton with PG-specific panels + accordion-extended for game sections (auction/market/resources). |
+| `sp4-session-power-grid-live.jsx` | component-mock | Root component for `sp4-session-power-grid-live.html` — wires skeleton + PG flavor + RightColumnTabs (Scoring, Market, Network, Plants, Chat). |
+| `sp4-session-power-grid-parts.jsx` | component-mock | Shared parts for Power Grid — `SectionCard` accordion, player rail, helper `sec(id)` for accordion state machine across 5 phases. |
+| `sp4-session-power-grid-summary.html` | page-mock | `/sessions/[id]` Power Grid post-game (final: cities powered + Elektro tiebreaker + plants capacity). Premium #4/7. |
+| `sp4-session-power-grid-summary.jsx` | component-mock | Root component for PG summary — hero + tabs (Scoreboard / Network snapshot / Step transitions / Stats). |
 | `sp4-session-puerto-rico-data.jsx` | component-mock | Puerto Rico-specific dataset (role-selection state, 5 goods, plantations + buildings grids). Premium #2/7. |
 | `sp4-session-puerto-rico-flavor.jsx` | component-mock | Puerto Rico flavor components — `RoleSelectionBoard`, `PlantationGrid`, `BuildingGrid`, `GalleonsShipping`, `TradingHouseSlots`, `ColonistShip`. |
 | `sp4-session-puerto-rico-live.html` | page-mock | `/sessions/[id]/live` Puerto Rico demo (heavy euro role-selection, 3-5 players, ~120min). Extends skeleton (mockup #1) with PR-specific panels. |
@@ -175,10 +182,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 59 |
-| component-mock | 30 |
+| page-mock | 61 |
+| component-mock | 35 |
 | dev-fixture | 12 |
-| **Total** | **101** |
+| **Total** | **108** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/sp4-session-power-grid-data.jsx
+++ b/admin-mockups/design_files/sp4-session-power-grid-data.jsx
@@ -1,0 +1,311 @@
+/* MeepleAI SP4 · Power Grid — DATA  (window.PG  +  window.SkeletonData shim)
+   /sessions/[id]/live — dataset game-specific letto da power-grid.json.
+
+   Espone:
+     window.SkeletonData = { STATES }   (shim: i renderer dello skeleton e
+                                          skeleton-parts.jsx leggono STATES qui)
+     window.PG = { game, agent, RES, SUPPLY, roster, PLANTS, market,
+                   resourceMarket, network, phases, phaseState, turnOrder(),
+                   ds (shape per i renderer polimorfici), counterWidgets,
+                   auction, chat, suggestions, events, summary }
+
+   MECCANICA CHIAVE (da power-grid.json): l'ordine di turno si RICALCOLA ogni
+   round per città possedute (leader = più città) e si RIBALTA nelle fasi
+   2-Auction e 3-Resources (leader gioca ULTIMO). Fasi 4-Building e
+   5-Bureaucracy in ordine normale. 3 Step di gioco (1/2/3).
+
+   Colori risorse: verbatim da power-grid.json. Tutto il resto = token CSS. */
+
+(function () {
+  // ─── shim per lo skeleton: i 5 stati canonici ─────────────────────────────
+  window.SkeletonData = window.SkeletonData || {
+    STATES: [
+      { id: 'default', lb: 'Default' },
+      { id: 'empty',   lb: 'Empty' },
+      { id: 'loading', lb: 'Loading' },
+      { id: 'error',   lb: 'Error' },
+      { id: 'sse',     lb: 'SSE ✕' },
+    ],
+  };
+
+  // ─── gioco + agente ───────────────────────────────────────────────────────
+  const game = {
+    id: 'power-grid', title: 'Power Grid', emoji: '⚡',
+    cover: 'linear-gradient(135deg, hsl(45,80%,46%), hsl(28,82%,42%))',
+    meta: '2-6 giocatori · ~120 min · Germania (base)',
+  };
+  const agent = { id: 'pg-agent', name: 'Power Grid Expert', emoji: '⚡', latency: '0.7s' };
+
+  // ─── risorse (colori da power-grid.json) ──────────────────────────────────
+  // glyph distinti + icona per leggibilità (coal/oil sono due slate vicini).
+  const RES = {
+    coal:    { id: 'coal',    lb: 'Carbone', glyph: 'C', icon: '⬛', color: '#2c3e50', dark: '#e8eef3', max: 24 },
+    oil:     { id: 'oil',     lb: 'Petrolio',glyph: 'O', icon: '🛢', color: '#34495e', dark: '#e8eef3', max: 24 },
+    garbage: { id: 'garbage', lb: 'Rifiuti', glyph: 'G', icon: '🗑', color: '#7d6608', dark: '#fdf5d0', max: 24 },
+    uranium: { id: 'uranium', lb: 'Uranio',  glyph: 'U', icon: '☢', color: '#1e8449', dark: '#e6fff0', max: 12 },
+  };
+  const RES_ORDER = ['coal', 'oil', 'garbage', 'uranium'];
+
+  // supply counters (Elektro / città / powered) — colori da JSON
+  const SUPPLY = {
+    elektro: { lb: 'Elektro',  glyph: 'E', color: '#f1c40f', dark: '#3a2c00' },
+    city:    { lb: 'Città',    glyph: 'C', color: '#9b59b6', dark: '#fff' },
+    powered: { lb: 'Alimentate', glyph: '⚡', color: '#f39c12', dark: '#3a2300' },
+  };
+
+  // ─── catalogo centrale: power plants ──────────────────────────────────────
+  // n = numero (= puntata minima). res = combustibile(i) o 'eco'. cons = unità
+  // consumate per attivare. cap = città alimentate. hybrid = brucia uno fra res.
+  const PLANTS = {
+    p03: { n: 3,  res: ['oil'],          cons: 2, cap: 1, eco: false },
+    p04: { n: 4,  res: ['coal'],         cons: 2, cap: 1, eco: false },
+    p06: { n: 6,  res: ['garbage'],      cons: 1, cap: 1, eco: false },
+    p11: { n: 11, res: ['uranium'],      cons: 1, cap: 2, eco: false },
+    p13: { n: 13, res: [],               cons: 0, cap: 1, eco: true  },
+    p15: { n: 15, res: ['coal', 'oil'],  cons: 2, cap: 3, hybrid: true },
+    p18: { n: 18, res: [],               cons: 0, cap: 2, eco: true  },
+    p19: { n: 19, res: ['garbage'],      cons: 2, cap: 3, eco: false },
+    p20: { n: 20, res: ['coal'],         cons: 3, cap: 5, eco: false },
+    p21: { n: 21, res: ['coal', 'oil'],  cons: 2, cap: 4, hybrid: true },
+    p23: { n: 23, res: ['uranium'],      cons: 1, cap: 3, eco: false },
+    p25: { n: 25, res: [],               cons: 0, cap: 4, eco: true  },
+    p27: { n: 27, res: ['oil'],          cons: 3, cap: 7, eco: false },
+    p31: { n: 31, res: ['uranium'],      cons: 1, cap: 4, eco: false },
+    p36: { n: 36, res: ['coal', 'oil'],  cons: 3, cap: 6, hybrid: true },
+    p42: { n: 42, res: [],               cons: 0, cap: 6, eco: true  },
+  };
+
+  // mercato visibile: 8 carte ordinate per numero crescente.
+  // currentMarket = comprabili (riga alta) · futureMarket = preview (riga bassa)
+  const market = {
+    current: ['p13', 'p15', 'p18', 'p20'],
+    future:  ['p21', 'p23', 'p25', 'p27'],
+  };
+
+  // ─── mercato risorse: 4 colonne con scarsità ──────────────────────────────
+  // per ogni risorsa, lista scaffali dal più caro (top) al più economico.
+  // available = token ancora acquistabile. Il "next price" = scaffale
+  // economico disponibile più basso. Più scarso ⇒ next price più alto.
+  function buildShelves(prices, perPrice, boughtCheap) {
+    // prices: array prezzi crescenti; perPrice: token per prezzo (1 o 3)
+    // boughtCheap: quanti token (dai più economici) già acquistati
+    const slots = [];
+    prices.forEach(price => { for (let i = 0; i < perPrice; i++) slots.push({ price, available: true }); });
+    for (let i = 0; i < boughtCheap && i < slots.length; i++) slots[i].available = false;
+    return slots;
+  }
+  const resourceMarket = {
+    coal:    { res: 'coal',    shelves: buildShelves([1,2,3,4,5,6,7,8], 3, 7) },   // next 3
+    oil:     { res: 'oil',     shelves: buildShelves([1,2,3,4,5,6,7,8], 3, 10) },  // next 4
+    garbage: { res: 'garbage', shelves: buildShelves([1,2,3,4,5,6,7,8], 3, 4) },   // next 2
+    uranium: { res: 'uranium', shelves: buildShelves([1,2,3,4,5,6,7,8,10,12,14,16], 1, 7) }, // next 10
+  };
+  const nextPrice = (res) => {
+    const av = resourceMarket[res].shelves.filter(s => s.available);
+    return av.length ? av[0].price : null;
+  };
+  const remaining = (res) => resourceMarket[res].shelves.filter(s => s.available).length;
+
+  // ─── roster (5 giocatori) — cities pilota l'ordine di turno ───────────────
+  // cities = città su mappa · powered = alimentate questo round · store =
+  // risorse in stock · plants = power plant possedute (max 3) con fuel caricato.
+  const roster = [
+    { id: 'p-marco', name: 'Marco', hue: 262, elektro: 22, cities: 14, powered: 13,
+      store: { coal: 4, oil: 1, garbage: 0, uranium: 0 },
+      plants: [ { ...PLANTS.p20, loaded: { coal: 3 } }, { ...PLANTS.p11, loaded: { uranium: 1 } }, { ...PLANTS.p15, loaded: { coal: 1, oil: 1 } } ] },
+    { id: 'p-anna', name: 'Anna', hue: 350, elektro: 41, cities: 12, powered: 12,
+      store: { coal: 2, oil: 5, garbage: 1, uranium: 0 },
+      plants: [ { ...PLANTS.p21, loaded: { coal: 2 } }, { ...PLANTS.p19, loaded: { garbage: 2 } }, { ...PLANTS.p06, loaded: { garbage: 0 } } ] },
+    { id: 'p-luca', name: 'Luca', hue: 174, elektro: 18, cities: 11, powered: 10,
+      store: { coal: 1, oil: 0, garbage: 0, uranium: 2 },
+      plants: [ { ...PLANTS.p23, loaded: { uranium: 1 } }, { ...PLANTS.p13, loaded: {} }, { ...PLANTS.p04, loaded: { coal: 1 } } ] },
+    { id: 'p-sara', name: 'Sara', hue: 38, elektro: 55, cities: 9, powered: 9,
+      store: { coal: 0, oil: 3, garbage: 0, uranium: 0 },
+      plants: [ { ...PLANTS.p18, loaded: {} }, { ...PLANTS.p03, loaded: { oil: 2 } } ] },
+    { id: 'p-dario', name: 'Dario', hue: 200, elektro: 30, cities: 7, powered: 7,
+      store: { coal: 2, oil: 2, garbage: 1, uranium: 0 },
+      plants: [ { ...PLANTS.p25, loaded: {} }, { ...PLANTS.p04, loaded: { coal: 2 } } ] },
+  ];
+  const byId = (id) => roster.find(p => p.id === id);
+
+  // ─── fasi + stato di gioco ────────────────────────────────────────────────
+  const phases = [
+    { id: 'order',   n: 1, lb: 'Ordine giocatori', short: 'Ordine', reverse: false, desc: 'Ricalcolo per città possedute', icon: '🔢' },
+    { id: 'auction', n: 2, lb: 'Asta centrali',    short: 'Asta',   reverse: true,  desc: '1-2 centrali per turno · puntate', icon: '🔨' },
+    { id: 'resource',n: 3, lb: 'Acquisto risorse', short: 'Risorse',reverse: true,  desc: 'Prezzo di mercato con scarsità', icon: '🛢' },
+    { id: 'build',   n: 4, lb: 'Costruzione',      short: 'Build',  reverse: false, desc: 'Posa nuove città sulla rete', icon: '🏗' },
+    { id: 'bureau',  n: 5, lb: 'Burocrazia',       short: 'Burocr.',reverse: false, desc: 'Alimenta → reddito + restock + step', icon: '⚙' },
+  ];
+  // default: Round 5, Step 2, fase attiva = 2 (Asta) → ordine RIBALTATO
+  const phaseState = { round: 5, step: 2, phaseIndex: 1, activePhaseId: 'auction' };
+
+  // ─── ordine di turno (ricalcolo + reverse) ───────────────────────────────
+  // base = per città decrescenti (leader primo). reverse ⇒ leader ultimo.
+  const baseOrder = [...roster].sort((a, b) => b.cities - a.cities || b.powered - a.powered);
+  const turnOrder = (phaseId) => {
+    const ph = phases.find(p => p.id === (phaseId || phaseState.activePhaseId)) || phases[1];
+    const ord = ph.reverse ? [...baseOrder].reverse() : baseOrder;
+    return { order: ord, reverse: ph.reverse, phase: ph };
+  };
+
+  // ─── asta in corso (fase 2) ───────────────────────────────────────────────
+  // plant a turno: p18 (eco, cap 2). Ordine reverse ⇒ inizia Dario.
+  const auction = {
+    plantId: 'p18',
+    minBid: 18,
+    highBid: 23,
+    highBidderId: 'p-anna',
+    nominatorId: 'p-dario',
+    inAuction: ['p-dario', 'p-sara', 'p-luca', 'p-anna', 'p-marco'],
+    passed: ['p-dario'],
+    awaitingId: 'p-sara', // a chi tocca rilanciare/passare
+    boughtThisPhase: 0, max: 1,
+  };
+
+  // ─── shape per i RENDERER POLIMORFICI dello skeleton ──────────────────────
+  // SCORING — ScoringPanelRenderer (branch Points): score = città alimentate.
+  const scoringCats = [
+    { id: 'cities-powered', label: 'Città alimentate (finale)', computation: 'Count',  description: 'Condizione di vittoria primaria: più città alimentate nella Burocrazia finale. Fine partita quando un giocatore raggiunge 17 città costruite.' },
+    { id: 'elektro-remaining', label: 'Elektro (spareggio 1)', computation: 'Sum',     description: 'Più Elektro residui vince i pareggi sulle città alimentate.' },
+    { id: 'plants-capacity', label: 'Capacità centrali (spareggio 2)', computation: 'Custom', description: 'Se ancora in pareggio, somma della capacità città delle centrali possedute.' },
+  ];
+  const plantsCapOf = (p) => p.plants.reduce((s, pl) => s + pl.cap, 0);
+  const scoringBreakdown = {};
+  roster.forEach(p => { scoringBreakdown[p.id] = {
+    'cities-powered': p.powered, 'elektro-remaining': p.elektro, 'plants-capacity': plantsCapOf(p),
+  }; });
+
+  // TURN — TurnIndicatorRenderer (branch Sequential): le 5 fasi del round.
+  // meta segnala la natura reverse-aware (lo strip custom porta la logica).
+  const turnShape = {
+    turnOrderType: 'Sequential',
+    phases: phases.map(p => `${p.n}. ${p.lb}`),
+    direction: 'custom-reverse',
+    turnActions: ['auction-bid', 'auction-pass', 'buy-resources', 'build-city', 'power-cities', 'discard-plant'],
+  };
+
+  // ds = oggetto unico consumato dai renderer skeleton (data.scoring/turn/...)
+  const ds = {
+    game, agent,
+    session: { elapsed: '1h 12min' },
+    players: baseOrder.map(p => ({ id: p.id, name: p.name, hue: p.hue, score: p.powered, turnDelta: 0 })),
+    scoring: { scoreType: 'Points', categories: scoringCats },
+    breakdown: scoringBreakdown,
+    meta: 'Fasi del round · ordine reverse-aware',
+    turn: turnShape,
+    turnState: { phaseIndex: phaseState.phaseIndex, round: phaseState.round },
+    chat: [
+      { id: 'c1', from: 'user',  t: '15:02', text: 'Se Anna alimenta 12 città ma ne ha 14, come funziona il reddito?' },
+      { id: 'c2', from: 'agent', t: '15:02', text: 'Il reddito dipende dalle città ALIMENTATE, non da quelle possedute. Anna sceglie quante alimentarne in base alle risorse: con 12 alimentate incassa 82 Elektro dalla tabella reddito.', citations: ['Power Grid §6', 'Income chart'] },
+      { id: 'c3', from: 'user',  t: '15:08', text: 'Perché Marco è ultimo nell\u2019asta se è in testa?' },
+      { id: 'c4', from: 'agent', t: '15:08', text: 'Esatto: nelle fasi Asta e Risorse l\u2019ordine si ribalta. Chi guida per città gioca per ULTIMO, così i giocatori in svantaggio scelgono centrali e comprano risorse prima.', citations: ['Power Grid §3'] },
+    ],
+    suggestions: ['Tabella reddito', 'Quando scatta lo Step 3?', 'Costo connessione'],
+    events: [
+      { kind: 'turn-change', who: 'p-dario', t: '15:09', text: '<strong>Dario</strong> mette all\u2019asta la centrale <strong>#18</strong> (eco, 2 città)' },
+      { kind: 'custom',      who: 'p-anna',  t: '15:09', text: '<strong>Anna</strong> rilancia a <strong>23 Elektro</strong>' },
+      { kind: 'custom',      who: 'p-dario', t: '15:10', text: '<strong>Dario</strong> passa sulla centrale #18' },
+      { kind: 'score-update',who: 'p-marco', t: '15:04', text: 'Burocrazia round 4: <strong>Marco</strong> alimenta 13 città → +€90 reddito' },
+      { kind: 'game-start',  who: null,      t: '14:01', text: 'Partita avviata · Germania (base) · 5 giocatori · Step 1' },
+    ],
+  };
+
+  // WIDGET — ToolkitRenderer: i CounterTools del JSON (dadi/timer esclusi).
+  const counterWidgets = [
+    { id: 'w-elektro', type: 'ResourceManager', isEnabled: true, displayOrder: 1,
+      config: { shared: false, resources: [
+        { label: 'Elektro · Marco', value: 22, max: 999 },
+        { label: 'Città alimentate', value: 13, max: 17 },
+        { label: 'Uranio (scorta)', value: 0, max: 12, danger: true },
+      ] } },
+    { id: 'w-score', type: 'ScoreTracker', isEnabled: true, displayOrder: 2, config: {} },
+    { id: 'w-turn',  type: 'TurnManager',  isEnabled: true, displayOrder: 3, config: { phaseBased: true } },
+    { id: 'w-note',  type: 'NoteManager',  isEnabled: false, displayOrder: 4, config: { text: '' } },
+    { id: 'w-rand',  type: 'RandomGenerator', isEnabled: false, displayOrder: 5, config: { name: 'Dadi' } },
+  ];
+
+  // ─── network map (Germania stilizzata · layout astratto/placeholder) ──────
+  // coords in viewBox 0..100. owner = id giocatore o null (non costruita).
+  // I nomi sono reali (base game sud); le posizioni sono uno SCHEMA, non
+  // geografia reale — segnaposto per la mappa di rilascio.
+  const network = {
+    region: 'Germania · Sud-Ovest (base)',
+    nodes: [
+      { id: 'essen',     name: 'Essen',      x: 10, y: 13, owner: 'p-anna',  lp: 'top' },
+      { id: 'dortmund',  name: 'Dortmund',   x: 27, y: 8,  owner: 'p-anna',  lp: 'top' },
+      { id: 'koln',      name: 'Köln',       x: 9,  y: 30, owner: 'p-luca',  lp: 'left' },
+      { id: 'aachen',    name: 'Aachen',     x: 6,  y: 45, owner: 'p-luca',  lp: 'top' },
+      { id: 'kassel',    name: 'Kassel',     x: 45, y: 17, owner: 'p-anna',  lp: 'top' },
+      { id: 'trier',     name: 'Trier',      x: 11, y: 61, owner: 'p-dario', lp: 'left' },
+      { id: 'wiesbaden', name: 'Wiesbaden',  x: 27, y: 47, owner: 'p-marco', lp: 'left' },
+      { id: 'frankfurt', name: 'Frankfurt',  x: 41, y: 36, owner: 'p-marco', lp: 'top' },
+      { id: 'wurzburg',  name: 'Würzburg',   x: 59, y: 37, owner: 'p-sara',  lp: 'top' },
+      { id: 'mannheim',  name: 'Mannheim',   x: 33, y: 63, owner: 'p-marco', lp: 'right' },
+      { id: 'stuttgart', name: 'Stuttgart',  x: 46, y: 76, owner: 'p-sara',  lp: 'bottom' },
+      { id: 'nurnberg',  name: 'Nürnberg',   x: 67, y: 55, owner: 'p-sara',  lp: 'right' },
+      { id: 'regensburg',name: 'Regensburg', x: 82, y: 61, owner: null,      lp: 'bottom' },
+      { id: 'augsburg',  name: 'Augsburg',   x: 61, y: 79, owner: null,      lp: 'right' },
+      { id: 'munchen',   name: 'München',    x: 78, y: 86, owner: null,      lp: 'bottom' },
+    ],
+    edges: [
+      ['essen','dortmund',5], ['essen','koln',10], ['koln','aachen',5], ['koln','dortmund',10],
+      ['aachen','trier',20], ['trier','wiesbaden',20], ['koln','wiesbaden',20],
+      ['wiesbaden','frankfurt',5], ['frankfurt','kassel',15], ['dortmund','kassel',20],
+      ['frankfurt','mannheim',15], ['wiesbaden','mannheim',10], ['mannheim','stuttgart',10],
+      ['frankfurt','wurzburg',15], ['kassel','wurzburg',20], ['wurzburg','nurnberg',10],
+      ['stuttgart','wurzburg',15], ['nurnberg','augsburg',20], ['stuttgart','augsburg',15],
+      ['augsburg','munchen',5], ['nurnberg','regensburg',10], ['regensburg','munchen',10],
+    ],
+    // città raggiungibili a costo minore dal current player (Marco) — highlight
+    reachableBy: { 'p-marco': ['augsburg', 'wurzburg'] },
+    connectCosts: [5, 10, 15, 20],
+  };
+
+  // ─── SUMMARY (post-game) ──────────────────────────────────────────────────
+  // Stato finale: Step 3, round 14, Marco raggiunge 17ª città → burocrazia
+  // finale. Vince chi alimenta più città; Elektro = spareggio.
+  const summary = {
+    rounds: 14, step: 3, endTrigger: 'Marco costruisce la 17ª città',
+    // standings ordinati per esito finale (powered desc, elektro desc)
+    standings: [
+      { id: 'p-anna',  name: 'Anna',  hue: 350, powered: 17, cities: 17, elektro: 18, plants: 3, maxCap: 6, plantsCap: 13, rank: 1, winner: true },
+      { id: 'p-marco', name: 'Marco', hue: 262, powered: 17, cities: 18, elektro: 9,  plants: 3, maxCap: 7, plantsCap: 15, rank: 2 },
+      { id: 'p-sara',  name: 'Sara',  hue: 38,  powered: 15, cities: 16, elektro: 41, plants: 3, maxCap: 6, plantsCap: 14, rank: 3 },
+      { id: 'p-luca',  name: 'Luca',  hue: 174, powered: 14, cities: 15, elektro: 12, plants: 3, maxCap: 4, plantsCap: 10, rank: 4 },
+      { id: 'p-dario', name: 'Dario', hue: 200, powered: 12, cities: 13, elektro: 27, plants: 2, maxCap: 6, plantsCap: 11, rank: 5 },
+    ],
+    tiebreak: { winnerId: 'p-anna', runnerUpId: 'p-marco', note: 'Anna e Marco pari a 17 città alimentate · vince Anna per Elektro residui (18 vs 9).' },
+    steps: [
+      { step: 1, round: 1,  trigger: 'Inizio partita', detail: 'Mercato 8 centrali (4+4) · mappa base · max 1 centrale/città.', icon: '①' },
+      { step: 2, round: 5,  trigger: '1º giocatore raggiunge 7 città', detail: 'Si può costruire come 2º occupante su una città (costo +). Carta più bassa rimossa.', icon: '②' },
+      { step: 3, round: 11, trigger: 'Carta "Step 3" pescata dal mazzo', detail: 'Mercato unico di 6 centrali (no future) · 3º occupante ammesso · fine ravvicinata.', icon: '③' },
+    ],
+    stats: {
+      // bid medio per fascia di centrale + spesa risorse per giocatore + meta
+      avgBidByTier: [
+        { tier: 'Centrali ≤15', avg: 14 },
+        { tier: 'Centrali 16-30', avg: 24 },
+        { tier: 'Centrali 31+', avg: 39 },
+      ],
+      spendByPlayer: [
+        { id: 'p-anna',  name: 'Anna',  hue: 350, plants: 184, resources: 132, connections: 211 },
+        { id: 'p-marco', name: 'Marco', hue: 262, plants: 203, resources: 158, connections: 226 },
+        { id: 'p-sara',  name: 'Sara',  hue: 38,  plants: 171, resources: 119, connections: 198 },
+        { id: 'p-luca',  name: 'Luca',  hue: 174, plants: 149, resources: 141, connections: 176 },
+        { id: 'p-dario', name: 'Dario', hue: 200, plants: 138, resources: 104, connections: 162 },
+      ],
+      facts: [
+        { lb: 'Round totali', v: '14' },
+        { lb: 'Centrali messe all\u2019asta', v: '31' },
+        { lb: 'Step 3 al round', v: '11' },
+        { lb: 'Risorsa più scarsa', v: 'Uranio' },
+      ],
+    },
+  };
+
+  window.PG = {
+    game, agent, RES, RES_ORDER, SUPPLY, PLANTS, market, resourceMarket,
+    nextPrice, remaining, roster, byId, phases, phaseState, baseOrder, turnOrder,
+    auction, ds, counterWidgets, network, plantsCapOf, summary,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-power-grid-flavor.jsx
+++ b/admin-mockups/design_files/sp4-session-power-grid-flavor.jsx
@@ -1,0 +1,275 @@
+/* MeepleAI SP4 · Power Grid — FLAVOR ATOMS  (window.PGFlavor)
+   Primitivi visivi game-specific condivisi da live + summary:
+     ResourceToken · ResourceCount · ResourceRow · ElektroCounter ·
+     SupplyStat · CityPip · PlantCard · PlantMini · StepIndicator ·
+     PhasePill · ReverseBadge · MiniAvatar
+
+   Colori risorse/elektro da window.PG (verbatim power-grid.json). Ogni altro
+   valore di colore/spazio/raggio = var di tokens.css. Legge window.MAI (eHsl). */
+
+(function () {
+  const M = window.MAI;
+  const PG = window.PG;
+  const eHsl = M.entityHsl;
+  const { RES, RES_ORDER, SUPPLY } = PG;
+  const mono = (s, w, c) => ({ fontFamily: 'var(--f-mono)', fontSize: s, fontWeight: w, color: c });
+  const disp = (s, w, c) => ({ fontFamily: 'var(--f-display)', fontSize: s, fontWeight: w, color: c });
+
+  const resOf = (id) => RES[id] || { lb: id, glyph: '?', color: '#888', dark: '#fff' };
+
+  // ─── MiniAvatar ───────────────────────────────────────────────────────────
+  const MiniAvatar = ({ p, size = 22, ring, dim }) => (
+    <div aria-hidden="true" style={{
+      width: size, height: size, borderRadius: '50%', flexShrink: 0, opacity: dim ? 0.4 : 1,
+      background: `linear-gradient(135deg, hsl(${p.hue},70%,64%), hsl(${p.hue},58%,44%))`,
+      color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      ...disp(size * 0.46, 800, '#fff'),
+      border: ring ? `2px solid ${eHsl('session')}` : '2px solid var(--bg-card)',
+    }}>{p.name[0]}</div>
+  );
+
+  // ─── ResourceToken — barile/disco colorato con glyph 1-lettera ────────────
+  const ResourceToken = ({ id, size = 18, title }) => {
+    const g = resOf(id);
+    const nuke = id === 'uranium';
+    return (
+      <span title={title || g.lb} aria-label={g.lb} style={{
+        width: size, height: size, borderRadius: nuke ? '50%' : 'var(--r-xs)', flexShrink: 0,
+        background: g.color, color: g.dark,
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        ...mono(size * 0.5, 800), border: '1px solid rgba(0,0,0,.28)',
+        boxShadow: 'inset 0 1px 1px rgba(255,255,255,.28), inset 0 -1px 2px rgba(0,0,0,.22)',
+      }}>{g.glyph}</span>
+    );
+  };
+
+  // ─── ResourceCount — token + numero ───────────────────────────────────────
+  const ResourceCount = ({ id, n, dim }) => (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 7px 2px 3px',
+      borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)',
+      opacity: dim && !n ? 0.42 : 1,
+    }}>
+      <ResourceToken id={id} size={15} />
+      <span style={{ ...mono(11, 800, n ? 'var(--text)' : 'var(--text-muted)'), fontVariantNumeric: 'tabular-nums', minWidth: 8, textAlign: 'center' }}>{n}</span>
+    </span>
+  );
+
+  // ResourceRow — i 4 contatori risorsa (magazzino giocatore)
+  const ResourceRow = ({ store, label = 'Risorse in scorta' }) => (
+    <div>
+      {label && <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 5 }}>{label}</div>}
+      <div aria-live="polite" style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+        {RES_ORDER.map(id => <ResourceCount key={id} id={id} n={store[id] || 0} dim />)}
+      </div>
+    </div>
+  );
+
+  // ─── ElektroCounter — valuta, display grande ──────────────────────────────
+  const ElektroCounter = ({ value, big, compact, label = 'Elektro' }) => {
+    const s = SUPPLY.elektro;
+    if (compact) {
+      return (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 8px 2px 3px', borderRadius: 'var(--r-pill)', background: `${s.color}1f`, border: `1px solid ${s.color}55`, flexShrink: 0 }}>
+          <span aria-hidden="true" style={{ width: 16, height: 16, borderRadius: '50%', flexShrink: 0, background: `radial-gradient(circle at 35% 30%, #ffe9a8, ${s.color})`, color: s.dark, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...mono(9, 800), border: '1px solid #b8860b' }}>€</span>
+          <span style={{ ...disp(12, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{value}</span>
+        </span>
+      );
+    }
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: big ? 9 : 7, padding: big ? '8px 13px' : '5px 9px',
+        borderRadius: 'var(--r-md)', background: `linear-gradient(135deg, ${s.color}22, ${s.color}10)`,
+        border: `1px solid ${s.color}55`,
+      }}>
+        <span aria-hidden="true" style={{
+          width: big ? 30 : 22, height: big ? 30 : 22, borderRadius: '50%', flexShrink: 0,
+          background: `radial-gradient(circle at 35% 30%, #ffe9a8, ${s.color})`, color: s.dark,
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          ...mono(big ? 13 : 10, 800), border: '1px solid #b8860b',
+          boxShadow: 'inset 0 1px 1px rgba(255,255,255,.5), inset 0 -1px 2px rgba(0,0,0,.25)',
+        }}>€</span>
+        <div style={{ minWidth: 0, lineHeight: 1 }}>
+          <div aria-live="polite" style={{ ...disp(big ? 24 : 17, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{value}</div>
+          <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>{label}</div>
+        </div>
+      </div>
+    );
+  };
+
+  // ─── SupplyStat — città / alimentate (mini stat) ──────────────────────────
+  const SupplyStat = ({ kind, value, sub, accent }) => {
+    const s = SUPPLY[kind] || SUPPLY.city;
+    const col = accent || 'session';
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '5px 9px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', flex: 1, minWidth: 0 }}>
+        <span aria-hidden="true" style={{ width: 22, height: 22, borderRadius: 'var(--r-sm)', flexShrink: 0, background: eHsl(col, 0.16), color: eHsl(col), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...mono(11, 800) }}>{s.glyph}</span>
+        <div style={{ minWidth: 0, lineHeight: 1 }}>
+          <div aria-live="polite" style={{ ...disp(17, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{value}</div>
+          <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', whiteSpace: 'nowrap' }}>{sub || s.lb}</div>
+        </div>
+      </div>
+    );
+  };
+
+  // ─── CityPip — pallino città colorato per owner ───────────────────────────
+  const CityPip = ({ player, size = 12, powered, empty }) => (
+    <span aria-hidden="true" title={player ? player.name : 'non costruita'} style={{
+      width: size, height: size, borderRadius: '50%', flexShrink: 0, display: 'inline-block',
+      background: empty ? 'transparent' : `hsl(${player.hue},62%,52%)`,
+      border: empty ? `1.5px dashed var(--border-strong)` : `1.5px solid ${powered ? SUPPLY.powered.color : 'rgba(0,0,0,.25)'}`,
+      boxShadow: !empty && powered ? `0 0 6px ${SUPPLY.powered.color}99` : 'none',
+    }} />
+  );
+
+  // ─── PlantCard — la carta centrale distintiva (numero grande + icona) ─────
+  // n = numero (puntata minima). Header colorato per tipo combustibile.
+  const fuelMeta = (plant) => {
+    if (plant.eco) return { e: 'toolkit', lb: 'Eco', tone: '#1e8449' };
+    if (plant.hybrid) return { e: 'agent', lb: 'Ibrida', tone: '#a04000' };
+    const id = plant.res[0];
+    const map = { coal: '#2c3e50', oil: '#34495e', garbage: '#7d6608', uranium: '#1e8449' };
+    return { e: 'kb', lb: RES[id].lb, tone: map[id] || '#555' };
+  };
+
+  // slots = combustibile attualmente caricato (live, su plant posseduta)
+  const PlantCard = ({ plant, w = 116, future, buyable, loaded, ghost, onClick, compact }) => {
+    const fm = fuelMeta(plant);
+    const h = compact ? 96 : 132;
+    if (ghost) {
+      return (
+        <div aria-hidden="true" style={{ width: w, height: h, borderRadius: 'var(--r-md)', border: '1.5px dashed var(--border-strong)', background: 'var(--bg-sunken)', opacity: 0.5, display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(9, 700, 'var(--text-muted)'), flexShrink: 0 }}>vuoto</div>
+      );
+    }
+    return (
+      <button type="button" onClick={onClick} disabled={!onClick}
+        aria-label={`Centrale ${plant.n}, ${fm.lb}, ${plant.cap} città, consumo ${plant.cons || 0}`}
+        style={{
+          width: w, minHeight: h, borderRadius: 'var(--r-md)', flexShrink: 0, position: 'relative',
+          textAlign: 'left', cursor: onClick ? 'pointer' : 'default', overflow: 'hidden',
+          background: 'var(--bg-card)', padding: 0,
+          border: buyable ? `2px solid ${eHsl('session', 0.55)}` : `1px solid var(--border)`,
+          boxShadow: buyable ? `0 4px 14px ${eHsl('session', 0.22)}` : 'var(--shadow-xs)',
+          opacity: future ? 0.72 : 1, display: 'flex', flexDirection: 'column',
+        }}>
+        {/* header: numero + tipo */}
+        <div style={{ display: 'flex', alignItems: 'stretch', borderBottom: `1px solid ${fm.tone}55` }}>
+          <div style={{ width: compact ? 36 : 44, flexShrink: 0, background: fm.tone, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...disp(compact ? 20 : 26, 800, '#fff'), fontVariantNumeric: 'tabular-nums', textShadow: '0 1px 2px rgba(0,0,0,.3)' }}>{plant.n}</div>
+          <div style={{ flex: 1, padding: '4px 7px', display: 'flex', flexDirection: 'column', justifyContent: 'center', background: `${fm.tone}14` }}>
+            <span style={{ ...mono(8, 800, fm.tone === '#7d6608' ? '#7d6608' : fm.tone), textTransform: 'uppercase', letterSpacing: '.05em' }}>{fm.lb}</span>
+            <span style={{ ...mono(7.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.04em' }}>min. {plant.n}</span>
+          </div>
+        </div>
+        {/* body: consumo → capacità */}
+        <div style={{ flex: 1, padding: compact ? '7px 8px' : '9px 9px', display: 'flex', flexDirection: 'column', gap: 6, justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            {plant.eco
+              ? <span style={{ ...mono(8.5, 800, eHsl('toolkit')), display: 'inline-flex', alignItems: 'center', gap: 4 }}><span aria-hidden="true">🌿</span>nessun combustibile</span>
+              : (<>
+                  {Array.from({ length: plant.cons }).map((_, i) => (
+                    plant.hybrid && i === 0
+                      ? <span key={i} style={{ display: 'inline-flex', alignItems: 'center' }}><ResourceToken id={plant.res[0]} size={15} /><span style={{ ...mono(9, 800, 'var(--text-muted)'), margin: '0 1px' }}>/</span><ResourceToken id={plant.res[1]} size={15} /></span>
+                      : <ResourceToken key={i} id={plant.hybrid ? plant.res[0] : plant.res[0]} size={15} />
+                  ))}
+                  <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>×{plant.cons}</span>
+                </>)}
+          </div>
+          {/* capacità città (grande, leggibilissima) */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ width: compact ? 24 : 28, height: compact ? 24 : 28, borderRadius: '50%', flexShrink: 0, background: eHsl('session', 0.14), color: eHsl('session'), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...disp(compact ? 14 : 16, 800), fontVariantNumeric: 'tabular-nums', border: `1.5px solid ${eHsl('session', 0.4)}` }}>{plant.cap}</span>
+            <span style={{ ...mono(8.5, 700, 'var(--text-muted)'), lineHeight: 1.1 }}>città<br/>alimentate</span>
+          </div>
+          {/* combustibile caricato (solo plant possedute) */}
+          {loaded && (
+            <div style={{ display: 'flex', gap: 3, alignItems: 'center', paddingTop: 4, borderTop: '1px solid var(--border-light)' }} aria-label="combustibile caricato">
+              {plant.eco
+                ? <span style={{ ...mono(8, 700, eHsl('toolkit')) }}>🌿 pronta</span>
+                : Array.from({ length: plant.cons }).map((_, i) => {
+                    const total = Object.values(loaded).reduce((a, b) => a + b, 0);
+                    return <span key={i} style={{ opacity: i < total ? 1 : 0.28 }}><ResourceToken id={plant.res[0]} size={12} title={i < total ? 'caricato' : 'vuoto'} /></span>;
+                  })}
+            </div>
+          )}
+        </div>
+        {buyable && <span style={{ position: 'absolute', top: 5, right: 5, ...mono(7.5, 800, '#fff'), background: eHsl('session'), padding: '1px 6px', borderRadius: 'var(--r-pill)', textTransform: 'uppercase', letterSpacing: '.05em' }}>asta</span>}
+      </button>
+    );
+  };
+
+  // ─── PlantMini — centrale del giocatore nel rail (numero + cap + fuel) ─────
+  const PlantMini = ({ plant, loaded }) => {
+    const fm = fuelMeta(plant);
+    const total = loaded ? Object.values(loaded).reduce((a, b) => a + b, 0) : 0;
+    return (
+      <div title={`Centrale ${plant.n} · ${plant.cap} città`} style={{
+        display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderRadius: 'var(--r-md)',
+        background: 'var(--bg-card)', border: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <span style={{ width: 30, height: 30, borderRadius: 'var(--r-sm)', flexShrink: 0, background: fm.tone, color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...disp(15, 800, '#fff'), fontVariantNumeric: 'tabular-nums' }}>{plant.n}</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <span style={{ ...mono(9, 800, eHsl('session')) }}>⚡{plant.cap}</span>
+            <span style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase' }}>{fm.lb}</span>
+          </div>
+          <div style={{ display: 'flex', gap: 2, marginTop: 3, alignItems: 'center' }}>
+            {plant.eco
+              ? <span style={{ ...mono(8, 700, eHsl('toolkit')) }}>🌿 pronta</span>
+              : Array.from({ length: plant.cons }).map((_, i) => (
+                  <span key={i} style={{ opacity: i < total ? 1 : 0.3 }}><ResourceToken id={plant.res[0]} size={11} /></span>
+                ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ─── StepIndicator — Step 1/2/3 prominente ────────────────────────────────
+  const StepIndicator = ({ step, compact }) => (
+    <div role="group" aria-label={`Step di gioco ${step} di 3`} style={{ display: 'inline-flex', alignItems: 'center', gap: compact ? 4 : 5 }}>
+      {!compact && <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Step</span>}
+      {[1, 2, 3].map(n => {
+        const on = n === step, past = n < step;
+        return (
+          <span key={n} aria-current={on ? 'true' : undefined} style={{
+            width: compact ? 18 : 22, height: compact ? 18 : 22, borderRadius: 'var(--r-sm)',
+            background: on ? eHsl('game') : past ? eHsl('game', 0.2) : 'var(--bg-muted)',
+            color: on ? '#fff' : past ? eHsl('game') : 'var(--text-muted)',
+            border: on ? 'none' : '1px solid var(--border)',
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            ...disp(compact ? 11 : 13, 800), boxShadow: on ? `0 2px 8px ${eHsl('game', 0.4)}` : 'none',
+          }}>{n}</span>
+        );
+      })}
+    </div>
+  );
+
+  // ─── PhasePill — fase compatta ────────────────────────────────────────────
+  const PhasePill = ({ phase, active }) => (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 9px', borderRadius: 'var(--r-pill)',
+      background: active ? eHsl('session', 0.14) : 'var(--bg-muted)',
+      color: active ? eHsl('session') : 'var(--text-muted)',
+      border: `1px solid ${active ? eHsl('session', 0.4) : 'var(--border-light)'}`,
+      ...mono(9.5, 800), whiteSpace: 'nowrap',
+    }}><span aria-hidden="true">{phase.icon}</span>{phase.n}. {phase.short}</span>
+  );
+
+  // ─── ReverseBadge — indicatore ordine ribaltato ───────────────────────────
+  const ReverseBadge = ({ reverse }) => (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 9px', borderRadius: 'var(--r-pill)',
+      background: reverse ? eHsl('event', 0.12) : eHsl('toolkit', 0.12),
+      color: reverse ? eHsl('event') : eHsl('toolkit'),
+      border: `1px solid ${reverse ? eHsl('event', 0.32) : eHsl('toolkit', 0.32)}`,
+      ...mono(9, 800), textTransform: 'uppercase', letterSpacing: '.05em', whiteSpace: 'nowrap',
+    }}>
+      <span aria-hidden="true">{reverse ? '⇄' : '→'}</span>{reverse ? 'Ordine ribaltato' : 'Ordine normale'}
+    </span>
+  );
+
+  window.PGFlavor = {
+    resOf, fuelMeta, mono, disp,
+    MiniAvatar, ResourceToken, ResourceCount, ResourceRow, ElektroCounter,
+    SupplyStat, CityPip, PlantCard, PlantMini, StepIndicator, PhasePill, ReverseBadge,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-power-grid-live.html
+++ b/admin-mockups/design_files/sp4-session-power-grid-live.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Power Grid · Live — /sessions/[id]/live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-power-grid-live.jsx
+++ b/admin-mockups/design_files/sp4-session-power-grid-live.jsx
@@ -1,0 +1,183 @@
+/* MeepleAI SP4 · Power Grid — SESSION LIVE  (App)
+   /sessions/[id]/live — estensione game-specific dello skeleton universale
+   applicata a Power Grid (euro auction + network building, 2-6 giocatori, ~120 min).
+
+   PREMIUM mockup. Lo skeleton (mockup #1) fornisce i renderer polimorfici +
+   la chrome universale; QUESTO layer aggiunge la board di Power Grid:
+   PhaseIndicator (5 fasi + Step), TurnOrderStrip reverse-aware, mercato 8
+   centrali, mercato risorse a scarsità, AuctionOverlay, NetworkMap e una
+   colonna destra a 5 tab (Scoring · Market · Network · Plants · Chat).
+
+   MECCANICA CHIAVE: l'ordine si RICALCOLA per città e si RIBALTA nelle fasi
+   2-Asta / 3-Risorse (leader gioca ULTIMO).
+
+   Riusa verbatim: TopBar · ChatAgentPanel · ActionLog · ScoringPanelRenderer
+   (Points) · TurnIndicatorRenderer (Sequential) · ToolkitRenderer. Dark = primaria.
+
+   Carica: sp4-parts-common · power-grid-data(shim SkeletonData) · skeleton-renderers
+           · skeleton-parts · power-grid-flavor · power-grid-parts · QUESTO file.
+   DEMO-NAV-HINTS: sp4-session-power-grid-summary.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const S = window.SkeletonParts;
+const PG = window.PG;
+const F = window.PGFlavor;
+const P = window.PGParts;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+const Intro = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+    {[
+      { e: 'session', h: 'Estende lo skeleton', b: 'Riusa TopBar · ChatAgent · ActionLog e i 3 renderer polimorfici. Aggiunge sopra la board di Power Grid: fasi, mercati, rete.' },
+      { e: 'event',   h: 'Ordine ribaltato', b: 'L\u2019ordine si ricalcola per città e si RIBALTA nelle fasi Asta e Risorse: il leader gioca per ultimo. Indicatore ⇄ sempre visibile.' },
+      { e: 'game',    h: 'Mercati & Step', b: '8 centrali (4 attuali + 4 future), mercato risorse a scarsità con prossimo prezzo, e i 3 Step di gioco scanditi dal conteggio città.' },
+      { e: 'toolkit', h: '5 stati canonici', b: 'default · empty · loading · error · sse-disconnect per ogni pannello (mercato centrali, risorse, rete, scoring, centrali).' },
+    ].map(c => (
+      <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+        <div style={{ fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, color: eHsl(c.e), marginBottom: 4 }}>{c.h}</div>
+        <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+      </div>
+    ))}
+  </div>
+);
+
+const StatesRow = ({ title, sub, entity, render }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ fontFamily: 'var(--f-display)', fontSize: 15, fontWeight: 800, color: eHsl(entity) }}>{title}</span>
+      {sub && <span style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)', fontWeight: 700 }}>{sub}</span>}
+    </div>
+    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', paddingBottom: 10 }}>
+      {P.STATES.map(s => (
+        <P.PanelFrame key={s.id} label={s.lb} entity={entity} dark={s.id === 'sse'}>
+          {render(s.id)}
+        </P.PanelFrame>
+      ))}
+    </div>
+  </div>
+);
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Power Grid · Live ⚡ · estensione skeleton</div>
+        <h1>Session live — Power Grid</h1>
+        <p className="lead">
+          Estensione game-specific dello <strong>skeleton universale</strong> applicata a <strong>Power Grid</strong>
+          (euro ad asta + costruzione rete, 2-6 giocatori, ~120 min). Lo skeleton fornisce i renderer polimorfici e
+          la chrome; questo layer aggiunge l\u2019<strong>indicatore di fase</strong> (5 fasi + Step), la
+          <strong> turn-order strip reverse-aware</strong>, il <strong>mercato delle 8 centrali</strong>, il
+          <strong> mercato risorse a scarsità</strong>, l\u2019<strong>overlay d\u2019asta</strong> e la
+          <strong> rete della Germania</strong>, più una colonna destra a 5 tab. Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        {/* INTERACTIVE — desktop */}
+        <div className="section-label">Interattivo · Desktop 1280 — fasi + ordine ⇄ · rail giocatore · mercati + asta · colonna tab</div>
+        <S.DesktopFrame ds={PG.ds} dark label="Desktop · live · Power Grid" url="meepleai.app/sessions/pg-7/live?tab=market" height={820}
+          desc="Top: PhaseIndicator (fase 2 Asta attiva, Step 2, Round 5) + TurnOrderStrip ribaltata (Marco leader → ultimo). SINISTRA plancia del giocatore attivo (Elektro · risorse · centrali · città; clic sugli altri per cambiarlo). CENTRO overlay asta + mercato 8 centrali + mercato risorse + log. DESTRA tab Scoring/Market/Network/Plants/Chat con selettore stato.">
+          <S.TopBar ds={PG.ds} connection="connected" />
+          <P.DesktopBody initialTab="market" initialState="default" />
+        </S.DesktopFrame>
+
+        {/* INTERACTIVE — mobile */}
+        <div className="section-label">Mobile 375 — phase indicator sticky · board scroll · tab → bottom-sheet</div>
+        <div className="phones-grid">
+          <P.PhoneShell label="01 · base · sheet chiuso" desc="PhaseIndicator sticky in alto, ordine ribaltato, board scrollabile (asta + mercati in scroll orizzontale). In basso strip tab." />
+          <P.PhoneShell label="02 · sheet Market" initialTab="market" desc="Tap su una tab apre il bottom-sheet: mercato centrali + mercato risorse + Step, con selettore stato." />
+          <P.PhoneShell label="03 · sheet Network · dark" dark initialTab="network" desc="NetworkMap nella tab dedicata: rete Germania con città color-coded per owner e costi connessione." />
+        </div>
+
+        {/* STATES — reused polymorphic renderers */}
+        <div className="section-label">Gallery stati · renderer polimorfici riusati — alimentati dal toolkit Power Grid</div>
+        <StatesRow title="ScoringPanelRenderer" sub="scoreType · Points — città alimentate + 3 categorie dal JSON (Count · Sum · Custom)" entity="session"
+          render={(st) => <R.ScoringPanelRenderer data={PG.ds} state={st} />} />
+        <StatesRow title="TurnIndicatorRenderer" sub="turnOrderType · Sequential — phase stepper sulle 5 fasi del round" entity="player"
+          render={(st) => <R.TurnIndicatorRenderer data={PG.ds} state={st} />} />
+        <StatesRow title="ToolkitRenderer" sub="dispatch widgets[] — CounterTools del JSON (dadi/timer esclusi)" entity="toolkit"
+          render={(st) => <R.ToolkitRenderer widgets={PG.counterWidgets} players={PG.ds.players} state={st} />} />
+
+        {/* STATES — PG-specific panels */}
+        <div className="section-label">Gallery stati · pannelli specifici Power Grid × 5 stati canonici</div>
+        <StatesRow title="PowerPlantMarket" sub="8 carte · Current + Future · 2 righe" entity="game"
+          render={(st) => <P.PowerPlantMarket state={st} compact withStep />} />
+        <StatesRow title="ResourceMarket" sub="4 colonne con scarsità + prossimo prezzo" entity="kb"
+          render={(st) => <P.ResourceMarket state={st} compact />} />
+        <StatesRow title="NetworkMap" sub="rete Germania · owner coloring + highlight raggiungibili" entity="session"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto' }}><P.NetworkMap state={st} h={250} showLegend={false} /></div>} />
+        <StatesRow title="PlantsTab" sub="dettaglio delle 3 centrali del giocatore" entity="kb"
+          render={(st) => <P.PlantsTab state={st} />} />
+
+        {/* PG component showcase */}
+        <div className="section-label">Componenti Power Grid · indicatore fase · ordine ribaltato · overlay asta · carta centrale</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <P.SectionCard title="PhaseIndicator + TurnOrderStrip" entity="session" accent flush>
+            <P.PhaseIndicator />
+            <P.TurnOrderStrip />
+          </P.SectionCard>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 16, alignItems: 'start' }}>
+            <div>
+              <div style={{ ...F.mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>AuctionOverlay · fase 2</div>
+              <P.AuctionOverlay />
+            </div>
+            <div data-theme="dark">
+              <div style={{ ...F.mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>AuctionOverlay · dark</div>
+              <div style={{ background: 'var(--bg)', padding: 12, borderRadius: 'var(--r-lg)' }}>
+                <P.AuctionOverlay compact />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <div style={{ ...F.mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>PlantCard · tipi combustibile (eco · ibrida · carbone · uranio · posseduta)</div>
+            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              <F.PlantCard plant={PG.PLANTS.p13} />
+              <F.PlantCard plant={PG.PLANTS.p21} buyable />
+              <F.PlantCard plant={PG.PLANTS.p20} />
+              <F.PlantCard plant={PG.PLANTS.p23} />
+              <F.PlantCard plant={PG.roster[0].plants[0]} loaded={PG.roster[0].plants[0].loaded} />
+              <F.PlantCard plant={PG.PLANTS.p27} future />
+            </div>
+          </div>
+
+          <P.SectionCard title="NetworkMap · rete Germania" entity="session" accent flush>
+            <P.NetworkMap />
+          </P.SectionCard>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; width: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-power-grid-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-power-grid-parts.jsx
@@ -1,0 +1,645 @@
+/* MeepleAI SP4 · Power Grid — COMPOSED PARTS  (window.PGParts)
+   Pannelli specifici Power Grid montati sopra lo skeleton universale:
+     SectionCard · PanelFrame · STATES
+     PhaseIndicator      — timeline 5 fasi del round + Step + Round (aria-current)
+     TurnOrderStrip      — ordine corrente + indicatore REVERSE (leader ultimo)
+     PlayerStateRail     — stato giocatore (Elektro · risorse · centrali · città)
+     PowerPlantMarket    — 8 carte (Current + Future) · 2 righe
+     AuctionOverlay      — flusso d'asta fase 2 (bidder + highest bid · aria-live)
+     ResourceMarket      — 4 colonne con scarsità + "prossimo prezzo"
+     NetworkMap          — mappa Germania (nodi+archi · owner coloring · highlight)
+     PlantsRail / PlantsTab · MarketTab
+     RightColumnTabs     — Scoring · Market · Network · Plants · Chat
+     DesktopBody · PhoneShell
+
+   Riusa: S.TopBar · S.ChatAgentPanel · S.ActionLogTimeline · S.StateSwitch
+          R.ScoringPanelRenderer · R.StateScaffold · M.StateBlock/Shimmer/SseBanner
+   Legge window.PG (dati) · window.PGFlavor (atomi) · window.MAI (eHsl). */
+
+(function () {
+  const M = window.MAI;
+  const R = window.SkeletonRenderers;
+  const S = window.SkeletonParts;
+  const PG = window.PG;
+  const F = window.PGFlavor;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const { mono, disp } = F;
+
+  const STATES = window.SkeletonData.STATES;
+
+  // ─── SectionCard — contenitore titolato ───────────────────────────────────
+  const SectionCard = ({ title, entity = 'session', accent, right, children, pad = 12, flush, collapsed, onHeaderClick }) => {
+    const collapsible = !!onHeaderClick;
+    const headStyle = { width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: accent ? eHsl(entity, collapsed ? 0.04 : 0.06) : 'var(--bg-muted)', border: 'none', borderBottom: collapsed ? 'none' : `1px solid ${accent ? eHsl(entity, 0.18) : 'var(--border-light)'}`, cursor: collapsible ? 'pointer' : 'default' };
+    const headInner = (
+      <React.Fragment>
+        <span style={{ ...mono(10, 800, accent ? eHsl(entity) : 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{title}</span>
+        <div style={{ flex: 1 }} />{right}
+        {collapsible && <span aria-hidden="true" style={{ ...mono(11, 800, eHsl(entity)), flexShrink: 0, transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span>}
+      </React.Fragment>
+    );
+    return (
+      <section style={{ background: 'var(--bg-card)', border: `1px solid ${accent || collapsible ? eHsl(entity, collapsed ? 0.2 : 0.3) : 'var(--border)'}`, borderRadius: 'var(--r-lg)', overflow: 'hidden', boxShadow: 'var(--shadow-sm)', flexShrink: 0 }}>
+        {title && (collapsible
+          ? <button type="button" onClick={onHeaderClick} aria-expanded={!collapsed} style={headStyle}>{headInner}</button>
+          : <div style={headStyle}>{headInner}</div>)}
+        {!collapsed && <div style={{ padding: flush ? 0 : pad }}>{children}</div>}
+      </section>
+    );
+  };
+
+  // ─── PanelFrame — frame rail per la gallery degli stati ───────────────────
+  const PanelFrame = ({ label, entity = 'session', dark, children, w = 300, h = 470 }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} data-theme={dark ? 'dark' : undefined}>
+      <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</div>
+      <div style={{ width: w, height: h, borderRadius: 'var(--r-lg)', border: `1px solid ${eHsl(entity, 0.3)}`, background: 'var(--bg-card)', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: 'var(--shadow-sm)' }}>{children}</div>
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PhaseIndicator — timeline delle 5 fasi · Step + Round prominenti
+  // ══════════════════════════════════════════════════════════════════════════
+  const PhaseIndicator = ({ compact, sticky }) => {
+    const { phases, phaseState } = PG;
+    return (
+      <div role="group" aria-label="Fase del round" style={{
+        display: 'flex', alignItems: 'center', gap: compact ? 8 : 14, padding: compact ? '8px 12px' : '10px 16px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderBottom: '1px solid var(--border)',
+        ...(sticky ? { position: 'sticky', top: 0, zIndex: 10 } : {}), flexShrink: 0, flexWrap: 'wrap', rowGap: 7,
+      }}>
+        {/* Round + Step block */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 7 : 10, flexShrink: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: 1 }}>
+            <span style={{ ...disp(compact ? 17 : 21, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>R{phaseState.round}</span>
+            <span style={{ ...mono(7.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Round</span>
+          </div>
+          <F.StepIndicator step={phaseState.step} compact={compact} />
+        </div>
+        <span aria-hidden="true" style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)', flexShrink: 0 }} />
+        {/* 5-phase timeline */}
+        <ol style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', alignItems: 'center', flexWrap: 'wrap', rowGap: 6, gap: compact ? 5 : 7, flex: 1, minWidth: 0 }}>
+          {phases.map((ph, i) => {
+            const on = i === phaseState.phaseIndex, past = i < phaseState.phaseIndex;
+            const e = on ? 'session' : ph.reverse ? 'event' : 'player';
+            return (
+              <li key={ph.id} aria-current={on ? 'step' : undefined} style={{ display: 'flex', alignItems: 'center', gap: compact ? 5 : 7, flexShrink: 0 }}>
+                <div title={ph.desc} style={{
+                  display: 'flex', alignItems: 'center', gap: 6, padding: compact ? '5px 8px' : '6px 11px', borderRadius: 'var(--r-pill)',
+                  background: on ? eHsl('session', 0.14) : past ? eHsl('toolkit', 0.07) : 'var(--bg-muted)',
+                  border: `1px solid ${on ? eHsl('session', 0.45) : past ? eHsl('toolkit', 0.25) : 'var(--border-light)'}`,
+                  boxShadow: on ? `0 3px 10px ${eHsl('session', 0.22)}` : 'none',
+                }}>
+                  <span aria-hidden="true" style={{
+                    width: compact ? 17 : 20, height: compact ? 17 : 20, borderRadius: '50%', flexShrink: 0,
+                    background: on ? eHsl('session') : past ? eHsl('toolkit', 0.25) : 'transparent',
+                    color: on ? '#fff' : past ? eHsl('toolkit') : 'var(--text-muted)',
+                    border: on || past ? 'none' : '1px solid var(--border-strong)',
+                    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...mono(compact ? 9 : 10, 800),
+                  }}>{past ? '✓' : ph.n}</span>
+                  {!compact && <span style={{ ...disp(11.5, on ? 800 : 600, on ? eHsl('session') : past ? 'var(--text-sec)' : 'var(--text-muted)'), whiteSpace: 'nowrap' }}>{ph.short}</span>}
+                  {ph.reverse && <span title="Ordine ribaltato in questa fase" aria-label="ordine ribaltato" style={{ ...mono(9, 800, on ? eHsl('event') : 'var(--text-muted)') }}>⇄</span>}
+                </div>
+                {i < phases.length - 1 && <span aria-hidden="true" style={{ ...mono(10, 800, past ? eHsl('toolkit') : 'var(--text-muted)') }}>{compact ? '·' : '→'}</span>}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // TurnOrderStrip — ordine corrente + REVERSE (leader gioca ultimo)
+  // ══════════════════════════════════════════════════════════════════════════
+  const TurnOrderStrip = ({ phaseId, awaitingId, compact }) => {
+    const { order, reverse, phase } = PG.turnOrder(phaseId);
+    const activeId = awaitingId || PG.auction.awaitingId;
+    return (
+      <div aria-label={`Ordine di gioco · fase ${phase.lb}`} style={{
+        display: 'flex', alignItems: 'center', gap: compact ? 7 : 10, padding: compact ? '7px 12px' : '8px 16px',
+        background: reverse ? eHsl('event', 0.05) : 'var(--bg-card)', borderBottom: '1px solid var(--border)',
+        flexWrap: 'wrap', rowGap: 6, flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', flexShrink: 0, lineHeight: 1.15 }}>
+          <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Ordine · F{phase.n}</span>
+          <F.ReverseBadge reverse={reverse} />
+        </div>
+        <span aria-hidden="true" style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)', flexShrink: 0 }} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap', rowGap: 5 }}>
+          {order.map((p, i) => {
+            const on = p.id === activeId;
+            const passed = PG.auction.passed.includes(p.id) && phase.id === 'auction';
+            return (
+              <React.Fragment key={p.id}>
+                <div title={`${p.name} · ${p.cities} città`} style={{
+                  display: 'flex', alignItems: 'center', gap: 5, padding: '3px 9px 3px 3px', borderRadius: 'var(--r-pill)', flexShrink: 0,
+                  background: on ? eHsl('player', 0.14) : 'var(--bg-muted)',
+                  border: `1px solid ${on ? eHsl('player', 0.45) : 'var(--border-light)'}`,
+                  opacity: passed ? 0.45 : 1,
+                }}>
+                  <span style={{ ...mono(8.5, 800, on ? eHsl('player') : 'var(--text-muted)'), width: 12, textAlign: 'center' }}>{i + 1}</span>
+                  <F.MiniAvatar p={p} size={20} ring={on} dim={passed} />
+                  {!compact && <span style={{ ...disp(11, on ? 800 : 600, on ? 'var(--text)' : 'var(--text-sec)') }}>{p.name}</span>}
+                  {on && <span className="mai-pulse-dot" aria-label="al turno" style={{ ...mono(8, 800, eHsl('player')) }}>●</span>}
+                  {passed && <span style={{ ...mono(7.5, 800, 'var(--text-muted)'), textTransform: 'uppercase' }}>pass</span>}
+                </div>
+                {i < order.length - 1 && <span aria-hidden="true" style={{ ...mono(10, 700, 'var(--text-muted)'), flexShrink: 0 }}>›</span>}
+              </React.Fragment>
+            );
+          })}
+        </div>
+        {reverse && <span style={{ ...mono(8.5, 700, eHsl('event')), flexShrink: 0, whiteSpace: 'nowrap', marginLeft: 'auto' }}>👑 {order[order.length - 1].name} (leader) gioca ultimo</span>}
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PlayerStateRail — stato del giocatore attivo (rail laterale)
+  // ══════════════════════════════════════════════════════════════════════════
+  const PlayerStateRail = ({ player, others, onPick }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <SectionCard title={`Plancia · ${player.name}`} entity="session" accent pad={11}
+        right={<span style={{ ...mono(8.5, 800, eHsl('player')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('player', 0.12), border: `1px solid ${eHsl('player', 0.3)}` }}>attivo</span>}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <F.ElektroCounter value={player.elektro} big />
+          <div style={{ display: 'flex', gap: 7 }}>
+            <F.SupplyStat kind="city" value={player.cities} sub="città" accent="player" />
+            <F.SupplyStat kind="powered" value={player.powered} sub="alimentate" accent="game" />
+          </div>
+          <F.ResourceRow store={player.store} />
+          <div>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 5 }}>
+              <span style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Centrali</span>
+              <span style={{ ...mono(9, 800, eHsl('session')) }}>{player.plants.length}/3</span>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+              {player.plants.map((pl, i) => <F.PlantMini key={i} plant={pl} loaded={pl.loaded} />)}
+              {Array.from({ length: 3 - player.plants.length }).map((_, i) => (
+                <div key={`e${i}`} style={{ height: 44, borderRadius: 'var(--r-md)', border: '1.5px dashed var(--border-strong)', background: 'var(--bg-sunken)', opacity: 0.5, display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(9, 700, 'var(--text-muted)') }}>slot libero</div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+      {others && (
+        <SectionCard title="Altri giocatori" entity="player" pad={10}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {others.map(p => (
+              <button key={p.id} type="button" onClick={() => onPick && onPick(p.id)} style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '6px 8px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', cursor: onPick ? 'pointer' : 'default', textAlign: 'left' }}>
+                <F.MiniAvatar p={p} size={24} />
+                <span style={{ flex: 1, minWidth: 0, ...disp(12, 800, 'var(--text)'), overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
+                <span title="città · alimentate" style={{ display: 'inline-flex', gap: 5, flexShrink: 0 }}>
+                  <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>🏙{p.cities}</span>
+                  <span style={{ ...mono(9, 700, eHsl('game')) }}>⚡{p.powered}</span>
+                </span>
+                <F.ElektroCounter value={p.elektro} compact />
+              </button>
+            ))}
+          </div>
+        </SectionCard>
+      )}
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PowerPlantMarket — 8 carte · Current (comprabili) + Future (preview)
+  // ══════════════════════════════════════════════════════════════════════════
+  const PowerPlantMarketInner = ({ compact }) => {
+    const cur = PG.market.current.map(id => PG.PLANTS[id]);
+    const fut = PG.market.future.map(id => PG.PLANTS[id]);
+    const minCell = compact ? 92 : 108;
+    const grid = { display: 'grid', gridTemplateColumns: `repeat(auto-fill, minmax(${minCell}px, 1fr))`, gap: 8 };
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: 12 }}>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 7 }}>
+            <span style={{ ...mono(9, 800, eHsl('session')), textTransform: 'uppercase', letterSpacing: '.07em' }}>Mercato attuale</span>
+            <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>4 centrali · all'asta</span>
+          </div>
+          <div style={grid}>
+            {cur.map((pl, i) => <F.PlantCard key={i} plant={pl} w="100%" buyable compact={compact} onClick={() => {}} />)}
+          </div>
+        </div>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 7 }}>
+            <span style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Mercato futuro</span>
+            <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>4 centrali · anteprima · non comprabili</span>
+          </div>
+          <div style={grid}>
+            {fut.map((pl, i) => <F.PlantCard key={i} plant={pl} w="100%" future compact={compact} />)}
+          </div>
+        </div>
+      </div>
+    );
+  };
+  const PowerPlantMarket = ({ state = 'default', compact, withStep, collapsed, onHeaderClick }) => (
+    <SectionCard title="Mercato centrali" entity="game" accent flush collapsed={collapsed} onHeaderClick={onHeaderClick}
+      right={withStep ? <F.StepIndicator step={PG.phaseState.step} compact /> : <span style={{ ...mono(8.5, 800, eHsl('game')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('game', 0.12), border: `1px solid ${eHsl('game', 0.3)}` }}>8 carte</span>}>
+      <R.StateScaffold state={state} sseWhere="mercato"
+        empty={{ icon: '⚡', title: 'Mercato vuoto', body: 'Le centrali compariranno all\u2019avvio della fase asta.' }}
+        error={{ title: 'Mercato non disponibile', body: 'Impossibile caricare il mercato delle centrali.' }}
+        loading={<div style={{ padding: 14, display: 'flex', gap: 8, flexWrap: 'wrap' }}>{Array.from({ length: 8 }).map((_, i) => <M.Shimmer key={i} h={compact ? 96 : 132} style={{ width: compact ? 104 : 116, borderRadius: 'var(--r-md)' }} />)}</div>}>
+        <PowerPlantMarketInner compact={compact} />
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ─── AuctionOverlay — flusso asta fase 2 (bidder + highest bid) ────────────
+  const AuctionOverlay = ({ compact, collapsed, onHeaderClick }) => {
+    const a = PG.auction;
+    const plant = PG.PLANTS[a.plantId];
+    const high = PG.byId(a.highBidderId);
+    const nom = PG.byId(a.nominatorId);
+    const awaiting = PG.byId(a.awaitingId);
+    const collapsible = !!onHeaderClick;
+    const head = (
+      <React.Fragment>
+        <span className="mai-pulse-dot" aria-hidden="true" style={{ color: eHsl('session'), fontSize: 10, flexShrink: 0 }}>●</span>
+        <span style={{ ...disp(12.5, 800, eHsl('session')), whiteSpace: 'nowrap' }}>Asta in corso</span>
+        {collapsible && <span aria-hidden="true" style={{ ...mono(11, 800, eHsl('session')), flexShrink: 0, marginLeft: 'auto', transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span>}
+        <span style={{ flexBasis: '100%', ...mono(8.5, 700, 'var(--text-muted)') }}>fase 2 · ordine ⇄ ribaltato · nominata da <strong style={{ color: `hsl(${nom.hue},60%,55%)` }}>{nom.name}</strong></span>
+      </React.Fragment>
+    );
+    const headStyle = { width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', rowGap: 4, padding: '7px 12px', background: eHsl('session', 0.1), border: 'none', borderBottom: collapsed ? 'none' : `1px solid ${eHsl('session', 0.25)}`, cursor: collapsible ? 'pointer' : 'default' };
+    return (
+      <div role="region" aria-label="Asta in corso" aria-live="polite" style={{
+        borderRadius: 'var(--r-lg)', overflow: 'hidden', border: `2px solid ${eHsl('session', collapsed ? 0.25 : 0.5)}`,
+        background: 'var(--bg-card)', boxShadow: collapsed ? 'var(--shadow-sm)' : `0 8px 28px ${eHsl('session', 0.25)}`, flexShrink: 0,
+      }}>
+        {collapsible
+          ? <button type="button" onClick={onHeaderClick} aria-expanded={!collapsed} style={headStyle}>{head}</button>
+          : <div style={headStyle}>{head}</div>}
+        {!collapsed && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 10 : 16, padding: 12, flexWrap: 'wrap' }}>
+          <F.PlantCard plant={plant} w={compact ? 104 : 112} compact={compact} />
+          <div style={{ flex: 1, minWidth: 160, display: 'flex', flexDirection: 'column', gap: 9 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+              <div>
+                <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Puntata minima</div>
+                <div style={{ ...disp(18, 800, 'var(--text-sec)'), fontVariantNumeric: 'tabular-nums' }}>€{a.minBid}</div>
+              </div>
+              <span aria-hidden="true" style={{ ...mono(14, 800, 'var(--text-muted)') }}>→</span>
+              <div>
+                <div style={{ ...mono(8.5, 800, eHsl('session')), textTransform: 'uppercase', letterSpacing: '.06em' }}>Offerta più alta</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <span style={{ ...disp(24, 800, eHsl('session')), fontVariantNumeric: 'tabular-nums' }}>€{a.highBid}</span>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 8px 2px 3px', borderRadius: 'var(--r-pill)', background: eHsl('player', 0.12), border: `1px solid ${eHsl('player', 0.3)}` }}>
+                    <F.MiniAvatar p={high} size={18} /><span style={{ ...disp(11, 800, 'var(--text)') }}>{high.name}</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px', borderRadius: 'var(--r-md)', background: eHsl('player', 0.07), border: `1px solid ${eHsl('player', 0.25)}`, flexWrap: 'wrap', rowGap: 8 }}>
+              <F.MiniAvatar p={awaiting} size={22} ring />
+              <span style={{ flex: '1 1 120px', minWidth: 0, ...mono(10, 700, 'var(--text-sec)') }}>Tocca a <strong style={{ color: 'var(--text)' }}>{awaiting.name}</strong> · rilancia o passa</span>
+              <div style={{ display: 'flex', gap: 6, flexShrink: 0, marginLeft: 'auto' }}>
+                <button type="button" style={{ padding: '5px 11px', borderRadius: 'var(--r-md)', background: eHsl('session'), color: '#fff', border: 'none', ...disp(11.5, 800, '#fff'), cursor: 'pointer', whiteSpace: 'nowrap' }}>Rilancia €{a.highBid + 1}</button>
+                <button type="button" style={{ padding: '5px 11px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', ...disp(11.5, 800, 'var(--text-sec)'), cursor: 'pointer', whiteSpace: 'nowrap' }}>Passa</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        )}
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ResourceMarket — 4 colonne con scarsità + prossimo prezzo
+  // ══════════════════════════════════════════════════════════════════════════
+  const ResourceColumn = ({ resId }) => {
+    const col = PG.resourceMarket[resId];
+    const res = PG.RES[resId];
+    const next = PG.nextPrice(resId);
+    const left = PG.remaining(resId);
+    // raggruppa scaffali per prezzo (dal più caro in alto al più economico in basso)
+    const byPrice = [];
+    [...col.shelves].forEach(s => {
+      let row = byPrice.find(r => r.price === s.price);
+      if (!row) { row = { price: s.price, slots: [] }; byPrice.push(row); }
+      row.slots.push(s);
+    });
+    byPrice.sort((a, b) => b.price - a.price); // caro in alto
+    const scarce = left <= 6;
+    return (
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+          <F.ResourceToken id={resId} size={18} />
+          <span style={{ ...disp(11.5, 800, 'var(--text)') }}>{res.lb}</span>
+        </div>
+        {/* scaffalatura: righe per prezzo */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2, padding: 6, borderRadius: 'var(--r-md)', background: 'var(--bg-sunken)', border: '1px solid var(--border-light)' }}>
+          {byPrice.map(row => {
+            const isNext = row.price === next && row.slots.some(s => s.available);
+            return (
+              <div key={row.price} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ ...mono(8.5, 800, isNext ? eHsl('game') : 'var(--text-muted)'), width: 22, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>€{row.price}</span>
+                <div style={{ flex: 1, display: 'flex', gap: 2, padding: '2px 4px', borderRadius: 'var(--r-sm)', background: isNext ? eHsl('game', 0.1) : 'transparent', border: isNext ? `1px solid ${eHsl('game', 0.3)}` : '1px solid transparent', minHeight: 18, alignItems: 'center' }}>
+                  {row.slots.map((s, i) => s.available
+                    ? <F.ResourceToken key={i} id={resId} size={13} />
+                    : <span key={i} aria-hidden="true" style={{ width: 13, height: 13, borderRadius: resId === 'uranium' ? '50%' : 'var(--r-xs)', border: '1px dashed var(--border-strong)', opacity: 0.4 }} />)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        {/* prossimo prezzo */}
+        <div style={{ padding: '6px 8px', borderRadius: 'var(--r-md)', background: scarce ? eHsl('event', 0.08) : eHsl('game', 0.08), border: `1px solid ${scarce ? eHsl('event', 0.3) : eHsl('game', 0.3)}` }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 4 }}>
+            <span style={{ ...mono(7.5, 800, scarce ? eHsl('event') : eHsl('game')), textTransform: 'uppercase', letterSpacing: '.05em' }}>Prossimo</span>
+            {scarce && <span style={{ ...mono(7, 800, eHsl('event')), textTransform: 'uppercase', letterSpacing: '.04em' }}>scarso</span>}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 4 }}>
+            <span style={{ ...disp(15, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{next != null ? `€${next}` : '—'}</span>
+            <span style={{ ...mono(8, 700, scarce ? eHsl('event') : 'var(--text-muted)') }}>{left} rim.</span>
+          </div>
+        </div>
+      </div>
+    );
+  };
+  const ResourceMarket = ({ state = 'default', compact, collapsed, onHeaderClick }) => (
+    <SectionCard title="Mercato risorse" entity="kb" accent flush collapsed={collapsed} onHeaderClick={onHeaderClick}
+      right={<span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>più scarso = più caro</span>}>
+      <R.StateScaffold state={state} sseWhere="risorse"
+        empty={{ icon: '🛢', title: 'Mercato risorse vuoto', body: 'Le risorse compariranno con la fase di rifornimento.' }}
+        error={{ title: 'Risorse non disponibili', body: 'Impossibile caricare i prezzi del mercato risorse.' }}
+        loading={<div style={{ padding: 14, display: 'flex', gap: 10 }}>{Array.from({ length: 4 }).map((_, i) => <M.Shimmer key={i} h={180} style={{ flex: 1 }} />)}</div>}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 10, padding: 12 }}>
+          {PG.RES_ORDER.map(id => <ResourceColumn key={id} resId={id} />)}
+        </div>
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // NetworkMap — mappa Germania (nodi + archi · owner coloring · highlight)
+  // ══════════════════════════════════════════════════════════════════════════
+  const COST_COLOR = { 5: 'toolkit', 10: 'tool', 15: 'agent', 20: 'event' };
+  const NetworkMap = ({ state = 'default', focusPlayerId = 'p-marco', h = 360, showLegend = true }) => {
+    const net = PG.network;
+    const nodeById = id => net.nodes.find(n => n.id === id);
+    const reach = net.reachableBy[focusPlayerId] || [];
+    return (
+      <SectionCard title="Rete · Germania" entity="session" accent flush
+        right={<span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{net.region}</span>}>
+        <R.StateScaffold state={state} sseWhere="rete"
+          empty={{ icon: '🗺', title: 'Rete vuota', body: 'Le città compariranno quando i giocatori costruiscono.' }}
+          error={{ title: 'Rete non disponibile', body: 'Impossibile caricare la mappa della rete.' }}
+          loading={<div style={{ padding: 14 }}><M.Shimmer h={h - 20} /></div>}>
+          <div style={{ padding: 10 }}>
+            <div style={{ position: 'relative', width: '100%', height: h, borderRadius: 'var(--r-md)', overflow: 'hidden', background: 'var(--bg-sunken)', border: '1px solid var(--border-light)' }}>
+              {/* placeholder texture: schema astratto, non geografia reale */}
+              <svg viewBox="-7 -10 114 112" preserveAspectRatio="xMidYMid meet" style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }} role="img" aria-label="Mappa rete città e connessioni">
+                <defs>
+                  <pattern id="pg-grid" width="8" height="8" patternUnits="userSpaceOnUse">
+                    <path d="M8 0H0V8" fill="none" stroke="var(--border-light)" strokeWidth="0.3" />
+                  </pattern>
+                </defs>
+                <rect x="-7" y="-10" width="114" height="112" fill="url(#pg-grid)" />
+                {/* archi + costo */}
+                {net.edges.map(([a, b, cost], i) => {
+                  const na = nodeById(a), nb = nodeById(b);
+                  const mx = (na.x + nb.x) / 2, my = (na.y + nb.y) / 2;
+                  const both = na.owner && nb.owner;
+                  return (
+                    <g key={i}>
+                      <line x1={na.x} y1={na.y} x2={nb.x} y2={nb.y} stroke={both ? eHsl('session', 0.45) : 'var(--border-strong)'} strokeWidth={both ? 0.7 : 0.5} strokeDasharray={both ? 'none' : '1.4 1.2'} />
+                      <circle cx={mx} cy={my} r="1.8" fill={`hsl(var(--c-${COST_COLOR[cost] || 'tool'}))`} stroke="var(--bg-sunken)" strokeWidth="0.45">
+                        <title>{`Costo connessione: €${cost}`}</title>
+                      </circle>
+                    </g>
+                  );
+                })}
+                {/* nodi città */}
+                {net.nodes.map(n => {
+                  const owner = n.owner ? PG.byId(n.owner) : null;
+                  const reachable = reach.includes(n.id);
+                  return (
+                    <g key={n.id}>
+                      {reachable && <circle cx={n.x} cy={n.y} r="4.4" fill="none" stroke={eHsl('game')} strokeWidth="0.7" strokeDasharray="1.4 1" />}
+                      <circle cx={n.x} cy={n.y} r="2.9"
+                        fill={owner ? `hsl(${owner.hue},62%,52%)` : 'var(--bg-card)'}
+                        stroke={owner ? 'rgba(0,0,0,.3)' : 'var(--border-strong)'} strokeWidth="0.5" />
+                      {(() => {
+                        const lp = n.lp || 'top';
+                        const pos = lp === 'bottom' ? { x: n.x, y: n.y + 5.6, a: 'middle' }
+                          : lp === 'left' ? { x: n.x - 4.2, y: n.y + 0.9, a: 'end' }
+                          : lp === 'right' ? { x: n.x + 4.2, y: n.y + 0.9, a: 'start' }
+                          : { x: n.x, y: n.y - 4.1, a: 'middle' };
+                        return <text x={pos.x} y={pos.y} textAnchor={pos.a} style={{ fontFamily: 'var(--f-display)', fontSize: 2.4, fontWeight: 700, fill: 'var(--text-sec)', stroke: 'var(--bg-sunken)', strokeWidth: 1, paintOrder: 'stroke', strokeLinejoin: 'round' }}>{n.name}</text>;
+                      })()}
+                    </g>
+                  );
+                })}
+              </svg>
+              {/* badge placeholder */}
+              <span style={{ position: 'absolute', bottom: 6, left: 8, ...mono(8, 700, 'var(--text-muted)'), background: 'var(--glass-bg)', padding: '2px 7px', borderRadius: 'var(--r-pill)', border: '1px solid var(--border-light)' }}>layout schematico · mappa reale al rilascio</span>
+            </div>
+            {showLegend && (
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 9, alignItems: 'center' }}>
+                <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Costo connessione</span>
+                {PG.network.connectCosts.map(c => (
+                  <span key={c} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, ...mono(9, 700, 'var(--text-sec)') }}>
+                    <span style={{ width: 12, height: 12, borderRadius: '50%', background: eHsl(COST_COLOR[c] || 'tool'), color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 7, fontWeight: 800 }}>{c}</span>€{c}
+                  </span>
+                ))}
+                <span aria-hidden="true" style={{ width: 1, height: 14, background: 'var(--border)' }} />
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, ...mono(9, 700, eHsl('game')) }}><span style={{ width: 11, height: 11, borderRadius: '50%', border: `1.5px dashed ${eHsl('game')}` }} />raggiungibili da {PG.byId(focusPlayerId).name}</span>
+              </div>
+            )}
+          </div>
+        </R.StateScaffold>
+      </SectionCard>
+    );
+  };
+
+  // ─── PlantsRail / PlantsTab — dettaglio 3 centrali del giocatore ───────────
+  const PlantsTab = ({ state = 'default', player }) => {
+    const p = player || PG.roster[0];
+    return (
+      <R.StateScaffold state={state} sseWhere="centrali"
+        empty={{ icon: '⚡', title: 'Nessuna centrale', body: 'Acquista centrali all\u2019asta per alimentare le città.' }}
+        error={{ title: 'Centrali non disponibili', body: 'Impossibile caricare le centrali del giocatore.' }}>
+        <R.Panel gap={11}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <F.MiniAvatar p={p} size={26} />
+            <span style={{ ...disp(13.5, 800, 'var(--text)') }}>Centrali di {p.name}</span>
+            <div style={{ flex: 1 }} />
+            <span style={{ ...mono(9, 800, eHsl('session')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.12), border: `1px solid ${eHsl('session', 0.3)}` }}>{p.plants.length}/3</span>
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {p.plants.map((pl, i) => <F.PlantCard key={i} plant={pl} w={120} loaded={pl.loaded} />)}
+            {Array.from({ length: 3 - p.plants.length }).map((_, i) => <F.PlantCard key={`g${i}`} ghost w={120} />)}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 11px', borderRadius: 'var(--r-md)', background: eHsl('game', 0.08), border: `1px solid ${eHsl('game', 0.28)}` }}>
+            <span style={{ ...mono(10, 700, 'var(--text-sec)') }}>Capacità totale · città alimentabili</span>
+            <span style={{ ...disp(18, 800, eHsl('game')), fontVariantNumeric: 'tabular-nums' }}>⚡ {PG.plantsCapOf(p)}</span>
+          </div>
+          <div style={{ ...mono(9.5, 700, 'var(--text-muted)'), lineHeight: 1.5 }}>Alimenti il minimo fra capacità totale e città possedute. Risorse caricate consumate in Burocrazia per incassare il reddito.</div>
+        </R.Panel>
+      </R.StateScaffold>
+    );
+  };
+
+  // ─── MarketTab — plant market + resource market + step (tab dedicata) ──────
+  const MarketTab = ({ state = 'default' }) => (
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', rowGap: 6 }}>
+        <span style={{ ...disp(13, 800, 'var(--text)'), whiteSpace: 'nowrap' }}>Mercato & Step</span>
+        <div style={{ flex: 1 }} />
+        <span style={{ flexShrink: 0 }}><F.StepIndicator step={PG.phaseState.step} /></span>
+      </div>
+      <PowerPlantMarket state={state} compact />
+      <ResourceMarket state={state} compact />
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // RightColumnTabs — Scoring · Market · Network · Plants · Chat
+  // ══════════════════════════════════════════════════════════════════════════
+  const RC_TABS = [
+    { id: 'scoring', icon: '🎯', label: 'Scoring', entity: 'session', render: (st) => <R.ScoringPanelRenderer data={PG.ds} state={st} /> },
+    { id: 'market',  icon: '⚡', label: 'Market',  entity: 'game',    render: (st) => <MarketTab state={st} /> },
+    { id: 'network', icon: '🗺', label: 'Network', entity: 'session', render: (st) => <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12 }}><NetworkMap state={st} h={300} /></div> },
+    { id: 'plants',  icon: '🏭', label: 'Plants',  entity: 'kb',      render: (st) => <PlantsTab state={st} /> },
+    { id: 'chat',    icon: '💬', label: 'Chat',    entity: 'agent',   render: () => <div style={{ flex: 1, minHeight: 0, padding: 12, display: 'flex' }}><S.ChatAgentPanel ds={PG.ds} /></div> },
+  ];
+  const RightColumnTabs = ({ initial = 'scoring', initialState = 'default', embedded }) => {
+    const [tab, setTab] = useState(initial);
+    const [st, setSt] = useState(initialState);
+    const active = RC_TABS.find(t => t.id === tab) || RC_TABS[0];
+    return (
+      <aside aria-label="Pannello sessione" style={{ width: embedded ? '100%' : 348, minWidth: embedded ? 0 : 300, flexShrink: 0, height: '100%', background: 'var(--bg-card)', borderLeft: embedded ? 'none' : '1px solid var(--border)', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <div role="tablist" aria-label="Sezioni" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0, overflow: 'hidden' }}>
+          {RC_TABS.map(t => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} onClick={() => setTab(t.id)} style={{ flex: '1 1 0', minWidth: 0, padding: '10px 3px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(10.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, whiteSpace: 'nowrap' }}>
+                <span aria-hidden="true" style={{ fontSize: 12, flexShrink: 0 }}>{t.icon}</span><span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        {active.id !== 'chat' && <S.StateSwitch value={st} onChange={setSt} />}
+        <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+      </aside>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // DESKTOP body — top band (phase + turn order) · 3 colonne
+  // ══════════════════════════════════════════════════════════════════════════
+  const DesktopBody = ({ initialTab, initialState }) => {
+    const [focusId, setFocusId] = useState('p-marco');
+    const [expanded, setExpanded] = useState('auction');
+    const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
+    const player = PG.byId(focusId);
+    const others = PG.baseOrder.filter(p => p.id !== focusId);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <PhaseIndicator />
+        <TurnOrderStrip />
+        <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+          {/* LEFT — player state rail */}
+          <div className="mai-cb-scroll" style={{ width: 252, flexShrink: 0, borderRight: '1px solid var(--border)', overflowY: 'auto', padding: 12, background: 'var(--bg)' }}>
+            <PlayerStateRail player={player} others={others} onPick={setFocusId} />
+          </div>
+          {/* CENTER — accordion: asta · mercato · risorse · registro */}
+          <main className="mai-cb-scroll" style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 10, background: 'var(--bg)' }}>
+            <AuctionOverlay {...sec('auction')} />
+            <PowerPlantMarket withStep {...sec('plants')} />
+            <ResourceMarket {...sec('resources')} />
+            <S.ActionLogTimeline ds={PG.ds} {...sec('log')} />
+          </main>
+          {/* RIGHT — tabs */}
+          <RightColumnTabs initial={initialTab} initialState={initialState} />
+        </div>
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // MOBILE — phase sticky · board scroll · tab strip → bottom sheet
+  // ══════════════════════════════════════════════════════════════════════════
+  const MobileSheet = ({ open, tab, st, setSt, onClose }) => {
+    const active = RC_TABS.find(t => t.id === tab) || RC_TABS[0];
+    return (
+      <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+        <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,12,8,.5)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+        <div role="dialog" aria-modal="true" aria-label={active.label} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '86%', background: 'var(--bg-card)', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl(active.entity)}`, boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 8, flexShrink: 0 }}>
+            <div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px 10px', flexShrink: 0 }}>
+            <span aria-hidden="true" style={{ fontSize: 16 }}>{active.icon}</span>
+            <span style={{ ...disp(15, 800, eHsl(active.entity)) }}>{active.label}</span>
+            <div style={{ flex: 1 }} />
+            <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+          </div>
+          {active.id !== 'chat' && <S.StateSwitch value={st} onChange={setSt} />}
+          <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const MobileBody = ({ initialTab }) => {
+    const [sheet, setSheet] = useState(initialTab || null);
+    const [st, setSt] = useState('default');
+    const [expanded, setExpanded] = useState('auction');
+    const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
+    const player = PG.roster[0];
+    return (
+      <>
+        <PhaseIndicator compact sticky />
+        <div className="mai-cb-scroll" style={{ flex: 1, overflowY: 'auto', minHeight: 0, background: 'var(--bg)' }}>
+          <TurnOrderStrip compact />
+          <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <AuctionOverlay compact {...sec('auction')} />
+            <PlayerStateRail player={player} />
+            <PowerPlantMarket compact withStep {...sec('plants')} />
+            <ResourceMarket compact {...sec('resources')} />
+            <S.ActionLogTimeline ds={PG.ds} compact />
+          </div>
+        </div>
+        <nav aria-label="Sezioni sessione" style={{ display: 'flex', gap: 5, flexShrink: 0, padding: '8px 8px', background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderTop: '1px solid var(--border)' }}>
+          {RC_TABS.map(t => (
+            <button key={t.id} type="button" onClick={() => { setSt('default'); setSheet(t.id); }} style={{ flex: '1 1 0', minWidth: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, padding: '7px 4px', borderRadius: 'var(--r-pill)', background: eHsl(t.entity, 0.1), border: `1px solid ${eHsl(t.entity, 0.28)}`, color: eHsl(t.entity), ...disp(10.5, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true" style={{ flexShrink: 0 }}>{t.icon}</span><span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label}</span>
+            </button>
+          ))}
+        </nav>
+        <MobileSheet open={!!sheet} tab={sheet} st={st} setSt={setSt} onClose={() => setSheet(null)} />
+      </>
+    );
+  };
+
+  // ─── PhoneShell ───────────────────────────────────────────────────────────
+  const PhoneSbar = () => (
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>15:09</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+  );
+  const PhoneShell = ({ label, desc, dark, initialTab }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+      <div className="phone" data-theme={dark ? 'dark' : undefined}>
+        <PhoneSbar />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <S.TopBar ds={PG.ds} compact />
+          <MobileBody initialTab={initialTab} />
+        </div>
+      </div>
+      {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 340, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  window.PGParts = {
+    STATES, SectionCard, PanelFrame,
+    PhaseIndicator, TurnOrderStrip, PlayerStateRail,
+    PowerPlantMarket, AuctionOverlay, ResourceMarket, NetworkMap,
+    PlantsTab, MarketTab, RightColumnTabs, DesktopBody, MobileBody, PhoneShell,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-power-grid-summary.html
+++ b/admin-mockups/design_files/sp4-session-power-grid-summary.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Power Grid · Summary — /sessions/[id]/summary</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-power-grid-summary.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-power-grid-summary.jsx
+++ b/admin-mockups/design_files/sp4-session-power-grid-summary.jsx
@@ -1,0 +1,329 @@
+/* MeepleAI SP4 · Power Grid — SESSION SUMMARY  (App)
+   /sessions/[id]/summary — riepilogo post-partita di Power Grid.
+
+   Hero: banner vincitore con città alimentate + spareggio Elektro.
+   Tab: Scoreboard (breakdown per giocatore · primary/tiebreaker/info) ·
+        Network (snapshot finale rete) · Step (timeline dei 3 step) ·
+        Stats (bid medio per fascia · spesa per giocatore · meta).
+
+   Riusa: OutcomeBadge · ComputationBadge · NetworkMap · MiniAvatar · atomi PG.
+   Carica gli stessi deps del live + QUESTO file.
+   DEMO-NAV-HINTS: sp4-session-power-grid-live.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const PG = window.PG;
+const F = window.PGFlavor;
+const P = window.PGParts;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+const { mono, disp } = F;
+const SUM = PG.summary;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+// ─── Hero — banner vincitore ──────────────────────────────────────────────
+const SummaryHero = ({ compact }) => {
+  const w = SUM.standings.find(s => s.winner);
+  const runnerUp = PG.byId(SUM.tiebreak.runnerUpId);
+  return (
+    <div style={{ position: 'relative', borderRadius: 'var(--r-xl)', overflow: 'hidden', border: `1px solid ${eHsl('toolkit', 0.35)}`, background: `linear-gradient(135deg, ${eHsl('toolkit', 0.12)}, ${eHsl('session', 0.08)})`, boxShadow: 'var(--shadow-md)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 12 : 18, padding: compact ? 14 : 20, flexWrap: 'wrap' }}>
+        <div style={{ width: compact ? 54 : 68, height: compact ? 66 : 84, borderRadius: 'var(--r-md)', background: PG.game.cover, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: compact ? 26 : 34, boxShadow: 'var(--shadow-sm)' }} aria-hidden="true">{PG.game.emoji}</div>
+        <div style={{ flex: 1, minWidth: 180 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+            <M.OutcomeBadge status="win" size="sm" />
+            <span style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{PG.game.title} · {SUM.rounds} round · Step {SUM.step}</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <F.MiniAvatar p={w} size={compact ? 32 : 40} ring />
+            <h2 style={{ ...disp(compact ? 22 : 30, 800, 'var(--text)'), margin: 0 }}>{w.name} vince <span aria-hidden="true">🏆</span></h2>
+          </div>
+          <div style={{ ...mono(11, 700, 'var(--text-sec)'), marginTop: 6, lineHeight: 1.5 }}>{SUM.tiebreak.note}</div>
+        </div>
+        {/* primary metric: cities powered */}
+        <div style={{ display: 'flex', gap: 10, flexShrink: 0 }}>
+          <div style={{ textAlign: 'center', padding: '10px 16px', borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: `1px solid ${eHsl('game', 0.3)}` }}>
+            <div style={{ ...disp(compact ? 30 : 40, 800, eHsl('game')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{w.powered}</div>
+            <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em', marginTop: 3 }}>città alimentate</div>
+          </div>
+          <div style={{ textAlign: 'center', padding: '10px 14px', borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+            <div style={{ ...disp(compact ? 22 : 28, 800, 'var(--text-sec)'), fontVariantNumeric: 'tabular-nums', lineHeight: 1, marginTop: compact ? 4 : 8 }}>€{w.elektro}</div>
+            <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em', marginTop: 3 }}>Elektro · spareggio</div>
+          </div>
+        </div>
+      </div>
+      <div style={{ ...mono(9, 700, 'var(--text-muted)'), padding: '6px 16px', borderTop: '1px solid var(--border-light)', background: 'var(--glass-bg)' }}>
+        Fine partita: <strong style={{ color: 'var(--text-sec)' }}>{SUM.endTrigger}</strong> → ultima Burocrazia · runner-up {runnerUp.name}
+      </div>
+    </div>
+  );
+};
+
+// ─── Scoreboard — breakdown per giocatore ─────────────────────────────────
+const COLS = [
+  { id: 'powered', lb: 'Città alimentate', sub: 'primary', comp: 'Count', big: true, e: 'game' },
+  { id: 'elektro', lb: 'Elektro', sub: 'spareggio 1', comp: 'Sum', e: 'session', prefix: '€' },
+  { id: 'plantsCap', lb: 'Cap. centrali', sub: 'spareggio 2', comp: 'Custom', e: 'toolkit' },
+  { id: 'cities', lb: 'Città possedute', sub: 'info', e: 'player' },
+  { id: 'plants', lb: 'N° centrali', sub: 'info', e: 'kb' },
+  { id: 'maxCap', lb: 'Cap. max singola', sub: 'info', e: 'kb' },
+];
+const ScoreboardTable = ({ state = 'default' }) => (
+  <R.StateScaffold state={state} sseWhere="punteggio"
+    empty={{ icon: '🏆', title: 'Nessun punteggio finale', body: 'La classifica comparirà a partita conclusa.' }}
+    error={{ title: 'Classifica non disponibile', body: 'Impossibile caricare il punteggio finale.' }}
+    loading={<div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>{Array.from({ length: 5 }).map((_, i) => <M.Shimmer key={i} h={48} />)}</div>}>
+    <div style={{ padding: 12, overflowX: 'auto' }} className="mai-cb-scroll">
+      <table style={{ width: '100%', borderCollapse: 'separate', borderSpacing: 0, minWidth: 640 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', padding: '6px 8px', ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>#</th>
+            <th style={{ textAlign: 'left', padding: '6px 8px', ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Giocatore</th>
+            {COLS.map(c => (
+              <th key={c.id} style={{ textAlign: 'center', padding: '6px 8px', whiteSpace: 'nowrap' }}>
+                <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5, justifyContent: 'center' }}>
+                  {c.comp && <R.ComputationBadge c={c.comp} size={15} />}
+                  <div style={{ textAlign: 'left', lineHeight: 1.1 }}>
+                    <div style={{ ...mono(9, 800, c.sub === 'primary' ? eHsl('game') : 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.04em' }}>{c.lb}</div>
+                    <div style={{ ...mono(7.5, 700, c.sub === 'info' ? 'var(--text-muted)' : eHsl(c.e)), textTransform: 'uppercase', letterSpacing: '.05em' }}>{c.sub}</div>
+                  </div>
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {SUM.standings.map(p => (
+            <tr key={p.id} style={{ background: p.winner ? eHsl('toolkit', 0.08) : 'transparent' }}>
+              <td style={{ padding: '9px 8px', borderTop: '1px solid var(--border-light)' }}>
+                <span style={{ width: 22, height: 22, borderRadius: 'var(--r-pill)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', background: p.winner ? eHsl('toolkit') : eHsl('session', 0.12), color: p.winner ? '#fff' : eHsl('session'), ...mono(11, 800) }}>{p.rank}</span>
+              </td>
+              <td style={{ padding: '9px 8px', borderTop: '1px solid var(--border-light)' }}>
+                <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                  <F.MiniAvatar p={p} size={26} ring={p.winner} />
+                  <span style={{ ...disp(13.5, 800, 'var(--text)') }}>{p.name}</span>
+                  {p.winner && <span aria-hidden="true">🏆</span>}
+                </div>
+              </td>
+              {COLS.map(c => (
+                <td key={c.id} style={{ padding: '9px 8px', borderTop: '1px solid var(--border-light)', textAlign: 'center' }}>
+                  <span style={{ ...disp(c.big ? 20 : 14, 800, c.big ? eHsl('game') : c.sub === 'info' ? 'var(--text-muted)' : 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{c.prefix || ''}{p[c.id]}</span>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{ ...mono(9, 700, 'var(--text-muted)'), marginTop: 10, lineHeight: 1.5, display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <R.ComputationBadge c="Count" size={14} /> primary · <R.ComputationBadge c="Sum" size={14} /> spareggio 1 · <R.ComputationBadge c="Custom" size={14} /> spareggio 2 · le altre colonne sono informative.
+      </div>
+    </div>
+  </R.StateScaffold>
+);
+
+// ─── Step timeline ────────────────────────────────────────────────────────
+const StepTimeline = () => (
+  <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 0 }}>
+    {SUM.steps.map((s, i) => (
+      <div key={s.step} style={{ display: 'flex', gap: 12 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0 }}>
+          <span style={{ width: 36, height: 36, borderRadius: '50%', background: eHsl('game'), color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...disp(18, 800, '#fff'), boxShadow: `0 3px 10px ${eHsl('game', 0.4)}` }}>{s.step}</span>
+          {i < SUM.steps.length - 1 && <span style={{ width: 2, flex: 1, minHeight: 28, background: eHsl('game', 0.3), margin: '4px 0' }} />}
+        </div>
+        <div style={{ flex: 1, paddingBottom: 18 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+            <span style={{ ...disp(15, 800, 'var(--text)') }}>Step {s.step}</span>
+            <span style={{ ...mono(9, 800, eHsl('game')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('game', 0.12), border: `1px solid ${eHsl('game', 0.3)}` }}>Round {s.round}</span>
+            <span style={{ ...mono(9.5, 700, 'var(--text-sec)') }}>{s.trigger}</span>
+          </div>
+          <div style={{ ...mono(10, 600, 'var(--text-muted)'), marginTop: 5, lineHeight: 1.5 }}>{s.detail}</div>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+// ─── Stats panel ──────────────────────────────────────────────────────────
+const Bar = ({ value, max, e, label, suffix }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+    <span style={{ ...mono(9.5, 700, 'var(--text-sec)'), width: 96, flexShrink: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
+    <div style={{ flex: 1, height: 16, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+      <div style={{ width: `${(value / max) * 100}%`, height: '100%', borderRadius: 'var(--r-pill)', background: eHsl(e), minWidth: 2 }} />
+    </div>
+    <span style={{ ...mono(10, 800, 'var(--text)'), width: 44, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{suffix || ''}{value}</span>
+  </div>
+);
+const StatsPanel = () => {
+  const st = SUM.stats;
+  const maxBid = Math.max(...st.avgBidByTier.map(t => t.avg));
+  const maxSpend = Math.max(...st.spendByPlayer.map(p => p.plants + p.resources + p.connections));
+  const SEG = [{ k: 'plants', lb: 'centrali', e: 'kb' }, { k: 'resources', lb: 'risorse', e: 'game' }, { k: 'connections', lb: 'connessioni', e: 'session' }];
+  return (
+    <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 8 }}>
+        {st.facts.map(f => (
+          <div key={f.lb} style={{ padding: '9px 11px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+            <div style={{ ...disp(20, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{f.v}</div>
+            <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>{f.lb}</div>
+          </div>
+        ))}
+      </div>
+      <div>
+        <div style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 9 }}>Bid medio per fascia di centrale</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          {st.avgBidByTier.map(t => <Bar key={t.tier} label={t.tier} value={t.avg} max={maxBid} e="session" suffix="€" />)}
+        </div>
+      </div>
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 9, flexWrap: 'wrap' }}>
+          <span style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Spesa Elektro per giocatore</span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {SEG.map(s => <span key={s.k} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, ...mono(8.5, 700, 'var(--text-sec)') }}><span style={{ width: 9, height: 9, borderRadius: 2, background: eHsl(s.e) }} />{s.lb}</span>)}
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {st.spendByPlayer.map(p => {
+            const total = p.plants + p.resources + p.connections;
+            return (
+              <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <F.MiniAvatar p={p} size={22} />
+                <span style={{ ...disp(11.5, 800, 'var(--text)'), width: 52, flexShrink: 0 }}>{p.name}</span>
+                <div style={{ flex: 1, height: 18, borderRadius: 'var(--r-pill)', overflow: 'hidden', display: 'flex', background: 'var(--bg-sunken)' }} aria-label={`${p.name} spesa totale €${total}`}>
+                  {SEG.map(s => <div key={s.k} title={`${s.lb}: €${p[s.k]}`} style={{ width: `${(p[s.k] / maxSpend) * 100}%`, height: '100%', background: eHsl(s.e) }} />)}
+                </div>
+                <span style={{ ...mono(10, 800, 'var(--text)'), width: 44, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>€{total}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Summary body (tabs) ──────────────────────────────────────────────────
+const SUM_TABS = [
+  { id: 'scoreboard', icon: '🏆', label: 'Scoreboard', entity: 'toolkit', render: (st) => <ScoreboardTable state={st} /> },
+  { id: 'network',    icon: '🗺', label: 'Network',    entity: 'session', render: (st) => <P.NetworkMap state={st} h={340} /> },
+  { id: 'steps',      icon: '③', label: 'Step',        entity: 'game',    render: () => <StepTimeline /> },
+  { id: 'stats',      icon: '📊', label: 'Stats',      entity: 'player',  render: () => <StatsPanel /> },
+];
+const SummaryBody = ({ initial = 'scoreboard', states, embedded }) => {
+  const [tab, setTab] = useState(initial);
+  const [st, setSt] = useState('default');
+  const active = SUM_TABS.find(t => t.id === tab) || SUM_TABS[0];
+  const stateful = active.id === 'scoreboard' || active.id === 'network';
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, background: 'var(--bg-card)' }}>
+      <div role="tablist" aria-label="Sezioni riepilogo" className="mai-cb-scroll" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0, overflowX: 'auto', background: 'var(--bg-card)' }}>
+        {SUM_TABS.map(t => {
+          const on = tab === t.id;
+          return (
+            <button key={t.id} type="button" role="tab" aria-selected={on} onClick={() => { setTab(t.id); setSt('default'); }} style={{ flex: '1 0 auto', padding: '11px 14px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(12.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6, whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true" style={{ fontSize: 14 }}>{t.icon}</span>{t.label}
+            </button>
+          );
+        })}
+      </div>
+      {states && stateful && <window.SkeletonParts.StateSwitch value={st} onChange={setSt} />}
+      <div role="tabpanel" className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>{active.render(st)}</div>
+    </div>
+  );
+};
+
+// ─── App ──────────────────────────────────────────────────────────────────
+const StatesRow = ({ title, sub, entity, render }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ ...disp(15, 800, eHsl(entity)) }}>{title}</span>
+      {sub && <span style={{ ...mono(10, 700, 'var(--text-muted)') }}>{sub}</span>}
+    </div>
+    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', paddingBottom: 10 }}>
+      {P.STATES.map(s => <P.PanelFrame key={s.id} label={s.lb} entity={entity} dark={s.id === 'sse'} w={340}>{render(s.id)}</P.PanelFrame>)}
+    </div>
+  </div>
+);
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ ...mono(11, 600, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Power Grid · Summary 🏁 · estensione skeleton</div>
+        <h1>Session summary — Power Grid</h1>
+        <p className="lead">
+          Riepilogo post-partita per <code>/sessions/[id]/summary</code>. Hero con il vincitore e la metrica primaria
+          (<strong>città alimentate</strong>, spareggio a Elektro), poi quattro tab:
+          <strong> Scoreboard</strong> (breakdown primary/spareggio/info per giocatore),
+          <strong> Network</strong> (snapshot finale della rete), <strong>Step</strong> (timeline dei 3 step di gioco) e
+          <strong> Stats</strong> (bid medio per fascia, spesa Elektro per giocatore, meta-partita).
+        </p>
+
+        <div className="section-label">Hero · vincitore + metrica primaria</div>
+        <SummaryHero />
+
+        <div className="section-label">Interattivo · Desktop 1280 — tab Scoreboard / Network / Step / Stats</div>
+        <window.SkeletonParts.DesktopFrame ds={PG.ds} dark label="Desktop · summary · Power Grid" url="meepleai.app/sessions/pg-7/summary" height={560}
+          desc="Tab Scoreboard: tabella con città alimentate (primary), Elektro e capacità centrali (spareggi), più colonne informative. Tab Network: rete finale color-coded. Tab Step: i 3 step e quando sono scattati. Tab Stats: bid medio e spesa Elektro per categoria.">
+          <window.SkeletonParts.TopBar ds={{ ...PG.ds, session: { elapsed: '2h 41min' } }} connection="offline" />
+          <SummaryBody states />
+        </window.SkeletonParts.DesktopFrame>
+
+        <div className="section-label">Mobile 375 — hero + tab in colonna</div>
+        <div className="phones-grid">
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+            <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>01 · Scoreboard</div>
+            <div className="phone">
+              <div className="phone-sbar" style={{ color: 'var(--text)' }}><span style={{ fontFamily: 'var(--f-mono)' }}>17:48</span><div className="ind"><span>●●●●</span><span>100%</span></div></div>
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', overflow: 'hidden', minHeight: 0 }}>
+                <div style={{ padding: 10 }}><SummaryHero compact /></div>
+                <SummaryBody initial="scoreboard" />
+              </div>
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }} data-theme="dark">
+            <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>02 · Stats · dark</div>
+            <div className="phone" data-theme="dark">
+              <div className="phone-sbar" style={{ color: 'var(--text)' }}><span style={{ fontFamily: 'var(--f-mono)' }}>17:49</span><div className="ind"><span>●●●●</span><span>100%</span></div></div>
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', overflow: 'hidden', minHeight: 0 }}>
+                <div style={{ padding: 10 }}><SummaryHero compact /></div>
+                <SummaryBody initial="stats" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="section-label">Gallery stati · Scoreboard × 5 stati canonici</div>
+        <StatesRow title="ScoreboardTable" sub="default · empty · loading · error · sse-disconnect" entity="toolkit"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto' }}><ScoreboardTable state={st} /></div>} />
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; width: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

Mockup **#4 di 7** della pipeline B19. Power Grid (heavy euro auction + network building, 2-6 players, ~120 min).

## ✨ Highlight: accordion pattern ESTESO

Lo skeleton ha accordion solo per chat/log. Power Grid lo **estende ai widget game-specific** (auction/market/resources) via helper `sec(id)`:

```jsx
const [expanded, setExpanded] = useState('auction');
const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
```

6 utilizzi accordion + aria-expanded coerente. Pattern migliorato vs Puerto Rico/Catan (che avevano stacked-always-open).

## Files (7 in admin-mockups/design_files/)

- sp4-session-power-grid-live.html / .jsx
- sp4-session-power-grid-summary.html / .jsx
- sp4-session-power-grid-data.jsx (PG-specific dataset)
- sp4-session-power-grid-flavor.jsx (7 component: PhaseTimeline, PowerPlantMarket, ResourceMarket, AuctionOverlay, NetworkMap, PlantsRail, TurnOrderStrip)
- sp4-session-power-grid-parts.jsx (SectionCard accordion + sec helper)

## Mechanics

- 5 phases per round + 3 game steps (1/2/3)
- REVERSE turn order (leader plays last in auction/resource phases)
- Power plant market: 8 cards Current + Future
- Resource market: 4 columns scarcity pricing
- Network map (country, color-coded territories)
- Plants rail (max 3 per player)

## Validation

- 0 cross-game contamination
- Baseline files NOT touched (tokens/components/sp4-parts-common/skeleton-*)
- Accordion pattern compliance verified ✅

## Docs sync

MOCKUPS_INDEX: +2 page-mock +5 component-mock, total 101 → 108

## Reference dataset

`claudedocs/seed-preview-from-pr-1761/power-grid.json` (curated 2026-06-01, was stub TBD post #1761).

## Pipeline progress

| # | Game | Stato |
|---|---|---|
| 1 | Skeleton | ✅ MERGED #1766 |
| 2 | Puerto Rico | ✅ MERGED #1769 |
| 3 | Catan | 🟡 #1770 OPEN |
| 4 | **Power Grid** | 🟡 **questo PR** |
| 5-7 | Zombicide / Paleo / Codenames | ⏸️ pending |

Co-Authored-By: Claude Code