### PR TITLE
chore(player-detail): #1547 a11y aria-live announce ErrorShell + NotFoundShell

### DIFF
--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -241,6 +241,8 @@ function ErrorShell({
   return (
     <div
       data-slot="player-detail-error"
+      role="status"
+      aria-live="polite"
       className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-4 text-center sm:p-8"
     >
       <span aria-hidden="true" className="text-4xl">
@@ -274,6 +276,8 @@ function NotFoundShell({
   return (
     <div
       data-slot="player-detail-not-found"
+      role="status"
+      aria-live="polite"
       className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-4 text-center sm:p-8"
     >
       <span aria-hidden="true" className="text-5xl">

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx
@@ -9,6 +9,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 // ─── Mock i18n ───────────────────────────────────────────────────────────────
@@ -302,5 +303,53 @@ describe('PlayerDetailView', () => {
     const { container } = renderView('sara-rossi');
     expect(getBySlot(container, 'sessions-tab-panel')).toBeDefined();
     mockSearchParams.delete('tab');
+  });
+
+  // ── a11y (#1547): FSM transition announcements for AT users ──────────────────
+  // Loading shell already has aria-busy + aria-live="polite". Error and not-found
+  // shells were silent transitions for screen readers; #1547 adds role="status" +
+  // aria-live="polite" so AT users get the same announcement consistency.
+
+  describe('a11y (#1547): FSM transition announcements', () => {
+    it('ErrorShell exposes role="status" + aria-live="polite"', () => {
+      mockStatsQuery.mockReturnValue({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+        refetch: vi.fn(),
+      });
+
+      const { container } = renderView('sara-rossi');
+      const shell = getBySlot(container, 'player-detail-error');
+      expect(shell).toHaveAttribute('role', 'status');
+      expect(shell).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('NotFoundShell exposes role="status" + aria-live="polite"', () => {
+      const { container } = renderView(null); // null playerId → not-found
+
+      const shell = getBySlot(container, 'player-detail-not-found');
+      expect(shell).toHaveAttribute('role', 'status');
+      expect(shell).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('ErrorShell passes axe a11y scan', async () => {
+      mockStatsQuery.mockReturnValue({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+        refetch: vi.fn(),
+      });
+
+      const { container } = renderView('sara-rossi');
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('NotFoundShell passes axe a11y scan', async () => {
+      const { container } = renderView(null);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds `role="status"` + `aria-live="polite"` to `PlayerDetailView`'s `ErrorShell` and `NotFoundShell` containers (lines 188-209, 224-242). The loading skeleton already has `aria-busy="true"` + `aria-live="polite"` — this extends the same announcement consistency to the error and not-found FSM transitions so screen-reader users get parity across all 4 FSM cells.

## Test plan

- [x] 4 new tests in `PlayerDetailView.test.tsx` (#1547 describe block):
  - ErrorShell exposes `role="status"` + `aria-live="polite"`
  - NotFoundShell exposes `role="status"` + `aria-live="polite"`
  - ErrorShell passes axe a11y scan
  - NotFoundShell passes axe a11y scan
- [x] `pnpm vitest run PlayerDetailView.test.tsx` → **24/24 pass** (327ms)
- [x] `pnpm lint` → 0 errors (6 pre-existing warnings on unrelated files)
- [x] `pnpm typecheck` → 0 errors

## Refs

- Gap report: `admin-mockups/design_handoff/players-detail-gap-report.md § 2.3`
- Cluster #1485 player-detail follow-up: 1/5 (#1546) → 2/5 (#1546 + #1547)

Closes #1547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)