### PR TITLE
feat(api/gamebook): #1774 manual text translate SSE endpoint (BE for #1560)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/TranslateGamebookTextRequest.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/TranslateGamebookTextRequest.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
+
+/// <summary>
+/// Request body for POST /api/v1/gamebook/campaigns/{cid}/text/translate (#1774).
+/// FE #1560 manual-mode textarea entry — no photo, no OCR.
+/// </summary>
+public sealed record TranslateGamebookTextRequest(
+    string Text,
+    string SourceLang,
+    string TargetLang,
+    Guid GameBookId);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
@@ -14,6 +14,7 @@ using Api.Models;
 using Api.Observability;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Translation;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Queries;
@@ -21,17 +22,8 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 internal sealed class TranslateGamebookSegmentQueryHandler
     : IStreamingQueryHandler<TranslateGamebookSegmentQuery, TranslateChunk>
 {
-    // DEC-14 (#1559): Maps ISO-639-1 upper-cased codes to English language names for prompt construction.
-    // Extend this dictionary if new source languages are detected by NTextCat.
-    private static readonly IReadOnlyDictionary<string, string> LangNameByCode =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["EN"] = "English",
-            ["FR"] = "French",
-            ["DE"] = "German",
-            ["ES"] = "Spanish",
-            ["IT"] = "Italian",
-        };
+    // DEC-14 (#1559): Language code → name mapping moved to Api.SharedKernel.Translation.LanguageCodes
+    // per DEC-BE-10 (#1774). Extend LanguageCodes.LangNameByCode to add new source languages.
 
     private readonly IGamebookCampaignSessionRepository _campaigns;
     private readonly IGamebookPhotoArtifactRepository _photos;
@@ -142,8 +134,7 @@ internal sealed class TranslateGamebookSegmentQueryHandler
             // DEC-14 (#1559): dynamic prompt — effective lang is: override > detected > "EN" default.
             var effectiveSourceLangCode =
                 (query.SourceLangOverride ?? detectedSourceLang ?? "EN").ToUpperInvariant();
-            var sourceLangName = LangNameByCode.TryGetValue(effectiveSourceLangCode, out var name)
-                ? name : "English";
+            var sourceLangName = LanguageCodes.TryGetLanguageName(effectiveSourceLangCode) ?? "English";
 
             var systemPrompt =
                 $"You are a translator from {sourceLangName} to Italian for a tabletop RPG storybook. " +

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQuery.cs
@@ -1,0 +1,17 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Streaming query for manual text translation flow (#1774).
+/// No photo, no OCR — text is provided directly by the user (FE #1560 textarea mode).
+/// DEC-BE-5: CallerUserId for ownership guard; GameBookId for glossary scoping.
+/// </summary>
+public sealed record TranslateGamebookTextQuery(
+    Guid CampaignId,
+    string Text,
+    string SourceLang,
+    string TargetLang,
+    Guid GameBookId,
+    Guid CallerUserId) : IStreamingQuery<TranslateChunk>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Services;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Models;
+using Api.Observability;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Translation;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Handler for #1774 manual text translate flow. Mirrors TranslateGamebookSegmentQueryHandler
+/// but accepts text directly (no photo, no OCR, no cache lookup).
+///
+/// DEC-BE-11 (#1774): NO TranslatedParagraph persistence (no segment FK target).
+/// DEC-BE-12 (#1774): NO SessionBookProgress update (manual mode bypasses linear progress invariant).
+/// DEC-BE-13 (#1774): Final chunk echoes user-provided SourceLang as DetectedSourceLang (audit);
+/// LangDetectionConfidence is null (no detection happened).
+/// </summary>
+internal sealed class TranslateGamebookTextQueryHandler
+    : IStreamingQueryHandler<TranslateGamebookTextQuery, TranslateChunk>
+{
+    private readonly IGamebookCampaignSessionRepository _campaigns;
+    private readonly IGamebookGlossaryRepository _glossary;
+    private readonly ILlmService _llm;
+    private readonly ICampaignOwnershipGuard _ownershipGuard;
+    private readonly ILogger<TranslateGamebookTextQueryHandler> _logger;
+
+    public TranslateGamebookTextQueryHandler(
+        IGamebookCampaignSessionRepository campaigns,
+        IGamebookGlossaryRepository glossary,
+        ILlmService llm,
+        ICampaignOwnershipGuard ownershipGuard,
+        ILogger<TranslateGamebookTextQueryHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(campaigns);
+        ArgumentNullException.ThrowIfNull(glossary);
+        ArgumentNullException.ThrowIfNull(llm);
+        ArgumentNullException.ThrowIfNull(ownershipGuard);
+        ArgumentNullException.ThrowIfNull(logger);
+        _campaigns = campaigns;
+        _glossary = glossary;
+        _llm = llm;
+        _ownershipGuard = ownershipGuard;
+        _logger = logger;
+    }
+
+    public async IAsyncEnumerable<TranslateChunk> Handle(
+        TranslateGamebookTextQuery query,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var status = "failure";
+        double? streamingLatencySec = null;
+        long? promptTokens = null;
+        long? completionTokens = null;
+        int totalApplicableTerms = 0;
+        int matchedTerms = 0;
+
+        try
+        {
+            await _ownershipGuard
+                .AssertOwnedByAsync(query.CampaignId, query.CallerUserId, cancellationToken)
+                .ConfigureAwait(false);
+
+            _ = await _campaigns.GetByIdAsync(query.CampaignId, cancellationToken).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Campaign {query.CampaignId} not found");
+
+            var glossaryEntries = await _glossary
+                .ListByCampaignAsync(query.CampaignId, cancellationToken)
+                .ConfigureAwait(false);
+
+            var glossaryTable = string.Join("\n", glossaryEntries.Select(g => $"- {g.TermEn} → {g.TermIt}"));
+
+            var sourceLangCode = query.SourceLang.ToUpperInvariant();
+            var sourceLangName = LanguageCodes.TryGetLanguageName(sourceLangCode) ?? "English";
+
+            var systemPrompt =
+                $"You are a translator from {sourceLangName} to Italian for a tabletop RPG storybook. " +
+                "Preserve narrative tone, use formal pronouns (voi/lei) when addressing players. " +
+                $"Apply this glossary EXACTLY ({sourceLangName} term → Italian term) without rephrasing the Italian:\n" +
+                (glossaryTable.Length > 0 ? glossaryTable : "(no glossary entries yet)") + "\n" +
+                "Output ONLY the Italian translation — no preamble, no notes.";
+
+            var fullText = new StringBuilder();
+
+            await foreach (var chunk in _llm.GenerateCompletionStreamAsync(
+                systemPrompt, query.Text, RequestSource.Manual, cancellationToken).ConfigureAwait(false))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrEmpty(chunk.Content))
+                {
+                    if (streamingLatencySec is null)
+                    {
+                        streamingLatencySec = stopwatch.Elapsed.TotalSeconds;
+                    }
+                    fullText.Append(chunk.Content);
+                    yield return new TranslateChunk(Delta: chunk.Content, IsComplete: false);
+                }
+                if (chunk.IsFinal && chunk.Usage is not null)
+                {
+                    promptTokens = chunk.Usage.PromptTokens;
+                    completionTokens = chunk.Usage.CompletionTokens;
+                    _logger.LogInformation(
+                        "gamebook.text.translate.cost campaign={CampaignId} tokens_in={In} tokens_out={Out}",
+                        query.CampaignId, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
+                }
+            }
+
+            var translatedIt = fullText.ToString().Trim();
+
+            // Glossary consistency tracking (DEC-BE-9)
+            foreach (var entry in glossaryEntries)
+            {
+                if (query.Text.Contains(entry.TermEn, StringComparison.OrdinalIgnoreCase))
+                {
+                    totalApplicableTerms++;
+                    if (translatedIt.Contains(entry.TermIt, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matchedTerms++;
+                    }
+                }
+            }
+
+            var appliedTerms = glossaryEntries
+                .Where(g => query.Text.Contains(g.TermEn, StringComparison.OrdinalIgnoreCase)
+                            && translatedIt.Contains(g.TermIt, StringComparison.OrdinalIgnoreCase))
+                .Select(g => g.TermEn)
+                .ToList();
+
+            // DEC-BE-11: NO TranslatedParagraph.Create / AddAsync / SaveChangesAsync
+            // DEC-BE-12: NO SessionBookProgress update, NO campaign.Touch()
+
+            // DEC-BE-13: final chunk echoes user-provided source lang, confidence null
+            yield return new TranslateChunk(
+                Delta: string.Empty,
+                IsComplete: true,
+                ParagraphId: null,
+                AppliedTerms: appliedTerms,
+                DetectedSourceLang: sourceLangCode,
+                LangDetectionConfidence: null);
+
+            status = "success";
+        }
+        finally
+        {
+            if (cancellationToken.IsCancellationRequested
+                && string.Equals(status, "failure", StringComparison.Ordinal))
+            {
+                status = "cancelled";
+            }
+
+            MeepleAiMetrics.RecordGamebookTranslationRequest(
+                status: status,
+                latencyFullSeconds: stopwatch.Elapsed.TotalSeconds,
+                latencyStreamingSeconds: streamingLatencySec,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                costUsd: null,
+                provider: "unknown",
+                sourceMethod: "manual");
+
+            if (totalApplicableTerms > 0)
+            {
+                var rate = (double)matchedTerms / totalApplicableTerms;
+                MeepleAiMetrics.RecordGamebookGlossaryConsistency(rate, HashCampaignId(query.CampaignId));
+            }
+        }
+    }
+
+    private static string HashCampaignId(Guid campaignId)
+    {
+        var bytes = SHA256.HashData(campaignId.ToByteArray());
+        return Convert.ToHexStringLower(bytes.AsSpan(0, 4));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Validators/TranslateGamebookTextRequestValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Validators/TranslateGamebookTextRequestValidator.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.SharedKernel.Translation;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Validators;
+
+/// <summary>
+/// Validates the manual text translation request per DEC-BE-4 (#1774).
+/// Text: 1-2000 chars, non-whitespace. SourceLang: EN|FR|DE|ES|IT (case-insensitive).
+/// TargetLang: IT only (fixed v1). GameBookId: non-empty.
+/// </summary>
+public sealed class TranslateGamebookTextRequestValidator : AbstractValidator<TranslateGamebookTextRequest>
+{
+    public TranslateGamebookTextRequestValidator()
+    {
+        RuleFor(r => r.Text)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Text must not be empty.")
+            .Must(t => !string.IsNullOrWhiteSpace(t)).WithMessage("Text must not be whitespace only.")
+            .Length(1, 2000).WithMessage("Text length must be between 1 and 2000 characters.");
+
+        RuleFor(r => r.SourceLang)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("SourceLang is required.")
+            .Must(LanguageCodes.IsValidSourceLang).WithMessage("SourceLang must be one of EN, FR, DE, ES, IT.");
+
+        RuleFor(r => r.TargetLang)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("TargetLang is required.")
+            .Must(tl => string.Equals(tl, "IT", StringComparison.OrdinalIgnoreCase))
+            .WithMessage("TargetLang must equal IT (fixed v1).");
+
+        RuleFor(r => r.GameBookId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.GamebookTranslation.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.GamebookTranslation.cs
@@ -98,6 +98,7 @@ internal static partial class MeepleAiMetrics
     /// <param name="completionTokens">Tokens generated as completion (null when usage unavailable)</param>
     /// <param name="costUsd">Cost in USD reported by provider (null when unavailable)</param>
     /// <param name="provider">LLM provider name (e.g. "openrouter", "deepseek")</param>
+    /// <param name="sourceMethod">Translation entry point: "ocr" (photo-based) or "manual" (textarea, #1774). Default "ocr" for backward compat.</param>
     public static void RecordGamebookTranslationRequest(
         string status,
         double latencyFullSeconds,
@@ -105,9 +106,14 @@ internal static partial class MeepleAiMetrics
         long? promptTokens,
         long? completionTokens,
         double? costUsd,
-        string provider)
+        string provider,
+        string sourceMethod = "ocr")
     {
-        GamebookTranslationRequestsTotal.Add(1, new TagList { { "status", status } });
+        GamebookTranslationRequestsTotal.Add(1, new TagList
+        {
+            { "status", status },
+            { "source_method", sourceMethod },
+        });
         GamebookTranslationLatencySeconds.Record(latencyFullSeconds, new TagList { { "stage", "full" } });
 
         if (latencyStreamingSeconds.HasValue)

--- a/apps/api/src/Api/Routing/GamebookPhotoEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookPhotoEndpoints.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.Extensions;
 using Api.Middleware.Exceptions;
+using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -27,6 +28,7 @@ internal static class GamebookPhotoEndpoints
         MapUploadPhotoEndpoint(group);
         MapSegmentPhotoEndpoint(group);
         MapTranslateStreamEndpoint(group);
+        MapTextTranslateStreamEndpoint(group);
         MapGetHistoryEndpoint(group);
         MapGetGlossaryEndpoint(group);
         MapBootstrapGlossaryEndpoint(group);
@@ -238,6 +240,116 @@ internal static class GamebookPhotoEndpoints
         .WithTags("Gamebook")
         .WithSummary("Stream paragraph translation as SSE")
         .WithDescription("Server-Sent Events stream of TranslateChunk events. Must be GET for EventSource compatibility. Pass photoId and paragraphNumber as query params. Optional sourceLangOverride (EN/FR/DE/ES/IT) overrides auto-detected source language. Final chunk has IsComplete=true with ParagraphId. Non-owner callers receive HTTP 403 BEFORE the stream opens (Issue #1415).")
+        .WithOpenApi();
+    }
+
+    /// <summary>
+    /// SSE endpoint for streaming manual text translation (#1774).
+    /// Accepts text directly (no photo, no OCR) via POST body. Validates the request BEFORE
+    /// writing SSE headers so that 400/401/403/404 can be returned as proper HTTP errors.
+    /// Exception priority chain identical to <see cref="MapTranslateStreamEndpoint"/>.
+    /// DEC-BE-11: no TranslatedParagraph persistence. DEC-BE-12: no SessionBookProgress update.
+    /// </summary>
+    private static void MapTextTranslateStreamEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/gamebook/campaigns/{campaignId:guid}/text/translate", async (
+            Guid campaignId,
+            [FromBody] TranslateGamebookTextRequest request,
+            IValidator<TranslateGamebookTextRequest> validator,
+            IMediator mediator,
+            ICampaignOwnershipGuard ownershipGuard,
+            HttpContext context,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!TryGetUserId(context, session, out var userId)) return Results.Unauthorized();
+
+            // Validate BEFORE SSE headers — allows returning 400 as proper HTTP error.
+            var validationResult = await validator.ValidateAsync(request, ct).ConfigureAwait(false);
+            if (!validationResult.IsValid)
+            {
+                return Results.ValidationProblem(
+                    validationResult.ToDictionary(),
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            // Pre-flight ownership check BEFORE SSE headers — allows 403/404 via middleware.
+            await ownershipGuard.AssertOwnedByAsync(campaignId, userId, ct).ConfigureAwait(false);
+
+            context.Response.Headers["Content-Type"] = "text/event-stream";
+            context.Response.Headers["Cache-Control"] = "no-cache";
+            context.Response.Headers["Connection"] = "keep-alive";
+
+            var query = new TranslateGamebookTextQuery(
+                campaignId,
+                request.Text,
+                request.SourceLang,
+                request.TargetLang,
+                request.GameBookId,
+                userId);
+
+            try
+            {
+                await foreach (var chunk in mediator.CreateStream(query, ct).ConfigureAwait(false))
+                {
+                    var json = System.Text.Json.JsonSerializer.Serialize(chunk, SseJsonOptions);
+                    await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
+                    await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException ex)
+            {
+                logger.LogInformation(ex,
+                    "Gamebook text translate stream cancelled for campaign {CampaignId}",
+                    campaignId);
+            }
+            catch (ForbiddenException) when (!context.Response.HasStarted)
+            {
+                throw;
+            }
+            catch (NotFoundException) when (!context.Response.HasStarted)
+            {
+                throw;
+            }
+            catch (ForbiddenException ex)
+            {
+                logger.LogWarning(ex,
+                    "Forbidden mid-stream (text translate) for campaign {CampaignId} (headers already flushed)",
+                    campaignId);
+                await EmitSseErrorAsync(context, code: "FORBIDDEN", message: ex.Message).ConfigureAwait(false);
+            }
+            catch (NotFoundException ex)
+            {
+                logger.LogWarning(ex,
+                    "NotFound mid-stream (text translate) for campaign {CampaignId} (headers already flushed)",
+                    campaignId);
+                await EmitSseErrorAsync(context, code: "NOT_FOUND", message: ex.Message).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error in gamebook text translate stream campaign {CampaignId}", campaignId);
+                await EmitSseErrorAsync(context, code: "INTERNAL_ERROR", message: ex.Message).ConfigureAwait(false);
+            }
+#pragma warning restore CA1031
+
+            return Results.Empty;
+        })
+        .RequireAuthenticatedUser()
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .WithTags("Gamebook")
+        .WithSummary("Stream manual text translation as SSE (#1774)")
+        .WithDescription(
+            "Server-Sent Events stream for manual text translation (FE #1560 textarea mode). " +
+            "Body must contain text (1-2000 chars), sourceLang (EN|FR|DE|ES|IT), targetLang=IT, gameBookId. " +
+            "Final chunk has IsComplete=true, ParagraphId=null (no persistence per DEC-BE-11), " +
+            "DetectedSourceLang echoes input, LangDetectionConfidence=null.")
         .WithOpenApi();
     }
 

--- a/apps/api/src/Api/SharedKernel/Translation/LanguageCodes.cs
+++ b/apps/api/src/Api/SharedKernel/Translation/LanguageCodes.cs
@@ -1,0 +1,27 @@
+namespace Api.SharedKernel.Translation;
+
+/// <summary>
+/// Shared language code dictionary and helpers for gamebook translation features.
+/// Extracted from TranslateGamebookSegmentQueryHandler (DEC-14 #1559) per DEC-BE-10 (#1774).
+/// </summary>
+public static class LanguageCodes
+{
+    /// <summary>Maps ISO-639-1 uppercase codes to English language names for prompt construction.</summary>
+    public static readonly IReadOnlyDictionary<string, string> LangNameByCode =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["EN"] = "English",
+            ["FR"] = "French",
+            ["DE"] = "German",
+            ["ES"] = "Spanish",
+            ["IT"] = "Italian",
+        };
+
+    /// <summary>Returns the English language name for the given code, or null if not supported.</summary>
+    public static string? TryGetLanguageName(string code) =>
+        LangNameByCode.TryGetValue(code, out var name) ? name : null;
+
+    /// <summary>Returns true if the code is one of EN/FR/DE/ES/IT (case-insensitive).</summary>
+    public static bool IsValidSourceLang(string? code) =>
+        code is not null && LangNameByCode.ContainsKey(code);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
@@ -1,0 +1,349 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Application.Services;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.LlmClients;
+using Api.SharedKernel.Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class TranslateGamebookTextQueryHandlerTests
+{
+    // ── Fakes ────────────────────────────────────────────────────────────────
+
+    private sealed class FakeCampaignRepo : IGamebookCampaignSessionRepository
+    {
+        public List<GamebookCampaignSession> Store { get; } = new();
+
+        public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid o, Guid? g, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
+
+        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default) { Store.Add(s); return Task.CompletedTask; }
+        public Task SaveChangesAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeGlossaryRepo : IGamebookGlossaryRepository
+    {
+        public List<GamebookGlossaryEntry> Store { get; } = new();
+
+        public Task<IReadOnlyList<GamebookGlossaryEntry>> ListByCampaignAsync(Guid campaignId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<GamebookGlossaryEntry>>(Store.Where(x => x.CampaignId == campaignId).ToList());
+
+        public Task<GamebookGlossaryEntry?> GetByTermAsync(Guid campaignId, string termEn, CancellationToken cancellationToken = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.CampaignId == campaignId && x.TermEn == termEn));
+
+        public Task<GamebookGlossaryEntry?> GetByTermItAsync(Guid campaignId, string termIt, CancellationToken cancellationToken = default)
+        {
+            var needle = (termIt ?? string.Empty).Trim();
+            return Task.FromResult(Store.FirstOrDefault(x =>
+                x.CampaignId == campaignId
+                && string.Equals(x.TermIt.Trim(), needle, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        public Task<GamebookGlossaryEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+
+        public Task AddRangeAsync(IEnumerable<GamebookGlossaryEntry> entries, CancellationToken cancellationToken = default)
+        { Store.AddRange(entries); return Task.CompletedTask; }
+
+        public Task AddAsync(GamebookGlossaryEntry entry, CancellationToken cancellationToken = default)
+        { Store.Add(entry); return Task.CompletedTask; }
+
+        public Task SaveChangesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Fake LLM that yields configurable deltas and a final chunk with usage.
+    /// </summary>
+    private sealed class FakeLlmService : ILlmService
+    {
+        private readonly string[] _deltas;
+        public string? CapturedSystemPrompt { get; private set; }
+
+        public FakeLlmService(string[]? deltas = null)
+        {
+            _deltas = deltas ?? new[] { "Ciao mondo." };
+        }
+
+        public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+            string systemPrompt,
+            string userPrompt,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            CapturedSystemPrompt = systemPrompt;
+            foreach (var delta in _deltas)
+            {
+                yield return new StreamChunk(Content: delta, IsFinal: false);
+                await Task.Yield();
+            }
+            yield return new StreamChunk(null, IsFinal: true, Usage: new LlmUsage(10, 5, 15));
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public Task<T?> GenerateJsonAsync<T>(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default) where T : class
+            => Task.FromResult<T?>(null);
+
+        public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(IReadOnlyList<LlmMessage> messages, RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+            IReadOnlyList<LlmMessage> messages,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk(null, IsFinal: true);
+            await Task.CompletedTask;
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionWithModelAsync(string explicitModel, string systemPrompt, string userPrompt, RequestSource source = RequestSource.Manual, int? maxTokens = null, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+    }
+
+    /// <summary>
+    /// Guard that always confirms ownership (for happy-path tests).
+    /// </summary>
+    private sealed class AlwaysOwnedGuard : ICampaignOwnershipGuard
+    {
+        public Task AssertOwnedByAsync(Guid campaignId, Guid userId, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Guard that always throws ForbiddenException (for ownership-denial tests).
+    /// </summary>
+    private sealed class AlwaysDeniedGuard : ICampaignOwnershipGuard
+    {
+        public Task AssertOwnedByAsync(Guid campaignId, Guid userId, CancellationToken cancellationToken)
+            => throw new ForbiddenException("Not the owner.");
+    }
+
+    // ── Fixture IDs ───────────────────────────────────────────────────────────
+
+    private static readonly Guid CampaignId = Guid.Parse("11111111-1111-4111-a111-111111111111");
+    private static readonly Guid GameBookId = Guid.Parse("22222222-2222-4222-a222-222222222222");
+    private static readonly Guid UserId = Guid.Parse("33333333-3333-4333-a333-333333333333");
+    private static readonly Guid SharedGameId = Guid.Parse("44444444-4444-4444-a444-444444444444");
+
+    private static TranslateGamebookTextQuery DefaultQuery(string text = "Hello world.", string sourceLang = "EN") =>
+        new(CampaignId, text, sourceLang, "IT", GameBookId, UserId);
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static TranslateGamebookTextQueryHandler BuildHandler(
+        FakeCampaignRepo campaignRepo,
+        FakeGlossaryRepo glossaryRepo,
+        ILlmService? llm = null,
+        ICampaignOwnershipGuard? guard = null) =>
+        new(
+            campaignRepo,
+            glossaryRepo,
+            llm ?? new FakeLlmService(),
+            guard ?? new AlwaysOwnedGuard(),
+            NullLogger<TranslateGamebookTextQueryHandler>.Instance);
+
+    private static (FakeCampaignRepo campaigns, FakeGlossaryRepo glossary)
+        BuildRepos()
+    {
+        var campaigns = new FakeCampaignRepo();
+        var glossary = new FakeGlossaryRepo();
+
+        // Seed campaign
+        campaigns.Store.Add(
+            GamebookCampaignSession.Create(GameRef.Shared(SharedGameId), UserId, "Test Campaign"));
+        return (campaigns, glossary);
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_OwnershipDenied_ThrowsForbidden()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var handler = BuildHandler(campaigns, glossary, guard: new AlwaysDeniedGuard());
+
+        await Assert.ThrowsAsync<ForbiddenException>(async () =>
+        {
+            await foreach (var _ in handler.Handle(DefaultQuery(), CancellationToken.None)) { }
+        });
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_EmitsDeltaChunks_AndFinalChunk()
+    {
+        var (campaigns, glossary) = BuildRepos();
+
+        // Use the actual campaign Id from the store
+        var campaign = campaigns.Store[0];
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Hello world.", "EN", "IT", GameBookId, UserId);
+        var llm = new FakeLlmService(new[] { "Ciao ", "mondo." });
+        var handler = BuildHandler(campaigns, glossary, llm: llm);
+
+        var chunks = new List<TranslateChunk>();
+        await foreach (var c in handler.Handle(query, CancellationToken.None))
+            chunks.Add(c);
+
+        chunks.Should().HaveCount(3, "two content deltas + one final");
+        chunks[0].Delta.Should().Be("Ciao ");
+        chunks[0].IsComplete.Should().BeFalse();
+        chunks[1].Delta.Should().Be("mondo.");
+        chunks[1].IsComplete.Should().BeFalse();
+        chunks[2].IsComplete.Should().BeTrue();
+        chunks[2].ParagraphId.Should().BeNull("DEC-BE-11: no TranslatedParagraph persisted");
+        chunks[2].DetectedSourceLang.Should().Be("EN", "DEC-BE-13: echoes user-provided source lang");
+        chunks[2].LangDetectionConfidence.Should().BeNull("no detection happened in manual mode");
+    }
+
+    [Fact]
+    public async Task Handle_WithGlossaryMatchInSourceAndTranslation_PopulatesAppliedTerms()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+
+        glossary.Store.Add(GamebookGlossaryEntry.Create(campaign.Id, "goblin", "goblin", GlossarySource.AutoBootstrap, UserId));
+        glossary.Store.Add(GamebookGlossaryEntry.Create(campaign.Id, "sword", "spada", GlossarySource.AutoBootstrap, UserId));
+
+        var llm = new FakeLlmService(new[] { "Vedi un goblin con una spada." });
+        var handler = BuildHandler(campaigns, glossary, llm: llm);
+
+        var query = new TranslateGamebookTextQuery(campaign.Id, "You see a goblin with a sword.", "EN", "IT", GameBookId, UserId);
+        var chunks = new List<TranslateChunk>();
+        await foreach (var c in handler.Handle(query, CancellationToken.None))
+            chunks.Add(c);
+
+        var final = chunks.Last();
+        final.AppliedTerms.Should().Contain("goblin");
+        final.AppliedTerms.Should().Contain("sword");
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotPersistTranslatedParagraph()
+    {
+        // DEC-BE-11: handler has no ITranslatedParagraphRepository dependency — verified at compile time.
+        // This test confirms the happy path completes with ParagraphId=null in the final chunk.
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+        var handler = BuildHandler(campaigns, glossary);
+
+        var chunks = new List<TranslateChunk>();
+        await foreach (var c in handler.Handle(
+            new TranslateGamebookTextQuery(campaign.Id, "Hello.", "EN", "IT", GameBookId, UserId),
+            CancellationToken.None))
+            chunks.Add(c);
+
+        chunks.Last().ParagraphId.Should().BeNull("DEC-BE-11: no TranslatedParagraph persisted, so ParagraphId is null");
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotUpdateSessionBookProgress()
+    {
+        // DEC-BE-12: handler has no ISessionBookProgressRepository dependency — verified at compile time.
+        // This test confirms the happy path completes without touching progress (final chunk LangDetectionConfidence=null).
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+        var handler = BuildHandler(campaigns, glossary);
+
+        var chunks = new List<TranslateChunk>();
+        await foreach (var c in handler.Handle(
+            new TranslateGamebookTextQuery(campaign.Id, "Hello.", "EN", "IT", GameBookId, UserId),
+            CancellationToken.None))
+            chunks.Add(c);
+
+        chunks.Last().LangDetectionConfidence.Should().BeNull("DEC-BE-12: manual mode, no detection confidence");
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotTouchCampaign()
+    {
+        // Verifies that no SaveChanges is called on campaigns repo (campaign.Touch() not invoked)
+        var campaigns = new FakeCampaignRepoWithSaveTracking();
+        campaigns.Store.Add(
+            GamebookCampaignSession.Create(GameRef.Shared(SharedGameId), UserId, "Test"));
+        var campaign = campaigns.Store[0];
+
+        var glossary = new FakeGlossaryRepo();
+        var handler = new TranslateGamebookTextQueryHandler(
+            campaigns,
+            glossary,
+            new FakeLlmService(),
+            new AlwaysOwnedGuard(),
+            NullLogger<TranslateGamebookTextQueryHandler>.Instance);
+
+        await foreach (var _ in handler.Handle(
+            new TranslateGamebookTextQuery(campaign.Id, "Hello.", "EN", "IT", GameBookId, UserId),
+            CancellationToken.None)) { }
+
+        campaigns.SaveChangesCalled.Should().BeFalse("DEC-BE-12: manual mode must NOT call SaveChanges on campaigns (no Touch())");
+    }
+
+    [Fact]
+    public async Task Handle_WithSourceLangFR_BuildsPromptWithFrench()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+        var llm = new FakeLlmService(new[] { "Ciao." });
+        var handler = BuildHandler(campaigns, glossary, llm: llm);
+
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Bonjour.", "FR", "IT", GameBookId, UserId);
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        llm.CapturedSystemPrompt.Should().NotBeNull();
+        llm.CapturedSystemPrompt.Should().Contain("French to Italian",
+            "SourceLang=FR must drive prompt to 'French to Italian'");
+    }
+
+    [Fact]
+    public async Task Handle_WithSourceLangCaseInsensitive_NormalizesToUpperCase()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+        var llm = new FakeLlmService(new[] { "Ciao." });
+        var handler = BuildHandler(campaigns, glossary, llm: llm);
+
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Bonjour.", "fr", "IT", GameBookId, UserId);
+        var chunks = new List<TranslateChunk>();
+        await foreach (var c in handler.Handle(query, CancellationToken.None))
+            chunks.Add(c);
+
+        llm.CapturedSystemPrompt.Should().Contain("French",
+            "lowercase 'fr' must normalize to 'FR' → 'French' in prompt");
+        chunks.Last().DetectedSourceLang.Should().Be("FR",
+            "final chunk must echo normalized uppercase source lang code");
+    }
+
+    // ── Additional tracking fake ──────────────────────────────────────────────
+
+    private sealed class FakeCampaignRepoWithSaveTracking : IGamebookCampaignSessionRepository
+    {
+        public List<GamebookCampaignSession> Store { get; } = new();
+        public bool SaveChangesCalled { get; private set; }
+
+        public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid o, Guid? g, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
+
+        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default) { Store.Add(s); return Task.CompletedTask; }
+
+        public Task SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveChangesCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/TranslateGamebookTextRequestValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/TranslateGamebookTextRequestValidatorTests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Validators;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Validators;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class TranslateGamebookTextRequestValidatorTests
+{
+    private readonly TranslateGamebookTextRequestValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithValidRequest_DoesNotErr()
+    {
+        var req = new TranslateGamebookTextRequest("Hello world.", "EN", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyText_ShouldHaveError()
+    {
+        var req = new TranslateGamebookTextRequest("", "EN", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(r => r.Text);
+    }
+
+    [Fact]
+    public void Validate_WithWhitespaceOnlyText_ShouldHaveError()
+    {
+        var req = new TranslateGamebookTextRequest("   ", "EN", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(r => r.Text);
+    }
+
+    [Fact]
+    public void Validate_WithTextAt2000Chars_DoesNotErr()
+    {
+        var req = new TranslateGamebookTextRequest(new string('a', 2000), "EN", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveValidationErrorFor(r => r.Text);
+    }
+
+    [Fact]
+    public void Validate_WithTextAt2001Chars_ShouldHaveError()
+    {
+        var req = new TranslateGamebookTextRequest(new string('a', 2001), "EN", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(r => r.Text);
+    }
+
+    [Theory]
+    [InlineData("EN")]
+    [InlineData("FR")]
+    [InlineData("DE")]
+    [InlineData("ES")]
+    [InlineData("IT")]
+    public void Validate_WithValidSourceLang_DoesNotErr(string lang)
+    {
+        var req = new TranslateGamebookTextRequest("Hello.", lang, "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveValidationErrorFor(r => r.SourceLang);
+    }
+
+    [Theory]
+    [InlineData("XX")]
+    [InlineData("ZZ")]
+    [InlineData("PL")]
+    [InlineData("")]
+    public void Validate_WithInvalidSourceLang_ShouldHaveError(string lang)
+    {
+        var req = new TranslateGamebookTextRequest("Hello.", lang, "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(r => r.SourceLang);
+    }
+
+    [Fact]
+    public void Validate_WithSourceLangLowercase_IsAccepted()
+    {
+        // Validator should accept lowercase per case-insensitive policy (LanguageCodes uses OrdinalIgnoreCase)
+        var req = new TranslateGamebookTextRequest("Hello.", "en", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveValidationErrorFor(r => r.SourceLang);
+    }
+
+    [Fact]
+    public void Validate_WithTargetLangNotIT_ShouldHaveError()
+    {
+        var req = new TranslateGamebookTextRequest("Hello.", "EN", "EN", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(r => r.TargetLang);
+    }
+
+    [Fact]
+    public void Validate_WithTargetLangIT_DoesNotErr()
+    {
+        var req = new TranslateGamebookTextRequest("Hello.", "EN", "IT", Guid.NewGuid());
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveValidationErrorFor(r => r.TargetLang);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyGameBookId_ShouldHaveError()
+    {
+        var req = new TranslateGamebookTextRequest("Hello.", "EN", "IT", Guid.Empty);
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(r => r.GameBookId);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/GamebookTextTranslateStreamEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/GamebookTextTranslateStreamEndpointTests.cs
@@ -1,0 +1,374 @@
+using System.Net;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.SessionTracking;
+
+/// <summary>
+/// Issue #1774: integration tests for POST /api/v1/gamebook/campaigns/{id}/text/translate (SSE).
+/// Verifies the pre-flight ownership/validation guards return proper HTTP error codes BEFORE
+/// any SSE bytes are flushed to the client, following the same conservative dual-acceptance
+/// pattern as <see cref="GamebookTranslateStreamEndpointTests"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// DEC-BE-11: Final chunk has ParagraphId=null (no TranslatedParagraph persistence).
+/// DEC-BE-12: SessionBookProgress is NOT updated by the text-translate handler.
+/// DEC-BE-13: Final chunk echoes the user-provided SourceLang as DetectedSourceLang;
+///            LangDetectionConfidence is null (no NTextCat detection in manual mode).
+/// </para>
+/// <para>
+/// Validation runs BEFORE any ownership check (pre-flight), so unauthenticated
+/// requests with invalid bodies still receive 400 — not 401.
+/// </para>
+/// <para>
+/// Because the real LLM service is replaced by the IntegrationWebApplicationFactory
+/// config stub (OpenRouter:ApiKey = "test-key" pointing to a non-existent host),
+/// HappyPath tests accept either 200/OK (SSE stream opened) or 401 (cookie not
+/// honored in this test pipeline) — following the conservative dual-acceptance pattern.
+/// </para>
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class GamebookTextTranslateStreamEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public GamebookTextTranslateStreamEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"text_translate_stream_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static string BuildUrl(Guid campaignId) =>
+        $"/api/v1/gamebook/campaigns/{campaignId}/text/translate";
+
+    private static TranslateGamebookTextRequest ValidBody(Guid gameBookId) =>
+        new("The adventurers enter the dungeon.", "EN", "IT", gameBookId);
+
+    /// <summary>
+    /// Seeds a campaign owned by the returned user + a GameBook for that campaign.
+    /// Returns the owner's session token and the ids needed to call the translate endpoint.
+    /// </summary>
+    private async Task<(Guid OwnerUserId, string SessionToken, Guid CampaignId, Guid GameBookId)>
+        SeedOwnedCampaignAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var sharedGameId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(GameRef.Shared(sharedGameId), userId, "Issue 1774 text translate test");
+        var book = GameBook.CreateCommunity(
+            GameRef.Shared(sharedGameId),
+            "Text Translate Test Book",
+            GameBookRole.Tutorial,
+            ParagraphScheme.ParagraphNumber,
+            "en",
+            sequentialRead: false,
+            kbSourceDocId: null,
+            physicalOnly: false,
+            createdBy: userId);
+
+        await dbContext.GamebookCampaignSessions.AddAsync(session);
+        await dbContext.GameBooks.AddAsync(book);
+        await dbContext.SaveChangesAsync();
+
+        return (userId, sessionToken, session.Id, book.Id);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test cases
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// S1 — Happy path: authenticated owner with a valid body should reach the SSE stream
+    /// (either 200 OK with SSE content-type OR 401 if cookie not honored in test pipeline).
+    /// Must never yield 403/404 for the legitimate owner.
+    /// DEC-BE-8 ownership pre-flight, DEC-BE-13 final chunk shape verified via conservative acceptance.
+    /// </summary>
+    [Fact]
+    public async Task HappyPath_OwnerCanTranslate_EmitsSse()
+    {
+        var owned = await SeedOwnedCampaignAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            BuildUrl(owned.CampaignId),
+            owned.SessionToken,
+            ValidBody(owned.GameBookId));
+
+        var response = await _client.SendAsync(request);
+
+        // Conservative dual-acceptance: SSE stream opened (200) or cookie not honored (401).
+        // Key assertions: NOT 403 (owner must not hit pre-flight forbidden) and NOT 404.
+        (response.StatusCode == HttpStatusCode.OK ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"Owner pre-flight should not yield Forbidden/NotFound. Got {response.StatusCode}");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "owner request must not hit the ForbiddenException pre-flush branch");
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound,
+            "owner request must not hit the NotFoundException pre-flush branch");
+
+        // If 200 OK, verify SSE content-type and that the stream is text/event-stream.
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream",
+                "the endpoint must flush SSE headers before streaming");
+        }
+    }
+
+    /// <summary>
+    /// S2 — Empty text body must return 400 BadRequest BEFORE any SSE headers are flushed.
+    /// Uses an authenticated request to bypass the auth middleware so FluentValidation fires.
+    /// Conservative acceptance: 400 (validator fired) or 401 (cookie not honored in test pipeline).
+    /// Must NEVER produce an SSE stream.
+    /// </summary>
+    [Fact]
+    public async Task InvalidText_Empty_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var body = new TranslateGamebookTextRequest("", "EN", "IT", Guid.NewGuid());
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, BuildUrl(Guid.NewGuid()), sessionToken, body);
+
+        var response = await _client.SendAsync(request);
+
+        // Auth fires before validation inside the handler body; accept 400 or 401.
+        (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"empty text must yield 400 BadRequest or 401, not {response.StatusCode}");
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream",
+            "a validation failure must never produce an SSE stream");
+
+        // If 400, confirm the body is a ValidationProblemDetails (not SSE).
+        if (response.StatusCode == HttpStatusCode.BadRequest)
+        {
+            var body2 = await response.Content.ReadAsStringAsync();
+            body2.Should().NotStartWith("data:", "a 400 response must not contain SSE data lines");
+        }
+    }
+
+    /// <summary>
+    /// S3 — Text exceeding 2000 characters must return 400 or 401 (conservative pattern).
+    /// </summary>
+    [Fact]
+    public async Task InvalidText_TooLong_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var body = new TranslateGamebookTextRequest(new string('a', 2001), "EN", "IT", Guid.NewGuid());
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, BuildUrl(Guid.NewGuid()), sessionToken, body);
+
+        var response = await _client.SendAsync(request);
+
+        (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"text of 2001 chars must yield 400 or 401, not {response.StatusCode}");
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream");
+    }
+
+    /// <summary>
+    /// S4 — Invalid sourceLang (not in EN/FR/DE/ES/IT allowlist) must return 400 or 401.
+    /// Conservative acceptance: 400 (validator fired) or 401 (cookie not honored in test pipeline).
+    /// </summary>
+    [Theory]
+    [InlineData("XX")]
+    [InlineData("PL")]
+    [InlineData("ZZ")]
+    public async Task InvalidSourceLang_NotInAllowlist_Returns400(string invalid)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var body = new TranslateGamebookTextRequest("Hello world.", invalid, "IT", Guid.NewGuid());
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, BuildUrl(Guid.NewGuid()), sessionToken, body);
+
+        var response = await _client.SendAsync(request);
+
+        (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"sourceLang='{invalid}' must yield 400 or 401, not {response.StatusCode}");
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream");
+    }
+
+    /// <summary>
+    /// S5 — TargetLang other than "IT" must return 400 or 401
+    /// (v1 target is fixed to Italian; validation fires after auth inside handler body).
+    /// </summary>
+    [Fact]
+    public async Task InvalidTargetLang_NotIT_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var body = new TranslateGamebookTextRequest("Hello world.", "EN", "EN", Guid.NewGuid());
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, BuildUrl(Guid.NewGuid()), sessionToken, body);
+
+        var response = await _client.SendAsync(request);
+
+        (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"targetLang=EN must yield 400 or 401, not {response.StatusCode}");
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream");
+    }
+
+    /// <summary>
+    /// S6 — GameBookId=Guid.Empty must return 400 or 401 (NotEmpty validation rule).
+    /// </summary>
+    [Fact]
+    public async Task InvalidGameBookId_Empty_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var body = new TranslateGamebookTextRequest("Hello world.", "EN", "IT", Guid.Empty);
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, BuildUrl(Guid.NewGuid()), sessionToken, body);
+
+        var response = await _client.SendAsync(request);
+
+        (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"gameBookId=Guid.Empty must yield 400 or 401, not {response.StatusCode}");
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream");
+    }
+
+    /// <summary>
+    /// S7 — Authenticated non-owner must receive 403 (or 401 if cookie not honored) before
+    /// any SSE byte is flushed. The pre-flight ICampaignOwnershipGuard fires before SSE headers.
+    /// </summary>
+    [Fact]
+    public async Task NotOwner_Returns403_OrUnauthorized()
+    {
+        var owned = await SeedOwnedCampaignAsync();
+
+        // Spin up a second user with their own session token.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var (_, otherToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+            var request = TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post,
+                BuildUrl(owned.CampaignId),
+                otherToken,
+                ValidBody(owned.GameBookId));
+
+            var response = await _client.SendAsync(request);
+
+            // Conservative dual-acceptance: 403 (ownership guard fired) or 401 (cookie not honored).
+            (response.StatusCode == HttpStatusCode.Forbidden ||
+                response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+                $"Non-owner should get Forbidden or Unauthorized, got {response.StatusCode}");
+
+            response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream",
+                "a pre-flight ownership failure must never produce an SSE stream");
+        }
+    }
+
+    /// <summary>
+    /// S8 — Request against a non-existent campaignId must return 404 (or 401)
+    /// before any SSE byte is flushed. NotFoundException from the ownership guard fires pre-SSE.
+    /// </summary>
+    [Fact]
+    public async Task NonExistentCampaign_Returns404_OrUnauthorized()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        // Use a random campaignId that was never seeded.
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            BuildUrl(Guid.NewGuid()),
+            sessionToken,
+            new TranslateGamebookTextRequest("Hello world.", "EN", "IT", Guid.NewGuid()));
+
+        var response = await _client.SendAsync(request);
+
+        (response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"Non-existent campaign should get NotFound or Unauthorized, got {response.StatusCode}");
+
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("text/event-stream",
+            "a pre-flight not-found failure must never produce an SSE stream");
+    }
+
+    /// <summary>
+    /// S9 — Backward-compat: the original GET /photos/translate endpoint is still reachable
+    /// after the T6 refactor that added the new sibling POST /text/translate endpoint.
+    /// An unauthenticated request returns 401 (not 404 or 500), confirming the route is
+    /// registered and nothing was accidentally broken by the new endpoint addition.
+    /// </summary>
+    [Fact]
+    public async Task BackwardCompat_PhotoTranslateEndpointStillRegistered()
+    {
+        var fakeUrl = $"/api/v1/gamebook/campaigns/{Guid.NewGuid()}/photos/translate" +
+                      $"?photoId={Guid.NewGuid()}&paragraphNumber=1&gameBookId={Guid.NewGuid()}";
+
+        var response = await _client.GetAsync(fakeUrl);
+
+        // The route must exist (not 404). Unauthenticated → 401 or 400 (validation before auth).
+        // A 404 would mean the route was accidentally removed.
+        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound,
+            "the original /photos/translate GET route must still be registered after T6 refactor");
+        response.StatusCode.Should().NotBe(HttpStatusCode.InternalServerError,
+            "the original /photos/translate route must not error on startup/routing");
+    }
+}


### PR DESCRIPTION
## Summary

BE PR for **#1774** (manual text translate SSE endpoint, supporting FE **#1560**). Adds `POST /api/v1/gamebook/campaigns/{cid}/text/translate` SSE endpoint that accepts text directly (no photo, no OCR) and streams Italian translation. Mirrors existing `/photos/translate` GET pattern but omits persistence (DEC-BE-11) and progress tracking (DEC-BE-12) since manual mode bypasses the segment FK and the linear progress invariant.

Closes #1774. **Unblocks FE #1560** (sessione successiva continua w/ Phase 2 FE).

## Architecture (spec-panel locked DEC-BE-1..DEC-BE-15)

Spec-panel critique posted on issue: [comment 4594574358](https://github.com/meepleAi-app/meepleai-monorepo/issues/1774#issuecomment-4594574358). 5-expert panel (Wiegers + Nygard + Crispin + Adzic + Fowler).

| Area | Decision | Tasks |
|---|---|---|
| Endpoint | `POST /gamebook/campaigns/{cid:guid}/text/translate` in `GamebookPhotoEndpoints.cs` sibling of `MapTranslateStreamEndpoint` (file rename deferred) | T6 |
| Request DTO | `TranslateGamebookTextRequest { Text(1-2000), SourceLang(EN/FR/DE/ES/IT), TargetLang=IT, GameBookId }` | T3 |
| Validator | FluentValidation w/ `Cascade(CascadeMode.Stop)`, case-insensitive lang allowlist via `LanguageCodes.IsValidSourceLang` | T3 |
| Shared kernel | `LanguageCodes` extracted: `LangNameByCode` dict + `TryGetLanguageName(code)` + `IsValidSourceLang(code)`. Segment handler refactored to consume (additive, behavior-preserved) | T1, T2 |
| Handler | `TranslateGamebookTextQueryHandler` parallel to segment handler, NO common helper extraction (DEC-BE-7 YAGNI — rule of three not yet triggered). NO `ITranslatedParagraphRepository` / `ISessionBookProgressRepository` injection (YAGNI — DEC-BE-11/12 omit persistence/progress) | T5 |
| Persistence | NO `TranslatedParagraph.Create + AddAsync + SaveChangesAsync` (DEC-BE-11 — no segment FK target) | T5 |
| Progress | NO `SessionBookProgress` update + NO `campaign.Touch()` (DEC-BE-12 — manual mode bypasses linear progress invariant) | T5 |
| Final SSE chunk | `ParagraphId=null`, `DetectedSourceLang = request.SourceLang.ToUpperInvariant()` (echo for audit), `LangDetectionConfidence=null` (no detection) | T5 |
| Exception chain | Identical 5-branch pattern: OperationCanceled → ForbiddenException pre/post-flush → NotFoundException pre/post-flush → catch-all | T6 |
| Metrics | `MeepleAiMetrics.RecordGamebookTranslationRequest` extended w/ `sourceMethod` param (default `"ocr"` backward compat); manual flow emits `"manual"` tag on counter | T4 |

## G/W/T Scenarios (S1-S8 + bonus backward compat)

- **S1** HappyPath_OwnerCanTranslate_EmitsSse — 200 + SSE final w/ IsComplete + ParagraphId=null + lang echo
- **S2** InvalidText_Empty → 400 (or 401 pre-auth)
- **S3** InvalidText_TooLong (2001 chars) → 400
- **S4** InvalidSourceLang (XX/ZZ/PL) → 400 (Theory)
- **S5** InvalidTargetLang (not IT) → 400
- **S6** InvalidGameBookId (Guid.Empty) → 400
- **S7** NotOwner → 403 Forbidden pre-SSE-flush
- **S8** NonExistentCampaign → 404 pre-SSE-flush
- **Bonus** BackwardCompat — existing photo/translate endpoint unchanged after T2 refactor

## Plan + 8 commits (TDD)

Plan: [`docs/superpowers/plans/2026-06-01-be-1774-text-translate-sse.md`](docs/superpowers/plans/2026-06-01-be-1774-text-translate-sse.md)

```
11f055400 fix T5 review M1 explicit campaign re-check
125bf964a T8 GamebookTextTranslateStream integration tests
5fad9110a T6 MapTextTranslateStreamEndpoint POST /text/translate
ac7c6b1b9 T5 TranslateGamebookTextQueryHandler + 8 tests
91f4d6cac T4 MeepleAiMetrics sourceMethod tag
33e82894a T3 TranslateGamebookText DTO+Query+Validator + 18 tests
7bf6e693c T2 segment handler uses LanguageCodes shared kernel
654eb9ef5 T1 LanguageCodes shared kernel for translation
```

## Test plan

- [x] Unit: `TranslateGamebookTextRequestValidatorTests` (18 expanded, 9 unique [Fact/Theory])
- [x] Unit: `TranslateGamebookTextQueryHandlerTests` (8 tests covering happy/glossary/no-persistence/no-progress/no-touch/lang dynamic/case-insensitive)
- [x] Integration: `GamebookTextTranslateStreamEndpointTests` (11 tests covering S1-S8 + backward compat)
- [x] **Total new tests: 37 PASS**
- [x] Existing `TranslateGamebookSegmentQueryHandlerTests`: **5/5 PASS** (T2 refactor behavior-preserved)
- [x] Full SessionTracking BC suite: **916/922 PASS, 6 PRE-EXISTING baseline failures** in `GamebookTranslateStreamEndpointTests:289` `Translate_InvalidSourceLangOverride_Returns400_BeforeAuth` (NOT introduced by this PR — verified via subagent running suite without T8)
- [x] Build: `dotnet build apps/api/src/Api` PASS 0 errors 0 warnings
- [x] Code reviewer: APPROVED_WITH_NOTES 0 CRIT 1 MAJOR fixed inline (M1 discard pattern → explicit campaign assignment w/ comment + SuppressMessage)

## Documented deviations from plan

- **Handler DI YAGNI**: removed unused `ITranslatedParagraphRepository` + `ISessionBookProgressRepository` from constructor per SonarQube S4487/S1481 errors (unused fields treated as errors). Plan said "keep for symmetry" but compiler discipline > symmetry. Test file simplified to assert via final-chunk shape (`ParagraphId=null`) + `FakeCampaignRepoWithSaveTracking` for no-touch verification.
- **T2 type mismatches discovered (P74)**: `LlmStreamChunk.Content` (not `Delta`), `LlmUsage` 3 args (PromptTokens, CompletionTokens, TotalTokens), `GlossarySource` enum (not `GamebookGlossarySource`), `GamebookCampaignSession.Create` takes `GameRef.Shared(...)`. Adapted from existing segment handler test patterns.
- **Validator test count**: 18 expanded (5 valid lang Theory + 4 invalid lang Theory + 9 other Facts), plan said "12" counting unique `[Fact]/[Theory]` declarations.
- **M1 review fix**: discard pattern `_ = await...` replaced w/ explicit `var campaign = await...` + comment + `#pragma warning disable IDE0059, S1854` documenting intent.
- **T7 no commit**: validator auto-discovery via `AddValidatorsFromAssemblyContaining<CreateSessionCommandValidator>` already covers `TranslateGamebookTextRequestValidator` — confirmed in `ApplicationServiceExtensions.cs:248`.

## Migration safety

NO database migrations, NO schema changes. Endpoint is additive (new route, no existing route modified). Existing SSE schema extended with same nullable fields (already shipped in #1559 BE PR1 #1787). Backward compat: old FE clients ignore new fields (JSON.parse spec).

## Follow-ups deferred

- File rename `GamebookPhotoEndpoints.cs` → `GamebookTranslateEndpoints.cs` (DEC-BE-1 acknowledged, scope creep avoided)
- Common helper extraction between segment + text handlers (DEC-BE-7 — rule of three not yet triggered)
- Validator minor cleanup: remove `.Must(t => !string.IsNullOrWhiteSpace(t))` redundancy w/ `NotEmpty` (review m1, low-priority)
- Validator test coverage: explicit case-insensitive `TargetLang="it"` test (review m2, document intent)
- Handler unit test: empty glossary path + cancellation mid-stream (review test quality nitpicks)
- Grafana dashboard segmentation by `source_method` tag (separate epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
