### PR TITLE
refactor(api/document-processing): #1801 followup - reindex handler nameof + InFlightStates derive

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
@@ -18,16 +19,19 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
 internal sealed class ReindexDocumentCommandHandler : ICommandHandler<ReindexDocumentCommand>
 {
     // Stati pre-terminali. Reindex bloccato finché non si raggiunge Ready o Failed.
+    // Derived from Enum.GetNames so adding a new pre-terminal state to PdfProcessingState
+    // (or renaming an existing one) automatically updates this set — no manual sync needed. Issue #1801.
     private static readonly HashSet<string> InFlightStates =
-        new(StringComparer.Ordinal)
-        {
-            "Pending",
-            "Uploading",
-            "Extracting",
-            "Chunking",
-            "Embedding",
-            "Indexing",
-        };
+        new(
+            Enum.GetNames<PdfProcessingState>()
+                .Except(
+                    new[]
+                    {
+                        nameof(PdfProcessingState.Ready),
+                        nameof(PdfProcessingState.Failed),
+                    },
+                    StringComparer.Ordinal),
+            StringComparer.Ordinal);
 
     private readonly MeepleAiDbContext _dbContext;
     private readonly IMediator _mediator;
@@ -80,7 +84,7 @@ internal sealed class ReindexDocumentCommandHandler : ICommandHandler<ReindexDoc
         }
 
         // Reset state + scrive la versione risolta.
-        pdf.ProcessingState = "Pending";
+        pdf.ProcessingState = nameof(PdfProcessingState.Pending);
         pdf.ProcessedAt = null;
         pdf.ProcessingError = null;
         pdf.RetryCount = 0;


### PR DESCRIPTION
## Summary

Closes the deferred portion of #1801 left out of PR #1804 (which merged 9 files but skipped `ReindexDocumentCommandHandler.cs` because #1800 had not yet merged at the time).

Now that both #1800 and #1804 are merged, this small follow-up closes the loop:

## Changes

`apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs`:
- Added `using Api.BoundedContexts.DocumentProcessing.Domain.Enums;`
- Replaced hardcoded `InFlightStates` HashSet with `Enum.GetNames<PdfProcessingState>().Except([nameof(Ready), nameof(Failed)], Ordinal)` derivation
- Replaced raw `"Pending"` at line 83 with `nameof(PdfProcessingState.Pending)`

## Test plan

- [x] Build clean (0 errors, 0 new warnings)
- [x] `dotnet test --filter "FullyQualifiedName~ReindexDocumentCommandHandlerTests"` → **13/13 passed** (all 6 in-flight states + 2 terminal + 5 facts)

## Why derived?

When a new `PdfProcessingState.X` (e.g. `Validating`) is added in the future, `InFlightStates` will include it automatically without the developer remembering to update the hardcoded list. The exact rename-safety pattern bug #1801 was created to eliminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)