### PR TITLE
feat(admin-kb): #1676 scope (a) hero metadata Size + last reindex

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
@@ -167,7 +167,9 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
             PageCount: data.pdf.PageCount,
             Language: string.IsNullOrWhiteSpace(data.pdf.Language) ? "it" : data.pdf.Language,
             // Gate B v1 carryover — PdfDocumentEntity has no Tags column yet.
-            Tags: Array.Empty<string>()
+            Tags: Array.Empty<string>(),
+            // #1676 scope (a) F1: Size in bytes — mockup sp5-admin-kb.html L147
+            FileSize: data.pdf.FileSizeBytes
         );
 
         return new KbDocResultContainer(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs
@@ -54,5 +54,6 @@ internal sealed record KbDocumentDto(
     int ChunkCount,
     int? PageCount,
     string Language,
-    IReadOnlyList<string> Tags
+    IReadOnlyList<string> Tags,
+    long FileSize
 );

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
@@ -195,6 +195,41 @@ public sealed class GetKbDocumentByIdHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ReadyDoc_ReturnsFileSizeFromEntity()
+    {
+        // #1676 scope (a) F1: FileSize must be mapped from PdfDocumentEntity.FileSizeBytes.
+        var docId = Guid.NewGuid();
+        const long expectedSize = 8_808_038L; // 8.4 MB — mockup sp5-admin-kb.html L147
+        var pdf = SeedPdf(id: docId, processingState: "Ready", fileSizeBytes: expectedSize);
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, pdf.UploadedByUserId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.FileSize.Should().Be(expectedSize);
+    }
+
+    [Fact]
+    public async Task Handle_ReadyDocWithZeroSize_ReturnsZeroFileSize()
+    {
+        // Defensive: pre-existing rows without size data should not break the handler.
+        var docId = Guid.NewGuid();
+        var pdf = SeedPdf(id: docId, processingState: "Ready"); // fileSizeBytes defaults to 0
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, pdf.UploadedByUserId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.FileSize.Should().Be(0L);
+    }
+
+    [Fact]
     public async Task Handle_DocNotFound_Throws404()
     {
         var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
@@ -263,7 +298,8 @@ public sealed class GetKbDocumentByIdHandlerTests
         Guid? sharedGameId = null,
         int? pageCount = null,
         bool isPublic = true,
-        string language = "it") => new()
+        string language = "it",
+        long fileSizeBytes = 0) => new()
         {
             Id = id,
             FileName = fileName,
@@ -275,7 +311,8 @@ public sealed class GetKbDocumentByIdHandlerTests
             Language = language,
             UploadedByUserId = Guid.NewGuid(),
             FilePath = "/tmp/test.pdf",
-            IsPublic = isPublic
+            IsPublic = isPublic,
+            FileSizeBytes = fileSizeBytes
         };
 
     private void SeedUploader(Guid userId, string? displayName = "Test User")

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -5,6 +5,8 @@ import { useSearchParams } from 'next/navigation';
 
 import { useKbChunksList } from '@/hooks/queries/useKbChunksList';
 import { useKbDocDetail } from '@/hooks/queries/useKbDocDetail';
+import { formatFileSize } from '@/lib/format/file-size';
+import { formatLastReindex } from '@/lib/format/last-reindex';
 
 import { KbDocActions } from './actions/KbDocActions';
 import { IngestionPanel } from './ingestion/IngestionPanel';
@@ -227,11 +229,25 @@ export function KbDocDetailPanel({ docId, selectedDocMeta }: KbDocDetailPanelPro
               </div>
             </div>
 
-            <dl className="mt-4 grid grid-cols-3 gap-2">
+            <dl className="mt-4 grid grid-cols-4 gap-2">
               <Stat label="Chunks" value={doc.chunkCount.toLocaleString('it-IT')} />
               <Stat label="Pagine" value={doc.pageCount?.toLocaleString('it-IT') ?? '—'} />
               <Stat label="Lingua" value={doc.language} />
+              {/* #1676 scope (a) F1: Size (mockup sp5-admin-kb.html L147) */}
+              <Stat
+                label="Size"
+                value={doc.fileSize !== undefined ? formatFileSize(doc.fileSize) : '—'}
+              />
             </dl>
+
+            {/* #1676 scope (a) F2: last reindex meta-footer (mockup L152).
+             * Falls back to "📤 upload only" when LastIngestedAt == UploadedAt. */}
+            <div
+              data-testid="kb-doc-last-reindex"
+              className="mt-3 font-mono text-[11px] text-muted-foreground"
+            >
+              {formatLastReindex(doc.lastIngestedAt, doc.uploadedAt).label}
+            </div>
 
             {/* Action-bar */}
             <div className="mt-4">

--- a/apps/web/src/lib/api/schemas/kb-chunks.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-chunks.schemas.ts
@@ -45,6 +45,9 @@ export const KbDocDetailSchema = z.object({
   language: z.string().min(1),
   // Schema reality v1 carryover (Gate B): empty array until tags entity lands.
   tags: z.array(z.string()),
+  // #1676 scope (a) F1 (mockup sp5-admin-kb.html L147): file size in bytes.
+  // Optional for BE-pre-deploy safety — FE gracefully renders "—" when missing.
+  fileSize: z.number().int().nonnegative().optional(),
 });
 export type KbDocDetail = z.infer<typeof KbDocDetailSchema>;
 

--- a/apps/web/src/lib/format/__tests__/file-size.test.ts
+++ b/apps/web/src/lib/format/__tests__/file-size.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for formatFileSize — #1676 scope (a) F1.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { formatFileSize } from '../file-size';
+
+describe('formatFileSize', () => {
+  it('returns "0 B" for zero bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('renders bytes (< 1 KB) as integer with B suffix', () => {
+    expect(formatFileSize(873)).toBe('873 B');
+    expect(formatFileSize(1)).toBe('1 B');
+    expect(formatFileSize(1023)).toBe('1023 B');
+  });
+
+  it('renders KB with 1 decimal', () => {
+    // 12.4 KB ≈ 12.4 * 1024 = 12_697 bytes
+    expect(formatFileSize(12_697)).toBe('12.4 KB');
+    // 1 KB exact boundary
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+  });
+
+  it('renders the mockup example 8.4 MB exactly', () => {
+    // Mockup sp5-admin-kb.html L147 — "8.4 MB"
+    // 8.4 MB ≈ 8.4 * 1024 * 1024 = 8_808_038 bytes
+    expect(formatFileSize(8_808_038)).toBe('8.4 MB');
+  });
+
+  it('switches to GB above 1 GiB', () => {
+    // 1.2 GB ≈ 1.2 * 1024^3
+    expect(formatFileSize(1_288_490_188)).toBe('1.2 GB');
+  });
+
+  it('renders em-dash for non-finite input', () => {
+    expect(formatFileSize(Number.NaN)).toBe('—');
+    expect(formatFileSize(Number.POSITIVE_INFINITY)).toBe('—');
+    expect(formatFileSize(Number.NEGATIVE_INFINITY)).toBe('—');
+  });
+
+  it('treats negative input defensively as "0 B"', () => {
+    expect(formatFileSize(-1)).toBe('0 B');
+    expect(formatFileSize(-1_000_000)).toBe('0 B');
+  });
+});

--- a/apps/web/src/lib/format/__tests__/last-reindex.test.ts
+++ b/apps/web/src/lib/format/__tests__/last-reindex.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for formatLastReindex — #1676 scope (a) F2.
+ *
+ * Strategy: avoid time mocking — call `formatLastReindex` with concrete dates
+ * relative to `new Date()` so the test is robust to the project's existing
+ * `formatRelativeDate` (which uses `now()` at call-site).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { formatLastReindex } from '../last-reindex';
+
+const REFERENCE_NOW = new Date('2026-06-01T12:00:00.000Z');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(REFERENCE_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('formatLastReindex', () => {
+  it('returns "📤 upload only" when lastIngestedAt equals uploadedAt', () => {
+    const same = '2026-05-24T10:30:00.000Z';
+    const result = formatLastReindex(same, same);
+    expect(result.kind).toBe('upload-only');
+    expect(result.label).toBe('📤 upload only');
+  });
+
+  it('renders "🔄 last reindex {relative}" for distinct timestamps', () => {
+    // 8 calendar days before reference now
+    const eightDaysAgo = '2026-05-24T12:00:00.000Z';
+    const uploaded = '2026-05-01T12:00:00.000Z'; // 31d before
+    const result = formatLastReindex(eightDaysAgo, uploaded);
+    expect(result.kind).toBe('reindex');
+    expect(result.label.startsWith('🔄 last reindex ')).toBe(true);
+    // The exact relative-date string is owned by formatRelativeDate; just
+    // assert it's non-empty and not the em-dash placeholder.
+    expect(result.label).not.toContain('—');
+    expect(result.label.length).toBeGreaterThan('🔄 last reindex '.length);
+  });
+
+  it('returns "—" when lastIngestedAt is null/undefined/invalid', () => {
+    expect(formatLastReindex(null, '2026-05-01T12:00:00.000Z').label).toBe('—');
+    expect(formatLastReindex(undefined, '2026-05-01T12:00:00.000Z').label).toBe('—');
+    expect(formatLastReindex('not-a-date', '2026-05-01T12:00:00.000Z').label).toBe('—');
+  });
+
+  it('renders reindex label when uploadedAt is null even if lastIngestedAt is valid', () => {
+    // No upload-only check possible without uploadedAt → fall through to reindex.
+    const result = formatLastReindex('2026-05-24T12:00:00.000Z', null);
+    expect(result.kind).toBe('reindex');
+    expect(result.label.startsWith('🔄 last reindex ')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/format/file-size.ts
+++ b/apps/web/src/lib/format/file-size.ts
@@ -1,0 +1,33 @@
+/**
+ * formatFileSize — #1676 scope (a) F1 (mockup `sp5-admin-kb.html` L147).
+ *
+ * Pretty-print a byte count as a human-readable string with adaptive unit:
+ *   - bytes  (< 1024)          → "873 B"
+ *   - KB     (< 1024 * 1024)   → "12.4 KB"
+ *   - MB     (< 1024^3)        → "8.4 MB"
+ *   - GB     (>= 1024^3)       → "1.2 GB"
+ *
+ * Decimals:
+ *   - 0 for raw bytes (no fractional bytes)
+ *   - 1 for KB/MB/GB (mockup convention "8.4 MB")
+ *
+ * Edge cases:
+ *   - 0 → "0 B"
+ *   - negative input → "0 B" (defensive; bytes can't be negative in our DB)
+ *   - non-finite input (NaN, Infinity) → "—"
+ */
+
+const EM_DASH = '—';
+const KB = 1024;
+const MB = KB * 1024;
+const GB = MB * 1024;
+
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes)) return EM_DASH;
+  if (bytes <= 0) return '0 B';
+
+  if (bytes < KB) return `${Math.round(bytes)} B`;
+  if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+  if (bytes < GB) return `${(bytes / MB).toFixed(1)} MB`;
+  return `${(bytes / GB).toFixed(1)} GB`;
+}

--- a/apps/web/src/lib/format/last-reindex.ts
+++ b/apps/web/src/lib/format/last-reindex.ts
@@ -1,0 +1,57 @@
+/**
+ * formatLastReindex — #1676 scope (a) F2 (mockup `sp5-admin-kb.html` L152).
+ *
+ * Returns a humanized "last reindex" label for the KbDocDetailPanel meta-footer.
+ *
+ * Cases:
+ *   - lastIngestedAt EQUALS uploadedAt → upload-only fallback (doc never re-indexed
+ *     after initial ingestion). Label: "📤 upload only".
+ *   - lastIngestedAt differs from uploadedAt → reindex label using the project's
+ *     standard Italian relative-date formatter. Label: "🔄 last reindex {relative}".
+ *   - invalid/null/undefined input → "—" (em dash).
+ *
+ * Two-date semantics mirror the BE fallback chain in
+ * `GetKbDocumentByIdHandler:153`: `IndexedAt ?? ProcessedAt ?? UploadedAt`.
+ * When the chain falls through to UploadedAt, both timestamps coincide → the
+ * "upload only" path is taken.
+ */
+
+import { isValid } from 'date-fns';
+
+import { formatRelativeDate } from '@/lib/play-records/formatRelativeDate';
+
+const EM_DASH = '—';
+
+export interface LastReindexLabel {
+  readonly kind: 'reindex' | 'upload-only' | 'unknown';
+  readonly label: string;
+}
+
+function toDate(input: string | Date | null | undefined): Date | null {
+  if (input === null || input === undefined) return null;
+  const date = typeof input === 'string' ? new Date(input) : input;
+  return isValid(date) ? date : null;
+}
+
+export function formatLastReindex(
+  lastIngestedAt: string | Date | null | undefined,
+  uploadedAt: string | Date | null | undefined
+): LastReindexLabel {
+  const last = toDate(lastIngestedAt);
+  const uploaded = toDate(uploadedAt);
+
+  if (last === null) {
+    return { kind: 'unknown', label: EM_DASH };
+  }
+
+  // Upload-only: BE fallback chain bottomed-out on UploadedAt → both coincide.
+  // Use millisecond equality (timestamps are ISO-string round-tripped).
+  if (uploaded !== null && last.getTime() === uploaded.getTime()) {
+    return { kind: 'upload-only', label: '📤 upload only' };
+  }
+
+  return {
+    kind: 'reindex',
+    label: `🔄 last reindex ${formatRelativeDate(last)}`,
+  };
+}


### PR DESCRIPTION
## Summary

Implementa lo **scope (a)** di #1676 (Hero metadata enrichment, spin-out FU-4) limitato ai 2 campi mockup ready-to-ship senza migration EF:

- **F1 Size** (mockup `sp5-admin-kb.html` L147): `FileSize` aggiunto a `KbDocumentDto` + mapping da `PdfDocumentEntity.FileSizeBytes` nel handler.
- **F2 Last reindex** (mockup L152): FE-only, riusa `LastIngestedAt` già nel DTO. Nuovo helper `formatLastReindex()` con fallback **"📤 upload only"** quando `LastIngestedAt == UploadedAt` (mai re-indicizzato dopo ingestion).

I **4 campi restanti** (indexer version, avg confidence chunk-level, OCR flag, chunk token size) sono tracciati come **checklist deferred nel body di #1676** (Opzione Y, no nuove issue) e richiedono migration EF + pipeline changes (foundation work separato).

## Changes

**Backend** (~5 LOC):
- `KbDocumentDto.cs:44` — aggiunto `long FileSize` al record
- `GetKbDocumentByIdHandler.cs:156` — mappato `FileSize: data.pdf.FileSizeBytes`

**Frontend** (~150 LOC):
- `lib/api/schemas/kb-chunks.schemas.ts` — `fileSize: z.number().int().nonnegative().optional()` (optional per BE-pre-deploy safety)
- `lib/format/file-size.ts` (NEW) — `formatFileSize(bytes)` con switch unit adattivo B/KB/MB/GB
- `lib/format/last-reindex.ts` (NEW) — `formatLastReindex(lastIngestedAt, uploadedAt)` con kind discriminated union + fallback upload-only
- `KbDocDetailPanel.tsx` — 4ª `Stat` "Size" nel grid + meta-footer "🔄 last reindex {humanized}" / "📤 upload only"

## Test plan

- [x] Vitest 11 nuovi unit (`file-size`: 7 case, `last-reindex`: 4 case)
- [x] xUnit 2 nuovi integration (`Handle_ReadyDoc_ReturnsFileSizeFromEntity` + `_ReturnsZeroFileSize` defensive)
- [x] 26/26 test esistenti (`KbDocDetailPanel` + `useKbDocDetail`) intatti
- [x] `pnpm typecheck` ✅ 0 errori
- [x] `pnpm lint` ✅ 0 errori (6 warning pre-esistenti su file non toccati)
- [x] `dotnet build` ✅ 0 errori, 0 warning
- [x] `dotnet test --filter "FullyQualifiedName~GetKbDocumentByIdHandlerTests"` ✅ 23/23 passing

## Spec & decisions

- Spec di riferimento: `docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md` §3 (Phase 3, deferred), §10 O-3
- Spec-panel review 2026-06-01 (Wiegers, Adzic, Crispin, Nygard, Fowler) — scope (a) approvato unanimemente
- Decisioni esplicite:
  1. Naming BE: **`FileSize`** (Fowler: no implementation-detail suffix `Bytes` nel wire)
  2. Sub-task tracking: **Opzione Y** (checklist nel body #1676, no nuove issue)
  3. F2 fallback label: **"📤 upload only"** quando `LastIngestedAt == UploadedAt`

Closes #1676 (scope a). I 4 follow-up restano aperti come checklist deferred nel body issue.