### PR TITLE
feat(player-detail): #1542 player achievements hook + count wire

### DIFF
--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -49,6 +49,7 @@ import {
   type PlayerTopGamesCardLabels,
 } from '@/components/features/player-detail';
 import { DetailPageLayout } from '@/components/ui/detail-layout';
+import { useAchievements } from '@/hooks/queries/useAchievements';
 import { usePlayerStatistics } from '@/hooks/queries/usePlayersFromRecords';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { PlayerStatistics } from '@/lib/api/schemas/play-records.schemas';
@@ -320,16 +321,22 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
     return tryLoadVisualTestFixture('default');
   }, [stateOverride]);
 
-  // ── Data hook (current user only — schema reality v1 carryover) ──────────
+  // ── Data hooks (current user only — schema reality v1 carryover) ─────────
   const statsQuery = usePlayerStatistics();
+  // #1542: pull achievements list to derive `achievementCount` from the real
+  // unlock count instead of the legacy hardcoded `0`. Graceful degrade: if the
+  // achievements query is still loading or errored, achievementCount stays 0.
+  const achievementsQuery = useAchievements();
 
   // ── Derived profile (fixture takes priority over real data) ─────────────
   const profile = useMemo<PlayerProfileFixture | null>(() => {
     if (fixture != null) return fixture;
     if (playerId == null) return null;
     if (statsQuery.data == null) return null;
-    return mapStatsToProfile(playerId, statsQuery.data);
-  }, [fixture, playerId, statsQuery.data]);
+    const base = mapStatsToProfile(playerId, statsQuery.data);
+    const unlockedCount = achievementsQuery.data?.filter(a => a.isUnlocked).length ?? 0;
+    return { ...base, achievementCount: unlockedCount };
+  }, [fixture, playerId, statsQuery.data, achievementsQuery.data]);
 
   // ── FSM state derivation ─────────────────────────────────────────────────
   const realKind = useMemo(() => {

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx
@@ -36,6 +36,14 @@ vi.mock('@/hooks/queries/usePlayersFromRecords', () => ({
   usePlayerStatistics: () => mockStatsQuery(),
 }));
 
+// ─── Mock useAchievements (#1542) ─────────────────────────────────────────────
+
+const mockAchievementsQuery = vi.fn();
+
+vi.mock('@/hooks/queries/useAchievements', () => ({
+  useAchievements: () => mockAchievementsQuery(),
+}));
+
 // ─── Mock visual fixture (IS_VISUAL_TEST_BUILD=false for most tests) ──────────
 
 vi.mock('@/lib/player-detail/player-detail-visual-test-fixture', () => ({
@@ -81,6 +89,13 @@ describe('PlayerDetailView', () => {
       isError: false,
       data: BASE_STATS,
       refetch: vi.fn(),
+    });
+    // #1542: achievements hook defaults to "loaded, empty list" so all existing
+    // tests get achievementCount=0 (same as the pre-#1542 hardcoded default).
+    mockAchievementsQuery.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [],
     });
   });
 

--- a/apps/web/src/components/profile/AchievementsGrid.tsx
+++ b/apps/web/src/components/profile/AchievementsGrid.tsx
@@ -2,33 +2,17 @@
 
 import React, { useState } from 'react';
 
-import { useQuery } from '@tanstack/react-query';
 import { Trophy, Lock, TrendingUp, Loader2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/primitives/button';
-import { apiClient } from '@/lib/api/client';
+import { useAchievements, type AchievementDto } from '@/hooks/queries/useAchievements';
 import { cn } from '@/lib/utils';
 
-export interface AchievementDto {
-  id: string;
-  code: string;
-  name: string;
-  description: string;
-  iconUrl: string;
-  points: number;
-  rarity: string;
-  category: string;
-  threshold: number;
-  progress: number | null;
-  isUnlocked: boolean;
-  unlockedAt: string | null;
-}
+// Re-export the type for downstream consumers (e.g. `lib/sessions-summary/fsm.ts`)
+// that imported it from this module before the hook extraction (#1542).
+export type { AchievementDto };
 
 type AchievementFilter = 'all' | 'earned' | 'locked' | 'in-progress';
-
-const achievementKeys = {
-  all: ['achievements'] as const,
-};
 
 function getStatus(a: AchievementDto): 'earned' | 'locked' | 'in-progress' {
   if (a.isUnlocked) return 'earned';
@@ -53,18 +37,7 @@ function getIcon(a: AchievementDto): string {
 export function AchievementsGrid(): React.ReactElement {
   const [filter, setFilter] = useState<AchievementFilter>('all');
 
-  const {
-    data: achievements,
-    isLoading,
-    error,
-  } = useQuery<AchievementDto[]>({
-    queryKey: achievementKeys.all,
-    queryFn: async () => {
-      const res = await apiClient.get<AchievementDto[]>('/api/v1/achievements');
-      return res ?? [];
-    },
-    staleTime: 5 * 60 * 1000,
-  });
+  const { data: achievements, isLoading, error } = useAchievements();
 
   const filtered = (achievements ?? []).filter(a => {
     if (filter === 'all') return true;

--- a/apps/web/src/hooks/queries/__tests__/useAchievements.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useAchievements.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * useAchievements hook unit tests (#1542).
+ *
+ * Mocks apiClient.get to verify:
+ *  - Hook calls the documented endpoint
+ *  - Returns parsed data on success
+ *  - Returns [] when the API returns null/undefined (defensive default)
+ *  - Surfaces errors via React Query's `error` state
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { apiClient } from '@/lib/api/client';
+
+import { useAchievements, type AchievementDto } from '../useAchievements';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const sampleAchievement: AchievementDto = {
+  id: '00000000-0000-0000-0000-000000000001',
+  code: 'first_win',
+  name: 'First Win',
+  description: 'Won your first game',
+  iconUrl: '🏆',
+  points: 10,
+  rarity: 'Common',
+  category: 'Gameplay',
+  threshold: 1,
+  progress: 100,
+  isUnlocked: true,
+  unlockedAt: '2026-06-01T12:00:00Z',
+};
+
+describe('useAchievements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls GET /api/v1/achievements and returns the parsed list', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce([sampleAchievement]);
+
+    const { result } = renderHook(() => useAchievements(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/achievements');
+    expect(result.current.data).toEqual([sampleAchievement]);
+  });
+
+  it('returns [] when the API returns null (defensive fallback)', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(null as unknown as AchievementDto[]);
+
+    const { result } = renderHook(() => useAchievements(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('surfaces the error when the API request fails', async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() => useAchievements(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe('network');
+  });
+});

--- a/apps/web/src/hooks/queries/useAchievements.ts
+++ b/apps/web/src/hooks/queries/useAchievements.ts
@@ -1,0 +1,57 @@
+/**
+ * React Query hook for the authenticated user's achievements.
+ *
+ * Mirrors the wire format of `Gamification.AchievementDto` (BE: Issue #3922).
+ * Endpoint: `GET /api/v1/achievements` (already exposed by `AchievementEndpoints.cs`).
+ *
+ * Consumers:
+ *  - `apps/web/src/components/profile/AchievementsGrid.tsx` — the full grid UI
+ *  - `apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx`
+ *    — derives `achievementCount` for the player overview header (#1542)
+ *
+ * @see Issue #1542 (player achievements list + FE hook, #1478 follow-up)
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+
+/**
+ * Achievement row as returned by `GET /api/v1/achievements`.
+ *
+ * Type mirrors `Api.BoundedContexts.Gamification.Application.DTOs.AchievementDto`
+ * (BE). Kept as an interface — no Zod parsing — to match the pattern already in
+ * `AchievementsGrid.tsx`; tighten with a Zod schema if/when the contract diverges.
+ */
+export interface AchievementDto {
+  id: string;
+  code: string;
+  name: string;
+  description: string;
+  iconUrl: string;
+  points: number;
+  rarity: string;
+  category: string;
+  threshold: number;
+  /** Progress toward unlock in [0, 100]. Null when not tracking. */
+  progress: number | null;
+  isUnlocked: boolean;
+  /** ISO date-time string. Null when not unlocked. */
+  unlockedAt: string | null;
+}
+
+export const achievementsKeys = {
+  all: ['achievements'] as const,
+};
+
+/** Fetch all achievements with the user's unlock status. */
+export function useAchievements() {
+  return useQuery<AchievementDto[]>({
+    queryKey: achievementsKeys.all,
+    queryFn: async () => {
+      const res = await apiClient.get<AchievementDto[]>('/api/v1/achievements');
+      return res ?? [];
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/docs/superpowers/plans/2026-06-02-fe-1542-player-achievements-hook.md
+++ b/docs/superpowers/plans/2026-06-02-fe-1542-player-achievements-hook.md
@@ -1,0 +1,86 @@
+# FE #1542 — player achievements hook + PlayerDetailView wire
+
+> **Status:** SHIPPED — implemented + tested + lint/typecheck pass.
+
+**Goal:** Wire the existing `GET /api/v1/achievements` endpoint (already implemented by `Gamification.GetAchievementsQueryHandler`, Issue #3922) into `PlayerDetailView.mapStatsToProfile` so `achievementCount` reflects the real unlock count instead of the legacy hardcoded `0`. Closes #1542.
+
+**P74 discovery (sessione 23, Step D):** the issue body described a missing BE endpoint + missing FE Zod/hook, but a fresh code audit revealed the BE is already 100% shipped via the **`Gamification`** bounded context (full repository pattern + cache + `AchievementRuleEvaluator` + `AchievementEvaluationJob` background job). The FE already consumed it via `AchievementsGrid.tsx` with an inline `useQuery`. Step D scope therefore reduces to extracting a shared hook and wiring it into the player overview.
+
+---
+
+## Architecture
+
+- **Hook extraction (DRY):** `apps/web/src/hooks/queries/useAchievements.ts` exports `useAchievements()` and re-exports `AchievementDto`. `AchievementsGrid.tsx` refactored to consume the shared hook (no behavioral change; same query key `['achievements']`, same staleTime 5min).
+- **PlayerDetailView wire (#1542 core):** `PlayerDetailView` calls both `usePlayerStatistics()` and `useAchievements()` in parallel; the `profile` `useMemo` derives `achievementCount = data?.filter(a => a.isUnlocked).length ?? 0`. Graceful degrade when achievements query is loading/errored (count stays 0).
+- **No new types/schemas:** the `AchievementDto` interface remains an inline TS interface (no Zod) — matches the pre-existing `AchievementsGrid` pattern; tighten with Zod when contract diverges.
+
+---
+
+## Locked Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| **DEC-1** | Reuse `Gamification.GetAchievementsQueryHandler` via existing `/api/v1/achievements` endpoint instead of creating a new `/players/me/achievements` endpoint | Wiegers / Fowler — DRY, single source of achievement data, no BE work |
+| **DEC-2** | Extract `useAchievements` hook to `apps/web/src/hooks/queries/` and refactor `AchievementsGrid` to consume it (vs duplicate hook with shared `AchievementDto`) | Fowler — single source of truth, smaller refactor than parallel hook+type duplicates |
+| **DEC-3** | Re-export `AchievementDto` from `AchievementsGrid.tsx` to preserve backward compatibility for downstream consumers (e.g. `lib/sessions-summary/fsm.ts` imports the type from this module) | Cockburn — minimize blast radius, no consumer-side breaking change |
+| **DEC-4** | Skip Zod schema parsing for now (mirror pre-existing inline interface pattern) | Adzic — minimal change; documented as MINOR tech-debt; revisit if contract diverges |
+| **DEC-5** | Graceful degrade `achievementCount = 0` when `useAchievements` is loading/errored (vs blocking render until achievements ready) | Wiegers — UX consistency with existing null-fallback fields like `leaderboardRank` |
+| **DEC-6** | Use `a.isUnlocked` (not progress > 0) as the unlock criterion for the count | Adzic — matches `Gamification.UserAchievement.IsUnlocked` semantics |
+| **DEC-7** | Profile `useMemo` dependency adds `achievementsQuery.data` (re-derive on achievements load) | Crispin — reactivity correctness, no manual invalidation needed |
+
+## G/W/T Scenarios
+
+- **A1**: G: user has 3 unlocked achievements + 2 locked → W: hook returns 5 items, PlayerDetailView derives count / T: `achievementCount === 3`
+- **A2**: G: useAchievements still loading (`data === undefined`) → W: PlayerDetailView renders / T: `achievementCount === 0` (graceful)
+- **A3**: G: useAchievements errored (`error != null`) → W: PlayerDetailView renders / T: `achievementCount === 0` (graceful)
+- **A4**: G: AchievementsGrid mounted → W: refactor to useAchievements hook / T: same render output as pre-refactor (no behavioral regression)
+- **A5**: G: API returns `null` → W: hook normalizes to `[]` (defensive) / T: `achievementCount === 0`
+- **A6**: G: hook called from any consumer → W: `apiClient.get('/api/v1/achievements')` invoked / T: assertion on mock
+
+---
+
+## File Structure
+
+| Path | Responsibility | Type |
+|------|---------------|------|
+| `apps/web/src/hooks/queries/useAchievements.ts` | Shared hook + `AchievementDto` interface | Create |
+| `apps/web/src/hooks/queries/__tests__/useAchievements.test.tsx` | 3 hook unit tests (success + null normalize + error) | Create |
+| `apps/web/src/components/profile/AchievementsGrid.tsx` | Refactor to consume shared hook; re-export `AchievementDto` for backcompat | Modify |
+| `apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx` | Add `useAchievements()` call + derive `achievementCount` in `profile` useMemo | Modify |
+| `apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx` | Add `vi.mock` for `useAchievements` + default `mockAchievementsQuery` returning `{data: []}` | Modify |
+| `docs/superpowers/plans/2026-06-02-fe-1542-player-achievements-hook.md` | This plan doc | Create |
+
+**Test commands:**
+- `cd apps/web && pnpm vitest run "src/hooks/queries/__tests__/useAchievements.test.tsx"`
+- `cd apps/web && pnpm vitest run "src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx"`
+- `cd apps/web && pnpm typecheck`
+- `cd apps/web && pnpm lint`
+
+---
+
+## Verification
+
+- ✅ `pnpm vitest run` useAchievements.test → **3/3 pass** (227ms)
+- ✅ `pnpm vitest run` PlayerDetailView.test → **24/24 pass** (337ms) — no regression after `useAchievements` mock added
+- ✅ `pnpm typecheck` → 0 errors
+- ✅ `pnpm lint` → 0 errors (6 pre-existing warnings on unrelated files)
+
+## Acceptance criteria
+
+- [x] FE Zod schema / hook ship with `useQuery` + cache + tests *(hook ✅; Zod skipped per DEC-4)*
+- [x] Orchestrator wires the achievement count from real data
+- [x] No regression in `AchievementBadgeGrid` (it stays compatible with `count` prop — the orchestrator passes `safeProfile.achievementCount` unchanged)
+
+## Out of scope
+
+- Zod schema for `AchievementDto` (DEC-4 — deferred MINOR tech-debt)
+- New `/players/me/achievements` endpoint (DEC-1 — superseded by existing `/api/v1/achievements`)
+- Refactor `AchievementBadgeGrid` placeholder → real achievement icon grid (post-MVP per #1542 body)
+
+## Cluster #1485 player-detail follow-up status
+
+- ✅ #1546 PlayerTopGamesCard (sessione 22)
+- ✅ #1547 a11y ErrorShell+NotFoundShell (Step B PR #1796)
+- ✅ #1540 + #1541 + #1550 BE bundle (Step C PR #1797)
+- ✅ **#1542 player achievements hook + wire (this PR, Step D)**
+- 🟡 #1549 PlayerTrendCard FE Tier L — Step E next (unblocked by Step C `WinRateTrend`)


### PR DESCRIPTION
## Summary

Wires the existing `GET /api/v1/achievements` endpoint (already shipped by `Gamification.GetAchievementsQueryHandler`, Issue #3922) into `PlayerDetailView.mapStatsToProfile` so `achievementCount` reflects the real unlock count instead of the legacy hardcoded `0`. Closes #1542.

## P74 discovery (sessione 23 Step D)

The issue body described "BE endpoint missing + FE Zod/hook missing", but a fresh audit revealed the BE is **already 100% shipped** via the `Gamification` bounded context (full repository pattern + cache + `AchievementRuleEvaluator` + `AchievementEvaluationJob` background job). The FE already consumed it inline via `AchievementsGrid.tsx` with `useQuery`. Step D reduces to:

1. **Hook extraction (DRY)**: new `apps/web/src/hooks/queries/useAchievements.ts` (shared hook + `AchievementDto` interface, mirrors `Gamification.AchievementDto` wire format)
2. **AchievementsGrid refactor**: consume shared hook (zero behavioral change; re-exports `AchievementDto` for downstream backcompat — `lib/sessions-summary/fsm.ts` imported the type from this module before)
3. **PlayerDetailView wire**: parallel `useAchievements()` call + derive `achievementCount = data?.filter(a => a.isUnlocked).length ?? 0` in the `profile` `useMemo`, replacing the legacy hardcoded `0` in `mapStatsToProfile`

## Architecture

- **DEC-1**: reuse existing `/api/v1/achievements` (vs new `/players/me/achievements`) — DRY single source of achievement data, no BE work
- **DEC-2**: extract hook (vs duplicate inline `useQuery`) — single source of truth
- **DEC-4**: skip Zod schema, match pre-existing inline interface pattern — tighten when contract diverges (deferred MINOR tech-debt)
- **DEC-5**: graceful degrade `achievementCount = 0` when query is loading/errored — UX consistency with other null-fallback fields like `leaderboardRank`

Plan + DEC-1..7 + G/W/T A1-A6 traceability: `docs/superpowers/plans/2026-06-02-fe-1542-player-achievements-hook.md`

## Test plan

- [x] `pnpm vitest run` useAchievements.test → **3/3 pass** (227ms) — success + null normalize + error
- [x] `pnpm vitest run` PlayerDetailView.test → **24/24 pass** (337ms) — no regression after `useAchievements` mock added
- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint` → 0 errors

## Cluster #1485 player-detail follow-up status

- ✅ #1546 PlayerTopGamesCard (sessione 22)
- ✅ #1547 a11y ErrorShell+NotFoundShell (Step B PR #1796)
- ✅ #1540 + #1541 + #1550 BE bundle (Step C PR #1797)
- ✅ **#1542 player achievements hook + wire (this PR, Step D)**
- 🟡 #1549 PlayerTrendCard FE Tier L — Step E next (unblocked by Step C `WinRateTrend`)

Closes #1542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)