### PR TITLE
fix(admin): #1735 #1741 — admin-ai polling+SVG + admin-monitor status-code refactor

### DIFF
--- a/apps/api/src/Api/Routing/AdminEventsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminEventsEndpoints.cs
@@ -154,8 +154,8 @@ internal static class AdminEventsEndpoints
         if (!authorized)
         {
             // SSE handlers cannot return IResult once the body has started, so we set the
-            // status code directly. ExtractStatusCode inspects the IResult type name to derive
-            // 401 vs 403 — safe because the response body has not started yet at this point.
+            // status code directly. ExtractStatusCode reads the public IStatusCodeHttpResult
+            // interface (#1741) — safe because the response body has not started yet at this point.
             context.Response.StatusCode = ExtractStatusCode(error);
             return;
         }
@@ -286,25 +286,19 @@ internal static class AdminEventsEndpoints
     }
 
     /// <summary>
-    /// Extracts the HTTP status code from an <see cref="IResult"/> by executing it against
-    /// a dummy response. Used only for the SSE auth-error path where we need the status code
-    /// before writing to the response body.
+    /// Extracts the HTTP status code from an <see cref="IResult"/> for the SSE auth-error path
+    /// where we need the status code before writing to the response body.
     /// </summary>
     /// <remarks>
-    /// ISSUE-1741: Replace type-name heuristic with <c>IStatusCodeHttpResult.StatusCode</c>
-    /// inspection (public since .NET 7) or restructure <c>RequireAdminSession</c> return type.
-    /// Current heuristic works but relies on internal ASP.NET Core type names.
+    /// #1741: Uses the public <see cref="IStatusCodeHttpResult"/> contract (ASP.NET Core ≥7),
+    /// replacing the previous type-name heuristic that depended on internal result-type names
+    /// (<c>UnauthorizedHttpResult</c> / <c>ForbidHttpResult</c>) which are not part of the
+    /// public API contract.
     /// </remarks>
     private static int ExtractStatusCode(IResult? result)
     {
-        // Heuristic: Results.Unauthorized() → 401, Results.Forbid() → 403
-        // We can't easily inspect IResult without executing it.
-        // Check the type name as a lightweight fallback.
-        if (result is null) return 401;
-        var name = result.GetType().Name;
-        if (name.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase)) return 401;
-        if (name.Contains("Forbid", StringComparison.OrdinalIgnoreCase)) return 403;
-        return 401; // safe default
+        if (result is IStatusCodeHttpResult sc) return sc.StatusCode ?? 401;
+        return 401; // safe default for null or non-status results
     }
 
     /// <summary>

--- a/apps/web/src/app/admin/(dashboard)/ai/RequestsTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/ai/RequestsTab.tsx
@@ -75,12 +75,15 @@ export function RequestsTab() {
   }, [range]);
 
   // #1729: Live range polls every 10s for near-real-time updates.
+  // #1735 B4: cancelled guard prevents stale tick from overwriting a newer range's data.
   useEffect(() => {
     if (range !== 'Live') return undefined;
+    let cancelled = false;
     const handle = setInterval(() => {
       api.admin
         .getAiMetricsTrend('Live')
         .then(data => {
+          if (cancelled) return;
           const points = (data?.datapoints ?? []).map(d => ({
             date: d.timestamp,
             avgLatencyMs: d.avgLatencyMs,
@@ -93,7 +96,10 @@ export function RequestsTab() {
         })
         .catch(() => {});
     }, 10_000);
-    return () => clearInterval(handle);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
   }, [range]);
 
   const setRange = (next: string) => {

--- a/apps/web/src/components/admin/ai/AiTrendChart.tsx
+++ b/apps/web/src/components/admin/ai/AiTrendChart.tsx
@@ -46,9 +46,13 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
   const volumePath = hasData ? buildSvgPath(data, d => d.requestCount) : '';
   const p50Path = hasPercentileSeries ? buildSvgPath(data, d => d.p50LatencyMs ?? 0) : '';
   const p95Path = hasPercentileSeries ? buildSvgPath(data, d => d.p95LatencyMs ?? 0) : '';
-  // errorRate is in [0, 1] — scale to a latency-comparable magnitude
-  // by mapping the max into the chart range. Drawn dashed in destructive tone.
-  const errorPath = hasPercentileSeries ? buildSvgPath(data, d => (d.errorRate ?? 0) * 1000) : '';
+  // #1735 B6: errorRate ∈ [0, 1] now uses an explicit fixed axis (0..1) instead of
+  // the prior cosmetic `* 1000` magic number. Each polyline still has its own Y-axis
+  // (auto-scaled by buildSvgPath), but a fixed [0, 1] range for error guarantees the
+  // polyline stays within the viewBox and reads as a stable percentage scale.
+  const errorPath = hasPercentileSeries
+    ? buildSvgPath(data, d => d.errorRate ?? 0, { fixedMin: 0, fixedMax: 1 })
+    : '';
 
   return (
     <section className="rounded-xl border border-border/60 bg-card/70 backdrop-blur-md p-4 space-y-3">
@@ -202,7 +206,11 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
   );
 }
 
-function buildSvgPath(data: TrendDatapoint[], pick: (d: TrendDatapoint) => number): string {
+function buildSvgPath(
+  data: TrendDatapoint[],
+  pick: (d: TrendDatapoint) => number,
+  options?: { fixedMin?: number; fixedMax?: number }
+): string {
   if (data.length === 0) return '';
   const innerWidth = CHART_WIDTH - PADDING * 2;
   const innerHeight = CHART_HEIGHT - PADDING * 2;
@@ -210,9 +218,15 @@ function buildSvgPath(data: TrendDatapoint[], pick: (d: TrendDatapoint) => numbe
     data.length === 1 ? PADDING + innerWidth / 2 : PADDING + (i / (data.length - 1)) * innerWidth
   );
   const ys = data.map(d => pick(d));
-  const maxY = Math.max(...ys, 1);
-  const minY = Math.min(...ys, 0);
+  // #1735 B6: callers may pass fixed bounds (e.g. {0, 1} for errorRate) to anchor
+  // the polyline to a stable axis. Values outside the range are clamped so the
+  // polyline never escapes the viewBox.
+  const maxY = options?.fixedMax ?? Math.max(...ys, 1);
+  const minY = options?.fixedMin ?? Math.min(...ys, 0);
   const range = Math.max(maxY - minY, 1);
-  const mapped = ys.map(y => CHART_HEIGHT - PADDING - ((y - minY) / range) * innerHeight);
+  const mapped = ys.map(y => {
+    const clamped = Math.min(Math.max(y, minY), maxY);
+    return CHART_HEIGHT - PADDING - ((clamped - minY) / range) * innerHeight;
+  });
   return data.map((_, i) => `${xs[i].toFixed(1)},${mapped[i].toFixed(1)}`).join(' ');
 }

--- a/apps/web/src/components/admin/ai/__tests__/AiTrendChart.test.tsx
+++ b/apps/web/src/components/admin/ai/__tests__/AiTrendChart.test.tsx
@@ -156,4 +156,63 @@ describe('AiTrendChart', () => {
     const active = screen.getByRole('button', { name: '7d', pressed: true });
     expect(active).toBeInTheDocument();
   });
+
+  // #1735 B6: error polyline used to scale errorRate ∈ [0, 1] via `* 1000`
+  // (cosmetic, since buildSvgPath auto-scales per-series). The fix anchors the
+  // error series to a fixed [0, 1] axis and clamps out-of-range values, so the
+  // polyline is guaranteed to stay within the SVG viewBox (Y between PADDING=24
+  // and CHART_HEIGHT-PADDING=116) regardless of the errorRate magnitude.
+  it('clamps the error polyline within the viewBox even with high errorRate (#1735 B6)', () => {
+    const extreme: TrendDatapoint[] = [
+      {
+        date: '2026-05-24',
+        avgLatencyMs: 100,
+        requestCount: 10,
+        p50LatencyMs: 80,
+        p95LatencyMs: 120,
+        errorRate: 0,
+      },
+      {
+        date: '2026-05-25',
+        avgLatencyMs: 105,
+        requestCount: 11,
+        p50LatencyMs: 82,
+        p95LatencyMs: 125,
+        errorRate: 0.5,
+      },
+      {
+        date: '2026-05-26',
+        avgLatencyMs: 110,
+        requestCount: 12,
+        p50LatencyMs: 85,
+        p95LatencyMs: 130,
+        errorRate: 1,
+      },
+    ];
+    const { container } = render(
+      <AiTrendChart
+        data={extreme}
+        range="Live"
+        onRangeChange={vi.fn()}
+        rangeOptions={['Live', '1h', '24h', '7d']}
+      />
+    );
+    const errorPolyline = container.querySelector('polyline[data-series="error"]');
+    expect(errorPolyline).toBeInTheDocument();
+    const points = errorPolyline?.getAttribute('points') ?? '';
+    const ys = points
+      .split(' ')
+      .map(pair => Number.parseFloat(pair.split(',')[1] ?? 'NaN'))
+      .filter(n => !Number.isNaN(n));
+    expect(ys).toHaveLength(3);
+    // CHART_HEIGHT=140, PADDING=24 → valid Y range [24, 116]
+    ys.forEach(y => {
+      expect(y).toBeGreaterThanOrEqual(24);
+      expect(y).toBeLessThanOrEqual(116);
+    });
+    // errorRate=1 (max) should map to the top edge (Y=PADDING=24),
+    // errorRate=0 should map to the bottom edge (Y=CHART_HEIGHT-PADDING=116).
+    expect(ys[0]).toBeCloseTo(116, 0);
+    expect(ys[2]).toBeCloseTo(24, 0);
+  });
 });

--- a/apps/web/src/components/admin/monitor/use-live-events.ts
+++ b/apps/web/src/components/admin/monitor/use-live-events.ts
@@ -100,6 +100,12 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
   // --- Derived filter object (stable ref guard handled via JSON-key deps) ---
   const filters: LiveEventFilters = { eventTypes, aggregateTypes, userId, aggregateId };
 
+  // Stable string keys for useCallback deps — extracting the `?.join(',')` expressions
+  // out of the dependency arrays satisfies react-hooks/exhaustive-deps (which forbids
+  // complex expressions as deps because it can't statically analyse them).
+  const eventTypesKey = eventTypes?.join(',');
+  const aggregateTypesKey = aggregateTypes?.join(',');
+
   // --- State ---
   const [events, setEvents] = useState<DomainEventDto[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -212,8 +218,8 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
       closeEventSource,
       clearBackoffTimer,
       updateEvents,
-      eventTypes?.join(','),
-      aggregateTypes?.join(','),
+      eventTypesKey,
+      aggregateTypesKey,
       userId,
       aggregateId,
     ]
@@ -258,14 +264,7 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}): UseLiveEvents
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      initialLimit,
-      attachEventSource,
-      eventTypes?.join(','),
-      aggregateTypes?.join(','),
-      userId,
-      aggregateId,
-    ]
+    [initialLimit, attachEventSource, eventTypesKey, aggregateTypesKey, userId, aggregateId]
   );
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sweep di 2 follow-up minor su `/admin` apparsi dopo i merge del 31/05:

- **#1735 (admin-ai)** — bugfix UI: polling \`cancelled\` guard + errorRate SVG viewBox clamp
- **#1741 (admin-monitor)** — refactor tech-debt: \`ExtractStatusCode\` via \`IStatusCodeHttpResult\` (public API ASP.NET ≥7)

Entrambi sono no-behavior-change con regression test mirati.

## Test plan
- [x] FE typecheck (\`pnpm typecheck\`) — 0 errori
- [x] FE lint (\`pnpm lint\`) — 4 errori in \`use-live-events.ts\` sono **baseline pre-esistenti** (introdotti da #1768 mergiata 31/05, non causati da questa PR)
- [x] FE test (\`AiTrendChart.test.tsx\`) — 10/10 pass (9 originali + 1 nuovo \`#1735 B6 viewBox clamp\`)
- [x] BE build (\`dotnet build\`) — 0 warning, 0 errori
- [x] BE integration tests (\`AdminEventsEndpointsIntegrationTests\`) — 8/8 pass, incluso \`Get_All_RequireAdminSession_401_403_200\` (regression net per #1741)

## Changes

### #1735 — admin-ai (2 file FE + 1 test)
- \`RequestsTab.tsx:78-97\` — polling \`useEffect\` ora replica il pattern \`let cancelled = false\` del sibling effect; previene flicker quando si cambia range mentre il fetch Live è in-flight.
- \`AiTrendChart.tsx:51\` — \`errorRate\` ancorato a un asse fisso \`[0, 1]\` invece del magic \`* 1000\`; \`buildSvgPath\` accetta \`fixedMin/fixedMax\` opzionali e clampa i valori, garantendo che la polyline non esca dal viewBox.
- \`AiTrendChart.test.tsx\` — +1 regression test che asserta Y ∈ [PADDING=24, CHART_HEIGHT-PADDING=116] anche con \`errorRate=1\`.

### #1741 — admin-monitor (1 file BE)
- \`AdminEventsEndpoints.cs:298-306\` — sostituito heuristic \`result.GetType().Name.Contains(...)\` con \`result is IStatusCodeHttpResult sc → sc.StatusCode\`. Stabile contro framework upgrade che rinominano i tipi interni (\`UnauthorizedHttpResult\` / \`ForbidHttpResult\`).

## Closes
- Closes #1735
- Closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)