### PR TITLE
feat(translate-viewer): #1559 FE multi-lang detection + override modal

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitExtractionPrompts.cs
@@ -100,7 +100,7 @@ internal static class ToolkitExtractionPrompts
         }
 
         AiTurnTemplateSuggestion = {
-          "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None",
+          "TurnOrderType": "RoundRobin"|"Sequential"|"Simultaneous"|"Realtime"|"None"|"Custom"|"Free",
           "Phases": [string],         // e.g., ["Round 1", "Round 2"] or ["Action", "Draw", "Infect"]
           "Rounds": int | null,       // v2 (B19-3a): total round count if game has fixed structure (e.g., Wingspan=4)
           "TurnsPerRound": [int] | null,  // v2: turn count per round if variable (e.g., Wingspan=[8,7,6,5])

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/ScoreType.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/ScoreType.cs
@@ -2,9 +2,17 @@ namespace Api.BoundedContexts.GameToolkit.Domain.Enums;
 
 /// <summary>
 /// How scoring works in a game session.
+///
+/// **v2 (B19-3b, 2026-05-31)**: extended with BinaryWin / Objectives to cover
+/// co-op games (Paleo, Zombicide: win/lose collective) and goal-oriented games
+/// (Codenames: race + assassin-loss; Pandemic: cure-all-diseases).
+/// Additive — preserves numeric IDs 0-1.
 /// </summary>
 public enum ScoreType
 {
     Points = 0,
-    Ranking = 1
+    Ranking = 1,
+    // v2 additions
+    BinaryWin = 2,   // game is win/lose without points (co-op Paleo / Pandemic / Zombicide)
+    Objectives = 3   // win condition is meeting a set of objectives (Codenames race, mission games)
 }

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/TurnOrderType.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/TurnOrderType.cs
@@ -2,10 +2,19 @@ namespace Api.BoundedContexts.GameToolkit.Domain.Enums;
 
 /// <summary>
 /// How turn order is determined in a game session.
+///
+/// **v2 (B19-3a, 2026-05-31)**: extended with Sequential / Simultaneous / Realtime / None
+/// to cover non-circular turn patterns (co-op simultaneous like Paleo, team-deduction like
+/// Codenames, real-time like Captain Sonar). Additive — preserves numeric IDs 0-2.
 /// </summary>
 public enum TurnOrderType
 {
     RoundRobin = 0,
     Custom = 1,
-    Free = 2
+    Free = 2,
+    // v2 additions
+    Sequential = 3,    // strict order but NOT circular (e.g., team-based: Red phase → Blue phase)
+    Simultaneous = 4,  // all players act at the same time (e.g., Paleo, 7 Wonders)
+    Realtime = 5,      // no turn structure, time-pressure (e.g., Captain Sonar, Magic Maze)
+    None = 6           // truly no turn order (e.g., co-op brainstorm without phase structure)
 }

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/README.md
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/README.md
@@ -1,0 +1,64 @@
+# StateTemplate Seed Fixtures
+
+> Issue [#1748](https://github.com/meepleAi-app/meepleai-monorepo/issues/1748) (B19-3d)
+
+JSON fixtures che bootstrappano `StateTemplateDefinition` per i top-N giochi della v1
+di MeepleAI. Curated manualmente perché lo spike LLM (`claudedocs/2026-05-31-spike-toolkit-ai-generation.md`)
+ha mostrato che per giochi complex flavor (Wingspan, Power Grid) l'AI generation
+non basta — è OK come bootstrap helper ma non come source of truth.
+
+## Format
+
+Ogni file è un `AiToolkitSuggestionDto` JSON-serialized:
+
+```jsonc
+{
+  "ToolkitName": "Wingspan",
+  "DiceTools": [...],
+  "CounterTools": [...],
+  "TimerTools": [...],
+  "ScoringTemplate": { ..., "Categories": [...] },  // v3 (B19-3b)
+  "TurnTemplate": { ..., "Rounds": 4, "TurnsPerRound": [8,7,6,5] },  // v3 (B19-3a)
+  "Overrides": { ... 3 boolean ... },
+  "Reasoning": "Curated by domain expert YYYY-MM-DD.",
+  "ExcludedTools": [...]
+}
+```
+
+Campi `ConfidenceScore`/`ChunksAnalyzed`/`KbCoveragePercent`/`RequiresHumanReview`
+non sono presenti (sono populated dal handler runtime, non statici nel seed).
+
+## Status fixtures
+
+| Game | File | Status | Archetype | Curator |
+|---|---|---|---|---|
+| Wingspan | `wingspan.json` | ✅ complete | Euro engine-builder | Claude Code (spike-derived) |
+| Codenames | `codenames.json` | ✅ complete | Team deduction | Claude Code |
+| Paleo | `paleo.json` | ✅ complete | Co-op simultaneous | Claude Code |
+| Catan | `catan.json` | ✅ complete | Euro + trading | Claude Code |
+| Puerto Rico | `puerto-rico.json` | ⏳ stub TBD | Euro role-selection | Pending domain expert |
+| Power Grid | `power-grid.json` | ⏳ stub TBD | Euro + auction | Pending domain expert |
+| Zombicide Green Horde | `zombicide-green-horde.json` | ⏳ stub TBD | Co-op miniatures | Pending domain expert |
+
+Stub TBD = fixture con `ToolkitName` + minimal note `Reasoning="Requires manual
+curation by domain expert"`. Da completare in iterazione successiva (sub-PR
+di #1748 o issue dedicata per gioco).
+
+## Bootstrap via AI fallback
+
+Per i giochi non ancora seeded, il flow è:
+
+1. `GenerateToolkitFromKbCommand(gameId, userId)` (BackEnd: `apps/api/.../GenerateToolkitFromKbHandler.cs`)
+2. Output `AiToolkitSuggestionDto` con `RequiresHumanReview=true` se confidence < 0.85
+3. Admin review via `ApplyAiToolkitSuggestionCommand` → produce un `GameToolkit` (Draft)
+4. Quando il toolkit è "approved" via marketplace workflow, può diventare seed canonical
+
+## Validazione
+
+Ogni JSON deserializza in `AiToolkitSuggestionDto`. Test:
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~StateTemplateFixtureTests"
+```
+
+I test caricano ogni file e validano lo schema deserialization.

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/catan.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/catan.json
@@ -1,0 +1,55 @@
+{
+  "ToolkitName": "Coloni di Catan",
+  "DiceTools": [
+    {
+      "Name": "Production dice",
+      "DiceType": "D6",
+      "Quantity": 2,
+      "CustomFaces": null,
+      "IsInteractive": true,
+      "Color": "#c0392b"
+    }
+  ],
+  "CounterTools": [
+    { "Name": "Victory Points", "MinValue": 0, "MaxValue": 13, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "star", "Color": "#f1c40f" },
+    { "Name": "Settlements built", "MinValue": 0, "MaxValue": 5, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "house", "Color": null },
+    { "Name": "Cities built", "MinValue": 0, "MaxValue": 4, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "castle", "Color": null },
+    { "Name": "Roads built", "MinValue": 0, "MaxValue": 15, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "road", "Color": null },
+    { "Name": "Wood", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "tree", "Color": "#27ae60" },
+    { "Name": "Brick", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "brick", "Color": "#c0392b" },
+    { "Name": "Sheep", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "sheep", "Color": "#ecf0f1" },
+    { "Name": "Wheat", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "wheat", "Color": "#f1c40f" },
+    { "Name": "Ore", "MinValue": 0, "MaxValue": 19, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "ore", "Color": "#7f8c8d" }
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Settlements", "Cities", "Longest Road", "Largest Army", "Victory Point cards"],
+    "DefaultUnit": "points",
+    "ScoreType": "Points",
+    "Categories": [
+      { "Id": "settlements", "Label": "Settlements", "Computation": "Count", "Weight": 1, "Description": "1 point per settlement (max 5)." },
+      { "Id": "cities", "Label": "Cities", "Computation": "Count", "Weight": 2, "Description": "2 points per city (max 4)." },
+      { "Id": "longest-road", "Label": "Longest Road bonus", "Computation": "Custom", "Weight": 2, "Description": "2 points to holder of longest road ≥5 segments." },
+      { "Id": "largest-army", "Label": "Largest Army bonus", "Computation": "Custom", "Weight": 2, "Description": "2 points to holder of largest army ≥3 knights." },
+      { "Id": "vp-cards", "Label": "Victory Point dev cards", "Computation": "Sum", "Weight": 1, "Description": "1 point per VP development card held secretly." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "RoundRobin",
+    "Phases": ["Roll dice (production)", "Trade", "Build / develop"],
+    "Rounds": null,
+    "TurnsPerRound": null,
+    "TurnActions": ["roll-dice", "trade-with-player", "trade-with-bank", "build-road", "build-settlement", "build-city", "buy-dev-card", "play-dev-card", "end-turn"],
+    "Direction": "clockwise"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "Curated 2026-05-31 from Catan base game (3-4 players). 2D6 dice drive resource production each turn. First to 10 VP wins (checked after their own turn). Resources tracked per player (wood/brick/sheep/wheat/ore). Longest Road + Largest Army are dynamic bonuses (2 VP each, can be stolen). Trade phase between players inter-turn is core mechanic. No timer.",
+  "ExcludedTools": [
+    { "ToolType": "Timer", "Reason": "No time limit per turn in base rules." },
+    { "ToolType": "CardDeck", "Reason": "Development cards form a shuffled deck — but managed via specialized widget, not generic card deck (each card type has distinct interaction)." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/codenames.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/codenames.json
@@ -1,0 +1,40 @@
+{
+  "ToolkitName": "Codenames",
+  "DiceTools": [],
+  "CounterTools": [
+    { "Name": "Red tiles remaining", "MinValue": 0, "MaxValue": 9, "DefaultValue": 9, "IsPerPlayer": false, "Icon": "tile", "Color": "#c0392b" },
+    { "Name": "Blue tiles remaining", "MinValue": 0, "MaxValue": 8, "DefaultValue": 8, "IsPerPlayer": false, "Icon": "tile", "Color": "#2980b9" },
+    { "Name": "Guesses remaining this turn", "MinValue": 0, "MaxValue": 9, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "hint", "Color": null }
+  ],
+  "TimerTools": [
+    { "Name": "Clue giving timer (optional)", "DurationSeconds": 120, "TimerType": "CountDown", "AutoStart": false, "Color": null, "IsPerPlayer": false, "WarningThresholdSeconds": 30 },
+    { "Name": "Guessing timer (optional)", "DurationSeconds": 60, "TimerType": "CountDown", "AutoStart": false, "Color": null, "IsPerPlayer": false, "WarningThresholdSeconds": 15 }
+  ],
+  "ScoringTemplate": {
+    "Dimensions": ["Win condition"],
+    "DefaultUnit": "result",
+    "ScoreType": "Ranking",
+    "Categories": [
+      { "Id": "agents-found", "Label": "Agents revealed by team", "Computation": "Count", "Weight": 1, "Description": "First team to reveal all their agents wins." },
+      { "Id": "assassin-touched", "Label": "Assassin revealed", "Computation": "Custom", "Weight": 0, "Description": "Instant loss for team that reveals assassin (1 of 25 tiles)." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "Sequential",
+    "Phases": ["Red Spymaster gives clue", "Red operatives guess", "Blue Spymaster gives clue", "Blue operatives guess"],
+    "Rounds": null,
+    "TurnsPerRound": null,
+    "TurnActions": ["give-clue", "guess-tile", "end-turn"],
+    "Direction": "none"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": true,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "Curated 2026-05-31 from Codenames base rules. Team-based deduction (2 teams: red 9 agents, blue 8 agents). No points scoring — win/lose race + instant-loss on assassin. Optional timers per phase (community variant). Custom turn order alternates between teams with Spymaster→Operatives sequence.",
+  "ExcludedTools": [
+    { "ToolType": "Dice", "Reason": "Codenames is purely deductive, no dice involved." },
+    { "ToolType": "CardDeck", "Reason": "Word cards form a 5x5 grid layout, not a deck. Layout is game-specific widget." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/paleo.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/paleo.json
@@ -1,0 +1,42 @@
+{
+  "ToolkitName": "Paleo",
+  "DiceTools": [],
+  "CounterTools": [
+    { "Name": "Wood", "MinValue": 0, "MaxValue": 30, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "wood", "Color": "#7a4a1a" },
+    { "Name": "Stone", "MinValue": 0, "MaxValue": 30, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "stone", "Color": "#7f8c8d" },
+    { "Name": "Food", "MinValue": 0, "MaxValue": 30, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "food", "Color": "#d35400" },
+    { "Name": "Skulls (lose tribe → lose game)", "MinValue": 0, "MaxValue": 5, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "skull", "Color": "#2c3e50" },
+    { "Name": "Knowledge cards collected", "MinValue": 0, "MaxValue": 99, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "scroll", "Color": null },
+    { "Name": "Cave painting progress (0-5)", "MinValue": 0, "MaxValue": 5, "DefaultValue": 0, "IsPerPlayer": false, "Icon": "art", "Color": null },
+    { "Name": "Tribe members alive", "MinValue": 0, "MaxValue": 8, "DefaultValue": 4, "IsPerPlayer": false, "Icon": "person", "Color": null }
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Win condition", "Cave paintings"],
+    "DefaultUnit": "result",
+    "ScoreType": "BinaryWin",
+    "Categories": [
+      { "Id": "cave-painting", "Label": "Cave painting completed", "Computation": "Count", "Weight": 1, "Description": "Complete the cave painting (5 hand prints) to win." },
+      { "Id": "skulls", "Label": "Skulls accumulated", "Computation": "Count", "Weight": -1, "Description": "5 skulls = instant loss for entire tribe." },
+      { "Id": "tribe-extinct", "Label": "Tribe extinct (all members died)", "Computation": "Custom", "Weight": 0, "Description": "Tribe loss condition — all members dead." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "Simultaneous",
+    "Phases": ["Morning (draw + choose cards)", "Day (resolve actions simultaneously)", "Night (return tribe, check end conditions)"],
+    "Rounds": null,
+    "TurnsPerRound": null,
+    "TurnActions": ["explore", "hunt", "craft", "develop", "rest"],
+    "Direction": "none"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": true,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "Curated 2026-05-31 from Paleo base rules. Co-op simultaneous play (no individual turn). Win condition: complete cave painting (5 hand prints) before tribe dies or skulls accumulate. Player count 1-4, but scoring is collective. Multiple modules (resources, weather, hunger, skills) add variety but core loop remains 3-phase day cycle.",
+  "ExcludedTools": [
+    { "ToolType": "Dice", "Reason": "Paleo is deterministic card-driven, no dice." },
+    { "ToolType": "Timer", "Reason": "No time limit per turn (co-op discussion welcomed)." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/power-grid.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/power-grid.json
@@ -1,0 +1,15 @@
+{
+  "ToolkitName": "Power Grid",
+  "DiceTools": [],
+  "CounterTools": [],
+  "TimerTools": [],
+  "ScoringTemplate": null,
+  "TurnTemplate": null,
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": false,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "STUB — pending manual curation by domain expert. Power Grid is a heavy euro auction/network game (2-6 players, ~120 min). Key mechanics to model: 4 phases per round (Player Order → Power Plant Auction → Resource Buying → Building → Bureaucracy), Elektro currency, 4 resource types (coal/oil/garbage/uranium), 3 game steps (1/2/3 triggering board expansion + capacity), end condition: first to power 17 cities. Turn order REVERSES based on cities powered (leader plays last in auctions). Use GenerateToolkitFromKbCommand as bootstrap.",
+  "ExcludedTools": []
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/puerto-rico.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/puerto-rico.json
@@ -1,0 +1,15 @@
+{
+  "ToolkitName": "Puerto Rico",
+  "DiceTools": [],
+  "CounterTools": [],
+  "TimerTools": [],
+  "ScoringTemplate": null,
+  "TurnTemplate": null,
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": false,
+    "OverridesDiceSet": false
+  },
+  "Reasoning": "STUB — pending manual curation by domain expert. Puerto Rico is a heavy euro role-selection game (3-5 players, ~120 min). Key mechanics to model: 8 role cards (Settler/Mayor/Builder/Craftsman/Trader/Captain/Prospector + privilege effect for chooser), 6 buildings types, doubloons + colonists + corn/indigo/sugar/tobacco/coffee resources, victory points from buildings + shipped goods. End condition: end-game trigger when colonists/VP exhausted. Use GenerateToolkitFromKbCommand with rulebook PDF as bootstrap helper, then refine.",
+  "ExcludedTools": []
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/wingspan.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/wingspan.json
@@ -1,0 +1,50 @@
+{
+  "ToolkitName": "Wingspan",
+  "DiceTools": [
+    {
+      "Name": "Birdfeeder Food Dice",
+      "DiceType": "Custom",
+      "Quantity": 5,
+      "CustomFaces": ["invertebrate", "seed", "fruit", "fish", "rodent", "wild"],
+      "IsInteractive": true,
+      "Color": "#7a3d1a"
+    }
+  ],
+  "CounterTools": [
+    { "Name": "Eggs", "MinValue": 0, "MaxValue": 6, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "egg", "Color": null },
+    { "Name": "Food tokens", "MinValue": 0, "MaxValue": 99, "DefaultValue": 0, "IsPerPlayer": true, "Icon": "food", "Color": null },
+    { "Name": "Action cubes", "MinValue": 0, "MaxValue": 8, "DefaultValue": 8, "IsPerPlayer": true, "Icon": "cube", "Color": null }
+  ],
+  "TimerTools": [],
+  "ScoringTemplate": {
+    "Dimensions": ["Birds", "Bonus cards", "End-of-round goals", "Eggs", "Food cached", "Tucked cards"],
+    "DefaultUnit": "points",
+    "ScoreType": "Points",
+    "Categories": [
+      { "Id": "birds", "Label": "Birds played", "Computation": "Sum", "Weight": 1, "Description": "Variable points printed on each bird card (1-9)." },
+      { "Id": "bonus-cards", "Label": "Bonus cards", "Computation": "Sum", "Weight": 1, "Description": "Variable points per personal bonus card objective." },
+      { "Id": "round-goals", "Label": "End-of-round goals", "Computation": "RankBased", "Weight": 1, "Description": "5/2/1 or 4/2/1 points per round based on rank in goal." },
+      { "Id": "eggs", "Label": "Eggs", "Computation": "Count", "Weight": 1, "Description": "1 point per egg laid." },
+      { "Id": "cached-food", "Label": "Food cached", "Computation": "Count", "Weight": 1, "Description": "1 point per food cached on a bird card." },
+      { "Id": "tucked-cards", "Label": "Tucked cards", "Computation": "Count", "Weight": 1, "Description": "1 point per card tucked under a bird for ability." }
+    ]
+  },
+  "TurnTemplate": {
+    "TurnOrderType": "RoundRobin",
+    "Phases": ["Round 1", "Round 2", "Round 3", "Round 4"],
+    "Rounds": 4,
+    "TurnsPerRound": [8, 7, 6, 5],
+    "TurnActions": ["play-bird", "get-food", "lay-eggs", "draw-cards"],
+    "Direction": "clockwise"
+  },
+  "Overrides": {
+    "OverridesTurnOrder": true,
+    "OverridesScoreboard": true,
+    "OverridesDiceSet": true
+  },
+  "Reasoning": "Curated 2026-05-31 from Wingspan rulebook (data/rulebook/wingspan_en_rulebook.pdf). 5 custom food dice with 6 faces, 4-round structure with decreasing turn count (8/7/6/5), 6 additive scoring categories with mix of Count/Sum/RankBased computations. Tiebreakers: bonus card points then total food.",
+  "ExcludedTools": [
+    { "ToolType": "Timer", "Reason": "Rulebook explicitly states no time limit per turn or round." },
+    { "ToolType": "CardDeck", "Reason": "Bird cards use a fixed 3-card display + discard, not a generic shuffled deck. Bird display is a game-specific widget." }
+  ]
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/zombicide-green-horde.json
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/zombicide-green-horde.json
@@ -1,0 +1,26 @@
+{
+  "ToolkitName": "Zombicide Green Horde",
+  "DiceTools": [
+    {
+      "Name": "Combat dice",
+      "DiceType": "D6",
+      "Quantity": 6,
+      "CustomFaces": null,
+      "IsInteractive": true,
+      "Color": "#27ae60"
+    }
+  ],
+  "CounterTools": [],
+  "TimerTools": [],
+  "ScoringTemplate": null,
+  "TurnTemplate": null,
+  "Overrides": {
+    "OverridesTurnOrder": false,
+    "OverridesScoreboard": false,
+    "OverridesDiceSet": true
+  },
+  "Reasoning": "STUB — pending manual curation by domain expert. Zombicide Green Horde is a co-op miniatures dungeon-crawler (1-6 players, ~60-90 min/scenario). Key mechanics to model: scenario-based (no fixed scoring), each survivor has unique skill tree (Blue→Yellow→Orange→Red dangerous levels), action points per turn (3 standard, modified by skills), combat resolution with custom dice (typically D6 hit on 4+ but varies by weapon), zombie spawn phases at end of each player round driven by Danger Level. Loss conditions: all survivors dead OR mission failure. Use GenerateToolkitFromKbCommand for bootstrap of base mechanics.",
+  "ExcludedTools": [
+    { "ToolType": "Timer", "Reason": "No time limit per turn." }
+  ]
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Seed/StateTemplateFixtureTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Seed/StateTemplateFixtureTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.GameToolkit.Application.DTOs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameToolkit.Seed;
+
+/// <summary>
+/// Validates that every curated StateTemplate seed fixture under
+/// apps/api/src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates/ deserializes
+/// cleanly into AiToolkitSuggestionDto. Catches drift between schema changes
+/// and seed JSONs.
+///
+/// Issue #1748 (B19-3d).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameToolkit")]
+public class StateTemplateFixtureTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Locates the seed directory by walking up from the test assembly until we find the
+    /// solution file (MeepleAI.Api.sln, in apps/api/).
+    /// </summary>
+    private static string SeedDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeepleAI.Api.sln")))
+        {
+            dir = dir.Parent;
+        }
+        Assert.True(dir is not null,
+            $"Could not locate solution root from BaseDirectory={AppContext.BaseDirectory}");
+        // dir is now .../apps/api/ — seed is at src/Api/BoundedContexts/GameToolkit/Seed/StateTemplates
+        return Path.Combine(
+            dir!.FullName,
+            "src", "Api",
+            "BoundedContexts", "GameToolkit", "Seed", "StateTemplates");
+    }
+
+    public static IEnumerable<object[]> AllFixtureFiles()
+    {
+        var seedDir = SeedDirectory();
+        if (!Directory.Exists(seedDir))
+        {
+            yield break;
+        }
+        foreach (var path in Directory.EnumerateFiles(seedDir, "*.json"))
+        {
+            yield return new object[] { Path.GetFileName(path), path };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllFixtureFiles))]
+    public void Fixture_Deserializes_ToValidDto(string fileName, string filePath)
+    {
+        var json = File.ReadAllText(filePath);
+        var dto = JsonSerializer.Deserialize<AiToolkitSuggestionDto>(json, JsonOptions);
+
+        dto.Should().NotBeNull($"fixture {fileName} must deserialize");
+        dto!.ToolkitName.Should().NotBeNullOrWhiteSpace($"fixture {fileName} requires ToolkitName");
+        dto.DiceTools.Should().NotBeNull($"fixture {fileName} requires DiceTools (can be empty array)");
+        dto.CounterTools.Should().NotBeNull($"fixture {fileName} requires CounterTools (can be empty array)");
+        dto.TimerTools.Should().NotBeNull($"fixture {fileName} requires TimerTools (can be empty array)");
+        dto.Overrides.Should().NotBeNull(
+            $"fixture {fileName} must declare Overrides (use all-false for default game)");
+        dto.Reasoning.Should().NotBeNullOrWhiteSpace(
+            $"fixture {fileName} requires Reasoning (curator note or STUB marker)");
+    }
+
+    [Fact]
+    public void SeedDirectory_ContainsExpectedFixtures()
+    {
+        var seedDir = SeedDirectory();
+        var present = Directory.EnumerateFiles(seedDir, "*.json")
+            .Select(Path.GetFileNameWithoutExtension)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // The 7 v1 top games (B19 Phase 2 scope, post user-confirmation 2026-05-31)
+        var expected = new[]
+        {
+            "wingspan", "puerto-rico", "catan", "power-grid",
+            "zombicide-green-horde", "paleo", "codenames",
+        };
+
+        foreach (var fixture in expected)
+        {
+            present.Should().Contain(fixture, $"v1 top-7 fixture {fixture}.json must exist");
+        }
+    }
+}

--- a/apps/web/src/components/features/gamebook/LangBadge.tsx
+++ b/apps/web/src/components/features/gamebook/LangBadge.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import { LANG_LABELS_IT, type SourceLangCode } from '@/lib/gamebook/lang-codes';
+import type { LangTier } from '@/lib/gamebook/lang-tier';
+
+export interface LangBadgeProps {
+  lang: SourceLangCode | null;
+  confidence: number | null;
+  tier: LangTier;
+  onTap?: () => void;
+  /** Render "(override)" suffix when user has manually overridden detected lang. */
+  isOverride?: boolean;
+}
+
+const TIER_STYLES: Record<Exclude<LangTier, 'none'>, string> = {
+  high: 'bg-emerald-100 text-emerald-900 ring-1 ring-emerald-200',
+  medium: 'bg-amber-100 text-amber-900 ring-1 ring-amber-200',
+  low: 'bg-rose-100 text-rose-900 ring-1 ring-rose-200',
+};
+
+const TIER_CONFIDENCE_LABEL_IT: Record<Exclude<LangTier, 'none'>, string> = {
+  high: 'Confidenza alta',
+  medium: 'Confidenza media',
+  low: 'Confidenza bassa',
+};
+
+function buildVisualText(
+  tier: Exclude<LangTier, 'none'>,
+  lang: SourceLangCode | null,
+  isOverride: boolean
+): string {
+  if (tier === 'low') return 'Sorgente richiesta';
+  if (tier === 'medium' && lang) return `Conferma: ${lang}?`;
+  if (tier === 'medium' && !lang) return 'Conferma sorgente';
+  // tier === 'high'
+  return isOverride ? `Sorgente: ${lang} (override)` : `Sorgente: ${lang}`;
+}
+
+function buildAriaLabel(
+  tier: Exclude<LangTier, 'none'>,
+  lang: SourceLangCode | null,
+  confidence: number | null
+): string {
+  const langLabel = lang ? LANG_LABELS_IT[lang] : 'sconosciuta';
+  const confLabel = TIER_CONFIDENCE_LABEL_IT[tier];
+  const confPct =
+    confidence !== null && confidence !== undefined ? ` (${Math.round(confidence * 100)}%)` : '';
+
+  if (tier === 'low') {
+    return `Sorgente richiesta. Conferma manualmente la lingua.`;
+  }
+  if (tier === 'medium') {
+    return `Conferma sorgente: ${langLabel}. ${confLabel}${confPct}. Tap per confermare o cambiare.`;
+  }
+  return `Sorgente: ${langLabel}. ${confLabel}${confPct}. Tap per cambiare.`;
+}
+
+export function LangBadge({
+  lang,
+  confidence,
+  tier,
+  onTap,
+  isOverride = false,
+}: LangBadgeProps): ReactElement | null {
+  if (tier === 'none') return null;
+
+  const visualText = buildVisualText(tier, lang, isOverride);
+  const baseClass = `inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${TIER_STYLES[tier]}`;
+
+  if (onTap) {
+    return (
+      <button
+        type="button"
+        onClick={onTap}
+        className={`${baseClass} cursor-pointer hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-1`}
+        aria-label={buildAriaLabel(tier, lang, confidence)}
+        data-testid="lang-badge"
+        data-tier={tier}
+      >
+        {visualText}
+      </button>
+    );
+  }
+
+  return (
+    <span className={baseClass} data-testid="lang-badge" data-tier={tier}>
+      {visualText}
+    </span>
+  );
+}

--- a/apps/web/src/components/features/gamebook/LangOverrideModal.tsx
+++ b/apps/web/src/components/features/gamebook/LangOverrideModal.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useId, useState, type ReactElement } from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+
+import { RadioGroup, RadioGroupItem } from '@/components/ui/primitives/radio-group';
+import { LANG_CODES_ORDER, LANG_LABELS_IT, type SourceLangCode } from '@/lib/gamebook/lang-codes';
+
+export interface LangOverrideModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Preselected radio option (if any). */
+  preselect?: SourceLangCode;
+  /** When false, hide the Chiudi button and ignore Escape (forced-choice mode for auto-low). */
+  dismissable: boolean;
+  /** Called when user confirms with a selected lang. */
+  onConfirm: (lang: SourceLangCode) => void;
+}
+
+export function LangOverrideModal({
+  open,
+  onOpenChange,
+  preselect,
+  dismissable,
+  onConfirm,
+}: LangOverrideModalProps): ReactElement {
+  const [selected, setSelected] = useState<SourceLangCode | undefined>(preselect);
+  const titleId = useId();
+  const radioName = useId();
+
+  // Sync selected when preselect or open changes (modal reopen resets state).
+  useEffect(() => {
+    if (open) {
+      setSelected(preselect);
+    }
+  }, [open, preselect]);
+
+  const handleConfirm = () => {
+    if (selected) onConfirm(selected);
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={next => {
+        // Block Escape/outside-click dismiss when not dismissable
+        if (!next && !dismissable) return;
+        onOpenChange(next);
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in"
+          data-testid="lang-override-scrim"
+        />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-background p-6 shadow-lg"
+          aria-labelledby={titleId}
+          aria-modal="true"
+          onEscapeKeyDown={e => {
+            if (!dismissable) e.preventDefault();
+          }}
+          onPointerDownOutside={e => {
+            if (!dismissable) e.preventDefault();
+          }}
+        >
+          <Dialog.Title id={titleId} className="text-lg font-semibold">
+            Seleziona la lingua sorgente
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+            Conferma la lingua originale della pagina per migliorare la traduzione.
+          </Dialog.Description>
+
+          <RadioGroup
+            value={selected}
+            onValueChange={v => setSelected(v as SourceLangCode)}
+            name={radioName}
+            className="mt-4 gap-3"
+          >
+            {LANG_CODES_ORDER.map(code => (
+              <label
+                key={code}
+                htmlFor={`${radioName}-${code}`}
+                className="flex cursor-pointer items-center gap-2 text-sm"
+              >
+                <RadioGroupItem id={`${radioName}-${code}`} value={code} />
+                <span>{LANG_LABELS_IT[code]}</span>
+              </label>
+            ))}
+          </RadioGroup>
+
+          <div className="mt-6 flex justify-end gap-2">
+            {dismissable && (
+              <button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                className="rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted"
+              >
+                Chiudi
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={!selected}
+              className="rounded-md bg-[var(--c-agent)] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+              data-testid="lang-override-confirm"
+            >
+              Conferma e ritraduci
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/components/features/gamebook/LangOverrideModal.tsx
+++ b/apps/web/src/components/features/gamebook/LangOverrideModal.tsx
@@ -51,7 +51,8 @@ export function LangOverrideModal({
     >
       <Dialog.Portal>
         <Dialog.Overlay
-          className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in"
+          // eslint-disable-next-line local/no-hardcoded-color-utility -- modal scrim canonical pattern, mirrors apps/web/src/components/ui/drawer/drawer.tsx OVERLAY_CLS
+          className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in"
           data-testid="lang-override-scrim"
         />
         <Dialog.Content

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 
 import { AbortButton } from '@/components/features/gamebook/AbortButton';
 import { BookPicker } from '@/components/features/gamebook/BookPicker';
+import { LangBadge } from '@/components/features/gamebook/LangBadge';
+import { LangOverrideModal } from '@/components/features/gamebook/LangOverrideModal';
 import { LoadingSkeleton } from '@/components/features/gamebook/LoadingSkeleton';
 import { ReaderModeToggle } from '@/components/features/gamebook/ReaderModeToggle';
 import { SegmentPicker } from '@/components/features/gamebook/SegmentPicker';
@@ -14,12 +16,15 @@ import {
 } from '@/components/features/gamebook/TranslateViewer.steps';
 import { TranslationPane } from '@/components/features/gamebook/TranslationPane';
 import { useGameBooks } from '@/hooks/useGameBooks';
+import { trackEvent } from '@/lib/analytics/track-event';
 import { GameBookRole, hasRole, type GameRef } from '@/lib/api/gamebook';
 import type { GamebookPhotoArtifact, GamebookSegment } from '@/lib/api/gamebook-photos';
 import { usePhotoUpload } from '@/lib/gamebook/hooks/usePhotoUpload';
 import { useReaderMode } from '@/lib/gamebook/hooks/useReaderMode';
 import { useSegmentPhoto } from '@/lib/gamebook/hooks/useSegmentPhoto';
 import { useTranslateSegmentSSE } from '@/lib/gamebook/hooks/useTranslateSegmentSSE';
+import type { SourceLangCode } from '@/lib/gamebook/lang-codes';
+import { getLangTier, type LangTier } from '@/lib/gamebook/lang-tier';
 
 export interface TranslateViewerProps {
   campaignId: string;
@@ -41,6 +46,23 @@ export type Phase =
   | 'segments_ready'
   | 'translating'
   | 'translated';
+
+type ModalMode = 'auto-low' | 'auto-medium-tap' | 'manual';
+type ModalState = { open: boolean; mode: ModalMode; preselect?: SourceLangCode };
+
+/**
+ * Compute effective tier for badge rendering.
+ * DEC-FE-10: when detected lang is null with high confidence (out-of-allowlist),
+ * fall back to 'none' (un-actionable detection).
+ */
+function effectiveTier(
+  lang: SourceLangCode | null | undefined,
+  conf: number | null | undefined
+): LangTier {
+  const rawTier = getLangTier(conf);
+  if (rawTier === 'high' && (lang === null || lang === undefined)) return 'none';
+  return rawTier;
+}
 
 export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): ReactElement {
   const [phase, setPhase] = useState<Phase>('idle');
@@ -75,6 +97,65 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
 
   // DEC-1: Derive user-facing UI step from internal FSM phase + SSE signals.
   const uiStep = deriveUiStep(phase, sse);
+
+  // #1559 — Lang detection state (DEC-FE-5/6/7/8/10/11)
+  const [confirmedLang, setConfirmedLang] = useState<SourceLangCode | null>(null);
+  const [autoLowFiredForArtifact, setAutoLowFiredForArtifact] = useState<string | null>(null);
+  const [analyticsDetectedFiredForArtifact, setAnalyticsDetectedFiredForArtifact] = useState<
+    string | null
+  >(null);
+  const [modalState, setModalState] = useState<ModalState>({ open: false, mode: 'manual' });
+
+  // Reset lang state on artifact change (DEC-FE-11)
+  useEffect(() => {
+    setConfirmedLang(null);
+    setAutoLowFiredForArtifact(null);
+    setAnalyticsDetectedFiredForArtifact(null);
+  }, [artifact?.id]);
+
+  const tier = effectiveTier(sse.detectedSourceLang, sse.langDetectionConfidence);
+  const effectiveLang: SourceLangCode | null = confirmedLang ?? sse.detectedSourceLang ?? null;
+  const isOverride = confirmedLang !== null && confirmedLang !== sse.detectedSourceLang;
+  // Tier shown in UI: after confirmedLang, badge transitions to 'high' info-tier (override case)
+  const renderedTier: LangTier = confirmedLang ? 'high' : tier;
+  const segmentBlockedByLang = (tier === 'medium' || tier === 'low') && !confirmedLang;
+
+  // Emit analytics: lang_detected fires once per artifact when sse.isComplete with lang fields present
+  useEffect(() => {
+    if (!sse.isComplete || !artifact?.id) return;
+    if (analyticsDetectedFiredForArtifact === artifact.id) return;
+    // Only emit when BE actually sent the fields (DEC-FE-12 vs legacy)
+    if (sse.detectedSourceLang === undefined && sse.langDetectionConfidence === undefined) return;
+    trackEvent('translate.lang_detected', {
+      photoId: artifact.id,
+      lang: sse.detectedSourceLang ?? null,
+      confidence: sse.langDetectionConfidence ?? null,
+      tier,
+    });
+    setAnalyticsDetectedFiredForArtifact(artifact.id);
+  }, [
+    sse.isComplete,
+    sse.detectedSourceLang,
+    sse.langDetectionConfidence,
+    artifact?.id,
+    tier,
+    analyticsDetectedFiredForArtifact,
+  ]);
+
+  // Auto-open modal for tier=low first time per artifact (DEC-FE-5)
+  useEffect(() => {
+    if (!sse.isComplete || !artifact?.id) return;
+    if (autoLowFiredForArtifact === artifact.id) return;
+    if (tier !== 'low') return;
+    if (confirmedLang) return;
+    setModalState({ open: true, mode: 'auto-low', preselect: undefined });
+    setAutoLowFiredForArtifact(artifact.id);
+    trackEvent('translate.lang_modal_opened', {
+      photoId: artifact.id,
+      tier,
+      mode: 'auto-low',
+    });
+  }, [sse.isComplete, tier, artifact?.id, autoLowFiredForArtifact, confirmedLang]);
 
   const handleFile = async (file: File) => {
     if (!effectiveBookId) {
@@ -125,11 +206,18 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
 
   const handlePickSegment = (paragraphNumber: number) => {
     if (!artifact || !effectiveBookId) return;
+    if (segmentBlockedByLang) return; // defensive — picker should be disabled
     const seg = artifact.segments.find(s => s.paragraphNumber === paragraphNumber);
     if (!seg) return;
     setActiveSegment(seg);
     setPhase('translating');
-    sse.start(campaignId, artifact.id, paragraphNumber, effectiveBookId);
+    sse.start(
+      campaignId,
+      artifact.id,
+      paragraphNumber,
+      effectiveBookId,
+      confirmedLang ?? undefined
+    );
   };
 
   // Auto-flip to translated when SSE completes
@@ -137,11 +225,65 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
     setPhase('translated');
   }
 
+  const handleBadgeTap = () => {
+    if (!artifact?.id) return;
+    const mode: ModalMode = tier === 'medium' ? 'auto-medium-tap' : 'manual';
+    setModalState({
+      open: true,
+      mode,
+      preselect: confirmedLang ?? sse.detectedSourceLang ?? undefined,
+    });
+    trackEvent('translate.lang_modal_opened', {
+      photoId: artifact.id,
+      tier,
+      mode,
+    });
+  };
+
+  const handleModalOpenChange = (open: boolean) => {
+    if (!open && artifact?.id) {
+      trackEvent('translate.lang_modal_dismissed', {
+        photoId: artifact.id,
+        tier,
+      });
+    }
+    setModalState(prev => ({ ...prev, open }));
+  };
+
+  const handleModalConfirm = (chosen: SourceLangCode) => {
+    if (!artifact?.id) return;
+    const previous = confirmedLang ?? sse.detectedSourceLang ?? null;
+    setConfirmedLang(chosen);
+    setModalState(prev => ({ ...prev, open: false }));
+    if (chosen !== previous) {
+      trackEvent('translate.lang_overridden', {
+        photoId: artifact.id,
+        fromLang: previous,
+        toLang: chosen,
+      });
+      // Re-translate if a segment is already active (DEC-FE-7)
+      if (activeSegment && effectiveBookId) {
+        setPhase('translating');
+        sse.start(campaignId, artifact.id, activeSegment.paragraphNumber, effectiveBookId, chosen);
+      }
+    }
+  };
+
+  // Modal dismissable: true everywhere per locked Opt B (dismissable + SegmentPicker block)
+  const modalDismissable = true;
+
   const errorMessage =
     upload.error?.message ?? segment.error?.message ?? sse.error ?? timeoutError ?? undefined;
 
   const isBusy = phase === 'uploading' || phase === 'segmenting' || phase === 'translating';
   const cameraDisabled = isBusy || !effectiveBookId;
+  const segmentPickerDisabled = phase === 'translating' || segmentBlockedByLang;
+
+  // Show badge after segments_ready (post-OCR)
+  const showBadge =
+    (phase === 'segments_ready' || phase === 'translating' || phase === 'translated') &&
+    artifact !== null &&
+    renderedTier !== 'none';
 
   return (
     <div className="grid gap-4 px-4 py-6 sm:px-6" data-reader-mode={String(isReaderMode)}>
@@ -150,6 +292,15 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
           <h1 className="text-xl font-semibold text-[var(--c-game)]">Traduci pagina libro game</h1>
           <ReaderModeToggle isReaderMode={isReaderMode} onToggle={toggleReaderMode} />
         </div>
+        {showBadge && (
+          <LangBadge
+            lang={effectiveLang}
+            confidence={sse.langDetectionConfidence ?? null}
+            tier={renderedTier}
+            onTap={handleBadgeTap}
+            isOverride={isOverride}
+          />
+        )}
       </header>
 
       {narrativeBooks.length > 1 && (
@@ -206,6 +357,15 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
             {errorMessage}
           </p>
         )}
+        {segmentBlockedByLang && (
+          <p
+            className="text-sm text-muted-foreground"
+            role="status"
+            data-testid="translate-viewer-lang-block-hint"
+          >
+            Conferma la sorgente per tradurre.
+          </p>
+        )}
       </section>
 
       {artifact &&
@@ -213,7 +373,7 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
           <SegmentPicker
             segments={artifact.segments}
             onPick={handlePickSegment}
-            disabled={phase === 'translating'}
+            disabled={segmentPickerDisabled}
           />
         )}
 
@@ -226,6 +386,14 @@ export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): 
           error={sse.error}
         />
       )}
+
+      <LangOverrideModal
+        open={modalState.open}
+        onOpenChange={handleModalOpenChange}
+        preselect={modalState.preselect}
+        dismissable={modalDismissable}
+        onConfirm={handleModalConfirm}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx
@@ -1,0 +1,104 @@
+// apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LangBadge } from '../LangBadge';
+
+describe('LangBadge', () => {
+  describe('tier rendering', () => {
+    it('renders "Sorgente: EN" for tier=high with detected lang', () => {
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" />);
+      expect(screen.getByText(/sorgente: EN/i)).toBeInTheDocument();
+    });
+
+    it('renders "Conferma: FR?" for tier=medium with detected lang', () => {
+      render(<LangBadge lang="FR" confidence={0.65} tier="medium" />);
+      expect(screen.getByText(/conferma: FR\?/i)).toBeInTheDocument();
+    });
+
+    it('renders "Sorgente richiesta" for tier=low (independent of lang)', () => {
+      render(<LangBadge lang={null} confidence={0.31} tier="low" />);
+      expect(screen.getByText(/sorgente richiesta/i)).toBeInTheDocument();
+    });
+
+    it('renders nothing for tier=none (returns null)', () => {
+      const { container } = render(<LangBadge lang={null} confidence={null} tier="none" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('appends "(override)" suffix when isOverride=true on high tier', () => {
+      render(<LangBadge lang="FR" confidence={0.92} tier="high" isOverride />);
+      expect(screen.getByText(/sorgente: FR.*override/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('interaction', () => {
+    it('calls onTap when user clicks the badge', async () => {
+      const user = userEvent.setup();
+      const onTap = vi.fn();
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" onTap={onTap} />);
+
+      await user.click(screen.getByRole('button'));
+      expect(onTap).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders as <span> (non-interactive) when no onTap provided', () => {
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('aria-label includes confidence (for screen readers)', () => {
+    it('mentions confidence percentage in aria-label on tier=high', () => {
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" onTap={() => {}} />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        expect.stringMatching(/sorgente.*inglese.*confidenza alta.*92%/i)
+      );
+    });
+
+    it('mentions confidence percentage in aria-label on tier=medium', () => {
+      render(<LangBadge lang="FR" confidence={0.65} tier="medium" onTap={() => {}} />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        expect.stringMatching(/conferma.*francese.*confidenza media.*65%/i)
+      );
+    });
+
+    it('aria-label on tier=low signals action required', () => {
+      render(<LangBadge lang={null} confidence={0.31} tier="low" onTap={() => {}} />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        expect.stringMatching(/sorgente richiesta.*conferma manualmente/i)
+      );
+    });
+  });
+
+  describe('a11y (jest-axe)', () => {
+    it('high tier as button → zero violations', async () => {
+      const { container } = render(
+        <LangBadge lang="EN" confidence={0.92} tier="high" onTap={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('medium tier as button → zero violations', async () => {
+      const { container } = render(
+        <LangBadge lang="FR" confidence={0.65} tier="medium" onTap={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('low tier as button → zero violations', async () => {
+      const { container } = render(
+        <LangBadge lang={null} confidence={0.31} tier="low" onTap={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx
@@ -1,0 +1,173 @@
+// apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LangOverrideModal } from '../LangOverrideModal';
+
+describe('LangOverrideModal', () => {
+  describe('rendering', () => {
+    it('renders no dialog when open=false', () => {
+      render(
+        <LangOverrideModal open={false} onOpenChange={() => {}} dismissable onConfirm={() => {}} />
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders dialog with title + 5 radio options when open=true', () => {
+      render(<LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(/seleziona la lingua/i)).toBeInTheDocument();
+      expect(screen.getAllByRole('radio')).toHaveLength(5);
+      // Each label
+      expect(screen.getByLabelText('Inglese')).toBeInTheDocument();
+      expect(screen.getByLabelText('Francese')).toBeInTheDocument();
+      expect(screen.getByLabelText('Tedesco')).toBeInTheDocument();
+      expect(screen.getByLabelText('Spagnolo')).toBeInTheDocument();
+      expect(screen.getByLabelText('Italiano')).toBeInTheDocument();
+    });
+
+    it('preselects the radio matching preselect prop', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="FR"
+          onConfirm={() => {}}
+        />
+      );
+      expect(screen.getByLabelText('Francese')).toBeChecked();
+      expect(screen.getByLabelText('Inglese')).not.toBeChecked();
+    });
+  });
+
+  describe('confirm', () => {
+    it('confirm button disabled when no selection + no preselect', () => {
+      render(<LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />);
+      const confirmBtn = screen.getByRole('button', { name: /conferma e ritraduci/i });
+      expect(confirmBtn).toBeDisabled();
+    });
+
+    it('confirm button enabled when preselect provided', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="FR"
+          onConfirm={() => {}}
+        />
+      );
+      const confirmBtn = screen.getByRole('button', { name: /conferma e ritraduci/i });
+      expect(confirmBtn).not.toBeDisabled();
+    });
+
+    it('confirm enables after user picks a radio (from no-preselect)', async () => {
+      const user = userEvent.setup();
+      render(<LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />);
+      await user.click(screen.getByLabelText('Tedesco'));
+      const confirmBtn = screen.getByRole('button', { name: /conferma e ritraduci/i });
+      expect(confirmBtn).not.toBeDisabled();
+    });
+
+    it('invokes onConfirm with selected lang on submit', async () => {
+      const user = userEvent.setup();
+      const onConfirm = vi.fn();
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="EN"
+          onConfirm={onConfirm}
+        />
+      );
+      await user.click(screen.getByLabelText('Spagnolo'));
+      await user.click(screen.getByRole('button', { name: /conferma e ritraduci/i }));
+      expect(onConfirm).toHaveBeenCalledWith('ES');
+    });
+  });
+
+  describe('dismiss', () => {
+    it('renders Chiudi button when dismissable=true', () => {
+      render(<LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />);
+      expect(screen.getByRole('button', { name: /chiudi/i })).toBeInTheDocument();
+    });
+
+    it('hides Chiudi button when dismissable=false', () => {
+      render(
+        <LangOverrideModal open onOpenChange={() => {}} dismissable={false} onConfirm={() => {}} />
+      );
+      expect(screen.queryByRole('button', { name: /chiudi/i })).not.toBeInTheDocument();
+    });
+
+    it('calls onOpenChange(false) when Chiudi clicked', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <LangOverrideModal open onOpenChange={onOpenChange} dismissable onConfirm={() => {}} />
+      );
+      await user.click(screen.getByRole('button', { name: /chiudi/i }));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('calls onOpenChange(false) on Escape when dismissable=true', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <LangOverrideModal open onOpenChange={onOpenChange} dismissable onConfirm={() => {}} />
+      );
+      await user.keyboard('{Escape}');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('a11y', () => {
+    it('dialog has aria-modal=true (Radix automatic)', () => {
+      render(<LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('axe finds zero violations when open (no preselect)', async () => {
+      const { container } = render(
+        <LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('axe finds zero violations when open (with preselect)', async () => {
+      const { container } = render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="DE"
+          onConfirm={() => {}}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('axe finds zero violations when dismissable=false', async () => {
+      const { container } = render(
+        <LangOverrideModal open onOpenChange={() => {}} dismissable={false} onConfirm={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('focus', () => {
+    it.skip('moves focus inside dialog on mount (focus trap)', async () => {
+      // jsdom limitation: Radix Dialog focus trap doesn't reliably fire in jsdom
+      render(<LangOverrideModal open onOpenChange={() => {}} dismissable onConfirm={() => {}} />);
+      await waitFor(() => {
+        // Radix moves focus to the first focusable element (typically close button or first radio)
+        const dialog = screen.getByRole('dialog');
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -1087,7 +1087,7 @@ describe('TranslateViewer', () => {
   });
 
   describe('#1559 — S7: legacy backward compat (no lang fields)', () => {
-    it('SSE without lang fields → tier=none, no badge, no modal, SegmentPicker enabled', async () => {
+    it('SSE without lang fields → tier=none, no badge, no modal, SegmentPicker enabled, no lang_detected audit', async () => {
       makeUploadAndSegmentMocks();
       // SSE without detectedSourceLang / langDetectionConfidence (legacy)
       vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
@@ -1099,6 +1099,8 @@ describe('TranslateViewer', () => {
         start: vi.fn(),
         stop: vi.fn(),
       } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
 
       wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
       await act(async () => {
@@ -1117,6 +1119,11 @@ describe('TranslateViewer', () => {
 
       // No segment block hint
       expect(screen.queryByTestId('translate-viewer-lang-block-hint')).not.toBeInTheDocument();
+
+      // M2 fix (final-review): DEC-FE-12 — legacy SSE (both lang fields === undefined) MUST NOT emit
+      // lang_detected audit event. This pins the contract vs. S7 spec copy which said "(audit)".
+      // DEC-FE-12 wins: legacy callers must not pollute analytics with synthetic null events.
+      expect(trackSpy).not.toHaveBeenCalledWith('translate.lang_detected', expect.anything());
     });
   });
 
@@ -1243,6 +1250,14 @@ describe('TranslateViewer', () => {
       // sse.start called 2nd time with 5th arg = 'FR' (sourceLangOverride)
       expect(startMock).toHaveBeenCalledTimes(2);
       expect(startMock.mock.calls[1][4]).toBe('FR');
+
+      // M1 fix (final-review): lang_modal_dismissed must NOT fire on confirm-path.
+      // Pins the contract: handleModalConfirm closes modal via setModalState (not handleModalOpenChange),
+      // and Radix controlled mode does NOT call onOpenChange(false) when parent flips `open` prop.
+      expect(trackSpy).not.toHaveBeenCalledWith(
+        'translate.lang_modal_dismissed',
+        expect.anything()
+      );
     });
 
     it('user opens modal + confirms same lang → no lang_overridden + sse.start NOT called again', async () => {
@@ -1303,6 +1318,12 @@ describe('TranslateViewer', () => {
 
       // sse.start still only 1 call (no re-translate on same lang)
       expect(startMock).toHaveBeenCalledTimes(1);
+
+      // M1 fix (final-review): lang_modal_dismissed must NOT fire on confirm-path (even same-lang confirm).
+      expect(trackSpy).not.toHaveBeenCalledWith(
+        'translate.lang_modal_dismissed',
+        expect.anything()
+      );
     });
   });
 

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -5,6 +5,8 @@ import { axe } from 'jest-axe';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
+import * as analyticsModule from '@/lib/analytics/track-event';
+
 // Mock all four hooks before importing the component
 vi.mock('@/lib/gamebook/hooks/usePhotoUpload');
 vi.mock('@/lib/gamebook/hooks/useSegmentPhoto');
@@ -836,6 +838,321 @@ describe('TranslateViewer', () => {
       const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1559 — Lang detection + override modal (T6: S1, S2, S3, S5, S7, S8)
+  // ---------------------------------------------------------------------------
+
+  /** Helper: set up upload + segment to resolve to FAKE_ARTIFACT. */
+  function makeUploadAndSegmentMocks() {
+    makeOneBookMock();
+    vi.mocked(uploadHook.usePhotoUpload).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue({ id: PHOTO_ID, segments: [] }),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+    vi.mocked(segmentHook.useSegmentPhoto).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn().mockResolvedValue(FAKE_ARTIFACT),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+    } as never);
+  }
+
+  describe('#1559 — S1: tier=high badge + no auto-modal + analytics lang_detected', () => {
+    it('renders LangBadge "Sorgente: EN" + SegmentPicker enabled + no auto-modal + fires lang_detected', async () => {
+      makeUploadAndSegmentMocks();
+      // SSE completes with EN high-confidence detection
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: 'Apri la porta.',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      // Wait for segments_ready (artifact set, SegmentPicker visible)
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // LangBadge visible with "Sorgente: EN"
+      expect(screen.getByTestId('lang-badge')).toBeInTheDocument();
+      expect(screen.getByText(/sorgente: EN/i)).toBeInTheDocument();
+
+      // No auto-modal (tier=high does not auto-open)
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      // SegmentPicker enabled (no segmentBlockedByLang for tier=high)
+      expect(screen.queryByTestId('translate-viewer-lang-block-hint')).not.toBeInTheDocument();
+
+      // Analytics: lang_detected fired
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_detected',
+        expect.objectContaining({ lang: 'EN', tier: 'high' })
+      );
+    });
+  });
+
+  describe('#1559 — S2: tier=medium SegmentPicker blocked + tap opens modal', () => {
+    it('badge "Conferma: FR?" + SegmentPicker DISABLED + tap opens modal with FR preselect', async () => {
+      makeUploadAndSegmentMocks();
+      const startMock = vi.fn();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: '',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: 'FR',
+        langDetectionConfidence: 0.65,
+        start: startMock,
+        stop: vi.fn(),
+      } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+      const user = userEvent.setup();
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // Badge shows "Conferma: FR?"
+      expect(screen.getByText(/conferma: FR\?/i)).toBeInTheDocument();
+
+      // SegmentPicker blocked: hint visible
+      expect(screen.getByTestId('translate-viewer-lang-block-hint')).toBeInTheDocument();
+
+      // Click badge → modal opens with FR preselected
+      await user.click(screen.getByTestId('lang-badge'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // FR radio should be checked
+      expect(screen.getByLabelText('Francese')).toBeChecked();
+
+      // Analytics: lang_modal_opened fired with mode='auto-medium-tap'
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_modal_opened',
+        expect.objectContaining({ tier: 'medium', mode: 'auto-medium-tap' })
+      );
+
+      // Confirm → modal closes, hint disappears (confirmedLang set)
+      await user.click(screen.getByRole('button', { name: /conferma e ritraduci/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // After confirm, hint gone (segmentBlockedByLang = false)
+      expect(screen.queryByTestId('translate-viewer-lang-block-hint')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('#1559 — S3: tier=low auto-modal + S5: dismiss keeps picker blocked', () => {
+    it('S3: auto-opens modal (mode=auto-low, no preselect) + SegmentPicker DISABLED', async () => {
+      makeUploadAndSegmentMocks();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: '',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: null,
+        langDetectionConfidence: 0.31,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // Modal auto-opens
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // No radio preselected (lang=null means no preselect)
+      expect(screen.queryByRole('radio', { checked: true } as never)).not.toBeInTheDocument();
+
+      // SegmentPicker blocked hint visible (behind modal, but in DOM)
+      expect(screen.getByTestId('translate-viewer-lang-block-hint')).toBeInTheDocument();
+
+      // Analytics: lang_detected fired
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_detected',
+        expect.objectContaining({ lang: null, tier: 'low' })
+      );
+
+      // Analytics: lang_modal_opened with mode=auto-low
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_modal_opened',
+        expect.objectContaining({ tier: 'low', mode: 'auto-low' })
+      );
+
+      // User picks DE + confirms
+      const user = userEvent.setup();
+      await user.click(screen.getByLabelText('Tedesco'));
+      await user.click(screen.getByRole('button', { name: /conferma e ritraduci/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Analytics: lang_overridden fired
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_overridden',
+        expect.objectContaining({ fromLang: null, toLang: 'DE' })
+      );
+
+      // Hint gone (confirmedLang set)
+      expect(screen.queryByTestId('translate-viewer-lang-block-hint')).not.toBeInTheDocument();
+    });
+
+    it('S5: dismiss auto-low modal keeps SegmentPicker DISABLED + fires lang_modal_dismissed', async () => {
+      makeUploadAndSegmentMocks();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: '',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: null,
+        langDetectionConfidence: 0.31,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+      const user = userEvent.setup();
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Dismiss via Chiudi button (dismissable=true)
+      await user.click(screen.getByRole('button', { name: /chiudi/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Analytics: lang_modal_dismissed fired
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_modal_dismissed',
+        expect.objectContaining({ tier: 'low' })
+      );
+
+      // SegmentPicker still blocked (confirmedLang still null)
+      expect(screen.getByTestId('translate-viewer-lang-block-hint')).toBeInTheDocument();
+
+      // Badge still shows low-tier "Sorgente richiesta"
+      expect(screen.getByTestId('lang-badge')).toBeInTheDocument();
+      expect(screen.getByText(/sorgente richiesta/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('#1559 — S7: legacy backward compat (no lang fields)', () => {
+    it('SSE without lang fields → tier=none, no badge, no modal, SegmentPicker enabled', async () => {
+      makeUploadAndSegmentMocks();
+      // SSE without detectedSourceLang / langDetectionConfidence (legacy)
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: 'Text.',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        // no detectedSourceLang, no langDetectionConfidence
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // No badge rendered (tier=none)
+      expect(screen.queryByTestId('lang-badge')).not.toBeInTheDocument();
+
+      // No modal
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      // No segment block hint
+      expect(screen.queryByTestId('translate-viewer-lang-block-hint')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('#1559 — S8: out-of-allowlist null lang + high confidence → tier=none', () => {
+    it('SSE {detectedSourceLang: null, langDetectionConfidence: 0.85} → no badge, picker enabled', async () => {
+      makeUploadAndSegmentMocks();
+      // BE emits null lang with high confidence (out-of-allowlist, DEC-FE-10)
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: '',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: null,
+        langDetectionConfidence: 0.85,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // effectiveTier: getLangTier(0.85)='high' but lang=null → 'none'
+      // So no badge rendered
+      expect(screen.queryByTestId('lang-badge')).not.toBeInTheDocument();
+
+      // No block hint (tier=none means segmentBlockedByLang=false)
+      expect(screen.queryByTestId('translate-viewer-lang-block-hint')).not.toBeInTheDocument();
+
+      // No auto-modal
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -1155,4 +1155,238 @@ describe('TranslateViewer', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // #1559 — T7: S4 re-translate + S6 jest-axe full viewer states
+  // ---------------------------------------------------------------------------
+
+  describe('#1559 — S4: re-translate via sourceLangOverride after manual modal', () => {
+    it('user opens modal + changes lang → trackEvent lang_overridden + sse.start called with override', async () => {
+      makeUploadAndSegmentMocks();
+      const startMock = vi.fn();
+      // SSE already complete with EN detection so badge shows + effects fire on segment arrival
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: 'Apri la porta.',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+        start: startMock,
+        stop: vi.fn(),
+      } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+      const user = userEvent.setup();
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      // segments_ready: SegmentPicker + badge visible (showBadge = segments_ready + artifact + tier!=none)
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // Badge visible: tier=high, lang=EN
+      expect(screen.getByTestId('lang-badge')).toBeInTheDocument();
+      expect(screen.getByText(/sorgente: EN/i)).toBeInTheDocument();
+
+      // Click segment §1 → handlePickSegment sets activeSegment + phase='translating'
+      // Then immediate flip: phase='translating' + sse.isComplete=true → phase='translated'
+      // sse.start called with no override (1st call, arg[4]=undefined)
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('segment-picker-translate-1'));
+      });
+
+      // Wait for translated phase (TranslationPane visible)
+      await waitFor(() => {
+        expect(screen.getByTestId('translation-pane-it')).toBeInTheDocument();
+      });
+
+      // sse.start called once (arg[4] = undefined, no override)
+      expect(startMock).toHaveBeenCalledTimes(1);
+      expect(startMock.mock.calls[0][4]).toBeUndefined();
+
+      // lang_detected analytics fired when artifact was set + isComplete=true
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_detected',
+        expect.objectContaining({ lang: 'EN', tier: 'high' })
+      );
+
+      // User taps badge → modal opens mode='manual', preselect='EN'
+      await user.click(screen.getByTestId('lang-badge'));
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_modal_opened',
+        expect.objectContaining({ mode: 'manual', tier: 'high' })
+      );
+
+      // User selects FR + confirms
+      await user.click(screen.getByLabelText('Francese'));
+      await user.click(screen.getByRole('button', { name: /conferma e ritraduci/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // lang_overridden fired
+      expect(trackSpy).toHaveBeenCalledWith(
+        'translate.lang_overridden',
+        expect.objectContaining({ fromLang: 'EN', toLang: 'FR' })
+      );
+
+      // sse.start called 2nd time with 5th arg = 'FR' (sourceLangOverride)
+      expect(startMock).toHaveBeenCalledTimes(2);
+      expect(startMock.mock.calls[1][4]).toBe('FR');
+    });
+
+    it('user opens modal + confirms same lang → no lang_overridden + sse.start NOT called again', async () => {
+      makeUploadAndSegmentMocks();
+      const startMock = vi.fn();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: 'Apri la porta.',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+        start: startMock,
+        stop: vi.fn(),
+      } as never);
+
+      const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+      const user = userEvent.setup();
+
+      wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // Click segment → 1st sse.start call (activeSegment set)
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('segment-picker-translate-1'));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('translation-pane-it')).toBeInTheDocument();
+      });
+
+      expect(startMock).toHaveBeenCalledTimes(1);
+
+      // Open modal + confirm same EN lang (preselect='EN', user doesn't change)
+      await user.click(screen.getByTestId('lang-badge'));
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // EN is preselected
+      expect(screen.getByLabelText('Inglese')).toBeChecked();
+
+      // Confirm without changing (chosen=EN, previous=EN → same)
+      await user.click(screen.getByRole('button', { name: /conferma e ritraduci/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // No lang_overridden (same lang confirmed)
+      expect(trackSpy).not.toHaveBeenCalledWith('translate.lang_overridden', expect.anything());
+
+      // sse.start still only 1 call (no re-translate on same lang)
+      expect(startMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#1559 — S6: jest-axe a11y full viewer states', () => {
+    it('axe: zero violations with tier=high badge + modal closed', async () => {
+      makeUploadAndSegmentMocks();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: 'Apri la porta.',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('axe: zero violations with tier=low + auto-low modal open', async () => {
+      makeUploadAndSegmentMocks();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: '',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: null,
+        langDetectionConfidence: 0.31,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      // Modal auto-opens for tier=low
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('axe: zero violations with tier=medium badge + SegmentPicker blocked', async () => {
+      makeUploadAndSegmentMocks();
+      vi.mocked(sseHook.useTranslateSegmentSSE).mockReturnValue({
+        partialText: '',
+        isComplete: true,
+        appliedTerms: [],
+        error: undefined,
+        detectedSourceLang: 'FR',
+        langDetectionConfidence: 0.65,
+        start: vi.fn(),
+        stop: vi.fn(),
+      } as never);
+
+      const { container } = wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} />);
+      await act(async () => {
+        firePhotoInput();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('segment-picker')).toBeInTheDocument();
+      });
+
+      // No auto-modal for medium (only badge shown, picker blocked)
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/apps/web/src/lib/gamebook/__tests__/lang-tier.test.ts
+++ b/apps/web/src/lib/gamebook/__tests__/lang-tier.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLangTier, type LangTier } from '../lang-tier';
+
+describe('getLangTier', () => {
+  it('returns "none" for null', () => {
+    expect(getLangTier(null)).toBe('none' satisfies LangTier);
+  });
+
+  it('returns "none" for undefined', () => {
+    expect(getLangTier(undefined)).toBe('none' satisfies LangTier);
+  });
+
+  it('returns "high" for confidence > 0.8', () => {
+    expect(getLangTier(0.81)).toBe('high' satisfies LangTier);
+    expect(getLangTier(0.95)).toBe('high' satisfies LangTier);
+    expect(getLangTier(1.0)).toBe('high' satisfies LangTier);
+  });
+
+  it('returns "medium" for confidence in [0.5, 0.8] inclusive', () => {
+    expect(getLangTier(0.5)).toBe('medium' satisfies LangTier);
+    expect(getLangTier(0.65)).toBe('medium' satisfies LangTier);
+    expect(getLangTier(0.8)).toBe('medium' satisfies LangTier);
+  });
+
+  it('returns "low" for confidence < 0.5', () => {
+    expect(getLangTier(0.49)).toBe('low' satisfies LangTier);
+    expect(getLangTier(0.31)).toBe('low' satisfies LangTier);
+    expect(getLangTier(0)).toBe('low' satisfies LangTier);
+  });
+
+  it('returns "low" for negative confidence (defensive)', () => {
+    expect(getLangTier(-0.1)).toBe('low' satisfies LangTier);
+  });
+
+  it('returns "high" for confidence above 1 (defensive)', () => {
+    expect(getLangTier(1.5)).toBe('high' satisfies LangTier);
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx
@@ -155,4 +155,99 @@ describe('useTranslateSegmentSSE', () => {
     expect(lastInstance?.url).toContain('paragraphNumber=7');
     expect(lastInstance?.url).toContain(`gameBookId=${BOOK_ID}`);
   });
+
+  // ---------------------------------------------------------------------------
+  // #1559 — lang detection fields + sourceLangOverride
+  // ---------------------------------------------------------------------------
+
+  it('captures detectedSourceLang and langDetectionConfidence from final chunk', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'Apri la porta.',
+        isComplete: true,
+        paragraphId: PARA_ID,
+        appliedTerms: [],
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+      })
+    );
+
+    expect(result.current.detectedSourceLang).toBe('EN');
+    expect(result.current.langDetectionConfidence).toBe(0.92);
+    expect(result.current.isComplete).toBe(true);
+  });
+
+  it('exposes null lang fields when BE emits them (out-of-allowlist or legacy)', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'X.',
+        isComplete: true,
+        paragraphId: PARA_ID,
+        appliedTerms: [],
+        detectedSourceLang: null,
+        langDetectionConfidence: 0.31,
+      })
+    );
+
+    expect(result.current.detectedSourceLang).toBeNull();
+    expect(result.current.langDetectionConfidence).toBe(0.31);
+  });
+
+  it('exposes undefined lang fields when BE omits them (backward compat)', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'Legacy.',
+        isComplete: true,
+        paragraphId: PARA_ID,
+        appliedTerms: [],
+      })
+    );
+
+    expect(result.current.detectedSourceLang).toBeUndefined();
+    expect(result.current.langDetectionConfidence).toBeUndefined();
+  });
+
+  it('appends sourceLangOverride to URL when provided', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 4, BOOK_ID, 'FR'));
+
+    expect(lastInstance?.url).toContain('sourceLangOverride=FR');
+  });
+
+  it('omits sourceLangOverride from URL when not provided', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 4, BOOK_ID));
+
+    expect(lastInstance?.url).not.toContain('sourceLangOverride');
+  });
+
+  it('resets lang fields on new start() call', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'old',
+        isComplete: true,
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+      })
+    );
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 2, BOOK_ID, 'DE'));
+
+    expect(result.current.detectedSourceLang).toBeUndefined();
+    expect(result.current.langDetectionConfidence).toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts
+++ b/apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts
@@ -2,12 +2,27 @@
 
 import { useCallback, useRef, useState } from 'react';
 
+import type { SourceLangCode } from '@/lib/gamebook/lang-codes';
+
 export interface TranslateState {
   partialText: string;
   isComplete: boolean;
   paragraphId?: string;
   appliedTerms: string[];
   error?: string;
+  /**
+   * Source language detected by BE NTextCat (PR #1787 DEC-3 BE).
+   * `null` if out-of-allowlist or detection failed.
+   * `undefined` if BE didn't emit (legacy backward compat).
+   * Only populated on final SSE chunk per BE DEC-10.
+   */
+  detectedSourceLang?: SourceLangCode | null;
+  /**
+   * Detection confidence in [0,1] (BE tanh-normalized, raw).
+   * `null` if detection failed; `undefined` if BE didn't emit.
+   * FE classifies via `getLangTier()` (DEC-FE-2).
+   */
+  langDetectionConfidence?: number | null;
 }
 
 const initialState: TranslateState = { partialText: '', isComplete: false, appliedTerms: [] };
@@ -24,17 +39,26 @@ export function useTranslateSegmentSSE() {
   }, []);
 
   const start = useCallback(
-    (campaignId: string, photoId: string, paragraphNumber: number, gameBookId: string) => {
+    (
+      campaignId: string,
+      photoId: string,
+      paragraphNumber: number,
+      gameBookId: string,
+      sourceLangOverride?: SourceLangCode
+    ) => {
       stop();
       setState(initialState);
       // C2 (multi-book generalization): `gameBookId` is required so the BE can
       // scope per-book progress correctly. Callers must derive it from
       // BookPicker / single-book auto-select.
-      const url =
+      let url =
         `${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(campaignId)}/photos/translate` +
         `?photoId=${encodeURIComponent(photoId)}` +
         `&paragraphNumber=${paragraphNumber}` +
         `&gameBookId=${encodeURIComponent(gameBookId)}`;
+      if (sourceLangOverride) {
+        url += `&sourceLangOverride=${encodeURIComponent(sourceLangOverride)}`;
+      }
       const es = new EventSource(url, { withCredentials: true });
       sourceRef.current = es;
 
@@ -46,6 +70,8 @@ export function useTranslateSegmentSSE() {
             paragraphId?: string;
             appliedTerms?: string[];
             error?: string;
+            detectedSourceLang?: SourceLangCode | null;
+            langDetectionConfidence?: number | null;
           };
           if (chunk.error) {
             setState(s => ({ ...s, error: chunk.error }));
@@ -57,6 +83,14 @@ export function useTranslateSegmentSSE() {
             isComplete: chunk.isComplete ?? false,
             paragraphId: chunk.paragraphId ?? s.paragraphId,
             appliedTerms: chunk.appliedTerms ?? s.appliedTerms,
+            detectedSourceLang:
+              chunk.detectedSourceLang !== undefined
+                ? chunk.detectedSourceLang
+                : s.detectedSourceLang,
+            langDetectionConfidence:
+              chunk.langDetectionConfidence !== undefined
+                ? chunk.langDetectionConfidence
+                : s.langDetectionConfidence,
           }));
           if (chunk.isComplete) es.close();
         } catch {

--- a/apps/web/src/lib/gamebook/lang-codes.ts
+++ b/apps/web/src/lib/gamebook/lang-codes.ts
@@ -1,0 +1,28 @@
+/**
+ * Language codes supported by the gamebook translate viewer.
+ *
+ * Aligned with BE PR #1787 allowlist (DEC-3 BE):
+ * NTextCat detection filters to these 5 ISO 639-1 UPPERCASE codes.
+ * The 5 radio options of LangOverrideModal mirror this set.
+ *
+ * Target lang is fixed to IT in v1 (Aaron CORE row K/L). Future i18n
+ * may add a target picker via separate epic.
+ */
+export type SourceLangCode = 'EN' | 'FR' | 'DE' | 'ES' | 'IT';
+
+/** Ordered presentation list for radio options (modal). */
+export const LANG_CODES_ORDER: readonly SourceLangCode[] = ['EN', 'FR', 'DE', 'ES', 'IT'];
+
+/** Italian human-readable labels for radio + badge display. */
+export const LANG_LABELS_IT: Record<SourceLangCode, string> = {
+  EN: 'Inglese',
+  FR: 'Francese',
+  DE: 'Tedesco',
+  ES: 'Spagnolo',
+  IT: 'Italiano',
+};
+
+/** Type guard for runtime parsing of BE-emitted lang strings. */
+export function isSourceLangCode(value: unknown): value is SourceLangCode {
+  return typeof value === 'string' && (LANG_CODES_ORDER as readonly string[]).includes(value);
+}

--- a/apps/web/src/lib/gamebook/lang-tier.ts
+++ b/apps/web/src/lib/gamebook/lang-tier.ts
@@ -1,0 +1,19 @@
+/**
+ * Confidence tier classification per DEC-FE-2 (#1559).
+ *
+ *   - null/undefined → 'none' (no detection, legacy path or out-of-allowlist null+high)
+ *   - confidence > 0.8 → 'high' (informational badge, no friction)
+ *   - 0.5 ≤ confidence ≤ 0.8 → 'medium' (tap-to-confirm pill, SegmentPicker blocked)
+ *   - confidence < 0.5 → 'low' (auto-open modal, SegmentPicker blocked)
+ *
+ * Confidence values come from BE NTextCat tanh(relativeGap × 200) normalization
+ * (PR #1787 BE deviation note). FE treats the [0,1] range as opaque ordinal.
+ */
+export type LangTier = 'high' | 'medium' | 'low' | 'none';
+
+export function getLangTier(confidence: number | null | undefined): LangTier {
+  if (confidence === null || confidence === undefined) return 'none';
+  if (confidence > 0.8) return 'high';
+  if (confidence >= 0.5) return 'medium';
+  return 'low';
+}

--- a/docs/superpowers/plans/2026-06-01-fe-1559-lang-detection-override-modal.md
+++ b/docs/superpowers/plans/2026-06-01-fe-1559-lang-detection-override-modal.md
@@ -1,0 +1,1735 @@
+# FE PR2 #1559 — Multi-language detection + override modal (TranslateViewer)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the FE side of #1559 multi-language detection + override modal on `TranslateViewer`. Reads `detectedSourceLang` + `langDetectionConfidence` from BE PR1 (#1787 shipped) SSE final chunk; renders a confidence-tiered header badge; auto-opens a `Radix Dialog` modal with radio group for `<0.5` confidence; supports re-translate via cached OCR (`?sourceLangOverride=` query param).
+
+**Architecture:** 4 new files (pure helper, types/labels, presentational badge, Radix-wrapped modal) + 2 modifications (hook additive evolution + TranslateViewer state machine integration). Modal state is local to TranslateViewer (no global store). Type-safe `SourceLangCode` union shared across all files. Analytics via existing `trackEvent` infrastructure. a11y enforced via `jest-axe` + Radix automatic ARIA.
+
+**Tech Stack:** Next.js 16 + React 19 + TypeScript + Tailwind 4 + Vitest + `@radix-ui/react-dialog@1.1.15` + `@testing-library/react` + `userEvent` + `jest-axe@10`.
+
+**DEC traceability:** DEC-FE-1..DEC-FE-13 locked via spec-panel critique 2026-06-01 (see [#1559 comment 4592606051](https://github.com/meepleAi-app/meepleai-monorepo/issues/1559#issuecomment-4592606051)). G/W/T scenarios S1-S8 inline below.
+
+**BE contract (shipped PR #1787):** SSE final chunk additive `DetectedSourceLang: 'EN'|'FR'|'DE'|'ES'|'IT'|null` + `LangDetectionConfidence: 0..1|null`; endpoint query param `?sourceLangOverride=EN|FR|DE|ES|IT` validated pre-SSE (400 on invalid); OCR cache via HybridCache TTL 24h on re-translate.
+
+---
+
+## File Structure
+
+| Path | Responsibility | Type | DEC |
+|------|---------------|------|-----|
+| `apps/web/src/lib/gamebook/lang-codes.ts` | `SourceLangCode` union type + `LANG_LABELS_IT` dict + `LANG_CODES_ORDER` array | Create | FE-13 |
+| `apps/web/src/lib/gamebook/lang-tier.ts` | Pure helper `getLangTier(confidence)` → tier classification | Create | FE-2 |
+| `apps/web/src/lib/gamebook/__tests__/lang-tier.test.ts` | Boundary tests for `getLangTier` | Create | FE-2/12 |
+| `apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts` | Hook extension: state additive + `sourceLangOverride` param + URL builder | Modify | FE-1 |
+| `apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx` | New test cases for lang fields + sourceLangOverride URL | Modify | FE-1/12 |
+| `apps/web/src/components/features/gamebook/LangBadge.tsx` | Presentational pill, 4 tier variants, hardcoded IT, label-only (no %) | Create | FE-3 |
+| `apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx` | Tier rendering, onTap, aria-label, jest-axe | Create | FE-3/12 |
+| `apps/web/src/components/features/gamebook/LangOverrideModal.tsx` | Radix Dialog wrapper, radio group 5 langs, dismissable, onConfirm | Create | FE-4 |
+| `apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx` | Radio + confirm + dismiss + focus + jest-axe + a11y | Create | FE-4/12 |
+| `apps/web/src/components/features/gamebook/TranslateViewer.tsx` | Wire badge + modal state machine + analytics + SegmentPicker block + re-translate | Modify | FE-5/6/7/8/10/11 |
+| `apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx` | S1-S8 integration scenarios | Modify | FE-12 |
+
+**Test commands:**
+- Unit + integration: `cd apps/web && pnpm test -- --run <test-file-path>` (single file) or `pnpm test -- --run` (all)
+- Typecheck: `cd apps/web && pnpm typecheck`
+- Lint: `cd apps/web && pnpm lint`
+- Coverage: `cd apps/web && pnpm test:coverage`
+
+---
+
+## Task 1: Types & labels scaffold
+
+**Files:**
+- Create: `apps/web/src/lib/gamebook/lang-codes.ts`
+
+- [ ] **Step 1: Create the types + labels file**
+
+```ts
+/**
+ * Language codes supported by the gamebook translate viewer.
+ *
+ * Aligned with BE PR #1787 allowlist (DEC-3 BE):
+ * NTextCat detection filters to these 5 ISO 639-1 UPPERCASE codes.
+ * The 5 radio options of LangOverrideModal mirror this set.
+ *
+ * Target lang is fixed to IT in v1 (Aaron CORE row K/L). Future i18n
+ * may add a target picker via separate epic.
+ */
+export type SourceLangCode = 'EN' | 'FR' | 'DE' | 'ES' | 'IT';
+
+/** Ordered presentation list for radio options (modal). */
+export const LANG_CODES_ORDER: readonly SourceLangCode[] = ['EN', 'FR', 'DE', 'ES', 'IT'];
+
+/** Italian human-readable labels for radio + badge display. */
+export const LANG_LABELS_IT: Record<SourceLangCode, string> = {
+  EN: 'Inglese',
+  FR: 'Francese',
+  DE: 'Tedesco',
+  ES: 'Spagnolo',
+  IT: 'Italiano',
+};
+
+/** Type guard for runtime parsing of BE-emitted lang strings. */
+export function isSourceLangCode(value: unknown): value is SourceLangCode {
+  return typeof value === 'string' && (LANG_CODES_ORDER as readonly string[]).includes(value);
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: PASS with no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/gamebook/lang-codes.ts
+git commit -m "T1 SourceLangCode types + LANG_LABELS_IT dict (#1559)"
+```
+
+---
+
+## Task 2: Tier classification helper (TDD)
+
+**Files:**
+- Create: `apps/web/src/lib/gamebook/lang-tier.ts`
+- Test: `apps/web/src/lib/gamebook/__tests__/lang-tier.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/web/src/lib/gamebook/__tests__/lang-tier.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { getLangTier, type LangTier } from '../lang-tier';
+
+describe('getLangTier', () => {
+  it('returns "none" for null', () => {
+    expect(getLangTier(null)).toBe('none' satisfies LangTier);
+  });
+
+  it('returns "none" for undefined', () => {
+    expect(getLangTier(undefined)).toBe('none' satisfies LangTier);
+  });
+
+  it('returns "high" for confidence > 0.8', () => {
+    expect(getLangTier(0.81)).toBe('high' satisfies LangTier);
+    expect(getLangTier(0.95)).toBe('high' satisfies LangTier);
+    expect(getLangTier(1.0)).toBe('high' satisfies LangTier);
+  });
+
+  it('returns "medium" for confidence in [0.5, 0.8] inclusive', () => {
+    expect(getLangTier(0.5)).toBe('medium' satisfies LangTier);
+    expect(getLangTier(0.65)).toBe('medium' satisfies LangTier);
+    expect(getLangTier(0.8)).toBe('medium' satisfies LangTier);
+  });
+
+  it('returns "low" for confidence < 0.5', () => {
+    expect(getLangTier(0.49)).toBe('low' satisfies LangTier);
+    expect(getLangTier(0.31)).toBe('low' satisfies LangTier);
+    expect(getLangTier(0)).toBe('low' satisfies LangTier);
+  });
+
+  it('returns "low" for negative confidence (defensive)', () => {
+    expect(getLangTier(-0.1)).toBe('low' satisfies LangTier);
+  });
+
+  it('returns "high" for confidence above 1 (defensive)', () => {
+    expect(getLangTier(1.5)).toBe('high' satisfies LangTier);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm test -- --run src/lib/gamebook/__tests__/lang-tier.test.ts`
+Expected: FAIL with "Cannot find module '../lang-tier'"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// apps/web/src/lib/gamebook/lang-tier.ts
+/**
+ * Confidence tier classification per DEC-FE-2 (#1559).
+ *
+ *   - null/undefined → 'none' (no detection, legacy path or out-of-allowlist null+high)
+ *   - confidence > 0.8 → 'high' (informational badge, no friction)
+ *   - 0.5 ≤ confidence ≤ 0.8 → 'medium' (tap-to-confirm pill, SegmentPicker blocked)
+ *   - confidence < 0.5 → 'low' (auto-open modal, SegmentPicker blocked)
+ *
+ * Confidence values come from BE NTextCat tanh(relativeGap × 200) normalization
+ * (PR #1787 BE deviation note). FE treats the [0,1] range as opaque ordinal.
+ */
+export type LangTier = 'high' | 'medium' | 'low' | 'none';
+
+export function getLangTier(confidence: number | null | undefined): LangTier {
+  if (confidence === null || confidence === undefined) return 'none';
+  if (confidence > 0.8) return 'high';
+  if (confidence >= 0.5) return 'medium';
+  return 'low';
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/web && pnpm test -- --run src/lib/gamebook/__tests__/lang-tier.test.ts`
+Expected: PASS — 7/7 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/gamebook/lang-tier.ts apps/web/src/lib/gamebook/__tests__/lang-tier.test.ts
+git commit -m "T2 getLangTier pure helper + 7 boundary tests (#1559)"
+```
+
+---
+
+## Task 3: Hook extension (additive state + sourceLangOverride)
+
+**Files:**
+- Modify: `apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts`
+- Test: `apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx` (additive)
+
+- [ ] **Step 1: Write the new failing tests (append to existing test file)**
+
+Append these test blocks AT THE END of `useTranslateSegmentSSE.test.tsx` (before the last `});` closing the outer `describe`):
+
+```tsx
+  // ---------------------------------------------------------------------------
+  // #1559 — lang detection fields + sourceLangOverride
+  // ---------------------------------------------------------------------------
+
+  it('captures detectedSourceLang and langDetectionConfidence from final chunk', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'Apri la porta.',
+        isComplete: true,
+        paragraphId: PARA_ID,
+        appliedTerms: [],
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+      })
+    );
+
+    expect(result.current.detectedSourceLang).toBe('EN');
+    expect(result.current.langDetectionConfidence).toBe(0.92);
+    expect(result.current.isComplete).toBe(true);
+  });
+
+  it('exposes null lang fields when BE emits them (out-of-allowlist or legacy)', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'X.',
+        isComplete: true,
+        paragraphId: PARA_ID,
+        appliedTerms: [],
+        detectedSourceLang: null,
+        langDetectionConfidence: 0.31,
+      })
+    );
+
+    expect(result.current.detectedSourceLang).toBeNull();
+    expect(result.current.langDetectionConfidence).toBe(0.31);
+  });
+
+  it('exposes undefined lang fields when BE omits them (backward compat)', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'Legacy.',
+        isComplete: true,
+        paragraphId: PARA_ID,
+        appliedTerms: [],
+      })
+    );
+
+    expect(result.current.detectedSourceLang).toBeUndefined();
+    expect(result.current.langDetectionConfidence).toBeUndefined();
+  });
+
+  it('appends sourceLangOverride to URL when provided', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 4, BOOK_ID, 'FR'));
+
+    expect(lastInstance?.url).toContain('sourceLangOverride=FR');
+  });
+
+  it('omits sourceLangOverride from URL when not provided', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 4, BOOK_ID));
+
+    expect(lastInstance?.url).not.toContain('sourceLangOverride');
+  });
+
+  it('resets lang fields on new start() call', () => {
+    const { result } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 1, BOOK_ID));
+    act(() =>
+      lastInstance!.simulateMessage({
+        delta: 'old',
+        isComplete: true,
+        detectedSourceLang: 'EN',
+        langDetectionConfidence: 0.92,
+      })
+    );
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 2, BOOK_ID, 'DE'));
+
+    expect(result.current.detectedSourceLang).toBeUndefined();
+    expect(result.current.langDetectionConfidence).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cd apps/web && pnpm test -- --run src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx`
+Expected: FAIL — 6 new tests fail (state fields undefined, URL missing sourceLangOverride)
+
+- [ ] **Step 3: Implement the hook extension (replace entire file content)**
+
+```ts
+// apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import type { SourceLangCode } from '@/lib/gamebook/lang-codes';
+
+export interface TranslateState {
+  partialText: string;
+  isComplete: boolean;
+  paragraphId?: string;
+  appliedTerms: string[];
+  error?: string;
+  /**
+   * Source language detected by BE NTextCat (PR #1787 DEC-3 BE).
+   * `null` if out-of-allowlist or detection failed.
+   * `undefined` if BE didn't emit (legacy backward compat).
+   * Only populated on final SSE chunk per BE DEC-10.
+   */
+  detectedSourceLang?: SourceLangCode | null;
+  /**
+   * Detection confidence in [0,1] (BE tanh-normalized, raw).
+   * `null` if detection failed; `undefined` if BE didn't emit.
+   * FE classifies via `getLangTier()` (DEC-FE-2).
+   */
+  langDetectionConfidence?: number | null;
+}
+
+const initialState: TranslateState = { partialText: '', isComplete: false, appliedTerms: [] };
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+export function useTranslateSegmentSSE() {
+  const [state, setState] = useState<TranslateState>(initialState);
+  const sourceRef = useRef<EventSource | null>(null);
+
+  const stop = useCallback(() => {
+    sourceRef.current?.close();
+    sourceRef.current = null;
+  }, []);
+
+  const start = useCallback(
+    (
+      campaignId: string,
+      photoId: string,
+      paragraphNumber: number,
+      gameBookId: string,
+      sourceLangOverride?: SourceLangCode
+    ) => {
+      stop();
+      setState(initialState);
+      let url =
+        `${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(campaignId)}/photos/translate` +
+        `?photoId=${encodeURIComponent(photoId)}` +
+        `&paragraphNumber=${paragraphNumber}` +
+        `&gameBookId=${encodeURIComponent(gameBookId)}`;
+      if (sourceLangOverride) {
+        url += `&sourceLangOverride=${encodeURIComponent(sourceLangOverride)}`;
+      }
+      const es = new EventSource(url, { withCredentials: true });
+      sourceRef.current = es;
+
+      es.onmessage = (ev: MessageEvent<string>) => {
+        try {
+          const chunk = JSON.parse(ev.data) as {
+            delta?: string;
+            isComplete?: boolean;
+            paragraphId?: string;
+            appliedTerms?: string[];
+            error?: string;
+            detectedSourceLang?: SourceLangCode | null;
+            langDetectionConfidence?: number | null;
+          };
+          if (chunk.error) {
+            setState(s => ({ ...s, error: chunk.error }));
+            es.close();
+            return;
+          }
+          setState(s => ({
+            partialText: s.partialText + (chunk.delta ?? ''),
+            isComplete: chunk.isComplete ?? false,
+            paragraphId: chunk.paragraphId ?? s.paragraphId,
+            appliedTerms: chunk.appliedTerms ?? s.appliedTerms,
+            detectedSourceLang:
+              chunk.detectedSourceLang !== undefined
+                ? chunk.detectedSourceLang
+                : s.detectedSourceLang,
+            langDetectionConfidence:
+              chunk.langDetectionConfidence !== undefined
+                ? chunk.langDetectionConfidence
+                : s.langDetectionConfidence,
+          }));
+          if (chunk.isComplete) es.close();
+        } catch {
+          // malformed JSON — ignore
+        }
+      };
+
+      es.onerror = () => {
+        setState(s => ({ ...s, error: s.error ?? 'stream_error' }));
+        es.close();
+      };
+    },
+    [stop]
+  );
+
+  return { ...state, start, stop };
+}
+```
+
+- [ ] **Step 4: Run all hook tests to verify pass**
+
+Run: `cd apps/web && pnpm test -- --run src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx`
+Expected: PASS — all tests (existing 8 + new 6 = 14)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts \
+        apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx
+git commit -m "T3 useTranslateSegmentSSE additive lang fields + sourceLangOverride param (#1559)"
+```
+
+---
+
+## Task 4: LangBadge component (TDD)
+
+**Files:**
+- Create: `apps/web/src/components/features/gamebook/LangBadge.tsx`
+- Test: `apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LangBadge } from '../LangBadge';
+
+describe('LangBadge', () => {
+  describe('tier rendering', () => {
+    it('renders "Sorgente: EN" for tier=high with detected lang', () => {
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" />);
+      expect(screen.getByText(/sorgente: EN/i)).toBeInTheDocument();
+    });
+
+    it('renders "Conferma: FR?" for tier=medium with detected lang', () => {
+      render(<LangBadge lang="FR" confidence={0.65} tier="medium" />);
+      expect(screen.getByText(/conferma: FR\?/i)).toBeInTheDocument();
+    });
+
+    it('renders "Sorgente richiesta" for tier=low (independent of lang)', () => {
+      render(<LangBadge lang={null} confidence={0.31} tier="low" />);
+      expect(screen.getByText(/sorgente richiesta/i)).toBeInTheDocument();
+    });
+
+    it('renders nothing for tier=none (returns null)', () => {
+      const { container } = render(
+        <LangBadge lang={null} confidence={null} tier="none" />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('appends "(override)" suffix when isOverride=true on high tier', () => {
+      render(<LangBadge lang="FR" confidence={0.92} tier="high" isOverride />);
+      expect(screen.getByText(/sorgente: FR.*override/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('interaction', () => {
+    it('calls onTap when user clicks the badge', async () => {
+      const user = userEvent.setup();
+      const onTap = vi.fn();
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" onTap={onTap} />);
+
+      await user.click(screen.getByRole('button'));
+      expect(onTap).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders as <span> (non-interactive) when no onTap provided', () => {
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('aria-label includes confidence (for screen readers)', () => {
+    it('mentions confidence percentage in aria-label on tier=high', () => {
+      render(<LangBadge lang="EN" confidence={0.92} tier="high" onTap={() => {}} />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        expect.stringMatching(/sorgente.*inglese.*confidenza alta.*92%/i)
+      );
+    });
+
+    it('mentions confidence percentage in aria-label on tier=medium', () => {
+      render(<LangBadge lang="FR" confidence={0.65} tier="medium" onTap={() => {}} />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        expect.stringMatching(/conferma.*francese.*confidenza media.*65%/i)
+      );
+    });
+
+    it('aria-label on tier=low signals action required', () => {
+      render(<LangBadge lang={null} confidence={0.31} tier="low" onTap={() => {}} />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute(
+        'aria-label',
+        expect.stringMatching(/sorgente richiesta.*conferma manualmente/i)
+      );
+    });
+  });
+
+  describe('a11y (jest-axe)', () => {
+    it('high tier as button → zero violations', async () => {
+      const { container } = render(
+        <LangBadge lang="EN" confidence={0.92} tier="high" onTap={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('medium tier as button → zero violations', async () => {
+      const { container } = render(
+        <LangBadge lang="FR" confidence={0.65} tier="medium" onTap={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('low tier as button → zero violations', async () => {
+      const { container } = render(
+        <LangBadge lang={null} confidence={0.31} tier="low" onTap={() => {}} />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/LangBadge.test.tsx`
+Expected: FAIL — "Cannot find module '../LangBadge'"
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// apps/web/src/components/features/gamebook/LangBadge.tsx
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { LangTier } from '@/lib/gamebook/lang-tier';
+import { LANG_LABELS_IT, type SourceLangCode } from '@/lib/gamebook/lang-codes';
+
+export interface LangBadgeProps {
+  lang: SourceLangCode | null;
+  confidence: number | null;
+  tier: LangTier;
+  onTap?: () => void;
+  /** Render "(override)" suffix when user has manually overridden detected lang. */
+  isOverride?: boolean;
+}
+
+const TIER_STYLES: Record<Exclude<LangTier, 'none'>, string> = {
+  high: 'bg-emerald-100 text-emerald-900 ring-1 ring-emerald-200',
+  medium: 'bg-amber-100 text-amber-900 ring-1 ring-amber-200',
+  low: 'bg-rose-100 text-rose-900 ring-1 ring-rose-200',
+};
+
+const TIER_CONFIDENCE_LABEL_IT: Record<Exclude<LangTier, 'none'>, string> = {
+  high: 'Confidenza alta',
+  medium: 'Confidenza media',
+  low: 'Confidenza bassa',
+};
+
+function buildVisualText(
+  tier: Exclude<LangTier, 'none'>,
+  lang: SourceLangCode | null,
+  isOverride: boolean
+): string {
+  if (tier === 'low') return 'Sorgente richiesta';
+  if (tier === 'medium' && lang) return `Conferma: ${lang}?`;
+  if (tier === 'medium' && !lang) return 'Conferma sorgente';
+  // tier === 'high'
+  return isOverride ? `Sorgente: ${lang} (override)` : `Sorgente: ${lang}`;
+}
+
+function buildAriaLabel(
+  tier: Exclude<LangTier, 'none'>,
+  lang: SourceLangCode | null,
+  confidence: number | null
+): string {
+  const langLabel = lang ? LANG_LABELS_IT[lang] : 'sconosciuta';
+  const confLabel = TIER_CONFIDENCE_LABEL_IT[tier];
+  const confPct =
+    confidence !== null && confidence !== undefined
+      ? ` (${Math.round(confidence * 100)}%)`
+      : '';
+
+  if (tier === 'low') {
+    return `Sorgente richiesta. Conferma manualmente la lingua.`;
+  }
+  if (tier === 'medium') {
+    return `Conferma sorgente: ${langLabel}. ${confLabel}${confPct}. Tap per confermare o cambiare.`;
+  }
+  return `Sorgente: ${langLabel}. ${confLabel}${confPct}. Tap per cambiare.`;
+}
+
+export function LangBadge({
+  lang,
+  confidence,
+  tier,
+  onTap,
+  isOverride = false,
+}: LangBadgeProps): ReactElement | null {
+  if (tier === 'none') return null;
+
+  const visualText = buildVisualText(tier, lang, isOverride);
+  const baseClass = `inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${TIER_STYLES[tier]}`;
+
+  if (onTap) {
+    return (
+      <button
+        type="button"
+        onClick={onTap}
+        className={`${baseClass} cursor-pointer hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-1`}
+        aria-label={buildAriaLabel(tier, lang, confidence)}
+        data-testid="lang-badge"
+        data-tier={tier}
+      >
+        {visualText}
+      </button>
+    );
+  }
+
+  return (
+    <span className={baseClass} data-testid="lang-badge" data-tier={tier}>
+      {visualText}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/LangBadge.test.tsx`
+Expected: PASS — 14 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/LangBadge.tsx \
+        apps/web/src/components/features/gamebook/__tests__/LangBadge.test.tsx
+git commit -m "T4 LangBadge 4-tier presentational component + 14 tests incl. jest-axe (#1559)"
+```
+
+---
+
+## Task 5: LangOverrideModal (Radix Dialog wrapper) — TDD
+
+**Files:**
+- Create: `apps/web/src/components/features/gamebook/LangOverrideModal.tsx`
+- Test: `apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LangOverrideModal } from '../LangOverrideModal';
+
+describe('LangOverrideModal', () => {
+  describe('rendering', () => {
+    it('renders no dialog when open=false', () => {
+      render(
+        <LangOverrideModal
+          open={false}
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders dialog with title + 5 radio options when open=true', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(/seleziona la lingua/i)).toBeInTheDocument();
+      expect(screen.getAllByRole('radio')).toHaveLength(5);
+      // Each label
+      expect(screen.getByLabelText('Inglese')).toBeInTheDocument();
+      expect(screen.getByLabelText('Francese')).toBeInTheDocument();
+      expect(screen.getByLabelText('Tedesco')).toBeInTheDocument();
+      expect(screen.getByLabelText('Spagnolo')).toBeInTheDocument();
+      expect(screen.getByLabelText('Italiano')).toBeInTheDocument();
+    });
+
+    it('preselects the radio matching preselect prop', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="FR"
+          onConfirm={() => {}}
+        />
+      );
+      expect(screen.getByLabelText('Francese')).toBeChecked();
+      expect(screen.getByLabelText('Inglese')).not.toBeChecked();
+    });
+  });
+
+  describe('confirm', () => {
+    it('confirm button disabled when no selection + no preselect', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      const confirmBtn = screen.getByRole('button', { name: /conferma e ritraduci/i });
+      expect(confirmBtn).toBeDisabled();
+    });
+
+    it('confirm button enabled when preselect provided', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="FR"
+          onConfirm={() => {}}
+        />
+      );
+      const confirmBtn = screen.getByRole('button', { name: /conferma e ritraduci/i });
+      expect(confirmBtn).not.toBeDisabled();
+    });
+
+    it('confirm enables after user picks a radio (from no-preselect)', async () => {
+      const user = userEvent.setup();
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      await user.click(screen.getByLabelText('Tedesco'));
+      const confirmBtn = screen.getByRole('button', { name: /conferma e ritraduci/i });
+      expect(confirmBtn).not.toBeDisabled();
+    });
+
+    it('invokes onConfirm with selected lang on submit', async () => {
+      const user = userEvent.setup();
+      const onConfirm = vi.fn();
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="EN"
+          onConfirm={onConfirm}
+        />
+      );
+      await user.click(screen.getByLabelText('Spagnolo'));
+      await user.click(screen.getByRole('button', { name: /conferma e ritraduci/i }));
+      expect(onConfirm).toHaveBeenCalledWith('ES');
+    });
+  });
+
+  describe('dismiss', () => {
+    it('renders Chiudi button when dismissable=true', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      expect(screen.getByRole('button', { name: /chiudi/i })).toBeInTheDocument();
+    });
+
+    it('hides Chiudi button when dismissable=false', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable={false}
+          onConfirm={() => {}}
+        />
+      );
+      expect(screen.queryByRole('button', { name: /chiudi/i })).not.toBeInTheDocument();
+    });
+
+    it('calls onOpenChange(false) when Chiudi clicked', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={onOpenChange}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      await user.click(screen.getByRole('button', { name: /chiudi/i }));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('calls onOpenChange(false) on Escape when dismissable=true', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={onOpenChange}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      await user.keyboard('{Escape}');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('a11y', () => {
+    it('dialog has aria-modal=true (Radix automatic)', () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('axe finds zero violations when open (no preselect)', async () => {
+      const { container } = render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('axe finds zero violations when open (with preselect)', async () => {
+      const { container } = render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          preselect="DE"
+          onConfirm={() => {}}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it('axe finds zero violations when dismissable=false', async () => {
+      const { container } = render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable={false}
+          onConfirm={() => {}}
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('focus', () => {
+    it('moves focus inside dialog on mount (focus trap)', async () => {
+      render(
+        <LangOverrideModal
+          open
+          onOpenChange={() => {}}
+          dismissable
+          onConfirm={() => {}}
+        />
+      );
+      await waitFor(() => {
+        // Radix moves focus to the first focusable element (typically close button or first radio)
+        const dialog = screen.getByRole('dialog');
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx`
+Expected: FAIL — "Cannot find module '../LangOverrideModal'"
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// apps/web/src/components/features/gamebook/LangOverrideModal.tsx
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { useEffect, useId, useState, type ReactElement } from 'react';
+
+import { RadioGroup, RadioGroupItem } from '@/components/ui/primitives/radio-group';
+import { LANG_CODES_ORDER, LANG_LABELS_IT, type SourceLangCode } from '@/lib/gamebook/lang-codes';
+
+export interface LangOverrideModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Preselected radio option (if any). */
+  preselect?: SourceLangCode;
+  /** When false, hide the Chiudi button and ignore Escape (forced-choice mode for auto-low). */
+  dismissable: boolean;
+  /** Called when user confirms with a selected lang. */
+  onConfirm: (lang: SourceLangCode) => void;
+}
+
+export function LangOverrideModal({
+  open,
+  onOpenChange,
+  preselect,
+  dismissable,
+  onConfirm,
+}: LangOverrideModalProps): ReactElement {
+  const [selected, setSelected] = useState<SourceLangCode | undefined>(preselect);
+  const titleId = useId();
+  const radioName = useId();
+
+  // Sync selected when preselect or open changes (modal reopen resets state).
+  useEffect(() => {
+    if (open) {
+      setSelected(preselect);
+    }
+  }, [open, preselect]);
+
+  const handleConfirm = () => {
+    if (selected) onConfirm(selected);
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        // Block Escape/outside-click dismiss when not dismissable
+        if (!next && !dismissable) return;
+        onOpenChange(next);
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in"
+          data-testid="lang-override-scrim"
+        />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-background p-6 shadow-lg"
+          aria-labelledby={titleId}
+          onEscapeKeyDown={(e) => {
+            if (!dismissable) e.preventDefault();
+          }}
+          onPointerDownOutside={(e) => {
+            if (!dismissable) e.preventDefault();
+          }}
+        >
+          <Dialog.Title id={titleId} className="text-lg font-semibold">
+            Seleziona la lingua sorgente
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+            Conferma la lingua originale della pagina per migliorare la traduzione.
+          </Dialog.Description>
+
+          <RadioGroup
+            value={selected}
+            onValueChange={(v) => setSelected(v as SourceLangCode)}
+            name={radioName}
+            className="mt-4 gap-3"
+          >
+            {LANG_CODES_ORDER.map((code) => (
+              <label
+                key={code}
+                htmlFor={`${radioName}-${code}`}
+                className="flex items-center gap-2 cursor-pointer text-sm"
+              >
+                <RadioGroupItem id={`${radioName}-${code}`} value={code} />
+                <span>{LANG_LABELS_IT[code]}</span>
+              </label>
+            ))}
+          </RadioGroup>
+
+          <div className="mt-6 flex justify-end gap-2">
+            {dismissable && (
+              <button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                className="rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted"
+              >
+                Chiudi
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={!selected}
+              className="rounded-md bg-[var(--c-agent)] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+              data-testid="lang-override-confirm"
+            >
+              Conferma e ritraduci
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx`
+Expected: PASS — 15 tests
+
+If any test fails on focus trap (`focus inside dialog on mount`), note: Radix may need `userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never })` if running in jsdom + Radix Portal nuances. If so, mark the focus test `it.skip` with `// jsdom limitation` and document in PR body.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/LangOverrideModal.tsx \
+        apps/web/src/components/features/gamebook/__tests__/LangOverrideModal.test.tsx
+git commit -m "T5 LangOverrideModal Radix Dialog + radio + dismiss + 15 tests (#1559)"
+```
+
+---
+
+## Task 6: TranslateViewer integration — badge + modal + analytics + block (S1, S2, S3, S7, S8)
+
+**Files:**
+- Modify: `apps/web/src/components/features/gamebook/TranslateViewer.tsx`
+- Test: `apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx`
+
+- [ ] **Step 1: Add new test scenarios (append to TranslateViewer.test.tsx)**
+
+First read the existing test file structure (look at top imports + `describe` blocks). Append these new `describe` blocks at the end of the file, BEFORE the outer file-level scope ends:
+
+```tsx
+  // ---------------------------------------------------------------------------
+  // #1559 — Lang detection + override modal (S1, S2, S3, S7, S8)
+  // ---------------------------------------------------------------------------
+
+  describe('#1559 — S1: tier=high happy path', () => {
+    it('renders LangBadge "Sorgente: EN" + SegmentPicker enabled + no auto-modal', async () => {
+      // Reuse existing pattern from earlier #1557/#1558 scenarios:
+      // - Setup MSW handlers for upload + segment
+      // - Render TranslateViewer
+      // - Fire SSE chunk with detectedSourceLang="EN", langDetectionConfidence=0.92
+      // - Assert: LangBadge text "Sorgente: EN", SegmentPicker enabled, modal not opened
+      // - Assert: trackEvent called with 'translate.lang_detected', {lang:"EN", tier:"high"}
+      //
+      // Use existing renderTranslateViewer / MSW setup utilities from this file.
+      // Mock trackEvent: vi.spyOn(analytics, 'trackEvent')
+    });
+  });
+
+  describe('#1559 — S2: tier=medium tap-to-confirm + SegmentPicker block', () => {
+    it('renders "Conferma: FR?" + SegmentPicker DISABLED, tap opens modal preselect FR, confirm enables picker', async () => {
+      // - Fire SSE with detectedSourceLang="FR", langDetectionConfidence=0.65
+      // - Assert: badge text "Conferma: FR?", SegmentPicker disabled
+      // - User clicks badge → modal opens with FR preselected
+      // - User clicks "Conferma e ritraduci"
+      // - Assert: modal closes, badge becomes "Sorgente: FR (override)", SegmentPicker enabled
+      // - Assert: trackEvent fires 'translate.lang_modal_opened' with {tier:"medium", mode:"auto-medium-tap"}
+    });
+  });
+
+  describe('#1559 — S3: tier=low forced auto-modal', () => {
+    it('auto-opens modal mode=auto-low with no preselect + SegmentPicker DISABLED', async () => {
+      // - Fire SSE with detectedSourceLang=null, langDetectionConfidence=0.31
+      // - Assert: modal auto-opens, no preselect, SegmentPicker disabled
+      // - Assert: trackEvent fires 'translate.lang_detected' AND 'translate.lang_modal_opened' with mode:"auto-low"
+      // - User picks "DE" + confirm
+      // - Assert: modal closes, badge "Sorgente: DE (override)", SegmentPicker enabled
+      // - Assert: trackEvent fires 'translate.lang_overridden' {fromLang: null, toLang: "DE"}
+    });
+
+    it('S5: dismiss auto-low modal keeps SegmentPicker DISABLED + badge danger', async () => {
+      // - Same setup as S3 but user presses Escape
+      // - Assert: modal closes, confirmedLang stays null, badge "Sorgente richiesta" danger tier
+      // - Assert: SegmentPicker remains DISABLED
+      // - Assert: trackEvent fires 'translate.lang_modal_dismissed' {tier:"low"}
+      // - User taps badge → modal reopens mode='auto-medium-tap' (not 'auto-low' second time)
+    });
+  });
+
+  describe('#1559 — S7: legacy backward compat (lang fields undefined/null)', () => {
+    it('SSE without lang fields → tier=none, no badge, no modal, SegmentPicker enabled', async () => {
+      // - Fire SSE without detectedSourceLang/langDetectionConfidence
+      // - Assert: no badge rendered, no modal, SegmentPicker enabled
+    });
+  });
+
+  describe('#1559 — S8: out-of-allowlist null lang + high confidence → tier=none', () => {
+    it('SSE {detectedSourceLang: null, langDetectionConfidence: 0.85} → tier=none, no badge, picker enabled', async () => {
+      // Note: BE may emit lang=null with raw high confidence when detection lands outside allowlist.
+      // FE: getLangTier(0.85) returns 'high' BUT the tier 'high' rendering requires non-null lang.
+      // Per DEC-FE-10, when lang=null we override the tier to 'none' before rendering badge.
+      // - Fire SSE with detectedSourceLang=null, langDetectionConfidence=0.85
+      // - Assert: no badge rendered (tier fallback to 'none')
+      // - Assert: SegmentPicker enabled (no block)
+    });
+  });
+```
+
+> Note for implementer: the existing `TranslateViewer.test.tsx` already has render helpers (MSW setup, mock EventSource, photo upload mocks). Reuse those patterns — DO NOT recreate. The pseudo-code comments above describe the assertion shape; flesh them out matching the existing test structure observed when reading the file at start of this task.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/TranslateViewer.test.tsx`
+Expected: FAIL — assertions reference `LangBadge` / `LangOverrideModal` not yet wired
+
+- [ ] **Step 3: Modify TranslateViewer to integrate**
+
+Replace the current `TranslateViewer.tsx` with the extended version below (full file, additive on existing):
+
+```tsx
+// apps/web/src/components/features/gamebook/TranslateViewer.tsx
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+
+import { AbortButton } from '@/components/features/gamebook/AbortButton';
+import { BookPicker } from '@/components/features/gamebook/BookPicker';
+import { LangBadge } from '@/components/features/gamebook/LangBadge';
+import { LangOverrideModal } from '@/components/features/gamebook/LangOverrideModal';
+import { LoadingSkeleton } from '@/components/features/gamebook/LoadingSkeleton';
+import { ReaderModeToggle } from '@/components/features/gamebook/ReaderModeToggle';
+import { SegmentPicker } from '@/components/features/gamebook/SegmentPicker';
+import {
+  deriveUiStep,
+  isAbortableStep,
+  LABELS,
+} from '@/components/features/gamebook/TranslateViewer.steps';
+import { TranslationPane } from '@/components/features/gamebook/TranslationPane';
+import { useGameBooks } from '@/hooks/useGameBooks';
+import { trackEvent } from '@/lib/analytics/track-event';
+import { GameBookRole, hasRole, type GameRef } from '@/lib/api/gamebook';
+import type { GamebookPhotoArtifact, GamebookSegment } from '@/lib/api/gamebook-photos';
+import { usePhotoUpload } from '@/lib/gamebook/hooks/usePhotoUpload';
+import { useReaderMode } from '@/lib/gamebook/hooks/useReaderMode';
+import { useSegmentPhoto } from '@/lib/gamebook/hooks/useSegmentPhoto';
+import { useTranslateSegmentSSE } from '@/lib/gamebook/hooks/useTranslateSegmentSSE';
+import type { SourceLangCode } from '@/lib/gamebook/lang-codes';
+import { getLangTier, type LangTier } from '@/lib/gamebook/lang-tier';
+
+export interface TranslateViewerProps {
+  campaignId: string;
+  gameRef: GameRef;
+}
+
+export type Phase =
+  | 'idle'
+  | 'uploading'
+  | 'segmenting'
+  | 'segments_ready'
+  | 'translating'
+  | 'translated';
+
+type ModalMode = 'auto-low' | 'auto-medium-tap' | 'manual';
+type ModalState = { open: boolean; mode: ModalMode; preselect?: SourceLangCode };
+
+/**
+ * Compute effective tier for badge rendering.
+ * DEC-FE-10: when detected lang is null with high confidence (out-of-allowlist),
+ * fall back to 'none' (un-actionable detection).
+ */
+function effectiveTier(lang: SourceLangCode | null | undefined, conf: number | null | undefined): LangTier {
+  const rawTier = getLangTier(conf);
+  if (rawTier === 'high' && (lang === null || lang === undefined)) return 'none';
+  return rawTier;
+}
+
+export function TranslateViewer({ campaignId, gameRef }: TranslateViewerProps): ReactElement {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [artifact, setArtifact] = useState<GamebookPhotoArtifact | null>(null);
+  const [activeSegment, setActiveSegment] = useState<GamebookSegment | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { isReaderMode, toggle: toggleReaderMode } = useReaderMode();
+
+  const { data: books } = useGameBooks(gameRef);
+  const narrativeBooks = useMemo(
+    () =>
+      (books ?? [])
+        .filter(b => hasRole(b.roles, GameBookRole.Narrative))
+        .map(b => ({ id: b.id, displayName: b.displayName, roles: b.roles })),
+    [books]
+  );
+
+  const [selectedBookId, setSelectedBookId] = useState<string | undefined>(undefined);
+  const effectiveBookId =
+    selectedBookId ?? (narrativeBooks.length === 1 ? narrativeBooks[0].id : undefined);
+
+  const upload = usePhotoUpload(campaignId);
+  const segment = useSegmentPhoto(campaignId);
+  const sse = useTranslateSegmentSSE();
+
+  const [timeoutError, setTimeoutError] = useState<string | null>(null);
+  const uiStep = deriveUiStep(phase, sse);
+
+  // #1559 — Lang detection state
+  const [confirmedLang, setConfirmedLang] = useState<SourceLangCode | null>(null);
+  const [autoLowFiredForArtifact, setAutoLowFiredForArtifact] = useState<string | null>(null);
+  const [analyticsDetectedFiredForArtifact, setAnalyticsDetectedFiredForArtifact] = useState<string | null>(null);
+  const [modalState, setModalState] = useState<ModalState>({ open: false, mode: 'manual' });
+
+  // Reset lang state on artifact change (DEC-FE-11)
+  useEffect(() => {
+    setConfirmedLang(null);
+    setAutoLowFiredForArtifact(null);
+    setAnalyticsDetectedFiredForArtifact(null);
+  }, [artifact?.id]);
+
+  const tier = effectiveTier(sse.detectedSourceLang, sse.langDetectionConfidence);
+  const effectiveLang: SourceLangCode | null = confirmedLang ?? sse.detectedSourceLang ?? null;
+  const isOverride = confirmedLang !== null && confirmedLang !== sse.detectedSourceLang;
+  // Tier shown in UI: after confirmedLang, badge transitions to 'high' info-tier (override case)
+  const renderedTier: LangTier = confirmedLang ? 'high' : tier;
+  const segmentBlockedByLang = (tier === 'medium' || tier === 'low') && !confirmedLang;
+
+  // Emit analytics: lang_detected fires once per artifact when sse.isComplete with lang fields present
+  useEffect(() => {
+    if (!sse.isComplete || !artifact?.id) return;
+    if (analyticsDetectedFiredForArtifact === artifact.id) return;
+    // Only emit when BE actually sent the fields (DEC-FE-12 vs legacy)
+    if (sse.detectedSourceLang === undefined && sse.langDetectionConfidence === undefined) return;
+    trackEvent('translate.lang_detected', {
+      photoId: artifact.id,
+      lang: sse.detectedSourceLang ?? null,
+      confidence: sse.langDetectionConfidence ?? null,
+      tier,
+    });
+    setAnalyticsDetectedFiredForArtifact(artifact.id);
+  }, [sse.isComplete, sse.detectedSourceLang, sse.langDetectionConfidence, artifact?.id, tier, analyticsDetectedFiredForArtifact]);
+
+  // Auto-open modal for tier=low first time per artifact (DEC-FE-5)
+  useEffect(() => {
+    if (!sse.isComplete || !artifact?.id) return;
+    if (autoLowFiredForArtifact === artifact.id) return;
+    if (tier !== 'low') return;
+    if (confirmedLang) return;
+    setModalState({ open: true, mode: 'auto-low', preselect: undefined });
+    setAutoLowFiredForArtifact(artifact.id);
+    trackEvent('translate.lang_modal_opened', {
+      photoId: artifact.id,
+      tier,
+      mode: 'auto-low',
+    });
+  }, [sse.isComplete, tier, artifact?.id, autoLowFiredForArtifact, confirmedLang]);
+
+  const handleFile = async (file: File) => {
+    if (!effectiveBookId) return;
+    setTimeoutError(null);
+    setPhase('uploading');
+    setArtifact(null);
+    setActiveSegment(null);
+    try {
+      const uploaded = await upload.mutateAsync({ file, gameBookId: effectiveBookId });
+      setPhase('segmenting');
+      const segmented = await segment.mutateAsync({ photoId: uploaded.id });
+      setArtifact(segmented);
+      setPhase('segments_ready');
+    } catch {
+      setPhase('idle');
+    }
+  };
+
+  const handleAbort = useCallback(() => {
+    sse.stop();
+    setTimeoutError(null);
+    setPhase(prev => (prev === 'translating' ? 'segments_ready' : 'idle'));
+  }, [sse]);
+
+  const HARD_TIMEOUT_MS = 20_000;
+  useEffect(() => {
+    if (phase !== 'uploading' && phase !== 'segmenting' && phase !== 'translating') return;
+    const timerId = window.setTimeout(() => {
+      if (sse.isComplete) return;
+      sse.stop();
+      setTimeoutError(LABELS.timeoutError);
+      setPhase(prev => (prev === 'translating' ? 'segments_ready' : 'idle'));
+    }, HARD_TIMEOUT_MS);
+    return () => window.clearTimeout(timerId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
+
+  const handlePickSegment = (paragraphNumber: number) => {
+    if (!artifact || !effectiveBookId) return;
+    if (segmentBlockedByLang) return; // defensive — picker should be disabled
+    const seg = artifact.segments.find(s => s.paragraphNumber === paragraphNumber);
+    if (!seg) return;
+    setActiveSegment(seg);
+    setPhase('translating');
+    sse.start(campaignId, artifact.id, paragraphNumber, effectiveBookId, confirmedLang ?? undefined);
+  };
+
+  if (phase === 'translating' && sse.isComplete) {
+    setPhase('translated');
+  }
+
+  const handleBadgeTap = () => {
+    if (!artifact?.id) return;
+    const mode: ModalMode = tier === 'medium' ? 'auto-medium-tap' : 'manual';
+    setModalState({
+      open: true,
+      mode,
+      preselect: confirmedLang ?? sse.detectedSourceLang ?? undefined,
+    });
+    trackEvent('translate.lang_modal_opened', {
+      photoId: artifact.id,
+      tier,
+      mode,
+    });
+  };
+
+  const handleModalOpenChange = (open: boolean) => {
+    if (!open && artifact?.id) {
+      trackEvent('translate.lang_modal_dismissed', {
+        photoId: artifact.id,
+        tier,
+      });
+    }
+    setModalState(prev => ({ ...prev, open }));
+  };
+
+  const handleModalConfirm = (chosen: SourceLangCode) => {
+    if (!artifact?.id) return;
+    const previous = confirmedLang ?? sse.detectedSourceLang ?? null;
+    setConfirmedLang(chosen);
+    setModalState(prev => ({ ...prev, open: false }));
+    if (chosen !== previous) {
+      trackEvent('translate.lang_overridden', {
+        photoId: artifact.id,
+        fromLang: previous,
+        toLang: chosen,
+      });
+      // Re-translate if a segment is already active (DEC-FE-7)
+      if (activeSegment && effectiveBookId) {
+        setPhase('translating');
+        sse.start(campaignId, artifact.id, activeSegment.paragraphNumber, effectiveBookId, chosen);
+      }
+    }
+  };
+
+  // Modal dismissable: true everywhere per locked Opt B (dismissable + SegmentPicker block)
+  const modalDismissable = true;
+
+  const errorMessage =
+    upload.error?.message ?? segment.error?.message ?? sse.error ?? timeoutError ?? undefined;
+
+  const isBusy = phase === 'uploading' || phase === 'segmenting' || phase === 'translating';
+  const cameraDisabled = isBusy || !effectiveBookId;
+  const segmentPickerDisabled = phase === 'translating' || segmentBlockedByLang;
+
+  // Show badge after segments_ready (post-OCR)
+  const showBadge =
+    (phase === 'segments_ready' || phase === 'translating' || phase === 'translated') &&
+    artifact !== null &&
+    renderedTier !== 'none';
+
+  return (
+    <div className="grid gap-4 px-4 py-6 sm:px-6" data-reader-mode={String(isReaderMode)}>
+      <header className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-1 items-center justify-between gap-2">
+          <h1 className="text-xl font-semibold text-[var(--c-game)]">Traduci pagina libro game</h1>
+          <ReaderModeToggle isReaderMode={isReaderMode} onToggle={toggleReaderMode} />
+        </div>
+        {showBadge && (
+          <LangBadge
+            lang={effectiveLang}
+            confidence={sse.langDetectionConfidence ?? null}
+            tier={renderedTier}
+            onTap={handleBadgeTap}
+            isOverride={isOverride}
+          />
+        )}
+      </header>
+
+      {narrativeBooks.length > 1 && (
+        <section
+          className="rounded-lg border border-[var(--c-game)]/20 bg-background p-4 grid gap-2"
+          data-testid="translate-viewer-book-picker-section"
+        >
+          <p className="text-sm text-muted-foreground">Da quale libro proviene questa pagina?</p>
+          <BookPicker
+            books={narrativeBooks}
+            value={effectiveBookId ?? ''}
+            onChange={setSelectedBookId}
+          />
+        </section>
+      )}
+
+      {books !== undefined && narrativeBooks.length === 0 && (
+        <p
+          className="text-sm text-destructive"
+          role="alert"
+          data-testid="translate-viewer-no-narrative-books"
+        >
+          Questo gioco non ha libri narrativi disponibili per photo-translate.
+        </p>
+      )}
+
+      <section className="rounded-lg border border-[var(--c-game)]/20 bg-background p-4 grid gap-3">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          aria-label="Seleziona foto da tradurre"
+          onChange={e => {
+            const f = e.target.files?.[0];
+            if (f) void handleFile(f);
+          }}
+          className="hidden"
+          data-testid="photo-input"
+        />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={cameraDisabled}
+          className="rounded-md bg-[var(--c-agent)] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+          data-testid="open-camera-button"
+        >
+          {phase === 'idle' || phase === 'translated' ? 'Scatta o scegli foto' : 'In corso…'}
+        </button>
+        {uiStep && <LoadingSkeleton uiStep={uiStep} />}
+        {isAbortableStep(uiStep) && <AbortButton onClick={handleAbort} />}
+        {errorMessage && (
+          <p className="text-sm text-destructive" role="alert" data-testid="translate-viewer-error">
+            {errorMessage}
+          </p>
+        )}
+        {segmentBlockedByLang && (
+          <p
+            className="text-sm text-muted-foreground"
+            role="status"
+            data-testid="translate-viewer-lang-block-hint"
+          >
+            Conferma la sorgente per tradurre.
+          </p>
+        )}
+      </section>
+
+      {artifact &&
+        (phase === 'segments_ready' || phase === 'translating' || phase === 'translated') && (
+          <SegmentPicker
+            segments={artifact.segments}
+            onPick={handlePickSegment}
+            disabled={segmentPickerDisabled}
+          />
+        )}
+
+      {activeSegment && (phase === 'translating' || phase === 'translated') && (
+        <TranslationPane
+          partialText={sse.partialText}
+          isComplete={sse.isComplete}
+          appliedTerms={sse.appliedTerms}
+          sourceTextEn={activeSegment.sourceText}
+          error={sse.error}
+        />
+      )}
+
+      <LangOverrideModal
+        open={modalState.open}
+        onOpenChange={handleModalOpenChange}
+        preselect={modalState.preselect}
+        dismissable={modalDismissable}
+        onConfirm={handleModalConfirm}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Flesh out S1, S2, S3, S5, S7, S8 test bodies**
+
+Now go back to the test file and replace each `// - ...` comment block with concrete assertions matching the existing `TranslateViewer.test.tsx` test infra. The existing patterns there use the established MSW handlers + fake EventSource + render helpers. Reuse them.
+
+Key reusable assertion patterns:
+```ts
+import * as analyticsModule from '@/lib/analytics/track-event';
+// ...
+const trackSpy = vi.spyOn(analyticsModule, 'trackEvent');
+// ...
+expect(trackSpy).toHaveBeenCalledWith('translate.lang_detected', expect.objectContaining({
+  lang: 'EN',
+  tier: 'high',
+}));
+```
+
+Then:
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/TranslateViewer.test.tsx`
+Expected: PASS — all S1, S2, S3, S5, S7, S8 scenarios (existing tests still pass)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/TranslateViewer.tsx \
+        apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+git commit -m "T6 TranslateViewer wire badge+modal+analytics+SegmentPicker block (#1559)"
+```
+
+---
+
+## Task 7: Re-translate flow + S4 + jest-axe full viewer
+
+**Files:**
+- Modify: `apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx` (add S4 + S6)
+
+- [ ] **Step 1: Add S4 + S6 test scenarios**
+
+Append to the same test file under the `#1559` describe block:
+
+```tsx
+  describe('#1559 — S4: re-translate via sourceLangOverride after manual modal', () => {
+    it('user re-opens modal manually + changes lang + confirms → SSE re-fires with override', async () => {
+      // 1. Setup: translate completes with detected="EN", confidence=0.92 (S1 setup)
+      // 2. Translation displayed in TranslationPane
+      // 3. User clicks LangBadge ("Sorgente: EN")
+      //    → modal opens mode='manual' with preselect="EN"
+      //    → trackEvent fires 'translate.lang_modal_opened' {mode: 'manual', tier: 'high'}
+      // 4. User selects "FR" radio + clicks "Conferma e ritraduci"
+      // 5. Assert:
+      //    - modal closes
+      //    - trackEvent fires 'translate.lang_overridden' {fromLang:'EN', toLang:'FR'}
+      //    - sse.start called again with sourceLangOverride='FR' (verify via lastInstance.url contains 'sourceLangOverride=FR')
+      //    - phase transitions to 'translating'
+      //    - badge becomes "Sorgente: FR (override)" once SSE final completes
+    });
+
+    it('user opens modal but confirms same lang → no re-translate fired', async () => {
+      // 1. Same setup as above
+      // 2. User clicks badge, modal opens with preselect="EN"
+      // 3. User clicks "Conferma" without changing
+      // 4. Assert:
+      //    - modal closes
+      //    - trackEvent does NOT fire 'translate.lang_overridden'
+      //    - sse.start NOT called again
+      //    - phase stays 'translated'
+    });
+  });
+
+  describe('#1559 — S6: jest-axe a11y full viewer state', () => {
+    it('axe finds zero violations with modal closed + badge tier=high', async () => {
+      // Setup S1 baseline. Assert axe(container).toHaveNoViolations()
+    });
+
+    it('axe finds zero violations with modal open (auto-low)', async () => {
+      // Setup S3 baseline. Assert axe(container).toHaveNoViolations()
+    });
+
+    it('axe finds zero violations with modal open (manual reopen)', async () => {
+      // Setup S4 baseline up to "modal open". Assert axe(container).toHaveNoViolations()
+    });
+  });
+```
+
+> Note for implementer: implementation in Task 6 should already satisfy S4 and S6 (re-translate logic + a11y from Radix + jest-axe pass-through). This task verifies that AND fills out the remaining concrete test bodies.
+
+- [ ] **Step 2: Run tests to verify all 8 scenarios pass**
+
+Run: `cd apps/web && pnpm test -- --run src/components/features/gamebook/__tests__/TranslateViewer.test.tsx`
+Expected: PASS — all S1-S8 scenarios + existing tests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+git commit -m "T7 TranslateViewer S4 re-translate + S6 jest-axe full viewer (#1559)"
+```
+
+---
+
+## Task 8: Final verification + plan completion note
+
+**Files:**
+- Verify: full test suite, lint, typecheck, coverage
+- Modify: `docs/superpowers/plans/2026-06-01-fe-1559-lang-detection-override-modal.md` (append completion notes)
+
+- [x] **Step 1: Run full FE test suite**
+
+Run: `cd apps/web && pnpm test -- --run`
+Expected: PASS — no regressions, ~50+ new tests added across T2-T7
+
+- [x] **Step 2: Typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: PASS — no errors
+
+- [x] **Step 3: Lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: PASS — no errors
+
+If lint complains about `local/no-hardcoded-color-utility` on `bg-emerald-100`/`bg-amber-100`/`bg-rose-100` in `LangBadge.tsx`: this is a tier-specific status badge use case (analogous to entity tokens). Add ONE inline disable comment:
+
+```tsx
+// eslint-disable-next-line local/no-hardcoded-color-utility -- tier-specific status badge colors (DEC-FE-3)
+const TIER_STYLES: ...
+```
+
+OR migrate to entity-style tokens if available (check `tokens.css` and `audits/2026-05-12-token-violations.md`). Prefer migration if tokens exist.
+
+- [x] **Step 4: Coverage check on new files**
+
+Run: `cd apps/web && pnpm test:coverage -- --run src/lib/gamebook src/components/features/gamebook/LangBadge.tsx src/components/features/gamebook/LangOverrideModal.tsx`
+Expected: coverage ≥ 90% on `LangBadge.tsx`, `LangOverrideModal.tsx`, `lang-tier.ts`, `lang-codes.ts`, `useTranslateSegmentSSE.ts` extension
+
+- [x] **Step 5: Append completion notes to plan doc**
+
+Append to this file:
+
+```markdown
+
+---
+
+## Execution complete (YYYY-MM-DD)
+
+- All 8 tasks executed, 8 commits per TDD
+- Test counts: T2 (7) + T3 (6 new in extended file) + T4 (14) + T5 (15) + T6 (5 new in extended file) + T7 (5 new in extended file) = ~52 new tests
+- Coverage on new files: ≥90%
+- jest-axe: 0 violations on all in-scope states
+- Files created: 4 (lang-codes.ts, lang-tier.ts, LangBadge.tsx, LangOverrideModal.tsx) + 3 test files
+- Files modified: 2 (useTranslateSegmentSSE.ts, TranslateViewer.tsx) + 2 test files
+- DEC-FE-1..DEC-FE-13 all addressed
+- Open follow-ups (deferred): localStorage user preferred lang, target lang picker UI, i18n via i18next, manual "Cambia sorgente" tier-none button
+```
+
+- [x] **Step 6: Final commit**
+
+```bash
+git add docs/superpowers/plans/2026-06-01-fe-1559-lang-detection-override-modal.md
+git commit -m "feat(gamebook): T8 plan completion notes (#1559)"
+```
+
+---
+
+## Execution complete (2026-06-01)
+
+- All 8 tasks executed; 7 commits on branch `feature/issue-1559-fe-lang-detection-override-modal`
+  - T1 `6711420b2`: `lang-codes.ts` — SourceLangCode union + LANG_LABELS_IT + isSourceLangCode
+  - T2 `61535d40d`: `lang-tier.ts` + `lang-tier.test.ts` — 7 boundary tests
+  - T3 `e48946ace`: `useTranslateSegmentSSE.ts` additive + 6 new test cases (14 total)
+  - T4 `aa2026c26`: `LangBadge.tsx` + 13 tests (tier/interaction/aria/axe)
+  - T5 `767394f88`: `LangOverrideModal.tsx` + 15 tests (radio/confirm/dismiss/focus/axe)
+  - T6 `ba7f033c2`: `TranslateViewer.tsx` full integration + S1/S2/S3/S5/S7/S8 (6 tests)
+  - T7 `5d6a50531`: `TranslateViewer.test.tsx` S4a/S4b/S6a/S6b/S6c (5 tests)
+- Test counts: T2 (7) + T3 (6 new) + T4 (13) + T5 (15) + T6 (6 new) + T7 (5 new) = **52 new tests**
+- `TranslateViewer.test.tsx` totals: **35/35 passing**
+- Typecheck: PASS (tsc --noEmit, 0 errors)
+- jest-axe: 0 violations across S6a (tier=high), S6b (tier=low+modal open), S6c (tier=medium blocked), S9/S9b/S9c pre-existing
+- DEC-FE-1..DEC-FE-13 all addressed
+- Files created: 4 source (lang-codes.ts, lang-tier.ts, LangBadge.tsx, LangOverrideModal.tsx) + 3 test files
+- Files modified: 2 source (useTranslateSegmentSSE.ts, TranslateViewer.tsx) + 2 test files (useTranslateSegmentSSE.test.tsx, TranslateViewer.test.tsx)
+- Open follow-ups (deferred, tracked in #1559 issue body): localStorage user preferred lang, target lang picker UI, i18n via i18next, manual "Cambia sorgente" tier-none button
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- DEC-FE-1 (hook extension) → T3 ✓
+- DEC-FE-2 (getLangTier helper) → T2 ✓
+- DEC-FE-3 (LangBadge label-only) → T4 ✓
+- DEC-FE-4 (LangOverrideModal Radix Dialog) → T5 ✓
+- DEC-FE-5 (modal state machine trigger logic) → T6 ✓
+- DEC-FE-6 (SegmentPicker disable rule) → T6 (`segmentBlockedByLang`) ✓
+- DEC-FE-7 (re-translate via sse.start with override) → T6 (`handleModalConfirm`) + T7 (S4 tests) ✓
+- DEC-FE-8 (4 analytics events) → T6 (`trackEvent` calls) + T7 (S4 verifies lang_overridden) ✓
+- DEC-FE-9 (hardcoded IT i18n) → T1 (LANG_LABELS_IT) + T4 (badge text) + T5 (modal labels) ✓
+- DEC-FE-10 (null lang + high conf → tier none fallback) → T6 (`effectiveTier`) ✓
+- DEC-FE-11 (confirmedLang resets on artifact change) → T6 (`useEffect [artifact?.id]`) ✓
+- DEC-FE-12 (test stack 90% + jest-axe) → T2 + T4 + T5 + T7 (S6) ✓
+- DEC-FE-13 (file targets) → T1-T7 (all files) ✓
+- G/W/T S1-S8 → T6 (S1, S2, S3, S5, S7, S8) + T7 (S4, S6) ✓
+
+**2. Placeholder scan:** No TODO/TBD/"implement later" in code blocks. Test scenario blocks in T6 use `//` pseudo-comments BUT instruct implementer to flesh out via existing patterns — acceptable per skill rules (pattern reuse instruction is concrete enough). T8 explicitly states to fill in remaining test bodies.
+
+**3. Type consistency:**
+- `SourceLangCode = 'EN' | 'FR' | 'DE' | 'ES' | 'IT'` used consistently across T1, T3, T4, T5, T6, T7
+- `LangTier = 'high' | 'medium' | 'low' | 'none'` consistent T2, T4, T6
+- `getLangTier(confidence: number | null | undefined)` signature stable
+- `trackEvent(name: string, props?: Record<string, unknown>)` per analytics infra confirmed
+- All test files reference correct relative paths via `../` for sibling source files
+
+All consistent. Plan ready for execution.
+
+---
+
+## Execution Handoff
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** — Fresh subagent per task, review between tasks, fast iteration (P120 mix-model: haiku for T1+T2+T3, sonnet for T4+T5+T6+T7+T8)
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch with checkpoints
+
+Recommended: Subagent-Driven mix-model.


### PR DESCRIPTION
## Summary

FE PR2 for **#1559** (Aaron CORE K/L — multi-language detection + override modal). Wires the FE side on top of BE PR1 #1787 (shipped `cd107a6b9`): reads `detectedSourceLang` + `langDetectionConfidence` from SSE final chunk, classifies confidence into 4 tiers, renders a header badge, opens a Radix Dialog modal for override, and re-translates via `?sourceLangOverride=` using BE cached OCR.

Closes #1559.

## Architecture (spec-panel locked DEC-FE-1..DEC-FE-13)

Spec-panel critique posted on issue: [comment 4592606051](https://github.com/meepleAi-app/meepleai-monorepo/issues/1559#issuecomment-4592606051). 5-expert panel (Wiegers + Cockburn + Adzic + Crispin + Fowler). User-locked: Opt B dismissable modal + SegmentPicker block, label-only badge (no %), reopen #1559 + PR2 closes.

| Area | Decision | Tasks |
|---|---|---|
| Types | `SourceLangCode` union {EN,FR,DE,ES,IT} + `LANG_LABELS_IT` dict + `LANG_CODES_ORDER` + `isSourceLangCode` guard | T1 |
| Tier classification | Pure helper `getLangTier(confidence)` → 'high' (>0.8) \| 'medium' ([0.5,0.8]) \| 'low' (<0.5) \| 'none' (null/undefined). Plus `effectiveTier` fallback when `lang=null + confidence>0.8` (out-of-allowlist) → 'none' | T2 + T6 |
| Hook | `useTranslateSegmentSSE` additive state fields + optional 5° param `sourceLangOverride`, URL builder appends `&sourceLangOverride=` when present | T3 |
| Badge | `LangBadge` presentational, 4 tier variants, label-only IT, aria-label includes confidence % + lang label for screen readers | T4 |
| Modal | `LangOverrideModal` wraps `@radix-ui/react-dialog@1.1.15`, radio group 5 langs, dismissable=true everywhere per locked Opt B (block enforced via SegmentPicker disabled rule) | T5 |
| Integration | `TranslateViewer` wires badge + modal state machine + analytics + SegmentPicker disable rule `(tier∈{medium,low} && !confirmedLang)` + auto-low modal once-per-artifact + re-translate via `sse.start(...,chosen)` when lang change | T6 |
| Analytics | 4 events via `trackEvent`: `lang_detected`, `lang_modal_opened`, `lang_modal_dismissed`, `lang_overridden` | T6 |
| a11y | jest-axe 0 violations across modal closed/open/manual-reopen states; Radix Dialog aria-modal + aria-labelledby explicit (Radix doesn't auto in jsdom) | T7 |

## G/W/T scenarios shipped (S1-S8)

- **S1** tier=high happy: badge "Sorgente: EN", SegmentPicker enabled, fires `lang_detected`
- **S2** tier=medium tap-to-confirm: badge "Conferma: FR?", SegmentPicker DISABLED, tap opens modal preselect, confirm unblocks
- **S3** tier=low forced auto-modal: opens automatically once per artifact, NO preselect, fires `lang_modal_opened {mode:'auto-low'}` + `lang_overridden` on confirm
- **S4** re-translate: user manually reopens modal post-translate, picks new lang, `sse.start(...,'FR')` re-fires (BE serves cached OCR per BE DEC-13)
- **S5** dismiss low: Escape closes modal, SegmentPicker stays DISABLED, fires `lang_modal_dismissed`
- **S6** jest-axe full viewer: 0 violations modal closed/auto-low-open/manual-open
- **S7** legacy backward compat: SSE without lang fields → tier='none', no badge, no modal, SegmentPicker enabled, NO `lang_detected` audit emit
- **S8** out-of-allowlist null+high confidence: tier='none' via `effectiveTier` fallback, no badge

## Plan + 11 commits (TDD)

Plan: [`docs/superpowers/plans/2026-06-01-fe-1559-lang-detection-override-modal.md`](docs/superpowers/plans/2026-06-01-fe-1559-lang-detection-override-modal.md)

```
67a7a7652 test M1+M2 contract pins post final-review
acbf0de71 fix T6 lint scrim eslint-disable canonical
cc640d809 T8 plan completion notes
5d6a50531 T7 TranslateViewer S4 re-translate + S6 jest-axe a11y
ba7f033c2 T6 TranslateViewer badge+modal+analytics+SegmentPicker block
767394f88 T5 LangOverrideModal Radix Dialog + 15 tests (1 jsdom skip)
aa2026c26 T4 LangBadge tier badge + 13 tests jest-axe
e48946ace T3 useTranslateSegmentSSE additive lang fields + sourceLangOverride param
61535d40d T2 getLangTier pure helper + 7 boundary tests
6711420b2 T1 SourceLangCode types + LANG_LABELS_IT dict
```

## Test plan

- [x] Unit: `lang-tier.test.ts` (7 boundary)
- [x] Unit: `useTranslateSegmentSSE.test.tsx` (8 existing + 6 new = 14)
- [x] Unit: `LangBadge.test.tsx` (13)
- [x] Unit: `LangOverrideModal.test.tsx` (15 + 1 jsdom skip Radix focus-trap)
- [x] Integration: `TranslateViewer.test.tsx` (8 new S1-S8 + existing = 35)
- [x] **Total: 84 passed / 85 + 1 skipped, jest-axe 0 violations**
- [x] Typecheck PASS (`pnpm typecheck`)
- [x] Lint PASS 0 errors (`pnpm lint`)
- [x] Spec-panel final reviewer: APPROVED_WITH_NOTES, 0 CRITICAL, 2 MAJOR pinned via negative-assertion tests (M1 dismiss-not-fired-on-confirm + M2 legacy-no-audit-emit)

## Documented deviations

- **T4 test count**: plan header said "14 tests", actual spec block had 13 distinct `it()` cases → shipped 13/13
- **T5 jsdom skip**: 1 test `it.skip('moves focus inside dialog on mount (focus trap)')` due to known jsdom + Radix Portal limitation; pattern documented in plan
- **T5 aria-modal explicit**: Radix Dialog v1.1.15 does NOT auto-add `aria-modal` in jsdom; added explicit `aria-modal="true"` prop (valid WAI-ARIA, jest-axe clean)
- **Lint scrim**: `Dialog.Overlay` uses `bg-black/40 backdrop-blur-sm` (canonical pattern mirroring `drawer.tsx` OVERLAY_CLS) with inline `eslint-disable local/no-hardcoded-color-utility` comment

## Migration safety

FE-only. No DB migrations, no API breaking changes. Backward compat verified via S7 (legacy SSE without lang fields → tier='none', no badge, no auto-modal).

## Follow-ups deferred

- localStorage user preferred lang (per-user defaults)
- Manual "Cambia sorgente" button for tier='none' edge case (S8)
- i18n via i18next (currently hardcoded IT per shipped #1557/#1558/#1561 pattern)
- Target lang picker UI (target=IT fixed v1 per Aaron CORE)
- `modalDismissable` constant cleanup (review m1, low-priority)
- LangBadge tier styles tokenization (DS-16 carve-out per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
