### PR TITLE
chore(docs): sync 3 plans post-merge for #1800 #1804 #1805 #1806

### DIFF
--- a/docs/superpowers/plans/2026-06-02-issue-1801-nameof-pdf-processing-state-refactor.md
+++ b/docs/superpowers/plans/2026-06-02-issue-1801-nameof-pdf-processing-state-refactor.md
@@ -1,0 +1,432 @@
+# Issue #1801 — Unify `nameof(PdfProcessingState.X)` vs string literals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sostituire i raw string literals di `PdfProcessingState` (`"Pending"`, `"Chunking"`, ecc.) con `nameof(PdfProcessingState.X)` nel BC `DocumentProcessing`, e derivare la `InFlightStates` HashSet di `ReindexDocumentCommandHandler` da `Enum.GetNames<PdfProcessingState>()` per rename-safety end-to-end.
+
+**Architecture:** Refactor puro (zero cambi semantici). I 4 file noti contengono 12 raw string literals + 1 HashSet con stringhe duplicate. Tutte le sostituzioni mantengono identica la semantica wire (le enum vengono serializzate in PascalCase identiche ai literals attuali). Nessun cambio a DB, migration, DTO o wire format.
+
+**Tech Stack:** .NET 9, C# (no runtime libs), xUnit per smoke verify.
+
+**Issue**: [#1801](https://github.com/meepleAi-app/meepleai-monorepo/issues/1801) (P3, tech-debt)
+
+**Branch**: `feature/issue-1801-nameof-refactor` (parent: `main-dev`)
+
+---
+
+## Scope freeze (out-of-scope)
+
+- File esclusi: file con match `"Pending|...|Failed"` su un'altra colonna/contesto (es. `OutboxStatus = "Pending"`, `ProcessingPriority = "Normal"`, log template strings).
+- Refactor di altri bounded context (UserLibrary, Infrastructure/BackgroundServices) — già canonici.
+- Wire format / migration / DTO — invariati.
+
+**Inventario completo (verificato via plan review 2026-06-02)**: 31 raw literals + 1 HashSet derive in **8 file** del BC `DocumentProcessing` (originale v1 del plan limitava a 4 file / 12 literals — incorretto, ora corretto).
+
+## File structure
+
+### Modified
+| Path | Change | Lines |
+|------|--------|-------|
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs` | 7 literals → `nameof()` | 140, 316, 325, 334, 724, 743, 746 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs` | 5 literals → `nameof()` | 477, 522, 636, 650, 791 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs` | 3 literals → `nameof()` | 34, 35, 46 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs` | 3 literals → `nameof()` | 75, 90, 109 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs` | 5 literals → `nameof()` | 77, 86, 98, 108, 148 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs` | 1 literal → `nameof()` | 41 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs` | 6 literals → `nameof()` | 170, 214, 462, 704, 752, 786 |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs` | 1 literal (line 83 `"Pending"`) + HashSet derivata da `Enum.GetNames<PdfProcessingState>()` | 21-30 (HashSet), 83 |
+
+### Created
+| Path | Purpose |
+|------|---------|
+| (none) | Refactor puro — nessun nuovo file. |
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight + branch hygiene
+
+**Files:**
+- (no edit)
+
+- [ ] **Step 1: Verify clean state**
+
+```bash
+cd D:/Repositories/meepleai-monorepo-dev
+git status --short
+git branch --show-current
+```
+
+Expected: clean tree (eccetto `docs/superpowers/plans/*` untracked) and HEAD is on `feature/issue-1673-reindex-version-selector` OR `main-dev`. If on the #1673 branch, switch and pull first:
+
+```bash
+git checkout main-dev
+git pull --ff-only
+```
+
+Expected: `Already up to date.` OR fast-forward.
+
+- [ ] **Step 2: Create feature branch**
+
+```bash
+git checkout -b feature/issue-1801-nameof-refactor
+git config branch.feature/issue-1801-nameof-refactor.parent main-dev
+git branch --show-current
+```
+
+Expected: `feature/issue-1801-nameof-refactor`.
+
+- [ ] **Step 3: Confirm baseline build green**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+```
+
+Expected: `Build succeeded. 0 Error(s).`
+
+(No commit in this task — setup only.)
+
+---
+
+### Task 2: Bulk refactor 7 product files (30 literals)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs` (7 literals)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs` (5 literals)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs` (3 literals)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs` (3 literals)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs` (5 literals)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs` (1 literal)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs` (6 literals)
+
+> **Note**: `ReindexDocumentCommandHandler.cs` is handled separately in Task 3 (combines 1 literal + HashSet derivation).
+
+#### Master substitution table
+
+For EACH file, apply these substitutions. The pattern is uniform: `pdfDoc.ProcessingState = "X"` → `pdfDoc.ProcessingState = nameof(PdfProcessingState.X)`, and `string.Equals(pdfDoc.ProcessingState, "X", ...)` → `string.Equals(pdfDoc.ProcessingState, nameof(PdfProcessingState.X), ...)`.
+
+| File | Line | Current | Replacement |
+|------|------|---------|-------------|
+| `PdfProcessingPipelineService.cs` | 140 | `pdfDoc.ProcessingState = "Chunking";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Chunking);` |
+| `PdfProcessingPipelineService.cs` | 316 | `pdfDoc.ProcessingState = "Embedding";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Embedding);` |
+| `PdfProcessingPipelineService.cs` | 325 | `pdfDoc.ProcessingState = "Indexing";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Indexing);` |
+| `PdfProcessingPipelineService.cs` | 334 | `pdfDoc.ProcessingState = "Ready";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);` |
+| `PdfProcessingPipelineService.cs` | 724 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `PdfProcessingPipelineService.cs` | 743 | `&& !string.Equals(pdfDoc.ProcessingState, "Ready", StringComparison.Ordinal))` | `&& !string.Equals(pdfDoc.ProcessingState, nameof(PdfProcessingState.Ready), StringComparison.Ordinal))` |
+| `PdfProcessingPipelineService.cs` | 746 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `CompleteChunkedUploadCommandHandler.cs` | 477 | `pdfDoc.ProcessingState = "Ready";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);` |
+| `CompleteChunkedUploadCommandHandler.cs` | 522 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `CompleteChunkedUploadCommandHandler.cs` | 636 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `CompleteChunkedUploadCommandHandler.cs` | 650 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `CompleteChunkedUploadCommandHandler.cs` | 791 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `VectorDocumentReadyStateHandler.cs` | 34 | `if (string.Equals(evt.CurrentProcessingState, "Ready", StringComparison.Ordinal)` | `if (string.Equals(evt.CurrentProcessingState, nameof(PdfProcessingState.Ready), StringComparison.Ordinal)` |
+| `VectorDocumentReadyStateHandler.cs` | 35 | `\|\| string.Equals(evt.CurrentProcessingState, "Failed", StringComparison.Ordinal))` | `\|\| string.Equals(evt.CurrentProcessingState, nameof(PdfProcessingState.Failed), StringComparison.Ordinal))` |
+| `VectorDocumentReadyStateHandler.cs` | 46 | `pdfEntity.ProcessingState = "Ready";` | `pdfEntity.ProcessingState = nameof(PdfProcessingState.Ready);` |
+| `ExtractPdfTextCommandHandler.cs` | 75 | `pdf.ProcessingState = "Extracting";` | `pdf.ProcessingState = nameof(PdfProcessingState.Extracting);` |
+| `ExtractPdfTextCommandHandler.cs` | 90 | `pdf.ProcessingState = "Failed";` | `pdf.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `ExtractPdfTextCommandHandler.cs` | 109 | `pdf.ProcessingState = "Ready";` | `pdf.ProcessingState = nameof(PdfProcessingState.Ready);` |
+| `IndexPdfCommandHandler.cs` | 77 | `pdf!.ProcessingState = "Indexing";` | `pdf!.ProcessingState = nameof(PdfProcessingState.Indexing);` |
+| `IndexPdfCommandHandler.cs` | 86 | `pdf.ProcessingState = "Failed";` | `pdf.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `IndexPdfCommandHandler.cs` | 98 | `pdf.ProcessingState = "Failed";` | `pdf.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `IndexPdfCommandHandler.cs` | 108 | `pdf.ProcessingState = "Ready";` | `pdf.ProcessingState = nameof(PdfProcessingState.Ready);` |
+| `IndexPdfCommandHandler.cs` | 148 | `failedPdf.ProcessingState = "Failed";` | `failedPdf.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `PurgeStaleDocumentsCommandHandler.cs` | 41 | `doc.ProcessingState = "Failed";` | `doc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `UploadPdfCommandHandler.Processing.cs` | 170 | `pdfDoc.ProcessingState = "Uploading";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Uploading);` |
+| `UploadPdfCommandHandler.Processing.cs` | 214 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `UploadPdfCommandHandler.Processing.cs` | 462 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `UploadPdfCommandHandler.Processing.cs` | 704 | `pdfDoc.ProcessingState = "Ready";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);` |
+| `UploadPdfCommandHandler.Processing.cs` | 752 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+| `UploadPdfCommandHandler.Processing.cs` | 786 | `pdfDoc.ProcessingState = "Failed";` | `pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);` |
+
+> **Robust strategy**: For each file, use `Read` to confirm current line numbers (may shift slightly after rebase), then `Edit` (or `MultiEdit`) with the exact `Current` text from the table. The `Current` text is unique enough within each file that line-number drift won't cause false matches.
+
+- [ ] **Step 1: Verify enum namespace is imported in each file**
+
+For each of the 7 files above, check the imports:
+
+```
+grep -l "using Api.BoundedContexts.DocumentProcessing.Domain.Enums;" \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+```
+
+Add the missing using to any file that doesn't list it. (`PdfProcessingState` lives in `Api.BoundedContexts.DocumentProcessing.Domain.Enums`.)
+
+- [ ] **Step 2: Apply the 30 substitutions from the master table**
+
+Apply per file (use the master substitution table above as the source of truth). Tip: process files in the order listed (top-down through the table). For each file, use `Read` first to confirm line numbers, then `Edit` (1 call per substitution OR `MultiEdit` for the bulk).
+
+- [ ] **Step 3: Build to verify zero errors**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+```
+
+Expected: `Build succeeded. 0 Error(s).` If a build fails with `CS0103: 'PdfProcessingState' does not exist`, the missing using directive is the cause — add it.
+
+- [ ] **Step 4: Commit (one commit per file for diff clarity)**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in pipeline service (7 literals)"
+
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in chunked upload handler (5 literals)"
+
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in vector ready state handler (3 literals)"
+
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in extract text handler (3 literals)"
+
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in index pdf handler (5 literals)"
+
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in purge stale handler (1 literal)"
+
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+git commit -m "refactor(api/document-processing): #1801 use nameof in upload processing helper (6 literals)"
+```
+
+(Skip any commit that has no staged changes — if a file ended up identical after Edit, drop the commit.)
+
+---
+
+### Task 3: Refactor `ReindexDocumentCommandHandler.cs` (1 literal + InFlightStates derive)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs`
+
+- [ ] **Step 1: Read current implementation**
+
+The current code (introduced by #1673) is:
+
+```csharp
+private static readonly HashSet<string> InFlightStates =
+    new(StringComparer.Ordinal)
+    {
+        "Pending",
+        "Uploading",
+        "Extracting",
+        "Chunking",
+        "Embedding",
+        "Indexing",
+    };
+```
+
+(Lines ~22-30 — confirm via Read before editing.)
+
+- [ ] **Step 2: Add `using` if needed**
+
+```
+grep -n "using Api.BoundedContexts.DocumentProcessing.Domain.Enums" apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
+```
+
+Add if missing.
+
+- [ ] **Step 3: Replace the HashSet with a derived set**
+
+Substitute the entire `InFlightStates` declaration with:
+
+```csharp
+// In-flight states = all enum values EXCEPT the two terminal states (Ready, Failed).
+// Derived from Enum.GetNames so adding a new pre-terminal state to PdfProcessingState
+// (or renaming an existing one) automatically updates this set — no manual sync needed.
+private static readonly HashSet<string> InFlightStates =
+    new(
+        Enum.GetNames<PdfProcessingState>()
+            .Except(
+                new[]
+                {
+                    nameof(PdfProcessingState.Ready),
+                    nameof(PdfProcessingState.Failed),
+                },
+                StringComparer.Ordinal),
+        StringComparer.Ordinal);
+```
+
+This guarantees: when a new enum value is added (e.g. `PdfProcessingState.Validating`), `InFlightStates` includes it automatically without the developer remembering to update the HashSet — the exact pattern bug we're refactoring away.
+
+- [ ] **Step 4: Replace literal at line ~83**
+
+At line ~83 (confirm via Read) the handler resets state to `"Pending"` after the conflict guard:
+
+```csharp
+pdf.ProcessingState = "Pending";
+```
+
+Replace with:
+
+```csharp
+pdf.ProcessingState = nameof(PdfProcessingState.Pending);
+```
+
+This is the single remaining raw literal in this file outside the (now-derived) HashSet.
+
+- [ ] **Step 5: Build to verify zero errors**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+```
+
+- [ ] **Step 6: Run reindex handler tests to verify zero semantic regression**
+
+```bash
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ReindexDocumentCommandHandlerTests" --no-build 2>&1 | tail -10
+```
+
+Expected: **13 passed**. The 6 in-flight states + 2 terminal states + 5 facts must all behave identically. If even one test fails, the derivation logic has a bug (e.g. `Enum.GetNames` returning unexpected casing).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
+git commit -m "refactor(api/document-processing): #1801 derive InFlightStates + use nameof in reindex handler"
+```
+
+---
+
+### Task 4: Final verification + PR
+
+**Files:**
+- (no edit)
+
+- [ ] **Step 1: Final grep — confirm no raw literals remain in the 8 in-scope files**
+
+```bash
+grep -nE '"(Pending|Uploading|Extracting|Chunking|Embedding|Indexing|Ready|Failed)"' \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs
+```
+
+Also run the BC-wide check to confirm no other ProcessingState assignments slipped through:
+
+```bash
+grep -nrE 'ProcessingState [=]=? "(Pending|Uploading|Extracting|Chunking|Embedding|Indexing|Ready|Failed)"' \
+  apps/api/src/Api/BoundedContexts/DocumentProcessing 2>&1 | grep -v '\.Designer\.cs'
+```
+
+Expected: **no matches** (except log message templates and exception strings that legitimately contain these words in a non-state context — review each match and confirm).
+
+If any match remains in a `ProcessingState = "..."` or `ProcessingState == "..."` context, this is an oversight: replace and re-commit.
+
+- [ ] **Step 2: Run all DocumentProcessing unit tests for regression**
+
+```bash
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=DocumentProcessing&Category=Unit" --no-build 2>&1 | tail -10
+```
+
+Expected: all previously-passing tests still pass (baseline was ~336 unit tests; should remain the same count — refactor adds no tests, removes no tests).
+
+- [ ] **Step 3: Rebase + push**
+
+```bash
+git fetch origin main-dev
+git rebase origin/main-dev
+# Expect clean rebase — no expected conflicts since only 4 files touched
+git push -u origin feature/issue-1801-nameof-refactor
+```
+
+If the rebase touches conflicting territory (e.g. someone else just changed one of these 4 files), resolve and re-run Step 2.
+
+- [ ] **Step 4: Open PR against `main-dev`**
+
+```bash
+gh pr create --base main-dev --title "refactor(api/document-processing): #1801 unify nameof(PdfProcessingState) usage" --body "$(cat <<'EOF'
+## Summary
+
+Closes #1801. Sostituisce 12 raw string literals + 1 HashSet hardcoded con riferimenti `nameof(PdfProcessingState.X)` o `Enum.GetNames<PdfProcessingState>()` derivation, per garantire rename-safety end-to-end nel BC \`DocumentProcessing\`.
+
+## Changes
+
+| File | Δ |
+|------|---|
+| \`PdfProcessingPipelineService.cs\` | 7 literals → \`nameof()\` |
+| \`CompleteChunkedUploadCommandHandler.cs\` | 2 literals → \`nameof()\` |
+| \`VectorDocumentReadyStateHandler.cs\` | 3 literals → \`nameof()\` |
+| \`ReindexDocumentCommandHandler.cs\` | \`InFlightStates\` derived from \`Enum.GetNames<PdfProcessingState>()\` excluding \`Ready\`/\`Failed\` |
+
+## Test plan
+
+- [x] Build clean (0 errors, 0 new warnings)
+- [x] \`dotnet test --filter \"BoundedContext=DocumentProcessing&Category=Unit\"\` all green
+- [x] \`ReindexDocumentCommandHandlerTests\` 13/13 (covers all 6 in-flight + 2 terminal states)
+- [x] No wire-format change, no DTO change, no migration
+
+## Notes
+
+- **Semantica wire invariata**: gli stati continuano a essere serializzati come stringhe PascalCase identiche ai literals attuali. Nessun impatto su client/DB.
+- **Cross-cutting**: file fuori scope (\`StalePdfRecoveryService\`, \`PdfSeeder\`, \`UserLibrary\`, \`RetryFailedPdfsJob\`) usano già \`nameof()\` — pattern unificato post-merge.
+- **Pattern win**: aggiungere un nuovo \`PdfProcessingState.X\` ora auto-include lo stato in \`InFlightStates\` se non è \`Ready\`/\`Failed\` — niente manuale sync da ricordare.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Comment on issue #1801**
+
+```bash
+gh issue comment 1801 --body "PR aperto contro \`main-dev\` (link sopra).
+
+## DoD updates
+- [x] 31 raw string literals sostituiti con \`nameof(PdfProcessingState.X)\` negli 8 file in scope.
+- [x] \`InFlightStates\` HashSet in \`ReindexDocumentCommandHandler\` ora derivata da \`Enum.GetNames<PdfProcessingState>()\`.
+- [x] Test esistenti continuano a passare senza modifiche.
+- [x] Nessuna allocazione runtime addizionale (HashSet costruita una volta in \`static readonly\`).
+
+Ready for code review."
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Issue #1801 requirement | Task |
+|-----------------------------|------|
+| Raw string literals in 7 product files → `nameof()` (30 substitutions) | Task 2 |
+| `ReindexDocumentCommandHandler` literal at line 83 → `nameof()` | Task 3 step 4 |
+| `InFlightStates` derived from `Enum.GetNames` (no manual sync) | Task 3 steps 1-3 |
+| Test esistenti pass | Task 3 step 6 + Task 4 step 2 |
+| Nessuna nuova allocazione runtime | Task 3 — `static readonly` mantenuto |
+| Final grep verifies no residual literals | Task 4 step 1 |
+
+### Placeholder scan
+
+- [x] No "TBD" / "TODO" / "implement later" — ogni sostituzione ha la replacement esatta.
+- [x] No "similar to Task N" senza codice esplicito.
+- [x] Ogni step ha o un comando esatto o una tabella di sostituzioni puntuali.
+
+### Type consistency
+
+| Symbol | Defined | Used |
+|--------|---------|------|
+| `PdfProcessingState` (enum) | Already exists at `Domain/Enums/PdfProcessingState.cs` | Tasks 2, 3, 4, 5 |
+| `nameof(PdfProcessingState.Pending)` etc. | Compile-time string from enum | Tasks 2-5 |
+| `Enum.GetNames<PdfProcessingState>()` | BCL API .NET 5+ | Task 5 |
+
+Nessuna nuova firma o tipo introdotto. Refactor puro.
+
+---
+
+## References
+
+- Issue: [#1801](https://github.com/meepleAi-app/meepleai-monorepo/issues/1801)
+- Parent context: PR #1800 (#1673) — code review carry-forward
+- Sibling pattern (canonical `nameof()` usage): `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Seeding/PdfSeeder.cs:194`
+- Enum source: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Enums/PdfProcessingState.cs`

--- a/docs/superpowers/plans/2026-06-02-issue-1802-rowversion-optimistic-concurrency.md
+++ b/docs/superpowers/plans/2026-06-02-issue-1802-rowversion-optimistic-concurrency.md
@@ -1,0 +1,1055 @@
+# Issue #1802 — RowVersion Optimistic Concurrency on PdfDocumentEntity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere `[Timestamp] byte[]? RowVersion` a `PdfDocumentEntity` e wrappare 17 handler che mutano la entity per surfacare `DbUpdateConcurrencyException` come 409 (Category A user-facing) / log warning + retry (Category B background) / silent skip (Category C maintenance), con Prometheus counter `meepleai_pdf_concurrency_conflicts_total` e 4 Testcontainers integration tests Barrier-synchronized.
+
+**Architecture:** Optimistic concurrency via PostgreSQL `xmin` system column mapped by EF Core `IsRowVersion()`. Per Newman's recommendation (workshop): implicit API surface — server-side catch + 409, no ETag header. Per Wiegers's enumeration (workshop): tutti i ~17 handler che mutano `PdfDocumentEntity` categorizzati A/B/C con error handling appropriato per ogni categoria.
+
+**Tech Stack:** .NET 9, EF Core 9 + Npgsql, FluentValidation, xUnit + Testcontainers, FluentAssertions, Prometheus.NET.
+
+**Issue**: [#1802](https://github.com/meepleAi-app/meepleai-monorepo/issues/1802) (P3, enhancement)
+
+**Branch**: `feature/issue-1802-rowversion-concurrency` (parent: `main-dev`)
+
+**Effort**: ~8h (post spec-panel workshop scope expansion)
+
+---
+
+## Scope freeze (out-of-scope)
+
+- Locking/blocking — stay with optimistic (read-modify-CAS).
+- Other entities outside `DocumentProcessing` BC.
+- `ETag` HTTP header pattern (#2055) — implicit 409 only.
+- Grafana dashboard panel — added separately if telemetry shows >5 conflicts/day.
+- UI/FE changes — toast `Re-index fallito` already handles new 409 naturally.
+
+## File structure
+
+### Created
+| Path | Responsibility |
+|------|---------------|
+| `apps/api/src/Api/Infrastructure/Migrations/<TIMESTAMP>_AddRowVersionToPdfDocuments.cs` | Foundation: EF migration aggiunge `xmin` mapping (no new column, just shadow concurrency token) |
+| `apps/api/src/Api/Infrastructure/Metrics/PdfConcurrencyMetrics.cs` | Prometheus counter `meepleai_pdf_concurrency_conflicts_total` + helper `RecordConflict(handlerName, category)` |
+| `apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfRowVersionConcurrencyIntegrationTests.cs` | 4 Testcontainers scenarios (Barrier-synchronized) |
+
+### Modified — Foundation
+| Path | Change |
+|------|--------|
+| `apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs` | + `[Timestamp] public byte[]? RowVersion { get; set; }` |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs` | + `builder.Property(e => e.RowVersion).IsRowVersion();` |
+
+### Modified — Category A handlers (9 user-facing, throw ConflictException on conflict)
+1. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs`
+2. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommandHandler.cs` + `DeletePdfCommandHandler.cs`
+3. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UpdatePdfMetadataCommandHandler.cs` (#1687)
+4. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/OverridePdfLanguageCommandHandler.cs`
+5. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/SetPdfVisibilityCommandHandler.cs`
+6. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReclassifyDocumentCommandHandler.cs`
+7. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CancelPdfProcessingCommandHandler.cs`
+8. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RetryPdfProcessingCommandHandler.cs`
+9. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/AddDocumentToCollectionCommandHandler.cs`
+
+### Modified — Category B handlers (6 background, log warning + return success)
+10. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs`
+11. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs`
+12. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs`
+13. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs`
+14. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs` (3 mutation sites: main + `MarkFailedAsync` + `TryMarkFailedAsync`)
+15. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/VectorDocumentReadyStateHandler.cs`
+
+### Modified — Category C handlers (2 maintenance, log debug + continue batch)
+16. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs`
+17. `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/RetryFailedPdfsJob.cs`
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight + branch hygiene
+
+**Files:**
+- (no edit)
+
+- [ ] **Step 1: Verify clean state**
+
+```bash
+cd D:/Repositories/meepleai-monorepo-dev
+git branch --show-current  # must be main-dev or feature/*
+git status --short          # must be clean (modulo .tmp files)
+git pull --ff-only          # update main-dev
+```
+
+Expected: clean tree (eccetto `docs/superpowers/plans/*` untracked).
+
+- [ ] **Step 2: Create feature branch from main-dev**
+
+```bash
+git checkout main-dev
+git pull --ff-only
+git checkout -b feature/issue-1802-rowversion-concurrency
+git config branch.feature/issue-1802-rowversion-concurrency.parent main-dev
+git branch --show-current
+```
+
+Expected: `feature/issue-1802-rowversion-concurrency`.
+
+- [ ] **Step 3: Baseline build**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+```
+
+Expected: `Build succeeded. 0 Error(s).`
+
+(No commit — setup only.)
+
+---
+
+### Task 2: Foundation — entity + EF config + migration
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs`
+- Create: `apps/api/src/Api/Infrastructure/Migrations/<TIMESTAMP>_AddRowVersionToPdfDocuments.cs` (auto-generated)
+
+#### Canonical pattern (from `RuleSpecEntity.cs:27-28` + `RuleSpecEntityConfiguration.cs:37-39`)
+
+```csharp
+[Timestamp]
+public byte[]? RowVersion { get; set; }   // nullable per PhotoBatchUpload landmine fix (migration 20260524190307)
+```
+
+```csharp
+builder.Property(e => e.RowVersion).IsRowVersion();
+```
+
+This maps to PostgreSQL `xmin` system column automatically (Npgsql provider convention). No `bytea` column added.
+
+- [ ] **Step 1: Add property to `PdfDocumentEntity.cs`**
+
+Find the line immediately AFTER `public string? IndexerVersion { get; set; }` (introduced by #1673):
+
+```csharp
+    // Issue #1673: Pipeline indexer version applied at last reindex.
+    // Nullable for backwards compat — backfilled to 'v0' on migration.
+    public string? IndexerVersion { get; set; }
+```
+
+Add after it:
+
+```csharp
+    // Issue #1802: Optimistic concurrency control via PostgreSQL xmin system column.
+    // Auto-mapped to xmin by Npgsql when configured with .IsRowVersion(). Nullable
+    // to avoid PhotoBatchUpload landmine (migration 20260524190307: NOT NULL caused
+    // InsertCommand double-mapping bug under Npgsql).
+    [Timestamp]
+    public byte[]? RowVersion { get; set; }
+```
+
+Verify the file has `using System.ComponentModel.DataAnnotations;` at the top. If missing, add it.
+
+- [ ] **Step 2: Add EF configuration to `PdfDocumentEntityConfiguration.cs`**
+
+In `PdfDocumentEntityConfiguration.cs`, after the existing `IndexerVersion` configuration block (introduced by #1673, lines ~168-176), add:
+
+```csharp
+        // Issue #1802: Optimistic concurrency via xmin (PostgreSQL system column).
+        // Pattern matches RuleSpecEntityConfiguration:38-39 — Npgsql auto-maps to xmin.
+        builder.Property(e => e.RowVersion)
+            .IsRowVersion();
+```
+
+- [ ] **Step 3: Generate migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddRowVersionToPdfDocuments --output-dir Infrastructure/Migrations
+```
+
+Expected: 2 new files `Infrastructure/Migrations/<TIMESTAMP>_AddRowVersionToPdfDocuments.cs` + `.Designer.cs`.
+
+- [ ] **Step 4: Verify the migration is empty/minimal**
+
+Read the generated `<TIMESTAMP>_AddRowVersionToPdfDocuments.cs`. Because `xmin` is a system column (not a new physical column), the `Up` method should be effectively a no-op — EF only records the conceptual addition in the model snapshot. If the migration is non-empty AND tries to add a `bytea` column, **STOP and report DONE_WITH_CONCERNS** — the pattern recognition failed and the implementer needs to verify the Npgsql provider behavior.
+
+If the migration is empty `protected override void Up(MigrationBuilder migrationBuilder) { }`, that's correct.
+
+- [ ] **Step 5: Build to verify zero errors**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+```
+
+Expected: `Build succeeded. 0 Error(s).`
+
+- [ ] **Step 6: Run existing PdfDocument tests to confirm no regression**
+
+```bash
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=DocumentProcessing&Category=Unit" --no-build 2>&1 | tail -8
+```
+
+Expected: all green (~336 unit tests). Existing tests instantiate `PdfDocumentEntity` directly; the new nullable `byte[]? RowVersion` doesn't break anything because EF auto-populates on insert.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(api/document-processing): #1802 add RowVersion (xmin) to PdfDocumentEntity"
+```
+
+---
+
+### Task 3: Observability — Prometheus counter + helper
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Metrics/PdfConcurrencyMetrics.cs`
+
+#### Why this comes BEFORE handler refactor
+
+The 17 handler refactors will all reference `PdfConcurrencyMetrics.RecordConflict(...)`. Defining the helper first lets later tasks call it without forward references.
+
+- [ ] **Step 1: Create the metrics helper**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Metrics/PdfConcurrencyMetrics.cs
+using Prometheus;
+
+namespace Api.Infrastructure.Metrics;
+
+/// <summary>
+/// Prometheus counter for PdfDocumentEntity optimistic concurrency conflicts (#1802).
+/// Cardinality bounded: ~17 handler labels × 3 categories = 51 series max.
+/// </summary>
+internal static class PdfConcurrencyMetrics
+{
+    private static readonly Counter ConflictsTotal = Prometheus.Metrics.CreateCounter(
+        name: "meepleai_pdf_concurrency_conflicts_total",
+        help: "Total number of DbUpdateConcurrencyException occurrences on PdfDocumentEntity, by handler and category.",
+        new CounterConfiguration
+        {
+            LabelNames = new[] { "handler", "category" },
+        });
+
+    /// <summary>
+    /// Record a concurrency conflict event.
+    /// </summary>
+    /// <param name="handlerName">Use <c>nameof(YourHandlerClass)</c> for rename-safety.</param>
+    /// <param name="category">One of <c>"A"</c> (user-facing), <c>"B"</c> (background pipeline), <c>"C"</c> (maintenance).</param>
+    public static void RecordConflict(string handlerName, string category)
+    {
+        ConflictsTotal.WithLabels(handlerName, category).Inc();
+    }
+}
+```
+
+- [ ] **Step 2: Verify Prometheus.NET is referenced**
+
+```bash
+grep -l "prometheus-net" apps/api/src/Api/Api.csproj
+```
+
+Expected: match found. The project uses Prometheus.NET for existing metrics (cf. `MeepleAiMetrics.cs`). If missing, **STOP and report NEEDS_CONTEXT**.
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+```
+
+Expected: `Build succeeded. 0 Error(s).`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Metrics/PdfConcurrencyMetrics.cs
+git commit -m "feat(api/document-processing): #1802 PdfConcurrencyMetrics counter helper"
+```
+
+---
+
+### Task 4: Category A — wrap 9 user-facing handlers (throw ConflictException)
+
+**Files (9 handler files — see "File structure" above):**
+
+#### Pattern (uniform across 9 handlers)
+
+For each handler, locate the **outermost** `SaveChangesAsync` call (the one that persists the user-initiated mutation). Wrap it in `try/catch (DbUpdateConcurrencyException)`:
+
+**Before**:
+```csharp
+await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+**After**:
+```csharp
+try
+{
+    await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+}
+catch (DbUpdateConcurrencyException)
+{
+    PdfConcurrencyMetrics.RecordConflict(nameof(<HandlerClass>), "A");
+    _logger.LogWarning(
+        "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category A)",
+        <pdfIdVariable>, nameof(<HandlerClass>));
+    throw new ConflictException(
+        $"Document {<pdfIdVariable>} was modified by another concurrent operation; please retry.");
+}
+```
+
+Required usings (add if missing):
+```csharp
+using Microsoft.EntityFrameworkCore;             // DbUpdateConcurrencyException
+using Api.Infrastructure.Metrics;                 // PdfConcurrencyMetrics
+using Api.Middleware.Exceptions;                  // ConflictException
+```
+
+#### Per-handler check before wrapping
+
+Each handler MUST have:
+- An `ILogger<T> _logger` field (most do — verify before editing)
+- A clear PdfDocument id variable to log + interpolate (usually `command.PdfId`, `pdf.Id`, or similar)
+
+If a handler does NOT have `_logger`, add it via constructor injection (DI registration is automatic via `AddScoped`).
+
+#### Sub-step structure (uniform for all 9 handlers)
+
+For each of the 9 handlers:
+
+- [ ] **Step A.N.1: Read the file** to identify the exact outermost `SaveChangesAsync` call + the `_logger` field + the pdf id variable.
+
+- [ ] **Step A.N.2: Add required usings** at the top of the file (if missing).
+
+- [ ] **Step A.N.3: Wrap the SaveChangesAsync** with the try/catch pattern above. Substitute `<HandlerClass>` and `<pdfIdVariable>` with the actual names.
+
+- [ ] **Step A.N.4: Build**:
+  ```bash
+  dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+  ```
+
+- [ ] **Step A.N.5: Run existing handler tests** (filter by class name) to verify no regression:
+  ```bash
+  cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~<HandlerClass>Tests" --no-build 2>&1 | tail -5
+  ```
+
+- [ ] **Step A.N.6: Commit per handler**:
+  ```bash
+  git add <handler-path>
+  git commit -m "feat(api/document-processing): #1802 Category A concurrency catch in <HandlerName>"
+  ```
+
+#### 9 handlers to refactor (in order)
+
+| N | Handler | pdfId variable hint | Sub-tasks |
+|---|---------|---------------------|-----------|
+| 1 | `ReindexDocumentCommandHandler` | `command.PdfId` | A.1.1 → A.1.6 |
+| 2 | `DeleteKbDocumentCommandHandler` (then `DeletePdfCommandHandler` if separate) | `command.Id` | A.2.1 → A.2.6 |
+| 3 | `UpdatePdfMetadataCommandHandler` | `command.PdfId` | A.3.1 → A.3.6 |
+| 4 | `OverridePdfLanguageCommandHandler` | `command.PdfId` | A.4.1 → A.4.6 |
+| 5 | `SetPdfVisibilityCommandHandler` | `command.PdfId` | A.5.1 → A.5.6 |
+| 6 | `ReclassifyDocumentCommandHandler` | `command.DocumentId` | A.6.1 → A.6.6 |
+| 7 | `CancelPdfProcessingCommandHandler` | `command.PdfId` | A.7.1 → A.7.6 |
+| 8 | `RetryPdfProcessingCommandHandler` | `command.PdfId` | A.8.1 → A.8.6 |
+| 9 | `AddDocumentToCollectionCommandHandler` | `command.DocumentId` | A.9.1 → A.9.6 |
+
+> **Note on handler N=2**: if `DeleteKbDocumentCommandHandler` and `DeletePdfCommandHandler` are two separate files (or two methods in one handler), wrap both with separate commits.
+
+> **Note on handler N=9**: this handler may not directly mutate `PdfDocumentEntity` — it might just update a join table. Verify by reading the handler first. If it only inserts into a join table, mark this sub-task as "out of scope" and skip with a `git commit --allow-empty` note? **NO** — instead just skip and document in the Task 4 final report.
+
+#### Task 4 acceptance
+
+- 9 commits (one per handler) with consistent messages.
+- Build clean after each commit.
+- Existing per-handler tests still pass.
+- No other files modified.
+
+---
+
+### Task 5: Category B — wrap 6 background pipeline handlers (log + return success)
+
+**Files (6 handler files):**
+
+#### Pattern (uniform across 6 handlers)
+
+Background pipeline handlers run inside Quartz jobs. They must NOT throw `ConflictException` (no HTTP boundary). They must log a warning and return success so Quartz does NOT retry (the next pipeline tick will re-read fresh state):
+
+**Before**:
+```csharp
+await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+**After**:
+```csharp
+try
+{
+    await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+}
+catch (DbUpdateConcurrencyException ex)
+{
+    PdfConcurrencyMetrics.RecordConflict(nameof(<HandlerClass>), "B");
+    _logger.LogWarning(ex,
+        "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
+        <pdfIdVariable>, nameof(<HandlerClass>));
+    return; // or "return successResult;" depending on handler signature
+}
+```
+
+The `return;` is **critical** for Category B: it tells Quartz "job succeeded" so no retry storm. The admin's mutation wins, the pipeline tick at the next scheduled run will re-read fresh state and proceed correctly.
+
+#### Special case: `PdfProcessingPipelineService.cs`
+
+This file has **3 distinct mutation sites** (per #1801 refactor in 7 commits):
+
+| Site | Line range | Description |
+|------|-----------|-------------|
+| Main pipeline `ProcessPdfAsync` | ~140-336 | Transitions Pending → Extracting → Chunking → Embedding → Indexing → Ready |
+| `MarkFailedAsync` | ~720-728 | Best-effort failure marking |
+| `TryMarkFailedAsync` | ~734-755 | Defensive failure marking after DbContext disposal |
+
+For each, the try/catch wrapping is the same shape, but the `pdfIdVariable` differs:
+- Main: `pdfDoc.Id` or `pdfId`
+- MarkFailedAsync: `pdfDoc.Id`
+- TryMarkFailedAsync: `pdfDocumentId`
+
+Apply the pattern to ALL THREE sites in `PdfProcessingPipelineService.cs`. ONE commit covers all three (single file).
+
+#### Sub-step structure (uniform for all 6 handlers)
+
+For each of the 6 handlers (or PdfProcessingPipelineService with its 3 sites):
+
+- [ ] **Step B.N.1: Read** to identify mutation site(s).
+
+- [ ] **Step B.N.2: Add usings** (DbUpdateConcurrencyException + Metrics).
+
+- [ ] **Step B.N.3: Wrap each `SaveChangesAsync`** with the Category B pattern.
+
+- [ ] **Step B.N.4: Build**.
+
+- [ ] **Step B.N.5: Run handler-specific tests**:
+  ```bash
+  cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~<HandlerClass>" --no-build 2>&1 | tail -5
+  ```
+
+- [ ] **Step B.N.6: Commit per handler**:
+  ```bash
+  git commit -m "feat(api/document-processing): #1802 Category B concurrency log in <HandlerName>"
+  ```
+
+#### 6 handlers to refactor
+
+| N | Handler | Mutation sites |
+|---|---------|----------------|
+| 1 | `UploadPdfCommandHandler.Processing` | 1 (main upload pipeline) |
+| 2 | `CompleteChunkedUploadCommandHandler` | 1 |
+| 3 | `ExtractPdfTextCommandHandler` | 1 |
+| 4 | `IndexPdfCommandHandler` | 1 |
+| 5 | `PdfProcessingPipelineService` | **3** (main + MarkFailedAsync + TryMarkFailedAsync) |
+| 6 | `VectorDocumentReadyStateHandler` | 1 |
+
+#### Task 5 acceptance
+
+- 6 commits.
+- Build clean.
+- All existing handler tests pass.
+- PdfProcessingPipelineService has all 3 mutation sites wrapped.
+
+---
+
+### Task 6: Category C — wrap 2 maintenance handlers (silent skip)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/PurgeStaleDocumentsCommandHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/RetryFailedPdfsJob.cs`
+
+#### Pattern
+
+Maintenance jobs iterate over batches of `PdfDocumentEntity`. Per-item concurrency conflicts are EXPECTED (an admin acted concurrently). They MUST NOT bubble exceptions — silent skip + LogDebug + continue the batch.
+
+For **batch SaveChanges** (one SaveChangesAsync covering N items), wrap with:
+
+```csharp
+try
+{
+    await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    _logger.LogInformation("Maintenance batch completed: {Count} items processed", processedCount);
+}
+catch (DbUpdateConcurrencyException ex)
+{
+    PdfConcurrencyMetrics.RecordConflict(nameof(<HandlerClass>), "C");
+    _logger.LogDebug(ex,
+        "Concurrency conflict in {Handler} (Category C) — some items mutated concurrently by admin; batch partially applied",
+        nameof(<HandlerClass>));
+    // No re-throw. Maintenance job is best-effort.
+}
+```
+
+For **per-item SaveChanges** (foreach with SaveChangesAsync per item), the try/catch goes inside the loop and continues on conflict:
+
+```csharp
+foreach (var item in batch)
+{
+    item.ProcessingState = nameof(PdfProcessingState.Failed);
+    try
+    {
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        processedCount++;
+    }
+    catch (DbUpdateConcurrencyException)
+    {
+        PdfConcurrencyMetrics.RecordConflict(nameof(<HandlerClass>), "C");
+        _logger.LogDebug(
+            "Skipped PdfDocument {PdfId} in {Handler} (Category C) — concurrent admin mutation",
+            item.Id, nameof(<HandlerClass>));
+        // Detach the failed entity so the next iteration's SaveChanges doesn't retry it
+        _db.Entry(item).State = EntityState.Detached;
+    }
+}
+_logger.LogInformation("Maintenance batch: {Processed}/{Total} items processed", processedCount, batch.Count);
+```
+
+> **Read both files first** to determine if they use batch SaveChanges or per-item SaveChanges. Apply the appropriate pattern.
+
+- [ ] **Step C.1: Refactor PurgeStaleDocumentsCommandHandler.cs**
+
+Read file. Apply Category C pattern. Build. Run tests. Commit:
+
+```bash
+git commit -m "feat(api/document-processing): #1802 Category C concurrency skip in PurgeStale"
+```
+
+- [ ] **Step C.2: Refactor RetryFailedPdfsJob.cs**
+
+Read file. Apply Category C pattern. Build. Run tests. Commit:
+
+```bash
+git commit -m "feat(api/document-processing): #1802 Category C concurrency skip in RetryFailedPdfs"
+```
+
+#### Task 6 acceptance
+
+- 2 commits, build clean, tests pass.
+
+---
+
+### Task 7: Integration test — 4 Testcontainers Barrier-synchronized scenarios
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfRowVersionConcurrencyIntegrationTests.cs`
+
+#### Reference pattern (from `ReindexDocumentVersionIntegrationTests.cs`)
+
+Use `SharedTestcontainersFixture` + `IntegrationServiceCollectionBuilder.CreateBase` + `[Collection("Integration-GroupA")]` per la convention del repo.
+
+For true parallelism: `Barrier` + `Task.Run` + `Task.WhenAll`.
+
+- [ ] **Step 1: Create the test file**
+
+```csharp
+// apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfRowVersionConcurrencyIntegrationTests.cs
+using System.Text.Json;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration tests for PdfDocumentEntity RowVersion optimistic concurrency.
+/// Issue #1802. Uses Barrier-synchronized parallel tasks for real race conditions.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1802")]
+public sealed class PdfRowVersionConcurrencyIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-000000001802");
+    private static readonly Guid TestSharedGameId = new("B0000000-0000-0000-0000-000000001802");
+
+    public PdfRowVersionConcurrencyIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_rowversion_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await MigrateWithRetryAsync(_dbContext);
+        await SeedBaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null) await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable d) await d.DisposeAsync();
+        try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); } catch { /* best-effort */ }
+    }
+
+    private static async Task MigrateWithRetryAsync(MeepleAiDbContext db)
+    {
+        // Mirror pattern from sibling integration tests (Npgsql transient retry).
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            try
+            {
+                await db.Database.MigrateAsync(TestCancellationToken);
+                return;
+            }
+            catch (Npgsql.NpgsqlException) when (attempt < 3)
+            {
+                await Task.Delay(TestConstants.Timing.RetryDelay, TestCancellationToken);
+            }
+        }
+    }
+
+    private async Task SeedBaseAsync()
+    {
+        _dbContext!.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "rowversion-test@meepleai.test",
+            PasswordHash = "x",
+            DisplayName = "RowVersion Test",
+        });
+        _dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = TestSharedGameId,
+            Title = "RowVersion Test Game",
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private async Task<PdfDocumentEntity> SeedReadyPdfAsync(string? indexerVersion = null)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rowversion.pdf",
+            FilePath = "/tmp/rowversion.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = TestUserId,
+            SharedGameId = TestSharedGameId,
+            ProcessingState = nameof(PdfProcessingState.Ready),
+            IndexerVersion = indexerVersion ?? IndexerVersionRegistry.Current.Version,
+        };
+        _dbContext!.PdfDocuments.Add(pdf);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return pdf;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Scenario 1: Parallel two reindex — only one succeeds
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Parallel_TwoReindex_OnlyOneSucceeds()
+    {
+        var pdf = await SeedReadyPdfAsync();
+
+        using var barrier = new Barrier(participantCount: 2);
+
+        // Use two independent service scopes (otherwise both tasks share the same
+        // tracked entity and DbContext — invalidates the race test).
+        Task<Exception?> RunReindex(string version) => Task.Run(async () =>
+        {
+            using var scope = _serviceProvider!.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+            try
+            {
+                await mediator.Send(new ReindexDocumentCommand(pdf.Id, version), TestCancellationToken);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        });
+
+        var resultA = RunReindex(IndexerVersionRegistry.Current.Version);
+        var resultB = RunReindex(IndexerVersionRegistry.Current.Version);
+
+        var exceptions = await Task.WhenAll(resultA, resultB);
+
+        // Exactly one succeeded (null), exactly one failed with ConflictException.
+        var successes = exceptions.Count(ex => ex is null);
+        var conflicts = exceptions.Count(ex => ex is ConflictException);
+        successes.Should().Be(1, "exactly one reindex must win the race");
+        conflicts.Should().Be(1, "exactly one reindex must lose with ConflictException");
+
+        // The winning RowVersion advanced.
+        var reloaded = await _dbContext!.PdfDocuments.AsNoTracking()
+            .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+        reloaded.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
+        reloaded.RowVersion.Should().NotBeNull().And.NotEqual(pdf.RowVersion);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Scenario 2: Reindex races with Delete — first wins, second 409
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reindex_RacesWithDelete_FirstWinsSecondGets409()
+    {
+        var pdf = await SeedReadyPdfAsync();
+
+        using var barrier = new Barrier(participantCount: 2);
+
+        Task<(string Op, Exception? Exception)> RunReindex() => Task.Run(async () =>
+        {
+            using var scope = _serviceProvider!.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+            try
+            {
+                await mediator.Send(new ReindexDocumentCommand(pdf.Id, IndexerVersionRegistry.Current.Version), TestCancellationToken);
+                return ("reindex", (Exception?)null);
+            }
+            catch (Exception ex) { return ("reindex", (Exception?)ex); }
+        });
+
+        Task<(string Op, Exception? Exception)> RunDelete() => Task.Run(async () =>
+        {
+            using var scope = _serviceProvider!.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+            try
+            {
+                await mediator.Send(new DeleteKbDocumentCommand(pdf.Id), TestCancellationToken);
+                return ("delete", (Exception?)null);
+            }
+            catch (Exception ex) { return ("delete", (Exception?)ex); }
+        });
+
+        var results = await Task.WhenAll(RunReindex(), RunDelete());
+
+        var successCount = results.Count(r => r.Exception is null);
+        var conflictCount = results.Count(r => r.Exception is ConflictException);
+        successCount.Should().Be(1, "exactly one operation must succeed");
+        conflictCount.Should().Be(1, "exactly one operation must conflict");
+
+        // If delete won: document removed. If reindex won: document remains with state=Pending.
+        var winner = results.Single(r => r.Exception is null);
+        var existsCheck = await _dbContext!.PdfDocuments.AsNoTracking()
+            .AnyAsync(p => p.Id == pdf.Id, TestCancellationToken);
+        if (winner.Op == "delete")
+        {
+            existsCheck.Should().BeFalse("delete winner removes the document");
+            var orphanChunks = await _dbContext.TextChunks.AsNoTracking()
+                .CountAsync(tc => tc.PdfDocumentId == pdf.Id, TestCancellationToken);
+            orphanChunks.Should().Be(0, "no orphan TextChunks (cascade)");
+        }
+        else
+        {
+            existsCheck.Should().BeTrue("reindex winner keeps the document");
+            var reloaded = await _dbContext.PdfDocuments.AsNoTracking()
+                .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+            reloaded.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Scenario 3: Reindex races with background pipeline RowVersion mutation
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reindex_RacesWithBackgroundPipeline_AdminGets409()
+    {
+        // Seed Ready, then simulate a background pipeline mutation (Ready → Chunking)
+        // in scope B while admin reads stale RowVersion and tries to reindex in scope A.
+        var pdf = await SeedReadyPdfAsync();
+
+        using var barrier = new Barrier(participantCount: 2);
+
+        Task<(string Op, Exception? Exception)> RunAdminReindex() => Task.Run(async () =>
+        {
+            using var scope = _serviceProvider!.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Force the admin scope to load the PDF (capture RowVersion v1) BEFORE the barrier.
+            var loaded = await db.PdfDocuments.FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+
+            barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+            try
+            {
+                await mediator.Send(new ReindexDocumentCommand(pdf.Id, IndexerVersionRegistry.Current.Version), TestCancellationToken);
+                return ("admin", (Exception?)null);
+            }
+            catch (Exception ex) { return ("admin", (Exception?)ex); }
+        });
+
+        Task<(string Op, Exception? Exception)> RunPipelineTick() => Task.Run(async () =>
+        {
+            using var scope = _serviceProvider!.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+            barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+            try
+            {
+                // Simulate a Category B mutation directly (no real pipeline service spin-up).
+                var entity = await db.PdfDocuments.FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+                entity.ProcessingState = nameof(PdfProcessingState.Chunking);
+                await db.SaveChangesAsync(TestCancellationToken);
+                return ("pipeline", (Exception?)null);
+            }
+            catch (Exception ex) { return ("pipeline", (Exception?)ex); }
+        });
+
+        var results = await Task.WhenAll(RunAdminReindex(), RunPipelineTick());
+
+        // Exactly one wins. The semantics depend on timing — what matters is consistency:
+        // EITHER both succeed (no race occurred — barrier timing variance) OR exactly one fails.
+        var failureCount = results.Count(r => r.Exception is not null);
+        failureCount.Should().BeLessThanOrEqualTo(1, "at most one operation should conflict (or zero if barrier failed to align)");
+
+        // The document MUST end in a consistent state — not partial.
+        var final = await _dbContext!.PdfDocuments.AsNoTracking()
+            .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+        final.ProcessingState.Should().BeOneOf(
+            nameof(PdfProcessingState.Pending),   // admin reindex won
+            nameof(PdfProcessingState.Chunking)); // pipeline won
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Scenario 4: Retry after conflict succeeds
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sequential_RetryAfterConflict_Succeeds()
+    {
+        var pdf = await SeedReadyPdfAsync();
+
+        // Step 1: provoke a conflict via parallel reindex (same as Scenario 1).
+        using (var barrier = new Barrier(participantCount: 2))
+        {
+            Task<Exception?> RunReindex() => Task.Run(async () =>
+            {
+                using var scope = _serviceProvider!.CreateScope();
+                var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+                barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+                try { await mediator.Send(new ReindexDocumentCommand(pdf.Id, IndexerVersionRegistry.Current.Version), TestCancellationToken); return null; }
+                catch (Exception ex) { return ex; }
+            });
+            await Task.WhenAll(RunReindex(), RunReindex());
+        }
+
+        // Step 2: the losing admin retries 1 second later (after winner persisted).
+        await Task.Delay(TimeSpan.FromSeconds(1), TestCancellationToken);
+
+        // Fresh read in fresh scope — gets the NEW RowVersion.
+        using var retryScope = _serviceProvider!.CreateScope();
+        var retryMediator = retryScope.ServiceProvider.GetRequiredService<IMediator>();
+        await retryMediator.Send(new ReindexDocumentCommand(pdf.Id, IndexerVersionRegistry.Current.Version), TestCancellationToken);
+
+        var final = await _dbContext!.PdfDocuments.AsNoTracking()
+            .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+        final.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending),
+            "retry after conflict should succeed and leave state=Pending");
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj 2>&1 | tail -3
+dotnet build apps/api/tests/Api.Tests/Api.Tests.csproj 2>&1 | tail -3
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Run the integration tests (requires Docker)**
+
+```bash
+docker info 2>&1 | head -3   # Confirm Docker running
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PdfRowVersionConcurrencyIntegrationTests" --no-build 2>&1 | tail -10
+```
+
+Expected: 4 passed. If Docker is NOT running locally, commit the test file anyway — CI will run them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfRowVersionConcurrencyIntegrationTests.cs
+git commit -m "test(api/document-processing): #1802 RowVersion concurrency E2E (4 Barrier-sync scenarios)"
+```
+
+---
+
+### Task 8: Final verification + PR + issue close-out
+
+**Files:**
+- (no edit)
+
+- [ ] **Step 1: Final regression sweep**
+
+```bash
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=DocumentProcessing&Category=Unit" --no-build 2>&1 | tail -5
+```
+
+Expected: all DocumentProcessing unit tests still pass (baseline ~336+).
+
+- [ ] **Step 2: Final grep — verify no unwrapped SaveChanges**
+
+```bash
+grep -rn 'await.*SaveChangesAsync' apps/api/src/Api/BoundedContexts/DocumentProcessing 2>&1 | grep -v 'PdfDocumentEntity\|Collection\|Test'
+```
+
+For each match, confirm it's inside a `try { … } catch (DbUpdateConcurrencyException)` block OR document why it's exempt (e.g. the SaveChanges only persists non-Pdf entities).
+
+- [ ] **Step 3: Verify Prometheus counter is wired**
+
+```bash
+grep -rn 'PdfConcurrencyMetrics.RecordConflict' apps/api/src/Api/BoundedContexts/DocumentProcessing
+```
+
+Expected: 17 sites (9 Category A + 6 Category B incl. 3 in PdfProcessingPipelineService + 2 Category C).
+
+- [ ] **Step 4: Rebase + push**
+
+```bash
+git fetch origin main-dev
+git rebase origin/main-dev
+git push -u origin feature/issue-1802-rowversion-concurrency
+```
+
+If conflicts: resolve and re-run regression sweep (Step 1).
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --base main-dev --title "feat(api/document-processing): #1802 RowVersion optimistic concurrency" --body "$(cat <<'EOF'
+## Summary
+
+Closes #1802. Adds optimistic concurrency control to `PdfDocumentEntity` via PostgreSQL `xmin` (mapped by EF Core `IsRowVersion()`) and wraps 17 handler mutation sites with category-appropriate error handling.
+
+## Categories (Wiegers full enumeration — workshop)
+
+- **Category A** (9 handlers, user-facing): catch `DbUpdateConcurrencyException` → throw `ConflictException` → 409 to caller. FE shows retry toast.
+- **Category B** (6 handlers, background pipeline): catch → log warning → return success. Quartz no retry; next pipeline tick re-reads.
+- **Category C** (2 handlers, maintenance): catch → log debug → continue batch.
+
+## Observability
+
+- New Prometheus counter `meepleai_pdf_concurrency_conflicts_total{handler,category}` (cardinality ≤51 series).
+- Structured warning logs at every conflict.
+
+## Test plan
+
+- [x] Build clean (0 errors, 0 new warnings)
+- [x] Existing DocumentProcessing unit tests pass (~336+)
+- [x] 4 Testcontainers integration tests (Barrier-synchronized parallel scenarios) pass
+- [x] No wire format change (server-only catch + 409)
+- [x] No DTO change
+
+## Notes
+
+- **PhotoBatchUpload landmine avoided**: entity uses `[Timestamp] byte[]? RowVersion` (nullable) per fix migration `20260524190307_FixPhotoBatchUploadRowVersionNullable`. Config uses `.IsRowVersion()` only (no `HasColumnName`) — Npgsql auto-maps to `xmin` system column.
+- **Implicit API surface** (workshop): no ETag header pattern (#2055). FE existing 409 toast handles new concurrency conflicts naturally.
+- **Grafana dashboard** (deferred to follow-up): added separately if telemetry shows >5 conflicts/day in production.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Comment on issue #1802**
+
+```bash
+gh issue comment 1802 --body "PR aperto contro \`main-dev\` (link sopra).
+
+## DoD updates
+- [x] \`[Timestamp] byte[]? RowVersion\` su \`PdfDocumentEntity\` (xmin mapping, PhotoBatchUpload landmine avoided).
+- [x] EF migration applicata.
+- [x] 9 Category A handler con \`DbUpdateConcurrencyException → ConflictException\`.
+- [x] 6 Category B handler con \`LogWarning + return success\` (incluso 3 mutation sites in PdfProcessingPipelineService).
+- [x] 2 Category C handler con \`LogDebug + silent skip\`.
+- [x] Prometheus counter \`meepleai_pdf_concurrency_conflicts_total\` wired su tutti i 17 catch sites.
+- [x] 4 Testcontainers integration tests (Barrier-sync parallel scenarios).
+- [x] Existing tests pass without modification.
+
+Ready for code review."
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Issue #1802 acceptance criterion | Task |
+|----------------------------------|------|
+| Add `[Timestamp] byte[]? RowVersion` to `PdfDocumentEntity` | Task 2 |
+| EF migration with `xmin` PostgreSQL convention | Task 2 |
+| `.IsRowVersion()` config (NOT `[Timestamp]` only) | Task 2 |
+| 9 Category A handlers throw ConflictException | Task 4 |
+| 6 Category B handlers log warning + return success | Task 5 |
+| 2 Category C handlers log debug + continue | Task 6 |
+| Prometheus counter `meepleai_pdf_concurrency_conflicts_total` | Task 3 + 4/5/6 |
+| Existing tests pass without modification | Tasks 4/5/6 step 5 (per-handler regression) + Task 8 step 1 |
+| 4 Testcontainers integration tests | Task 7 |
+| PhotoBatchUpload landmine avoidance | Task 2 (nullable byte[]) |
+
+### Placeholder scan
+
+- [x] No "TBD" / "TODO" / "implement later".
+- [x] No "Add appropriate error handling" — every catch has explicit exception type + counter + log + action.
+- [x] No "Similar to Task N" — Task 4/5/6 have explicit per-handler tables AND uniform pattern code blocks repeated for clarity.
+- [x] No "Write tests for the above" — Task 7 has 4 fully-coded scenarios.
+
+### Type consistency
+
+| Symbol | Defined | Used |
+|--------|---------|------|
+| `PdfDocumentEntity.RowVersion` (byte[]?) | Task 2 | Tasks 4/5/6 (handler refactors) + Task 7 (integration tests) |
+| `PdfConcurrencyMetrics.RecordConflict(handler, category)` | Task 3 | Tasks 4/5/6 (17 catch sites) |
+| `DbUpdateConcurrencyException` (Microsoft.EntityFrameworkCore) | EF library | Tasks 4/5/6 |
+| `ConflictException(string)` | existing `Api.Middleware.Exceptions.ConflictException` | Task 4 only (Category A) |
+| `PdfProcessingState` enum values via `nameof(...)` | #1801 (already in main-dev) | Task 7 (integration test fixtures) |
+| `IndexerVersionRegistry.Current.Version` | #1673 (already in main-dev) | Task 7 |
+| `ReindexDocumentCommand(Guid, string?)` | #1673 (already in main-dev) | Task 7 |
+| `DeleteKbDocumentCommand(Guid)` | #1653 (already in main-dev) | Task 7 |
+
+All cross-references resolve to merged code on main-dev.
+
+---
+
+## References
+
+- Issue: [#1802](https://github.com/meepleAi-app/meepleai-monorepo/issues/1802) (post-workshop body, 8.5/10 spec quality)
+- Sibling RowVersion pattern: `RuleSpecEntity.cs:27-28` + `RuleSpecEntityConfiguration.cs:38-39`
+- PhotoBatchUpload landmine: migration `20260524190307_FixPhotoBatchUploadRowVersionNullable.cs`
+- Workshop decisions (2026-06-02): full scope, implicit API, 4 scenarios, observability yes
+- Spec-panel review (Wiegers, Fowler, Nygard, Newman, Crispin, Adzic): conversation history 2026-06-02
+- Related PRs: #1800 (#1673 reindex selector), #1804 (#1801 nameof refactor), #1805 (#1801 close-out)

--- a/docs/superpowers/plans/2026-06-02-sp5-admin-kb-1673-reindex-version-selector.md
+++ b/docs/superpowers/plans/2026-06-02-sp5-admin-kb-1673-reindex-version-selector.md
@@ -1,0 +1,1992 @@
+# SP5 Admin KB #1673 — Re-index with version selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere supporto al re-index versionato per documenti KB lato admin — registry di versioni indicizzatore code-resident, persistenza per-doc della versione applicata, audit, UI con dropdown versione + 409 su reindex in-flight.
+
+**Architecture:** Approccio foundation-first basato sul design doc `2026-06-01-sp5-admin-kb-fu4-spinouts-design.md` §3.2 (D-B: code-resident strategy registry ≤3 versioni). Aggiungiamo la colonna `pdf_documents.indexer_version`, estendiamo `ReindexDocumentCommand` con parametro opzionale `IndexerVersion`, esponiamo un nuovo endpoint `GET /api/v1/admin/indexer/versions` per popolare il dropdown, e renderizziamo la versione nel hero metadata del detail panel (chiude anche #1676 sub-task F3). Il registry oggi contiene solo `Current` (selectable) + `Legacy v0` (marker per row backfilled, non selectable) — strategie diverse verranno aggiunte quando una vera divergenza pipeline viene shippata.
+
+**Tech Stack:**
+- BE: .NET 9 / ASP.NET Minimal APIs + MediatR (CQRS), EF Core 9 (PostgreSQL + pgvector), FluentValidation, xUnit + Testcontainers, FluentAssertions
+- FE: Next.js 16 (App Router) + React 19, TypeScript, TanStack Query v5, Zod, Vitest + React Testing Library, Tailwind 4
+
+**Issue**: [#1673](https://github.com/meepleAi-app/meepleai-monorepo/issues/1673) (P3) · parent design doc `docs/superpowers/specs/2026-06-01-sp5-admin-kb-fu4-spinouts-design.md` §3.2
+
+**Branch**: `feature/issue-1673-reindex-version-selector` (parent: `main-dev`)
+
+---
+
+## File Structure (decomposition)
+
+### BE — Created
+| Path | Responsibility |
+|------|---------------|
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersion.cs` | Value object record (Version, DisplayName, IsSelectable) |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs` | Static registry (Current, Legacy, All, TryGet) |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/GetIndexerVersionRegistryQuery.cs` | MediatR query (parameterless) |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/GetIndexerVersionRegistryHandler.cs` | Returns selectable versions from registry |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/IndexerVersionDto.cs` | DTO (Version, DisplayName, IsCurrent) |
+| `apps/api/src/Api/Infrastructure/Migrations/<TIMESTAMP>_AddIndexerVersionToPdfDocuments.cs` | EF migration: nullable column + backfill `'v0'` |
+| `apps/api/src/Api/Routing/AdminIndexerEndpoints.cs` | Endpoint `GET /api/v1/admin/indexer/versions` |
+| `apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs` | Unit tests value object + registry |
+| `apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandValidatorTests.cs` | Unit tests validator (PdfId + IndexerVersion) |
+| `apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandHandlerTests.cs` | Unit tests handler (resolution + conflict + persistence) |
+| `apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetIndexerVersionRegistryHandlerTests.cs` | Unit tests query handler |
+| `apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentVersionIntegrationTests.cs` | Integration: end-to-end + audit + 409 in-flight |
+| `apps/web/src/components/admin/knowledge-base/explorer/actions/KbReindexDropdown.tsx` | Dropdown button (version picker + confirm) |
+| `apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbReindexDropdown.test.tsx` | Vitest component test |
+| `apps/web/src/hooks/queries/useIndexerVersions.ts` | TanStack Query hook (registry fetch) |
+| `apps/web/src/lib/api/schemas/indexer-versions.schemas.ts` | Zod schemas (registry response) |
+
+### BE — Modified
+| Path | Change |
+|------|--------|
+| `apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs` | + `string? IndexerVersion { get; set; }` |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs` | + Property mapping `indexer_version varchar(32) NULL` |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommand.cs` | + `string? IndexerVersion` param + `[AuditableAction]` attribute |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs` | Version resolution + conflict guard + persistence |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/ReindexDocumentCommandValidator.cs` | + Validation: IndexerVersion null OR in registry as selectable |
+| `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs` | Reindex endpoint accepts optional body `{ "indexerVersion": "v1.0" }` |
+| `apps/api/src/Api/Program.cs` | Wire `MapAdminIndexerEndpoints` |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs` | + `string? IndexerVersion` field |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs` | Populate IndexerVersion from entity |
+
+### FE — Modified
+| Path | Change |
+|------|--------|
+| `apps/web/src/lib/api/clients/pdfClient.ts` | `reindexDocument(pdfId, body?)` + `getIndexerVersions()` |
+| `apps/web/src/lib/api/schemas/kb-chunks.schemas.ts` | Add `indexerVersion: z.string().nullable().optional()` to `KbDocDetailSchema` |
+| `apps/web/src/hooks/queries/useKbDocActions.ts` | `useReindexDoc(docId)` accepts `{ indexerVersion?: string }` payload |
+| `apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx` | Swap button → `<KbReindexDropdown>` |
+| `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx` | Render `indexerVersion` in hero metadata block |
+
+---
+
+## Tasks
+
+### Task 1: BE Domain — `IndexerVersion` value object + `IndexerVersionRegistry`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersion.cs`
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs`
+
+- [ ] **Step 1: Write failing tests for `IndexerVersion` + `IndexerVersionRegistry`**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1673")]
+public sealed class IndexerVersionRegistryTests
+{
+    [Fact]
+    public void Current_ReturnsLatestSelectableVersion()
+    {
+        IndexerVersionRegistry.Current.Version.Should().Be("v1.0");
+        IndexerVersionRegistry.Current.IsSelectable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Legacy_ReturnsV0NonSelectable()
+    {
+        IndexerVersionRegistry.Legacy.Version.Should().Be("v0");
+        IndexerVersionRegistry.Legacy.IsSelectable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void All_ContainsLegacyAndCurrent()
+    {
+        var versions = IndexerVersionRegistry.All;
+        versions.Should().HaveCountGreaterThanOrEqualTo(2);
+        versions.Should().Contain(v => v.Version == "v0");
+        versions.Should().Contain(v => v.Version == "v1.0");
+    }
+
+    [Theory]
+    [InlineData("v0")]
+    [InlineData("v1.0")]
+    public void TryGet_KnownVersion_ReturnsTrue(string input)
+    {
+        IndexerVersionRegistry.TryGet(input, out var version).Should().BeTrue();
+        version!.Version.Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData("v99")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryGet_UnknownVersion_ReturnsFalse(string? input)
+    {
+        IndexerVersionRegistry.TryGet(input, out var version).Should().BeFalse();
+        version.Should().BeNull();
+    }
+
+    [Fact]
+    public void IsSelectable_LegacyV0_ReturnsFalse()
+    {
+        IndexerVersionRegistry.IsSelectable("v0").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSelectable_Current_ReturnsTrue()
+    {
+        IndexerVersionRegistry.IsSelectable("v1.0").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSelectable_Unknown_ReturnsFalse()
+    {
+        IndexerVersionRegistry.IsSelectable("v99").Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~IndexerVersionRegistryTests" --no-build 2>&1 | tail -20
+```
+
+Expected: build failure with "The type or namespace name 'IndexerVersion' could not be found".
+
+- [ ] **Step 3: Implement `IndexerVersion` value object**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersion.cs
+namespace Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+
+/// <summary>
+/// Identifies a pipeline indexer version. Code-resident registry per design doc D-B
+/// (2026-06-01-sp5-admin-kb-fu4-spinouts-design.md §3.2): ≤3 versioni concorrenti, nessuna
+/// container infrastructure. Issue #1673.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>IsSelectable</b>: <c>false</c> per il marker storico <c>v0</c> (pre-versioning,
+/// usato dal backfill della migration). <c>true</c> per ogni versione effettivamente
+/// invocabile da `/admin/pdfs/{id}/reindex`.
+/// </para>
+/// </remarks>
+internal sealed record IndexerVersion(string Version, string DisplayName, bool IsSelectable);
+```
+
+- [ ] **Step 4: Implement `IndexerVersionRegistry`**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs
+using System.Diagnostics.CodeAnalysis;
+
+namespace Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+
+/// <summary>
+/// Code-resident registry of pipeline indexer versions per design doc D-B.
+/// Issue #1673.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Aggiungere una nuova versione</b>: introdurre la `static readonly IndexerVersion Vx_y`,
+/// includerla in <see cref="All"/>, aggiornare <see cref="Current"/>. NIENTE breaking change
+/// per <see cref="Legacy"/> (v0 resta marker di backfill).
+/// </para>
+/// <para>
+/// <b>Deprecation policy</b> (OQ-2 risolta dal spec-panel review PR #1790): le versioni
+/// storiche restano nel registry per ≥18 mesi post-supersession da una versione più recente.
+/// Oltre quel termine il code-resident slot può essere riciclato.
+/// </para>
+/// </remarks>
+internal static class IndexerVersionRegistry
+{
+    /// <summary>
+    /// Marker per documenti pre-versioning ingeriti prima dell'introduzione del versioning.
+    /// Non selectable: serve solo a non lasciare la colonna nullable per le righe storiche.
+    /// </summary>
+    public static readonly IndexerVersion Legacy =
+        new("v0", "v0 (legacy pre-versioning)", IsSelectable: false);
+
+    /// <summary>
+    /// Versione corrente della pipeline. Equivale al comportamento di default quando
+    /// `reindexDocument` viene chiamato senza `IndexerVersion` esplicito.
+    /// </summary>
+    public static readonly IndexerVersion Current =
+        new("v1.0", "v1.0 — current pipeline", IsSelectable: true);
+
+    public static IReadOnlyList<IndexerVersion> All { get; } = [Legacy, Current];
+
+    /// <summary>
+    /// Restituisce la lista delle versioni effettivamente invocabili da `/reindex`.
+    /// </summary>
+    public static IReadOnlyList<IndexerVersion> Selectable { get; } =
+        All.Where(v => v.IsSelectable).ToArray();
+
+    public static bool TryGet(string? version, [NotNullWhen(true)] out IndexerVersion? result)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            result = null;
+            return false;
+        }
+
+        result = All.FirstOrDefault(v => string.Equals(v.Version, version, StringComparison.Ordinal));
+        return result is not null;
+    }
+
+    public static bool IsSelectable(string? version) =>
+        TryGet(version, out var v) && v.IsSelectable;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~IndexerVersionRegistryTests" --no-build 2>&1 | tail -10
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersion.cs apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/ValueObjects/IndexerVersionRegistry.cs apps/api/tests/Api.Tests/Unit/DocumentProcessing/IndexerVersionRegistryTests.cs
+git commit -m "feat(api/document-processing): #1673 add IndexerVersion value object + registry"
+```
+
+---
+
+### Task 2: BE Migration — `indexer_version` column + backfill `'v0'`
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs`
+- Create: `apps/api/src/Api/Infrastructure/Migrations/<TIMESTAMP>_AddIndexerVersionToPdfDocuments.cs` (generated)
+
+- [ ] **Step 1: Add property to `PdfDocumentEntity`**
+
+In `apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs`, dopo `public string? VersionLabel { get; set; }` (riga 94), aggiungere:
+
+```csharp
+    // Issue #1673: Pipeline indexer version applied at last reindex.
+    // Nullable for backwards compat — backfilled to 'v0' on migration.
+    public string? IndexerVersion { get; set; }
+```
+
+- [ ] **Step 2: Add property mapping to `PdfDocumentEntityConfiguration`**
+
+In `apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs`, dopo il blocco `VersionLabel` (riga 163-166), aggiungere:
+
+```csharp
+        // Issue #1673: Pipeline indexer version (nullable; backfilled to 'v0').
+        builder.Property(e => e.IndexerVersion)
+            .HasMaxLength(32)
+            .HasColumnName("indexer_version")
+            .IsRequired(false);
+
+        builder.HasIndex(e => e.IndexerVersion)
+            .HasDatabaseName("ix_pdf_documents_indexer_version");
+```
+
+- [ ] **Step 3: Generate migration**
+
+```
+cd apps/api/src/Api
+dotnet ef migrations add AddIndexerVersionToPdfDocuments --output-dir Infrastructure/Migrations
+```
+
+Expected: 2 new files in `Infrastructure/Migrations/<TIMESTAMP>_AddIndexerVersionToPdfDocuments.*`.
+
+- [ ] **Step 4: Edit migration to backfill `'v0'` for existing rows**
+
+Aprire `<TIMESTAMP>_AddIndexerVersionToPdfDocuments.cs`. Nel metodo `Up`, dopo `migrationBuilder.AddColumn<string>(...)` aggiungere:
+
+```csharp
+            // Backfill legacy marker for rows ingested before versioning support.
+            migrationBuilder.Sql(
+                "UPDATE pdf_documents SET indexer_version = 'v0' WHERE indexer_version IS NULL;");
+```
+
+Il metodo `Down` può restare auto-generato (rimuove la colonna).
+
+- [ ] **Step 5: Verify build**
+
+```
+dotnet build apps/api/src/Api/Api.csproj --no-restore 2>&1 | tail -10
+```
+
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 6: Run existing PdfDocument tests to confirm no regression**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=DocumentProcessing" --no-build 2>&1 | tail -15
+```
+
+Expected: tutti pass (la colonna nullable non rompe niente).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(api/document-processing): #1673 add indexer_version column + v0 backfill"
+```
+
+---
+
+### Task 3: BE Validator — extend `ReindexDocumentCommandValidator`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/ReindexDocumentCommandValidator.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommand.cs` (extend signature first)
+- Create: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandValidatorTests.cs`
+
+- [ ] **Step 1: Extend `ReindexDocumentCommand` signature**
+
+Sostituire l'intero contenuto di `ReindexDocumentCommand.cs` con:
+
+```csharp
+using Api.BoundedContexts.Administration.Application.Attributes;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Command to reindex a PDF document (delete vectors/chunks, reset to Pending, re-trigger pipeline).
+/// PDF Storage Management Hub: Phase 5. Issue #1673 estende con selettore versione indexer.
+/// </summary>
+/// <param name="PdfId">ID del documento PDF da re-indicizzare.</param>
+/// <param name="IndexerVersion">
+/// Versione pipeline da applicare. <c>null</c> = usa la versione storica del documento se
+/// presente, altrimenti <c>IndexerVersionRegistry.Current.Version</c>.
+/// </param>
+[AuditableAction("DocumentReindex", "Document", Level = 2)]
+internal sealed record ReindexDocumentCommand(Guid PdfId, string? IndexerVersion = null) : ICommand;
+```
+
+- [ ] **Step 2: Write failing tests for validator**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandValidatorTests.cs
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Validators;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1673")]
+public sealed class ReindexDocumentCommandValidatorTests
+{
+    private readonly ReindexDocumentCommandValidator _validator = new();
+
+    [Fact]
+    public void PdfId_Empty_FailsWithNotEmpty()
+    {
+        var result = _validator.TestValidate(new ReindexDocumentCommand(Guid.Empty));
+        result.ShouldHaveValidationErrorFor(c => c.PdfId);
+    }
+
+    [Fact]
+    public void IndexerVersion_Null_Passes()
+    {
+        var result = _validator.TestValidate(new ReindexDocumentCommand(Guid.NewGuid()));
+        result.ShouldNotHaveValidationErrorFor(c => c.IndexerVersion);
+    }
+
+    [Fact]
+    public void IndexerVersion_Current_Passes()
+    {
+        var result = _validator.TestValidate(new ReindexDocumentCommand(Guid.NewGuid(), "v1.0"));
+        result.ShouldNotHaveValidationErrorFor(c => c.IndexerVersion);
+    }
+
+    [Fact]
+    public void IndexerVersion_LegacyV0_FailsAsNotSelectable()
+    {
+        var result = _validator.TestValidate(new ReindexDocumentCommand(Guid.NewGuid(), "v0"));
+        result.ShouldHaveValidationErrorFor(c => c.IndexerVersion)
+            .WithErrorMessage("Indexer version 'v0' is not selectable (legacy marker).");
+    }
+
+    [Fact]
+    public void IndexerVersion_Unknown_FailsAsUnknown()
+    {
+        var result = _validator.TestValidate(new ReindexDocumentCommand(Guid.NewGuid(), "v99"));
+        result.ShouldHaveValidationErrorFor(c => c.IndexerVersion)
+            .WithErrorMessage("Unknown indexer version 'v99'.");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — they should fail at compile time**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ReindexDocumentCommandValidatorTests" --no-build 2>&1 | tail -10
+```
+
+Expected: failure (validator non aggiornato).
+
+- [ ] **Step 4: Update `ReindexDocumentCommandValidator`**
+
+Sostituire l'intero contenuto:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using FluentValidation;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Validators;
+
+/// <summary>
+/// Validator for ReindexDocumentCommand. Issue #1673: enforces optional IndexerVersion
+/// must be a known, selectable version.
+/// </summary>
+internal sealed class ReindexDocumentCommandValidator : AbstractValidator<ReindexDocumentCommand>
+{
+    public ReindexDocumentCommandValidator()
+    {
+        RuleFor(x => x.PdfId)
+            .NotEmpty()
+            .WithMessage("PDF ID is required.");
+
+        RuleFor(x => x.IndexerVersion)
+            .Cascade(CascadeMode.Stop)
+            .Must(BeKnownIfProvided)
+            .WithMessage(c => $"Unknown indexer version '{c.IndexerVersion}'.")
+            .Must(BeSelectableIfProvided)
+            .WithMessage(c => $"Indexer version '{c.IndexerVersion}' is not selectable (legacy marker).");
+    }
+
+    private static bool BeKnownIfProvided(string? version) =>
+        version is null || IndexerVersionRegistry.TryGet(version, out _);
+
+    private static bool BeSelectableIfProvided(string? version) =>
+        version is null || IndexerVersionRegistry.IsSelectable(version);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cd apps/api/src/Api && dotnet build && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ReindexDocumentCommandValidatorTests" --no-build 2>&1 | tail -10
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommand.cs apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/ReindexDocumentCommandValidator.cs apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandValidatorTests.cs
+git commit -m "feat(api/document-processing): #1673 extend ReindexDocumentCommand with IndexerVersion"
+```
+
+---
+
+### Task 4: BE Handler — version resolution + conflict guard + persistence
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandHandlerTests.cs`
+
+- [ ] **Step 1: Write failing unit tests for handler**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandHandlerTests.cs
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1673")]
+public sealed class ReindexDocumentCommandHandlerTests : IAsyncLifetime
+{
+    private MeepleAiDbContext _db = default!;
+    private Mock<IMediator> _mediator = default!;
+
+    public ValueTask InitializeAsync()
+    {
+        var opts = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"reindex_{Guid.NewGuid():N}")
+            .Options;
+        _db = new MeepleAiDbContext(opts);
+        _mediator = new Mock<IMediator>(MockBehavior.Strict);
+        _mediator.Setup(m => m.Send(It.IsAny<EnqueuePdfCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Unit.Value);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _db.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task<PdfDocumentEntity> SeedPdfAsync(string state = "Ready", string? indexerVersion = null)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = state,
+            IndexerVersion = indexerVersion,
+        };
+        _db.PdfDocuments.Add(pdf);
+        await _db.SaveChangesAsync();
+        return pdf;
+    }
+
+    private ReindexDocumentCommandHandler CreateHandler() =>
+        new(_db, _mediator.Object, NullLogger<ReindexDocumentCommandHandler>.Instance);
+
+    [Fact]
+    public async Task Handle_NoExplicitVersion_NoStoredVersion_UsesCurrent()
+    {
+        var pdf = await SeedPdfAsync();
+        var handler = CreateHandler();
+
+        await handler.Handle(new ReindexDocumentCommand(pdf.Id), CancellationToken.None);
+
+        var reloaded = await _db.PdfDocuments.FirstAsync(p => p.Id == pdf.Id);
+        reloaded.IndexerVersion.Should().Be("v1.0");
+    }
+
+    [Fact]
+    public async Task Handle_NoExplicitVersion_StoredVersionPresent_UsesStored()
+    {
+        var pdf = await SeedPdfAsync(indexerVersion: "v1.0");
+        var handler = CreateHandler();
+
+        await handler.Handle(new ReindexDocumentCommand(pdf.Id), CancellationToken.None);
+
+        var reloaded = await _db.PdfDocuments.FirstAsync(p => p.Id == pdf.Id);
+        reloaded.IndexerVersion.Should().Be("v1.0");
+    }
+
+    [Fact]
+    public async Task Handle_ExplicitVersionOverridesStored()
+    {
+        var pdf = await SeedPdfAsync(indexerVersion: "v0");
+        var handler = CreateHandler();
+
+        await handler.Handle(new ReindexDocumentCommand(pdf.Id, "v1.0"), CancellationToken.None);
+
+        var reloaded = await _db.PdfDocuments.FirstAsync(p => p.Id == pdf.Id);
+        reloaded.IndexerVersion.Should().Be("v1.0");
+    }
+
+    [Theory]
+    [InlineData("Pending")]
+    [InlineData("Uploading")]
+    [InlineData("Extracting")]
+    [InlineData("Chunking")]
+    [InlineData("Embedding")]
+    [InlineData("Indexing")]
+    public async Task Handle_DocInFlight_ThrowsConflictException(string state)
+    {
+        var pdf = await SeedPdfAsync(state: state);
+        var handler = CreateHandler();
+
+        var act = () => handler.Handle(new ReindexDocumentCommand(pdf.Id), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ConflictException>();
+        ex.WithMessage($"*currently being processed*state={state}*");
+    }
+
+    [Theory]
+    [InlineData("Ready")]
+    [InlineData("Failed")]
+    public async Task Handle_DocTerminalState_AllowsReindex(string state)
+    {
+        var pdf = await SeedPdfAsync(state: state);
+        var handler = CreateHandler();
+
+        await handler.Handle(new ReindexDocumentCommand(pdf.Id), CancellationToken.None);
+
+        var reloaded = await _db.PdfDocuments.FirstAsync(p => p.Id == pdf.Id);
+        reloaded.ProcessingState.Should().Be("Pending");
+    }
+
+    [Fact]
+    public async Task Handle_PdfNotFound_ThrowsNotFoundException()
+    {
+        var handler = CreateHandler();
+        var act = () => handler.Handle(new ReindexDocumentCommand(Guid.NewGuid()), CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_Success_EnqueuesPdfForProcessing()
+    {
+        var pdf = await SeedPdfAsync();
+        var handler = CreateHandler();
+
+        await handler.Handle(new ReindexDocumentCommand(pdf.Id), CancellationToken.None);
+
+        _mediator.Verify(m => m.Send(
+            It.Is<EnqueuePdfCommand>(c => c.PdfId == pdf.Id),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```
+cd apps/api/src/Api && dotnet build && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ReindexDocumentCommandHandlerTests" --no-build 2>&1 | tail -20
+```
+
+Expected: 11 failed (handler non aggiornato + `NotFoundException` non lanciato).
+
+- [ ] **Step 3: Update handler**
+
+Sostituire l'intero contenuto di `ReindexDocumentCommandHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Handler for ReindexDocumentCommand. Issue #1673 estende il flusso con:
+/// 1. Risoluzione versione: <c>command.IndexerVersion ?? pdf.IndexerVersion ?? Current</c>.
+/// 2. Conflict guard: se il documento è in pipeline (stati non-terminali), 409 Conflict.
+/// 3. Persistenza della versione risolta su <c>pdf.IndexerVersion</c>.
+/// 4. Audit via <c>[AuditableAction("DocumentReindex", "Document", Level=2)]</c> sul command.
+/// </summary>
+internal sealed class ReindexDocumentCommandHandler : ICommandHandler<ReindexDocumentCommand>
+{
+    // Stati pre-terminali. Reindex bloccato finché non si raggiunge Ready o Failed.
+    private static readonly HashSet<string> InFlightStates =
+        new(StringComparer.Ordinal)
+        {
+            "Pending",
+            "Uploading",
+            "Extracting",
+            "Chunking",
+            "Embedding",
+            "Indexing",
+        };
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IMediator _mediator;
+    private readonly ILogger<ReindexDocumentCommandHandler> _logger;
+
+    public ReindexDocumentCommandHandler(
+        MeepleAiDbContext dbContext,
+        IMediator mediator,
+        ILogger<ReindexDocumentCommandHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(ReindexDocumentCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var pdf = await _dbContext.PdfDocuments
+            .FirstOrDefaultAsync(p => p.Id == command.PdfId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pdf is null)
+        {
+            throw new NotFoundException($"PDF document {command.PdfId} not found");
+        }
+
+        // Conflict guard: rifiuta il reindex se la pipeline è in-flight.
+        if (InFlightStates.Contains(pdf.ProcessingState))
+        {
+            throw new ConflictException(
+                $"Document {command.PdfId} is currently being processed (state={pdf.ProcessingState}); cannot reindex until it reaches Ready or Failed.");
+        }
+
+        // Risoluzione versione: explicit → stored → current.
+        var resolvedVersion = command.IndexerVersion
+            ?? pdf.IndexerVersion
+            ?? IndexerVersionRegistry.Current.Version;
+
+        // Cancella chunks associati.
+        var chunks = await _dbContext.TextChunks
+            .Where(tc => tc.PdfDocumentId == command.PdfId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (chunks.Count > 0)
+        {
+            _dbContext.TextChunks.RemoveRange(chunks);
+        }
+
+        // Reset state + scrive la versione risolta.
+        pdf.ProcessingState = "Pending";
+        pdf.ProcessedAt = null;
+        pdf.ProcessingError = null;
+        pdf.RetryCount = 0;
+        pdf.ErrorCategory = null;
+        pdf.FailedAtState = null;
+        pdf.IndexerVersion = resolvedVersion;
+
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Enqueue Quartz.
+        try
+        {
+            var userId = pdf.UploadedByUserId;
+            await _mediator.Send(
+                new EnqueuePdfCommand(command.PdfId, userId, Priority: 0),
+                cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Reindexed PDF {PdfId} with version {IndexerVersion} enqueued for processing",
+                command.PdfId, resolvedVersion);
+        }
+#pragma warning disable CA1031 // Best-effort enqueue
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not enqueue reindexed PDF {PdfId} (may already be queued)", command.PdfId);
+        }
+#pragma warning restore CA1031
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ReindexDocumentCommandHandlerTests" --no-build 2>&1 | tail -15
+```
+
+Expected: 11 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ReindexDocumentCommandHandler.cs apps/api/tests/Api.Tests/Unit/DocumentProcessing/ReindexDocumentCommandHandlerTests.cs
+git commit -m "feat(api/document-processing): #1673 version resolution + conflict guard in reindex handler"
+```
+
+---
+
+### Task 5: BE Query — `GetIndexerVersionRegistryQuery` + handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/GetIndexerVersionRegistryQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/GetIndexerVersionRegistryHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/IndexerVersionDto.cs`
+- Create: `apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetIndexerVersionRegistryHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetIndexerVersionRegistryHandlerTests.cs
+using Api.BoundedContexts.DocumentProcessing.Application.Queries.GetIndexerVersionRegistry;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.DocumentProcessing;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1673")]
+public sealed class GetIndexerVersionRegistryHandlerTests
+{
+    private readonly GetIndexerVersionRegistryHandler _handler = new();
+
+    [Fact]
+    public async Task Handle_ReturnsOnlySelectableVersions()
+    {
+        var result = await _handler.Handle(new GetIndexerVersionRegistryQuery(), CancellationToken.None);
+
+        result.Should().NotBeEmpty();
+        result.Should().OnlyContain(v => !string.Equals(v.Version, "v0", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Handle_MarksCurrentVersion()
+    {
+        var result = await _handler.Handle(new GetIndexerVersionRegistryQuery(), CancellationToken.None);
+
+        var current = result.Should().ContainSingle(v => v.IsCurrent).Subject;
+        current.Version.Should().Be("v1.0");
+        current.DisplayName.Should().NotBeNullOrWhiteSpace();
+    }
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetIndexerVersionRegistryHandlerTests" --no-build 2>&1 | tail -10
+```
+
+Expected: build failure (`GetIndexerVersionRegistryQuery` not defined).
+
+- [ ] **Step 3: Implement DTO**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/IndexerVersionDto.cs
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries.GetIndexerVersionRegistry;
+
+/// <summary>
+/// Public projection of an <see cref="Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects.IndexerVersion"/>.
+/// </summary>
+public sealed record IndexerVersionDto(string Version, string DisplayName, bool IsCurrent);
+```
+
+- [ ] **Step 4: Implement Query + Handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/GetIndexerVersionRegistryQuery.cs
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries.GetIndexerVersionRegistry;
+
+/// <summary>
+/// Returns selectable indexer versions for the admin dropdown.
+/// Issue #1673.
+/// </summary>
+internal sealed record GetIndexerVersionRegistryQuery : IQuery<IReadOnlyList<IndexerVersionDto>>;
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/GetIndexerVersionRegistryHandler.cs
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries.GetIndexerVersionRegistry;
+
+internal sealed class GetIndexerVersionRegistryHandler
+    : IQueryHandler<GetIndexerVersionRegistryQuery, IReadOnlyList<IndexerVersionDto>>
+{
+    public Task<IReadOnlyList<IndexerVersionDto>> Handle(
+        GetIndexerVersionRegistryQuery request,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<IndexerVersionDto> result = IndexerVersionRegistry.Selectable
+            .Select(v => new IndexerVersionDto(
+                Version: v.Version,
+                DisplayName: v.DisplayName,
+                IsCurrent: string.Equals(v.Version, IndexerVersionRegistry.Current.Version, StringComparison.Ordinal)))
+            .ToList();
+        return Task.FromResult(result);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cd apps/api/src/Api && dotnet build && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetIndexerVersionRegistryHandlerTests" --no-build 2>&1 | tail -10
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/ apps/api/tests/Api.Tests/Unit/DocumentProcessing/GetIndexerVersionRegistryHandlerTests.cs
+git commit -m "feat(api/document-processing): #1673 GetIndexerVersionRegistryQuery"
+```
+
+---
+
+### Task 6: BE Endpoints — `GET /admin/indexer/versions` + extend reindex body
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/AdminIndexerEndpoints.cs`
+- Modify: `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs`
+- Modify: `apps/api/src/Api/Program.cs`
+
+- [ ] **Step 1: Create `AdminIndexerEndpoints.cs`**
+
+```csharp
+// apps/api/src/Api/Routing/AdminIndexerEndpoints.cs
+using Api.BoundedContexts.DocumentProcessing.Application.Queries.GetIndexerVersionRegistry;
+using Api.Filters;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoints for indexer pipeline metadata.
+/// Issue #1673: registry per dropdown versione reindex.
+/// </summary>
+internal static class AdminIndexerEndpoints
+{
+    public static void MapAdminIndexerEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/admin/indexer")
+            .WithTags("Admin - Indexer")
+            .AddEndpointFilter<RequireAdminSessionFilter>();
+
+        group.MapGet("/versions", GetVersions)
+            .WithName("GetIndexerVersions")
+            .WithSummary("Returns selectable indexer versions for the reindex dropdown");
+    }
+
+    private static async Task<IResult> GetVersions(
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var versions = await mediator.Send(new GetIndexerVersionRegistryQuery(), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(versions);
+    }
+}
+```
+
+- [ ] **Step 2: Update reindex endpoint to accept optional body**
+
+In `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs`, sostituire il metodo `ReindexDocument` e aggiungere il record richiesta in fondo al file:
+
+```csharp
+    private static async Task<IResult> ReindexDocument(
+        Guid pdfId,
+        ReindexDocumentRequest? request,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        await mediator.Send(
+            new ReindexDocumentCommand(pdfId, request?.IndexerVersion),
+            cancellationToken).ConfigureAwait(false);
+        return Results.Ok(new { success = true, message = "Document queued for reindexing" });
+    }
+```
+
+In fondo al file, dopo `BulkDeletePdfsRequest`:
+
+```csharp
+internal record ReindexDocumentRequest(string? IndexerVersion);
+```
+
+- [ ] **Step 3: Wire endpoint group in Program.cs**
+
+Cercare `MapAdminPdfManagementEndpoints` in `Program.cs` e affiancare la chiamata:
+
+```bash
+grep -n "MapAdminPdfManagementEndpoints" apps/api/src/Api/Program.cs
+```
+
+Sotto la riga trovata, aggiungere:
+
+```csharp
+app.MapAdminIndexerEndpoints();
+```
+
+- [ ] **Step 4: Verify build**
+
+```
+dotnet build apps/api/src/Api/Api.csproj --no-restore 2>&1 | tail -5
+```
+
+Expected: Build succeeded. 0 Error(s).
+
+- [ ] **Step 5: Run full BE test suite for regressions**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=DocumentProcessing&Category=Unit" --no-build 2>&1 | tail -10
+```
+
+Expected: tutti i test DocumentProcessing pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/AdminIndexerEndpoints.cs apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs apps/api/src/Api/Program.cs
+git commit -m "feat(api/routing): #1673 GET /admin/indexer/versions + extend reindex body"
+```
+
+---
+
+### Task 7: BE Integration test — end-to-end reindex + 409 in-flight
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentVersionIntegrationTests.cs`
+
+- [ ] **Step 1: Write integration test**
+
+Pattern modellato su `DeleteKbDocumentCommandHandlerIntegrationTests.cs`. Usa Testcontainers Postgres via `SharedTestcontainersFixture`.
+
+```csharp
+// apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentVersionIntegrationTests.cs
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration tests for ReindexDocumentCommandHandler version selector. Issue #1673.
+/// Verifies version persistence + audit row + 409 on in-flight reindex.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1673")]
+public sealed class ReindexDocumentVersionIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-000000001673");
+    private static readonly Guid TestSharedGameId = new("B0000000-0000-0000-0000-000000001673");
+
+    public ReindexDocumentVersionIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_reindex_v_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+        await SeedBaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null) await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable d) await d.DisposeAsync();
+        await _fixture.DropDatabaseAsync(_databaseName);
+    }
+
+    private async Task SeedBaseAsync()
+    {
+        _dbContext!.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "reindex-v-test@meepleai.test",
+            PasswordHash = "x",
+            DisplayName = "Reindex V Test",
+        });
+        _dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = TestSharedGameId,
+            Name = "Reindex V Test Game",
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private async Task<PdfDocumentEntity> SeedPdfAsync(string state = "Ready", string? indexerVersion = null)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "reindex-v.pdf",
+            FilePath = "/tmp/reindex-v.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = TestUserId,
+            SharedGameId = TestSharedGameId,
+            ProcessingState = state,
+            IndexerVersion = indexerVersion,
+        };
+        _dbContext!.PdfDocuments.Add(pdf);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return pdf;
+    }
+
+    [Fact]
+    public async Task Reindex_ExplicitVersion_PersistsOnEntity()
+    {
+        var pdf = await SeedPdfAsync();
+
+        await _mediator!.Send(
+            new ReindexDocumentCommand(pdf.Id, "v1.0"),
+            TestCancellationToken);
+
+        var reloaded = await _dbContext!.PdfDocuments
+            .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+        reloaded.IndexerVersion.Should().Be("v1.0");
+        reloaded.ProcessingState.Should().Be("Pending");
+    }
+
+    [Fact]
+    public async Task Reindex_NullVersionWithStoredV0_KeepsStoredValue()
+    {
+        // v0 backfill marker stored → reindex senza override usa il valore stored, NON Current.
+        // L'admin che vuole promuovere alla pipeline corrente deve passare esplicitamente "v1.0"
+        // dal dropdown (Adzic scenario di rollback / promote-on-demand).
+        var pdf = await SeedPdfAsync(indexerVersion: "v0");
+
+        await _mediator!.Send(
+            new ReindexDocumentCommand(pdf.Id),
+            TestCancellationToken);
+
+        var reloaded = await _dbContext!.PdfDocuments
+            .FirstAsync(p => p.Id == pdf.Id, TestCancellationToken);
+        reloaded.IndexerVersion.Should().Be("v0");
+    }
+
+    [Fact]
+    public async Task Reindex_InFlight_ThrowsConflictException()
+    {
+        var pdf = await SeedPdfAsync(state: "Chunking");
+
+        var act = () => _mediator!.Send(
+            new ReindexDocumentCommand(pdf.Id, "v1.0"),
+            TestCancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Reindex_WritesAuditOutboxRow()
+    {
+        var pdf = await SeedPdfAsync();
+
+        await _mediator!.Send(
+            new ReindexDocumentCommand(pdf.Id, "v1.0"),
+            TestCancellationToken);
+
+        // Filtra client-side (jsonb non supporta SQL LIKE) per identificare la riga
+        // di audit emessa dal command pattern [AuditableAction].
+        var rows = await _dbContext!.AuditOutbox.AsNoTracking().ToListAsync(TestCancellationToken);
+        rows.Should().Contain(r =>
+            string.Equals(r.Action, "DocumentReindex", StringComparison.Ordinal)
+            && string.Equals(r.Resource, "Document", StringComparison.Ordinal));
+    }
+}
+```
+
+> **Nota integration test infrastructure**: la classe `IntegrationServiceCollectionBuilder.CreateBase` registra MediatR + EF + MeepleAiDbContext con la connection string isolata. Se manca un servizio richiesto dal handler (es. `IAuditOutboxRepository`) la chiamata di test fallirà sollevando un'eccezione di DI: in quel caso aggiungere `services.AddScoped<...>` nel test prima di `BuildServiceProvider()`, **mai** mockare l'audit outbox — è proprio la riga che vogliamo verificare.
+
+- [ ] **Step 2: Run integration tests**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ReindexDocumentVersionIntegrationTests" --no-build 2>&1 | tail -15
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Integration/DocumentProcessing/ReindexDocumentVersionIntegrationTests.cs
+git commit -m "test(api/document-processing): #1673 reindex version E2E + 409 + audit"
+```
+
+---
+
+### Task 8: BE DTO — expose `IndexerVersion` in `KbDocumentDto`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs`
+
+- [ ] **Step 1: Extend DTO**
+
+Sostituire la signature di `KbDocumentDto`:
+
+```csharp
+internal sealed record KbDocumentDto(
+    Guid Id,
+    string Title,
+    string DocType,
+    Guid? GameId,
+    string? GameName,
+    string UploaderName,
+    DateTime UploadedAt,
+    DateTime LastIngestedAt,
+    string ProcessingStatus,
+    int ChunkCount,
+    int? PageCount,
+    string Language,
+    IReadOnlyList<string> Tags,
+    long FileSize,
+    // Issue #1673: indexer version applicato all'ultimo reindex (null = mai indicizzato; "v0" = pre-versioning).
+    string? IndexerVersion
+);
+```
+
+- [ ] **Step 2: Populate field in handler**
+
+In `GetKbDocumentByIdHandler.cs:156-173`, aggiungere `IndexerVersion: data.pdf.IndexerVersion,` come ultimo argomento nel `new KbDocumentDto(...)`.
+
+- [ ] **Step 3: Verify build**
+
+```
+dotnet build apps/api/src/Api/Api.csproj --no-restore 2>&1 | tail -5
+```
+
+Expected: Build succeeded.
+
+- [ ] **Step 4: Run KnowledgeBase tests**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetKbDocumentById" --no-build 2>&1 | tail -10
+```
+
+Expected: tutti i test KB pass. Eventuali test che asseriscono lo shape del DTO con un costruttore posizionale vanno aggiornati (l'ultimo parametro è `IndexerVersion: null` per default nei mock).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
+git commit -m "feat(api/knowledge-base): #1673 surface IndexerVersion in KbDocumentDto"
+```
+
+---
+
+### Task 9: FE Client + Zod — `indexerVersion` schemas + API client
+
+**Files:**
+- Create: `apps/web/src/lib/api/schemas/indexer-versions.schemas.ts`
+- Modify: `apps/web/src/lib/api/schemas/kb-chunks.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/pdfClient.ts`
+
+- [ ] **Step 1: Create indexer-versions schema**
+
+```typescript
+// apps/web/src/lib/api/schemas/indexer-versions.schemas.ts
+/**
+ * Indexer Versions Schemas (Issue #1673)
+ *
+ * Zod schemas for GET /api/v1/admin/indexer/versions.
+ * Matches IndexerVersionDto from
+ * apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetIndexerVersionRegistry/IndexerVersionDto.cs.
+ */
+
+import { z } from 'zod';
+
+export const IndexerVersionSchema = z.object({
+  version: z.string().min(1),
+  displayName: z.string().min(1),
+  isCurrent: z.boolean(),
+});
+
+export type IndexerVersion = z.infer<typeof IndexerVersionSchema>;
+
+export const IndexerVersionListSchema = z.array(IndexerVersionSchema);
+export type IndexerVersionList = z.infer<typeof IndexerVersionListSchema>;
+```
+
+- [ ] **Step 2: Extend `KbDocDetailSchema`**
+
+In `apps/web/src/lib/api/schemas/kb-chunks.schemas.ts:33-51`, aggiungere alla definizione di `KbDocDetailSchema`, dopo `fileSize: z.number().int().nonnegative().optional(),`:
+
+```typescript
+  // Issue #1673: indexer version applicato all'ultimo reindex. Nullable per documenti
+  // mai indicizzati; "v0" è il marker legacy pre-versioning (read-only nell'UI).
+  indexerVersion: z.string().min(1).nullable().optional(),
+```
+
+- [ ] **Step 3: Extend `pdfClient.reindexDocument` + add `getIndexerVersions`**
+
+In `apps/web/src/lib/api/clients/pdfClient.ts`, trovare `reindexDocument` (riga ~355) e sostituirla con:
+
+```typescript
+    /**
+     * Reindex a PDF document with optional indexer version (Issue #1673).
+     * POST /api/v1/admin/pdfs/{pdfId}/reindex
+     */
+    async reindexDocument(
+      pdfId: string,
+      body?: { indexerVersion?: string }
+    ): Promise<void> {
+      const payload =
+        body?.indexerVersion !== undefined ? { indexerVersion: body.indexerVersion } : {};
+      return httpClient.post(
+        `/api/v1/admin/pdfs/${encodeURIComponent(pdfId)}/reindex`,
+        payload
+      );
+    },
+
+    /**
+     * Get the registry of selectable indexer versions (Issue #1673).
+     * GET /api/v1/admin/indexer/versions
+     */
+    async getIndexerVersions(): Promise<IndexerVersionList> {
+      return httpClient.get('/api/v1/admin/indexer/versions', IndexerVersionListSchema);
+    },
+```
+
+In testa al file aggiungere l'import:
+
+```typescript
+import {
+  IndexerVersionListSchema,
+  type IndexerVersionList,
+} from '../schemas/indexer-versions.schemas';
+```
+
+Se la pagina barrel `apps/web/src/lib/api/schemas/index.ts` esporta gli schemi, aggiungere `export * from './indexer-versions.schemas';` (verifica con `grep -n "from './kb-chunks.schemas'" apps/web/src/lib/api/schemas/index.ts` per il pattern esistente).
+
+- [ ] **Step 4: Type-check FE**
+
+```
+cd apps/web && pnpm typecheck 2>&1 | tail -10
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/indexer-versions.schemas.ts apps/web/src/lib/api/schemas/kb-chunks.schemas.ts apps/web/src/lib/api/clients/pdfClient.ts apps/web/src/lib/api/schemas/index.ts
+git commit -m "feat(web/api): #1673 indexer versions client + schema + indexerVersion in KbDocDetail"
+```
+
+---
+
+### Task 10: FE Hooks — `useIndexerVersions` + extend `useReindexDoc`
+
+**Files:**
+- Create: `apps/web/src/hooks/queries/useIndexerVersions.ts`
+- Modify: `apps/web/src/hooks/queries/useKbDocActions.ts`
+- Create: `apps/web/src/hooks/queries/__tests__/useIndexerVersions.test.tsx`
+
+- [ ] **Step 1: Create `useIndexerVersions` hook**
+
+```typescript
+// apps/web/src/hooks/queries/useIndexerVersions.ts
+/**
+ * useIndexerVersions — TanStack Query hook for the indexer version registry.
+ * Issue #1673.
+ */
+
+'use client';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { IndexerVersionList } from '@/lib/api/schemas/indexer-versions.schemas';
+
+export const indexerVersionsKeys = {
+  all: ['admin', 'indexer', 'versions'] as const,
+};
+
+/**
+ * Fetch the selectable indexer versions for the reindex dropdown.
+ * The registry is static within a deploy, so we cache for 1 hour and disable refetch on focus.
+ */
+export function useIndexerVersions(): UseQueryResult<IndexerVersionList, Error> {
+  return useQuery({
+    queryKey: indexerVersionsKeys.all,
+    queryFn: () => api.pdf.getIndexerVersions(),
+    staleTime: 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+```
+
+- [ ] **Step 2: Update `useReindexDoc` to accept payload**
+
+In `apps/web/src/hooks/queries/useKbDocActions.ts:68-77`, sostituire `useReindexDoc` con:
+
+```typescript
+/**
+ * Trigger a reindex for a specific document (admin). Optionally pass an indexer
+ * version to override the stored one. Issue #1673.
+ *
+ * Invalidates the detail view and the full chunks list for this doc.
+ *
+ * @example
+ * const { mutateAsync } = useReindexDoc(docId);
+ * await mutateAsync({ indexerVersion: 'v1.0' });
+ */
+export function useReindexDoc(
+  docId: string
+): UseMutationResult<void, Error, { indexerVersion?: string } | void> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload) =>
+      api.pdf.reindexDocument(
+        docId,
+        payload && 'indexerVersion' in payload && payload.indexerVersion !== undefined
+          ? { indexerVersion: payload.indexerVersion }
+          : undefined
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbDocDetailKeys.byId(docId) });
+      qc.invalidateQueries({ queryKey: kbChunksListKeys.all });
+    },
+  });
+}
+```
+
+> **Compatibilità chiamate esistenti**: il chiamante attuale `reindexMutation.mutate(undefined, ...)` resta valido grazie al union type `… | void`. Le chiamate non vengono rompute.
+
+- [ ] **Step 3: Write hook unit test**
+
+```typescript
+// apps/web/src/hooks/queries/__tests__/useIndexerVersions.test.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { api } from '@/lib/api';
+
+import { useIndexerVersions } from '../useIndexerVersions';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: {
+      getIndexerVersions: vi.fn(),
+    },
+  },
+}));
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useIndexerVersions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the registry list on success', async () => {
+    vi.mocked(api.pdf.getIndexerVersions).mockResolvedValue([
+      { version: 'v1.0', displayName: 'v1.0 — current pipeline', isCurrent: true },
+    ]);
+
+    const { result } = renderHook(() => useIndexerVersions(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([
+      { version: 'v1.0', displayName: 'v1.0 — current pipeline', isCurrent: true },
+    ]);
+  });
+
+  it('exposes errors via isError', async () => {
+    vi.mocked(api.pdf.getIndexerVersions).mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useIndexerVersions(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});
+```
+
+- [ ] **Step 4: Run FE tests**
+
+```
+cd apps/web && pnpm test --run src/hooks/queries/__tests__/useIndexerVersions.test.tsx 2>&1 | tail -20
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Run existing `useKbDocActions` tests for regression**
+
+```
+cd apps/web && pnpm test --run src/hooks/queries/__tests__/useKbDocActions.test.tsx 2>&1 | tail -10
+```
+
+Expected: all pass — the `mutate(undefined, ...)` call signature stays valid.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/hooks/queries/useIndexerVersions.ts apps/web/src/hooks/queries/useKbDocActions.ts apps/web/src/hooks/queries/__tests__/useIndexerVersions.test.tsx
+git commit -m "feat(web/hooks): #1673 useIndexerVersions + useReindexDoc payload support"
+```
+
+---
+
+### Task 11: FE Component — `<KbReindexDropdown>`
+
+**Files:**
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/actions/KbReindexDropdown.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbReindexDropdown.test.tsx`
+
+- [ ] **Step 1: Write component test (TDD-first)**
+
+```tsx
+// apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbReindexDropdown.test.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { api } from '@/lib/api';
+
+import { KbReindexDropdown } from '../KbReindexDropdown';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: {
+      reindexDocument: vi.fn(),
+      getIndexerVersions: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('KbReindexDropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.pdf.getIndexerVersions).mockResolvedValue([
+      { version: 'v1.0', displayName: 'v1.0 — current pipeline', isCurrent: true },
+    ]);
+    vi.mocked(api.pdf.reindexDocument).mockResolvedValue(undefined);
+  });
+
+  it('renders the default reindex button (current version)', async () => {
+    render(<KbReindexDropdown docId="abc" processingStatus="ready" />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(await screen.findByRole('button', { name: /re-index/i })).toBeInTheDocument();
+  });
+
+  it('disables the trigger while processing/queued', () => {
+    render(<KbReindexDropdown docId="abc" processingStatus="processing" />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('button', { name: /re-index/i })).toBeDisabled();
+  });
+
+  it('opens the version menu and triggers reindex with selected version', async () => {
+    const user = userEvent.setup();
+    render(<KbReindexDropdown docId="abc" processingStatus="ready" />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(await screen.findByRole('button', { name: /scegli versione/i }));
+    await user.click(await screen.findByRole('menuitem', { name: /v1\.0/i }));
+
+    await waitFor(() =>
+      expect(api.pdf.reindexDocument).toHaveBeenCalledWith('abc', { indexerVersion: 'v1.0' })
+    );
+  });
+
+  it('default click reindexes without explicit version (server uses Current)', async () => {
+    const user = userEvent.setup();
+    render(<KbReindexDropdown docId="abc" processingStatus="ready" />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(await screen.findByRole('button', { name: /^⟳ re-index$/i }));
+
+    await waitFor(() =>
+      expect(api.pdf.reindexDocument).toHaveBeenCalledWith('abc', undefined)
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```
+cd apps/web && pnpm test --run src/components/admin/knowledge-base/explorer/actions/__tests__/KbReindexDropdown.test.tsx 2>&1 | tail -10
+```
+
+Expected: failure (component does not exist).
+
+- [ ] **Step 3: Implement component**
+
+```tsx
+// apps/web/src/components/admin/knowledge-base/explorer/actions/KbReindexDropdown.tsx
+'use client';
+
+import { useState } from 'react';
+
+import { toast } from 'sonner';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useReindexDoc } from '@/hooks/queries/useKbDocActions';
+import { useIndexerVersions } from '@/hooks/queries/useIndexerVersions';
+
+export interface KbReindexDropdownProps {
+  readonly docId: string;
+  readonly processingStatus: 'queued' | 'processing' | 'ready' | 'failed';
+}
+
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+/**
+ * KbReindexDropdown — split-button per il re-index versionato (Issue #1673).
+ *
+ * Layout:
+ *   [ ⟳ Re-index ] [ ▾ ]
+ *
+ * Comportamento:
+ *   - Click sul body → reindex con default server (`indexerVersion` omesso).
+ *   - Click sul caret → menu con versioni selectable; selezione → reindex con versione esplicita.
+ *   - Entrambi i bottoni si disabilitano quando il documento è in pipeline.
+ */
+export function KbReindexDropdown({ docId, processingStatus }: KbReindexDropdownProps) {
+  const reindex = useReindexDoc(docId);
+  const versionsQuery = useIndexerVersions();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const disabled =
+    processingStatus === 'processing' ||
+    processingStatus === 'queued' ||
+    reindex.isPending;
+
+  const runReindex = (indexerVersion?: string) => {
+    const payload = indexerVersion ? { indexerVersion } : undefined;
+    reindex.mutate(payload, {
+      onSuccess: () =>
+        toast.success(
+          indexerVersion
+            ? `Re-index avviato (${indexerVersion})`
+            : 'Re-index avviato'
+        ),
+      onError: (err: Error) => toast.error(`Re-index fallito: ${err.message}`),
+    });
+  };
+
+  return (
+    <div className="inline-flex">
+      <button
+        type="button"
+        onClick={() => runReindex()}
+        disabled={disabled}
+        className={`rounded-l-md border border-r-0 border-border px-3 py-1.5 text-xs font-medium hover:bg-muted/70 disabled:cursor-not-allowed disabled:opacity-50 ${FOCUS_RING}`}
+        aria-label="⟳ Re-index"
+      >
+        ⟳ Re-index
+      </button>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            disabled={disabled || versionsQuery.isLoading}
+            className={`rounded-r-md border border-border px-2 py-1.5 text-xs font-medium hover:bg-muted/70 disabled:cursor-not-allowed disabled:opacity-50 ${FOCUS_RING}`}
+            aria-label="Scegli versione"
+          >
+            ▾
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {versionsQuery.data?.map((v) => (
+            <DropdownMenuItem
+              key={v.version}
+              onSelect={() => runReindex(v.version)}
+            >
+              {v.displayName}
+              {v.isCurrent ? ' · default' : ''}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+```
+
+> **Nota componente `DropdownMenu`**: deve esistere in `@/components/ui/dropdown-menu`. Verifica con `ls apps/web/src/components/ui/dropdown-menu*`. Se manca, usa shadcn CLI: `cd apps/web && pnpm dlx shadcn@latest add dropdown-menu`. Se il design system ha già un'astrazione equivalente (es. `Menu` di Radix), prediligi quella e aggiorna l'import.
+
+- [ ] **Step 4: Run component tests**
+
+```
+cd apps/web && pnpm test --run src/components/admin/knowledge-base/explorer/actions/__tests__/KbReindexDropdown.test.tsx 2>&1 | tail -15
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/actions/KbReindexDropdown.tsx apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbReindexDropdown.test.tsx
+git commit -m "feat(web/admin-kb): #1673 KbReindexDropdown split-button"
+```
+
+---
+
+### Task 12: FE Integration — swap button in `KbDocActions` + render hero metadata
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx`
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`
+- Modify (if present): `apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx`
+
+- [ ] **Step 1: Swap the button in `KbDocActions`**
+
+In `apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx`:
+
+1. **Rimuovi** l'import di `useReindexDoc` e il blocco `reindexMutation` + `handleReindex` + il bottone `⟳ Re-index` corrente (linee 12, 50, 64-69, 105-118).
+2. **Aggiungi** l'import:
+
+   ```typescript
+   import { KbReindexDropdown } from './KbReindexDropdown';
+   ```
+
+3. **Sostituisci** il primo bottone con il componente:
+
+   ```tsx
+   {/* 1. Re-index (split-button con dropdown versione — Issue #1673) */}
+   <KbReindexDropdown docId={docId} processingStatus={processingStatus} />
+   ```
+
+`isReindexDisabled` non serve più (gestito internamente dal dropdown).
+
+- [ ] **Step 2: Update `KbDocActions` test if it referenced the old button**
+
+```
+grep -n "Re-index\|reindex" apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx
+```
+
+Se il test esistente click-a il vecchio bottone, sostituisci l'asserzione con uno spy sul mock di `KbReindexDropdown` (es. `vi.mock('../KbReindexDropdown', () => ({ KbReindexDropdown: ({ docId }: { docId: string }) => <button data-testid="reindex-dropdown">{docId}</button> }))`) per mantenere l'isolamento del unit test.
+
+- [ ] **Step 3: Render `indexerVersion` nel hero metadata del detail panel**
+
+Apri `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`. Cerca la sezione `doc-stats` o equivalente dove vengono renderizzati `fileSize` / `lastIngestedAt`:
+
+```
+grep -n "fileSize\|lastIngestedAt" apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+```
+
+Aggiungi, accanto agli altri stats e dopo `fileSize`:
+
+```tsx
+{doc.indexerVersion ? (
+  <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+    📦 {doc.indexerVersion === 'v0' ? 'v0 (legacy)' : doc.indexerVersion}
+  </span>
+) : null}
+```
+
+Il guard `doc.indexerVersion ? … : null` evita di mostrare la riga per doc mai indicizzati.
+
+- [ ] **Step 4: Run all admin/knowledge-base tests**
+
+```
+cd apps/web && pnpm test --run src/components/admin/knowledge-base 2>&1 | tail -15
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Type-check + lint**
+
+```
+cd apps/web && pnpm typecheck && pnpm lint 2>&1 | tail -10
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx
+git commit -m "feat(web/admin-kb): #1673 wire reindex dropdown + render indexerVersion in hero"
+```
+
+---
+
+### Task 13: PR creation + issue close-out
+
+**Files:**
+- (no code changes)
+
+- [ ] **Step 1: Final BE + FE smoke run**
+
+```
+cd apps/api/src/Api && dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=DocumentProcessing" --no-build 2>&1 | tail -10
+cd ../../../web && pnpm test --run src/components/admin/knowledge-base src/hooks/queries 2>&1 | tail -10
+cd ../../../web && pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: tutti green.
+
+- [ ] **Step 2: Verify branch is up-to-date with main-dev**
+
+```
+git fetch origin main-dev
+git log --oneline origin/main-dev..HEAD | head -20
+git log --oneline HEAD..origin/main-dev | head -5
+```
+
+Se ci sono commit nuovi su origin/main-dev, fare rebase: `git rebase origin/main-dev`. Risolvere conflitti (probabili su `MeepleAiDbContextModelSnapshot.cs` se altre migration sono atterrate nel frattempo; in tal caso rigenerare con `dotnet ef migrations remove && dotnet ef migrations add AddIndexerVersionToPdfDocuments`).
+
+- [ ] **Step 3: Push branch + open PR**
+
+```
+git push -u origin feature/issue-1673-reindex-version-selector
+gh pr create --base main-dev --title "feat(admin-kb): #1673 re-index with version selector" --body "$(cat <<'EOF'
+## Summary
+
+Implementa #1673 (P3) — selettore versione per il re-index dei documenti KB lato admin, in linea con il design doc `2026-06-01-sp5-admin-kb-fu4-spinouts-design.md` §3.2 (D-B: code-resident registry).
+
+## Changes
+
+### BE
+- Nuovo value object \`IndexerVersion\` + registry code-resident (\`v0\` legacy + \`v1.0\` current selectable).
+- Migration \`AddIndexerVersionToPdfDocuments\` con backfill \`'v0'\` per righe storiche.
+- \`ReindexDocumentCommand\` esteso con \`IndexerVersion\` opzionale + \`[AuditableAction("DocumentReindex", "Document", Level=2)]\`.
+- Handler: version resolution chain (explicit → stored → current), conflict guard 409 su stato in-flight, persistenza versione applicata.
+- Nuovo endpoint \`GET /api/v1/admin/indexer/versions\` + estensione body \`POST /admin/pdfs/{id}/reindex\`.
+- \`KbDocumentDto\` esteso con \`IndexerVersion\` (chiude #1676 sub-task F3).
+
+### FE
+- Zod schema \`indexer-versions.schemas.ts\` + \`indexerVersion\` opzionale in \`KbDocDetailSchema\`.
+- \`pdfClient.reindexDocument(pdfId, body?)\` + \`pdfClient.getIndexerVersions()\`.
+- \`useIndexerVersions()\` hook + \`useReindexDoc\` accetta payload.
+- \`<KbReindexDropdown>\` split-button (default click reindex con server-current; caret = dropdown versione).
+- Hero metadata del detail panel mostra \`📦 v1.0\` (o \`v0 (legacy)\`).
+
+## Test plan
+- [ ] BE unit \`IndexerVersionRegistryTests\` (8 tests)
+- [ ] BE unit \`ReindexDocumentCommandValidatorTests\` (5)
+- [ ] BE unit \`ReindexDocumentCommandHandlerTests\` (11, incl. 6 in-flight states + 2 terminal states)
+- [ ] BE unit \`GetIndexerVersionRegistryHandlerTests\` (2)
+- [ ] BE integration \`ReindexDocumentVersionIntegrationTests\` (4, incl. audit outbox + 409 in-flight)
+- [ ] FE unit \`useIndexerVersions.test.tsx\` (2)
+- [ ] FE unit \`KbReindexDropdown.test.tsx\` (4)
+- [ ] \`pnpm typecheck && pnpm lint\` green
+- [ ] Smoke manuale su \`/admin/knowledge-base\` per verificare che il default click resti backward-compatible
+
+## Notes
+- Strategy effettiva di pipeline NON aggiunta: oggi il registry contiene solo \`Current\`; quando atterrerà una vera divergenza, verrà aggiunta come nuovo entry in \`IndexerVersionRegistry\` + impl strategy separata (la firma del registry è preparata per quel caso).
+- Foundation per #1675 (\`goldsetVersion\`) analoga: usa lo stesso pattern code-resident.
+- OQ-2 (deprecation policy 18m) seguita: il registry resta entro 2 versioni per ora.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: After PR open — local issue tracker update**
+
+```
+gh issue comment 1673 --body "PR opened against \`main-dev\` (link sopra). DoD updates:
+- [x] BE: IndexerVersion registry + endpoint + persistence
+- [x] FE: dropdown + KbDocDetailPanel hero render
+- [x] Audit: \`DocumentReindex\` level 2
+- [x] Test: unit + integration green
+Ready for code review."
+```
+
+- [ ] **Step 5: Update memory ledger (post-merge)**
+
+Dopo merge, aggiornare `C:\Users\Utente\.claude\projects\D--Repositories-meepleai-monorepo-dev\memory\MEMORY.md` aggiungendo riga nella sezione "Executed Plans":
+
+```markdown
+- `sp5-admin-kb-1673-reindex-version-selector` ✅ PR#<NUMBER> (`<SHA>` <DATE>) — code-resident registry + persistence + 409 in-flight + audit; chiude anche #1676 sub-task F3
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+| Design doc §3.2 requirement | Task |
+|-----------------------------|------|
+| `IndexerVersion` value object + Registry (D-B code-resident) | Task 1 |
+| `pdf_documents.indexer_version` column + backfill | Task 2 |
+| `ReindexDocumentCommand` extended with `IndexerVersion` opzionale | Task 3 |
+| `[AuditableAction("DocumentReindex", "Document", Level=2)]` | Task 3 |
+| Handler resolution chain `explicit → stored → current` | Task 4 |
+| Conflict guard su in-flight (Adzic edge case "race") | Task 4 |
+| Persistenza versione su entity | Task 4 |
+| `GET /admin/indexer/versions` | Task 5 + 6 |
+| `POST /admin/pdfs/{id}/reindex` body extension | Task 6 |
+| Integration E2E + audit outbox | Task 7 |
+| FE dropdown versione | Task 11 + 12 |
+| Render `indexerVersion` nel hero (chiude #1676 F3) | Task 12 |
+
+### Placeholder scan
+- [x] No "TBD" / "TODO" / "implement later" found.
+- [x] No "add appropriate error handling" — explicit ConflictException + NotFoundException specified.
+- [x] No "similar to Task N" without code repetition.
+- [x] Every step has either code blocks, exact commands, or explicit edit diffs.
+
+### Type consistency
+| Symbol | Defined in | Used in |
+|--------|-----------|---------|
+| `IndexerVersion` (record) | Task 1 | Task 1 (registry) |
+| `IndexerVersionRegistry.Current.Version` | Task 1 | Task 4 (resolution), Task 5 (DTO) |
+| `IndexerVersionRegistry.TryGet` / `IsSelectable` / `Selectable` | Task 1 | Task 3 (validator), Task 5 (handler) |
+| `ReindexDocumentCommand(Guid PdfId, string? IndexerVersion)` | Task 3 | Task 4 (handler), Task 6 (endpoint), Task 7 (integration) |
+| `IndexerVersionDto(Version, DisplayName, IsCurrent)` | Task 5 | Task 6 (endpoint), Task 9 (Zod) |
+| `IndexerVersion` (Zod / TS) | Task 9 | Task 10 (hook), Task 11 (component) |
+| `KbDocumentDto.IndexerVersion` | Task 8 | Task 12 (KbDocDetailPanel render) |
+| `KbDocDetailSchema.indexerVersion` | Task 9 | Task 12 (consumer) |
+| `useReindexDoc` payload `{ indexerVersion?: string } \| void` | Task 10 | Task 11 (component dispatch) |
+| `useIndexerVersions().data` returns `IndexerVersionList` | Task 10 | Task 11 (component) |
+| `KbReindexDropdown` props `{ docId, processingStatus }` | Task 11 | Task 12 (wiring) |
+
+Tutti i nomi sono coerenti tra task. Type signatures matched end-to-end.
+
+---
+
+## References
+- Design doc consolidato: [`docs/superpowers/specs/2026-06-01-sp5-admin-kb-fu4-spinouts-design.md`](../specs/2026-06-01-sp5-admin-kb-fu4-spinouts-design.md) §3.2
+- Issue: [#1673](https://github.com/meepleAi-app/meepleai-monorepo/issues/1673)
+- Parent (closed): F3-FU-4 #1653, design `2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md`
+- Spec-panel review 2026-06-01 (PR #1790): OQ-2 deprecation policy 18m, D-A/D-B confirmed
+- Memoria sessione 2026-06-01: `memory/project_session_2026-06-01_admin_sequence.md`
+- Memoria audit admin: `memory/project_sp5_admin_integration_audit.md`
+- Pattern audit `[AuditableAction]`: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommand.cs`
+- Pattern integration test: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeleteKbDocumentCommandHandlerIntegrationTests.cs`


### PR DESCRIPTION
## Summary
Catch-up commit per 3 implementation plan creati il 2026-06-02 che non sono stati inclusi nelle PR di implementazione corrispondenti.

| Plan file | PR di implementazione mergiata |
|---|---|
| `2026-06-02-issue-1801-nameof-pdf-processing-state-refactor.md` | #1804 (`f362b8b16`) + #1805 (`93cb395e4`) |
| `2026-06-02-issue-1802-rowversion-optimistic-concurrency.md` | #1806 (`6bf7193e4`) |
| `2026-06-02-sp5-admin-kb-1673-reindex-version-selector.md` | #1800 (`21873a16d`) |

## Rationale
Allineamento alla convenzione `docs/superpowers/plans/` (plan files preservati come as-built docs per memoria di progetto). Zero code change — solo 3 file `.md` aggiunti.

## Test plan
- [x] Solo file `.md` aggiunti — nessuna verifica funzionale necessaria
- [x] Pre-commit hooks superati (TypeScript typecheck, frontend lint-staged)
- [x] `git diff main-dev...HEAD --stat` → 3 file, 3479 insertions, 0 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)