### PR TITLE
refactor(api/document-processing): #1801 unify nameof(PdfProcessingState) usage

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
@@ -474,7 +475,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 pdfId, pdfGuid, allDocumentChunks, embeddings!, pdfDoc, fullText!, db, scope, cancellationToken).ConfigureAwait(false);
 
             // Mark as completed
-            pdfDoc.ProcessingState = "Ready";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -519,7 +520,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
 
             if (!extractResult.Success)
             {
-                pdfDoc.ProcessingState = "Failed";
+                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
                 pdfDoc.ProcessingError = extractResult.ErrorMessage;
                 pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -633,7 +634,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
 
         if (!embeddingResult.Success)
         {
-            pdfDoc.ProcessingState = "Failed";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
             pdfDoc.ProcessingError = embeddingResult.ErrorMessage;
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -647,7 +648,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
         {
             var mismatchMessage = $"Embedding service returned {embeddings.Count} vectors for {allDocumentChunks.Count} chunks";
             _logger.LogWarning("Embedding count mismatch for PDF {PdfId}: {Message}", pdfId, mismatchMessage);
-            pdfDoc.ProcessingState = "Failed";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
             pdfDoc.ProcessingError = mismatchMessage;
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -788,7 +789,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 var pdfDoc = await db.PdfDocuments.FindAsync(new object[] { pdfGuid }, cancellationToken).ConfigureAwait(false);
                 if (pdfDoc != null)
                 {
-                    pdfDoc.ProcessingState = "Failed";
+                    pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
                     pdfDoc.ProcessingError = ex.Message;
                     pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
                     await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
 using Api.Services.Pdf;
@@ -72,7 +73,7 @@ internal class ExtractPdfTextCommandHandler : ICommandHandler<ExtractPdfTextComm
         try
         {
             // 3. Update status to processing
-            pdf.ProcessingState = "Extracting";
+            pdf.ProcessingState = nameof(PdfProcessingState.Extracting);
             pdf.ExtractingStartedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -87,7 +88,7 @@ internal class ExtractPdfTextCommandHandler : ICommandHandler<ExtractPdfTextComm
             {
                 _logger.LogError("Text extraction failed for PDF {PdfId}: {Error}",
                     pdfId, extractResult.ErrorMessage);
-                pdf.ProcessingState = "Failed";
+                pdf.ProcessingState = nameof(PdfProcessingState.Failed);
                 pdf.ProcessingError = extractResult.ErrorMessage;
                 pdf.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
                 await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -106,7 +107,7 @@ internal class ExtractPdfTextCommandHandler : ICommandHandler<ExtractPdfTextComm
             pdf.ExtractedText = fullText;
             pdf.PageCount = extractResult.TotalPages;
             pdf.CharacterCount = extractResult.TotalCharacters;
-            pdf.ProcessingState = "Ready";
+            pdf.ProcessingState = nameof(PdfProcessingState.Ready);
             pdf.ProcessingError = null;
             pdf.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Configuration;
 using Api.Infrastructure;
@@ -74,7 +75,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
             }
 
             // Track processing state: mark as Indexing (covers chunk + embed + index phases)
-            pdf!.ProcessingState = "Indexing";
+            pdf!.ProcessingState = nameof(PdfProcessingState.Indexing);
             pdf.IndexingStartedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -83,7 +84,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 pdfId, pdf.ExtractedText!, cancellationToken).ConfigureAwait(false);
             if (!chunkingSuccess)
             {
-                pdf.ProcessingState = "Failed";
+                pdf.ProcessingState = nameof(PdfProcessingState.Failed);
                 return await MarkIndexingFailedAsync(vectorDoc!, chunkingError!, chunkErrorCode!.Value, cancellationToken).ConfigureAwait(false);
             }
 
@@ -95,7 +96,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 pdfId, effectiveGameId.ToString(), pdf.ExtractedText!, documentChunks!, vectorDoc!, cancellationToken).ConfigureAwait(false);
             if (!indexingSuccess)
             {
-                pdf.ProcessingState = "Failed";
+                pdf.ProcessingState = nameof(PdfProcessingState.Failed);
                 return await MarkIndexingFailedAsync(vectorDoc!, "Vector indexing failed", PdfIndexingErrorCode.VectorIndexingFailed, cancellationToken).ConfigureAwait(false);
             }
 
@@ -105,7 +106,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
             await SaveTextChunksToPostgresAsync(pdfId, chunkGameId, pdf.SharedGameId, documentChunks!, cancellationToken).ConfigureAwait(false);
 
             // Mark processing complete
-            pdf.ProcessingState = "Ready";
+            pdf.ProcessingState = nameof(PdfProcessingState.Ready);
             pdf.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             pdf.IsActiveForRag = true; // Auto-enable after successful indexing so vectors are searchable
 
@@ -145,7 +146,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                     .FirstOrDefaultAsync(p => p.Id.ToString() == pdfId, CancellationToken.None).ConfigureAwait(false);
                 if (failedPdf != null)
                 {
-                    failedPdf.ProcessingState = "Failed";
+                    failedPdf.ProcessingState = nameof(PdfProcessingState.Failed);
                     failedPdf.ProcessingError = $"Unexpected error: {ex.Message}";
                     await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
                 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,7 @@ internal sealed class PurgeStaleDocumentsCommandHandler
         foreach (var doc in staleDocs)
         {
             var originalState = doc.ProcessingState;
-            doc.ProcessingState = "Failed";
+            doc.ProcessingState = nameof(PdfProcessingState.Failed);
             doc.ProcessingError = "Processing timed out (stale) - purged by admin";
             doc.ErrorCategory = "Service";
             doc.FailedAtState = originalState;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -167,7 +167,7 @@ internal partial class UploadPdfCommandHandler
 
         // Mark as processing (optimistic locking)
         _logger.LogInformation("🔄 [PDF-DEBUG-VALIDATE] Updating status from 'pending' to 'processing'");
-        pdfDoc.ProcessingState = "Uploading";
+        pdfDoc.ProcessingState = nameof(PdfProcessingState.Uploading);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("✅ [PDF-DEBUG-VALIDATE] Status updated, proceeding with processing");
 
@@ -211,7 +211,7 @@ internal partial class UploadPdfCommandHandler
             {
                 RecordPipelineMetricSafely("extraction_error", 0);
                 await UpdateProgressAsync(db, pdfId, ProcessingStep.Failed, 0, 0, startTime, extractResult.ErrorMessage, cancellationToken).ConfigureAwait(false);
-                pdfDoc.ProcessingState = "Failed";
+                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
                 pdfDoc.ProcessingError = extractResult.ErrorMessage;
                 pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -459,7 +459,7 @@ internal partial class UploadPdfCommandHandler
     {
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Failed, 0, 0, startTime, errorMessage, cancellationToken).ConfigureAwait(false);
         await quotaService.ReleaseQuotaAsync(userId, pdfId, CancellationToken.None).ConfigureAwait(false);
-        pdfDoc.ProcessingState = "Failed";
+        pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
         pdfDoc.ProcessingError = errorMessage;
         pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -701,7 +701,7 @@ internal partial class UploadPdfCommandHandler
         var totalPages = pdfDoc.PageCount ?? 0;
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Completed, totalPages, totalPages, startTime, null, cancellationToken).ConfigureAwait(false);
 
-        pdfDoc.ProcessingState = "Ready";
+        pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
         pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -749,7 +749,7 @@ internal partial class UploadPdfCommandHandler
                 .ConfigureAwait(false);
             if (pdfDoc != null)
             {
-                pdfDoc.ProcessingState = "Failed";
+                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
                 pdfDoc.ProcessingError = "Processing cancelled by user";
                 pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
                 await db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
@@ -783,7 +783,7 @@ internal partial class UploadPdfCommandHandler
                 .ConfigureAwait(false);
             if (pdfDoc != null)
             {
-                pdfDoc.ProcessingState = "Failed";
+                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
                 pdfDoc.ProcessingError = errorMessage;
                 pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/PdfDocumentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/PdfDocumentDto.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+
 namespace Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 
 /// <summary>
@@ -15,7 +17,7 @@ internal record PdfDocumentDto(
     int? PageCount,
     string DocumentType = "base", // Issue #2051: base, expansion, errata, homerule
     bool IsPublic = false, // Admin Wizard: Public library visibility
-    string ProcessingState = "Pending", // Issue #5186: granular 7-state pipeline (PdfProcessingState enum value)
+    string ProcessingState = nameof(PdfProcessingState.Pending), // Issue #5186: granular 7-state pipeline (PdfProcessingState enum value)
     int ProgressPercentage = 0, // Issue #5186: 0-100 based on current state
     int RetryCount = 0, // Issue #5186: number of retries attempted
     int MaxRetries = 3, // Issue #5186: always 3 per domain model

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.IntegrationEvents;
 using MediatR;
@@ -31,8 +32,8 @@ internal sealed class VectorDocumentReadyStateHandler
         CancellationToken cancellationToken)
     {
         // Only update if state is not already Ready or Failed
-        if (string.Equals(evt.CurrentProcessingState, "Ready", StringComparison.Ordinal)
-            || string.Equals(evt.CurrentProcessingState, "Failed", StringComparison.Ordinal))
+        if (string.Equals(evt.CurrentProcessingState, nameof(PdfProcessingState.Ready), StringComparison.Ordinal)
+            || string.Equals(evt.CurrentProcessingState, nameof(PdfProcessingState.Failed), StringComparison.Ordinal))
         {
             return;
         }
@@ -43,7 +44,7 @@ internal sealed class VectorDocumentReadyStateHandler
 
         if (pdfEntity != null)
         {
-            pdfEntity.ProcessingState = "Ready";
+            pdfEntity.ProcessingState = nameof(PdfProcessingState.Ready);
             await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetAllPdfsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetAllPdfsQueryHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.SharedKernel.Application.Interfaces;
@@ -37,15 +38,15 @@ internal sealed class GetAllPdfsQueryHandler : IQueryHandler<GetAllPdfsQuery, Pd
         {
             pdfsQuery = query.Status.ToLowerInvariant() switch
             {
-                "completed" => pdfsQuery.Where(p => p.ProcessingState == "Ready"),
-                "failed" => pdfsQuery.Where(p => p.ProcessingState == "Failed"),
-                "pending" => pdfsQuery.Where(p => p.ProcessingState == "Pending"),
+                "completed" => pdfsQuery.Where(p => p.ProcessingState == nameof(PdfProcessingState.Ready)),
+                "failed" => pdfsQuery.Where(p => p.ProcessingState == nameof(PdfProcessingState.Failed)),
+                "pending" => pdfsQuery.Where(p => p.ProcessingState == nameof(PdfProcessingState.Pending)),
                 "processing" => pdfsQuery.Where(p =>
-                    p.ProcessingState == "Uploading" ||
-                    p.ProcessingState == "Extracting" ||
-                    p.ProcessingState == "Chunking" ||
-                    p.ProcessingState == "Embedding" ||
-                    p.ProcessingState == "Indexing"),
+                    p.ProcessingState == nameof(PdfProcessingState.Uploading) ||
+                    p.ProcessingState == nameof(PdfProcessingState.Extracting) ||
+                    p.ProcessingState == nameof(PdfProcessingState.Chunking) ||
+                    p.ProcessingState == nameof(PdfProcessingState.Embedding) ||
+                    p.ProcessingState == nameof(PdfProcessingState.Indexing)),
                 _ => pdfsQuery
             };
         }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfAnalyticsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfAnalyticsQueryHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -38,13 +39,13 @@ internal class GetPdfAnalyticsQueryHandler : IRequestHandler<GetPdfAnalyticsQuer
 
         // Counts
         var totalUploaded = await timeFilteredQuery.CountAsync(cancellationToken).ConfigureAwait(false);
-        var successCount = await timeFilteredQuery.CountAsync(p => p.ProcessingState == "Ready", cancellationToken).ConfigureAwait(false);
-        var failedCount = await timeFilteredQuery.CountAsync(p => p.ProcessingState == "Failed", cancellationToken).ConfigureAwait(false);
+        var successCount = await timeFilteredQuery.CountAsync(p => p.ProcessingState == nameof(PdfProcessingState.Ready), cancellationToken).ConfigureAwait(false);
+        var failedCount = await timeFilteredQuery.CountAsync(p => p.ProcessingState == nameof(PdfProcessingState.Failed), cancellationToken).ConfigureAwait(false);
         var successRate = totalUploaded > 0 ? (decimal)successCount / totalUploaded * 100 : 0m;
 
         // Processing times from documents with completed processing
         var durations = await timeFilteredQuery
-            .Where(p => p.ProcessingState == "Ready" && p.ProcessedAt != null)
+            .Where(p => p.ProcessingState == nameof(PdfProcessingState.Ready) && p.ProcessedAt != null)
             .Select(p => new { p.UploadedAt, p.ProcessedAt })
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -88,8 +89,8 @@ internal class GetPdfAnalyticsQueryHandler : IRequestHandler<GetPdfAnalyticsQuer
             {
                 Date = g.Key,
                 TotalCount = g.Count(),
-                SuccessCount = g.Count(p => p.ProcessingState == "Ready"),
-                FailedCount = g.Count(p => p.ProcessingState == "Failed")
+                SuccessCount = g.Count(p => p.ProcessingState == nameof(PdfProcessingState.Ready)),
+                FailedCount = g.Count(p => p.ProcessingState == nameof(PdfProcessingState.Failed))
             })
             .OrderBy(d => d.Date)
             .ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -137,7 +137,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 langResult.DetectedLanguage, langResult.Confidence, pdfDoc.Id);
 
             // Issue #4215: Transition to Chunking state
-            pdfDoc.ProcessingState = "Chunking";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Chunking);
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             // Step 3: Chunk text
@@ -313,7 +313,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             }
 
             // Issue #4215: Transition to Embedding state
-            pdfDoc.ProcessingState = "Embedding";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Embedding);
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             // Step 4a: Generate embeddings (for all chunks: original + translated)
@@ -322,7 +322,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             var embeddings = await GenerateEmbeddingsAsync(pdfDoc, allChunkInputs, cancellationToken).ConfigureAwait(false);
 
             // Issue #4215: Transition to Indexing state
-            pdfDoc.ProcessingState = "Indexing";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Indexing);
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             // Step 4b: Index in pgvector
@@ -331,7 +331,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             await SaveTextChunksAsync(pdfDoc, allChunkInputs, cancellationToken).ConfigureAwait(false);
 
             // Issue #4215: Mark as Ready (final state)
-            pdfDoc.ProcessingState = "Ready";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
             pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -721,7 +721,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     private async Task MarkFailedAsync(PdfDocumentEntity pdfDoc, string errorMessage)
     {
         // Issue #4215: Use Failed state
-        pdfDoc.ProcessingState = "Failed";
+        pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
         pdfDoc.ProcessingError = errorMessage;
         pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
         await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
@@ -740,10 +740,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 .ConfigureAwait(false);
 
             if (pdfDoc != null
-                && !string.Equals(pdfDoc.ProcessingState, "Ready", StringComparison.Ordinal))
+                && !string.Equals(pdfDoc.ProcessingState, nameof(PdfProcessingState.Ready), StringComparison.Ordinal))
             {
                 // Issue #4215: Use Failed state
-                pdfDoc.ProcessingState = "Failed";
+                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
                 pdfDoc.ProcessingError = errorMessage.Length > 500
                     ? errorMessage[..500]
                     : errorMessage;


### PR DESCRIPTION
## Summary

Closes #1801 (partial — see Scope refinement below). Sostituisce **43 raw string literals** + 1 DTO default value con riferimenti `nameof(PdfProcessingState.X)` nei file del BC `DocumentProcessing`, per garantire rename-safety end-to-end.

## Scope refinement

L'issue originale prevedeva il refactor anche di `ReindexDocumentCommandHandler.cs` (1 literal line 83 + `InFlightStates` HashSet → `Enum.GetNames` derive). Quel file è stato introdotto/esteso da [PR #1800](https://github.com/meepleAi-app/meepleai-monorepo/pull/1800) (#1673 reindex version selector) ancora aperta.

Per evitare duplicazione di codice / merge conflict tra PR sorelle, **lo scope di questa PR si ferma agli altri 9 file**. Il refactor del Reindex handler verrà fatto in una mini-PR follow-up post-merge di #1800.

## Changes (9 files, 44 substitutions)

| File | Δ |
|------|---|
| `PdfProcessingPipelineService.cs` | 7 literals → `nameof()` (5 assignments + 1 comparison + 1 Failed reassignment) |
| `CompleteChunkedUploadCommandHandler.cs` | 5 literals → `nameof()` |
| `VectorDocumentReadyStateHandler.cs` | 3 literals → `nameof()` (1 assignment + 2 comparisons) |
| `ExtractPdfTextCommandHandler.cs` | 3 literals → `nameof()` |
| `IndexPdfCommandHandler.cs` | 5 literals → `nameof()` |
| `PurgeStaleDocumentsCommandHandler.cs` | 1 literal → `nameof()` |
| `UploadPdfCommandHandler.Processing.cs` | 6 literals → `nameof()` |
| `GetAllPdfsQueryHandler.cs` | 8 literals → `nameof()` (LINQ predicates) |
| `GetPdfAnalyticsQueryHandler.cs` | 5 literals → `nameof()` (LINQ predicates) |
| `PdfDocumentDto.cs` | 1 default param value → `nameof()` |

`using Api.BoundedContexts.DocumentProcessing.Domain.Enums;` aggiunto a 7 file che non lo avevano.

## Test plan

- [x] Build clean (0 errors, 0 new warnings)
- [x] `dotnet test --filter "BoundedContext=DocumentProcessing&Category=Unit"` → **318 passed, 0 failed**
- [x] No wire format change (gli stati continuano a serializzarsi come stringhe PascalCase identiche)
- [x] No DTO change visibile al client
- [x] No migration

## Notes

- **Semantica wire invariata**: `nameof(PdfProcessingState.Ready)` è risolto a compile-time alla stringa `"Ready"` identica al literal precedente.
- **EF Core compatibility**: `nameof()` nei LINQ expression tree (GetAllPdfsQueryHandler + GetPdfAnalyticsQueryHandler) funziona perché viene risolto a constant string a compile-time, prima della expression tree compilation. SQL generato è identico.
- **Pattern win**: rinominare un valore di `PdfProcessingState` ora rompe tutti i riferimenti `nameof()` a compile-time (rename-safety) invece di causare bug silenti.
- **Follow-up**: post-merge di #1800, una mini-PR (~5 min) chiuderà il refactor del `ReindexDocumentCommandHandler.cs` (1 literal + InFlightStates derive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)