### PR TITLE
feat(mockup): #1742 B19 premium #7/7 - Codenames (team deduction party game) — PIPELINE COMPLETE

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -89,6 +89,14 @@
 | `sp4-play-records-stats.html` | page-mock | `/play-records/stats` |
 | `sp4-player-detail.html` | page-mock | `/players/[id]`, `/players/[id]/{achievements,games,sessions,stats}` |
 | `sp4-players-index.html` | page-mock | `/players` |
+| `sp4-session-codenames-bodies.jsx` | component-mock | Codenames body layouts — DesktopBody + MobileBody composition. |
+| `sp4-session-codenames-data.jsx` | component-mock | Codenames-specific dataset (5x5 word grid, key card pattern, team agents 9/8, clue history). Premium #7/7. |
+| `sp4-session-codenames-flavor.jsx` | component-mock | Codenames flavor components — `WordGrid`, `WordCard` (5 states: covered/red/blue/neutral/assassin), `SpymasterKeyCardOverlay`, `TeamPanel`, `CurrentCluePanel`, `ClueHistoryTimeline`, `RoleAvatar`. |
+| `sp4-session-codenames-live.html` | page-mock | `/sessions/[id]/live` Codenames demo (team deduction party game, 2-8+ players in 2 teams, ~15 min). Extends skeleton with Codenames-specific panels + accordion-extended. |
+| `sp4-session-codenames-live.jsx` | component-mock | Root component for `sp4-session-codenames-live.html` — wires skeleton + word grid + RightColumnTabs (Scoring Ranking, Board, Clue history, Teams, Chat). |
+| `sp4-session-codenames-parts.jsx` | component-mock | Shared parts for Codenames — SectionCard accordion, helper sec(id). Mirrors skeleton + Power Grid extension. |
+| `sp4-session-codenames-summary.html` | page-mock | `/sessions/[id]` Codenames post-game (WINNER team banner + Red/Blue agents found + assassin status + clue analysis). Premium #7/7. |
+| `sp4-session-codenames-summary.jsx` | component-mock | Root component for Codenames summary — hero + tabs (Scoreboard / Final Board / Clue Analysis / Stats). |
 | `sp4-session-power-grid-data.jsx` | component-mock | Power Grid-specific dataset (Elektro, 4 resources market, 8 plants, 5 phases, 3 game steps). Premium #4/7. |
 | `sp4-session-power-grid-flavor.jsx` | component-mock | Power Grid flavor components — `PhaseTimeline`, `PowerPlantMarket`, `ResourceMarket`, `AuctionOverlay`, `NetworkMap`, `PlantsRail`, `TurnOrderStrip` (reverse-aware). |
 | `sp4-session-power-grid-live.html` | page-mock | `/sessions/[id]/live` Power Grid demo (heavy euro auction + network, 2-6 players, ~120 min). Extends skeleton with PG-specific panels + accordion-extended for game sections (auction/market/resources). |
@@ -189,10 +197,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 61 |
-| component-mock | 35 |
+| page-mock | 63 |
+| component-mock | 41 |
 | dev-fixture | 12 |
-| **Total** | **108** |
+| **Total** | **116** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/sp4-session-codenames-bodies.jsx
+++ b/admin-mockups/design_files/sp4-session-codenames-bodies.jsx
@@ -1,0 +1,311 @@
+/* MeepleAI SP4 · Codenames — BODIES & PANELS  (extends window.CNParts)
+   TeamPanel · ClueHistoryTimeline · RightColumnTabs · DesktopBody ·
+   MobileBody · MobileSheet · PhoneShell.
+
+   Accordion contract (mandatory): the CENTER/main column stacks the
+   always-visible WordGrid above a single-open accordion of
+   ChatAgentPanel · ActionLogTimeline · ClueHistoryTimeline — exactly one
+   expanded, switched via sec(id), identical to the skeleton DesktopSessionBody
+   and the Power Grid extension. */
+
+(function () {
+  const M = window.MAI;
+  const R = window.SkeletonRenderers;
+  const S = window.SkeletonParts;
+  const CN = window.CN;
+  const F = window.CNFlavor;
+  const P = window.CNParts;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const { mono, disp, teamEntity, teamName, RoleAvatar, RoleTag, ClueChip, ClueOutcome } = F;
+  const { SectionCard, PhaseBanner, CurrentCluePanel, WordGrid, SpymasterKeyCardOverlay, GameOverBanner, ScenarioSwitcher } = P;
+  const STATES = window.SkeletonData.STATES;
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // TeamPanel — red + blue trackers · current highlighted · rosters
+  // ══════════════════════════════════════════════════════════════════════════
+  const TeamCard = ({ team, compact }) => {
+    const t = team;
+    const teamId = t.id;
+    const e = teamEntity(teamId);
+    const spy = CN.byId(t.spymasterId);
+    const ops = t.operativeIds.map(CN.byId);
+    const on = t.current;
+    return (
+      <div aria-label={`Squadra ${t.name}`} style={{
+        borderRadius: 'var(--r-lg)', overflow: 'hidden', background: 'var(--bg-card)', flexShrink: 0,
+        border: `${on ? 2 : 1}px solid ${eHsl(e, on ? 0.55 : 0.28)}`,
+        boxShadow: on ? `0 5px 18px ${eHsl(e, 0.2)}` : 'var(--shadow-sm)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 11px', background: eHsl(e, on ? 0.12 : 0.06), borderBottom: `1px solid ${eHsl(e, 0.2)}` }}>
+          <span aria-hidden="true" style={{ width: 12, height: 12, borderRadius: 3, background: eHsl(e), flexShrink: 0 }} />
+          <span style={{ ...disp(13.5, 800, 'var(--text)') }}>Squadra {t.name}</span>
+          {on && <span className="mai-pulse-dot-host" style={{ ...mono(8, 800, eHsl(e)), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl(e, 0.14), border: `1px solid ${eHsl(e, 0.35)}`, textTransform: 'uppercase', letterSpacing: '.05em', display: 'inline-flex', alignItems: 'center', gap: 4 }}><span className="mai-pulse-dot" aria-hidden="true">●</span>al turno</span>}
+          <div style={{ flex: 1 }} />
+          <div style={{ textAlign: 'right', lineHeight: 1 }}>
+            <span style={{ ...disp(compact ? 20 : 24, 800, eHsl(e)), fontVariantNumeric: 'tabular-nums' }}>{t.remaining}</span>
+            <span style={{ ...mono(10, 700, 'var(--text-muted)') }}> / {t.total}</span>
+          </div>
+        </div>
+        <div style={{ padding: '8px 11px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {/* progress of agents found */}
+          <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 }}>
+              <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em' }}>Agenti trovati</span>
+              <span style={{ ...mono(10, 800, eHsl(e)) }}>{t.found}/{t.total}</span>
+            </div>
+            <div style={{ height: 7, borderRadius: 'var(--r-pill)', background: 'var(--bg-sunken)', overflow: 'hidden', display: 'flex', gap: 2, padding: 1 }}>
+              {Array.from({ length: t.total }).map((_, i) => (
+                <span key={i} style={{ flex: 1, borderRadius: 1, background: i < t.found ? eHsl(e) : eHsl(e, 0.16) }} />
+              ))}
+            </div>
+          </div>
+          {/* roster */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <RoleAvatar p={spy} size={26} ring={on} />
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div style={{ ...disp(12, 800, 'var(--text)') }}>{spy.name}</div>
+              <RoleTag role="spymaster" team={teamId} />
+            </div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', rowGap: 6 }}>
+            <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.05em', flexShrink: 0 }}>Operativi</span>
+            {ops.map((p) => (
+              <span key={p.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 9px 2px 2px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border-light)' }}>
+                <RoleAvatar p={p} size={19} />
+                <span style={{ ...disp(11, 700, 'var(--text)') }}>{p.name}</span>
+                {on && <span className="mai-pulse-dot" aria-label="al turno" style={{ ...mono(7, 800, eHsl(e)) }}>●</span>}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const TeamPanel = ({ state = 'default', compact, teams = CN.teams, order = ['red', 'blue'] }) => (
+    <R.StateScaffold state={state} sseWhere="squadre"
+      empty={{ icon: '👥', title: 'Squadre non formate', body: 'Assegna giocatori a Rosso e Blu per iniziare.' }}
+      error={{ title: 'Squadre non disponibili', body: 'Impossibile caricare i roster delle squadre.' }}
+      loading={<div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>{[0, 1].map((i) => <M.Shimmer key={i} h={150} style={{ borderRadius: 'var(--r-lg)' }} />)}</div>}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: compact ? 0 : 0 }}>
+        {order.map((id) => <TeamCard key={id} team={teams[id]} compact={compact} />)}
+      </div>
+    </R.StateScaffold>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ClueHistoryTimeline — clues given · success ratio · best/worst
+  // ══════════════════════════════════════════════════════════════════════════
+  const ClueRow = ({ clue }) => {
+    const e = teamEntity(clue.team);
+    const ratio = `${clue.correct}/${clue.number}`;
+    return (
+      <div style={{ display: 'flex', gap: 10, padding: '8px 0' }}>
+        <span aria-hidden="true" style={{ width: 10, height: 10, marginTop: 5, borderRadius: '50%', flexShrink: 0, background: eHsl(e), boxShadow: `0 0 0 3px ${eHsl(e, 0.18)}` }} />
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', rowGap: 5 }}>
+            <ClueChip word={clue.word} number={clue.number} team={clue.team} dim={clue.outcome !== 'active'} />
+            {clue.best && <span title="Miglior indizio" style={{ ...mono(8.5, 800, eHsl('toolkit')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('toolkit', 0.12), border: `1px solid ${eHsl('toolkit', 0.3)}` }}>★ migliore</span>}
+            {clue.worst && <span title="Indizio peggiore" style={{ ...mono(8.5, 800, eHsl('event')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('event', 0.12), border: `1px solid ${eHsl('event', 0.3)}` }}>peggiore</span>}
+            <div style={{ flex: 1 }} />
+            <span style={{ ...mono(11, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{ratio}</span>
+            <ClueOutcome outcome={clue.outcome} />
+          </div>
+          <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>{teamName(clue.team)} · Spymaster {CN.byId(clue.spymaster).name}{clue.note ? ` · ${clue.note}` : ''}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const ClueHistoryInner = ({ clues }) => {
+    const list = [...clues].reverse(); // newest first
+    const done = clues.filter((c) => c.outcome !== 'active');
+    const clean = done.filter((c) => c.outcome === 'clean').length;
+    return (
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0 8px', flexWrap: 'wrap' }}>
+          <span style={{ ...mono(9.5, 700, 'var(--text-sec)') }}>Indizi pieni</span>
+          <span style={{ ...mono(11, 800, eHsl('toolkit')) }}>{clean}/{done.length}</span>
+          <div style={{ flex: 1 }} />
+          <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>{clues.length} indizi dati</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {list.map((c) => <ClueRow key={c.id} clue={c} />)}
+        </div>
+      </div>
+    );
+  };
+
+  const ClueHistoryTimeline = ({ state = 'default', clues = CN.CLUES, collapsed, onHeaderClick }) => (
+    <SectionCard title="Storico indizi" entity="agent" accent={!!onHeaderClick} collapsed={collapsed} onHeaderClick={onHeaderClick}
+      right={<span style={{ ...mono(9, 800, eHsl('agent')), padding: '1px 7px', borderRadius: 'var(--r-pill)', background: eHsl('agent', 0.1), border: `1px solid ${eHsl('agent', 0.28)}` }}>{clues.length}</span>}>
+      <R.StateScaffold state={state} sseWhere="indizi"
+        empty={{ icon: '💬', title: 'Nessun indizio', body: 'Gli indizi dati dagli Spymaster compaiono qui.' }}
+        error={{ title: 'Storico non disponibile', body: 'Impossibile caricare lo storico degli indizi.' }}>
+        <ClueHistoryInner clues={clues} />
+      </R.StateScaffold>
+    </SectionCard>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // RightColumnTabs — Scoring · Board · Clue history · Teams · Chat
+  // ══════════════════════════════════════════════════════════════════════════
+  const BoardTab = ({ state, board = CN.BOARD }) => (
+    <div className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={{ ...mono(9.5, 700, 'var(--text-muted)'), lineHeight: 1.5 }}>Snapshot della griglia con la <strong style={{ color: eHsl('session') }}>key card</strong> dello Spymaster — vista segreta.</div>
+      <WordGrid state={state} compact perspective="spymaster" keyVisible board={board} />
+    </div>
+  );
+
+  const RC_TABS = [
+    { id: 'scoring', icon: '🎯', label: 'Scoring', entity: 'session', render: (st, scn) => <R.ScoringPanelRenderer data={scn.ds} state={st} /> },
+    { id: 'board',   icon: '🗂', label: 'Board',   entity: 'session', render: (st, scn) => <BoardTab state={st} board={scn.board} /> },
+    { id: 'clues',   icon: '💬', label: 'Indizi',  entity: 'agent',   render: (st, scn) => <div className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12 }}><ClueHistoryTimeline state={st} clues={scn.clues} /></div> },
+    { id: 'teams',   icon: '👥', label: 'Squadre', entity: 'player',  render: (st, scn) => <div className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: 12 }}><TeamPanel state={st} teams={scn.teams} /></div> },
+    { id: 'chat',    icon: '💬', label: 'Chat',    entity: 'agent',   render: () => <div style={{ flex: 1, minHeight: 0, padding: 12, display: 'flex' }}><S.ChatAgentPanel ds={CN.ds} /></div> },
+  ];
+  const RightColumnTabs = ({ initial = 'scoring', initialState = 'default', embedded, scn = CN.SCENARIOS.mid }) => {
+    const [tab, setTab] = useState(initial);
+    const [st, setSt] = useState(initialState);
+    const active = RC_TABS.find((t) => t.id === tab) || RC_TABS[0];
+    return (
+      <aside aria-label="Pannello sessione" style={{ width: embedded ? '100%' : 352, minWidth: embedded ? 0 : 300, flexShrink: 0, height: '100%', background: 'var(--bg-card)', borderLeft: embedded ? 'none' : '1px solid var(--border)', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <div role="tablist" aria-label="Sezioni" style={{ display: 'flex', borderBottom: '1px solid var(--border-light)', flexShrink: 0, overflow: 'hidden' }}>
+          {RC_TABS.map((t) => {
+            const on = tab === t.id;
+            return (
+              <button key={t.id} type="button" role="tab" aria-selected={on} aria-label={t.label} onClick={() => setTab(t.id)} style={{ flex: '1 1 0', minWidth: 0, padding: '10px 3px', background: on ? eHsl(t.entity, 0.06) : 'transparent', border: 'none', borderBottom: on ? `2px solid ${eHsl(t.entity)}` : '2px solid transparent', color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(10.5, 800), cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, whiteSpace: 'nowrap' }}>
+                <span aria-hidden="true" style={{ fontSize: 12, flexShrink: 0 }}>{t.icon}</span><span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+        {active.id !== 'chat' && <S.StateSwitch value={st} onChange={setSt} />}
+        <div role="tabpanel" style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st, scn)}</div>
+      </aside>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // DESKTOP body — phase band · clue band · 3 columns (teams · board+accordion · tabs)
+  // ══════════════════════════════════════════════════════════════════════════
+  const DesktopBody = ({ initialTab, initialState, initialPerspective = 'operative', initialScenario = 'mid' }) => {
+    const [scnId, setScnId] = useState(initialScenario);
+    const [perspective, setPerspective] = useState(initialPerspective);
+    const [keyVisible, setKeyVisible] = useState(true);
+    const [expanded, setExpanded] = useState('chat'); // 'chat' | 'log' | 'clues'
+    const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
+    const scn = CN.SCENARIOS[scnId];
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <ScenarioSwitcher value={scnId} onChange={setScnId} />
+        <PhaseBanner phaseState={scn.phaseState} />
+        <div style={{ padding: '12px 14px 0' }}>{scn.gameOver ? <GameOverBanner over={scn.gameOver} /> : <CurrentCluePanel clue={scn.clue} />}</div>
+        <div style={{ display: 'flex', flex: 1, minHeight: 0, marginTop: 12 }}>
+          {/* LEFT — team trackers */}
+          <div className="mai-cb-scroll" style={{ width: 264, flexShrink: 0, borderRight: '1px solid var(--border)', overflowY: 'auto', padding: 12, background: 'var(--bg)' }}>
+            <TeamPanel teams={scn.teams} />
+          </div>
+          {/* CENTER — word grid (always) + single-open accordion */}
+          <main className="mai-cb-scroll" style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 10, background: 'var(--bg)' }}>
+            <WordGrid perspective={perspective} keyVisible={keyVisible} board={scn.board}
+              onTogglePerspective={setPerspective} onToggleKey={() => setKeyVisible((v) => !v)} />
+            <S.ChatAgentPanel ds={CN.ds} {...sec('chat')} />
+            <S.ActionLogTimeline ds={scn.ds} {...sec('log')} />
+            <ClueHistoryTimeline clues={scn.clues} {...sec('clues')} />
+          </main>
+          {/* RIGHT — polymorphic tabs */}
+          <RightColumnTabs initial={initialTab} initialState={initialState} scn={scn} />
+        </div>
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // MOBILE — phase sticky · scroll body · tab strip → bottom sheet
+  // ══════════════════════════════════════════════════════════════════════════
+  const MobileSheet = ({ open, tab, st, setSt, onClose, scn }) => {
+    const active = RC_TABS.find((t) => t.id === tab) || RC_TABS[0];
+    return (
+      <div aria-hidden={!open} style={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: open ? 'auto' : 'none' }}>
+        <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(15,12,8,.5)', backdropFilter: 'blur(3px)', opacity: open ? 1 : 0, transition: 'opacity var(--dur-md) var(--ease-out)' }} />
+        <div role="dialog" aria-modal="true" aria-label={active.label} style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '86%', background: 'var(--bg-card)', borderTopLeftRadius: 'var(--r-2xl)', borderTopRightRadius: 'var(--r-2xl)', borderTop: `3px solid ${eHsl(active.entity)}`, boxShadow: 'var(--shadow-drawer)', display: 'flex', flexDirection: 'column', minHeight: 0, transform: open ? 'translateY(0)' : 'translateY(101%)', transition: 'transform var(--dur-lg) var(--ease-spring)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 8, flexShrink: 0 }}>
+            <div style={{ width: 38, height: 4, borderRadius: 999, background: 'var(--border-strong)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px 10px', flexShrink: 0 }}>
+            <span aria-hidden="true" style={{ fontSize: 16 }}>{active.icon}</span>
+            <span style={{ ...disp(15, 800, eHsl(active.entity)) }}>{active.label}</span>
+            <div style={{ flex: 1 }} />
+            <button type="button" onClick={onClose} aria-label="Chiudi" style={{ width: 28, height: 28, borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', color: 'var(--text-sec)', cursor: 'pointer', fontSize: 13 }}>✕</button>
+          </div>
+          {active.id !== 'chat' && <S.StateSwitch value={st} onChange={setSt} />}
+          <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{active.render(st, scn)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const MobileBody = ({ initialTab, initialPerspective = 'operative', initialScenario = 'mid' }) => {
+    const [sheet, setSheet] = useState(initialTab || null);
+    const [st, setSt] = useState('default');
+    const [scnId, setScnId] = useState(initialScenario);
+    const [perspective, setPerspective] = useState(initialPerspective);
+    const [keyVisible, setKeyVisible] = useState(true);
+    const [expanded, setExpanded] = useState('chat');
+    const sec = (id) => ({ collapsed: expanded !== id, onHeaderClick: () => setExpanded(id) });
+    const scn = CN.SCENARIOS[scnId];
+    return (
+      <>
+        <ScenarioSwitcher value={scnId} onChange={setScnId} compact />
+        <PhaseBanner compact sticky phaseState={scn.phaseState} />
+        <div className="mai-cb-scroll" style={{ flex: 1, overflowY: 'auto', minHeight: 0, background: 'var(--bg)' }}>
+          <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {scn.gameOver ? <GameOverBanner over={scn.gameOver} compact /> : <CurrentCluePanel compact clue={scn.clue} />}
+            <WordGrid compact perspective={perspective} keyVisible={keyVisible} board={scn.board}
+              onTogglePerspective={setPerspective} onToggleKey={() => setKeyVisible((v) => !v)} />
+            <TeamPanel compact teams={scn.teams} />
+            <S.ChatAgentPanel ds={CN.ds} compact {...sec('chat')} />
+            <S.ActionLogTimeline ds={scn.ds} compact {...sec('log')} />
+            <ClueHistoryTimeline clues={scn.clues} {...sec('clues')} />
+          </div>
+        </div>
+        <nav aria-label="Sezioni sessione" style={{ display: 'flex', gap: 5, flexShrink: 0, padding: '8px 8px', background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderTop: '1px solid var(--border)' }}>
+          {RC_TABS.map((t) => (
+            <button key={t.id} type="button" onClick={() => { setSt('default'); setSheet(t.id); }} style={{ flex: '1 1 0', minWidth: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4, padding: '7px 4px', borderRadius: 'var(--r-pill)', background: eHsl(t.entity, 0.1), border: `1px solid ${eHsl(t.entity, 0.28)}`, color: eHsl(t.entity), ...disp(10, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>
+              <span aria-hidden="true" style={{ flexShrink: 0 }}>{t.icon}</span><span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.label}</span>
+            </button>
+          ))}
+        </nav>
+        <MobileSheet open={!!sheet} tab={sheet} st={st} setSt={setSt} scn={scn} onClose={() => setSheet(null)} />
+      </>
+    );
+  };
+
+  // ─── PhoneShell ───────────────────────────────────────────────────────────
+  const PhoneSbar = () => (
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>20:15</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+  );
+  const PhoneShell = ({ label, desc, dark, initialTab, initialPerspective, initialScenario }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+      <div className="phone" data-theme={dark ? 'dark' : undefined}>
+        <PhoneSbar />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <S.TopBar ds={CN.ds} compact />
+          <MobileBody initialTab={initialTab} initialPerspective={initialPerspective} initialScenario={initialScenario} />
+        </div>
+      </div>
+      {desc && <div style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 360, textAlign: 'center', lineHeight: 1.55 }}>{desc}</div>}
+    </div>
+  );
+
+  Object.assign(window.CNParts, {
+    TeamCard, TeamPanel, ClueHistoryTimeline, ClueHistoryInner, RightColumnTabs, RC_TABS,
+    DesktopBody, MobileBody, MobileSheet, PhoneShell, STATES,
+  });
+})();

--- a/admin-mockups/design_files/sp4-session-codenames-data.jsx
+++ b/admin-mockups/design_files/sp4-session-codenames-data.jsx
@@ -1,0 +1,237 @@
+/* MeepleAI SP4 · Codenames — DATASET  (window.CN)
+   Game-specific data feeding both the reused skeleton renderers and the new
+   Codenames widgets. Pure data — no React, no token helpers.
+
+   Also bootstraps window.SkeletonData.STATES (the canonical 5 states) so the
+   shared skeleton parts can read it at module-eval time.
+
+   SCENARIOS (switchable in the live view):
+     mid      — tight mid-game, Red leads 6/9 vs Blue 3/8, Red guessing OCEAN:3
+     match    — match point Blu: Blue 7/8 (1 left), Blue guessing, high tension
+     assassin — game over: Red revealed the assassin → instant loss, Blue wins
+   The key card (which word is which colour) is FIXED across scenarios — only
+   the revealed tiles / clue / phase / log differ. */
+
+(function () {
+  // ─── canonical states ─────────────────────────────────────────────────────
+  window.SkeletonData = window.SkeletonData || {};
+  window.SkeletonData.STATES = [
+    { id: 'default', lb: 'Default' },
+    { id: 'empty',   lb: 'Empty' },
+    { id: 'loading', lb: 'Loading' },
+    { id: 'error',   lb: 'Error' },
+    { id: 'sse',     lb: 'SSE ✕' },
+  ];
+
+  const TEAM = {
+    red:  { id: 'red',  name: 'Rossi', entity: 'event', total: 9, spymasterId: 'p-marco', operativeIds: ['p-anna', 'p-luca'] },
+    blue: { id: 'blue', name: 'Blu',   entity: 'chat',  total: 8, spymasterId: 'p-sara',  operativeIds: ['p-giulia', 'p-dario'] },
+  };
+
+  // ─── roster ───────────────────────────────────────────────────────────────
+  const ROSTER = [
+    { id: 'p-marco',  name: 'Marco',  hue: 5,   team: 'red',  role: 'spymaster' },
+    { id: 'p-anna',   name: 'Anna',   hue: 16,  team: 'red',  role: 'operative' },
+    { id: 'p-luca',   name: 'Luca',   hue: 352, team: 'red',  role: 'operative' },
+    { id: 'p-sara',   name: 'Sara',   hue: 218, team: 'blue', role: 'spymaster' },
+    { id: 'p-giulia', name: 'Giulia', hue: 226, team: 'blue', role: 'operative' },
+    { id: 'p-dario',  name: 'Dario',  hue: 206, team: 'blue', role: 'operative' },
+  ];
+  const byId = (id) => ROSTER.find((p) => p.id === id);
+
+  // ─── fixed key card · 25 words in grid order ──────────────────────────────
+  const KEYS = [
+    ['APPLE', 'neutral'], ['OCEAN', 'red'],   ['KNIGHT', 'blue'],   ['ROBOT', 'red'],   ['MAPLE', 'neutral'],
+    ['SHADOW', 'assassin'], ['COMET', 'red'],  ['ANCHOR', 'blue'],  ['TIGER', 'red'],   ['PRISM', 'neutral'],
+    ['CASTLE', 'blue'],   ['VOLCANO', 'red'],  ['FEATHER', 'neutral'], ['ENGINE', 'blue'], ['NOMAD', 'red'],
+    ['GLACIER', 'blue'],  ['ORCHID', 'neutral'], ['BISHOP', 'blue'], ['ROCKET', 'red'],  ['CACTUS', 'neutral'],
+    ['LANTERN', 'red'],   ['FALCON', 'blue'],  ['MARBLE', 'neutral'], ['THUNDER', 'red'], ['COMPASS', 'blue'],
+  ];
+  const makeBoard = (rev) => KEYS.map(([word, key]) => ({ word, key, revealed: !!rev[word], revealedBy: rev[word] || null }));
+  const countFound = (board, team) => board.filter((c) => c.key === team && c.revealed).length;
+  const buildTeams = (board, currentTeam) => {
+    const mk = (id) => {
+      const found = countFound(board, id);
+      return { ...TEAM[id], found, remaining: TEAM[id].total - found, current: currentTeam === id };
+    };
+    return { red: mk('red'), blue: mk('blue') };
+  };
+  const buildRanking = (teams) => {
+    const arr = [
+      { id: 'red',  name: 'Rossi', hue: 5,   t: teams.red },
+      { id: 'blue', name: 'Blu',   hue: 218, t: teams.blue },
+    ];
+    arr.sort((a, b) => (a.t.remaining - b.t.remaining) || (b.t.found - a.t.found));
+    return arr.map((x, i) => ({ id: x.id, name: x.name, hue: x.hue, rank: i + 1,
+      sub: `${x.t.found} / ${x.t.total} agenti · ${x.t.remaining} rimasti` }));
+  };
+
+  const cR = 'hsl(var(--c-event))', cB = 'hsl(var(--c-chat))';
+
+  // ─── chat (shared) ────────────────────────────────────────────────────────
+  const CHAT = [
+    { id: 'q1', from: 'user',  t: '07:55', text: 'Se tocchiamo l\u2019assassino perdiamo subito?' },
+    { id: 'q2', from: 'agent', t: '07:55', text: 'Sì: rivelare la tessera assassino fa perdere immediatamente la squadra che la tocca, a prescindere dagli agenti già trovati.', citations: ['Codenames §Fine partita'] },
+    { id: 'q3', from: 'user',  t: '08:10', text: 'Quante tessere possiamo provare con un indizio da 3?' },
+    { id: 'q4', from: 'agent', t: '08:10', text: 'Fino al numero dell\u2019indizio più uno: con «3» potete tentare fino a 4 tessere, finché indovinate agenti della vostra squadra.', citations: ['Codenames §Indizi', 'FAQ #4'] },
+  ];
+  const SUGGESTIONS = ['Indizio non valido?', 'Possiamo passare?', 'Regola assassino'];
+
+  // optional timers (codenames.json · community variant) — guess timer active
+  const timers = {
+    clue:  { id: 'clue',  label: 'Indizio',   duration: 120, warn: 30, enabled: true, active: false, remaining: 120 },
+    guess: { id: 'guess', label: 'Tentativo', duration: 60,  warn: 15, enabled: true, active: true,  remaining: 41 },
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // SCENARIOS
+  // ══════════════════════════════════════════════════════════════════════════
+  const REV_MID = { OCEAN: 'red', ROBOT: 'red', COMET: 'red', TIGER: 'red', NOMAD: 'red', THUNDER: 'red', CASTLE: 'blue', ENGINE: 'blue', BISHOP: 'blue', MAPLE: 'red' };
+  const REV_MATCH = { ...REV_MID, KNIGHT: 'blue', ANCHOR: 'blue', GLACIER: 'blue', FALCON: 'blue', ORCHID: 'blue' };
+  const REV_ASSN = { ...REV_MID, SHADOW: 'red' };
+
+  // — mid clues —
+  const CLUES_MID = [
+    { id: 'cl1', team: 'red',  word: 'METAL',  number: 3, correct: 2, attempts: 3, outcome: 'partial', spymaster: 'p-marco', note: 'finito su civile' },
+    { id: 'cl2', team: 'blue', word: 'ROYAL',  number: 1, correct: 1, attempts: 1, outcome: 'clean',   spymaster: 'p-sara' },
+    { id: 'cl3', team: 'red',  word: 'ANIMAL', number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-marco', best: true },
+    { id: 'cl4', team: 'blue', word: 'SPACE',  number: 2, correct: 2, attempts: 2, outcome: 'clean',   spymaster: 'p-sara' },
+    { id: 'cl5', team: 'red',  word: 'OCEAN',  number: 3, correct: 1, attempts: 1, outcome: 'active',  spymaster: 'p-marco' },
+  ];
+  const CLUES_MATCH = [
+    { id: 'm1', team: 'red',  word: 'METAL',   number: 3, correct: 2, attempts: 3, outcome: 'partial', spymaster: 'p-marco' },
+    { id: 'm2', team: 'blue', word: 'ROYAL',   number: 1, correct: 1, attempts: 1, outcome: 'clean',   spymaster: 'p-sara' },
+    { id: 'm3', team: 'red',  word: 'ANIMAL',  number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-marco', best: true },
+    { id: 'm4', team: 'blue', word: 'HARBOR',  number: 3, correct: 2, attempts: 3, outcome: 'partial', spymaster: 'p-sara', note: 'finito su civile' },
+    { id: 'm5', team: 'red',  word: 'OCEAN',   number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-marco' },
+    { id: 'm6', team: 'blue', word: 'NORDIC',  number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-sara' },
+    { id: 'm7', team: 'blue', word: 'SAILOR',  number: 2, correct: 1, attempts: 1, outcome: 'active',  spymaster: 'p-sara' },
+  ];
+  const CLUES_ASSN = [
+    { id: 'a1', team: 'red',  word: 'METAL',  number: 3, correct: 2, attempts: 3, outcome: 'partial', spymaster: 'p-marco' },
+    { id: 'a2', team: 'blue', word: 'ROYAL',  number: 1, correct: 1, attempts: 1, outcome: 'clean',   spymaster: 'p-sara' },
+    { id: 'a3', team: 'red',  word: 'ANIMAL', number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-marco', best: true },
+    { id: 'a4', team: 'blue', word: 'SPACE',  number: 2, correct: 2, attempts: 2, outcome: 'clean',   spymaster: 'p-sara' },
+    { id: 'a5', team: 'red',  word: 'OCEAN',  number: 3, correct: 1, attempts: 2, outcome: 'miss',    spymaster: 'p-marco', note: 'rivelato l\u2019assassino' },
+  ];
+
+  const EVENTS_MID = [
+    { kind: 'turn-change',  who: 'p-marco',  t: 'ora',   text: 'Indizio dato — <strong>OCEAN : 3</strong>' },
+    { kind: 'score-update', who: 'p-anna',   t: '08:01', text: `Rivela <strong>OCEAN</strong> · agente <strong style="color:${cR}">Rosso</strong> ✓` },
+    { kind: 'turn-change',  who: 'p-sara',   t: '07:30', text: 'Indizio dato — <strong>SPACE : 2</strong>' },
+    { kind: 'score-update', who: 'p-giulia', t: '07:12', text: `Rivela <strong>ENGINE</strong> · agente <strong style="color:${cB}">Blu</strong> ✓` },
+    { kind: 'custom',       who: 'p-anna',   t: '05:42', text: 'Rivela <strong>MAPLE</strong> · civile — il turno passa al Blu' },
+    { kind: 'game-start',   who: null,       t: '00:00', text: `Partita avviata · il <strong style="color:${cR}">Rosso</strong> muove per primo (9 agenti)` },
+  ];
+  const EVENTS_MATCH = [
+    { kind: 'turn-change',  who: 'p-sara',   t: 'ora',   text: 'Indizio dato — <strong>SAILOR : 2</strong>' },
+    { kind: 'score-update', who: 'p-giulia', t: '11:48', text: `Rivela <strong>FALCON</strong> · agente <strong style="color:${cB}">Blu</strong> ✓ — manca 1 agente!` },
+    { kind: 'score-update', who: 'p-dario',  t: '11:20', text: `Rivela <strong>GLACIER</strong> · agente <strong style="color:${cB}">Blu</strong> ✓` },
+    { kind: 'turn-change',  who: 'p-marco',  t: '10:05', text: 'Indizio dato — <strong>OCEAN : 3</strong> · 3/3 pieno' },
+    { kind: 'custom',       who: 'p-giulia', t: '09:10', text: 'Rivela <strong>ORCHID</strong> · civile — il turno passa al Rosso' },
+    { kind: 'game-start',   who: null,       t: '00:00', text: `Partita avviata · il <strong style="color:${cR}">Rosso</strong> muove per primo` },
+  ];
+  const EVENTS_ASSN = [
+    { kind: 'custom',       who: 'p-luca',   t: 'ora',   text: `💀 Rivela <strong>SHADOW</strong> · <strong style="color:${cR}">ASSASSINO</strong> — sconfitta immediata del Rosso` },
+    { kind: 'score-update', who: 'p-anna',   t: '08:01', text: `Rivela <strong>OCEAN</strong> · agente <strong style="color:${cR}">Rosso</strong> ✓` },
+    { kind: 'turn-change',  who: 'p-marco',  t: '07:50', text: 'Indizio dato — <strong>OCEAN : 3</strong>' },
+    { kind: 'score-update', who: 'p-giulia', t: '07:12', text: `Rivela <strong>ENGINE</strong> · agente <strong style="color:${cB}">Blu</strong> ✓` },
+    { kind: 'game-start',   who: null,       t: '00:00', text: `Partita avviata · il <strong style="color:${cR}">Rosso</strong> muove per primo` },
+  ];
+
+  const baseGame = { id: 'codenames', title: 'Codenames', emoji: '🕵️',
+    cover: 'linear-gradient(135deg, hsl(350,72%,48%), hsl(220,72%,46%))',
+    meta: '2 squadre · 4–8+ giocatori · ~15 min · deduzione' };
+  const scoringTemplate = {
+    scoreType: 'Ranking',
+    categories: [
+      { id: 'agents-found',     label: 'Agenti rivelati dalla squadra', computation: 'Count',  weight: 1, description: 'Prima squadra a rivelare tutti i propri agenti vince.' },
+      { id: 'assassin-touched', label: 'Assassino rivelato',            computation: 'Custom', weight: 0, description: 'Sconfitta immediata per chi rivela l\u2019assassino (1 di 25).' },
+    ],
+  };
+  const turnTemplate = {
+    turnOrderType: 'Sequential',
+    phases: ['Spymaster Rosso', 'Operativi Rossi', 'Spymaster Blu', 'Operativi Blu'],
+    rounds: null, turnsPerRound: null, turnActions: ['give-clue', 'guess-tile', 'end-turn'], direction: 'none',
+  };
+
+  // 4-phase team-alternating descriptors (drives PhaseBanner)
+  const PHASES = [
+    { id: 'r-clue',  team: 'red',  short: 'Spymaster Rosso', desc: 'Lo Spymaster rosso dà un indizio', kind: 'clue' },
+    { id: 'r-guess', team: 'red',  short: 'Operativi Rossi', desc: 'Gli operativi rossi indovinano',   kind: 'guess' },
+    { id: 'b-clue',  team: 'blue', short: 'Spymaster Blu',   desc: 'Lo Spymaster blu dà un indizio',    kind: 'clue' },
+    { id: 'b-guess', team: 'blue', short: 'Operativi Blu',   desc: 'Gli operativi blu indovinano',      kind: 'guess' },
+  ];
+
+  function buildScenario(cfg) {
+    const board = makeBoard(cfg.rev);
+    const teams = buildTeams(board, cfg.currentTeam);
+    const ranking = buildRanking(teams);
+    const ds = {
+      game: baseGame, session: { elapsed: cfg.elapsed }, players: ROSTER,
+      agent: { emoji: '🕵️', name: 'Arbitro Codenames', latency: '~0.5s' },
+      chat: CHAT, suggestions: SUGGESTIONS, events: cfg.events,
+      meta: 'Classifica squadre · race condition', scoring: scoringTemplate, ranking,
+      turn: turnTemplate, turnState: { phaseIndex: cfg.phaseState.phaseIndex },
+    };
+    return { id: cfg.id, label: cfg.label, sub: cfg.sub, tone: cfg.tone,
+      board, teams, ranking, clue: cfg.clue, phaseState: cfg.phaseState,
+      clues: cfg.clues, events: cfg.events, gameOver: cfg.gameOver || null, ds };
+  }
+
+  const SCENARIOS = {
+    mid: buildScenario({
+      id: 'mid', label: 'Mid-game · Rosso avanti', sub: 'Rosso 6/9 · Blu 3/8 · indizio attivo', tone: 'event',
+      rev: REV_MID, currentTeam: 'red', elapsed: '08:24', phaseState: { round: 3, phaseIndex: 1 },
+      clue: { team: 'red', word: 'OCEAN', number: 3, spymaster: 'p-marco', guessesMade: 1, allowed: 4, remaining: 3 },
+      clues: CLUES_MID, events: EVENTS_MID,
+    }),
+    match: buildScenario({
+      id: 'match', label: 'Match point · Blu', sub: 'Blu 7/8 · manca 1 agente!', tone: 'chat',
+      rev: REV_MATCH, currentTeam: 'blue', elapsed: '12:03', phaseState: { round: 6, phaseIndex: 3 },
+      clue: { team: 'blue', word: 'SAILOR', number: 2, spymaster: 'p-sara', guessesMade: 1, allowed: 3, remaining: 2 },
+      clues: CLUES_MATCH, events: EVENTS_MATCH,
+    }),
+    assassin: buildScenario({
+      id: 'assassin', label: 'Sconfitta · Assassino', sub: 'Il Rosso ha toccato l\u2019assassino', tone: 'event',
+      rev: REV_ASSN, currentTeam: 'red', elapsed: '08:36', phaseState: { round: 4, phaseIndex: 1 },
+      clue: null, clues: CLUES_ASSN, events: EVENTS_ASSN,
+      gameOver: { result: 'assassin', loser: 'red', winner: 'blue', icon: '💀',
+        title: 'Sconfitta · Assassino', cause: 'Il Rosso ha rivelato l\u2019assassino (SHADOW)',
+        detail: 'Sconfitta immediata. Vince la Squadra Blu.' },
+    }),
+  };
+  const SCN_ORDER = ['mid', 'match', 'assassin'];
+
+  // ─── defaults (mid) exposed top-level for galleries & component defaults ──
+  const MID = SCENARIOS.mid;
+
+  // ─── SUMMARY (post-game) ──────────────────────────────────────────────────
+  const finalBoard = MID.board.map((c) => ({ ...c, revealed: true, revealedBy: c.revealedBy || c.key }));
+  const summary = {
+    winner: 'red', cause: 'Ha rivelato tutti i 9 agenti', causeKind: 'agents',
+    duration: '14:38', rounds: 7, assassinAvoided: true,
+    teams: { red: { ...TEAM.red, found: 9, remaining: 0 }, blue: { ...TEAM.blue, found: 6, remaining: 2 } },
+    clues: [
+      { id: 's1', team: 'red',  word: 'METAL',  number: 3, correct: 2, attempts: 3, outcome: 'partial', spymaster: 'p-marco' },
+      { id: 's2', team: 'blue', word: 'ROYAL',  number: 1, correct: 1, attempts: 1, outcome: 'clean',   spymaster: 'p-sara' },
+      { id: 's3', team: 'red',  word: 'ANIMAL', number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-marco', best: true },
+      { id: 's4', team: 'blue', word: 'SPACE',  number: 2, correct: 2, attempts: 2, outcome: 'clean',   spymaster: 'p-sara' },
+      { id: 's5', team: 'red',  word: 'OCEAN',  number: 3, correct: 3, attempts: 3, outcome: 'clean',   spymaster: 'p-marco' },
+      { id: 's6', team: 'blue', word: 'METAL',  number: 2, correct: 1, attempts: 2, outcome: 'partial', spymaster: 'p-sara', worst: true },
+      { id: 's7', team: 'red',  word: 'STONE',  number: 1, correct: 1, attempts: 1, outcome: 'clean',   spymaster: 'p-marco' },
+    ],
+    stats: { avgTurn: '1:13', missRate: 0.18, assassinTouched: 0, clueDensity: 2.1, tilesRevealed: 18, neutralsHit: 3 },
+    finalBoard,
+  };
+
+  window.CN = {
+    TEAM, ROSTER, byId, KEYS, makeBoard, buildTeams, PHASES,
+    SCENARIOS, SCN_ORDER,
+    // defaults (mid scenario) — used by galleries & component prop fallbacks
+    BOARD: MID.board, teams: MID.teams, currentClue: MID.clue, current: CLUES_MID[CLUES_MID.length - 1],
+    phaseState: MID.phaseState, CLUES: MID.clues, EVENTS: MID.events, ds: MID.ds,
+    timers,
+    summary, COLS: 5, ROWS: 5,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-codenames-flavor.jsx
+++ b/admin-mockups/design_files/sp4-session-codenames-flavor.jsx
@@ -1,0 +1,168 @@
+/* MeepleAI SP4 · Codenames — FLAVOR ATOMS  (window.CNFlavor)
+   Small reusable bits + type helpers, all from tokens.css.
+   Reads window.MAI (entityHsl) + window.CN (data). */
+
+(function () {
+  const M = window.MAI;
+  const CN = window.CN;
+  const eHsl = M.entityHsl;
+
+  // type helpers (mirror PGFlavor.mono/disp)
+  const mono = (size, weight, color) => ({ fontFamily: 'var(--f-mono)', fontSize: size, fontWeight: weight, color });
+  const disp = (size, weight, color) => ({ fontFamily: 'var(--f-display)', fontSize: size, fontWeight: weight, color });
+
+  const teamEntity = (team) => (team === 'red' ? 'event' : 'chat');
+  const teamName   = (team) => (team === 'red' ? 'Rossi' : 'Blu');
+
+  // ─── key-card swatch colors (the "real" identity of a tile) ───────────────
+  // assassin uses the deepest ink; neutral uses a warm beige from the palette.
+  const KEY = {
+    red:      { e: 'event', label: 'Agente Rosso',  swatch: 'hsl(var(--c-event))' },
+    blue:     { e: 'chat',  label: 'Agente Blu',     swatch: 'hsl(var(--c-chat))' },
+    neutral:  { e: null,    label: 'Civile',         swatch: 'var(--bg-sunken)' },
+    assassin: { e: null,    label: 'Assassino',      swatch: '#0f0c08' },
+  };
+
+  // ─── RoleAvatar — player chip; spymaster gets a distinguishing badge ──────
+  const RoleAvatar = ({ p, size = 26, ring, showRole, dim }) => {
+    const spy = p.role === 'spymaster';
+    const e = teamEntity(p.team);
+    return (
+      <span style={{ position: 'relative', display: 'inline-flex', flexShrink: 0, opacity: dim ? 0.5 : 1 }}>
+        <span aria-hidden="true" style={{
+          width: size, height: size, borderRadius: '50%',
+          background: `linear-gradient(135deg, hsl(${p.hue},72%,62%), hsl(${p.hue},60%,42%))`,
+          color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          ...disp(size * 0.44, 800), border: ring ? `2px solid ${eHsl(e)}` : '2px solid var(--bg-card)',
+        }}>{p.name[0]}</span>
+        {spy && (
+          <span title="Spymaster" aria-label="Spymaster" style={{
+            position: 'absolute', bottom: -3, right: -4, width: size * 0.5, height: size * 0.5, minWidth: 13, minHeight: 13,
+            borderRadius: '50%', background: eHsl(e), color: '#fff', border: '1.5px solid var(--bg-card)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: Math.max(7, size * 0.26),
+          }}>🕶</span>
+        )}
+        {showRole && (
+          <span style={{ ...mono(7.5, 800, eHsl(e)), position: 'absolute', top: -7, left: '50%', transform: 'translateX(-50%)', whiteSpace: 'nowrap', textTransform: 'uppercase', letterSpacing: '.04em' }}>
+            {spy ? 'SPY' : 'OP'}
+          </span>
+        )}
+      </span>
+    );
+  };
+
+  // ─── RoleTag — text role pill ─────────────────────────────────────────────
+  const RoleTag = ({ role, team }) => {
+    const e = teamEntity(team);
+    const spy = role === 'spymaster';
+    return (
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 3, padding: '1px 7px', borderRadius: 'var(--r-pill)',
+        background: eHsl(e, 0.12), border: `1px solid ${eHsl(e, 0.3)}`, ...mono(8.5, 800, eHsl(e)),
+        textTransform: 'uppercase', letterSpacing: '.05em', whiteSpace: 'nowrap',
+      }}>
+        <span aria-hidden="true">{spy ? '🕶' : '🔎'}</span>{spy ? 'Spymaster' : 'Operativo'}
+      </span>
+    );
+  };
+
+  // ─── ClueChip — "WORD : N" with team color ────────────────────────────────
+  const ClueChip = ({ word, number, team, big, dim }) => {
+    const e = teamEntity(team);
+    return (
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: big ? 9 : 6, padding: big ? '6px 12px' : '3px 9px',
+        borderRadius: 'var(--r-md)', background: eHsl(e, dim ? 0.06 : 0.12), border: `1px solid ${eHsl(e, dim ? 0.2 : 0.34)}`,
+        opacity: dim ? 0.8 : 1,
+      }}>
+        <span style={{ ...disp(big ? 18 : 12.5, 800, 'var(--text)'), letterSpacing: '.04em', textTransform: 'uppercase' }}>{word}</span>
+        <span aria-hidden="true" style={{ ...mono(big ? 14 : 10, 700, eHsl(e)) }}>:</span>
+        <span style={{
+          width: big ? 26 : 18, height: big ? 26 : 18, borderRadius: 'var(--r-sm)', flexShrink: 0,
+          background: eHsl(e), color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          ...disp(big ? 14 : 10.5, 800), fontVariantNumeric: 'tabular-nums',
+        }}>{number}</span>
+      </span>
+    );
+  };
+
+  // ─── GuessPips — N+1 slots: filled = correct, hollow = remaining, dashed = bonus
+  const GuessPips = ({ made, number, team }) => {
+    const e = teamEntity(team);
+    const slots = [];
+    for (let i = 0; i < number; i++) slots.push(i < made ? 'done' : 'open');
+    slots.push(made > number ? 'done' : 'bonus');
+    return (
+      <div role="img" aria-label={`${made} indovinati su ${number} (+1 bonus)`} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        {slots.map((kind, i) => (
+          <span key={i} aria-hidden="true" style={{
+            width: 13, height: 13, borderRadius: '50%', flexShrink: 0,
+            background: kind === 'done' ? eHsl(e) : 'transparent',
+            border: kind === 'done' ? 'none' : kind === 'bonus' ? `1.5px dashed ${eHsl(e, 0.6)}` : `1.5px solid ${eHsl(e, 0.4)}`,
+          }} />
+        ))}
+      </div>
+    );
+  };
+
+  // ─── KeyCell — small swatch used in the Spymaster key-card mini grid ──────
+  const KeyCell = ({ keyType, revealed, size = 'auto' }) => {
+    const k = KEY[keyType] || KEY.neutral;
+    const isDark = keyType === 'assassin';
+    return (
+      <span aria-hidden="true" style={{
+        aspectRatio: '1', width: size === 'auto' ? '100%' : size, borderRadius: 'var(--r-xs)',
+        background: k.e ? eHsl(k.e, revealed ? 1 : 0.85) : k.swatch,
+        border: `1px solid ${isDark ? 'rgba(255,255,255,.18)' : k.e ? eHsl(k.e) : 'var(--border-strong)'}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 9, color: '#fff', opacity: revealed ? 0.45 : 1,
+      }}>{isDark ? '💀' : ''}</span>
+    );
+  };
+
+  // ─── TimerChip — countdown with warning state · aria-live ─────────────────
+  const fmt = (s) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+  const TimerChip = ({ timer, compact }) => {
+    if (!timer || !timer.enabled) return null;
+    const warn = timer.remaining <= timer.warn;
+    const e = !timer.active ? null : warn ? 'event' : 'session';
+    const fg = e ? eHsl(e) : 'var(--text-muted)';
+    return (
+      <span role="timer" aria-live="polite" aria-label={`${timer.label}: ${fmt(timer.remaining)}${timer.active ? '' : ' · in pausa'}`}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 5, padding: compact ? '2px 8px' : '4px 10px',
+          borderRadius: 'var(--r-pill)', background: e ? eHsl(e, 0.1) : 'var(--bg-muted)',
+          border: `1px solid ${e ? eHsl(e, 0.32) : 'var(--border)'}`, whiteSpace: 'nowrap',
+        }}>
+        <span aria-hidden="true" className={timer.active && warn ? 'mai-pulse-dot' : undefined} style={{ fontSize: compact ? 10 : 11, color: fg }}>{timer.active ? '⏱' : '⏸'}</span>
+        <span style={{ ...mono(compact ? 9 : 10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.04em' }}>{timer.label}</span>
+        <span style={{ ...mono(compact ? 11 : 12.5, 800, fg), fontVariantNumeric: 'tabular-nums' }}>{timer.active ? fmt(timer.remaining) : `${timer.duration}s`}</span>
+      </span>
+    );
+  };
+
+  // ─── OutcomeBadge for a clue result ───────────────────────────────────────
+  const CLUE_OUTCOME = {
+    clean:   { e: 'toolkit', lb: 'Pieno',     icon: '✓' },
+    partial: { e: 'agent',   lb: 'Parziale',  icon: '◑' },
+    miss:    { e: 'event',   lb: 'Mancato',   icon: '✕' },
+    active:  { e: 'session', lb: 'In corso',  icon: '●', pulse: true },
+  };
+  const ClueOutcome = ({ outcome }) => {
+    const o = CLUE_OUTCOME[outcome] || CLUE_OUTCOME.clean;
+    return (
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4, padding: '1px 8px', borderRadius: 'var(--r-pill)',
+        background: eHsl(o.e, 0.12), border: `1px solid ${eHsl(o.e, 0.3)}`, ...mono(8.5, 800, eHsl(o.e)),
+        textTransform: 'uppercase', letterSpacing: '.04em', whiteSpace: 'nowrap',
+      }}>
+        <span aria-hidden="true" className={o.pulse ? 'mai-pulse-dot' : undefined}>{o.icon}</span>{o.lb}
+      </span>
+    );
+  };
+
+  window.CNFlavor = {
+    mono, disp, teamEntity, teamName, KEY,
+    RoleAvatar, RoleTag, ClueChip, GuessPips, KeyCell, TimerChip, ClueOutcome, CLUE_OUTCOME, fmt,
+  };
+})();

--- a/admin-mockups/design_files/sp4-session-codenames-live.html
+++ b/admin-mockups/design_files/sp4-session-codenames-live.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Codenames · Session Live — /sessions/[id]/live</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-bodies.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-codenames-live.jsx
+++ b/admin-mockups/design_files/sp4-session-codenames-live.jsx
@@ -1,0 +1,158 @@
+/* MeepleAI SP4 · Codenames — LIVE
+   /sessions/[id]/live  — Codenames extension of the universal session skeleton.
+
+   Codenames is the lone team-deduction / asymmetric-info archetype of the
+   premium set: the Spymaster knows the key card, Operatives don't. The 5×5 word
+   grid is the always-visible centerpiece; the mandatory chat/log accordion sits
+   below it (one panel open at a time); the right column is the polymorphic tab
+   stack (Scoring=Ranking · Board=key card · Indizi · Squadre · Chat).
+
+   Below the live frames: full states gallery — every game-specific renderer
+   (WordGrid · TeamPanel · ClueHistory) and the reused polymorphic renderers
+   (ScoringPanel→Ranking · TurnIndicator→Sequential) × the 5 canonical states.
+
+   Loads: sp4-parts-common.jsx · sp4-session-codenames-data.jsx ·
+          sp4-session-skeleton-renderers.jsx · sp4-session-skeleton-parts.jsx ·
+          sp4-session-codenames-flavor.jsx · sp4-session-codenames-parts.jsx ·
+          sp4-session-codenames-bodies.jsx
+   DEMO-NAV-HINTS: sp4-session-codenames-summary.html */
+
+const S = window.SkeletonParts;
+const R = window.SkeletonRenderers;
+const M = window.MAI;
+const CN = window.CN;
+const P = window.CNParts;
+const F = window.CNFlavor;
+const eHsl = M.entityHsl;
+const STATES = window.SkeletonData.STATES;
+const { mono, disp } = F;
+
+const GalleryRow = ({ title, sub, entity, children }) => (
+  <div style={{ marginBottom: 26 }}>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+      <span style={{ ...disp(15, 800, eHsl(entity)) }}>{title}</span>
+      {sub && <span style={{ ...mono(10, 700, 'var(--text-muted)') }}>{sub}</span>}
+    </div>
+    <div className="mai-cb-scroll" style={{ display: 'flex', gap: 16, overflowX: 'auto', paddingBottom: 10 }}>{children}</div>
+  </div>
+);
+
+const StatesOf = ({ entity, Renderer, render, h = 480 }) =>
+  STATES.map((s) => (
+    <P.PanelFrame key={s.id} label={s.lb} entity={entity} h={h}>
+      {render ? render(s.id) : <Renderer data={CN.ds} state={s.id} />}
+    </P.PanelFrame>
+  ));
+
+function Intro() {
+  const cards = [
+    { e: 'session', h: 'Archetipo unico', b: 'Unica deduzione a squadre con info asimmetrica del set premium: lo Spymaster vede la key card, gli Operatives no.' },
+    { e: 'event',   h: 'Griglia 5×5 al centro', b: '25 carte parola sempre visibili. Toggle prospettiva Operativo / Spymaster + key card nascondibile per lo screen-share.' },
+    { e: 'agent',   h: 'Chat / log / indizi in accordion', b: 'Colonna principale: WordGrid fissa + accordion a pannello singolo (Chat · Registro · Storico indizi), identico allo skeleton.' },
+    { e: 'toolkit', h: '5 stati canonici', b: 'default · empty · loading · error · sse-disconnect su ogni renderer, riusando gli atomi MAI.' },
+  ];
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12, margin: '4px 0 8px' }}>
+      {cards.map((c) => (
+        <div key={c.h} style={{ padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(c.e, 0.06), border: `1px solid ${eHsl(c.e, 0.25)}` }}>
+          <div style={{ ...disp(13, 800, eHsl(c.e)), marginBottom: 4 }}>{c.h}</div>
+          <div style={{ fontFamily: 'var(--f-body)', fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5 }}>{c.b}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <S.ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ ...mono(11, 600, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Codenames · Session live 🕵️</div>
+        <h1>Codenames — session live (deduzione a squadre)</h1>
+        <p className="lead">
+          Estensione game-specific dello <strong>skeleton universale</strong> per <code>/sessions/[id]/live</code>.
+          La struttura (scoring <strong>Ranking</strong>, turni <strong>Sequential</strong> a 4 fasi alternate, widget) è letta dal
+          Toolkit JSON; sopra, i widget specifici di Codenames — <strong>griglia 5×5</strong>, <strong>key card Spymaster</strong>,
+          tracker squadre, storico indizi. Dark = modalità primaria.
+        </p>
+        <Intro />
+
+        {/* SIDE-BY-SIDE — Operative vs Spymaster perspective */}
+        <div className="section-label">Side-by-side · Desktop 1280 — selettore scenario (mid-game · match point · assassino) · prospettiva Operativo vs Spymaster</div>
+        <div className="sk-sxs">
+          <S.DesktopFrame ds={CN.ds} label="Vista Operativo · mid-game" url="meepleai.app/sessions/cdn-7/live?view=operative" height={800}
+            desc="Cambia scenario dal selettore in alto. Operativi: solo tessere rivelate colorate. Griglia 5×5 al centro, accordion Chat aperto, colonna destra su Scoring (Ranking · squadre).">
+            <S.TopBar ds={CN.ds} connection="connected" />
+            <P.DesktopBody initialTab="scoring" initialState="default" initialPerspective="operative" initialScenario="mid" />
+          </S.DesktopFrame>
+          <S.DesktopFrame ds={CN.ds} label="Vista Spymaster · match point Blu" url="meepleai.app/sessions/cdn-7/live?view=spymaster" height={800} dark
+            desc="Scenario «match point»: al Blu manca 1 agente. Lo Spymaster vede i colori reali (tint + key card) e può nasconderli per lo screen-share. Passa a «Sconfitta · Assassino» per il banner di fine partita.">
+            <S.TopBar ds={CN.ds} connection="connected" />
+            <P.DesktopBody initialTab="board" initialState="default" initialPerspective="spymaster" initialScenario="match" />
+          </S.DesktopFrame>
+        </div>
+
+        {/* MOBILE */}
+        <div className="section-label">Mobile 375 — selettore scenario · griglia compatta · accordion · tab strip → bottom-sheet</div>
+        <div className="phones-grid">
+          <P.PhoneShell label="Operativo · mid-game" initialPerspective="operative" initialScenario="mid" desc="PhaseBanner sticky, indizio attuale, griglia 5×5 compatta, tracker squadre, accordion Chat/Registro/Indizi." />
+          <P.PhoneShell label="Sconfitta Assassino · dark" dark initialPerspective="operative" initialScenario="assassin" desc="Scenario di fine partita: banner di sconfitta, tessera assassino rivelata sulla griglia, CTA verso il recap." />
+        </div>
+
+        {/* CHROME showcase — phase banner + current clue */}
+        <div className="section-label">Chrome di turno — PhaseBanner (4 fasi alternate · aria-current) + indizio attuale</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 12 }}>
+          <div style={{ borderRadius: 'var(--r-lg)', border: '1px solid var(--border)', overflow: 'hidden' }}><P.PhaseBanner /></div>
+          <P.CurrentCluePanel />
+        </div>
+
+        {/* STATES GALLERY — game-specific renderers */}
+        <div className="section-label">Gallery stati · WordGrid — 5×5 carte parola (operativo) × 5 stati canonici</div>
+        <GalleryRow title="WordGrid" sub="griglia · covered/red/blue/neutral/assassin" entity="session">
+          <StatesOf entity="session" h={520} render={(st) => <P.WordGrid state={st} compact perspective="operative" />} />
+        </GalleryRow>
+
+        <div className="section-label">Gallery stati · TeamPanel — tracker Rosso + Blu × 5 stati</div>
+        <GalleryRow title="TeamPanel" sub="agenti rimasti · roster · turno corrente" entity="player">
+          <StatesOf entity="player" h={420} render={(st) => <div style={{ padding: 12, overflowY: 'auto' }}><P.TeamPanel state={st} /></div>} />
+        </GalleryRow>
+
+        <div className="section-label">Gallery stati · ClueHistoryTimeline — indizi dati · success rate × 5 stati</div>
+        <GalleryRow title="ClueHistoryTimeline" sub="storico · pieno/parziale/mancato · migliore/peggiore" entity="agent">
+          <StatesOf entity="agent" h={420} render={(st) => <div style={{ padding: 12, overflowY: 'auto' }}><P.ClueHistoryTimeline state={st} /></div>} />
+        </GalleryRow>
+
+        {/* STATES GALLERY — reused polymorphic renderers */}
+        <div className="section-label">Gallery stati · ScoringPanelRenderer (riuso) — scoreType <strong>Ranking</strong> (race condition) × 5 stati</div>
+        <GalleryRow title="ScoringPanelRenderer · Ranking" sub="classifica squadre · agenti trovati + assassino" entity="session">
+          <StatesOf entity="session" h={420} Renderer={R.ScoringPanelRenderer} />
+        </GalleryRow>
+
+        <div className="section-label">Gallery stati · TurnIndicatorRenderer (riuso) — turnOrderType <strong>Sequential</strong> (4 fasi alternate) × 5 stati</div>
+        <GalleryRow title="TurnIndicatorRenderer · Sequential" sub="phase stepper a squadra" entity="player">
+          <StatesOf entity="player" h={420} Renderer={R.TurnIndicatorRenderer} />
+        </GalleryRow>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { height: 7px; width: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .sk-sxs { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px; align-items: start; }
+        @media (max-width: 1100px) { .sk-sxs { grid-template-columns: 1fr; } }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-codenames-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-codenames-parts.jsx
@@ -1,0 +1,310 @@
+/* MeepleAI SP4 · Codenames — COMPOSED PARTS  (window.CNParts)
+   Game-specific widgets mounted on the universal skeleton:
+     SectionCard · PanelFrame · PhaseBanner · CurrentCluePanel ·
+     WordCard · WordGrid · SpymasterKeyCardOverlay · TeamPanel ·
+     ClueHistoryTimeline · RightColumnTabs · DesktopBody · MobileBody · PhoneShell
+
+   Reuses from skeleton: S.TopBar · S.ChatAgentPanel · S.ActionLogTimeline ·
+   S.StateSwitch · R.ScoringPanelRenderer (Ranking) · R.TurnIndicatorRenderer
+   (Sequential) · R.StateScaffold · M.Shimmer/StateBlock.
+   Accordion: one panel expanded at a time via sec(id), exactly like the
+   skeleton DesktopSessionBody + Power Grid extension. */
+
+(function () {
+  const M = window.MAI;
+  const R = window.SkeletonRenderers;
+  const S = window.SkeletonParts;
+  const CN = window.CN;
+  const F = window.CNFlavor;
+  const eHsl = M.entityHsl;
+  const { useState } = React;
+  const { mono, disp, teamEntity, RoleAvatar, RoleTag, ClueChip, GuessPips, KeyCell, TimerChip, ClueOutcome } = F;
+  const STATES = window.SkeletonData.STATES;
+
+  // ─── SectionCard — titled collapsible container (skeleton/PG pattern) ─────
+  const SectionCard = ({ title, entity = 'session', accent, right, children, pad = 12, flush, collapsed, onHeaderClick }) => {
+    const collapsible = !!onHeaderClick;
+    const headStyle = { width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: accent ? eHsl(entity, collapsed ? 0.04 : 0.06) : 'var(--bg-muted)', border: 'none', borderBottom: collapsed ? 'none' : `1px solid ${accent ? eHsl(entity, 0.18) : 'var(--border-light)'}`, cursor: collapsible ? 'pointer' : 'default' };
+    const headInner = (
+      <React.Fragment>
+        <span style={{ ...mono(10, 800, accent ? eHsl(entity) : 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{title}</span>
+        <div style={{ flex: 1 }} />{right}
+        {collapsible && <span aria-hidden="true" style={{ ...mono(11, 800, eHsl(entity)), flexShrink: 0, transform: collapsed ? 'rotate(-90deg)' : 'none', transition: 'transform var(--dur-sm) var(--ease-out)' }}>▾</span>}
+      </React.Fragment>
+    );
+    return (
+      <section style={{ background: 'var(--bg-card)', border: `1px solid ${accent || collapsible ? eHsl(entity, collapsed ? 0.2 : 0.3) : 'var(--border)'}`, borderRadius: 'var(--r-lg)', overflow: 'hidden', boxShadow: 'var(--shadow-sm)', flexShrink: 0 }}>
+        {title && (collapsible
+          ? <button type="button" onClick={onHeaderClick} aria-expanded={!collapsed} style={headStyle}>{headInner}</button>
+          : <div style={headStyle}>{headInner}</div>)}
+        {!collapsed && <div style={{ padding: flush ? 0 : pad }}>{children}</div>}
+      </section>
+    );
+  };
+
+  const PanelFrame = ({ label, entity = 'session', dark, children, w = 320, h = 480 }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} data-theme={dark ? 'dark' : undefined}>
+      <div style={{ ...mono(10, 800, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.07em' }}>{label}</div>
+      <div style={{ width: w, height: h, borderRadius: 'var(--r-lg)', border: `1px solid ${eHsl(entity, 0.3)}`, background: 'var(--bg-card)', overflow: 'hidden', display: 'flex', flexDirection: 'column', boxShadow: 'var(--shadow-sm)' }}>{children}</div>
+    </div>
+  );
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PhaseBanner — 4-phase team-alternating timeline (aria-current step)
+  // ══════════════════════════════════════════════════════════════════════════
+  const PhaseBanner = ({ compact, sticky, phaseState = CN.phaseState }) => {
+    const { PHASES } = CN;
+    return (
+      <div role="group" aria-label="Fase del turno" style={{
+        display: 'flex', alignItems: 'center', gap: compact ? 8 : 13, padding: compact ? '8px 12px' : '10px 16px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(14px)', borderBottom: '1px solid var(--border)',
+        ...(sticky ? { position: 'sticky', top: 0, zIndex: 10 } : {}), flexShrink: 0, flexWrap: 'wrap', rowGap: 7,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: 1, flexShrink: 0 }}>
+          <span style={{ ...disp(compact ? 16 : 20, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>R{phaseState.round}</span>
+          <span style={{ ...mono(7.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>Round</span>
+        </div>
+        <span aria-hidden="true" style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)', flexShrink: 0 }} />
+        <ol style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', alignItems: 'center', flexWrap: 'wrap', rowGap: 6, gap: compact ? 4 : 6, flex: 1, minWidth: 0 }}>
+          {PHASES.map((ph, i) => {
+            const on = i === phaseState.phaseIndex, past = i < phaseState.phaseIndex;
+            const e = teamEntity(ph.team);
+            return (
+              <li key={ph.id} aria-current={on ? 'step' : undefined} style={{ display: 'flex', alignItems: 'center', gap: compact ? 4 : 6, flexShrink: 0 }}>
+                <div title={ph.desc} style={{
+                  display: 'flex', alignItems: 'center', gap: 6, padding: compact ? '5px 8px' : '6px 11px', borderRadius: 'var(--r-pill)',
+                  background: on ? eHsl(e, 0.16) : past ? eHsl(e, 0.06) : 'var(--bg-muted)',
+                  border: `1px solid ${on ? eHsl(e, 0.5) : past ? eHsl(e, 0.2) : 'var(--border-light)'}`,
+                  boxShadow: on ? `0 3px 10px ${eHsl(e, 0.22)}` : 'none',
+                }}>
+                  <span aria-hidden="true" style={{
+                    width: compact ? 17 : 20, height: compact ? 17 : 20, borderRadius: '50%', flexShrink: 0,
+                    background: on ? eHsl(e) : past ? eHsl(e, 0.2) : 'transparent',
+                    color: on ? '#fff' : past ? eHsl(e) : 'var(--text-muted)',
+                    border: on || past ? 'none' : '1px solid var(--border-strong)',
+                    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: compact ? 9 : 10.5,
+                  }}>{past ? '✓' : ph.kind === 'clue' ? '🕶' : '🔎'}</span>
+                  {!compact && <span style={{ ...disp(11.5, on ? 800 : 600, on ? eHsl(e) : past ? 'var(--text-sec)' : 'var(--text-muted)'), whiteSpace: 'nowrap' }}>{ph.short}</span>}
+                  {on && <span className="mai-pulse-dot" aria-hidden="true" style={{ ...mono(8, 800, eHsl(e)) }}>●</span>}
+                </div>
+                {i < PHASES.length - 1 && <span aria-hidden="true" style={{ ...mono(10, 800, past ? eHsl(e) : 'var(--text-muted)') }}>{compact ? '·' : '→'}</span>}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // CurrentCluePanel — prominent active-clue area (clue · pips · timer)
+  // ══════════════════════════════════════════════════════════════════════════
+  const CurrentCluePanel = ({ compact, clue = CN.currentClue }) => {
+    const c = clue;
+    const e = teamEntity(c.team);
+    const spy = CN.byId(c.spymaster);
+    return (
+      <div role="region" aria-label="Indizio attuale" aria-live="polite" style={{
+        display: 'flex', alignItems: 'center', gap: compact ? 12 : 18, flexWrap: 'wrap', rowGap: 10,
+        padding: compact ? '11px 13px' : '13px 16px', borderRadius: 'var(--r-lg)',
+        background: 'var(--bg-card)', border: `2px solid ${eHsl(e, 0.45)}`, boxShadow: `0 6px 22px ${eHsl(e, 0.16)}`, flexShrink: 0,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+            <span className="mai-pulse-dot" aria-hidden="true" style={{ fontSize: 9, color: eHsl(e) }}>●</span>
+            <span style={{ ...mono(9, 800, eHsl(e)), textTransform: 'uppercase', letterSpacing: '.07em' }}>Indizio · {F.teamName(c.team)} indovinano</span>
+          </div>
+          <ClueChip word={c.word} number={c.number} team={c.team} big={!compact} />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <RoleAvatar p={spy} size={20} />
+            <span style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>dato da <strong style={{ color: 'var(--text-sec)' }}>{spy.name}</strong> · Spymaster</span>
+          </div>
+        </div>
+        <span aria-hidden="true" style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)', flexShrink: 0 }} />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1, minWidth: 140 }}>
+          <div>
+            <div style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 5 }}>Tentativi</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 9, flexWrap: 'wrap' }}>
+              <GuessPips made={c.guessesMade} number={c.number} team={c.team} />
+              <span style={{ ...mono(10, 700, 'var(--text-sec)') }}>
+                <strong style={{ color: eHsl(e), fontSize: 13 }}>{c.guessesMade}</strong> indovinati · ancora <strong style={{ color: 'var(--text)' }}>{c.remaining}</strong> <span style={{ color: 'var(--text-muted)' }}>(incl. +1 bonus)</span>
+              </span>
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 7, flexWrap: 'wrap' }}>
+            <TimerChip timer={CN.timers.guess} compact={compact} />
+            <div style={{ display: 'flex', gap: 6, marginLeft: 'auto' }}>
+              <button type="button" style={{ padding: '5px 11px', borderRadius: 'var(--r-md)', background: eHsl(e), color: '#fff', border: 'none', ...disp(11.5, 800, '#fff'), cursor: 'pointer', whiteSpace: 'nowrap' }}>Indovina</button>
+              <button type="button" style={{ padding: '5px 11px', borderRadius: 'var(--r-md)', background: 'var(--bg-muted)', border: '1px solid var(--border)', ...disp(11.5, 800, 'var(--text-sec)'), cursor: 'pointer', whiteSpace: 'nowrap' }}>Passa</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // WordCard — one tile · states: covered / red / blue / neutral / assassin
+  // ══════════════════════════════════════════════════════════════════════════
+  const WordCard = ({ cell, revealKey, compact }) => {
+    const k = cell.key;
+    const h = compact ? 46 : 64;
+    const baseFs = compact ? 9.5 : 13;
+    let bg = 'var(--bg-card)', fg = 'var(--text)', border = '1px solid var(--border)', stripe = null, badge = null, opacity = 1, txtDeco = 'none';
+
+    if (cell.revealed) {
+      if (k === 'red')      { bg = eHsl('event'); fg = '#fff'; border = `1px solid ${eHsl('event')}`; badge = '✓'; }
+      else if (k === 'blue'){ bg = eHsl('chat');  fg = '#fff'; border = `1px solid ${eHsl('chat')}`;  badge = '✓'; }
+      else if (k === 'neutral') { bg = 'var(--bg-sunken)'; fg = 'var(--text-muted)'; border = '1px solid var(--border-strong)'; opacity = 0.92; txtDeco = 'line-through'; }
+      else /* assassin */   { bg = '#0f0c08'; fg = '#fff'; border = `1.5px solid ${eHsl('event', 0.7)}`; badge = '💀'; }
+    } else if (revealKey) {
+      // Spymaster key view: tint covered tiles by their real identity
+      if (k === 'red')       { bg = eHsl('event', 0.14); border = `1px solid ${eHsl('event', 0.5)}`; stripe = eHsl('event'); }
+      else if (k === 'blue') { bg = eHsl('chat', 0.14);  border = `1px solid ${eHsl('chat', 0.5)}`;  stripe = eHsl('chat'); }
+      else if (k === 'neutral') { bg = 'var(--bg-muted)'; border = '1px solid var(--border-strong)'; stripe = 'var(--text-muted)'; }
+      else /* assassin */    { bg = 'repeating-linear-gradient(45deg, #0f0c08, #0f0c08 6px, #241c13 6px, #241c13 12px)'; fg = '#fff'; border = `1.5px solid ${eHsl('event', 0.7)}`; stripe = eHsl('event'); badge = '💀'; }
+    }
+
+    const status = cell.revealed ? (F.KEY[k].label + ' · rivelato') : revealKey ? (F.KEY[k].label + ' · coperto') : 'coperta';
+    return (
+      <button type="button" aria-label={`Parola ${cell.word}, ${status}`} aria-pressed={cell.revealed || undefined}
+        disabled={cell.revealed}
+        style={{
+          position: 'relative', height: h, borderRadius: 'var(--r-md)', background: bg, border, color: fg, opacity,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '4px 6px', overflow: 'hidden',
+          cursor: cell.revealed ? 'default' : 'pointer', textAlign: 'center', boxShadow: cell.revealed ? 'none' : 'var(--shadow-xs)',
+          transition: 'transform var(--dur-xs) var(--ease-out), box-shadow var(--dur-xs) var(--ease-out)',
+        }}>
+        {stripe && <span aria-hidden="true" style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 4, background: stripe }} />}
+        <span style={{ ...disp(baseFs, 800, fg), letterSpacing: '.02em', textTransform: 'uppercase', textDecoration: txtDeco, lineHeight: 1.1, wordBreak: 'break-word' }}>{cell.word}</span>
+        {badge && <span aria-hidden="true" style={{ position: 'absolute', bottom: 3, right: 5, fontSize: compact ? 9 : 11, opacity: 0.9 }}>{badge}</span>}
+      </button>
+    );
+  };
+
+  // ─── WordGrid — 5×5, perspective-aware, with board toolbar + states ───────
+  const WordGridInner = ({ perspective, keyVisible, compact, board = CN.BOARD }) => {
+    const reveal = perspective === 'spymaster' && keyVisible;
+    return (
+      <div role="grid" aria-label="Griglia 5×5 delle parole" style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: compact ? 5 : 7 }}>
+        {board.map((cell, i) => <WordCard key={i} cell={cell} revealKey={reveal} compact={compact} />)}
+      </div>
+    );
+  };
+  const WordGrid = ({ state = 'default', compact, perspective = 'operative', keyVisible = true, onTogglePerspective, onToggleKey, board = CN.BOARD }) => {
+    const spy = perspective === 'spymaster';
+    return (
+      <SectionCard title="Griglia parole" entity="session" accent flush
+        right={
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+            <div role="group" aria-label="Prospettiva" style={{ display: 'inline-flex', borderRadius: 'var(--r-pill)', background: 'var(--bg-card)', border: '1px solid var(--border)', overflow: 'hidden' }}>
+              {[['operative', '🔎 Operativo'], ['spymaster', '🕶 Spymaster']].map(([id, lb]) => {
+                const on = perspective === id;
+                const e = id === 'spymaster' ? 'session' : 'player';
+                return (
+                  <button key={id} type="button" aria-pressed={on} onClick={() => onTogglePerspective && onTogglePerspective(id)}
+                    style={{ padding: '3px 9px', border: 'none', background: on ? eHsl(e, 0.16) : 'transparent', color: on ? eHsl(e) : 'var(--text-muted)', ...mono(9, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>{lb}</button>
+                );
+              })}
+            </div>
+            {spy && (
+              <button type="button" aria-pressed={keyVisible} onClick={() => onToggleKey && onToggleKey()} title="Mostra/nascondi key card (privacy screen-share)"
+                style={{ padding: '3px 9px', borderRadius: 'var(--r-pill)', background: keyVisible ? eHsl('session', 0.14) : 'var(--bg-muted)', border: `1px solid ${keyVisible ? eHsl('session', 0.4) : 'var(--border)'}`, color: keyVisible ? eHsl('session') : 'var(--text-muted)', ...mono(9, 800), cursor: 'pointer', whiteSpace: 'nowrap' }}>
+                {keyVisible ? '👁 Key visibile' : '🚫 Key nascosta'}
+              </button>
+            )}
+          </div>
+        }>
+        <R.StateScaffold state={state} sseWhere="griglia"
+          empty={{ icon: '🗂', title: 'Griglia non pronta', body: 'Le 25 parole compaiono all\u2019avvio della partita.' }}
+          error={{ title: 'Griglia non disponibile', body: 'Impossibile caricare le carte parola.' }}
+          loading={<div style={{ padding: 12, display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: compact ? 5 : 7 }}>{Array.from({ length: 25 }).map((_, i) => <M.Shimmer key={i} h={compact ? 46 : 64} />)}</div>}>
+          <div style={{ padding: compact ? 9 : 12 }}>
+            <WordGridInner perspective={perspective} keyVisible={keyVisible} compact={compact} board={board} />
+            {spy && keyVisible && <SpymasterKeyCardOverlay onToggleKey={onToggleKey} board={board} embedded />}
+          </div>
+        </R.StateScaffold>
+      </SectionCard>
+    );
+  };
+
+  // ─── SpymasterKeyCardOverlay — secret 5×5 key (toggleable) ────────────────
+  const SpymasterKeyCardOverlay = ({ onToggleKey, embedded, board = CN.BOARD }) => {
+    const counts = { red: 0, blue: 0, neutral: 0, assassin: 0 };
+    board.forEach((c) => { counts[c.key]++; });
+    return (
+      <div role="region" aria-label="Key card Spymaster" style={{ marginTop: 11, padding: 11, borderRadius: 'var(--r-md)', background: 'var(--bg-sunken)', border: `1px dashed ${eHsl('session', 0.4)}` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 9, flexWrap: 'wrap', rowGap: 6 }}>
+          <span style={{ ...mono(9, 800, eHsl('session')), textTransform: 'uppercase', letterSpacing: '.06em' }}>🔑 Key card · segreta</span>
+          <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+            {[['red', 'event'], ['blue', 'chat'], ['neutral', null], ['assassin', null]].map(([k, e]) => (
+              <span key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, ...mono(8.5, 700, 'var(--text-sec)') }}>
+                <span style={{ width: 10, height: 10, borderRadius: 2, background: e ? eHsl(e) : k === 'assassin' ? '#0f0c08' : 'var(--bg-muted)', border: '1px solid var(--border-strong)' }} />{counts[k]}
+              </span>
+            ))}
+          </div>
+          {onToggleKey && <button type="button" aria-pressed="true" onClick={onToggleKey} style={{ marginLeft: 'auto', padding: '2px 9px', borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', border: '1px solid var(--border)', ...mono(8.5, 800, 'var(--text-muted)'), cursor: 'pointer' }}>🚫 Nascondi</button>}
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 4, maxWidth: embedded ? 260 : '100%' }}>
+          {board.map((c, i) => <KeyCell key={i} keyType={c.key} revealed={c.revealed} />)}
+        </div>
+        <div style={{ ...mono(8.5, 700, 'var(--text-muted)'), marginTop: 8, lineHeight: 1.5 }}>Solo per lo Spymaster · nascondi durante screen-share. I quadretti sbiaditi sono già rivelati.</div>
+      </div>
+    );
+  };
+
+  // ─── GameOverBanner — end-of-game result (e.g. assassin defeat) ───────────
+  const GameOverBanner = ({ over, compact }) => {
+    const winnerE = teamEntity(over.winner);
+    return (
+      <div role="alert" style={{
+        position: 'relative', overflow: 'hidden', borderRadius: 'var(--r-lg)', flexShrink: 0,
+        padding: compact ? '13px 14px' : '16px 18px',
+        background: 'repeating-linear-gradient(45deg, #0f0c08, #0f0c08 10px, #1a140d 10px, #1a140d 20px)',
+        border: `2px solid ${eHsl('event', 0.6)}`, boxShadow: `0 8px 28px ${eHsl('event', 0.25)}`, color: '#fff',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 12 : 16, flexWrap: 'wrap', rowGap: 8 }}>
+          <span aria-hidden="true" style={{ fontSize: compact ? 32 : 42, lineHeight: 1 }}>{over.icon}</span>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{ ...mono(9, 800, eHsl('event')), textTransform: 'uppercase', letterSpacing: '.1em', marginBottom: 3 }}>Partita conclusa</div>
+            <div style={{ ...disp(compact ? 18 : 22, 800, '#fff') }}>{over.title}</div>
+            <div style={{ ...disp(compact ? 12 : 13.5, 600, 'rgba(255,255,255,.9)'), marginTop: 3 }}>{over.cause}</div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, padding: '6px 12px', borderRadius: 'var(--r-pill)', background: eHsl(winnerE, 0.22), border: `1px solid ${eHsl(winnerE, 0.55)}` }}>
+              <span aria-hidden="true">🏆</span><span style={{ ...disp(12.5, 800, '#fff') }}>Vince {F.teamName(over.winner)}</span>
+            </span>
+            <a href="sp4-session-codenames-summary.html" style={{ padding: '7px 13px', borderRadius: 'var(--r-md)', background: '#fff', color: '#1a140d', ...disp(12, 800), whiteSpace: 'nowrap' }}>Vai al recap →</a>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ─── ScenarioSwitcher — switch the depicted game state ────────────────────
+  const ScenarioSwitcher = ({ value, onChange, compact }) => (
+    <div role="group" aria-label="Scenario partita" style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: compact ? '6px 12px' : '7px 16px',
+      background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)', flexShrink: 0, flexWrap: 'wrap', rowGap: 6,
+    }}>
+      <span style={{ ...mono(8.5, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.07em', flexShrink: 0 }}>Scenario</span>
+      <div style={{ display: 'inline-flex', borderRadius: 'var(--r-pill)', background: 'var(--bg-card)', border: '1px solid var(--border)', overflow: 'hidden' }}>
+        {CN.SCN_ORDER.map((id) => {
+          const sc = CN.SCENARIOS[id];
+          const on = value === id;
+          const e = sc.tone;
+          return (
+            <button key={id} type="button" aria-pressed={on} onClick={() => onChange && onChange(id)}
+              title={sc.sub}
+              style={{ padding: compact ? '4px 9px' : '5px 12px', border: 'none', background: on ? eHsl(e, 0.16) : 'transparent', color: on ? eHsl(e) : 'var(--text-muted)', ...mono(compact ? 8.5 : 9.5, 800), cursor: 'pointer', whiteSpace: 'nowrap', borderRight: id !== 'assassin' ? '1px solid var(--border-light)' : 'none' }}>
+              {sc.label}
+            </button>
+          );
+        })}
+      </div>
+      {!compact && <span style={{ ...mono(9, 700, 'var(--text-muted)') }}>{CN.SCENARIOS[value].sub}</span>}
+    </div>
+  );
+
+  window.CNParts = { SectionCard, PanelFrame, PhaseBanner, CurrentCluePanel, WordCard, WordGrid, WordGridInner, SpymasterKeyCardOverlay, GameOverBanner, ScenarioSwitcher };
+})();

--- a/admin-mockups/design_files/sp4-session-codenames-summary.html
+++ b/admin-mockups/design_files/sp4-session-codenames-summary.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · Codenames · Session Summary — /sessions/[id]/summary</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-parts-common.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-data.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-renderers.jsx"></script>
+<script type="text/babel" src="sp4-session-skeleton-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-flavor.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-parts.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-bodies.jsx"></script>
+<script type="text/babel" src="sp4-session-codenames-summary.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-codenames-summary.jsx
+++ b/admin-mockups/design_files/sp4-session-codenames-summary.jsx
@@ -1,0 +1,300 @@
+/* MeepleAI SP4 · Codenames — SUMMARY (post-game)
+   /sessions/[id]/summary  — Codenames recap.
+
+   Hero winner banner (Red / Blue / Assassin defeat) + 4 tabs:
+     Scoreboard (Ranking) · Final Board (full reveal) · Clue Analysis · Stats.
+   Reuses skeleton/flavor atoms (OutcomeBadge · ClueChip · ClueOutcome ·
+   RoleAvatar · WordCard). Dark = primary.
+
+   Loads: sp4-parts-common.jsx · sp4-session-codenames-data.jsx ·
+          sp4-session-skeleton-renderers.jsx · sp4-session-skeleton-parts.jsx ·
+          sp4-session-codenames-flavor.jsx · sp4-session-codenames-parts.jsx ·
+          sp4-session-codenames-bodies.jsx */
+
+const S = window.SkeletonParts;
+const R = window.SkeletonRenderers;
+const M = window.MAI;
+const CN = window.CN;
+const P = window.CNParts;
+const F = window.CNFlavor;
+const eHsl = M.entityHsl;
+const { useState } = React;
+const { mono, disp, teamEntity, teamName, RoleAvatar, ClueChip, ClueOutcome } = F;
+const SUM = CN.summary;
+
+// ─── Hero — winner banner ───────────────────────────────────────────────────
+const RESULTS = {
+  red:      { winner: 'red',  title: 'Squadra Rossa vince', icon: '🏆', e: 'event', cause: 'Ha rivelato tutti i 9 agenti', kind: 'agents' },
+  blue:     { winner: 'blue', title: 'Squadra Blu vince',   icon: '🏆', e: 'chat',  cause: 'Ha rivelato tutti gli 8 agenti', kind: 'agents' },
+  assassin: { winner: 'blue', title: 'Sconfitta · Assassino', icon: '💀', e: null,  cause: 'Il Rosso ha rivelato l\u2019assassino — sconfitta immediata', kind: 'assassin' },
+};
+
+const SummaryHero = ({ result = RESULTS.red, duration = SUM.duration, rounds = SUM.rounds, compact }) => {
+  const dark = result.kind === 'assassin';
+  const accent = result.e ? eHsl(result.e) : '#fff';
+  const bg = dark
+    ? 'repeating-linear-gradient(45deg, #0f0c08, #0f0c08 10px, #1a140d 10px, #1a140d 20px)'
+    : `linear-gradient(135deg, ${eHsl(result.e, 0.9)}, ${eHsl(result.e, 0.55)})`;
+  return (
+    <div role="status" style={{
+      position: 'relative', overflow: 'hidden', borderRadius: 'var(--r-xl)', padding: compact ? '20px 18px' : '30px 28px',
+      background: bg, border: dark ? `1.5px solid ${eHsl('event', 0.6)}` : 'none',
+      boxShadow: result.e ? `0 12px 36px ${eHsl(result.e, 0.32)}` : 'var(--shadow-lg)', color: '#fff',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: compact ? 14 : 20, flexWrap: 'wrap' }}>
+        <div aria-hidden="true" style={{ fontSize: compact ? 40 : 54, lineHeight: 1, filter: 'drop-shadow(0 3px 8px rgba(0,0,0,.3))' }}>{result.icon}</div>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ ...mono(compact ? 9 : 10, 800, 'rgba(255,255,255,.75)'), textTransform: 'uppercase', letterSpacing: '.12em', marginBottom: 4 }}>Esito partita · Codenames</div>
+          <div style={{ ...disp(compact ? 24 : 34, 800, '#fff'), letterSpacing: '-0.01em' }}>{result.title}</div>
+          <div style={{ ...disp(compact ? 13 : 15, 600, 'rgba(255,255,255,.92)'), marginTop: 4 }}>{result.cause}</div>
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: compact ? 14 : 18 }}>
+        {[['⏱', 'Durata', duration], ['🔁', 'Round', rounds], ['🗝', 'Assassino', SUM.assassinAvoided && result.kind !== 'assassin' ? 'evitato' : 'rivelato']].map(([ic, lb, v]) => (
+          <span key={lb} style={{ display: 'inline-flex', alignItems: 'center', gap: 7, padding: '6px 12px', borderRadius: 'var(--r-pill)', background: 'rgba(0,0,0,.22)', border: '1px solid rgba(255,255,255,.22)' }}>
+            <span aria-hidden="true">{ic}</span>
+            <span style={{ ...mono(9, 800, 'rgba(255,255,255,.7)'), textTransform: 'uppercase', letterSpacing: '.06em' }}>{lb}</span>
+            <span style={{ ...disp(13, 800, '#fff'), fontVariantNumeric: 'tabular-nums' }}>{v}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// ─── Scoreboard tab — team results (Ranking) ────────────────────────────────
+const TeamResultRow = ({ teamId, rank, winner }) => {
+  const t = SUM.teams[teamId];
+  const e = teamEntity(teamId);
+  const isWin = teamId === winner;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', borderRadius: 'var(--r-lg)', background: isWin ? eHsl(e, 0.1) : 'var(--bg-card)', border: `${isWin ? 2 : 1}px solid ${eHsl(e, isWin ? 0.5 : 0.28)}` }}>
+      <span style={{ width: 30, height: 30, borderRadius: 'var(--r-pill)', flexShrink: 0, background: isWin ? eHsl(e) : eHsl(e, 0.14), color: isWin ? '#fff' : eHsl(e), display: 'flex', alignItems: 'center', justifyContent: 'center', ...disp(14, 800) }}>{rank}</span>
+      <span aria-hidden="true" style={{ width: 12, height: 12, borderRadius: 3, background: eHsl(e), flexShrink: 0 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ ...disp(15, 800, 'var(--text)') }}>Squadra {t.name}</div>
+        <div style={{ ...mono(10, 700, 'var(--text-muted)') }}>{t.found} / {t.total} agenti rivelati</div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+        <span style={{ ...disp(22, 800, eHsl(e)), fontVariantNumeric: 'tabular-nums' }}>{t.found}<span style={{ ...mono(11, 700, 'var(--text-muted)') }}>/{t.total}</span></span>
+        {isWin && <span style={{ fontSize: 17 }} aria-hidden="true">🏆</span>}
+      </div>
+    </div>
+  );
+};
+const ScoreboardTab = ({ winner }) => {
+  const ranked = winner === 'red' ? ['red', 'blue'] : ['blue', 'red'];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>Classifica finale</span>
+        <div style={{ flex: 1 }} />
+        <span style={{ ...mono(9, 800, eHsl('session')), padding: '2px 8px', borderRadius: 'var(--r-pill)', background: eHsl('session', 0.12), border: `1px solid ${eHsl('session', 0.3)}` }}>scoreType · Ranking</span>
+      </div>
+      {ranked.map((id, i) => <TeamResultRow key={id} teamId={id} rank={i + 1} winner={winner} />)}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', borderRadius: 'var(--r-md)', background: eHsl('toolkit', 0.08), border: `1px solid ${eHsl('toolkit', 0.3)}` }}>
+        <span aria-hidden="true" style={{ fontSize: 16 }}>🗝</span>
+        <span style={{ ...disp(12.5, 800, 'var(--text)') }}>Assassino evitato</span>
+        <div style={{ flex: 1 }} />
+        <span style={{ ...mono(10, 700, eHsl('toolkit')) }}>nessuna squadra ha toccato la tessera nera</span>
+      </div>
+    </div>
+  );
+};
+
+// ─── Final Board tab — full reveal ──────────────────────────────────────────
+const FinalBoardTab = ({ compact }) => {
+  const counts = { red: 0, blue: 0, neutral: 0, assassin: 0 };
+  CN.BOARD.forEach((c) => counts[c.key]++);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+        <span style={{ ...mono(10, 800, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>Griglia finale · tutte rivelate</span>
+        <div style={{ flex: 1 }} />
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {[['red', 'event', 'Rossi'], ['blue', 'chat', 'Blu'], ['neutral', null, 'Civili'], ['assassin', null, 'Assassino']].map(([k, e, lb]) => (
+            <span key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, ...mono(9, 700, 'var(--text-sec)') }}>
+              <span style={{ width: 11, height: 11, borderRadius: 2, background: e ? eHsl(e) : k === 'assassin' ? '#0f0c08' : 'var(--bg-sunken)', border: '1px solid var(--border-strong)' }} />{lb} {counts[k]}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div role="grid" aria-label="Griglia finale 5×5" style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: compact ? 5 : 7 }}>
+        {SUM.finalBoard.map((cell, i) => <P.WordCard key={i} cell={cell} compact={compact} />)}
+      </div>
+    </div>
+  );
+};
+
+// ─── Clue Analysis tab ──────────────────────────────────────────────────────
+const ClueAnalysisTab = () => {
+  const clues = SUM.clues;
+  const best = clues.find((c) => c.best);
+  const worst = clues.find((c) => c.worst);
+  const byTeam = (team) => clues.filter((c) => c.team === team);
+  const Highlight = ({ label, clue, tone }) => clue && (
+    <div style={{ flex: 1, minWidth: 180, padding: 12, borderRadius: 'var(--r-lg)', background: eHsl(tone, 0.08), border: `1px solid ${eHsl(tone, 0.3)}` }}>
+      <div style={{ ...mono(9, 800, eHsl(tone)), textTransform: 'uppercase', letterSpacing: '.06em', marginBottom: 7 }}>{label}</div>
+      <ClueChip word={clue.word} number={clue.number} team={clue.team} />
+      <div style={{ ...mono(10, 700, 'var(--text-sec)'), marginTop: 7 }}>{clue.correct}/{clue.attempts} corretti · Spymaster {CN.byId(clue.spymaster).name}</div>
+    </div>
+  );
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+        <Highlight label="★ Miglior indizio" clue={best} tone="toolkit" />
+        <Highlight label="Indizio peggiore" clue={worst} tone="event" />
+      </div>
+      {['red', 'blue'].map((team) => {
+        const list = byTeam(team);
+        const e = teamEntity(team);
+        const corr = list.reduce((s, c) => s + c.correct, 0);
+        const att = list.reduce((s, c) => s + c.attempts, 0);
+        return (
+          <div key={team} style={{ borderRadius: 'var(--r-lg)', overflow: 'hidden', border: `1px solid ${eHsl(e, 0.28)}`, background: 'var(--bg-card)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: eHsl(e, 0.08), borderBottom: `1px solid ${eHsl(e, 0.2)}` }}>
+              <span aria-hidden="true" style={{ width: 11, height: 11, borderRadius: 3, background: eHsl(e) }} />
+              <span style={{ ...disp(13, 800, 'var(--text)') }}>Spymaster {CN.byId(list[0].spymaster).name} · {teamName(team)}</span>
+              <div style={{ flex: 1 }} />
+              <span style={{ ...mono(10, 800, eHsl(e)) }}>{corr}/{att} corretti</span>
+            </div>
+            <div style={{ padding: '4px 12px' }}>
+              {list.map((c) => (
+                <div key={c.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid var(--border-light)', flexWrap: 'wrap', rowGap: 6 }}>
+                  <ClueChip word={c.word} number={c.number} team={c.team} dim />
+                  {c.best && <span style={{ ...mono(8.5, 800, eHsl('toolkit')) }}>★</span>}
+                  <div style={{ flex: 1 }} />
+                  <span style={{ ...mono(11, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums' }}>{c.correct}/{c.number}</span>
+                  <ClueOutcome outcome={c.outcome} />
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ─── Stats tab ──────────────────────────────────────────────────────────────
+const StatsTab = () => {
+  const s = SUM.stats;
+  const cards = [
+    { e: 'session', lb: 'Durata totale', v: SUM.duration, sub: `${SUM.rounds} round` },
+    { e: 'player',  lb: 'Durata media / turno', v: s.avgTurn, sub: 'mm:ss' },
+    { e: 'agent',   lb: 'Miss rate', v: `${Math.round(s.missRate * 100)}%`, sub: 'tentativi sbagliati' },
+    { e: 'event',   lb: 'Assassino toccato', v: s.assassinTouched, sub: 'volte' },
+    { e: 'toolkit', lb: 'Clue density', v: s.clueDensity, sub: 'parole / indizio' },
+    { e: 'kb',      lb: 'Tessere rivelate', v: `${s.tilesRevealed}/25`, sub: `${s.neutralsHit} civili` },
+  ];
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 10 }}>
+      {cards.map((c) => (
+        <div key={c.lb} style={{ padding: 14, borderRadius: 'var(--r-lg)', background: 'var(--bg-card)', border: `1px solid ${eHsl(c.e, 0.28)}`, borderLeft: `3px solid ${eHsl(c.e)}` }}>
+          <div style={{ ...mono(8.5, 800, eHsl(c.e)), textTransform: 'uppercase', letterSpacing: '.06em' }}>{c.lb}</div>
+          <div style={{ ...disp(26, 800, 'var(--text)'), fontVariantNumeric: 'tabular-nums', margin: '4px 0 2px' }}>{c.v}</div>
+          <div style={{ ...mono(9.5, 700, 'var(--text-muted)') }}>{c.sub}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ─── SummaryView — hero + tabs ──────────────────────────────────────────────
+const SUM_TABS = [
+  { id: 'scoreboard', icon: '🎯', label: 'Scoreboard', entity: 'session' },
+  { id: 'board',      icon: '🗂', label: 'Griglia',    entity: 'event' },
+  { id: 'clues',      icon: '💬', label: 'Indizi',     entity: 'agent' },
+  { id: 'stats',      icon: '📊', label: 'Stats',      entity: 'toolkit' },
+];
+const SummaryView = ({ result = RESULTS.red, compact, initialTab = 'scoreboard' }) => {
+  const [tab, setTab] = useState(initialTab);
+  return (
+    <div className="mai-cb-scroll" style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--bg)', padding: compact ? 12 : 18, display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <SummaryHero result={result} compact={compact} />
+      <div role="tablist" aria-label="Sezioni recap" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {SUM_TABS.map((t) => {
+          const on = tab === t.id;
+          return (
+            <button key={t.id} type="button" role="tab" aria-selected={on} onClick={() => setTab(t.id)} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 13px', borderRadius: 'var(--r-pill)', background: on ? eHsl(t.entity, 0.14) : 'var(--bg-card)', border: `1px solid ${on ? eHsl(t.entity, 0.45) : 'var(--border)'}`, color: on ? eHsl(t.entity) : 'var(--text-sec)', ...disp(11.5, 800), cursor: 'pointer' }}>
+              <span aria-hidden="true">{t.icon}</span>{t.label}
+            </button>
+          );
+        })}
+      </div>
+      <div role="tabpanel">
+        {tab === 'scoreboard' && <ScoreboardTab winner={result.winner} />}
+        {tab === 'board' && <FinalBoardTab compact={compact} />}
+        {tab === 'clues' && <ClueAnalysisTab />}
+        {tab === 'stats' && <StatsTab />}
+      </div>
+    </div>
+  );
+};
+
+// ─── PhoneSummary ───────────────────────────────────────────────────────────
+const PhoneSummary = ({ label, dark, result, initialTab }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+    <div style={{ ...mono(11, 700, 'var(--text-sec)'), textTransform: 'uppercase', letterSpacing: '.08em' }}>{label}{dark && <span style={{ color: eHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
+    <div className="phone" data-theme={dark ? 'dark' : undefined}>
+      <div className="phone-sbar" style={{ color: 'var(--text)' }}><span style={{ fontFamily: 'var(--f-mono)' }}>20:31</span><div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div></div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg)', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+        <S.TopBar ds={CN.ds} compact connection="connected" />
+        <SummaryView result={result} compact initialTab={initialTab} />
+      </div>
+    </div>
+  </div>
+);
+
+function App() {
+  return (
+    <div className="stage">
+      <S.ThemeToggle />
+      <div className="stage-wrap">
+        <div style={{ ...mono(11, 600, 'var(--text-muted)'), textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 8 }}>SP4 · Codenames · Session summary 🏆</div>
+        <h1>Codenames — recap partita</h1>
+        <p className="lead">
+          Post-partita per <code>/sessions/[id]/summary</code>: hero del vincitore (Rosso / Blu / sconfitta Assassino) e quattro tab —
+          <strong> Scoreboard</strong> (Ranking), <strong>Griglia finale</strong> (reveal totale), <strong>Analisi indizi</strong> (success rate, migliore/peggiore) e <strong>Stats</strong>.
+        </p>
+
+        <div className="section-label">Hero · 3 esiti — Rosso vince · Blu vince · sconfitta Assassino</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 14, marginBottom: 8 }}>
+          <SummaryHero result={RESULTS.red} compact />
+          <SummaryHero result={RESULTS.blue} compact />
+          <SummaryHero result={RESULTS.assassin} compact />
+        </div>
+
+        <div className="section-label">Desktop 1280 — recap completo · cambia tab</div>
+        <S.DesktopFrame ds={CN.ds} label="Recap · Rosso vince" url="meepleai.app/sessions/cdn-7/summary" height={720}
+          desc="Hero + tab Scoreboard / Griglia finale / Analisi indizi / Stats.">
+          <S.TopBar ds={CN.ds} connection="connected" />
+          <SummaryView result={RESULTS.red} />
+        </S.DesktopFrame>
+
+        <div className="section-label">Mobile 375 — recap · scoreboard e griglia finale</div>
+        <div className="phones-grid">
+          <PhoneSummary label="Recap · Scoreboard" result={RESULTS.red} initialTab="scoreboard" />
+          <PhoneSummary label="Recap · Griglia · dark" dark result={RESULTS.red} initialTab="board" />
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+        @keyframes mai-pulse-dot-anim { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: .6; } }
+        .mai-shimmer { background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important; background-size: 200% 100% !important; animation: mai-shimmer-anim 1.4s linear infinite; }
+        .mai-pulse-dot { animation: mai-pulse-dot-anim 1.5s ease-in-out infinite; transform-origin: center; display: inline-block; }
+        .mai-cb-scroll::-webkit-scrollbar { width: 7px; height: 7px; }
+        .mai-cb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+        .phones-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: var(--s-7); align-items: start; }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage code { background: var(--bg-muted); padding: 1px 6px; border-radius: var(--r-sm); font-size: .85em; font-family: var(--f-mono); }
+        @media (prefers-reduced-motion: reduce) { .mai-pulse-dot, .mai-shimmer { animation: none !important; } }
+        .phone > div::-webkit-scrollbar { display: none; }
+        button:focus-visible, a:focus-visible { outline: 2px solid hsl(var(--c-session)); outline-offset: 2px; }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

Mockup **#7 di 7** della pipeline B19 — **ULTIMO**. Codenames (team deduction party game, 2-8+ players in 2 teams, ~15 min).

**Archetype UNICO**: team deduction con info asymmetrica (Spymaster sa codes, Operatives no). Unico non-euro / non-co-op del set premium.

## 🎉 PIPELINE B19 COMPLETE

| # | Game | Stato |
|---|---|---|
| 1 | Skeleton (universal) | ✅ MERGED #1766 |
| 2 | Puerto Rico | ✅ MERGED #1769 |
| 3 | Catan | 🟡 #1770 OPEN (branch policy) |
| 4 | Power Grid | ✅ MERGED #1782 |
| 5 | Zombicide GH | ✅ MERGED #1783 |
| 6 | Paleo | 🟡 #1784 OPEN (branch policy) |
| 7 | **Codenames** | 🟡 **questo PR** |

## ✨ Accordion pattern

**9 utilizzi totali** (3 in parts + 6 in bodies) con helper `sec(id)` coerente con skeleton + Power Grid + Zombicide + Paleo.

## Files (8 in admin-mockups/design_files/) — extra bodies.jsx vs altri

- sp4-session-codenames-live.html / .jsx
- sp4-session-codenames-summary.html / .jsx
- sp4-session-codenames-data.jsx (5x5 word grid + key card + team agents)
- sp4-session-codenames-flavor.jsx (7 component: WordGrid, WordCard 5-states, SpymasterKeyCardOverlay, TeamPanel, CurrentCluePanel, ClueHistoryTimeline, RoleAvatar)
- sp4-session-codenames-parts.jsx (SectionCard accordion)
- sp4-session-codenames-bodies.jsx (DesktopBody + MobileBody composition)

## Mechanics

- 5x5 word grid (25 cards) con stati covered / red / blue / neutral / assassin
- Spymaster ha segret key card overlay toggleable
- 4-phase Sequential alternating: Red Spymaster clue → Red guess → Blue Spymaster clue → Blue guess
- Optional timers (community variant): clue 120s + guess 60s
- Ranking ScoreType con assassin instant-loss
- Team-based (Red 9 agents start, Blue 8 if Red first; inverse otherwise)

## Validation

- 0 cross-game contamination
- Baseline files NOT touched

## Docs sync

MOCKUPS_INDEX: +2 page-mock +6 component-mock, total 108 → 116

## Reference dataset

`claudedocs/seed-preview-from-pr-1761/codenames.json` (already complete pre-#1761)

🤖 Generated with Claude Code