### PR TITLE
feat(mockup): #1742 B19 premium #5/7 - Zombicide Green Horde (co-op dungeon-crawler)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -110,6 +110,13 @@
 | `sp4-session-wingspan-summary-sections.jsx` | component-mock | Celebrative body sections of `/sessions/[id]` Wingspan demo (podium, KPI, diary, photos, chat highlights, share) — unchanged in 2026-05-31 consolidation. **Wingspan-flavored content**. |
 | `sp4-session-wingspan-summary-tabs.jsx` | component-mock | `window.SummaryReviewTabs` — 3 new consolidated tabs (scoreboard · notes · players) × 5 stati each (default · empty · loading · error · offline). **Wingspan scoring categories hard-coded**. See consolidation ADR. |
 | `sp4-session-wingspan-summary.html` | page-mock | `/sessions/[id]` Wingspan demo + consolidated tabs `?tab=scoreboard\|notes\|players` (was 3 separate sub-routes pre-2026-05-31, see ADR). **Wingspan-specific**. |
+| `sp4-session-zombicide-data.jsx` | component-mock | Zombicide Green Horde-specific dataset (survivors w/ skill trees, zombie counts per type, scenario objectives). Premium #5/7. |
+| `sp4-session-zombicide-flavor.jsx` | component-mock | Zombicide GH flavor components — `SurvivorCard` (skill tree Blue→Yellow→Orange→Red + equipment + wounds + AP), `BoardStatePanel`, `CombatDicePanel`, `SpawnDeckIndicator`, `PhaseTimeline` (3-phase round), `MapTilesGrid`. |
+| `sp4-session-zombicide-live.html` | page-mock | `/sessions/[id]/live` Zombicide GH demo (co-op miniatures dungeon-crawler, 1-6 players, ~60-90 min/scenario). Extends skeleton + accordion-extended for game panels. |
+| `sp4-session-zombicide-live.jsx` | component-mock | Root component for `sp4-session-zombicide-live.html` — wires skeleton + Zombicide flavor + RightColumnTabs (Scoring, Dice, Board, Equip, Chat). |
+| `sp4-session-zombicide-parts.jsx` | component-mock | Shared parts for Zombicide — SectionCard accordion (16 utilizzi), helper `sec(id)` per accordion state machine across survivors/board/spawn panels. |
+| `sp4-session-zombicide-summary.html` | page-mock | `/sessions/[id]` Zombicide post-game (VICTORY/DEFEAT banner + mission objectives + survivors final state + XP totals + kill stats). Premium #5/7. |
+| `sp4-session-zombicide-summary.jsx` | component-mock | Root component for Zombicide summary — hero + tabs (Scoreboard / Survivors / Board final / Stats). |
 | `sp4-sessions-index.html` | page-mock | `/sessions`, `/games/[id]/sessions` (reuse) |
 | `sp4-toolkit-detail.html` | page-mock | `/toolkit` + sub-routes, `/library/[gameId]/toolbox`, `/library/[gameId]/toolkit`, `/library/private/[id]/toolkit/configure` |
 | `sp4-upload-wizard-extended.html` | page-mock | `/upload`, `/gamebook/upload` (partial) |
@@ -175,10 +182,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 59 |
-| component-mock | 30 |
+| page-mock | 61 |
+| component-mock | 35 |
 | dev-fixture | 12 |
-| **Total** | **101** |
+| **Total** | **108** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/sp4-session-zombicide-data.jsx
+++ b/admin-mockups/design_files/sp4-session-zombicide-data.jsx
@@ -1,0 +1,363 @@
+/* MeepleAI SP4 · Zombicide: Green Horde — DATA  (window.ZOM  +  window.SkeletonData shim)
+   /sessions/[id]/live — dataset game-specific letto da zombicide-green-horde.json.
+
+   Espone:
+     window.SkeletonData = { STATES }   (shim: skeleton-renderers + skeleton-parts
+                                          leggono STATES qui)
+     window.ZOM = { game, agent, levelOf, LEVELS, DANGER, ZTYPES, ZORDER, EQUIP,
+                    survivors, byId, board, objectives, phases, phaseState,
+                    combat, weaponsRef, spawnDeck, mapTiles, ds (shape per i
+                    renderer polimorfici), counterWidgets, chat, suggestions,
+                    events, summary }
+
+   MECCANICA CHIAVE (da zombicide-green-horde.json): co-op a missione (BinaryWin —
+   nessun punteggio, vittoria/sconfitta condivisa). Per-survivor: ferite (0-2, 2 =
+   morto, carta flippata), XP che pilota i livelli skill (Blu 0-6 → Giallo 7-18 →
+   Arancione 19-42 → Rosso 43+), punti azione (3 base + bonus skill), equipaggiamento
+   (2 mani + corpo + zaino). Plancia: conteggi zombie per tipo. Round in 3 fasi:
+   Giocatori (orario) → Zombie attivano → Finale (spawn per Danger Level).
+   Combat: D6, colpo 4+ (modificato dall'arma). Danger Level = survivor con XP più alto.
+
+   Colori zombie/skill: verbatim da zombicide-green-horde.json / mappati su token.
+   Tutto il resto = var di tokens.css. */
+
+(function () {
+  // ─── shim per lo skeleton: i 5 stati canonici ─────────────────────────────
+  window.SkeletonData = window.SkeletonData || {
+    STATES: [
+      { id: 'default', lb: 'Default' },
+      { id: 'empty',   lb: 'Empty' },
+      { id: 'loading', lb: 'Loading' },
+      { id: 'error',   lb: 'Error' },
+      { id: 'sse',     lb: 'SSE ✕' },
+    ],
+  };
+
+  // ─── gioco + agente ───────────────────────────────────────────────────────
+  const game = {
+    id: 'zombicide-gh', title: 'Zombicide: Green Horde', emoji: '🧟',
+    cover: 'linear-gradient(135deg, hsl(140,42%,24%), hsl(96,38%,16%))',
+    meta: '1-6 giocatori · ~60-90 min · co-op dungeon-crawler',
+  };
+  const agent = { id: 'zom-agent', name: 'Zombicide GH Expert', emoji: '🧟', latency: '0.6s' };
+
+  // ─── livelli skill (soglie XP da JSON) · color-coded per livello ──────────
+  // Blu → --c-info · Giallo → --c-warning · Arancione → --c-game · Rosso → --c-danger
+  const LEVELS = [
+    { id: 'blue',   e: 'info',    lb: 'Blu',       min: 0,  max: 6,  range: '0-6' },
+    { id: 'yellow', e: 'warning', lb: 'Giallo',    min: 7,  max: 18, range: '7-18' },
+    { id: 'orange', e: 'game',    lb: 'Arancione', min: 19, max: 42, range: '19-42' },
+    { id: 'red',    e: 'danger',  lb: 'Rosso',     min: 43, max: 99, range: '43+' },
+  ];
+  const levelOf = (xp) => xp >= 43 ? 'red' : xp >= 19 ? 'orange' : xp >= 7 ? 'yellow' : 'blue';
+  const levelMeta = (id) => LEVELS.find(l => l.id === id) || LEVELS[0];
+  const levelIndex = (id) => LEVELS.findIndex(l => l.id === id);
+
+  // ─── Danger Level (aggressività spawn · determinato dal survivor con XP top) ─
+  const DANGER = [
+    { id: 'blue',   e: 'info',    lb: 'Blu',       spawn: 'Spawn base · pochi zombie' },
+    { id: 'yellow', e: 'warning', lb: 'Giallo',    spawn: 'Spawn rinforzati' },
+    { id: 'orange', e: 'game',    lb: 'Arancione', spawn: 'Orde · più Fatty/Runner' },
+    { id: 'red',    e: 'danger',  lb: 'Rosso',     spawn: 'Orde massime · Abominio possibile' },
+  ];
+
+  // ─── tipi zombie (colori verbatim da zombicide-green-horde.json) ──────────
+  const ZTYPES = {
+    walker:      { id: 'walker',      lb: 'Walker',      glyph: 'W', color: '#27ae60', actions: 1, dmg: 1, note: 'Mossa base · 1 attività' },
+    orc:         { id: 'orc',         lb: 'Walker Orc',  glyph: 'O', color: '#1e8a4e', actions: 1, dmg: 1, note: 'Più resistente del Walker' },
+    runner:      { id: 'runner',      lb: 'Runner',      glyph: 'R', color: '#16a085', actions: 2, dmg: 1, note: '2 attività · velocissimo' },
+    fatty:       { id: 'fatty',       lb: 'Fatty',       glyph: 'F', color: '#15795a', actions: 1, dmg: 1, note: 'Serve danno 2 · genera Walker' },
+    abomination: { id: 'abomination', lb: 'Abomination', glyph: 'A', color: '#7d3c98', actions: 1, dmg: 1, note: 'Solo danno 3 lo uccide' },
+    necromancer: { id: 'necromancer', lb: 'Necromancer', glyph: 'N', color: '#5b2c6f', actions: 1, dmg: 0, note: 'Fugge e apre nuovi spawn' },
+  };
+  const ZORDER = ['walker', 'orc', 'runner', 'fatty', 'abomination', 'necromancer'];
+
+  // ─── catalogo equipaggiamento ─────────────────────────────────────────────
+  // type: melee · ranged · armor · item. range in tessere. dice/dmg per attacco.
+  const EQUIP = {
+    katana:       { id: 'katana',       name: 'Katana',           type: 'melee',  glyph: '🗡', range: '0',   dice: 2, dmg: 1, accent: 'danger' },
+    fireaxe:      { id: 'fireaxe',      name: 'Ascia da fuoco',   type: 'melee',  glyph: '🪓', range: '0',   dice: 2, dmg: 1, accent: 'danger' },
+    sword:        { id: 'sword',        name: 'Spada',            type: 'melee',  glyph: '⚔', range: '0',   dice: 1, dmg: 1, accent: 'danger' },
+    pistol:       { id: 'pistol',       name: 'Pistola',          type: 'ranged', glyph: '•', range: '0-1', dice: 1, dmg: 1, accent: 'session' },
+    sawedoff:     { id: 'sawedoff',     name: 'Canne mozze',      type: 'ranged', glyph: '═', range: '0-1', dice: 1, dmg: 2, accent: 'session', area: true },
+    crossbow:     { id: 'crossbow',     name: 'Balestra',         type: 'ranged', glyph: '↟', range: '0-3', dice: 1, dmg: 2, accent: 'session' },
+    handcrossbow: { id: 'handcrossbow', name: 'Balestra a mano',  type: 'ranged', glyph: '↑', range: '0-1', dice: 2, dmg: 1, accent: 'session' },
+    longbow:      { id: 'longbow',      name: 'Arco lungo',       type: 'ranged', glyph: ')', range: '0-3', dice: 1, dmg: 1, accent: 'session', reload: true },
+    riot:         { id: 'riot',         name: 'Antisommossa',     type: 'armor',  glyph: '🛡', save: '4+',  accent: 'kb' },
+    plate:        { id: 'plate',        name: 'Armatura piastre', type: 'armor',  glyph: '🛡', save: '3+',  accent: 'kb' },
+    molotov:      { id: 'molotov',      name: 'Molotov',          type: 'item',   glyph: '🔥', range: '0-1', dmg: 'fuoco', accent: 'event' },
+    torch:        { id: 'torch',        name: 'Torcia',           type: 'item',   glyph: '🔦', accent: 'agent' },
+    water:        { id: 'water',        name: 'Acqua',            type: 'item',   glyph: '💧', accent: 'tool' },
+  };
+  const eq = (id) => EQUIP[id] || { id, name: id, type: 'item', glyph: '?', accent: 'tool' };
+  const EQUIP_SLOTS = [
+    { id: 'rightHand', lb: 'Mano dx' },
+    { id: 'leftHand',  lb: 'Mano sx' },
+    { id: 'body',      lb: 'Corpo' },
+    { id: 'backpack',  lb: 'Zaino' },
+  ];
+
+  // ─── skill tree helper: ogni survivor ha 4 livelli (Blu/Giallo/Aran/Rosso) ─
+  // status derivato dall'XP: 'done' (livello raggiunto, chosen highlighted),
+  // 'available' (livello appena raggiunto, da scegliere), 'locked' (futuro, greyed).
+  const treeStatus = (survivorLevel, rowLevel) => {
+    const a = levelIndex(survivorLevel), b = levelIndex(rowLevel);
+    return b < a ? 'done' : b === a ? 'available' : 'locked';
+  };
+
+  // ─── survivors (4 · co-op) — XP pilota livello e Danger Level ──────────────
+  // tree[].chosen = skill ottenuto · options = alternative a quel livello.
+  const survivors = [
+    {
+      id: 's-bruno', name: 'Bruno', player: 'Marco', hue: 8, klass: 'Berserker',
+      xp: 47, wounds: 1, apBase: 3, apBonus: 0, zone: 'Cattedrale · tile 03b',
+      equip: { rightHand: 'katana', leftHand: 'pistol', body: 'riot', backpack: 'molotov' },
+      kills: { walker: 14, orc: 5, runner: 3, fatty: 2, abomination: 1, necromancer: 0 },
+      tree: [
+        { level: 'blue',   chosen: '+1 Azione Mischia', options: ['+1 Azione Mischia'] },
+        { level: 'yellow', chosen: 'Carica',            options: ['Carica', '+1 dado Mischia', 'Robusto'] },
+        { level: 'orange', chosen: '+1 dado: Mischia',  options: ['+1 dado: Mischia', 'Spaccaossa', 'Berserk'] },
+        { level: 'red',    chosen: 'Furia',             options: ['Furia', 'Esecuzione'] },
+      ],
+    },
+    {
+      id: 's-elena', name: 'Elena', player: 'Anna', hue: 282, klass: 'Heroine',
+      xp: 31, wounds: 0, apBase: 3, apBonus: 1, zone: 'Sagrato · tile 01a',
+      equip: { rightHand: 'crossbow', leftHand: 'handcrossbow', body: 'plate', backpack: 'water' },
+      kills: { walker: 11, orc: 2, runner: 4, fatty: 1, abomination: 0, necromancer: 2 },
+      tree: [
+        { level: 'blue',   chosen: '+1 Azione',          options: ['+1 Azione'] },
+        { level: 'yellow', chosen: 'Mira',               options: ['Mira', '+1 dado: Distanza', 'Scattante'] },
+        { level: 'orange', chosen: '+1 Azione Movimento', options: ['+1 Azione Movimento', 'Cecchino', 'Ambidestra'] },
+        { level: 'red',    chosen: null,                 options: ['Leader nato', 'Tiratore scelto'] },
+      ],
+    },
+    {
+      id: 's-tomas', name: 'Tomas', player: 'Luca', hue: 150, klass: 'Tracker',
+      xp: 14, wounds: 0, apBase: 3, apBonus: 0, zone: 'Vicolo · tile 02c',
+      equip: { rightHand: 'longbow', leftHand: null, body: null, backpack: 'torch' },
+      kills: { walker: 6, orc: 1, runner: 2, fatty: 0, abomination: 0, necromancer: 1 },
+      tree: [
+        { level: 'blue',   chosen: '+1 Free Move',  options: ['+1 Free Move'] },
+        { level: 'yellow', chosen: null,            options: ['Furtivo', '+1 dado: Distanza', 'Fortunato'] },
+        { level: 'orange', chosen: null,            options: ['Cecchino', 'Ranger', 'Lince'] },
+        { level: 'red',    chosen: null,            options: ['Tiratore scelto', 'Leader nato'] },
+      ],
+    },
+    {
+      id: 's-greta', name: 'Greta', player: 'Sara', hue: 40, klass: 'Hunter',
+      xp: 5, wounds: 1, apBase: 3, apBonus: 0, zone: 'Cripta · tile 04b',
+      equip: { rightHand: 'sawedoff', leftHand: null, body: 'riot', backpack: 'molotov' },
+      kills: { walker: 4, orc: 0, runner: 1, fatty: 1, abomination: 0, necromancer: 0 },
+      tree: [
+        { level: 'blue',   chosen: '+1 dado: Distanza', options: ['+1 dado: Distanza'] },
+        { level: 'yellow', chosen: null,                options: ['Robusto', 'Carica', 'Slegato'] },
+        { level: 'orange', chosen: null,                options: ['Spaccaossa', 'Devastante', 'Berserk'] },
+        { level: 'red',    chosen: null,                options: ['Furia', 'Esecuzione'] },
+      ],
+    },
+  ];
+  survivors.forEach(s => {
+    s.level = levelOf(s.xp);
+    s.ap = s.apBase + s.apBonus;
+    s.dead = s.wounds >= 2;
+    s.killTotal = Object.values(s.kills).reduce((a, b) => a + b, 0);
+    s.tree.forEach(row => { row.status = treeStatus(s.level, row.level); });
+  });
+  const byId = (id) => survivors.find(s => s.id === id);
+  const topSurvivor = [...survivors].sort((a, b) => b.xp - a.xp)[0];
+  const dangerLevel = topSurvivor.level; // Danger Level = livello del survivor con XP top
+
+  // ─── stato plancia (conteggi zombie per tipo) ─────────────────────────────
+  const board = {
+    walker: 14, orc: 6, runner: 4, fatty: 3, abomination: 1, necromancer: 2,
+  };
+  const zombieTotal = ZORDER.reduce((s, t) => s + (board[t] || 0), 0);
+
+  // ─── obiettivi scenario (checklist) ───────────────────────────────────────
+  const objectives = [
+    { id: 'o1', label: 'Salva i 3 civili nascosti', done: false, progress: '2/3' },
+    { id: 'o2', label: 'Uccidi tutti i Necromancer', done: false, progress: '0/2' },
+    { id: 'o3', label: 'Apri il portone della cripta', done: true },
+    { id: 'o4', label: 'Raggiungi il punto di estrazione', done: false },
+  ];
+
+  // ─── round in 3 fasi ──────────────────────────────────────────────────────
+  const phases = [
+    { id: 'players', n: 1, lb: 'Fase Giocatori', short: 'Giocatori', desc: 'Ogni survivor spende i punti azione, in senso orario', icon: '🧍' },
+    { id: 'zombies', n: 2, lb: 'Fase Zombie',    short: 'Zombie',    desc: 'Gli zombie esistenti si attivano per tipo', icon: '🧟' },
+    { id: 'end',     n: 3, lb: 'Fase Finale',    short: 'Finale',    desc: 'Spawn per Danger Level · pesca carte spawn', icon: '⚙' },
+  ];
+  const phaseState = { round: 6, phaseIndex: 0, activePhaseId: 'players', dir: 'clockwise' };
+
+  // ─── combat dice (D6 · colpo 4+ · modificato dall'arma) ───────────────────
+  const combat = {
+    diceType: 'D6', dice: 6, threshold: 4,
+    weaponId: 'crossbow',
+    lastRoll: [5, 2, 6, 4, 1, 3], // hit dove ≥ threshold
+  };
+  const weaponsRef = [
+    { id: 'pistol',   lb: 'Pistola',     range: '0-1', dice: 1, hit: '4+', note: '' },
+    { id: 'sawedoff', lb: 'Canne mozze', range: '0-1', dice: 1, hit: '4+', note: 'area' },
+    { id: 'crossbow', lb: 'Balestra',    range: '0-3', dice: 1, hit: '4+', note: 'danno 2' },
+    { id: 'longbow',  lb: 'Arco lungo',  range: '0-3', dice: 1, hit: '4+', note: 'ricarica' },
+    { id: 'katana',   lb: 'Katana',      range: '0',   dice: 2, hit: '4+', note: 'mischia' },
+  ];
+
+  // ─── spawn deck (carte rimaste · pescate in Fase Finale per Danger Level) ──
+  const spawnDeck = {
+    remaining: 18, total: 40, drawnThisRound: 0,
+    byDanger: [
+      { level: 'blue',   draws: 1 },
+      { level: 'yellow', draws: 1 },
+      { level: 'orange', draws: 2 },
+      { level: 'red',    draws: 2 },
+    ],
+    note: 'In Danger Rosso ogni spawn point pesca 2 carte · Abominio possibile.',
+  };
+
+  // ─── map tiles (snapshot schematico · placeholder, non geografia reale) ────
+  const mapTiles = {
+    scenario: 'Scenario · "Caccia al Necromante" (GH base)',
+    cols: 3, rows: 2,
+    cells: [
+      { id: '01a', name: 'Sagrato',   survivors: ['s-elena'], z: { walker: 2 },            objective: false, spawn: false },
+      { id: '02c', name: 'Vicolo',    survivors: ['s-tomas'], z: { runner: 2, walker: 1 }, objective: false, spawn: true },
+      { id: '03b', name: 'Cattedrale',survivors: ['s-bruno'], z: { walker: 5, fatty: 1 },  objective: true,  spawn: false },
+      { id: '04b', name: 'Cripta',    survivors: ['s-greta'], z: { walker: 3, abomination: 1 }, objective: true, spawn: true },
+      { id: '05a', name: 'Cortile',   survivors: [],          z: { orc: 4, necromancer: 1 }, objective: false, spawn: true },
+      { id: '06d', name: 'Estrazione',survivors: [],          z: { necromancer: 1 },        objective: true,  spawn: false, exit: true },
+    ],
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ds = oggetto consumato dai RENDERER POLIMORFICI dello skeleton
+  // ══════════════════════════════════════════════════════════════════════════
+  const playersShape = survivors.map(s => ({ id: s.id, name: s.name, hue: s.hue, score: s.xp, turnDelta: 0 }));
+
+  // SCORING — branch BinaryWin (co-op · nessun punteggio · esito condiviso)
+  const scoring = {
+    scoreType: 'BinaryWin',
+    collective: {
+      goalLabel: 'Obiettivi missione', goalValue: 1, goalMax: 4, goalHint: 'completati',
+      failLabel: 'Survivor a terra', failValue: 1, failMax: 4, failHint: 'tutti morti = sconfitta',
+    },
+    categories: [
+      { id: 'mission-success', label: 'Obiettivi missione completati', computation: 'Custom', weight: 1,  description: 'Specifici dello scenario: salva civili, uccidi i Necromancer, raggiungi l\u2019estrazione.' },
+      { id: 'survivors-alive', label: 'Survivor vivi a fine partita',   computation: 'Count',  weight: 1,  description: 'Alcuni scenari richiedono tutti i survivor vivi; altri tollerano perdite.' },
+      { id: 'total-xp',        label: 'XP totali guadagnati (info)',     computation: 'Sum',    weight: 0,  description: 'XP cumulati: pilotano la progressione skill e il Danger Level, non il punteggio.' },
+    ],
+  };
+
+  // TURN — branch Sequential (le 3 fasi del round)
+  const turnShape = {
+    turnOrderType: 'Sequential',
+    phases: phases.map(p => `${p.n}. ${p.lb}`),
+    direction: 'clockwise',
+    turnActions: ['move', 'attack-melee', 'attack-ranged', 'open-door', 'search', 'trade', 'objective-action', 'use-skill'],
+  };
+
+  const ds = {
+    game, agent,
+    session: { elapsed: '47 min' },
+    players: playersShape,
+    scoring,
+    meta: 'Fasi del round · co-op a missione',
+    turn: turnShape,
+    turnState: { phaseIndex: phaseState.phaseIndex, round: phaseState.round },
+    chat: [
+      { id: 'c1', from: 'user',  t: '15:31', text: 'Bruno è adiacente a un Abominio: la mia Katana lo uccide?' },
+      { id: 'c2', from: 'agent', t: '15:31', text: 'No. L\u2019Abominio si elimina solo con danno 3. La Katana fa danno 1: serve un\u2019arma da danno 3 (es. Molotov, lanciafiamme) o effetti che cumulano danno.', citations: ['Zombicide GH §Zombi', 'FAQ #4'] },
+      { id: 'c3', from: 'user',  t: '15:38', text: 'A che distanza spara la balestra di Elena?' },
+      { id: 'c4', from: 'agent', t: '15:38', text: 'La Balestra ha gittata 0-3 tessere e fa danno 2 per colpo. A distanza 0 puoi colpire la tua stessa zona solo se non ci sono survivor (rischio di amici a terra).', citations: ['Zombicide GH §Armi'] },
+    ],
+    suggestions: ['Come si attiva un Runner?', 'Soglia colpo a distanza', 'Spawn con Danger Rosso'],
+    events: [
+      { kind: 'turn-change', who: 's-bruno', t: '15:40', text: '<strong>Bruno</strong> entra in <strong>Cattedrale</strong> e attacca in mischia: <strong>3 colpi</strong> → 3 Walker eliminati' },
+      { kind: 'custom',      who: 's-elena', t: '15:39', text: '<strong>Elena</strong> abbatte un <strong>Necromancer</strong> con la balestra (danno 2)' },
+      { kind: 'score-update',who: 's-bruno', t: '15:39', text: '<strong>Bruno</strong> sale a <strong>47 XP</strong> → livello <strong>Rosso</strong> · Danger Level → Rosso' },
+      { kind: 'custom',      who: 's-greta', t: '15:36', text: '<strong>Greta</strong> subisce 1 ferita da un Fatty nella Cripta (1/2)' },
+      { kind: 'game-start',  who: null,      t: '14:53', text: 'Scenario avviato · "Caccia al Necromante" · 4 survivor · Danger Blu' },
+    ],
+  };
+
+  // WIDGET — ToolkitRenderer: i CounterTools / DiceTools del JSON
+  const counterWidgets = [
+    { id: 'w-zombies', type: 'ResourceManager', isEnabled: true, displayOrder: 1,
+      config: { shared: true, resources: [
+        { label: 'Walker', value: board.walker, max: 99 },
+        { label: 'Runner', value: board.runner, max: 30 },
+        { label: 'Fatty', value: board.fatty, max: 20 },
+        { label: 'Abomination', value: board.abomination, max: 5, danger: true },
+        { label: 'Necromancer', value: board.necromancer, max: 5, danger: true },
+      ] } },
+    { id: 'w-survivor', type: 'ResourceManager', isEnabled: true, displayOrder: 2,
+      config: { shared: false, resources: [
+        { label: 'Ferite · Bruno', value: 1, max: 2, danger: true },
+        { label: 'XP · Bruno', value: 47, max: 99 },
+        { label: 'Punti azione', value: 3, max: 6 },
+      ] } },
+    { id: 'w-xp',   type: 'ScoreTracker',    isEnabled: true,  displayOrder: 3, config: {} },
+    { id: 'w-turn', type: 'TurnManager',     isEnabled: true,  displayOrder: 4, config: { phaseBased: true } },
+    { id: 'w-dice', type: 'RandomGenerator', isEnabled: true,  displayOrder: 5, config: { name: 'Dadi combattimento', quantity: 6, faces: ['1', '2', '3', '4', '5', '6'], last: '5·2·6·4·1·3' } },
+    { id: 'w-note', type: 'NoteManager',     isEnabled: false, displayOrder: 6, config: { text: '' } },
+  ];
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SUMMARY (post-partita) — esito VITTORIA (missione completata, 1 caduto)
+  // ══════════════════════════════════════════════════════════════════════════
+  const summary = {
+    result: 'victory', // 'victory' | 'defeat'
+    mission: 'Caccia al Necromante',
+    rounds: 9, turns: 31,
+    survivorsAlive: 3, survivorsTotal: 4,
+    defeatCause: 'Tutti i survivor a terra', // usato solo se result === 'defeat'
+    objectives: [
+      { id: 'o1', label: 'Salva i 3 civili nascosti', done: true },
+      { id: 'o2', label: 'Uccidi tutti i Necromancer', done: true },
+      { id: 'o3', label: 'Apri il portone della cripta', done: true },
+      { id: 'o4', label: 'Raggiungi il punto di estrazione', done: true },
+    ],
+    // stato finale per survivor (skill tree finale, livello, kill, ferite, armi)
+    survivors: [
+      { id: 's-bruno', name: 'Bruno', player: 'Marco', hue: 8,   klass: 'Berserker', xp: 58, level: 'red',    wounds: 1, dead: false,
+        kills: { walker: 18, orc: 7, runner: 4, fatty: 3, abomination: 1, necromancer: 0 }, weapons: ['Katana', 'Pistola', 'Molotov'] },
+      { id: 's-elena', name: 'Elena', player: 'Anna', hue: 282, klass: 'Heroine',   xp: 49, level: 'red',    wounds: 0, dead: false,
+        kills: { walker: 14, orc: 3, runner: 6, fatty: 1, abomination: 0, necromancer: 4 }, weapons: ['Balestra', 'Balestra a mano'] },
+      { id: 's-tomas', name: 'Tomas', player: 'Luca', hue: 150, klass: 'Tracker',   xp: 27, level: 'orange', wounds: 1, dead: false,
+        kills: { walker: 9, orc: 2, runner: 3, fatty: 1, abomination: 0, necromancer: 1 }, weapons: ['Arco lungo', 'Torcia'] },
+      { id: 's-greta', name: 'Greta', player: 'Sara', hue: 40,  klass: 'Hunter',    xp: 12, level: 'yellow', wounds: 2, dead: true,
+        kills: { walker: 6, orc: 0, runner: 2, fatty: 1, abomination: 0, necromancer: 0 }, weapons: ['Canne mozze', 'Molotov'] },
+    ],
+    // zombie uccisi totali per tipo (istogramma)
+    zombieKills: { walker: 47, orc: 12, runner: 15, fatty: 6, abomination: 1, necromancer: 5 },
+    // transizioni Danger Level per round
+    dangerByRound: [
+      { round: 1, level: 'blue' }, { round: 2, level: 'blue' }, { round: 3, level: 'yellow' },
+      { round: 4, level: 'yellow' }, { round: 5, level: 'orange' }, { round: 6, level: 'orange' },
+      { round: 7, level: 'orange' }, { round: 8, level: 'red' }, { round: 9, level: 'red' },
+    ],
+    stats: {
+      facts: [
+        { lb: 'Round totali', v: '9' },
+        { lb: 'Turni totali', v: '31' },
+        { lb: 'Tiri medi / combat', v: '4.2' },
+        { lb: 'Zombie eliminati', v: '86' },
+      ],
+      avgXpPerTurn: '7.8',
+      mostUsedWeapons: [
+        { name: 'Katana', uses: 22, e: 'danger' },
+        { name: 'Balestra', uses: 19, e: 'session' },
+        { name: 'Arco lungo', uses: 14, e: 'session' },
+        { name: 'Canne mozze', uses: 9, e: 'event' },
+      ],
+    },
+  };
+
+  window.ZOM = {
+    game, agent, levelOf, levelMeta, levelIndex, LEVELS, DANGER, ZTYPES, ZORDER, EQUIP, eq, EQUIP_SLOTS,
+    survivors, byId, topSurvivor, dangerLevel, board, zombieTotal, objectives,
+    phases, phaseState, combat, weaponsRef, spawnDeck, mapTiles,
+    ds, counterWidgets, summary,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-zombicide-flavor.jsx
+++ b/admin-mockups/design_files/sp4-session-zombicide-flavor.jsx
@@ -1,0 +1,452 @@
+/* MeepleAI SP4 · Zombicide: Green Horde — FLAVOR ATOMS  (window.ZOMFlavor)
+   Primitivi visivi game-specific condivisi da live + summary:
+     mono · disp · SurvivorAvatar · WoundPips · XPBar · APCounter · LevelChip ·
+     SkillTree · EquipChip · EquipSlots · ZombieToken · ZombieCounter ·
+     DangerLevel · DieFace · DiceTray · WeaponRefRow · ObjectiveRow ·
+     PhaseTimeline · MapTilesGrid
+
+   Colori zombie/skill da window.ZOM (verbatim zombicide-green-horde.json /
+   mappati su token). Ogni altro valore = var di tokens.css. Legge window.MAI (eHsl). */
+
+(function () {
+  const M = window.MAI;
+  const Z = window.ZOM;
+  const eHsl = M.entityHsl;
+  const { LEVELS, levelMeta, levelIndex, ZTYPES, DANGER } = Z;
+  const mono = (s, w, c) => ({ fontFamily: 'var(--f-mono)', fontSize: s, fontWeight: w, color: c });
+  const disp = (s, w, c) => ({ fontFamily: 'var(--f-display)', fontSize: s, fontWeight: w, color: c });
+
+  // ─── SurvivorAvatar (morto = desaturato + teschio) ────────────────────────
+  const SurvivorAvatar = ({ s, size = 26, ring, dead }) => {
+    const isDead = dead != null ? dead : s.dead;
+    return (
+      <div aria-hidden="true" title={s.name} style={{
+        width: size, height: size, borderRadius: '50%', flexShrink: 0, position: 'relative',
+        background: isDead ? 'var(--bg-sunken)' : `linear-gradient(135deg, hsl(${s.hue},66%,62%), hsl(${s.hue},54%,42%))`,
+        color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        ...disp(size * 0.46, 800, isDead ? 'var(--text-muted)' : '#fff'),
+        border: ring ? `2px solid ${eHsl('session')}` : '2px solid var(--bg-card)',
+        filter: isDead ? 'grayscale(1)' : 'none',
+      }}>{isDead ? '☠' : s.name[0]}</div>
+    );
+  };
+
+  // ─── WoundPips (0/1/2 · 2 = morto · aria assertivo) ───────────────────────
+  const WoundPips = ({ wounds, dead, size = 16 }) => {
+    const isDead = dead != null ? dead : wounds >= 2;
+    return (
+      <div role="status" aria-live="assertive"
+        aria-label={isDead ? 'Survivor a terra: 2 ferite' : `Ferite: ${wounds} su 2`}
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        {[0, 1].map(i => {
+          const filled = i < wounds;
+          return (
+            <span key={i} aria-hidden="true" style={{
+              width: size, height: size, borderRadius: 'var(--r-sm)', display: 'inline-flex',
+              alignItems: 'center', justifyContent: 'center', ...mono(size * 0.6, 800, filled ? '#fff' : 'var(--text-muted)'),
+              background: filled ? eHsl('danger', 0.9) : 'var(--bg-sunken)',
+              border: `1px solid ${filled ? eHsl('danger') : 'var(--border-strong)'}`,
+            }}>{filled ? '✚' : ''}</span>
+          );
+        })}
+        {isDead && <span style={{ ...mono(8.5, 800, eHsl('danger')), textTransform: 'uppercase', letterSpacing: '.05em', marginLeft: 2 }}>a terra</span>}
+      </div>
+    );
+  };
+
+  // ─── LevelChip — livello skill color-coded ────────────────────────────────
+  const LevelChip = ({ level, compact }) => {
+    const m = levelMeta(level);
+    return (
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4, padding: compact ? '1px 7px' : '2px 9px',
+        borderRadius: 'var(--r-pill)', background: eHsl(m.e, 0.14), color: eHsl(m.e),
+        border: `1px solid ${eHsl(m.e, 0.4)}`, ...mono(compact ? 8.5 : 9.5, 800),
+        textTransform: 'uppercase', letterSpacing: '.05em', whiteSpace: 'nowrap',
+      }}>
+        <span aria-hidden="true" style={{ width: 8, height: 8, borderRadius: '50%', background: eHsl(m.e), flexShrink: 0 }} />{m.lb}
+      </span>
+    );
+  };
+
+  // ─── XPBar — 4 segmenti (Blu/Giallo/Aran/Rosso) + marker XP corrente ──────
+  const XPBar = ({ xp, level, compact }) => {
+    const lv = level || Z.levelOf(xp);
+    const idx = levelIndex(lv);
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 4 }}>
+          <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>XP · progressione</span>
+          <span style={{ ...disp(compact ? 13 : 15, 800, eHsl(levelMeta(lv).e)), fontVariantNumeric: 'tabular-nums' }}>{xp}</span>
+        </div>
+        <div style={{ display: 'flex', gap: 3 }} role="img" aria-label={`XP ${xp}, livello ${levelMeta(lv).lb}`}>
+          {LEVELS.map((l, i) => {
+            const reached = i <= idx;
+            const isCur = i === idx;
+            return (
+              <div key={l.id} title={`${l.lb} · ${l.range} XP`} style={{ flex: l.id === 'red' ? 0.7 : 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <div style={{
+                  height: compact ? 7 : 9, borderRadius: 'var(--r-pill)',
+                  background: reached ? eHsl(l.e, isCur ? 1 : 0.55) : 'var(--bg-sunken)',
+                  border: `1px solid ${reached ? eHsl(l.e) : 'var(--border-light)'}`,
+                  boxShadow: isCur ? `0 0 8px ${eHsl(l.e, 0.5)}` : 'none',
+                }} />
+                <span style={{ ...mono(7, 700, isCur ? eHsl(l.e) : 'var(--text-muted)'), textAlign: 'center' }}>{l.range}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  // ─── APCounter — punti azione (3 base + bonus skill) ──────────────────────
+  const APCounter = ({ ap, base, bonus, compact }) => (
+    <div role="group" aria-label={`Punti azione: ${ap}`} style={{
+      display: 'inline-flex', alignItems: 'center', gap: 6, padding: compact ? '4px 9px' : '6px 11px',
+      borderRadius: 'var(--r-md)', background: eHsl('warning', 0.1), border: `1px solid ${eHsl('warning', 0.32)}`,
+    }}>
+      <span aria-hidden="true" style={{ ...disp(compact ? 16 : 19, 800, eHsl('warning')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>⚡{ap}</span>
+      <div style={{ lineHeight: 1.05 }}>
+        <div style={{ ...mono(8, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>azioni</div>
+        <div style={{ ...mono(8, 700, 'var(--text-sec)') }}>{base} base{bonus ? ` +${bonus}` : ''}</div>
+      </div>
+    </div>
+  );
+
+  // ─── SkillTree — 4 livelli color-coded · chosen highlighted · futuri greyed ─
+  // layout: 'grid' (4 colonne) o 'rows' (verticale, per contesti stretti)
+  const SkillNode = ({ name, tone, kind }) => {
+    // kind: 'chosen' | 'option' | 'pick' | 'locked'
+    const styles = {
+      chosen: { bg: eHsl(tone, 0.16), bd: eHsl(tone, 0.5), col: eHsl(tone), wt: 800, opacity: 1, dash: false },
+      pick:   { bg: 'var(--bg-card)', bd: eHsl(tone, 0.45), col: eHsl(tone), wt: 700, opacity: 1, dash: true },
+      option: { bg: 'var(--bg-muted)', bd: 'var(--border-light)', col: 'var(--text-muted)', wt: 600, opacity: 0.7, dash: false },
+      locked: { bg: 'var(--bg-sunken)', bd: 'var(--border-light)', col: 'var(--text-muted)', wt: 600, opacity: 0.5, dash: true },
+    }[kind];
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 5, padding: '4px 7px', borderRadius: 'var(--r-sm)',
+        background: styles.bg, border: `1px ${styles.dash ? 'dashed' : 'solid'} ${styles.bd}`,
+        opacity: styles.opacity,
+      }}>
+        {kind === 'chosen' && <span aria-hidden="true" style={{ ...mono(8.5, 800, styles.col), flexShrink: 0 }}>✓</span>}
+        {kind === 'pick' && <span aria-hidden="true" style={{ ...mono(8.5, 800, styles.col), flexShrink: 0 }}>◆</span>}
+        {kind === 'locked' && <span aria-hidden="true" style={{ ...mono(8, 700, styles.col), flexShrink: 0 }}>🔒</span>}
+        <span style={{ ...disp(10.5, styles.wt, styles.col), whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{name}</span>
+      </div>
+    );
+  };
+  const SkillLevelColumn = ({ row, layout }) => {
+    const m = levelMeta(row.level);
+    const isRow = layout === 'rows';
+    // nodi: il chosen (se c'è) + alternative. Per livello locked tutte greyed.
+    const nodes = [];
+    row.options.forEach(opt => {
+      if (row.status === 'done') {
+        nodes.push({ name: opt, kind: opt === row.chosen ? 'chosen' : 'option' });
+      } else if (row.status === 'available') {
+        nodes.push({ name: opt, kind: row.chosen ? (opt === row.chosen ? 'chosen' : 'option') : 'pick' });
+      } else {
+        nodes.push({ name: opt, kind: 'locked' });
+      }
+    });
+    return (
+      <div style={{
+        flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 5,
+        padding: 7, borderRadius: 'var(--r-md)',
+        background: row.status === 'locked' ? 'var(--bg-sunken)' : eHsl(m.e, 0.05),
+        border: `1px solid ${row.status === 'locked' ? 'var(--border-light)' : eHsl(m.e, row.status === 'available' ? 0.4 : 0.22)}`,
+        ...(isRow ? { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap' } : {}),
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5, ...(isRow ? { width: 92, flexShrink: 0 } : { marginBottom: 1 }) }}>
+          <span aria-hidden="true" style={{ width: 9, height: 9, borderRadius: '50%', background: eHsl(m.e), flexShrink: 0, opacity: row.status === 'locked' ? 0.5 : 1 }} />
+          <span style={{ ...mono(8.5, 800, row.status === 'locked' ? 'var(--text-muted)' : eHsl(m.e)), textTransform: 'uppercase', letterSpacing: '.04em' }}>{m.lb}</span>
+          {row.status === 'available' && !row.chosen && <span style={{ ...mono(7, 800, eHsl(m.e)), textTransform: 'uppercase' }}>scegli</span>}
+        </div>
+        <div style={{ display: 'flex', flexDirection: isRow ? 'row' : 'column', gap: 4, flexWrap: 'wrap', flex: isRow ? 1 : 'none', minWidth: 0 }}>
+          {nodes.map((n, i) => <SkillNode key={i} name={n.name} tone={m.e} kind={n.kind} />)}
+        </div>
+      </div>
+    );
+  };
+  const SkillTree = ({ survivor, layout = 'grid' }) => (
+    <div role="group" aria-label={`Albero abilità di ${survivor.name}`} style={{
+      display: layout === 'rows' ? 'flex' : 'grid',
+      ...(layout === 'rows' ? { flexDirection: 'column', gap: 6 } : { gridTemplateColumns: 'repeat(4, 1fr)', gap: 6 }),
+    }}>
+      {survivor.tree.map(row => <SkillLevelColumn key={row.level} row={row} layout={layout} />)}
+    </div>
+  );
+
+  // ─── EquipChip / EquipSlots ───────────────────────────────────────────────
+  const TYPE_LB = { melee: 'Mischia', ranged: 'Distanza', armor: 'Armatura', item: 'Oggetto' };
+  const EquipCard = ({ id, slotLb, w }) => {
+    const e = Z.eq(id);
+    const empty = !id;
+    if (empty) {
+      return (
+        <div style={{ width: w, minHeight: 64, borderRadius: 'var(--r-md)', border: '1.5px dashed var(--border-strong)', background: 'var(--bg-sunken)', opacity: 0.55, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2, flexShrink: 0 }}>
+          <span style={{ ...mono(8, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>{slotLb}</span>
+          <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>vuoto</span>
+        </div>
+      );
+    }
+    const acc = e.accent || 'tool';
+    return (
+      <div title={`${e.name} · ${TYPE_LB[e.type]}`} style={{
+        width: w, minHeight: 64, borderRadius: 'var(--r-md)', background: 'var(--bg-card)',
+        border: `1px solid ${eHsl(acc, 0.35)}`, overflow: 'hidden', display: 'flex', flexDirection: 'column', flexShrink: 0,
+        boxShadow: 'var(--shadow-xs)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 7px', background: eHsl(acc, 0.1), borderBottom: `1px solid ${eHsl(acc, 0.2)}` }}>
+          <span aria-hidden="true" style={{ fontSize: 12, flexShrink: 0 }}>{e.glyph}</span>
+          <span style={{ flex: 1, minWidth: 0, ...mono(7.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.04em' }}>{slotLb}</span>
+          <span style={{ ...mono(7.5, 800, eHsl(acc)), textTransform: 'uppercase' }}>{TYPE_LB[e.type]}</span>
+        </div>
+        <div style={{ flex: 1, padding: '5px 7px', display: 'flex', flexDirection: 'column', justifyContent: 'space-between', gap: 3 }}>
+          <span style={{ ...disp(11.5, 800, 'var(--text)'), lineHeight: 1.15 }}>{e.name}</span>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {e.range != null && <span style={{ ...mono(8, 700, 'var(--text-sec)') }}>gittata {e.range}</span>}
+            {e.dice != null && <span style={{ ...mono(8, 700, eHsl(acc)) }}>{e.dice} dado{e.dice > 1 ? 'i' : ''}</span>}
+            {e.dmg != null && <span style={{ ...mono(8, 700, 'var(--text-sec)') }}>danno {e.dmg}</span>}
+            {e.save && <span style={{ ...mono(8, 700, eHsl(acc)) }}>save {e.save}</span>}
+            {e.area && <span style={{ ...mono(8, 800, eHsl('event')) }}>area</span>}
+            {e.reload && <span style={{ ...mono(8, 700, 'var(--text-muted)') }}>ricarica</span>}
+          </div>
+        </div>
+      </div>
+    );
+  };
+  const EquipSlots = ({ survivor, w = 124, cols }) => (
+    <div style={{ display: 'grid', gridTemplateColumns: cols ? `repeat(${cols}, 1fr)` : `repeat(auto-fill, minmax(${w}px, 1fr))`, gap: 6 }}>
+      {Z.EQUIP_SLOTS.map(slot => <EquipCard key={slot.id} id={survivor.equip[slot.id]} slotLb={slot.lb} w="100%" />)}
+    </div>
+  );
+
+  // ─── ZombieToken — gettone colorato distintivo per tipo (glyph 1-lettera) ──
+  const ZombieToken = ({ type, size = 22, title }) => {
+    const z = ZTYPES[type] || { lb: type, glyph: '?', color: '#888' };
+    return (
+      <span title={title || z.lb} aria-label={z.lb} style={{
+        width: size, height: size, borderRadius: 'var(--r-sm)', flexShrink: 0,
+        background: z.color, color: '#fff',
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        ...mono(size * 0.5, 800), border: '1px solid rgba(0,0,0,.3)',
+        boxShadow: 'inset 0 1px 1px rgba(255,255,255,.22), inset 0 -1px 2px rgba(0,0,0,.28)',
+      }}>{z.glyph}</span>
+    );
+  };
+
+  // ─── ZombieCounter — counter grande con icona distintiva (aria tipo+count) ─
+  const ZombieCounter = ({ type, count, big }) => {
+    const z = ZTYPES[type];
+    const boss = type === 'abomination' || type === 'necromancer';
+    return (
+      <div role="status" aria-label={`${z.lb}: ${count} sulla plancia`} style={{
+        display: 'flex', alignItems: 'center', gap: big ? 9 : 7, padding: big ? '9px 11px' : '7px 9px',
+        borderRadius: 'var(--r-md)', background: 'var(--bg-card)',
+        border: `1px solid ${boss ? z.color : 'var(--border)'}`,
+        boxShadow: boss ? `0 0 0 1px ${z.color}44` : 'var(--shadow-xs)',
+      }}>
+        <ZombieToken type={type} size={big ? 30 : 26} />
+        <div style={{ minWidth: 0, lineHeight: 1.05, flex: 1 }}>
+          <div style={{ ...mono(8.5, 800, 'var(--text-sec)'), whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{z.lb}</div>
+          <div style={{ ...mono(7.5, 700, 'var(--text-muted)') }}>{z.actions} att · dmg {z.dmg || '—'}</div>
+        </div>
+        <span aria-hidden="true" style={{ ...disp(big ? 24 : 20, 800, count > 0 ? 'var(--text)' : 'var(--text-muted)'), fontVariantNumeric: 'tabular-nums' }}>{count}</span>
+      </div>
+    );
+  };
+
+  // ─── DangerLevel — indicatore Blu/Giallo/Aran/Rosso (current evidenziato) ──
+  const DangerLevel = ({ current, compact, reason }) => {
+    const idx = levelIndex(current);
+    return (
+      <div role="group" aria-label={`Danger Level: ${levelMeta(current).lb}`} style={{ display: 'flex', alignItems: 'center', gap: compact ? 6 : 9, flexWrap: 'wrap', rowGap: 5 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.1, flexShrink: 0 }}>
+          <span style={{ ...mono(8, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Danger Level</span>
+          {!compact && reason && <span style={{ ...mono(7.5, 700, 'var(--text-muted)') }}>{reason}</span>}
+        </div>
+        <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', rowGap: 4, minWidth: 0 }}>
+          {DANGER.map((d, i) => {
+            const on = i === idx, past = i < idx;
+            return (
+              <span key={d.id} aria-current={on ? 'true' : undefined} title={d.spawn} style={{
+                display: 'inline-flex', alignItems: 'center', gap: 4, padding: compact ? '2px 7px' : '3px 9px', borderRadius: 'var(--r-pill)', flexShrink: 0,
+                background: on ? eHsl(d.e, 0.16) : past ? eHsl(d.e, 0.06) : 'var(--bg-muted)',
+                border: `1px solid ${on ? eHsl(d.e, 0.5) : past ? eHsl(d.e, 0.22) : 'var(--border-light)'}`,
+                boxShadow: on ? `0 0 8px ${eHsl(d.e, 0.4)}` : 'none',
+              }}>
+                <span aria-hidden="true" style={{ width: 8, height: 8, borderRadius: '50%', background: eHsl(d.e), opacity: on || past ? 1 : 0.4, flexShrink: 0 }} />
+                <span style={{ ...mono(compact ? 8.5 : 9.5, on ? 800 : 600, on ? eHsl(d.e) : 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.04em' }}>{d.lb}</span>
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  // ─── DieFace — faccia D6 a pip · hit (≥soglia) evidenziato ─────────────────
+  const PIPS = {
+    1: [[1, 1]], 2: [[0, 0], [2, 2]], 3: [[0, 0], [1, 1], [2, 2]],
+    4: [[0, 0], [0, 2], [2, 0], [2, 2]], 5: [[0, 0], [0, 2], [1, 1], [2, 0], [2, 2]],
+    6: [[0, 0], [0, 2], [1, 0], [1, 2], [2, 0], [2, 2]],
+  };
+  const DieFace = ({ value, hit, size = 40, rolling }) => {
+    const cells = Array.from({ length: 9 });
+    const on = PIPS[value] || [];
+    const onSet = new Set(on.map(([r, c]) => r * 3 + c));
+    return (
+      <div role="img" aria-label={`Dado ${value}${hit ? ', colpo' : ', mancato'}`} className={rolling ? 'zom-die-roll' : undefined} style={{
+        width: size, height: size, borderRadius: 'var(--r-md)', flexShrink: 0,
+        background: hit ? eHsl('toolkit', 0.16) : 'var(--bg-card)',
+        border: `2px solid ${hit ? eHsl('toolkit') : 'var(--border-strong)'}`,
+        boxShadow: hit ? `0 0 10px ${eHsl('toolkit', 0.4)}` : 'var(--shadow-xs)',
+        display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gridTemplateRows: 'repeat(3, 1fr)',
+        padding: size * 0.16, gap: size * 0.04,
+      }}>
+        {cells.map((_, i) => (
+          <span key={i} style={{ borderRadius: '50%', alignSelf: 'center', justifySelf: 'center',
+            width: size * 0.15, height: size * 0.15,
+            background: onSet.has(i) ? (hit ? eHsl('toolkit') : 'var(--text-sec)') : 'transparent' }} />
+        ))}
+      </div>
+    );
+  };
+  const DiceTray = ({ roll, threshold, size = 40 }) => (
+    <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap' }}>
+      {roll.map((v, i) => <DieFace key={i} value={v} hit={v >= threshold} size={size} />)}
+    </div>
+  );
+
+  // ─── WeaponRefRow — riferimento rapido arma (gittata + dadi) ───────────────
+  const WeaponRefRow = ({ w }) => {
+    const e = Z.eq(w.id);
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 9px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+        <span aria-hidden="true" style={{ fontSize: 13, flexShrink: 0 }}>{e.glyph}</span>
+        <span style={{ flex: 1, minWidth: 0, ...disp(11.5, 800, 'var(--text)') }}>{w.lb}</span>
+        <span style={{ ...mono(9, 700, 'var(--text-sec)') }}>gittata <strong style={{ color: 'var(--text)' }}>{w.range}</strong></span>
+        <span style={{ ...mono(9, 700, eHsl('session')) }}>{w.dice}d · {w.hit}</span>
+        {w.note && <span style={{ ...mono(8, 800, eHsl('event')), textTransform: 'uppercase' }}>{w.note}</span>}
+      </div>
+    );
+  };
+
+  // ─── ObjectiveRow — riga obiettivo scenario ───────────────────────────────
+  const ObjectiveRow = ({ o }) => (
+    <div role="listitem" style={{
+      display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 'var(--r-md)',
+      background: o.done ? eHsl('toolkit', 0.07) : 'var(--bg-card)',
+      border: `1px solid ${o.done ? eHsl('toolkit', 0.28) : 'var(--border)'}`,
+    }}>
+      <span aria-hidden="true" style={{
+        width: 19, height: 19, borderRadius: 'var(--r-sm)', flexShrink: 0,
+        background: o.done ? eHsl('toolkit') : 'transparent',
+        border: o.done ? 'none' : `2px solid ${eHsl('session', 0.4)}`,
+        color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(11, 800),
+      }}>{o.done ? '✓' : ''}</span>
+      <span style={{ flex: 1, minWidth: 0, ...disp(12, 700, 'var(--text)'), textDecoration: o.done ? 'line-through' : 'none', opacity: o.done ? 0.7 : 1 }}>{o.label}</span>
+      {o.progress && !o.done && <span style={{ ...mono(9, 800, eHsl('session')), flexShrink: 0 }}>{o.progress}</span>}
+    </div>
+  );
+
+  // ─── PhaseTimeline — banner 3 fasi del round (aria-current) ────────────────
+  const PhaseTimeline = ({ compact, sticky }) => {
+    const { phases, phaseState } = Z;
+    return (
+      <div role="group" aria-label="Fase del round" style={{
+        display: 'flex', alignItems: 'center', gap: compact ? 8 : 14, padding: compact ? '8px 12px' : '10px 16px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderBottom: '1px solid var(--border)',
+        ...(sticky ? { position: 'sticky', top: 0, zIndex: 10 } : {}), flexShrink: 0, flexWrap: 'wrap', rowGap: 7,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: 1, flexShrink: 0 }}>
+          <span style={{ ...disp(compact ? 17 : 21, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>R{phaseState.round}</span>
+          <span style={{ ...mono(7.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Round</span>
+        </div>
+        <span aria-hidden="true" style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)', flexShrink: 0 }} />
+        <ol style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', alignItems: 'center', flexWrap: 'wrap', rowGap: 6, gap: compact ? 5 : 7, flex: 1, minWidth: 0 }}>
+          {phases.map((ph, i) => {
+            const on = i === phaseState.phaseIndex, past = i < phaseState.phaseIndex;
+            return (
+              <li key={ph.id} aria-current={on ? 'step' : undefined} style={{ display: 'flex', alignItems: 'center', gap: compact ? 5 : 7, flexShrink: 0 }}>
+                <div title={ph.desc} style={{
+                  display: 'flex', alignItems: 'center', gap: 6, padding: compact ? '5px 8px' : '6px 11px', borderRadius: 'var(--r-pill)',
+                  background: on ? eHsl('session', 0.14) : past ? eHsl('toolkit', 0.07) : 'var(--bg-muted)',
+                  border: `1px solid ${on ? eHsl('session', 0.45) : past ? eHsl('toolkit', 0.25) : 'var(--border-light)'}`,
+                  boxShadow: on ? `0 3px 10px ${eHsl('session', 0.22)}` : 'none',
+                }}>
+                  <span aria-hidden="true" style={{
+                    width: compact ? 17 : 20, height: compact ? 17 : 20, borderRadius: '50%', flexShrink: 0,
+                    background: on ? eHsl('session') : past ? eHsl('toolkit', 0.25) : 'transparent',
+                    color: on ? '#fff' : past ? eHsl('toolkit') : 'var(--text-muted)',
+                    border: on || past ? 'none' : '1px solid var(--border-strong)',
+                    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', ...mono(compact ? 9 : 10, 800),
+                  }}>{past ? '✓' : ph.n}</span>
+                  {!compact && <span style={{ ...disp(11.5, on ? 800 : 600, on ? eHsl('session') : past ? 'var(--text-sec)' : 'var(--text-muted)'), whiteSpace: 'nowrap' }}>{ph.short}</span>}
+                </div>
+                {i < phases.length - 1 && <span aria-hidden="true" style={{ ...mono(10, 800, past ? eHsl('toolkit') : 'var(--text-muted)') }}>{compact ? '·' : '→'}</span>}
+              </li>
+            );
+          })}
+        </ol>
+        <span style={{ ...mono(8.5, 700, 'var(--text-muted)'), flexShrink: 0, whiteSpace: 'nowrap', textTransform: 'uppercase', letterSpacing: '.05em' }} aria-hidden="true">↻ orario</span>
+      </div>
+    );
+  };
+
+  // ─── MapTilesGrid — snapshot schematico tessere (placeholder) ──────────────
+  const MapTilesGrid = ({ tiles, focusId, h }) => {
+    const t = tiles || Z.mapTiles;
+    return (
+      <div>
+        <div style={{ position: 'relative', borderRadius: 'var(--r-md)', overflow: 'hidden', background: 'var(--bg-sunken)', border: '1px solid var(--border-light)', padding: 8 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: `repeat(${t.cols}, 1fr)`, gap: 6 }}>
+            {t.cells.map(cell => {
+              const hasFocus = focusId && cell.survivors.includes(focusId);
+              return (
+                <div key={cell.id} style={{
+                  minHeight: h ? h / t.rows - 12 : 92, borderRadius: 'var(--r-sm)', padding: 6, position: 'relative',
+                  background: 'repeating-linear-gradient(45deg, var(--bg-card), var(--bg-card) 7px, var(--bg-muted) 7px, var(--bg-muted) 14px)',
+                  border: `1px solid ${hasFocus ? eHsl('session', 0.55) : cell.exit ? eHsl('toolkit', 0.4) : 'var(--border)'}`,
+                  boxShadow: hasFocus ? `0 0 0 1px ${eHsl('session', 0.4)}` : 'none',
+                  display: 'flex', flexDirection: 'column', gap: 4,
+                }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <span style={{ ...mono(7.5, 800, 'var(--text-muted)') }}>{cell.id}</span>
+                    <span style={{ ...disp(9.5, 800, 'var(--text-sec)'), whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{cell.name}</span>
+                    {cell.objective && <span title="obiettivo" aria-hidden="true" style={{ ...mono(9, 800, eHsl('toolkit')), marginLeft: 'auto' }}>★</span>}
+                    {cell.exit && <span title="estrazione" aria-hidden="true" style={{ ...mono(7.5, 800, eHsl('toolkit')), textTransform: 'uppercase' }}>exit</span>}
+                  </div>
+                  <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'center' }}>
+                    {cell.survivors.map(sid => { const s = Z.byId(sid); return s ? <SurvivorAvatar key={sid} s={s} size={18} ring={sid === focusId} /> : null; })}
+                    {cell.spawn && <span title="spawn point" style={{ ...mono(7.5, 800, eHsl('event')), padding: '0 4px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.12), border: `1px solid ${eHsl('event', 0.3)}` }}>spawn</span>}
+                  </div>
+                  <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap', marginTop: 'auto', alignItems: 'center' }}>
+                    {Object.entries(cell.z).map(([type, n]) => (
+                      <span key={type} style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+                        <ZombieToken type={type} size={14} />
+                        <span style={{ ...mono(8, 800, 'var(--text-sec)'), fontVariantNumeric: 'tabular-nums' }}>{n}</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <span style={{ display: 'inline-block', marginTop: 8, ...mono(8, 700, 'var(--text-muted)'), background: 'var(--glass-bg)', padding: '2px 7px', borderRadius: 'var(--r-pill)', border: '1px solid var(--border-light)' }}>layout schematico · mappa reale al rilascio</span>
+        </div>
+      </div>
+    );
+  };
+
+  window.ZOMFlavor = {
+    mono, disp,
+    SurvivorAvatar, WoundPips, LevelChip, XPBar, APCounter,
+    SkillTree, SkillNode, EquipCard, EquipSlots,
+    ZombieToken, ZombieCounter, DangerLevel, DieFace, DiceTray,
+    WeaponRefRow, ObjectiveRow, PhaseTimeline, MapTilesGrid,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-zombicide-live.html
+++ b/admin-mockups/design_files/sp4-session-zombicide-live.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Zombicide: Green Horde · Live — /sessions/[id]/live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-zombicide-live.jsx
+++ b/admin-mockups/design_files/sp4-session-zombicide-live.jsx
@@ -1,0 +1,209 @@
+/* MeepleAI SP4 · Zombicide: Green Horde — SESSION LIVE  (App)
+   /sessions/[id]/live — estensione game-specific dello skeleton universale
+   applicata a Zombicide: Green Horde (co-op miniatures dungeon-crawler,
+   1-6 giocatori, ~60-90 min/scenario).
+
+   PREMIUM mockup. Lo skeleton (mockup #1) fornisce i renderer polimorfici +
+   la chrome universale; QUESTO layer aggiunge la board di Zombicide GH:
+   PhaseTimeline (3 fasi del round), DangerLevel (pilota lo spawn), SurvivorCard
+   (skill tree + equip + ferite + AP), BoardStatePanel (conteggi zombie),
+   CombatDicePanel (D6 rollable), SpawnDeckPanel, MapTilesGrid e una colonna
+   destra a 5 tab (Scoring · Dice · Board · Equip · Chat).
+
+   ACCORDION (CRITICAL): la colonna LEFT replica il pattern accordion dello
+   skeleton (un solo pannello expanded), esteso via sec(id) a Survivor · Board ·
+   Spawn · ChatAgent · ActionLog (questi ultimi due riusati verbatim).
+
+   Riusa verbatim: TopBar · ChatAgentPanel · ActionLog · ScoringPanelRenderer
+   (BinaryWin) · TurnIndicatorRenderer (Sequential 3-fasi) · ToolkitRenderer.
+   Dark = modalità primaria (ambiance Zombicide).
+
+   Carica: sp4-parts-common · zombicide-data(shim SkeletonData) · skeleton-renderers
+           · skeleton-parts · zombicide-flavor · zombicide-parts · QUESTO file.
+   DEMO-NAV-HINTS: sp4-session-zombicide-summary.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const S = window.SkeletonParts;
+const Z = window.ZOM;
+const F = window.ZOMFlavor;
+const P = window.ZOMParts;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+const { mono, disp } = F;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+const Intro = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+    {[
+      { e: 'session', h: 'Estende lo skeleton', b: 'Riusa TopBar · ChatAgent · ActionLog e i 3 renderer polimorfici. Aggiunge sopra la board di Zombicide GH: fasi, survivor, plancia, dadi.' },
+      { e: 'event',   h: 'Plancia & Danger', b: 'Conteggi zombie per 6 tipi (Walker → Necromancer). Il Danger Level segue il survivor con XP più alto e detta l\u2019aggressività dello spawn.' },
+      { e: 'game',    h: 'Skill tree XP', b: 'Ogni survivor cresce su 4 livelli color-coded: Blu (0-6) → Giallo (7-18) → Arancione (19-42) → Rosso (43+). Skill ottenuti highlighted, prossimi greyed.' },
+      { e: 'toolkit', h: '5 stati canonici', b: 'default · empty · loading · error · sse-disconnect per ogni pannello (survivor, plancia, dadi, spawn, mappa, scoring).' },
+    ].map(c => (
+      <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+        <div style={{ ...disp(13, 800, eHsl(c.e)), marginBottom: 4 }}>{c.h}</div>
+        <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+      </div>
+    ))}
+  </div>
+);
+
+const StatesRow = ({ title, sub, entity, render }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ ...disp(15, 800, eHsl(entity)) }}>{title}</span>
+      {sub && <span style={{ ...mono(10, 700, 'var(--text-muted)') }}>{sub}</span>}
+    </div>
+    <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>
+      {P.STATES.map(s => (
+        <P.PanelFrame key={s.id} label={s.lb} entity={entity} dark={s.id === 'sse'}>
+          {render(s.id)}
+        </P.PanelFrame>
+      ))}
+    </div>
+  </div>
+);
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ ...mono(11, 600, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Zombicide: Green Horde · Live 🧟 · estensione skeleton</div>
+        <h1>Session live — Zombicide: Green Horde</h1>
+        <p className="lead">
+          Estensione game-specific dello <strong>skeleton universale</strong> applicata a <strong>Zombicide: Green Horde</strong>
+          (co-op miniatures dungeon-crawler, 1-6 giocatori, ~60-90 min). Lo skeleton fornisce i renderer polimorfici e la
+          chrome; questo layer aggiunge il <strong>banner a 3 fasi</strong>, il <strong>Danger Level</strong>, la
+          <strong> SurvivorCard</strong> (skill tree + equip + ferite + AP), lo <strong>stato plancia</strong>, i
+          <strong> dadi da combattimento</strong> (D6 rollable), il <strong>mazzo spawn</strong> e la
+          <strong> mappa a tessere</strong>, più una colonna destra a 5 tab. Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        {/* INTERACTIVE — desktop */}
+        <div className="section-label">Interattivo · Desktop 1280 — fasi + danger · rail survivor · accordion · colonna tab</div>
+        <S.DesktopFrame ds={Z.ds} dark label="Desktop · live · Zombicide GH" url="meepleai.app/sessions/zom-4/live?tab=scoring" height={840}
+          desc="Top: PhaseTimeline (Fase Giocatori attiva, Round 6) + strip Danger Level (Rosso · pilotato da Bruno). SINISTRA rail del gruppo survivor (clic per cambiare l'attivo) + sintesi plancia. CENTRO accordion (un solo pannello aperto): SurvivorCard · Stato plancia · Mazzo spawn · ChatAgent · ActionLog. DESTRA tab Scoring (BinaryWin) / Dice / Board / Equip / Chat con selettore stato.">
+          <S.TopBar ds={Z.ds} connection="connected" />
+          <P.DesktopBody initialTab="scoring" initialState="default" />
+        </S.DesktopFrame>
+
+        {/* INTERACTIVE — mobile */}
+        <div className="section-label">Mobile 375 — banner fase sticky · accordion scroll · survivor drawer · tab → bottom-sheet</div>
+        <div className="phones-grid">
+          <P.PhoneShell label="01 · base · sheet chiuso" desc="PhaseTimeline sticky, strip Danger + chip survivor (tap → drawer scheda), accordion scrollabile. In basso strip tab." />
+          <P.PhoneShell label="02 · sheet Dice" initialTab="dice" desc="Tap su una tab apre il bottom-sheet: dadi D6 rollable (live), conteggio colpi e riferimento armi." />
+          <P.PhoneShell label="03 · sheet Board · dark" dark initialTab="board" desc="Tab Board: snapshot tessere con survivor + cluster zombie e mazzo spawn rimanente." />
+        </div>
+
+        {/* STATES — reused polymorphic renderers */}
+        <div className="section-label">Gallery stati · renderer polimorfici riusati — alimentati dal toolkit Zombicide GH</div>
+        <StatesRow title="ScoringPanelRenderer" sub="scoreType · BinaryWin — esito co-op condiviso · 3 categorie dal JSON (Custom · Count · Sum)" entity="session"
+          render={(st) => <R.ScoringPanelRenderer data={Z.ds} state={st} />} />
+        <StatesRow title="TurnIndicatorRenderer" sub="turnOrderType · Sequential — phase stepper sulle 3 fasi del round" entity="player"
+          render={(st) => <R.TurnIndicatorRenderer data={Z.ds} state={st} />} />
+        <StatesRow title="ToolkitRenderer" sub="dispatch widgets[] — Counter/DiceTools del JSON (zombie · survivor · dadi · turni)" entity="toolkit"
+          render={(st) => <R.ToolkitRenderer widgets={Z.counterWidgets} players={Z.ds.players} state={st} />} />
+
+        {/* STATES — ZOM-specific panels */}
+        <div className="section-label">Gallery stati · pannelli specifici Zombicide GH × 5 stati canonici</div>
+        <StatesRow title="SurvivorCard" sub="skill tree + equip + ferite + AP" entity="session"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto', padding: 10 }}><P.SurvivorCard state={st} survivor={Z.survivors[0]} layout="rows" /></div>} />
+        <StatesRow title="BoardStatePanel" sub="conteggi zombie + Danger Level + obiettivi" entity="event"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto' }}><P.BoardStatePanel state={st} compact /></div>} />
+        <StatesRow title="CombatDicePanel" sub="D6 rollable · colpo 4+ · riferimento armi" entity="tool"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto' }}><P.CombatDicePanel state={st} compact /></div>} />
+        <StatesRow title="SpawnDeckPanel" sub="carte spawn rimaste · pesca per Danger Level" entity="event"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto' }}><P.SpawnDeckPanel state={st} /></div>} />
+
+        {/* ZOM component showcase */}
+        <div className="section-label">Componenti Zombicide GH · banner fase · danger · skill tree · gettoni zombie · dadi · carta morto</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <P.SectionCard title="PhaseTimeline + Danger Level" entity="session" accent flush>
+            <F.PhaseTimeline />
+            <div style={{ padding: '10px 14px' }}><F.DangerLevel current={Z.dangerLevel} reason={`pilotato da ${Z.topSurvivor.name} (XP ${Z.topSurvivor.xp})`} /></div>
+          </P.SectionCard>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 16, alignItems: 'start' }}>
+            <div>
+              <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>SkillTree · 4 livelli (Bruno · Rosso)</div>
+              <div style={{ padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+                <F.SkillTree survivor={Z.survivors[0]} layout="rows" />
+              </div>
+            </div>
+            <div data-theme="dark">
+              <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>SkillTree · in progress (Tomas · Giallo) · dark</div>
+              <div style={{ padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg)' }}>
+                <F.SkillTree survivor={Z.byId('s-tomas')} layout="rows" />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>ZombieCounter · 6 tipi distintivi</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(170px, 1fr))', gap: 8 }}>
+              {Z.ZORDER.map(t => <F.ZombieCounter key={t} type={t} count={Z.board[t]} big />)}
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 16, alignItems: 'start' }}>
+            <div>
+              <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>WoundPips · XPBar · APCounter · EquipCard</div>
+              <div style={{ padding: 14, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)', display: 'flex', flexDirection: 'column', gap: 12 }}>
+                <div style={{ display: 'flex', gap: 14, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}><F.WoundPips wounds={0} /><span style={{ ...mono(8, 700, 'var(--text-muted)') }}>0 ferite</span></div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}><F.WoundPips wounds={1} /><span style={{ ...mono(8, 700, 'var(--text-muted)') }}>1 ferita</span></div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}><F.WoundPips wounds={2} /><span style={{ ...mono(8, 700, 'var(--text-muted)') }}>morto</span></div>
+                  <F.APCounter ap={4} base={3} bonus={1} />
+                </div>
+                <F.XPBar xp={31} level="orange" />
+                <F.EquipSlots survivor={Z.survivors[0]} cols={2} />
+              </div>
+            </div>
+            <div>
+              <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>Survivor a terra · carta flippata (2 ferite)</div>
+              <div style={{ padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: `1px solid ${eHsl('danger', 0.35)}` }}>
+                <P.SurvivorCardInner s={{ ...Z.byId('s-greta'), wounds: 2, dead: true }} layout="rows" />
+              </div>
+            </div>
+          </div>
+
+          <P.SectionCard title="MapTilesGrid · snapshot tessere" entity="session" accent flush>
+            <div style={{ padding: 12 }}><F.MapTilesGrid focusId="s-bruno" /></div>
+          </P.SectionCard>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        @keyframes zom-die-roll-anim { 0% { transform: rotate(-14deg) scale(.86); } 60% { transform: rotate(8deg) scale(1.06); } 100% { transform: rotate(0) scale(1); } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .zom-die-roll { animation: zom-die-roll-anim .4s var(--ease-spring); }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; width: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer, .zom-die-roll { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-zombicide-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-zombicide-parts.jsx
@@ -1,0 +1,535 @@
+/* MeepleAI SP4 · Zombicide: Green Horde — COMPOSED PARTS  (window.ZOMParts)
+   Pannelli specifici Zombicide GH montati sopra lo skeleton universale:
+     SectionCard · PanelFrame · STATES
+     SurvivorCard       — skill tree + equipment + ferite + AP + zona
+     SurvivorsRail      — lista survivor (picker attivo) + sintesi plancia
+     BoardStatePanel    — conteggi zombie + Danger Level + obiettivi
+     CombatDicePanel    — D6 rollable (interattivo · aria-live) + ref armi
+     SpawnDeckPanel     — carte spawn rimaste · pesca per Danger Level
+     MapPanel           — snapshot tessere + spawn deck
+     EquipOverviewPanel — equipaggiamento di tutti i survivor
+     RightColumnTabs    — Scoring · Dice · Board · Equip · Chat
+     DesktopBody · MobileBody · PhoneShell
+
+   ACCORDION (CRITICAL · match skeleton): la colonna LEFT replica il pattern
+   accordion (un solo pannello expanded; header collapsed = solo titolo;
+   aria-expanded). Esteso via helper sec(id) a ChatAgent · ActionLog ·
+   Survivor · Board · Spawn (riuso verbatim S.ChatAgentPanel · S.ActionLogTimeline).
+
+   Riusa: S.TopBar · S.ChatAgentPanel · S.ActionLogTimeline · R.ScoringPanelRenderer
+          (BinaryWin) · R.StateScaffold · M.StateBlock/Shimmer/SseBanner.
+   Legge window.ZOM (dati) · window.ZOMFlavor (atomi) · window.MAI (eHsl). */
+
+(function () {
+  const M = window.MAI;
+  const R = window.SkeletonRenderers;
+  const S = window.SkeletonParts;
+  const Z = window.ZOM;
+  const F = window.ZOMFlavor;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const { mono, disp } = F;
+
+  const STATES = window.SkeletonData.STATES;
+
+  // ─── SectionCard — contenitore titolato collassabile (accordion) ──────────
+  const SectionCard = ({ title, entity = 'session', accent, icon, right, children, pad = 12, flush, collapsed, onHeaderClick, sub }) => {
+    const collapsible = !!onHeaderClick;
+    const headStyle = { width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: accent ? eHsl(entity, collapsed ? 0.04 : 0.06) : 'var(--bg-muted)', border: 'none', borderBottom: collapsed ? 'none' : `1px solid ${accent ? eHsl(entity, 0.18) : 'var(--border-light)'}`, cursor: collapsible ? 'pointer' : 'default' };
+    const headInner = (
+      <React.Fragment>
+        {icon && <span aria-hidden="true" style={{ fontSize: 13, flexShrink: 0 }}>{icon}</span>}
+        <span style={{ ...mono(10, 800, accent ? eHsl(entity) : 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{title}</span>
+        {sub && <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{sub}</span>}
+        <div style={{ flex: 1 }} />{right}
+        {collapsible && <span aria-hidden="true" style={{ ...mono(11, 800, eHsl(entity)), flexShrink: 0, transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span>}
+      </React.Fragment>
+    );
+    return (
+      <section style={{ background: 'var(--bg-card)', border: `1px solid ${accent || collapsible ? eHsl(entity, collapsed ? 0.2 : 0.3) : 'var(--border)'}`, borderRadius: 'var(--r-lg)', overflow: 'hidden', boxShadow: 'var(--shadow-sm)', flexShrink: 0 }}>
+        {title && (collapsible
+          ? <button type="button" onClick={onHeaderClick} aria-expanded={!collapsed} style={headStyle}>{headInner}</button>
+          : <div style={headStyle}>{headInner}</div>)}
+        {!collapsed && <div style={{ padding: flush ? 0 : pad }}>{children}</div>}
+      </section>
+    );
+  };
+
+  // ─── PanelFrame — frame rail per la gallery degli stati ───────────────────
+  const PanelFrame = ({ label, entity = 'session', dark, children, w = 320, h = 470 }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} data-theme={dark ? 'dark' : undefined}>
+      <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</div>
+      <div style={{ width: w, height: h, borderRadius: 'var(--r-lg)', border: `1px solid ${eHsl(entity, 0.3)}`, background: 'var(--bg-card)', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: 'var(--shadow-sm)' }}>{children}</div>
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SurvivorCard — carta survivor ricca (skill tree + equip + ferite + AP)
+  // ══════════════════════════════════════════════════════════════════════════
+  const SurvivorCardInner = ({ s, layout = 'grid' }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 11, opacity: s.dead ? 0.82 : 1 }}>
+      {/* identità + stato */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 11, flexWrap: 'wrap', rowGap: 8 }}>
+        <F.SurvivorAvatar s={s} size={46} ring />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
+            <span style={{ ...disp(17, 800, 'var(--text)') }}>{s.name}</span>
+            <F.LevelChip level={s.level} />
+          </div>
+          <div style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{s.klass} · controllato da {s.player}</div>
+        </div>
+        <F.WoundPips wounds={s.wounds} dead={s.dead} />
+        <F.APCounter ap={s.ap} base={s.apBase} bonus={s.apBonus} />
+      </div>
+      {/* zona */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '6px 10px', borderRadius: 'var(--r-md)', background: eHsl('session', 0.06), border: `1px solid ${eHsl('session', 0.22)}` }}>
+        <span aria-hidden="true" style={{ ...mono(11, 800, eHsl('session')) }}>📍</span>
+        <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Zona</span>
+        <span style={{ ...disp(12, 800, 'var(--text)') }}>{s.zone}</span>
+      </div>
+      {/* XP */}
+      <F.XPBar xp={s.xp} level={s.level} />
+      {/* skill tree */}
+      <div>
+        <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Albero abilità · 4 livelli</div>
+        <F.SkillTree survivor={s} layout={layout} />
+      </div>
+      {/* equipaggiamento */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 6 }}>
+          <span style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Equipaggiamento</span>
+          <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>2 mani · corpo · zaino</span>
+        </div>
+        <F.EquipSlots survivor={s} cols={layout === 'rows' ? 2 : 4} />
+      </div>
+    </div>
+  );
+  const SurvivorCard = ({ state = 'default', survivor, layout = 'grid', collapsed, onHeaderClick }) => {
+    const s = survivor || Z.survivors[0];
+    return (
+      <SectionCard title={`Survivor · ${s.name}`} entity="session" accent icon="🧍" pad={12} collapsed={collapsed} onHeaderClick={onHeaderClick}
+        right={!collapsed && <F.LevelChip level={s.level} compact />}>
+        <R.StateScaffold state={state} sseWhere="survivor"
+          empty={{ icon: '🧍', title: 'Nessun survivor', body: 'I survivor compariranno alla creazione del gruppo.' }}
+          error={{ title: 'Survivor non disponibile', body: 'Impossibile caricare la scheda del survivor.' }}
+          loading={<div style={{ padding: 2, display: 'flex', flexDirection: 'column', gap: 10 }}>{[52, 36, 40, 90, 70].map((h, i) => <M.Shimmer key={i} h={h} />)}</div>}>
+          <SurvivorCardInner s={s} layout={layout} />
+        </R.StateScaffold>
+      </SectionCard>
+    );
+  };
+
+  // ─── SurvivorsRail — lista survivor (picker) + sintesi plancia ────────────
+  const SurvivorsRail = ({ activeId, onPick }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <SectionCard title="Gruppo survivor" entity="session" accent icon="👥" pad={9}
+        right={<span style={{ ...mono(8.5, 800, eHsl('session')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.12), border: `1px solid ${eHsl('session', 0.3)}` }}>{Z.survivors.filter(s => !s.dead).length}/{Z.survivors.length} vivi</span>}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {Z.survivors.map(s => {
+            const on = s.id === activeId;
+            return (
+              <button key={s.id} type="button" onClick={() => onPick && onPick(s.id)} aria-pressed={on} style={{
+                display: 'flex', alignItems: 'center', gap: 8, padding: '7px 8px', borderRadius: 'var(--r-md)', textAlign: 'left', cursor: onPick ? 'pointer' : 'default',
+                background: on ? eHsl('session', 0.1) : 'var(--bg-muted)', border: `1px solid ${on ? eHsl('session', 0.4) : 'var(--border-light)'}`,
+              }}>
+                <F.SurvivorAvatar s={s} size={28} ring={on} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                    <span style={{ ...disp(12.5, 800, 'var(--text)'), overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
+                    <F.LevelChip level={s.level} compact />
+                  </div>
+                  <div style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{s.klass} · ⚡{s.ap} · {s.killTotal} kill</div>
+                </div>
+                <F.WoundPips wounds={s.wounds} dead={s.dead} size={13} />
+              </button>
+            );
+          })}
+        </div>
+      </SectionCard>
+      <SectionCard title="Sintesi plancia" entity="event" icon="🧟" pad={10}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px', borderRadius: 'var(--r-md)', background: eHsl('event', 0.08), border: `1px solid ${eHsl('event', 0.25)}` }}>
+            <span aria-hidden="true" style={{ ...disp(22, 800, eHsl('event')), fontVariantNumeric: 'tabular-nums' }}>{Z.zombieTotal}</span>
+            <span style={{ ...mono(9, 700, 'var(--text-sec)'), lineHeight: 1.3 }}>zombie<br/>sulla plancia</span>
+          </div>
+          <F.DangerLevel current={Z.dangerLevel} reason={`XP top · ${Z.topSurvivor.name}`} />
+        </div>
+      </SectionCard>
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // BoardStatePanel — conteggi zombie + Danger Level + obiettivi
+  // ══════════════════════════════════════════════════════════════════════════
+  const BoardStateInner = ({ compact }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 12 }}>
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 8 }}>
+          <span style={{ ...mono(9, 800, eHsl('event')), textTransform: 'uppercase', letterSpacing: '.07em' }}>Zombie per tipo</span>
+          <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{Z.zombieTotal} totali</span>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: `repeat(auto-fill, minmax(${compact ? 130 : 150}px, 1fr))`, gap: 7 }} role="list" aria-label="Conteggi zombie per tipo">
+          {Z.ZORDER.map(t => <F.ZombieCounter key={t} type={t} count={Z.board[t]} big={!compact} />)}
+        </div>
+      </div>
+      <div style={{ padding: '9px 11px', borderRadius: 'var(--r-md)', background: eHsl('danger', 0.06), border: `1px solid ${eHsl('danger', 0.28)}` }}>
+        <F.DangerLevel current={Z.dangerLevel} reason={`pilotato da ${Z.topSurvivor.name} (XP ${Z.topSurvivor.xp})`} />
+        <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), marginTop: 7, lineHeight: 1.5 }}>{Z.DANGER.find(d => d.id === Z.dangerLevel).spawn} · determina l\u2019aggressività dello spawn nella Fase Finale.</div>
+      </div>
+      <div>
+        <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Obiettivi scenario</div>
+        <div role="list" style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {Z.objectives.map(o => <F.ObjectiveRow key={o.id} o={o} />)}
+        </div>
+      </div>
+    </div>
+  );
+  const BoardStatePanel = ({ state = 'default', compact, collapsed, onHeaderClick }) => (
+    <SectionCard title="Stato plancia" entity="event" accent icon="🧟" flush collapsed={collapsed} onHeaderClick={onHeaderClick}
+      right={!collapsed && <span style={{ ...mono(8.5, 800, eHsl('event')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.12), border: `1px solid ${eHsl('event', 0.3)}` }}>{Z.zombieTotal} zombie</span>}>
+      <R.StateScaffold state={state} sseWhere="plancia"
+        empty={{ icon: '🧟', title: 'Plancia pulita', body: 'Nessuno zombie in gioco · in attesa del primo spawn.' }}
+        error={{ title: 'Plancia non disponibile', body: 'Impossibile caricare lo stato della plancia.' }}
+        loading={<div style={{ padding: 14, display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>{Array.from({ length: 6 }).map((_, i) => <M.Shimmer key={i} h={52} />)}</div>}>
+        <BoardStateInner compact={compact} />
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // CombatDicePanel — D6 rollable (interattivo) + riferimento armi
+  // ══════════════════════════════════════════════════════════════════════════
+  const rollDice = (n) => Array.from({ length: n }, () => 1 + Math.floor(Math.random() * 6));
+  const CombatDiceInner = ({ compact }) => {
+    const [roll, setRoll] = useState(Z.combat.lastRoll);
+    const [rolling, setRolling] = useState(false);
+    const [wid, setWid] = useState(Z.combat.weaponId);
+    const w = Z.weaponsRef.find(x => x.id === wid) || Z.weaponsRef[0];
+    const threshold = Z.combat.threshold;
+    const diceCount = compact ? 5 : Z.combat.dice;
+    const hits = roll.filter(v => v >= threshold).length;
+    const doRoll = () => {
+      setRolling(true);
+      setRoll(rollDice(diceCount));
+      setTimeout(() => setRolling(false), 420);
+    };
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 12 }}>
+        {/* arma + soglia */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', rowGap: 8 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Arma</span>
+            <div role="group" aria-label="Seleziona arma" style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+              {Z.weaponsRef.map(x => {
+                const on = x.id === wid;
+                return <button key={x.id} type="button" onClick={() => setWid(x.id)} aria-pressed={on} style={{ padding: '3px 9px', borderRadius: 'var(--r-pill)', background: on ? eHsl('tool', 0.14) : 'var(--bg-muted)', border: `1px solid ${on ? eHsl('tool', 0.4) : 'var(--border-light)'}`, color: on ? eHsl('tool') : 'var(--text-sec)', ...disp(10.5, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>{x.lb}</button>;
+              })}
+            </div>
+          </div>
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 7, padding: '4px 10px', borderRadius: 'var(--r-md)', background: eHsl('toolkit', 0.08), border: `1px solid ${eHsl('toolkit', 0.3)}` }}>
+            <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>Colpo</span>
+            <span style={{ ...disp(15, 800, eHsl('toolkit')) }}>{threshold}+</span>
+          </div>
+        </div>
+        {/* tray */}
+        <div role="status" aria-live="polite" aria-label={`${hits} colpi su ${roll.length} dadi`} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: 'var(--bg-sunken)', border: '1px solid var(--border-light)', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <F.DiceTray roll={roll} threshold={threshold} size={compact ? 34 : 42} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+              <span style={{ ...disp(compact ? 24 : 30, 800, eHsl('toolkit')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{hits}</span>
+              <span style={{ ...mono(9.5, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>colpi</span>
+            </div>
+            <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>{roll.length} dadi · {roll.length - hits} mancati</span>
+            <button type="button" onClick={doRoll} disabled={rolling} style={{ marginLeft: 'auto', padding: '8px 16px', borderRadius: 'var(--r-md)', background: eHsl('tool'), color: '#06222b', border: 'none', ...disp(12.5, 800, '#06222b'), cursor: rolling ? 'default' : 'pointer', boxShadow: `0 3px 10px ${eHsl('tool', 0.35)}`, opacity: rolling ? 0.7 : 1 }}>🎲 {rolling ? 'Lancio…' : 'Tira i dadi'}</button>
+          </div>
+        </div>
+        {/* riferimento armi */}
+        <div>
+          <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Riferimento armi · gittata</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {Z.weaponsRef.map(x => <F.WeaponRefRow key={x.id} w={x} />)}
+          </div>
+        </div>
+      </div>
+    );
+  };
+  const CombatDicePanel = ({ state = 'default', compact, collapsed, onHeaderClick }) => (
+    <SectionCard title="Dadi combattimento" entity="tool" accent icon="🎲" flush collapsed={collapsed} onHeaderClick={onHeaderClick}
+      right={!collapsed && <span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>D6 · colpo {Z.combat.threshold}+</span>}>
+      <R.StateScaffold state={state} sseWhere="dadi"
+        empty={{ icon: '🎲', title: 'Nessun tiro', body: 'Tira i dadi durante un attacco per vedere i colpi.' }}
+        error={{ title: 'Dadi non disponibili', body: 'Impossibile caricare lo strumento dadi.' }}
+        loading={<div style={{ padding: 14, display: 'flex', gap: 8 }}>{Array.from({ length: 6 }).map((_, i) => <M.Shimmer key={i} h={42} style={{ width: 42 }} />)}</div>}>
+        <CombatDiceInner compact={compact} />
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SpawnDeckPanel — carte spawn rimaste · pesca per Danger Level
+  // ══════════════════════════════════════════════════════════════════════════
+  const SpawnDeckInner = () => {
+    const sd = Z.spawnDeck;
+    const pct = Math.round((sd.remaining / sd.total) * 100);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 11, padding: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 5 }}>
+            <span style={{ ...disp(32, 800, eHsl('event')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{sd.remaining}</span>
+            <span style={{ ...mono(10, 700, 'var(--text-muted)') }}>/ {sd.total} carte</span>
+          </div>
+          <div style={{ flex: 1, minWidth: 120 }}>
+            <div style={{ height: 10, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+              <div style={{ width: `${pct}%`, height: '100%', borderRadius: 'var(--r-pill)', background: eHsl('event') }} />
+            </div>
+            <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), marginTop: 4 }}>{pct}% del mazzo spawn rimasto · {sd.drawnThisRound} pescate questo round</div>
+          </div>
+        </div>
+        <div>
+          <div style={{ ...mono(9, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Pescate per Danger Level</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {sd.byDanger.map(d => {
+              const m = Z.levelMeta(d.level);
+              const on = d.level === Z.dangerLevel;
+              return (
+                <div key={d.level} aria-current={on ? 'true' : undefined} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 9px', borderRadius: 'var(--r-md)', background: on ? eHsl(m.e, 0.1) : 'var(--bg-muted)', border: `1px solid ${on ? eHsl(m.e, 0.4) : 'var(--border-light)'}` }}>
+                  <span aria-hidden="true" style={{ width: 9, height: 9, borderRadius: '50%', background: eHsl(m.e), flexShrink: 0 }} />
+                  <span style={{ flex: 1, ...disp(11.5, on ? 800 : 600, on ? eHsl(m.e) : 'var(--text-sec)') }}>Danger {m.lb}</span>
+                  {on && <span style={{ ...mono(7.5, 800, eHsl(m.e)), textTransform: 'uppercase' }}>attuale</span>}
+                  <span style={{ ...mono(10, 800, 'var(--text)') }}>{d.draws}× / spawn</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div style={{ ...mono(9, 700, 'var(--text-muted)'), lineHeight: 1.5, padding: '7px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>{Z.spawnDeck.note}</div>
+      </div>
+    );
+  };
+  const SpawnDeckPanel = ({ state = 'default', collapsed, onHeaderClick }) => (
+    <SectionCard title="Mazzo spawn" entity="event" accent icon="🃏" flush collapsed={collapsed} onHeaderClick={onHeaderClick}
+      right={!collapsed && <span style={{ ...mono(8.5, 800, eHsl('event')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.12), border: `1px solid ${eHsl('event', 0.3)}` }}>{Z.spawnDeck.remaining} rim.</span>}>
+      <R.StateScaffold state={state} sseWhere="spawn"
+        empty={{ icon: '🃏', title: 'Mazzo esaurito', body: 'Nessuna carta spawn rimasta · rimescola gli scarti.' }}
+        error={{ title: 'Mazzo non disponibile', body: 'Impossibile caricare il mazzo spawn.' }}
+        loading={<div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>{Array.from({ length: 4 }).map((_, i) => <M.Shimmer key={i} h={32} />)}</div>}>
+        <SpawnDeckInner />
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ─── MapPanel — snapshot tessere + mazzo spawn (tab Board) ────────────────
+  const MapPanel = ({ state = 'default', focusId, h = 340 }) => (
+    <SectionCard title="Mappa · tessere" entity="session" accent icon="🗺" flush
+      right={<span style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{Z.mapTiles.scenario}</span>}>
+      <R.StateScaffold state={state} sseWhere="mappa"
+        empty={{ icon: '🗺', title: 'Mappa vuota', body: 'Le tessere compariranno all\u2019avvio dello scenario.' }}
+        error={{ title: 'Mappa non disponibile', body: 'Impossibile caricare lo snapshot della mappa.' }}
+        loading={<div style={{ padding: 14 }}><M.Shimmer h={h - 20} /></div>}>
+        <div style={{ padding: 10 }}>
+          <F.MapTilesGrid focusId={focusId} />
+        </div>
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ─── EquipOverviewPanel — equip di tutti i survivor (tab Equip) ────────────
+  const EquipOverviewPanel = ({ state = 'default' }) => (
+    <R.StateScaffold state={state} sseWhere="equipaggiamento"
+      empty={{ icon: '🎒', title: 'Nessun equipaggiamento', body: 'Cerca nelle zone per trovare armi e oggetti.' }}
+      error={{ title: 'Equipaggiamento non disponibile', body: 'Impossibile caricare l\u2019inventario dei survivor.' }}
+      loading={<div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>{Array.from({ length: 4 }).map((_, i) => <M.Shimmer key={i} h={80} />)}</div>}>
+      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }} className="mai-cb-scroll">
+        {Z.survivors.map(s => (
+          <div key={s.id}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 6 }}>
+              <F.SurvivorAvatar s={s} size={22} />
+              <span style={{ ...disp(12.5, 800, 'var(--text)') }}>{s.name}</span>
+              <F.LevelChip level={s.level} compact />
+              {s.dead && <span style={{ ...mono(8, 800, eHsl('danger')), textTransform: 'uppercase' }}>a terra</span>}
+            </div>
+            <F.EquipSlots survivor={s} cols={2} />
+          </div>
+        ))}
+      </div>
+    </R.StateScaffold>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // RightColumnTabs — Scoring · Dice · Board · Equip · Chat
+  // ══════════════════════════════════════════════════════════════════════════
+  const RC_TABS = [
+    { id: 'scoring', icon: '🎯', label: 'Scoring', entity: 'session', stateful: true,  render: (st) => <R.ScoringPanelRenderer data={Z.ds} state={st} /> },
+    { id: 'dice',    icon: '🎲', label: 'Dice',    entity: 'tool',    stateful: false, render: (st) => <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}><CombatDicePanel state={st} compact /></div> },
+    { id: 'board',   icon: '🗺', label: 'Board',   entity: 'event',   stateful: true,  render: (st) => <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }} className="mai-cb-scroll"><MapPanel state={st} focusId="s-bruno" /><SpawnDeckPanel state={st} /></div> },
+    { id: 'equip',   icon: '🎒', label: 'Equip',   entity: 'kb',      stateful: true,  render: (st) => <EquipOverviewPanel state={st} /> },
+    { id: 'chat',    icon: '💬', label: 'Chat',    entity: 'agent',   stateful: false, render: () => <div style={{ flex: 1, minHeight: 0, padding: 12, display: 'flex' }}><S.ChatAgentPanel ds={Z.ds} /></div> },
+  ];
+  const RightColumnTabs = ({ initial = 'scoring', initialState = 'default', embedded }) => {
+    const [tab, setTab] = useState(initial);
+    const [st, setSt] = useState(initialState);
+    const active = RC_TABS.find(t => t.id === tab) || RC_TABS[0];
+    return (
+      <aside aria-label="Pannello sessione" style={{ width: embedded ? '100%' : 348, minWidth: embedded ? 0 : 300, flexShrink: 0, height: '100%', background: 'var(--bg-card)', borderLeft: embedded ? 'none' : '1px solid var(--border)', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <div role="tablist" aria-label="Sezioni" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0, overflow: 'hidden' }}>
+          {RC_TABS.map(t => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} onClick={() => setTab(t.id)} style={{ flex: '1 1 0', minWidth: 0, padding: '10px 3px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(10.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, whiteSpace: 'nowrap' }}>
+                <span aria-hidden="true" style={{ fontSize: 12, flexShrink: 0 }}>{t.icon}</span><span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        {active.stateful && <S.StateSwitch value={st} onChange={setSt} />}
+        <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+      </aside>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // DESKTOP body — banner fase + danger · rail survivor · accordion · tabs
+  // ══════════════════════════════════════════════════════════════════════════
+  const DesktopBody = ({ initialTab, initialState }) => {
+    const [focusId, setFocusId] = useState('s-bruno');
+    const [expanded, setExpanded] = useState('survivor');
+    const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
+    const survivor = Z.byId(focusId);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <F.PhaseTimeline />
+        {/* danger strip */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 16px', background: 'var(--bg-card)', borderBottom: '1px solid var(--border)', flexWrap: 'wrap', rowGap: 6, flexShrink: 0 }}>
+          <F.DangerLevel current={Z.dangerLevel} reason={`pilotato da ${Z.topSurvivor.name} (XP ${Z.topSurvivor.xp})`} />
+          <span aria-hidden="true" style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)', flexShrink: 0 }} />
+          <span style={{ ...mono(9, 700, 'var(--text-sec)') }}>🧟 {Z.zombieTotal} zombie · 🃏 {Z.spawnDeck.remaining} spawn · ★ {Z.objectives.filter(o => o.done).length}/{Z.objectives.length} obiettivi</span>
+        </div>
+        <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+          {/* LEFT — survivors rail */}
+          <div className="mai-cb-scroll" style={{ width: 258, flexShrink: 0, borderRight: '1px solid var(--border)', overflowY: 'auto', padding: 12, background: 'var(--bg)' }}>
+            <SurvivorsRail activeId={focusId} onPick={setFocusId} />
+          </div>
+          {/* CENTER — accordion (un solo pannello expanded · include ChatAgent + ActionLog) */}
+          <main className="mai-cb-scroll" style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 10, background: 'var(--bg)' }}>
+            <SurvivorCard survivor={survivor} {...sec('survivor')} />
+            <BoardStatePanel {...sec('board')} />
+            <SpawnDeckPanel {...sec('spawn')} />
+            <S.ChatAgentPanel ds={Z.ds} {...sec('chat')} />
+            <S.ActionLogTimeline ds={Z.ds} {...sec('log')} />
+          </main>
+          {/* RIGHT — tabs */}
+          <RightColumnTabs initial={initialTab} initialState={initialState} />
+        </div>
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // MOBILE — banner fase sticky · accordion scroll · tab strip → bottom sheet
+  //          + survivor card in bottom-sheet drawer al tap
+  // ══════════════════════════════════════════════════════════════════════════
+  const BottomSheet = ({ open, label, icon, entity, onClose, children, stateSwitch }) => (
+    <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+      <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(8,12,8,.55)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+      <div role="dialog" aria-modal="true" aria-label={label} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '86%', background: 'var(--bg-card)', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl(entity)}`, boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 8, flexShrink: 0 }}>
+          <div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px 10px', flexShrink: 0 }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>{icon}</span>
+          <span style={{ ...disp(15, 800, eHsl(entity)) }}>{label}</span>
+          <div style={{ flex: 1 }} />
+          <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+        </div>
+        {stateSwitch}
+        <div className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflowY: 'auto' }}>{children}</div>
+      </div>
+    </div>
+  );
+
+  const MobileTabSheet = ({ open, tab, st, setSt, onClose }) => {
+    const active = RC_TABS.find(t => t.id === tab) || RC_TABS[0];
+    return (
+      <BottomSheet open={open} label={active.label} icon={active.icon} entity={active.entity} onClose={onClose}
+        stateSwitch={active.stateful ? <S.StateSwitch value={st} onChange={setSt} /> : null}>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+      </BottomSheet>
+    );
+  };
+
+  const MobileBody = ({ initialTab }) => {
+    const [sheet, setSheet] = useState(initialTab || null);
+    const [st, setSt] = useState('default');
+    const [survDrawer, setSurvDrawer] = useState(null);
+    const [expanded, setExpanded] = useState('survivor');
+    const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
+    const drawerSurv = survDrawer ? Z.byId(survDrawer) : null;
+    return (
+      <>
+        <F.PhaseTimeline compact sticky />
+        <div className="mai-cb-scroll" style={{ flex: 1, overflowY: 'auto', minHeight: 0, background: 'var(--bg)' }}>
+          {/* danger + survivor chips (tap → drawer) */}
+          <div style={{ padding: '9px 12px', display: 'flex', flexDirection: 'column', gap: 9, borderBottom: '1px solid var(--border)', background: 'var(--bg-card)' }}>
+            <F.DangerLevel current={Z.dangerLevel} compact reason={Z.topSurvivor.name} />
+            <div className="mai-cb-scroll" style={{ display: 'flex', gap: 6, overflowX: 'auto' }}>
+              {Z.survivors.map(s => (
+                <button key={s.id} type="button" onClick={() => setSurvDrawer(s.id)} style={{ flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px 4px 4px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', cursor: 'pointer' }}>
+                  <F.SurvivorAvatar s={s} size={22} />
+                  <span style={{ ...disp(11, 800, 'var(--text)') }}>{s.name}</span>
+                  <F.WoundPips wounds={s.wounds} dead={s.dead} size={11} />
+                </button>
+              ))}
+            </div>
+          </div>
+          <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <SurvivorCard survivor={Z.survivors[0]} layout="rows" {...sec('survivor')} />
+            <BoardStatePanel compact {...sec('board')} />
+            <SpawnDeckPanel {...sec('spawn')} />
+            <S.ChatAgentPanel ds={Z.ds} compact {...sec('chat')} />
+            <S.ActionLogTimeline ds={Z.ds} compact {...sec('log')} />
+          </div>
+        </div>
+        <nav aria-label="Sezioni sessione" style={{ display: 'flex', gap: 5, flexShrink: 0, padding: '8px 8px', background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderTop: '1px solid var(--border)' }}>
+          {RC_TABS.map(t => (
+            <button key={t.id} type="button" onClick={() => { setSt('default'); setSheet(t.id); }} style={{ flex: '1 1 0', minWidth: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, padding: '7px 4px', borderRadius: 'var(--r-pill)', background: eHsl(t.entity, 0.1), border: `1px solid ${eHsl(t.entity, 0.28)}`, color: eHsl(t.entity), ...disp(10.5, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true" style={{ flexShrink: 0 }}>{t.icon}</span><span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label}</span>
+            </button>
+          ))}
+        </nav>
+        <MobileTabSheet open={!!sheet} tab={sheet} st={st} setSt={setSt} onClose={() => setSheet(null)} />
+        {/* survivor bottom-sheet drawer al tap */}
+        <BottomSheet open={!!drawerSurv} label={drawerSurv ? `Survivor · ${drawerSurv.name}` : ''} icon="🧍" entity="session" onClose={() => setSurvDrawer(null)}>
+          {drawerSurv && <div style={{ padding: 12 }}><SurvivorCardInner s={drawerSurv} layout="rows" /></div>}
+        </BottomSheet>
+      </>
+    );
+  };
+
+  // ─── PhoneShell ───────────────────────────────────────────────────────────
+  const PhoneSbar = () => (
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>21:14</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+  );
+  const PhoneShell = ({ label, desc, dark, initialTab }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+      <div className="phone" data-theme={dark ? 'dark' : undefined}>
+        <PhoneSbar />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <S.TopBar ds={Z.ds} compact />
+          <MobileBody initialTab={initialTab} />
+        </div>
+      </div>
+      {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 340, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  window.ZOMParts = {
+    STATES, SectionCard, PanelFrame,
+    SurvivorCard, SurvivorCardInner, SurvivorsRail, BoardStatePanel, CombatDicePanel,
+    SpawnDeckPanel, MapPanel, EquipOverviewPanel, RightColumnTabs,
+    DesktopBody, MobileBody, PhoneShell,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-zombicide-summary.html
+++ b/admin-mockups/design_files/sp4-session-zombicide-summary.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Zombicide: Green Horde · Summary — /sessions/[id]/summary</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-zombicide-summary.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-zombicide-summary.jsx
+++ b/admin-mockups/design_files/sp4-session-zombicide-summary.jsx
@@ -1,0 +1,437 @@
+/* MeepleAI SP4 · Zombicide: Green Horde — SESSION SUMMARY  (App)
+   /sessions/[id]/summary — riepilogo post-partita di Zombicide GH.
+
+   Hero: banner VITTORIA / SCONFITTA large.
+     · VITTORIA → nome missione + survivor vivi + XP totali guadagnati
+     · SCONFITTA → causa (tutti morti / civile ucciso / Necromancer fuggito / timeout)
+   Tab: Scoreboard (BinaryWin · obiettivi check/cross + survivor vivi + XP per survivor) ·
+        Survivors (skill tree finale · livello · kill per tipo · ferite · armi) ·
+        Board (snapshot tessere finale + zombie uccisi per tipo · istogramma) ·
+        Stats (turni, XP/turno, kill ratio, tiri medi, armi più usate, Danger per round).
+
+   Riusa: OutcomeBadge · ComputationBadge · ScoringPanelRenderer atoms · MapTilesGrid ·
+          SurvivorAvatar · SkillTree · WoundPips · LevelChip · atomi ZOM.
+   Carica gli stessi deps del live + QUESTO file.
+   DEMO-NAV-HINTS: sp4-session-zombicide-live.html
+*/
+
+const M = window.MAI;
+const R = window.SkeletonRenderers;
+const S = window.SkeletonParts;
+const Z = window.ZOM;
+const F = window.ZOMFlavor;
+const P = window.ZOMParts;
+const eHsl = M.entityHsl;
+const { useState, useEffect } = React;
+const { mono, disp } = F;
+const SUM = Z.summary;
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+const totalXp = (sum) => sum.survivors.reduce((a, s) => a + s.xp, 0);
+
+// ─── Hero — banner VITTORIA / SCONFITTA ───────────────────────────────────
+const SummaryHero = ({ sum = SUM, compact }) => {
+  const win = sum.result === 'victory';
+  const e = win ? 'toolkit' : 'danger';
+  const xp = totalXp(sum);
+  return (
+    <div role="status" style={{ position: 'relative', borderRadius: 'var(--r-xl)', overflow: 'hidden', border: `1px solid ${eHsl(e, 0.4)}`, background: `linear-gradient(135deg, ${eHsl(e, 0.14)}, ${eHsl('session', 0.06)})`, boxShadow: 'var(--shadow-md)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 12 : 18, padding: compact ? 14 : 22, flexWrap: 'wrap' }}>
+        <div style={{ width: compact ? 54 : 70, height: compact ? 66 : 88, borderRadius: 'var(--r-md)', background: Z.game.cover, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: compact ? 26 : 36, boxShadow: 'var(--shadow-sm)' }} aria-hidden="true">{Z.game.emoji}</div>
+        <div style={{ flex: 1, minWidth: 200 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 5 }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '3px 11px', borderRadius: 'var(--r-pill)', background: eHsl(e, 0.16), color: eHsl(e), border: `1px solid ${eHsl(e, 0.4)}`, ...mono(10, 800), textTransform: 'uppercase', letterSpacing: '.08em' }}>
+              <span aria-hidden="true">{win ? '🏆' : '☠'}</span>{win ? 'Vittoria' : 'Sconfitta'}
+            </span>
+            <span style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{Z.game.title} · {sum.rounds} round · {sum.turns} turni</span>
+          </div>
+          <h2 style={{ ...disp(compact ? 24 : 34, 800, 'var(--text)'), margin: '2px 0 4px' }}>
+            {win ? <>Missione completata <span aria-hidden="true">🏆</span></> : <>Gruppo annientato <span aria-hidden="true">☠</span></>}
+          </h2>
+          <div style={{ ...mono(11, 700, 'var(--text-sec)'), lineHeight: 1.5 }}>
+            {win
+              ? <>Scenario <strong style={{ color: 'var(--text)' }}>"{sum.mission}"</strong> · obiettivi raggiunti con {sum.survivorsAlive}/{sum.survivorsTotal} survivor vivi.</>
+              : <>Scenario <strong style={{ color: 'var(--text)' }}>"{sum.mission}"</strong> · causa: <strong style={{ color: eHsl('danger') }}>{sum.defeatCause}</strong>.</>}
+          </div>
+        </div>
+        {/* metriche primarie */}
+        <div style={{ display: 'flex', gap: 10, flexShrink: 0 }}>
+          <div style={{ textAlign: 'center', padding: '10px 16px', borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: `1px solid ${eHsl(win ? 'toolkit' : 'danger', 0.3)}` }}>
+            <div style={{ ...disp(compact ? 28 : 38, 800, eHsl(win ? 'toolkit' : 'danger')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{sum.survivorsAlive}<span style={{ ...disp(compact ? 16 : 20, 800, 'var(--text-muted)') }}>/{sum.survivorsTotal}</span></div>
+            <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em', marginTop: 3 }}>survivor vivi</div>
+          </div>
+          <div style={{ textAlign: 'center', padding: '10px 16px', borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: '1px solid var(--border)' }}>
+            <div style={{ ...disp(compact ? 26 : 34, 800, eHsl('game')), fontVariantNumeric: 'tabular-nums', lineHeight: 1, marginTop: compact ? 2 : 4 }}>{xp}</div>
+            <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em', marginTop: 3 }}>XP totali</div>
+          </div>
+        </div>
+      </div>
+      <div style={{ ...mono(9, 700, 'var(--text-muted)'), padding: '6px 16px', borderTop: '1px solid var(--border-light)', background: 'var(--glass-bg)' }}>
+        BinaryWin · co-op · {sum.objectives.filter(o => o.done).length}/{sum.objectives.length} obiettivi completati · Danger Level finale <strong style={{ color: eHsl(Z.levelMeta(sum.dangerByRound[sum.dangerByRound.length - 1].level).e) }}>{Z.levelMeta(sum.dangerByRound[sum.dangerByRound.length - 1].level).lb}</strong>
+      </div>
+    </div>
+  );
+};
+
+// ─── Scoreboard (BinaryWin) — obiettivi + survivor vivi + XP per survivor ──
+const ScoreboardPanel = ({ state = 'default' }) => (
+  <R.StateScaffold state={state} sseWhere="esito"
+    empty={{ icon: '🏆', title: 'Nessun esito', body: 'L\u2019esito comparirà a partita conclusa.' }}
+    error={{ title: 'Esito non disponibile', body: 'Impossibile caricare il riepilogo della missione.' }}
+    loading={<div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>{Array.from({ length: 5 }).map((_, i) => <M.Shimmer key={i} h={44} />)}</div>}>
+    <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* condizioni BinaryWin */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <span style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Condizioni di vittoria</span>
+          <span style={{ ...mono(9, 800, eHsl('session')), padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.12), border: `1px solid ${eHsl('session', 0.3)}`, textTransform: 'uppercase' }}>scoreType · BinaryWin</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {Z.ds.scoring.categories.map(cat => (
+            <div key={cat.id} title={cat.description} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+              <R.ComputationBadge c={cat.computation} />
+              <span style={{ flex: 1, minWidth: 0, ...disp(12, 700, 'var(--text)') }}>{cat.label}</span>
+              <span style={{ ...mono(9.5, 800, cat.weight > 0 ? eHsl('toolkit') : 'var(--text-muted)') }}>{cat.weight > 0 ? 'vince' : 'info'}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* obiettivi missione */}
+      <div>
+        <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Obiettivi missione</div>
+        <div role="list" style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {SUM.objectives.map(o => (
+            <div key={o.id} role="listitem" style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 'var(--r-md)', background: o.done ? eHsl('toolkit', 0.07) : eHsl('danger', 0.06), border: `1px solid ${o.done ? eHsl('toolkit', 0.28) : eHsl('danger', 0.25)}` }}>
+              <span aria-hidden="true" style={{ width: 20, height: 20, borderRadius: '50%', flexShrink: 0, background: o.done ? eHsl('toolkit') : eHsl('danger'), color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', ...mono(11, 800) }}>{o.done ? '✓' : '✕'}</span>
+              <span style={{ flex: 1, ...disp(12.5, 700, 'var(--text)') }}>{o.label}</span>
+              <span style={{ ...mono(9, 800, o.done ? eHsl('toolkit') : eHsl('danger')), textTransform: 'uppercase' }}>{o.done ? 'fatto' : 'fallito'}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* survivor vivi + XP */}
+      <div>
+        <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 6 }}>Survivor · stato finale + XP</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {SUM.survivors.map(s => (
+            <div key={s.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 'var(--r-md)', background: s.dead ? eHsl('danger', 0.05) : 'var(--bg-card)', border: `1px solid ${s.dead ? eHsl('danger', 0.25) : 'var(--border)'}` }}>
+              <F.SurvivorAvatar s={s} size={30} dead={s.dead} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{ ...disp(13.5, 800, 'var(--text)') }}>{s.name}</span>
+                  <F.LevelChip level={s.level} compact />
+                </div>
+                <div style={{ ...mono(8.5, 700, 'var(--text-muted)') }}>{s.klass} · {Object.values(s.kills).reduce((a, b) => a + b, 0)} kill</div>
+              </div>
+              <F.WoundPips wounds={s.wounds} dead={s.dead} size={14} />
+              <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                <div style={{ ...disp(18, 800, eHsl('game')), fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>{s.xp}</div>
+                <div style={{ ...mono(7.5, 800, 'var(--text-muted)'), textTransform: 'uppercase' }}>XP</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </R.StateScaffold>
+);
+
+// ─── Survivors tab — skill tree finale · kill per tipo · armi ──────────────
+const SurvivorsTab = ({ state = 'default' }) => (
+  <R.StateScaffold state={state} sseWhere="survivor"
+    empty={{ icon: '🧍', title: 'Nessun survivor', body: 'I dettagli compariranno a fine partita.' }}
+    error={{ title: 'Survivor non disponibili', body: 'Impossibile caricare le schede finali.' }}>
+    <div className="mai-cb-scroll" style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 14, overflowY: 'auto', flex: 1, minHeight: 0 }}>
+      {SUM.survivors.map(s => {
+        const survForTree = Z.byId(s.id) || s;
+        return (
+          <div key={s.id} style={{ borderRadius: 'var(--r-lg)', border: `1px solid ${s.dead ? eHsl('danger', 0.3) : 'var(--border)'}`, background: 'var(--bg-card)', overflow: 'hidden' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '9px 11px', background: s.dead ? eHsl('danger', 0.06) : 'var(--bg-muted)', borderBottom: '1px solid var(--border-light)', flexWrap: 'wrap', rowGap: 6 }}>
+              <F.SurvivorAvatar s={s} size={30} dead={s.dead} />
+              <span style={{ ...disp(14, 800, 'var(--text)') }}>{s.name}</span>
+              <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>{s.klass}</span>
+              <F.LevelChip level={s.level} compact />
+              <div style={{ flex: 1 }} />
+              <F.WoundPips wounds={s.wounds} dead={s.dead} size={14} />
+              <span style={{ ...disp(16, 800, eHsl('game')), fontVariantNumeric: 'tabular-nums' }}>{s.xp} XP</span>
+            </div>
+            <div style={{ padding: 11, display: 'flex', flexDirection: 'column', gap: 11 }}>
+              <F.SkillTree survivor={survForTree} layout="rows" />
+              {/* kill per tipo */}
+              <div>
+                <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 5 }}>Eliminazioni per tipo</div>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  {Z.ZORDER.map(t => (
+                    <span key={t} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '3px 8px 3px 3px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)', opacity: s.kills[t] ? 1 : 0.45 }}>
+                      <F.ZombieToken type={t} size={15} />
+                      <span style={{ ...mono(10, 800, s.kills[t] ? 'var(--text)' : 'var(--text-muted)'), fontVariantNumeric: 'tabular-nums' }}>{s.kills[t]}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+              {/* armi usate */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Armi</span>
+                {s.weapons.map(w => <span key={w} style={{ ...mono(9.5, 700, 'var(--text-sec)'), padding: '2px 9px', borderRadius: 'var(--r-pill)', background: eHsl('kb', 0.08), border: `1px solid ${eHsl('kb', 0.25)}`, color: eHsl('kb') }}>{w}</span>)}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  </R.StateScaffold>
+);
+
+// ─── Board final tab — snapshot tessere + zombie uccisi per tipo ───────────
+const BoardFinalTab = ({ state = 'default' }) => {
+  const kills = SUM.zombieKills;
+  const max = Math.max(...Object.values(kills));
+  const totalKills = Object.values(kills).reduce((a, b) => a + b, 0);
+  return (
+    <R.StateScaffold state={state} sseWhere="plancia"
+      empty={{ icon: '🗺', title: 'Nessuna plancia', body: 'Lo snapshot finale comparirà a partita conclusa.' }}
+      error={{ title: 'Plancia non disponibile', body: 'Impossibile caricare lo snapshot finale.' }}
+      loading={<div style={{ padding: 14 }}><M.Shimmer h={200} /></div>}>
+      <div className="mai-cb-scroll" style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 16, overflowY: 'auto', flex: 1, minHeight: 0 }}>
+        <div>
+          <div style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 8 }}>Snapshot finale · {Z.mapTiles.scenario}</div>
+          <F.MapTilesGrid />
+        </div>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 9 }}>
+            <span style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>Zombie eliminati per tipo</span>
+            <span style={{ ...mono(9, 800, eHsl('event')) }}>{totalKills} totali</span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {Z.ZORDER.map(t => {
+              const z = Z.ZTYPES[t];
+              return (
+                <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, width: 122, flexShrink: 0 }}>
+                    <F.ZombieToken type={t} size={18} />
+                    <span style={{ ...disp(11, 800, 'var(--text)'), whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{z.lb}</span>
+                  </span>
+                  <div style={{ flex: 1, height: 18, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+                    <div style={{ width: `${(kills[t] / max) * 100}%`, height: '100%', borderRadius: 'var(--r-pill)', background: z.color, minWidth: 3 }} />
+                  </div>
+                  <span style={{ ...mono(11, 800, 'var(--text)'), width: 30, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{kills[t]}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </R.StateScaffold>
+  );
+};
+
+// ─── Stats tab — turni · XP/turno · kill ratio · armi · danger per round ───
+const StatsTab = () => {
+  const st = SUM.stats;
+  const maxKill = Math.max(...SUM.survivors.map(s => Object.values(s.kills).reduce((a, b) => a + b, 0)));
+  const maxUse = Math.max(...st.mostUsedWeapons.map(w => w.uses));
+  return (
+    <div className="mai-cb-scroll" style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 16, overflowY: 'auto', flex: 1, minHeight: 0 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 8 }}>
+        {st.facts.map(f => (
+          <div key={f.lb} style={{ padding: '9px 11px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+            <div style={{ ...disp(20, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{f.v}</div>
+            <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>{f.lb}</div>
+          </div>
+        ))}
+        <div style={{ padding: '9px 11px', borderRadius: 'var(--r-md)', background: eHsl('game', 0.08), border: `1px solid ${eHsl('game', 0.28)}` }}>
+          <div style={{ ...disp(20, 800, eHsl('game')), fontVariantNumeric: 'tabular-nums' }}>{st.avgXpPerTurn}</div>
+          <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>XP / turno medio</div>
+        </div>
+      </div>
+      {/* kill ratio per survivor */}
+      <div>
+        <div style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 9 }}>Kill ratio per survivor</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {SUM.survivors.map(s => {
+            const k = Object.values(s.kills).reduce((a, b) => a + b, 0);
+            return (
+              <div key={s.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <F.SurvivorAvatar s={s} size={22} dead={s.dead} />
+                <span style={{ ...disp(11.5, 800, 'var(--text)'), width: 52, flexShrink: 0 }}>{s.name}</span>
+                <div style={{ flex: 1, height: 16, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+                  <div style={{ width: `${(k / maxKill) * 100}%`, height: '100%', borderRadius: 'var(--r-pill)', background: `hsl(${s.hue},58%,52%)`, minWidth: 3 }} />
+                </div>
+                <span style={{ ...mono(10, 800, 'var(--text)'), width: 28, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{k}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      {/* armi più usate */}
+      <div>
+        <div style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 9 }}>Armi più usate</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          {st.mostUsedWeapons.map(w => (
+            <div key={w.name} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ ...mono(9.5, 700, 'var(--text-sec)'), width: 96, flexShrink: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{w.name}</span>
+              <div style={{ flex: 1, height: 16, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden' }}>
+                <div style={{ width: `${(w.uses / maxUse) * 100}%`, height: '100%', borderRadius: 'var(--r-pill)', background: eHsl(w.e) }} />
+              </div>
+              <span style={{ ...mono(10, 800, 'var(--text)'), width: 28, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{w.uses}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* danger level per round */}
+      <div>
+        <div style={{ ...mono(9.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 9 }}>Danger Level per round</div>
+        <div style={{ display: 'flex', alignItems: 'flex-end', gap: 4 }}>
+          {SUM.dangerByRound.map(d => {
+            const m = Z.levelMeta(d.level);
+            const hgt = { blue: 22, yellow: 38, orange: 56, red: 74 }[d.level];
+            return (
+              <div key={d.round} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+                <div title={`Round ${d.round} · ${m.lb}`} style={{ width: '100%', height: hgt, borderRadius: 'var(--r-sm)', background: eHsl(m.e), border: `1px solid ${eHsl(m.e)}` }} />
+                <span style={{ ...mono(7.5, 700, 'var(--text-muted)') }}>R{d.round}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div style={{ display: 'flex', gap: 10, marginTop: 8, flexWrap: 'wrap' }}>
+          {Z.LEVELS.map(l => <span key={l.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, ...mono(8.5, 700, 'var(--text-sec)') }}><span style={{ width: 9, height: 9, borderRadius: 2, background: eHsl(l.e) }} />{l.lb}</span>)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Summary body (tabs) ──────────────────────────────────────────────────
+const SUM_TABS = [
+  { id: 'scoreboard', icon: '🏆', label: 'Scoreboard', entity: 'toolkit', stateful: true,  render: (st) => <ScoreboardPanel state={st} /> },
+  { id: 'survivors',  icon: '🧍', label: 'Survivors',  entity: 'session', stateful: false, render: (st) => <SurvivorsTab state={st} /> },
+  { id: 'board',      icon: '🗺', label: 'Board',      entity: 'event',   stateful: true,  render: (st) => <BoardFinalTab state={st} /> },
+  { id: 'stats',      icon: '📊', label: 'Stats',      entity: 'player',  stateful: false, render: () => <StatsTab /> },
+];
+const SummaryBody = ({ initial = 'scoreboard', states, embedded }) => {
+  const [tab, setTab] = useState(initial);
+  const [st, setSt] = useState('default');
+  const active = SUM_TABS.find(t => t.id === tab) || SUM_TABS[0];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, background: 'var(--bg-card)' }}>
+      <div role="tablist" aria-label="Sezioni riepilogo" className="mai-cb-scroll" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0, overflowX: 'auto', background: 'var(--bg-card)' }}>
+        {SUM_TABS.map(t => {
+          const on = tab === t.id;
+          return (
+            <button key={t.id} type="button" role="tab" aria-selected={on} onClick={() => { setTab(t.id); setSt('default'); }} style={{ flex: '1 0 auto', padding: '11px 14px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(12.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6, whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true" style={{ fontSize: 14 }}>{t.icon}</span>{t.label}
+            </button>
+          );
+        })}
+      </div>
+      {states && active.stateful && <S.StateSwitch value={st} onChange={setSt} />}
+      <div role="tabpanel" className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>{active.render(st)}</div>
+    </div>
+  );
+};
+
+// ─── App ──────────────────────────────────────────────────────────────────
+const StatesRow = ({ title, sub, entity, render }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ ...disp(15, 800, eHsl(entity)) }}>{title}</span>
+      {sub && <span style={{ ...mono(10, 700, 'var(--text-muted)') }}>{sub}</span>}
+    </div>
+    <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>
+      {P.STATES.map(s => <P.PanelFrame key={s.id} label={s.lb} entity={entity} dark={s.id === 'sse'} w={340}>{render(s.id)}</P.PanelFrame>)}
+    </div>
+  </div>
+);
+
+// scheda DEFEAT alternativa (showcase)
+const DEFEAT = { ...SUM, result: 'defeat', survivorsAlive: 0, defeatCause: 'Tutti i survivor a terra',
+  objectives: SUM.objectives.map((o, i) => ({ ...o, done: i < 1 })) };
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ ...mono(11, 600, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Zombicide: Green Horde · Summary 🏁 · estensione skeleton</div>
+        <h1>Session summary — Zombicide: Green Horde</h1>
+        <p className="lead">
+          Riepilogo post-partita per <code>/sessions/[id]/summary</code>. Hero con esito <strong>VITTORIA / SCONFITTA</strong>
+          (missione, survivor vivi, XP totali · oppure causa della sconfitta), poi quattro tab:
+          <strong> Scoreboard</strong> (BinaryWin · obiettivi + survivor + XP),
+          <strong> Survivors</strong> (skill tree finale, kill per tipo, armi),
+          <strong> Board</strong> (snapshot tessere + zombie uccisi per tipo) e
+          <strong> Stats</strong> (turni, XP/turno, kill ratio, armi, Danger per round). Dark = primaria.
+        </p>
+
+        <div className="section-label">Hero · esito + metriche primarie (vittoria)</div>
+        <SummaryHero />
+
+        <div className="section-label">Hero · variante sconfitta (causa esplicita)</div>
+        <SummaryHero sum={DEFEAT} />
+
+        <div className="section-label">Interattivo · Desktop 1280 — tab Scoreboard / Survivors / Board / Stats</div>
+        <S.DesktopFrame ds={{ ...Z.ds, session: { elapsed: '1h 38min' } }} dark label="Desktop · summary · Zombicide GH" url="meepleai.app/sessions/zom-4/summary" height={600}
+          desc="Tab Scoreboard: condizioni BinaryWin + obiettivi check/cross + survivor vivi e XP. Tab Survivors: skill tree finale, kill per tipo, armi usate. Tab Board: snapshot tessere + istogramma zombie uccisi. Tab Stats: kill ratio, armi più usate, Danger Level per round.">
+          <S.TopBar ds={{ ...Z.ds, session: { elapsed: '1h 38min' } }} connection="offline" />
+          <SummaryBody states />
+        </S.DesktopFrame>
+
+        <div className="section-label">Mobile 375 — hero + tab in colonna</div>
+        <div className="phones-grid">
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+            <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>01 · Scoreboard</div>
+            <div className="phone">
+              <div className="phone-sbar" style={{ color: 'var(--text)' }}><span style={{ fontFamily: 'var(--f-mono)' }}>22:51</span><div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div></div>
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', overflow: 'hidden', minHeight: 0 }}>
+                <div style={{ padding: 10 }}><SummaryHero compact /></div>
+                <SummaryBody initial="scoreboard" />
+              </div>
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }} data-theme="dark">
+            <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>02 · Survivors · dark</div>
+            <div className="phone" data-theme="dark">
+              <div className="phone-sbar" style={{ color: 'var(--text)' }}><span style={{ fontFamily: 'var(--f-mono)' }}>22:52</span><div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div></div>
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', overflow: 'hidden', minHeight: 0 }}>
+                <div style={{ padding: 10 }}><SummaryHero compact /></div>
+                <SummaryBody initial="survivors" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="section-label">Gallery stati · Scoreboard × 5 stati canonici</div>
+        <StatesRow title="ScoreboardPanel" sub="default · empty · loading · error · sse-disconnect" entity="toolkit"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto' }}><ScoreboardPanel state={st} /></div>} />
+        <StatesRow title="BoardFinalTab" sub="snapshot tessere + zombie uccisi per tipo" entity="event"
+          render={(st) => <div style={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column' }}><BoardFinalTab state={st} /></div>} />
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; width: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

Mockup **#5 di 7** della pipeline B19. Zombicide Green Horde (co-op miniatures dungeon-crawler, 1-6 players, ~60-90 min/scenario).

## ✨ Accordion pattern

**16 utilizzi** in `sp4-session-zombicide-parts.jsx` con helper `sec(id)` coerente con skeleton + Power Grid.

## Files (7 in admin-mockups/design_files/)

- sp4-session-zombicide-live.html / .jsx
- sp4-session-zombicide-summary.html / .jsx
- sp4-session-zombicide-data.jsx (survivor + zombie + scenario dataset)
- sp4-session-zombicide-flavor.jsx (6 component: SurvivorCard, BoardStatePanel, CombatDicePanel, SpawnDeckIndicator, PhaseTimeline, MapTilesGrid)
- sp4-session-zombicide-parts.jsx (SectionCard accordion + sec helper)

## Mechanics

- Survivor cards: skill tree 4 levels (Blue→Yellow→Orange→Red) + equipment + wounds (0-2) + AP
- 10 counter types: HP, XP, AP, equipment, zombies per type (Walker / Walker Orc / Runner / Fatty / Abomination / Necromancer)
- 3-phase round: Players → Zombies activate → End spawn
- BinaryWin scoring (mission complete OR all dead OR scenario fail)

## Validation

- 0 cross-game contamination
- Baseline files NOT touched

## Docs sync

MOCKUPS_INDEX: +2 page-mock +5 component-mock, total 101 → 108

## Reference dataset

`claudedocs/seed-preview-from-pr-1761/zombicide-green-horde.json` (curated 2026-06-01)

## Pipeline progress

| # | Game | Stato |
|---|---|---|
| 1 | Skeleton | ✅ MERGED #1766 |
| 2 | Puerto Rico | ✅ MERGED #1769 |
| 3 | Catan | 🟡 #1770 OPEN |
| 4 | Power Grid | 🟡 #1782 OPEN |
| 5 | **Zombicide GH** | 🟡 **questo PR** |
| 6 | Paleo | ⏸️ pending |
| 7 | Codenames | ⏸️ pending |

Co-Authored-By: Claude Code