### PR TITLE
feat(player-detail): #1549 PlayerTrendCard SVG line chart (#1485 follow-up F3)

### DIFF
--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -47,6 +47,7 @@ import {
   type PlayerLeaderboardCardLabels,
   type PlayerStatsGridLabels,
   type PlayerTopGamesCardLabels,
+  type PlayerTrendCardLabels,
 } from '@/components/features/player-detail';
 import { DetailPageLayout } from '@/components/ui/detail-layout';
 import { useAchievements } from '@/hooks/queries/useAchievements';
@@ -57,6 +58,7 @@ import { derivePlayerDetailUiState } from '@/lib/player-detail/player-detail-sta
 import {
   IS_VISUAL_TEST_BUILD,
   tryLoadVisualTestFixture,
+  type MonthlyWinRatePoint,
   type PlayerProfileFixture,
   type TopGameItem,
 } from '@/lib/player-detail/player-detail-visual-test-fixture';
@@ -183,6 +185,12 @@ function mapStatsToProfile(playerId: string, stats: PlayerStatistics): PlayerPro
 
   const displayName = decodeURIComponent(playerId).replace(/-/g, ' ');
 
+  // #1550 BE bundle: winRateTrend is optional during BE rollout. The mapper
+  // copies the values through; PlayerTrendCard handles points.length < 2 with
+  // a graceful empty state.
+  const trendPoints: ReadonlyArray<MonthlyWinRatePoint> =
+    stats.winRateTrend?.map(p => ({ month: p.month, winRate: p.winRate })) ?? [];
+
   return {
     playerId,
     displayName,
@@ -190,10 +198,14 @@ function mapStatsToProfile(playerId: string, stats: PlayerStatistics): PlayerPro
     totalWins,
     winRate,
     favoriteGameName: favoriteGameName && favoriteGameName.length > 0 ? favoriteGameName : null,
-    favoriteAgentName: null, // TBD: no favorite agent data in current schema
-    achievementCount: 0, // TBD: no achievement data in current schema
-    leaderboardRank: null, // TBD: no leaderboard data in current schema
+    // #1541 BE: favoriteAgentName populates once BE deploys the field; until then `?? null`.
+    favoriteAgentName: stats.favoriteAgentName ?? null,
+    // #1542 FE: achievementCount is overridden by the orchestrator (useAchievements hook).
+    achievementCount: 0,
+    // #1540 BE: leaderboardRank populates once BE deploys the field; until then `?? null`.
+    leaderboardRank: stats.leaderboardRank ?? null,
     topGames: deriveTopGames(stats),
+    trendPoints,
   };
 }
 
@@ -405,6 +417,35 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
     [t]
   );
 
+  const trendLabels = useMemo<PlayerTrendCardLabels>(
+    () => ({
+      title: t('pages.playerDetail.sections.trend.title'),
+      deltaUp: t('pages.playerDetail.sections.trend.deltaUp'),
+      deltaDown: t('pages.playerDetail.sections.trend.deltaDown'),
+      deltaFlat: t('pages.playerDetail.sections.trend.deltaFlat'),
+      deltaUpAriaLabel: t('pages.playerDetail.sections.trend.deltaUpAriaLabel'),
+      deltaDownAriaLabel: t('pages.playerDetail.sections.trend.deltaDownAriaLabel'),
+      deltaFlatAriaLabel: t('pages.playerDetail.sections.trend.deltaFlatAriaLabel'),
+      empty: t('pages.playerDetail.sections.trend.empty'),
+      trendSummaryAriaLabel: t('pages.playerDetail.sections.trend.trendSummaryAriaLabel'),
+      monthsShort: [
+        t('pages.playerDetail.sections.trend.monthsShort.jan'),
+        t('pages.playerDetail.sections.trend.monthsShort.feb'),
+        t('pages.playerDetail.sections.trend.monthsShort.mar'),
+        t('pages.playerDetail.sections.trend.monthsShort.apr'),
+        t('pages.playerDetail.sections.trend.monthsShort.may'),
+        t('pages.playerDetail.sections.trend.monthsShort.jun'),
+        t('pages.playerDetail.sections.trend.monthsShort.jul'),
+        t('pages.playerDetail.sections.trend.monthsShort.aug'),
+        t('pages.playerDetail.sections.trend.monthsShort.sep'),
+        t('pages.playerDetail.sections.trend.monthsShort.oct'),
+        t('pages.playerDetail.sections.trend.monthsShort.nov'),
+        t('pages.playerDetail.sections.trend.monthsShort.dec'),
+      ],
+    }),
+    [t]
+  );
+
   const achievementLabels = useMemo<AchievementBadgeGridLabels>(
     () => ({
       title: t('pages.playerDetail.sections.achievements.title'),
@@ -495,6 +536,7 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
     leaderboard: leaderboardLabels,
     favoriteAgent: favoriteAgentLabels,
     topGames: topGamesLabels,
+    trend: trendLabels,
   };
 
   const sessionsLabels: SessionsTabPanelLabels = {

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerOverviewRegion.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerOverviewRegion.tsx
@@ -15,10 +15,12 @@ import {
   PlayerLeaderboardCard,
   PlayerStatsGrid,
   PlayerTopGamesCard,
+  PlayerTrendCard,
   type FavoriteAgentCardLabels,
   type PlayerLeaderboardCardLabels,
   type PlayerStatsGridLabels,
   type PlayerTopGamesCardLabels,
+  type PlayerTrendCardLabels,
 } from '@/components/features/player-detail';
 import type { PlayerProfileFixture } from '@/lib/player-detail/player-detail-visual-test-fixture';
 
@@ -27,6 +29,7 @@ export interface PlayerOverviewRegionLabels {
   readonly leaderboard: PlayerLeaderboardCardLabels;
   readonly favoriteAgent: FavoriteAgentCardLabels;
   readonly topGames: PlayerTopGamesCardLabels;
+  readonly trend: PlayerTrendCardLabels;
 }
 
 export interface PlayerOverviewRegionProps {
@@ -62,6 +65,7 @@ export function PlayerOverviewRegion({
         />
       </div>
       <PlayerTopGamesCard items={stats.topGames} labels={labels.topGames} />
+      <PlayerTrendCard points={stats.trendPoints} labels={labels.trend} />
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerOverviewRegion.test.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerOverviewRegion.test.tsx
@@ -35,6 +35,31 @@ const labels = {
     rankAriaLabel: 'Posizione {rank}',
     empty: 'Nessun gioco giocato ancora',
   },
+  trend: {
+    title: 'Andamento ultimi 6 mesi',
+    deltaUp: '↗ +{percent}%',
+    deltaDown: '↘ {percent}%',
+    deltaFlat: '→ 0%',
+    deltaUpAriaLabel: 'Win rate in salita di {percent}%',
+    deltaDownAriaLabel: 'Win rate in discesa di {percent}%',
+    deltaFlatAriaLabel: 'Win rate invariato',
+    empty: 'Non ci sono ancora dati sufficienti per mostrare un trend',
+    trendSummaryAriaLabel: 'Andamento win rate da {from}% a {to}% negli ultimi {count} mesi',
+    monthsShort: [
+      'Gen',
+      'Feb',
+      'Mar',
+      'Apr',
+      'Mag',
+      'Giu',
+      'Lug',
+      'Ago',
+      'Set',
+      'Ott',
+      'Nov',
+      'Dic',
+    ],
+  },
 } as const;
 
 const profile: PlayerProfileFixture = {
@@ -51,6 +76,11 @@ const profile: PlayerProfileFixture = {
     { gameId: null, gameName: 'Azul', playCount: 10, winCount: 6 },
     { gameId: null, gameName: 'Catan', playCount: 8, winCount: 3 },
   ],
+  trendPoints: [
+    { month: '2026-04', winRate: 0.4 },
+    { month: '2026-05', winRate: 0.5 },
+    { month: '2026-06', winRate: 0.6 },
+  ],
 };
 
 describe('PlayerOverviewRegion', () => {
@@ -63,6 +93,7 @@ describe('PlayerOverviewRegion', () => {
     expect(container.querySelector('[data-slot="player-detail-leaderboard"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="player-detail-favorite-agent"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="player-detail-top-games"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="player-detail-trend"]')).not.toBeNull();
   });
 
   it('exposes a region root with data-slot="player-overview-region"', () => {

--- a/apps/web/src/components/features/player-detail/PlayerTrendCard.tsx
+++ b/apps/web/src/components/features/player-detail/PlayerTrendCard.tsx
@@ -1,0 +1,299 @@
+/**
+ * PlayerTrendCard — /players/[id] v2 component (issue #1549, #1485 follow-up F3).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-player-detail.jsx:594-636`
+ * (function `TrendCard`). Inline SVG line + gradient area chart showing the
+ * player's win-rate trend over the last 6 ISO months.
+ *
+ * Pure component: all i18n strings injected via `labels`. No hooks, no chart
+ * dep — handcrafted SVG keeps bundle weight under the Tier L budget.
+ *
+ * Renders:
+ *   - Title row + delta badge (↗ +N% / ↘ -N% / hidden when < 2 points)
+ *   - SVG line chart: gradient area + polyline + data-point circles
+ *   - Footer axis with short month labels per data point
+ *   - Empty state when points.length < 2
+ *
+ * Data source: `PlayerStatistics.WinRateTrend` (post-#1550 BE bundle); each
+ * entry is `{month: YYYY-MM, winRate: 0..1}`, already ordered ascending.
+ *
+ * WCAG:
+ *   - SVG is `aria-hidden="true"` (decorative). The trend datum is announced
+ *     via a sr-only summary so AT users get the same information.
+ *   - Delta arrow glyph is `aria-hidden`; the accessible name comes from the
+ *     interpolated `delta{Up,Down,Flat}AriaLabel`.
+ *   - Empty state uses `role="status"` for polite announcement.
+ *
+ * Refs #1485 gap report § 2.2, #1549, #1550.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+/**
+ * Single monthly bucket — the public input contract of `PlayerTrendCard`.
+ * Mirrors `PlayerStatistics.WinRateTrend` BE shape (#1550).
+ */
+export interface MonthlyWinRatePoint {
+  /** ISO `YYYY-MM`. Lexicographic comparison ⇒ chronological for this format. */
+  readonly month: string;
+  /** Win rate in [0, 1]. `0` is a valid datum (played but never won). */
+  readonly winRate: number;
+}
+
+export interface PlayerTrendCardLabels {
+  readonly title: string;
+  /** Template: "↗ +{percent}%" — `{percent}` substituted with integer ≥ 0. */
+  readonly deltaUp: string;
+  /** Template: "↘ {percent}%" — `{percent}` already includes the leading minus. */
+  readonly deltaDown: string;
+  /** Template: "→ 0%" — emitted when delta is exactly 0. */
+  readonly deltaFlat: string;
+  /** Template aria-label for positive delta. */
+  readonly deltaUpAriaLabel: string;
+  /** Template aria-label for negative delta. */
+  readonly deltaDownAriaLabel: string;
+  /** Aria-label when delta is exactly 0. */
+  readonly deltaFlatAriaLabel: string;
+  /** Shown when fewer than 2 points are available. */
+  readonly empty: string;
+  /**
+   * Short month labels (3 chars typically), indexed by 1-based ISO month
+   * (e.g. labels.monthsShort[0] = "Jan"/"Gen", labels.monthsShort[11] = "Dec"/"Dic").
+   */
+  readonly monthsShort: ReadonlyArray<string>;
+  /** Aria summary template: e.g. "Win rate trend from {from}% to {to}% over {count} months". */
+  readonly trendSummaryAriaLabel: string;
+}
+
+export interface PlayerTrendCardProps {
+  readonly points: ReadonlyArray<MonthlyWinRatePoint>;
+  readonly labels: PlayerTrendCardLabels;
+  readonly className?: string;
+}
+
+// ─── SVG geometry constants ───────────────────────────────────────────────────
+
+const SVG_VIEWBOX_WIDTH = 280;
+const SVG_VIEWBOX_HEIGHT = 100;
+const SVG_PADDING_Y = 8; // top/bottom padding so circles don't clip the viewbox
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function interpolate(template: string, values: Record<string, string | number>): string {
+  return Object.entries(values).reduce(
+    (acc, [key, val]) => acc.replace(`{${key}}`, String(val)),
+    template
+  );
+}
+
+/** Maps a winRate in [0, 1] to an SVG Y coordinate with top/bottom padding. */
+function toSvgY(winRate: number): number {
+  const usable = SVG_VIEWBOX_HEIGHT - 2 * SVG_PADDING_Y;
+  return SVG_PADDING_Y + (1 - winRate) * usable;
+}
+
+/** Distributes N points evenly across the X axis (first at 0, last at width). */
+function toSvgX(index: number, total: number): number {
+  if (total <= 1) return SVG_VIEWBOX_WIDTH / 2;
+  return (index / (total - 1)) * SVG_VIEWBOX_WIDTH;
+}
+
+/** Extracts the 1-based month number from an ISO YYYY-MM key. */
+function parseMonthNumber(monthIso: string): number | null {
+  const match = /^\d{4}-(\d{2})$/.exec(monthIso);
+  if (!match) return null;
+  const m = Number.parseInt(match[1] ?? '', 10);
+  return Number.isFinite(m) && m >= 1 && m <= 12 ? m : null;
+}
+
+interface DeltaInfo {
+  readonly direction: 'up' | 'down' | 'flat';
+  /** Absolute integer percentage difference (rounded). */
+  readonly absPercent: number;
+  /** Signed integer percentage difference (negative when down). */
+  readonly signedPercent: number;
+}
+
+/** Computes the rounded percentage delta from first to last point. */
+function computeDelta(points: ReadonlyArray<MonthlyWinRatePoint>): DeltaInfo | null {
+  if (points.length < 2) return null;
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (!first || !last) return null;
+  const diff = last.winRate - first.winRate;
+  const signed = Math.round(diff * 100);
+  const abs = Math.abs(signed);
+  if (signed > 0) return { direction: 'up', absPercent: abs, signedPercent: signed };
+  if (signed < 0) return { direction: 'down', absPercent: abs, signedPercent: signed };
+  return { direction: 'flat', absPercent: 0, signedPercent: 0 };
+}
+
+export function PlayerTrendCard({ points, labels, className }: PlayerTrendCardProps): ReactElement {
+  const hasEnoughPoints = points.length >= 2;
+  const delta = computeDelta(points);
+
+  return (
+    <div
+      data-slot="player-detail-trend"
+      className={clsx(
+        'flex flex-col gap-3 rounded-2xl border border-border bg-card p-4 shadow-sm',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="font-display text-[15px] font-extrabold text-foreground">{labels.title}</h3>
+        {delta != null ? <DeltaBadge delta={delta} labels={labels} /> : null}
+      </div>
+
+      {!hasEnoughPoints ? (
+        <p
+          data-slot="player-detail-trend-empty"
+          role="status"
+          className="text-sm text-muted-foreground"
+        >
+          {labels.empty}
+        </p>
+      ) : (
+        <>
+          <TrendChartSvg points={points} />
+          <TrendAxis points={points} labels={labels} />
+          {/* sr-only summary so AT users learn the trend without parsing the SVG */}
+          <span data-slot="player-detail-trend-summary" className="sr-only">
+            {interpolate(labels.trendSummaryAriaLabel, {
+              from: Math.round((points[0]?.winRate ?? 0) * 100),
+              to: Math.round((points[points.length - 1]?.winRate ?? 0) * 100),
+              count: points.length,
+            })}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Delta badge ──────────────────────────────────────────────────────────────
+
+function DeltaBadge({
+  delta,
+  labels,
+}: {
+  delta: DeltaInfo;
+  labels: PlayerTrendCardLabels;
+}): ReactElement {
+  let template: string;
+  let ariaTemplate: string;
+  let colorClass: string;
+
+  if (delta.direction === 'up') {
+    template = labels.deltaUp;
+    ariaTemplate = labels.deltaUpAriaLabel;
+    colorClass = 'text-emerald-700 dark:text-emerald-400';
+  } else if (delta.direction === 'down') {
+    template = labels.deltaDown;
+    ariaTemplate = labels.deltaDownAriaLabel;
+    colorClass = 'text-rose-700 dark:text-rose-400';
+  } else {
+    template = labels.deltaFlat;
+    ariaTemplate = labels.deltaFlatAriaLabel;
+    colorClass = 'text-muted-foreground';
+  }
+
+  // For deltaUp the template wants the unsigned percent (it provides the "+");
+  // for deltaDown the signed percent already carries the minus.
+  const percentToken = delta.direction === 'down' ? delta.signedPercent : delta.absPercent;
+
+  return (
+    <span
+      data-slot="player-detail-trend-delta"
+      className={clsx('font-mono text-[10px] font-bold tabular-nums', colorClass)}
+    >
+      <span aria-hidden="true">{interpolate(template, { percent: percentToken })}</span>
+      <span className="sr-only">{interpolate(ariaTemplate, { percent: delta.absPercent })}</span>
+    </span>
+  );
+}
+
+// ─── SVG line chart ───────────────────────────────────────────────────────────
+
+function TrendChartSvg({ points }: { points: ReadonlyArray<MonthlyWinRatePoint> }): ReactElement {
+  const coords = points.map((p, idx) => ({
+    x: toSvgX(idx, points.length),
+    y: toSvgY(p.winRate),
+  }));
+
+  const lineD = coords.map((c, idx) => `${idx === 0 ? 'M' : 'L'}${c.x},${c.y}`).join(' ');
+  const areaD = `${lineD} L${SVG_VIEWBOX_WIDTH},${SVG_VIEWBOX_HEIGHT} L0,${SVG_VIEWBOX_HEIGHT} Z`;
+
+  // Use a deterministic-but-unique gradient id so multiple cards on the page
+  // don't collide (e.g. fixture playground or future "compare two players"
+  // surfaces). React's `useId` would be cleaner; we keep this dependency-free.
+  const gradientId = `player-trend-grad-${points.length}-${Math.round(coords[0]?.y ?? 0)}`;
+
+  return (
+    <div className="relative h-[110px] w-full">
+      <svg
+        viewBox={`0 0 ${SVG_VIEWBOX_WIDTH} ${SVG_VIEWBOX_HEIGHT}`}
+        preserveAspectRatio="none"
+        className="h-full w-full text-violet-700 dark:text-violet-400"
+        aria-hidden="true"
+        data-slot="player-detail-trend-svg"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="0.35" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={areaD} fill={`url(#${gradientId})`} />
+        <path
+          d={lineD}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {coords.map((c, idx) => (
+          <circle
+            key={`${c.x.toFixed(2)}-${idx}`}
+            cx={c.x}
+            cy={c.y}
+            r="3"
+            fill="var(--card)"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+// ─── Axis labels ──────────────────────────────────────────────────────────────
+
+function TrendAxis({
+  points,
+  labels,
+}: {
+  points: ReadonlyArray<MonthlyWinRatePoint>;
+  labels: PlayerTrendCardLabels;
+}): ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      data-slot="player-detail-trend-axis"
+      className="flex justify-between font-mono text-[9px] font-bold text-muted-foreground"
+    >
+      {points.map((p, idx) => {
+        const monthNum = parseMonthNumber(p.month);
+        const label = monthNum != null ? (labels.monthsShort[monthNum - 1] ?? p.month) : p.month;
+        return <span key={`${p.month}-${idx}`}>{label}</span>;
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/features/player-detail/__tests__/PlayerTrendCard.test.tsx
+++ b/apps/web/src/components/features/player-detail/__tests__/PlayerTrendCard.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * PlayerTrendCard unit tests — /players/[id] v2 (#1549, #1485 follow-up F3).
+ *
+ * Coverage (mirror PlayerTopGamesCard.test pattern):
+ *   T1. Renders chart + delta badge with positive trend (rising win rate)
+ *   T2. Renders chart + delta badge with negative trend (falling win rate)
+ *   T3. Renders empty state when points.length < 2 (insufficient data)
+ *   T4. Computes flat-delta arrow when first and last win rates are equal
+ *   T5. Renders axis labels using monthsShort[N-1] from labels (i18n localization)
+ *   T6. Passes axe a11y scan in populated and empty states; SVG aria-hidden;
+ *       sr-only summary exposes the trend numerically.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+
+import { PlayerTrendCard } from '../PlayerTrendCard';
+import type { MonthlyWinRatePoint, PlayerTrendCardLabels } from '../PlayerTrendCard';
+
+const monthsShort = [
+  'Gen',
+  'Feb',
+  'Mar',
+  'Apr',
+  'Mag',
+  'Giu',
+  'Lug',
+  'Ago',
+  'Set',
+  'Ott',
+  'Nov',
+  'Dic',
+];
+
+const labels: PlayerTrendCardLabels = {
+  title: 'Andamento ultimi 6 mesi',
+  deltaUp: '↗ +{percent}%',
+  deltaDown: '↘ {percent}%',
+  deltaFlat: '→ 0%',
+  deltaUpAriaLabel: 'Andamento in salita di {percent}%',
+  deltaDownAriaLabel: 'Andamento in discesa di {percent}%',
+  deltaFlatAriaLabel: 'Andamento stabile',
+  empty: 'Non ci sono ancora dati sufficienti per mostrare un trend',
+  monthsShort,
+  trendSummaryAriaLabel: 'Andamento win rate da {from}% a {to}% negli ultimi {count} mesi',
+};
+
+const RISING: ReadonlyArray<MonthlyWinRatePoint> = [
+  { month: '2026-01', winRate: 0.4 },
+  { month: '2026-02', winRate: 0.5 },
+  { month: '2026-03', winRate: 0.6 },
+];
+
+const FALLING: ReadonlyArray<MonthlyWinRatePoint> = [
+  { month: '2026-04', winRate: 0.7 },
+  { month: '2026-05', winRate: 0.5 },
+  { month: '2026-06', winRate: 0.3 },
+];
+
+describe('PlayerTrendCard', () => {
+  it('T1: renders chart + positive delta badge when trend is rising', () => {
+    const { container } = render(<PlayerTrendCard points={RISING} labels={labels} />);
+
+    expect(screen.getByText('Andamento ultimi 6 mesi')).toBeInTheDocument();
+    // Last (0.6) - First (0.4) = 0.2 → 20% positive delta
+    expect(screen.getByText('↗ +20%')).toBeInTheDocument();
+    // SVG and summary present (chart rendered)
+    expect(container.querySelector('[data-slot="player-detail-trend-svg"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="player-detail-trend-summary"]')).not.toBeNull();
+  });
+
+  it('T2: renders chart + negative delta badge when trend is falling', () => {
+    render(<PlayerTrendCard points={FALLING} labels={labels} />);
+
+    // Last (0.3) - First (0.7) = -0.4 → -40% (template includes the minus)
+    expect(screen.getByText('↘ -40%')).toBeInTheDocument();
+    // Accessible name uses absolute value via deltaDownAriaLabel template.
+    expect(screen.getByText('Andamento in discesa di 40%')).toHaveClass('sr-only');
+  });
+
+  it('T3: renders empty state when points.length < 2', () => {
+    const { container } = render(
+      <PlayerTrendCard points={[{ month: '2026-06', winRate: 0.5 }]} labels={labels} />
+    );
+
+    const empty = screen.getByText('Non ci sono ancora dati sufficienti per mostrare un trend');
+    expect(empty).toBeInTheDocument();
+    expect(empty).toHaveAttribute('role', 'status');
+    // SVG and summary NOT rendered in empty state.
+    expect(container.querySelector('[data-slot="player-detail-trend-svg"]')).toBeNull();
+    expect(container.querySelector('[data-slot="player-detail-trend-summary"]')).toBeNull();
+    // Delta badge NOT rendered with insufficient data.
+    expect(container.querySelector('[data-slot="player-detail-trend-delta"]')).toBeNull();
+  });
+
+  it('T4: renders flat delta arrow when first and last win rates are equal', () => {
+    const flat: ReadonlyArray<MonthlyWinRatePoint> = [
+      { month: '2026-05', winRate: 0.5 },
+      { month: '2026-06', winRate: 0.5 },
+    ];
+    render(<PlayerTrendCard points={flat} labels={labels} />);
+
+    expect(screen.getByText('→ 0%')).toBeInTheDocument();
+    expect(screen.getByText('Andamento stabile')).toHaveClass('sr-only');
+  });
+
+  it('T5: renders axis labels using monthsShort[N-1] from i18n', () => {
+    const { container } = render(<PlayerTrendCard points={RISING} labels={labels} />);
+
+    const axis = container.querySelector('[data-slot="player-detail-trend-axis"]');
+    expect(axis).not.toBeNull();
+    // RISING covers months 01, 02, 03 → Gen, Feb, Mar.
+    expect(axis?.textContent).toContain('Gen');
+    expect(axis?.textContent).toContain('Feb');
+    expect(axis?.textContent).toContain('Mar');
+  });
+
+  it('T6: passes axe a11y scan in populated and empty states; SVG aria-hidden', async () => {
+    const populated = render(<PlayerTrendCard points={RISING} labels={labels} />);
+    const populatedResults = await axe(populated.container);
+    expect(populatedResults).toHaveNoViolations();
+    // SVG is decorative.
+    const svg = populated.container.querySelector('[data-slot="player-detail-trend-svg"]');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+    // sr-only summary exposes the trend numerically (40% → 60% over 3 months).
+    expect(
+      populated.container.querySelector('[data-slot="player-detail-trend-summary"]')
+    ).toHaveTextContent('Andamento win rate da 40% a 60% negli ultimi 3 mesi');
+    populated.unmount();
+
+    const empty = render(<PlayerTrendCard points={[]} labels={labels} />);
+    const emptyResults = await axe(empty.container);
+    expect(emptyResults).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/player-detail/index.ts
+++ b/apps/web/src/components/features/player-detail/index.ts
@@ -41,3 +41,10 @@ export type {
   PlayerTopGamesCardLabels,
   TopGameItem,
 } from '@/components/features/player-detail/PlayerTopGamesCard';
+
+export { PlayerTrendCard } from '@/components/features/player-detail/PlayerTrendCard';
+export type {
+  PlayerTrendCardProps,
+  PlayerTrendCardLabels,
+  MonthlyWinRatePoint,
+} from '@/components/features/player-detail/PlayerTrendCard';

--- a/apps/web/src/lib/player-detail/player-detail-visual-test-fixture.ts
+++ b/apps/web/src/lib/player-detail/player-detail-visual-test-fixture.ts
@@ -37,11 +37,13 @@ export const IS_VISUAL_TEST_BUILD = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_
 /** The two states the fixture can simulate for visual-regression purposes. */
 export type PlayerDetailFixtureState = 'default' | 'not-found';
 
-// Re-export the component-owned `TopGameItem` contract so the fixture and the
-// orchestrator share a single source of truth without coupling production code
-// to this test-fixture module's lifecycle.
+// Re-export component-owned contracts so the fixture and the orchestrator share
+// a single source of truth without coupling production code to this test-fixture
+// module's lifecycle.
 export type { TopGameItem } from '@/components/features/player-detail/PlayerTopGamesCard';
+export type { MonthlyWinRatePoint } from '@/components/features/player-detail/PlayerTrendCard';
 import type { TopGameItem } from '@/components/features/player-detail/PlayerTopGamesCard';
+import type { MonthlyWinRatePoint } from '@/components/features/player-detail/PlayerTrendCard';
 
 /** Shape of a player profile for display in the v2 player detail view. */
 export interface PlayerProfileFixture {
@@ -68,6 +70,12 @@ export interface PlayerProfileFixture {
    * The orchestrator slices to `maxItems` (default 5) inside the card.
    */
   topGames: ReadonlyArray<TopGameItem>;
+  /**
+   * Win-rate trend per ISO month (last 6 months sliding window). Empty array
+   * when there are no completed sessions in the window. Ordered ascending
+   * by month string (YYYY-MM lexicographic == chronological for ISO format).
+   */
+  trendPoints: ReadonlyArray<MonthlyWinRatePoint>;
 }
 
 /**
@@ -90,6 +98,14 @@ const FIXTURE_DEFAULT: PlayerProfileFixture = {
     { gameId: null, gameName: 'Catan', playCount: 8, winCount: 4 },
     { gameId: null, gameName: 'Carcassonne', playCount: 3, winCount: 2 },
     { gameId: null, gameName: 'Azul', playCount: 2, winCount: 1 },
+  ],
+  trendPoints: [
+    { month: '2026-01', winRate: 0.42 },
+    { month: '2026-02', winRate: 0.55 },
+    { month: '2026-03', winRate: 0.48 },
+    { month: '2026-04', winRate: 0.62 },
+    { month: '2026-05', winRate: 0.58 },
+    { month: '2026-06', winRate: 0.71 },
   ],
 };
 

--- a/docs/superpowers/plans/2026-06-02-fe-1549-player-trend-card.md
+++ b/docs/superpowers/plans/2026-06-02-fe-1549-player-trend-card.md
@@ -1,0 +1,101 @@
+# FE #1549 — PlayerTrendCard SVG line chart (#1485 follow-up F3)
+
+> **Status:** SHIPPED — implemented + tested + lint/typecheck pass.
+
+**Goal:** Implement `PlayerTrendCard` as a pure presentational component with inline SVG line + area chart showing the player's win-rate trend over the last 6 ISO months. Wire into `PlayerOverviewRegion` below `PlayerTopGamesCard`. Consumes `PlayerStatistics.WinRateTrend` (shipped by Step C, BE bundle PR #1797). Closes #1549.
+
+**Mockup source:** `admin-mockups/design_files/sp4-player-detail.jsx:594-636` (function `TrendCard`).
+
+---
+
+## Architecture
+
+- **Pure presentational SRP** — no hooks, no chart library dep, no `useMemo`. All i18n strings injected via `labels`. Mirror sibling pattern from `PlayerTopGamesCard` (sessione 22) and `PlayerLeaderboardCard`.
+- **Inline SVG** with `viewBox="0 0 280 100"` + `preserveAspectRatio="none"` (mockup parity). Gradient area + polyline + data-point circles. SVG is `aria-hidden="true"` (decorative); a `sr-only` summary span exposes the trend numerically to assistive tech.
+- **Delta badge** computes signed integer percentage from first→last winRate; renders ↗/↘/→ glyph + colored class. Aria label uses absolute value with directional template.
+- **Empty state** when `points.length < 2` — single point can't form a line.
+- **Color**: `text-violet-700 dark:text-violet-400` for line + area gradient (via `currentColor` + `stop-opacity`); `text-emerald-700` for positive delta, `text-rose-700` for negative, `text-muted-foreground` for flat.
+
+---
+
+## Locked Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| **DEC-1** | Inline SVG (no `recharts`/chart library) | Fowler — bundle weight; mockup uses 280×100 viewbox handcrafted; future tooltips out of scope |
+| **DEC-2** | `MonthlyWinRatePoint` owned by component (production input contract); fixture re-exports | Fowler — single source of truth, mirror DEC-2 of #1546 (M1 fix pattern) |
+| **DEC-3** | SVG dimensions are constants (`SVG_VIEWBOX_WIDTH=280`, `SVG_PADDING_Y=8`) — top/bottom padding so circles don't clip viewbox | Crispin — testable invariants, predictable layout |
+| **DEC-4** | Delta direction: `up` when last − first > 0, `down` when < 0, `flat` when == 0 (rounded to integer percent). 1 point → no delta badge | Wiegers — explicit FSM, no ambiguity |
+| **DEC-5** | `deltaUp` template includes the leading `+` ("↗ +{percent}%"); `deltaDown` template uses signed token ("↘ {percent}%" with leading minus) | Adzic — two explicit templates, no string concat conditional |
+| **DEC-6** | Delta accessible name uses absolute value (`deltaUpAriaLabel` says "+5%", `deltaDownAriaLabel` says "down by 5%") — no double-negative | Cockburn — natural-language phrasing |
+| **DEC-7** | `monthsShort` is a 12-element array indexed by ISO month - 1 (e.g. monthsShort[0] = "Jan") — passed via labels | Adzic — i18n parity en+it explicit |
+| **DEC-8** | Axis labels rendered as `<span>` per data point (1:1 with points); fallback to raw `YYYY-MM` when month parse fails | Wiegers — defensive against malformed input |
+| **DEC-9** | Empty state uses `role="status"` for polite AT announcement | Crispin — mirror PlayerTopGamesCard DEC-5 |
+| **DEC-10** | `useId` not used for gradient id — derive deterministic id from `points.length + first y` to avoid id collision when multiple cards render | Fowler — zero React dependency added, sufficient uniqueness for current usage |
+| **DEC-11** | Trend summary sr-only template: "Win rate trend from {from}% to {to}% over {count} months" — single sentence with first/last values | Adzic — AT users get the trend gist in one breath |
+
+## G/W/T Scenarios (T1-T6)
+
+- **T1**: G: 3 points 0.4/0.5/0.6 / W: render / T: "↗ +20%" badge, SVG and summary present
+- **T2**: G: 3 points 0.7/0.5/0.3 / W: render / T: "↘ -40%" badge, sr-only "down by 40%"
+- **T3**: G: 1 point / W: render / T: empty state with `role="status"`, no SVG/summary/delta
+- **T4**: G: 2 equal points / W: render / T: "→ 0%" badge, sr-only "Win rate unchanged"
+- **T5**: G: 3 points months 01/02/03 / W: render / T: axis shows "Gen Feb Mar" (i18n it)
+- **T6**: axe scan populated + empty → no violations; SVG aria-hidden true; sr-only summary "40% to 60% over 3 months"
+
+---
+
+## File Structure
+
+| Path | Responsibility | Type |
+|------|---------------|------|
+| `apps/web/src/components/features/player-detail/PlayerTrendCard.tsx` | Pure SVG line chart component + `MonthlyWinRatePoint` type + delta computation | Create |
+| `apps/web/src/components/features/player-detail/__tests__/PlayerTrendCard.test.tsx` | 6 unit tests (T1-T6) | Create |
+| `apps/web/src/components/features/player-detail/index.ts` | Barrel export (component + 3 types) | Modify |
+| `apps/web/src/lib/player-detail/player-detail-visual-test-fixture.ts` | Re-export `MonthlyWinRatePoint` from component; add `trendPoints` field to `PlayerProfileFixture`; populate `FIXTURE_DEFAULT.trendPoints` | Modify |
+| `apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx` | Add `trendLabels` useMemo (12 month labels + 8 strings); extend `mapStatsToProfile` to copy `stats.winRateTrend → trendPoints`; pass through `overviewLabels.trend` | Modify |
+| `apps/web/src/app/(authenticated)/players/[id]/_components/PlayerOverviewRegion.tsx` | Extend labels type + render `<PlayerTrendCard>` after `<PlayerTopGamesCard>` | Modify |
+| `apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerOverviewRegion.test.tsx` | Add `trendPoints` to fixture profile + `trend` labels object + assertion for new slot | Modify |
+| `apps/web/src/locales/en.json` | Add `pages.playerDetail.sections.trend.*` (8 strings + 12 monthsShort) | Modify |
+| `apps/web/src/locales/it.json` | Add `pages.playerDetail.sections.trend.*` (same shape, IT translations) | Modify |
+| `docs/superpowers/plans/2026-06-02-fe-1549-player-trend-card.md` | This plan doc | Create |
+
+**Test commands:**
+- `cd apps/web && pnpm vitest run src/components/features/player-detail/__tests__/PlayerTrendCard.test.tsx`
+- `cd apps/web && pnpm vitest run src/lib/player-detail src/components/features/player-detail src/app/\(authenticated\)/players/\[id\]/_components/__tests__`
+- `cd apps/web && pnpm typecheck`
+- `cd apps/web && pnpm lint`
+
+---
+
+## Verification
+
+- ✅ `pnpm vitest run` PlayerTrendCard.test → **6/6 pass** (170ms)
+- ✅ `pnpm vitest run` all player-detail tests → **104/104 pass** (incl. PlayerTopGamesCard 7 + new PlayerTrendCard 6 + PlayerOverviewRegion 3 + PlayerDetailView 24 + fixture 6 + state 12 + 9 sibling test files)
+- ✅ `pnpm typecheck` → 0 errors
+- ✅ `pnpm lint` → 0 errors (6 pre-existing warnings on unrelated files)
+
+## Acceptance criteria
+
+- [x] `PlayerTrendCard.tsx` created with props `{ points, labels, className? }`
+- [x] Inline SVG line + area gradient (mockup style); axis labels; rendered as a card with `bg-card border-border rounded-2xl p-4`
+- [x] Empty state when `points.length < 2` ("Not enough data to show a trend")
+- [x] DS-15 compliant + jest-axe assertion
+- [x] i18n keys `pages.playerDetail.sections.trend.{title, deltaUp, deltaDown, deltaFlat, deltaUpAriaLabel, deltaDownAriaLabel, deltaFlatAriaLabel, empty, trendSummaryAriaLabel, monthsShort.{jan..dec}}` added en+it
+- [x] Barrel export + orchestrator wiring in `PlayerOverviewRegion` (after `PlayerTopGamesCard`)
+
+## Out of scope
+
+- Tooltip on hover (mockup doesn't include it; defer)
+- Multi-line comparison chart (e.g. user vs avg) — single-line only
+- Time range selector (always last 6 months per spec)
+
+## Cluster #1485 player-detail follow-up status
+
+- ✅ #1546 PlayerTopGamesCard (sessione 22)
+- ✅ #1547 a11y ErrorShell+NotFoundShell (Step B PR #1796)
+- ✅ #1540 + #1541 + #1550 BE bundle (Step C PR #1797)
+- ✅ #1542 player achievements hook + wire (Step D PR #1798)
+- ✅ **#1549 PlayerTrendCard FE Tier L (this PR, Step E)**
+
+🎉 **Cluster #1485 player-detail follow-up: 5/5 done.**


### PR DESCRIPTION
## Summary

Implements `PlayerTrendCard` as a pure presentational component with inline SVG line + area gradient chart showing the player's win-rate trend over the last 6 ISO months. Wires into `PlayerOverviewRegion` below `PlayerTopGamesCard`. Consumes `PlayerStatistics.WinRateTrend` shipped by Step C BE bundle (PR #1797). Closes #1549.

🎉 **This PR closes Cluster #1485 player-detail follow-up: 5/5 done.**

## Architecture

- **Pure presentational SRP** — no hooks, no chart library dep (handcrafted SVG keeps bundle weight under the Tier L budget)
- **Inline SVG** with `viewBox="0 0 280 100"` + gradient area + polyline + data-point circles; SVG `aria-hidden`, `sr-only` summary exposes the trend numerically to assistive tech
- **Delta badge** — up/down/flat directions with colored class (emerald/rose/muted); aria labels use absolute value with directional template (no double-negative)
- **Empty state** when `points.length < 2` (single point can't form a line)
- **i18n**: 12-element `monthsShort` array indexed by ISO month − 1 (Jan..Dec en/it)

Plan + DEC-1..11 + G/W/T T1-T6 traceability: `docs/superpowers/plans/2026-06-02-fe-1549-player-trend-card.md`

## Test plan

- [x] `pnpm vitest run` PlayerTrendCard.test → **6/6 pass** (170ms)
- [x] `pnpm vitest run` all player-detail suite → **104/104 pass** (incl. PlayerOverviewRegion updated for new slot + PlayerDetailView wired with trendLabels)
- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint` → 0 errors

## Cluster #1485 player-detail follow-up — 🎉 COMPLETE

- ✅ #1546 PlayerTopGamesCard (sessione 22)
- ✅ #1547 a11y ErrorShell+NotFoundShell (Step B PR #1796)
- ✅ #1540 + #1541 + #1550 BE bundle (Step C PR #1797)
- ✅ #1542 player achievements hook + wire (Step D PR #1798)
- ✅ **#1549 PlayerTrendCard FE Tier L (this PR, Step E)**

Closes #1549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)