### PR TITLE
test(libro-detail): #1552 #1553 #1554 unit tests + a11y focus management

### DIFF
--- a/apps/web/src/components/features/gamebook/CampaignSetupDrawer.tsx
+++ b/apps/web/src/components/features/gamebook/CampaignSetupDrawer.tsx
@@ -22,6 +22,8 @@
 import {
   cloneElement,
   isValidElement,
+  useEffect,
+  useRef,
   useState,
   type MouseEvent,
   type ReactElement,
@@ -135,12 +137,33 @@ export function CampaignSetupDrawer({
     },
   });
 
+  const stepContainerRef = useRef<HTMLDivElement>(null);
+  const isInitialMountRef = useRef(true);
+
+  useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false;
+      return;
+    }
+    const container = stepContainerRef.current;
+    if (!container) return;
+    const focusable = container.querySelector<HTMLElement>(
+      'input:not([disabled]), button:not([disabled]):not([aria-disabled="true"]), [role="radio"]:not([aria-disabled="true"]), [tabindex="0"]'
+    );
+    if (focusable) {
+      focusable.focus();
+    } else {
+      container.focus();
+    }
+  }, [step]);
+
   function reset(): void {
     setOpen(false);
     setStep(1);
     setTitle('Campagna con i ragazzi');
     setPresetId('group-a');
     mutation.reset();
+    isInitialMountRef.current = true;
   }
 
   const trimmedTitle = title.trim();
@@ -190,7 +213,15 @@ export function CampaignSetupDrawer({
 
         <Stepper current={step} />
 
-        <div className="flex-1 overflow-y-auto px-4 py-3">
+        <div
+          ref={stepContainerRef}
+          tabIndex={-1}
+          aria-label={
+            step === 1 ? 'Step 1: Nome' : step === 2 ? 'Step 2: Giocatori' : 'Step 3: Conferma'
+          }
+          className="flex-1 overflow-y-auto px-4 py-3 outline-none"
+          data-testid="campaign-setup-step-content"
+        >
           {step === 1 && (
             <StepName
               title={title}

--- a/apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx
@@ -1,0 +1,457 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import type { ReactNode } from 'react';
+
+import * as client from '@/lib/api/gamebook-campaigns';
+
+import { CampaignSetupDrawer } from '../CampaignSetupDrawer';
+
+expect.extend(toHaveNoViolations);
+
+vi.mock('@/lib/api/gamebook-campaigns');
+const pushSpy = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushSpy }),
+}));
+
+/**
+ * Force desktop mode so Radix Dialog is used instead of Vaul.
+ * Vaul requires PointerEvent capture, scrollIntoView, and transform parsing
+ * APIs that jsdom does not implement. Radix Dialog renders cleanly in jsdom.
+ */
+function installDesktopMatchMedia(): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches: true, // (min-width: 768px) → true → desktop mode
+      media: '(min-width: 768px)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      onchange: null,
+    }),
+  });
+}
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  installDesktopMatchMedia();
+  pushSpy.mockReset();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Step 1: Name + Preset ───────────────────────────────────────────────────
+
+describe('CampaignSetupDrawer — Step 1 (Name + Preset)', () => {
+  it('renders title input + 3 preset radios when opened', () => {
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    expect(screen.getByTestId('campaign-setup-title')).toBeVisible();
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+
+    // Default preset "Gruppo A · I ragazzi" should be checked
+    const groupARadio = screen.getByText('Gruppo A · I ragazzi').closest('[role="radio"]');
+    expect(groupARadio).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('disables Next button when title is 2 chars or shorter', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'ab');
+
+    expect(screen.getByTestId('campaign-setup-next')).toBeDisabled();
+    expect(screen.getByText(/almeno 3 caratteri/i)).toBeInTheDocument();
+  });
+
+  it('enables Next button when title is 3+ chars', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'abc');
+
+    expect(screen.getByTestId('campaign-setup-next')).not.toBeDisabled();
+  });
+
+  it('switches preset and updates aria-checked', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    // Click on "Gruppo B · Coppia" radio
+    const gruppoBText = screen.getByText('Gruppo B · Coppia');
+    const gruppoBRadio = gruppoBText.closest('[role="radio"]');
+    await user.click(gruppoBRadio!);
+
+    expect(gruppoBRadio).toHaveAttribute('aria-checked', 'true');
+
+    // Gruppo A should now be unchecked
+    const gruppoAText = screen.getByText('Gruppo A · I ragazzi');
+    const gruppoARadio = gruppoAText.closest('[role="radio"]');
+    expect(gruppoARadio).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('jest-axe smoke on step 1 default render', async () => {
+    const { container } = wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    await waitFor(() => screen.getByTestId('campaign-setup-title'));
+
+    // aria-hidden-focus may fire for Radix portal elements mounted outside test container
+    const results = await axe(container, {
+      rules: { 'aria-hidden-focus': { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ─── Step 2: Players ─────────────────────────────────────────────────────────
+
+describe('CampaignSetupDrawer — Step 2 (Players)', () => {
+  it('renders host + guest chips for default preset group-a', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    // Type a valid title so Next is enabled
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Step 2 should show player chips for group-a (Aaron host + Marco + Giulia + Luca)
+    expect(screen.getByText('Aaron')).toBeInTheDocument();
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(screen.getByText('Giulia')).toBeInTheDocument();
+    expect(screen.getByText('Luca')).toBeInTheDocument();
+
+    // Host indicator
+    expect(screen.getByText(/Host · tu/)).toBeInTheDocument();
+
+    // "Aggiungi giocatore" button should be disabled
+    const addButton = screen.getByRole('button', { name: /Aggiungi giocatore/ });
+    expect(addButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows agent suggestion card with player count', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Agent suggestion card — "4 giocatori" appears in both the party heading and
+    // the agent <strong>, so use getAllByText to confirm at least one instance.
+    expect(screen.getByText(/Nanolith Tutor/)).toBeInTheDocument();
+    const playerCountMatches = screen.getAllByText(/4 giocatori/);
+    expect(playerCountMatches.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── Step 3: Confirm ─────────────────────────────────────────────────────────
+
+describe('CampaignSetupDrawer — Step 3 (Confirm)', () => {
+  it('renders review card with campaign metadata', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    // Step 1 → 2
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    // Step 2 → 3
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Review card
+    expect(screen.getByTestId('campaign-setup-review')).toBeInTheDocument();
+
+    // Campaign title heading
+    expect(screen.getByText('Test campaign')).toBeInTheDocument();
+
+    // Preset row
+    expect(screen.getByText('Preset')).toBeInTheDocument();
+    expect(screen.getByText('Gruppo A · I ragazzi')).toBeInTheDocument();
+
+    // Submit button
+    expect(screen.getByTestId('campaign-setup-submit')).toBeInTheDocument();
+  });
+});
+
+// ─── Footer + Submit ─────────────────────────────────────────────────────────
+
+describe('CampaignSetupDrawer — Footer + Submit', () => {
+  it('Back button text changes from "Annulla" on step 1 to "← Indietro" on step 2+', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    // Step 1: Back button says "Annulla"
+    expect(screen.getByTestId('campaign-setup-back')).toHaveTextContent(/Annulla/);
+
+    // Advance to step 2
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Step 2: Back button says "← Indietro"
+    expect(screen.getByTestId('campaign-setup-back')).toHaveTextContent(/Indietro/);
+  });
+
+  it('clicking Back on step 2 returns to step 1', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    // Advance to step 2
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Confirm we are on step 2 (title input not visible)
+    expect(screen.queryByTestId('campaign-setup-title')).not.toBeInTheDocument();
+
+    // Go back
+    await user.click(screen.getByTestId('campaign-setup-back'));
+
+    // We should be back on step 1
+    expect(screen.getByTestId('campaign-setup-title')).toBeInTheDocument();
+  });
+
+  it('submit success: calls createCampaign and navigates', async () => {
+    vi.mocked(client.createCampaign).mockResolvedValueOnce({
+      id: 'c1',
+      gameRefId: 'g1',
+      gameRefKind: 0,
+      ownerUserId: 'u',
+      title: 'Test campaign',
+      currentParagraph: 0,
+      history: [],
+      lastReadAt: '2026-06-02T00:00:00Z',
+      createdAt: '2026-06-02T00:00:00Z',
+      updatedAt: '2026-06-02T00:00:00Z',
+    } as never);
+
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    // Step 1 → 2 → 3
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    await user.click(screen.getByTestId('campaign-setup-submit'));
+
+    await waitFor(() =>
+      expect(client.createCampaign).toHaveBeenCalledWith({ gameId: 'g1', title: 'Test campaign' })
+    );
+    await waitFor(() => expect(pushSpy).toHaveBeenCalledWith('/library/g1/play/c1'));
+  });
+
+  it('submit error: shows error message', async () => {
+    vi.mocked(client.createCampaign).mockRejectedValueOnce(new Error('Boom failure'));
+
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    await user.click(screen.getByTestId('campaign-setup-submit'));
+
+    await waitFor(() => expect(screen.getByText(/Boom failure/)).toBeInTheDocument());
+  });
+
+  it('submit pending: button text changes to "Creazione…" and disables', async () => {
+    // Never-resolving promise — keeps mutation in pending state
+    vi.mocked(client.createCampaign).mockImplementationOnce(() => new Promise(() => {}));
+
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    await user.click(screen.getByTestId('campaign-setup-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('campaign-setup-submit')).toHaveTextContent(/Creazione/)
+    );
+    expect(screen.getByTestId('campaign-setup-submit')).toBeDisabled();
+  });
+});
+
+// ─── Focus Management (#1554) ─────────────────────────────────────────────────
+
+describe('CampaignSetupDrawer — Focus management (#1554)', () => {
+  it('does NOT move focus on initial mount (preserves autoFocus on title input)', async () => {
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+    // The title input has autoFocus and should retain focus on first render.
+    // If the useEffect([step]) fires on initial mount, focus would jump to the
+    // step container (tabIndex=-1) instead — that's the regression we guard against.
+    const titleInput = await screen.findByTestId('campaign-setup-title');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(titleInput);
+    });
+  });
+
+  it('step 1 → 2: focus moves into step 2 region after Next click', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    const nextBtn = screen.getByTestId('campaign-setup-next');
+    await user.click(nextBtn);
+
+    // Focus must have moved away from the Next button, into the step content
+    // container — and not vacuously passed by landing on document.body.
+    const stepContent = await screen.findByTestId('campaign-setup-step-content');
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(nextBtn);
+      expect(document.activeElement).not.toBe(document.body);
+      expect(
+        stepContent.contains(document.activeElement) || document.activeElement === stepContent
+      ).toBe(true);
+    });
+  });
+
+  it('step 2 → 3: focus moves into step 3 region after Next click', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    // Advance to step 2
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Advance to step 3
+    const nextBtn = screen.getByTestId('campaign-setup-next');
+    await user.click(nextBtn);
+
+    // Focus must have moved away from the Next button, into the step content
+    // container — and not vacuously passed by landing on document.body.
+    const stepContent = await screen.findByTestId('campaign-setup-step-content');
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(nextBtn);
+      expect(document.activeElement).not.toBe(document.body);
+      expect(
+        stepContent.contains(document.activeElement) || document.activeElement === stepContent
+      ).toBe(true);
+    });
+  });
+
+  it('step 3 → 2 (back): focus moves into step 2 region after Back click', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    // Advance to step 3
+    await user.click(screen.getByTestId('campaign-setup-next'));
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Go back to step 2
+    const backBtn = screen.getByTestId('campaign-setup-back');
+    await user.click(backBtn);
+
+    // Focus must have moved away from the Back button, into the step content
+    // container — and not vacuously passed by landing on document.body.
+    const stepContent = await screen.findByTestId('campaign-setup-step-content');
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(backBtn);
+      expect(document.activeElement).not.toBe(document.body);
+      expect(
+        stepContent.contains(document.activeElement) || document.activeElement === stepContent
+      ).toBe(true);
+    });
+  });
+
+  it('modal-trap regression: focus stays inside the drawer after step change', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // After step change, focus must remain inside the drawer
+    await waitFor(() => {
+      const drawer = screen.getByTestId('campaign-setup-drawer');
+      expect(drawer.contains(document.activeElement)).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+import { LibroGameDetailView } from '../LibroGameDetailView';
+
+expect.extend(toHaveNoViolations);
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/components/features/gamebook/NanolithCampaignCTA', () => ({
+  NanolithCampaignCTA: ({ gameId, gameTitle }: { gameId: string; gameTitle: string }) => (
+    <div data-testid="mock-nanolith-cta">
+      CTA {gameId} {gameTitle}
+    </div>
+  ),
+}));
+
+// ─── Fixture helper ─────────────────────────────────────────────────────────
+
+function makeLibraryGameDetail(overrides: Partial<LibraryGameDetail> = {}): LibraryGameDetail {
+  return {
+    libraryEntryId: 'l1',
+    userId: 'u1',
+    gameId: 'g1',
+    addedAt: '2026-01-01T00:00:00Z',
+    notes: null,
+    isFavorite: false,
+    currentState: 'owned',
+    stateChangedAt: null,
+    stateNotes: null,
+    isAvailableForPlay: true,
+    hasCustomPdf: false,
+    hasRagAccess: false,
+    gameTitle: 'Nanolith',
+    gamePublisher: 'Kosmos',
+    gameYearPublished: 2024,
+    gameIconUrl: null,
+    gameImageUrl: null,
+    description: 'Test description',
+    minPlayers: 2,
+    maxPlayers: 4,
+    playingTimeMinutes: 90,
+    complexityRating: null,
+    averageRating: 7.5,
+    timesPlayed: 3,
+    lastPlayed: null,
+    winRate: null,
+    avgDuration: null,
+    ...overrides,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('LibroGameDetailView', () => {
+  it('renders default tab "info" with InfoPanel', () => {
+    const gameDetail = makeLibraryGameDetail();
+    render(<LibroGameDetailView gameDetail={gameDetail} />);
+
+    expect(screen.getByText('Descrizione')).toBeVisible();
+    expect(screen.getByText('Test description')).toBeVisible();
+    expect(screen.getByText('Knowledge base')).toBeVisible();
+  });
+
+  it('renders all 4 MetaStat cells with formatted values', () => {
+    const gameDetail = makeLibraryGameDetail({
+      minPlayers: 2,
+      maxPlayers: 4,
+      playingTimeMinutes: 90,
+      averageRating: 7.5,
+      gameYearPublished: 2024,
+    });
+    render(<LibroGameDetailView gameDetail={gameDetail} />);
+
+    expect(screen.getByText('2–4')).toBeVisible();
+    expect(screen.getByText('1–2h')).toBeVisible();
+    expect(screen.getByText('7.5')).toBeVisible();
+    expect(screen.getByText('2024')).toBeVisible();
+
+    // MetaStat labels are inside the meta grid div
+    const metaLabels = screen.getAllByText('giocatori');
+    expect(metaLabels[0]).toBeVisible();
+    expect(screen.getByText('durata')).toBeVisible();
+    expect(screen.getByText('BGG')).toBeVisible();
+    expect(screen.getByText('anno')).toBeVisible();
+  });
+
+  it('renders 5 Pip chips with correct aria-labels', () => {
+    const gameDetail = makeLibraryGameDetail({
+      chunkCount: 3,
+      sessionsCount: 5,
+      hasRagAccess: true,
+      timesPlayed: 2,
+    });
+    render(<LibroGameDetailView gameDetail={gameDetail} />);
+
+    expect(screen.getByLabelText('KB 3')).toBeVisible();
+    expect(screen.getByLabelText('chat 0')).toBeVisible();
+    expect(screen.getByLabelText('Tutor 1')).toBeVisible();
+    expect(screen.getByLabelText('giocatori 0')).toBeVisible();
+    expect(screen.getByLabelText('partite 5')).toBeVisible();
+  });
+
+  it('switches tabs and shows placeholder text', async () => {
+    const gameDetail = makeLibraryGameDetail();
+    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    const user = userEvent.setup();
+
+    // Click AI Chat tab
+    await user.click(screen.getByRole('tab', { name: 'AI Chat' }));
+    expect(screen.getByText(/Pannello/i)).toBeVisible();
+    // Verify placeholder panel is visible by checking both the label and complete text together
+    const chatPanel = screen.getByRole('tabpanel');
+    expect(chatPanel).toHaveTextContent('Pannello');
+    expect(chatPanel).toHaveTextContent('AI Chat');
+    expect(chatPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+
+    // Click Toolbox tab
+    await user.click(screen.getByRole('tab', { name: 'Toolbox' }));
+    const toolboxPanel = screen.getByRole('tabpanel');
+    expect(toolboxPanel).toHaveTextContent('Toolbox');
+    expect(toolboxPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+
+    // Click Toolkit tab
+    await user.click(screen.getByRole('tab', { name: 'Toolkit' }));
+    const toolkitPanel = screen.getByRole('tabpanel');
+    expect(toolkitPanel).toHaveTextContent('Toolkit');
+    expect(toolkitPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+  });
+
+  it("KB badge variant: kbStatus='indexing'", () => {
+    const gameDetail = makeLibraryGameDetail({ kbStatus: 'indexing' });
+    render(<LibroGameDetailView gameDetail={gameDetail} />);
+
+    expect(screen.getByText('Indicizzazione in corso…')).toBeVisible();
+    expect(screen.getByText(/pipeline OCR\/embedding/)).toBeVisible();
+  });
+
+  it("KB badge variant: kbStatus='error'", () => {
+    const gameDetail = makeLibraryGameDetail({ kbStatus: 'error' });
+    render(<LibroGameDetailView gameDetail={gameDetail} />);
+
+    // The source uses smart quote in "l'indicizzazione" — use regex to match
+    expect(screen.getByText(/Errore durante l.indicizzazione/)).toBeVisible();
+    expect(screen.getByText(/hanno fallito il processing/)).toBeVisible();
+  });
+
+  it('jest-axe smoke — no a11y violations on default render', async () => {
+    const gameDetail = makeLibraryGameDetail();
+    const { container } = render(<LibroGameDetailView gameDetail={gameDetail} />);
+
+    const results = await axe(container, {
+      rules: {
+        // InfoPanel starts with h3 inside tabpanel; heading hierarchy isolated per panel OK
+        'heading-order': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/lib/games/__tests__/is-libro-game.test.ts
+++ b/apps/web/src/lib/games/__tests__/is-libro-game.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { isLibroGame } from '../is-libro-game';
+
+describe('isLibroGame', () => {
+  it('returns true for Nanolith', () => {
+    expect(isLibroGame({ gameTitle: 'Nanolith' })).toBe(true);
+  });
+
+  it('returns false for non-allowlisted title (Catan)', () => {
+    expect(isLibroGame({ gameTitle: 'Catan' })).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isLibroGame({ gameTitle: '' })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isLibroGame({ gameTitle: null })).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isLibroGame({ gameTitle: undefined })).toBe(false);
+    expect(isLibroGame({})).toBe(false);
+  });
+});

--- a/docs/superpowers/plans/2026-06-02-fe-libro-detail-test-bundle.md
+++ b/docs/superpowers/plans/2026-06-02-fe-libro-detail-test-bundle.md
@@ -1,0 +1,150 @@
+# Plan — Libro Detail Test Bundle (#1552 + #1553 + #1554)
+
+**Date**: 2026-06-02
+**Issues**: #1552 (test LibroGameDetailView + isLibroGame) + #1553 (test CampaignSetupDrawer) + #1554 (a11y focus drawer step)
+**Parent epic / cluster**: #1486 libro-detail conformity follow-up
+**Branch**: `feature/issue-1552-libro-detail-test-bundle` from `main-dev`
+**Effort**: ~3-4h (Tier S+M+XS bundle)
+**Type**: FE-only, no BE deps, no schema changes
+**Risk**: Low — characterization tests + small a11y polish
+
+---
+
+## Scope summary
+
+Three follow-up issues from libro-detail gap report (`admin-mockups/design_handoff/libro-detail-gap-report.md`):
+
+1. **#1552 (S, ~1h)** — Unit tests for `LibroGameDetailView` (337 LOC, tab state + subcomponents + KB badge variants) and `isLibroGame` utility (24 LOC, allowlist detection).
+2. **#1553 (M, ~2h)** — Unit tests for `CampaignSetupDrawer` (515 LOC, 3-step wizard FSM + form validation + preset selection + submit branches).
+3. **#1554 (XS, ~30min)** — A11y focus management when `CampaignSetupDrawer` step changes via Next/Back: move keyboard focus to first interactive element of new step.
+
+Single PR `feat(libro-detail)` bundle. Closes #1552, #1553, #1554.
+
+---
+
+## DEC locked (spec-panel critique)
+
+- **DEC-1** — Bundle PR singolo, 2 commit logici: (a) `test(libro-detail)`: tutti i nuovi file test, (b) `chore(libro-detail)`: focus a11y useEffect+ref + estensione test (`chore` per a11y polish — P148 commitlint type-enum).
+- **DEC-2** — TDD ordering: T1 utility → T2 presentational → T3 FSM baseline → T4 focus RED → T5 source GREEN → T6 final verify. (T1+T2+T3 sono characterization tests, T4 è genuine TDD).
+- **DEC-3** — jest-axe 1× per file su default render. Utility `is-libro-game.test.ts` skip axe (pure function).
+- **DEC-4** — Focus management strategy: `useRef<HTMLDivElement>(null)` su step content container, `useEffect([step])` dopo skip-initial-mount guard chiama `ref.current?.querySelector<HTMLElement>('button:not([disabled]), input:not([disabled]), [role="radio"]')` e `.focus()`. Pattern stabilizzato (no dipendenza da external focus-management hook).
+- **DEC-5** — NO mock i18n (componenti non usano hooks i18n, strings hardcoded italiano).
+- **DEC-6** — Fixture `LibraryGameDetail`: helper `makeLibraryGameDetail()` con minimal valid object + override params per case-specific test. Co-located in test file (non in shared fixture lib, scope locale).
+- **DEC-7** — Mock pattern (eredita NewCampaignDialog.test.tsx pattern): `vi.mock('@/lib/api/gamebook-campaigns')` + `vi.mock('next/navigation')` con pushSpy. Drawer test richiede `installMatchMedia(true)` + jsdom PointerEvent/scrollIntoView shims (pattern da `drawer.test.tsx`).
+
+## G/W/T scenarios
+
+### S1 — Utility `isLibroGame` (#1552 part 1)
+- **G** `gameTitle = 'Nanolith'`, **W** `isLibroGame({ gameTitle })`, **T** `=== true`
+- 4 negativi: `'Catan'`, `''`, `null`, `undefined` → tutti `false`
+
+### S2 — `LibroGameDetailView` default render (#1552 part 2)
+- **G** `gameDetail` minimal valid, **W** mount component, **T** tab `'info'` active + `InfoPanel` rendered + 4 `MetaStat` cells + 5 `Pip` chips + KB badge row + jest-axe `0 violations`
+
+### S3 — `LibroGameDetailView` tab switch (#1552 part 2)
+- **G** default render, **W** `userEvent.click(getByRole('tab', { name: 'AI Chat' }))`, **T** `getByText(/Pannello AI Chat · in arrivo/)` visible
+
+### S4 — `LibroGameDetailView` KB badge variants (#1552 part 2)
+- 4 case parameterized: `kbStatus='ready'`, `kbStatus='indexing'`, `kbStatus='error'`, fallback `hasRagAccess=true`, fallback `hasRagAccess=false` → assert title text matches
+
+### S5 — `CampaignSetupDrawer` Step 1 (#1553 part 1)
+- **G** drawer open step 1, **W** type 2 char in title, **T** Next button disabled + error message `≥ 3 caratteri`
+- **W** type 3+ char, **T** Next enabled, error gone
+- **W** click preset radio `group-b`, **T** `aria-checked='true'` su radio + altri 2 `aria-checked='false'`
+
+### S6 — `CampaignSetupDrawer` Step 2 + Step 3 (#1553 part 2)
+- **G** advance to step 2, **T** 4 player chips visible (Aaron host + 3 guest preset group-a) + agent suggestion card
+- **G** advance to step 3, **T** review card with campaign title + preset name + ManaPips list
+
+### S7 — `CampaignSetupDrawer` submit branches (#1553 part 3)
+- **G** step 3, **W** click Submit + createCampaign resolves, **T** `pushSpy` called with `/library/g1/play/<campaignId>`
+- **G** step 3, **W** click Submit + createCampaign rejects, **T** error message visible
+- **G** step 3 mid-mutation, **T** button text `Creazione…` + `disabled`
+
+### S8 — `CampaignSetupDrawer` focus management (#1554)
+- **G** drawer open step 1, **W** click Next button, **T** `document.activeElement` matches first focusable in step 2 (host chip area — but step 2 has no interactive elements except disabled "Aggiungi giocatore" button → fallback target: footer Next button? Need to re-verify mockup)
+- **G** drawer open step 2, **W** click Next, **T** activeElement matches first focusable in step 3 (Submit button if step 3 is review-only)
+- **G** drawer open step 3, **W** click Back, **T** activeElement matches first focusable in step 2
+- **NOTE**: Step 2 has only disabled "Aggiungi giocatore" — interactive elements in step 2 are `[role="button"]` chips which are not focusable by default. May need to **add `tabIndex={-1}` to step container** as fallback focus target if no focusable child exists. Decision deferred to T5 source implementation.
+
+---
+
+## Task breakdown
+
+| # | Task | Effort | Files | Mode |
+|---|------|--------|-------|------|
+| **T1** | `is-libro-game.test.ts` — 5 case + axe skip | XS | NEW `apps/web/src/lib/games/__tests__/is-libro-game.test.ts` | mechanical (haiku) |
+| **T2** | `LibroGameDetailView.test.tsx` — ~7 case (S2/S3/S4) | S | NEW `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx` | mechanical (haiku) |
+| **T3** | `CampaignSetupDrawer.test.tsx` baseline (S5/S6/S7) — ~12 case | M | NEW `apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx` | stateful (sonnet) |
+| **T4** | Extend CampaignSetupDrawer.test.tsx with focus assertions (S8) — 3 case + step-2 fallback assertion | XS | EDIT same file as T3 | judgment (sonnet) — **RED expected** |
+| **T5** | Implement focus management in CampaignSetupDrawer.tsx | XS | EDIT `apps/web/src/components/features/gamebook/CampaignSetupDrawer.tsx` | source change (sonnet) — **GREEN expected** |
+| **T6** | Final verify | XS | run typecheck + lint + test scope | verify (sonnet) |
+
+**Total**: ~35-40 test cases new, 1 source file modified, 3 test files created.
+
+---
+
+## Acceptance criteria traceability
+
+### #1552 AC
+- [ ] `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx` created (T2)
+- [ ] Covers tab state (default `info`, switch to other tabs) (S3)
+- [ ] Covers `MetaStat` rendering (S2)
+- [ ] Covers `Pip` rendering (S2)
+- [ ] Covers `InfoPanel` with description + KB status (S4)
+- [ ] Covers placeholder text "in arrivo con la prossima iter" (S3)
+- [ ] `apps/web/src/lib/games/__tests__/is-libro-game.test.ts` created (T1)
+- [ ] Covers allowlist `['Nanolith']` → true; other titles → false; empty/undefined → false (S1)
+- [ ] jest-axe assertion on default render (S2)
+- [ ] `pnpm typecheck && pnpm lint && pnpm test` PASS (T6)
+
+### #1553 AC
+- [ ] `apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx` created (T3)
+- [ ] Covers Step 1: title input rendering, preset radio cards, validation error <3 chars, Next disabled until valid (S5)
+- [ ] Covers Step 2: host chip + guest chips + agent suggestion (S6)
+- [ ] Covers Step 3: review card with meta + ManaPips (S6)
+- [ ] Covers footer: Back/Next/Submit/Cancel handlers (S7)
+- [ ] Covers submit branches: `mutation.isPending` → "Creazione…" + disabled, error branch shows message (S7)
+- [ ] jest-axe assertion on at least one step (S5 default render = step 1)
+- [ ] `pnpm typecheck && pnpm lint && pnpm test` PASS (T6)
+
+### #1554 AC
+- [ ] Step 1 → 2 moves focus to first interactive element of step 2 (S8)
+- [ ] Step 2 → 3 moves focus to first interactive element of step 3 (S8)
+- [ ] Step 3 → 2 (back) moves focus (S8)
+- [ ] Unit test asserts `document.activeElement` after setStep (T4)
+- [ ] No regression in modal-trap behavior — focus stays inside drawer (verify via Radix focus-trap default + no regressions in existing CampaignSetupDrawer.test.tsx submit flow)
+
+---
+
+## Out of scope (deferred / not addressed)
+
+- i18n migration of hardcoded Italian strings — separate concern, not in #1552/#1553 AC
+- Additional KB badge variants beyond 4 documented (no other states in source)
+- Wiring of "Aggiungi giocatore" button (disabled by design, per `// Iter 4 — wire-up in iter futuro`)
+- Cross-browser focus management verification (jsdom only, real-browser Playwright deferred to e2e)
+- Integration test for `/library/[gameId]` page consuming `LibroGameDetailView` — already covered by `apps/web/src/app/(authenticated)/library/[gameId]/__tests__/page.test.tsx` (mocks component, verifies orchestrator wiring)
+
+---
+
+## Pipeline standard (sessione precedente verified)
+
+1. ✅ Branch hygiene (HEAD main-dev, status clean, pull --ff-only)
+2. ✅ Feature branch + parent config
+3. ✅ Plan doc (this file)
+4. T1+T2 subagent haiku mechanical (parallel possibile — independent files)
+5. T3 subagent sonnet stateful
+6. T4 subagent sonnet judgment (RED expected)
+7. T5 subagent sonnet source change (GREEN expected)
+8. T6 verify
+9. Final code-reviewer feature-dev:code-reviewer sonnet
+10. Commit 2× + push + PR open + body
+11. CI watch (3 FE Tests shards + FE Static + FE Fast + GitGuardian + CodeQL) + merge normale no-admin (baseline #1773 resolved per memoria)
+12. Cleanup branch
+
+## References
+
+- Gap report: `admin-mockups/design_handoff/libro-detail-gap-report.md § 5 (a11y) + § 6 (test coverage) + § 8 F3`
+- Pattern test analogo: `apps/web/src/components/features/gamebook/__tests__/NewCampaignDialog.test.tsx`
+- Pattern Drawer test: `apps/web/src/components/ui/drawer/drawer.test.tsx` (matchMedia + PointerEvent shims)
+- Source: `LibroGameDetailView.tsx` (337 LOC), `CampaignSetupDrawer.tsx` (515 LOC), `is-libro-game.ts` (24 LOC)


### PR DESCRIPTION
## Summary

Bundle of 3 follow-up issues from **#1486** libro-detail conformity audit ([`libro-detail-gap-report.md`](../admin-mockups/design_handoff/libro-detail-gap-report.md) § 5 + § 6 + § 8):

- **#1552** Test S — Unit tests for `LibroGameDetailView` (337 LOC) + `isLibroGame` utility (24 LOC)
- **#1553** Test M — Unit tests for `CampaignSetupDrawer` (515 LOC, 3-step FSM wizard)
- **#1554** A11y XS — Focus management on drawer step change (keyboard a11y, WCAG 2.4.3)

**Plan**: [`docs/superpowers/plans/2026-06-02-fe-libro-detail-test-bundle.md`](../docs/superpowers/plans/2026-06-02-fe-libro-detail-test-bundle.md)

## Changes

### Test files (NEW)
- `apps/web/src/lib/games/__tests__/is-libro-game.test.ts` — 5 tests (allowlist detection: Nanolith→true, Catan/empty/null/undefined→false)
- `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx` — 7 tests (default tab `info`, 4 MetaStat cells, 5 Pip chips, tab switch placeholder, KB badge variants `indexing`+`error`, jest-axe smoke)
- `apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx` — 18 tests (3-step FSM baseline + 5 focus management)

### Source (1 file modified)
- `apps/web/src/components/features/gamebook/CampaignSetupDrawer.tsx` (+32/-1)
  - Added `useRef<HTMLDivElement>(null)` on step content container + `useRef<boolean>(true)` for skip-initial-mount guard
  - Added `useEffect([step])` querying first focusable (`input/button:not([disabled]), [role="radio"]:not([aria-disabled="true"])`) and calling `.focus()`; fallback to container `.focus()` via `tabIndex={-1}`
  - Container gains `aria-label` per step ('Step 1: Nome' / 'Step 2: Giocatori' / 'Step 3: Conferma') for screen reader announcement
  - `reset()` re-arms skip-initial-mount guard

## DEC locked (spec-panel critique)

- **DEC-1** Bundle PR singolo, 2 commit logici (`test(libro-detail)` + `chore(libro-detail)`).
- **DEC-2** TDD ordering: T1+T2+T3 characterization tests → T4 focus assertion RED → T5 source GREEN → T6 verify.
- **DEC-3** jest-axe 1× per file su default render. Utility skip axe (pure function).
- **DEC-4** Focus strategy: `useRef` step container + `useEffect([step])` + first-focusable query + fallback `container.focus()` via `tabIndex={-1}` + `isInitialMountRef` skip-initial guard.
- **DEC-5** NO mock i18n (componenti non usano hooks i18n).
- **DEC-6** Fixture `LibraryGameDetail`: helper `makeLibraryGameDetail()` co-located in test file.
- **DEC-7** Mock pattern eredita NewCampaignDialog.test.tsx (`vi.mock` createCampaign + useRouter) + drawer.test.tsx pattern (`matchMedia` forzato desktop per Radix).

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors (6 pre-existing warnings in unrelated files)
- [x] `pnpm vitest run` — **30/30** new tests pass (5 + 7 + 18)
- [x] No regression in `/library/[gameId]/__tests__/page.test.tsx` (6/6 still passing)
- [x] Final code-reviewer APPROVED_WITH_NOTES — M2 (vacuous focus assertion) fixed inline + coverage gap #1554 initial-mount skip added inline

## Closes

- Closes #1552 — test(libro-detail): LibroGameDetailView + isLibroGame unit tests
- Closes #1553 — test(libro-detail): CampaignSetupDrawer unit tests
- Closes #1554 — a11y(libro-detail): focus management on drawer step change

## Deferred review notes (follow-up PR — non-blocking)

From code-reviewer APPROVED_WITH_NOTES feedback (3 MAJOR + 2 MINOR, all confidence ≤85%):

- **M1** `installDesktopMatchMedia` uses no-op listener shims vs canonical `Set<Listener>` in `drawer.test.tsx`. Functional impact: nil (Drawer reads `matchMedia.matches` synchronously, no change events). Maintenance concern only.
- **M3** `vi.clearAllMocks` + `vi.restoreAllMocks` lifecycle redundancy. Functional impact: low (each `beforeEach` re-installs matchMedia). Cleanup concern.
- **mn1** Fixture comment in `LibroGameDetailView.test.tsx` mentions `chunkCount: 3` but `agent` Pip count uses `hasRagAccess` only — documentation clarity, no defect.
- **mn2** `as never` cast on `createCampaign` mock return — bypasses DTO shape type-check. Quick fix: replace with `as GamebookCampaignDto`.
- **Coverage gaps** #1552: `kbStatus='ready'` + `hasRagAccess` fallback variants not explicitly tested (only `indexing` + `error` are). AC `InfoPanel with description + KB status` is covered via default-render test that exercises `'KB non ancora indicizzato'` fallback path.

## Pipeline reference

Sessione 24 — pattern P67/P74/P107/P120/P124/P133/P145/P148/P150 standard oliata. Single PR cluster #1486 follow-up bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)