### PR TITLE
docs(design): #1489 add sp4-editor mockup bundle (B14 user-facing)

### DIFF
--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -275,6 +275,46 @@
     <div class="tags"><span class="tag">4 stati</span><span class="tag">Cost preview</span><span class="tag">Async progress</span></div>
   </a>
 
+  <a class="hub-card e-game" href="sp4-editor-index.html">
+    <div class="arrow">→</div>
+    <div class="num">B14 · #1489 · 1/5</div>
+    <h3>Editor regole — atom + PDF split</h3>
+    <p>RuleSpec atom editor split-view 60/40: pane sinistro accordion section-grouped con card atom inline-editable (text + page/line metadata + select-to-sync), pane destro PDF preview con highlight overlay sync. 11 stati: default / editing / saving / saved / validation-error / conflict / published / lock-acquiring / lock-held-by-other / loading / empty. Mobile stack con bottom-sheet drawer PDF.</p>
+    <div class="tags"><span class="tag">11 stati</span><span class="tag">Split-view</span><span class="tag">PDF preview</span></div>
+  </a>
+
+  <a class="hub-card e-agent" href="sp4-editor-proposals-index.html">
+    <div class="arrow">→</div>
+    <div class="num">B14 · #1489 · 2/5</div>
+    <h3>Typology proposals — list</h3>
+    <p>Lista typology AI agent proposals con filtri search + status chips, table desktop + cards mobile, 5 status badges (Draft/PendingReview/Approved/Rejected/Live), 9 stati: default / empty / loading / error / filter-search / filter-status / filter-empty / rejected-row-expanded / mobile-cards. Action buttons per-status (Edit/Test/Submit/View).</p>
+    <div class="tags"><span class="tag">9 stati</span><span class="tag">Table+Cards</span><span class="tag">Status badges</span></div>
+  </a>
+
+  <a class="hub-card e-agent" href="sp4-editor-proposals-create.html">
+    <div class="arrow">→</div>
+    <div class="num">B14 · #1489 · 3/5</div>
+    <h3>Create proposal — form multi-section</h3>
+    <p>Form full-page multi-section per creare nuova typology AI agent proposal: 5 sezioni accordion (Identità / Capabilities / System prompt con highlight {var} / Test config / Game scope), validation realtime con required indicators, unique-name check inline, draft autosave + submit-for-review modal. 8 stati: default-empty / partial-filled / all-valid / validation-errors / saving / draft-saved / submitting / submit-success.</p>
+    <div class="tags"><span class="tag">8 stati</span><span class="tag">5-section form</span><span class="tag">Code highlight</span></div>
+  </a>
+
+  <a class="hub-card e-agent" href="sp4-editor-proposals-edit.html">
+    <div class="arrow">→</div>
+    <div class="num">B14 · #1489 · 4/5</div>
+    <h3>Edit proposal — status-variant + revisions + audit</h3>
+    <p>Edit typology proposal con 4 status variants profondi (Draft editable / PendingReview locked / Approved read-only+live / Rejected con alert feedback admin). 7 sezioni: 5 form S3 (riusate) + Revisions diff inline vs versione approvata + Audit trail timeline (8 evento tipi). 10 stati: draft-edit / draft-edit-dirty / pending-review / approved-readonly / approved-with-stats / rejected-fresh / rejected-addressing / revisions-expanded / audit-trail-expanded / submitting-update. Dirty-field tracking per re-submission post-rejection.</p>
+    <div class="tags"><span class="tag">10 stati</span><span class="tag">4 status modes</span><span class="tag">Diff + Audit</span></div>
+  </a>
+
+  <a class="hub-card e-agent" href="sp4-editor-proposals-test.html">
+    <div class="arrow">→</div>
+    <div class="num">B14 · #1489 · 5/5</div>
+    <h3>Test playground — FSM streaming + trace</h3>
+    <p>Playground streaming per testare typology pre-submit: split-view (config sidebar 320px + chat body fluid), FSM streaming 4 stati (idle / streaming con cursor blink animato / completed / error con 3 variant rate-limit/timeout/network), trace drawer destra con token count + latency + cost + tool calls + RAG sources, compare mode v3 Draft vs v2 Approved side-by-side. 12 stati totali: idle-empty / typing-input / streaming-active / streaming-stop-clicked / completed-single / completed-multi / error-rate-limit / error-timeout / error-network / trace-drawer-open / compare-mode / mobile-stack.</p>
+    <div class="tags"><span class="tag">12 stati</span><span class="tag">FSM streaming</span><span class="tag">Trace + Compare</span></div>
+  </a>
+
   <a class="hub-card e-event" href="sp7-game-night-live.html">
     <div class="arrow">→</div>
     <div class="num">SP7 · K · #487</div>

--- a/admin-mockups/design_files/sp4-editor-index.html
+++ b/admin-mockups/design_files/sp4-editor-index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · B14 editor · #1/5 · Editor regole — /editor</title>
+<!-- route: /editor — RuleSpec atom editor con PDF preview split-view -->
+<!--
+  @route /editor
+  @brief B14 (issue #1489) — Editor user-facing (agent proposals)
+  @screen 1 of 5 — sp4-editor-index
+  @tier S
+  @pattern Split-view (atom-list editor 60% + PDF preview 40%) · stack mobile con drawer PDF
+  @states default · editing · saving · saved · validation-error · conflict-detected · published · lock-acquiring · lock-held-by-other · loading · empty
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-editor-index.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-editor-index.jsx
+++ b/admin-mockups/design_files/sp4-editor-index.jsx
@@ -1,0 +1,910 @@
+/* sp4-editor-index.jsx
+   Route: /editor — RuleSpec atom editor con PDF preview (split-view)
+   B14 (issue #1489) · screen 1 of 5 · Tier S
+   Pattern (LOCKED): Split-view — pane sinistro atom-list editor (60%) + pane destro PDF preview (40%).
+   Mobile: stack, solo atom-list; il metadata "📄 p.N" apre un bottom-sheet con la pagina PDF.
+   Loadable standalone via Babel. Injects own component CSS; relies on tokens.css + components.css.
+
+   Modello: RuleSpec = array flat di RuleAtom { id, n, section, text, page, sec }.
+   v2 components surfaced here (annotate at implementation time):
+   /* v2: RuleSpecSplitEditor, AtomListPane, AtomCard, SectionAccordion, RuleEditorToolbar,
+          SaveStatusPill, ValidationPill, PdfPreviewPane, PdfPageView, AtomHighlightOverlay,
+          ConflictResolutionModal, LockBanner, VersionHistoryPanel, MobilePdfSheet */
+
+const { useState, useEffect, useMemo, useRef } = React;
+
+/* ──────────────────────────────────────────────────────────
+   Component CSS — solo token da tokens.css / components.css.
+   ────────────────────────────────────────────────────────── */
+const EDITOR_CSS = `
+.ed-stage { min-height:100vh; padding:72px 24px 96px; background:var(--bg); color:var(--text); }
+.ed-wrap { max-width:1380px; margin:0 auto; }
+.ed-kicker { font-family:var(--f-mono); font-size:var(--fs-xs); letter-spacing:.1em; text-transform:uppercase; color:var(--text-muted); }
+.ed-stage h1 { font-size:var(--fs-3xl); margin:8px 0 6px; }
+.ed-stage h1 .acc { color:hsl(var(--c-game)); }
+.ed-lead { color:var(--text-sec); font-size:var(--fs-md); max-width:780px; line-height:var(--lh-body); }
+.ed-notes { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:22px 0 4px; }
+.ed-note { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:14px 16px; }
+.ed-note h4 { font-family:var(--f-display); font-size:var(--fs-sm); text-transform:uppercase; letter-spacing:.04em; color:hsl(var(--c-game)); margin-bottom:6px; }
+.ed-note p { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.ed-note p b { color:var(--text); font-weight:var(--fw-bold); }
+.ed-note code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:11px; }
+
+/* preview rail */
+.ed-rail { position:sticky; top:0; z-index:var(--z-sticky); margin:26px 0 18px; padding:12px 0;
+  background:var(--bg); display:flex; align-items:flex-start; gap:14px; flex-wrap:wrap; border-bottom:1px solid var(--border); }
+.ed-rail .lab { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); padding-top:8px; }
+.ed-states { display:flex; gap:6px; flex-wrap:wrap; flex:1; }
+.ed-sbtn { display:inline-flex; align-items:center; gap:7px; padding:7px 12px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-sbtn:hover { transform:translateY(-1px); border-color:var(--border-strong); }
+.ed-sbtn .pip { width:7px; height:7px; border-radius:50%; background:currentColor; opacity:.6; }
+.ed-sbtn.on { background:hsl(var(--c-game)); border-color:transparent; color:#fff; }
+.ed-sbtn.on .pip { opacity:1; background:#fff; }
+
+/* viewport labels */
+.ed-vp-label { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em;
+  color:var(--text-muted); margin:30px 0 12px; display:flex; align-items:center; gap:10px; }
+.ed-vp-label::after { content:''; flex:1; height:1px; background:var(--border); }
+
+/* desktop frame */
+.ed-desk { width:100%; max-width:1340px; height:792px; border-radius:var(--r-lg); overflow:hidden;
+  background:var(--bg-card); border:1px solid var(--border); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; }
+.ed-chrome { height:38px; flex-shrink:0; display:flex; align-items:center; gap:8px; padding:0 14px;
+  background:var(--bg-muted); border-bottom:1px solid var(--border); font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ed-chrome .dots { display:flex; gap:6px; }
+.ed-chrome .dots i { width:11px; height:11px; border-radius:50%; display:block; }
+.ed-chrome .dots i:nth-child(1){ background:#ff5f57; } .ed-chrome .dots i:nth-child(2){ background:#febc2e; } .ed-chrome .dots i:nth-child(3){ background:#28c840; }
+.ed-chrome .url { flex:1; text-align:center; background:var(--bg-card); border-radius:var(--r-sm); padding:4px 10px; margin:0 16%; }
+
+/* phone */
+.ed-phone-row { display:flex; gap:28px; align-items:flex-start; flex-wrap:wrap; }
+.ed-phone-cap { font-size:var(--fs-sm); color:var(--text-sec); max-width:300px; line-height:var(--lh-snug); }
+.ed-phone-cap h4 { font-family:var(--f-display); font-size:var(--fs-base); margin-bottom:6px; }
+
+/* ─── editor app ─── */
+.ed-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+.ed-app :focus-visible { outline:2px solid hsl(var(--c-game)); outline-offset:2px; border-radius:var(--r-xs); }
+
+/* top banner */
+.ed-banner { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:10px 18px; font-size:var(--fs-sm); font-weight:var(--fw-bold); font-family:var(--f-display); }
+.ed-banner.pub { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); border-bottom:1px solid hsl(var(--c-success) / .3); }
+.ed-banner.lock { background:hsl(var(--c-warning) / .15); color:hsl(var(--c-warning)); border-bottom:1px solid hsl(var(--c-warning) / .3); }
+.ed-banner .grow { flex:1; }
+.ed-banner .bcta { padding:5px 12px; border-radius:var(--r-md); border:none; cursor:pointer; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.ed-banner.lock .bcta { background:hsl(var(--c-player)); color:#fff; }
+.ed-banner.pub .bcta { background:var(--bg-card); color:hsl(var(--c-success)); border:1px solid hsl(var(--c-success) / .4); }
+.ed-pchip { display:inline-flex; align-items:center; gap:6px; padding:3px 10px 3px 3px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .16); color:hsl(var(--c-player)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.ed-pchip .av { width:20px; height:20px; border-radius:50%; background:hsl(var(--c-player)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:var(--fw-ext); }
+
+/* split */
+.ed-split { flex:1; display:grid; grid-template-columns:1.5fr 1fr; overflow:hidden; min-height:0; }
+
+/* panes */
+.ed-pane { display:flex; flex-direction:column; min-height:0; overflow:hidden; }
+.ed-pane.left { background:var(--bg); }
+.ed-pane.right { background:var(--bg-muted); border-left:1px solid var(--border); }
+
+/* left header */
+.ed-lhead { flex-shrink:0; background:var(--bg-card); border-bottom:1px solid var(--border);
+  display:flex; align-items:center; gap:10px; padding:11px 16px; flex-wrap:wrap; }
+.ed-brand { width:28px; height:28px; border-radius:var(--r-sm); flex-shrink:0;
+  background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event))); color:#fff;
+  display:flex; align-items:center; justify-content:center; font-family:var(--f-display); font-weight:var(--fw-ext); font-size:14px; }
+.ed-gamesel { display:inline-flex; align-items:center; gap:7px; padding:6px 11px; border-radius:var(--r-pill);
+  background:hsl(var(--c-game) / .12); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .25);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-gamesel:hover { background:hsl(var(--c-game) / .18); }
+.ed-gamesel .chev { font-size:9px; opacity:.7; }
+.ed-title { font-family:var(--f-display); font-size:var(--fs-md); font-weight:var(--fw-bold); white-space:nowrap; }
+.ed-lhead .grow { flex:1; min-width:6px; }
+
+/* pills */
+.ed-pill { display:inline-flex; align-items:center; gap:6px; padding:6px 11px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); white-space:nowrap; border:1px solid transparent; }
+.ed-pill .dot { width:8px; height:8px; border-radius:50%; background:currentColor; }
+.ed-pill .pulse { width:8px; height:8px; border-radius:50%; background:currentColor; animation:edpulse 1s var(--ease-in-out) infinite; }
+@keyframes edpulse { 0%,100%{ opacity:1; transform:scale(1);} 50%{ opacity:.35; transform:scale(.7);} }
+.ed-pill.ok    { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); }
+.ed-pill.warn  { background:hsl(var(--c-warning) / .16); color:hsl(var(--c-warning)); }
+.ed-pill.danger{ background:hsl(var(--c-danger) / .14); color:hsl(var(--c-danger)); }
+.ed-pill.btn { cursor:pointer; } .ed-pill.btn:hover { filter:brightness(.97); }
+
+.ed-publish { display:inline-flex; align-items:center; gap:7px; padding:8px 15px; border-radius:var(--r-md); border:none;
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer;
+  background:hsl(var(--c-toolkit)); color:#fff; box-shadow:var(--shadow-xs); transition:all var(--dur-sm) var(--ease-out); }
+.ed-publish:hover:not(:disabled) { transform:translateY(-1px); box-shadow:var(--shadow-sm); }
+.ed-publish:disabled { opacity:.4; cursor:not-allowed; }
+
+/* toolbar */
+.ed-toolbar { flex-shrink:0; display:flex; align-items:center; gap:8px; padding:9px 16px; background:var(--bg);
+  border-bottom:1px solid var(--border); }
+.ed-search { flex:1; min-width:80px; position:relative; }
+.ed-search input { width:100%; padding:7px 10px 7px 30px; border-radius:var(--r-md); border:1px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:var(--fs-sm); color:var(--text); outline:none; }
+.ed-search input:focus { border-color:hsl(var(--c-game) / .5); box-shadow:0 0 0 3px hsl(var(--c-game) / .12); }
+.ed-search .ic { position:absolute; left:10px; top:50%; transform:translateY(-50%); font-size:13px; opacity:.6; }
+.ed-selectw { position:relative; }
+.ed-select { padding:7px 28px 7px 11px; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg-card);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text-sec); cursor:pointer; appearance:none; outline:none; }
+.ed-selectw::after { content:'▾'; position:absolute; right:11px; top:50%; transform:translateY(-50%); font-size:10px; color:var(--text-muted); pointer-events:none; }
+.ed-tbtn { display:inline-flex; align-items:center; gap:6px; padding:7px 11px; border-radius:var(--r-md); border:1px solid hsl(var(--c-game) / .35);
+  background:transparent; color:hsl(var(--c-game)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; white-space:nowrap;
+  transition:all var(--dur-sm) var(--ease-out); }
+.ed-tbtn:hover { background:hsl(var(--c-game) / .1); }
+.ed-vtoggle { display:inline-flex; padding:3px; gap:2px; background:var(--bg-muted); border-radius:var(--r-md); border:1px solid var(--border); }
+.ed-vtoggle button { width:30px; height:28px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted);
+  font-size:14px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center; }
+.ed-vtoggle button[aria-pressed="true"] { background:var(--bg-card); color:hsl(var(--c-game)); box-shadow:var(--shadow-xs); }
+
+/* atom body */
+.ed-lbody { flex:1; overflow-y:auto; padding:10px 16px 24px; min-height:0; }
+
+/* section accordion */
+.ed-section { margin-bottom:10px; }
+.ed-shead { display:flex; align-items:center; gap:9px; padding:9px 10px; border-radius:var(--r-md); cursor:pointer;
+  background:var(--bg-card); border:1px solid var(--border); transition:background var(--dur-sm) var(--ease-out); }
+.ed-shead:hover { background:var(--bg-hover); }
+.ed-caret { font-size:10px; color:var(--text-muted); width:12px; transition:transform var(--dur-sm) var(--ease-out); }
+.ed-sname { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-base); color:var(--text); }
+.ed-scount { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ed-shead .grow { flex:1; }
+.ed-saddbtn { display:inline-flex; align-items:center; gap:4px; padding:4px 9px; border-radius:var(--r-sm); border:1px solid hsl(var(--c-game) / .35);
+  background:transparent; color:hsl(var(--c-game)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; }
+.ed-saddbtn:hover { background:hsl(var(--c-game) / .1); }
+.ed-ctx { width:26px; height:26px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted); cursor:pointer; font-size:15px; }
+.ed-ctx:hover { background:var(--bg-muted); color:var(--text); }
+.ed-satoms { padding:8px 0 2px 4px; display:flex; flex-direction:column; gap:8px; }
+
+/* atom card */
+.ed-atom { position:relative; display:flex; gap:11px; padding:11px 12px; border-radius:var(--r-md);
+  background:var(--bg-card); border:1px solid var(--border-light); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-atom:hover { border-color:var(--border-strong); }
+.ed-atom.sel { background:hsl(var(--c-game) / .08); border-color:hsl(var(--c-game) / .45); }
+.ed-atom.editing { border-color:hsl(var(--c-game) / .6); box-shadow:0 0 0 3px hsl(var(--c-game) / .18); }
+.ed-atom.invalid { border-color:hsl(var(--c-danger) / .6); box-shadow:0 0 0 3px hsl(var(--c-danger) / .14); }
+.ed-atom .num { font-family:var(--f-mono); font-size:var(--fs-sm); color:var(--text-muted); flex-shrink:0; padding-top:2px; min-width:18px; }
+.ed-atom .body { flex:1; min-width:0; }
+.ed-atom .text { font-size:var(--fs-md); color:var(--text); line-height:var(--lh-body); }
+.ed-atom .ta { width:100%; min-height:62px; resize:vertical; padding:9px 10px; border-radius:var(--r-sm); border:1px solid var(--border);
+  background:var(--bg); color:var(--text); font-family:var(--f-body); font-size:var(--fs-md); line-height:var(--lh-body); outline:none; }
+.ed-atom .ta:focus { border-color:hsl(var(--c-game) / .5); }
+.ed-atom .ta.bad { border-color:hsl(var(--c-danger) / .6); }
+.ed-aerr { display:flex; align-items:center; gap:6px; margin-top:6px; font-size:var(--fs-sm); font-weight:var(--fw-bold); color:hsl(var(--c-danger)); }
+.ed-afoot { display:flex; align-items:center; gap:10px; margin-top:8px; }
+.ed-aref { display:inline-flex; align-items:center; gap:5px; padding:2px 8px; border-radius:var(--r-sm); cursor:pointer;
+  font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); background:var(--bg-muted); transition:all var(--dur-sm) var(--ease-out); }
+.ed-aref:hover { color:hsl(var(--c-game)); background:hsl(var(--c-game) / .12); }
+.ed-afoot .grow { flex:1; }
+.ed-aact { width:26px; height:26px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted); cursor:pointer; font-size:13px; }
+.ed-aact:hover { background:var(--bg-muted); color:var(--text); }
+.ed-dirty { position:absolute; top:9px; right:9px; width:9px; height:9px; border-radius:50%; background:hsl(var(--c-warning)); box-shadow:0 0 0 3px hsl(var(--c-warning) / .2); }
+.ed-asaving { position:absolute; inset:0; border-radius:var(--r-md); background:hsl(var(--c-game) / .06); backdrop-filter:blur(.5px);
+  display:flex; align-items:center; justify-content:center; pointer-events:none; }
+.ed-asaving .lbl { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:hsl(var(--c-warning)); display:inline-flex; gap:7px; align-items:center; }
+
+/* atom save-row (when editing) */
+.ed-editrow { display:flex; gap:7px; margin-top:9px; }
+.ed-ebtn { padding:7px 13px; border-radius:var(--r-sm); border:none; cursor:pointer; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.ed-ebtn.pri { background:hsl(var(--c-game)); color:#fff; } .ed-ebtn.pri:disabled { opacity:.4; cursor:not-allowed; }
+.ed-ebtn.sec { background:var(--bg-muted); color:var(--text-sec); }
+
+/* empty section */
+.ed-sempty { text-align:center; padding:18px 10px; color:var(--text-muted); }
+.ed-sempty .tx { font-size:var(--fs-sm); margin-bottom:10px; }
+
+/* right pane (PDF) */
+.ed-rhead { flex-shrink:0; background:var(--bg-card); border-bottom:1px solid var(--border);
+  display:flex; align-items:center; gap:8px; padding:10px 14px; flex-wrap:wrap; }
+.ed-kbpip { display:inline-flex; align-items:center; gap:6px; padding:5px 11px; border-radius:var(--r-pill);
+  background:hsl(var(--c-kb) / .14); color:hsl(var(--c-kb)); font-family:var(--f-mono); font-size:var(--fs-xs); font-weight:var(--fw-bold); cursor:pointer; border:1px solid hsl(var(--c-kb) / .25); }
+.ed-kbpip:hover { background:hsl(var(--c-kb) / .2); }
+.ed-rhead .grow { flex:1; }
+.ed-pagenav { display:inline-flex; align-items:center; gap:3px; font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-sec); }
+.ed-navbtn { width:24px; height:24px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg); color:var(--text-sec); cursor:pointer; font-size:11px; }
+.ed-navbtn:hover { background:var(--bg-muted); }
+.ed-pagenum { padding:0 8px; font-weight:var(--fw-bold); }
+.ed-zoom { display:inline-flex; align-items:center; gap:3px; font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-sec); }
+.ed-iconbtn { width:28px; height:28px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg); color:var(--text-sec);
+  display:inline-flex; align-items:center; justify-content:center; cursor:pointer; font-size:13px; }
+.ed-iconbtn:hover { background:var(--bg-muted); color:var(--text); }
+.ed-syncdot { display:inline-flex; align-items:center; gap:5px; padding:4px 9px; border-radius:var(--r-pill); font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); }
+.ed-syncdot.on { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); }
+.ed-syncdot.off { background:var(--bg-muted); color:var(--text-muted); }
+.ed-syncdot i { width:7px; height:7px; border-radius:50%; background:currentColor; }
+
+.ed-rbody { flex:1; overflow-y:auto; padding:18px; min-height:0; display:flex; justify-content:center; }
+/* PDF page */
+.ed-page { width:100%; max-width:420px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-sm);
+  box-shadow:var(--shadow-md); padding:34px 32px 44px; font-family:Georgia, 'Times New Roman', serif; align-self:flex-start; }
+.ed-page .ph { text-align:center; border-bottom:1px solid var(--border); padding-bottom:12px; margin-bottom:16px; }
+.ed-page .ph .pt { font-size:17px; font-weight:bold; color:var(--text); letter-spacing:.01em; }
+.ed-page .ph .ps { font-size:11px; color:var(--text-muted); font-family:var(--f-mono); margin-top:4px; }
+.ed-para { margin-bottom:14px; padding:4px 8px; border-radius:var(--r-xs); transition:background var(--dur-md) var(--ease-out), box-shadow var(--dur-md) var(--ease-out); }
+.ed-para h6 { font-size:13px; font-weight:bold; color:var(--text); margin:0 0 4px; font-family:Georgia, serif; }
+.ed-para p { font-size:12.5px; line-height:1.62; color:var(--text-sec); margin:0; text-align:justify; }
+.ed-para.hl { background:hsl(var(--c-game) / .18); box-shadow:inset 3px 0 0 hsl(var(--c-game)), 0 0 0 1px hsl(var(--c-game) / .3); }
+.ed-rempty { display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; color:var(--text-muted); padding:40px; gap:10px; align-self:center; }
+.ed-rempty .em { font-size:38px; opacity:.6; }
+.ed-rempty .tx { font-size:var(--fs-sm); max-width:220px; }
+
+/* versions panel (published) */
+.ed-versions { width:100%; max-width:340px; align-self:flex-start; }
+.ed-versions h5 { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); margin-bottom:12px; }
+.ed-vrow { display:flex; align-items:center; gap:10px; padding:11px 12px; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg-card); margin-bottom:8px; }
+.ed-vrow.cur { border-color:hsl(var(--c-success) / .45); background:hsl(var(--c-success) / .06); }
+.ed-vtag { font-family:var(--f-mono); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); }
+.ed-vrow.cur .ed-vtag { color:hsl(var(--c-success)); }
+.ed-vmeta { font-size:var(--fs-xs); color:var(--text-muted); margin-top:2px; }
+.ed-vbadge2 { margin-left:auto; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); padding:2px 8px; border-radius:var(--r-pill); background:hsl(var(--c-success)); color:#fff; }
+.ed-vrest { margin-left:auto; padding:4px 9px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg); color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; }
+
+/* footer */
+.ed-footer { flex-shrink:0; display:flex; align-items:center; gap:14px; padding:10px 18px;
+  background:var(--bg-card); border-top:1px solid var(--border); }
+.ed-footer .fl { min-width:0; }
+.ed-footer .fl .ln1 { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); }
+.ed-footer .fl .ln2 { font-size:var(--fs-xs); color:var(--text-muted); margin-top:1px; }
+.ed-footer .grow { flex:1; }
+.ed-fbtn { display:inline-flex; align-items:center; gap:6px; padding:8px 13px; border-radius:var(--r-md); border:1px solid var(--border);
+  background:var(--bg-muted); color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; white-space:nowrap; }
+.ed-fbtn:hover { background:var(--bg-hover); color:var(--text); }
+.ed-kbd { font-family:var(--f-mono); font-size:10px; background:var(--bg-muted); border:1px solid var(--border); border-bottom-width:2px; border-radius:var(--r-xs); padding:1px 5px; color:var(--text-sec); }
+
+/* ─── overlays ─── */
+.ed-saveveil { position:absolute; inset:0; z-index:var(--z-overlay); background:hsl(var(--c-game) / .04);
+  display:flex; align-items:flex-start; justify-content:center; padding-top:90px; pointer-events:none; }
+.ed-savebar { position:absolute; top:0; left:0; height:3px; background:hsl(var(--c-warning)); z-index:var(--z-overlay); animation:edsave 1.4s var(--ease-in-out) infinite; }
+@keyframes edsave { 0%{ left:-30%; width:30%; } 60%{ left:60%; width:45%; } 100%{ left:100%; width:30%; } }
+
+/* loader overlay (lock-acquiring) */
+.ed-loadveil { position:absolute; inset:0; z-index:var(--z-modal); background:rgba(20,12,4,.42); backdrop-filter:blur(2px);
+  display:flex; flex-direction:column; align-items:center; justify-content:center; gap:16px; color:#fff; }
+.ed-spin { width:38px; height:38px; border-radius:50%; border:3px solid rgba(255,255,255,.3); border-top-color:hsl(var(--c-player)); animation:edspin .8s linear infinite; }
+@keyframes edspin { to { transform:rotate(360deg); } }
+.ed-loadveil .lt { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-base); }
+
+/* toast */
+.ed-toast { position:absolute; right:18px; bottom:74px; z-index:var(--z-toast); max-width:320px;
+  display:flex; align-items:center; gap:11px; padding:13px 15px; border-radius:var(--r-lg);
+  background:var(--bg-card); border:1px solid hsl(var(--c-success) / .4); border-left:4px solid hsl(var(--c-success));
+  box-shadow:var(--shadow-lg); animation:edtoast var(--dur-lg) var(--ease-spring); }
+@keyframes edtoast { from{ transform:translateY(20px); opacity:0; } to{ transform:none; opacity:1; } }
+.ed-toast .ti { width:28px; height:28px; border-radius:50%; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:14px; background:hsl(var(--c-success)); color:#fff; }
+.ed-toast .tt { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); }
+
+/* conflict modal */
+.ed-modal-veil { position:absolute; inset:0; z-index:var(--z-modal); background:rgba(20,12,4,.5); backdrop-filter:blur(3px);
+  display:flex; align-items:center; justify-content:center; padding:24px; animation:edfade var(--dur-md) var(--ease-out); }
+@keyframes edfade { from{ opacity:0; } to{ opacity:1; } }
+.ed-modal { width:100%; max-width:460px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl);
+  box-shadow:var(--shadow-lg); overflow:hidden; animation:edpop var(--dur-md) var(--ease-spring); }
+@keyframes edpop { from{ transform:translateY(12px) scale(.97); opacity:0; } to{ transform:none; opacity:1; } }
+.ed-modal .mh { display:flex; align-items:center; gap:12px; padding:18px 20px 14px; border-bottom:1px solid var(--border); }
+.ed-modal .mh .ic { width:40px; height:40px; border-radius:50%; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:20px; background:hsl(var(--c-danger) / .14); color:hsl(var(--c-danger)); }
+.ed-modal .mh h3 { font-family:var(--f-display); font-size:var(--fs-lg); }
+.ed-modal .mb { padding:16px 20px; }
+.ed-modal .mb p { font-size:var(--fs-base); color:var(--text-sec); line-height:var(--lh-body); }
+.ed-modal .mf { display:flex; flex-direction:column; gap:8px; padding:6px 20px 20px; }
+.ed-cbtn { padding:11px 14px; border-radius:var(--r-md); border:1px solid var(--border); cursor:pointer; text-align:left;
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-base); background:var(--bg); color:var(--text);
+  display:flex; align-items:center; gap:10px; transition:all var(--dur-sm) var(--ease-out); }
+.ed-cbtn:hover { transform:translateY(-1px); border-color:var(--border-strong); box-shadow:var(--shadow-xs); }
+.ed-cbtn .csub { font-weight:var(--fw-reg); font-size:var(--fs-xs); color:var(--text-muted); margin-left:auto; }
+.ed-cbtn.primary { background:hsl(var(--c-session)); border-color:transparent; color:#fff; }
+.ed-cbtn.primary .csub { color:rgba(255,255,255,.8); }
+
+/* skeleton */
+@keyframes edshimmer { 0%{ background-position:-400px 0; } 100%{ background-position:400px 0; } }
+.ed-sk { border-radius:var(--r-sm); background:linear-gradient(90deg,var(--bg-muted) 25%,var(--bg-hover) 37%,var(--bg-muted) 63%); background-size:800px 100%; animation:edshimmer 1.4s linear infinite; }
+
+/* mobile bottom-sheet PDF */
+.ed-sheet-veil { position:absolute; inset:0; z-index:var(--z-drawer); background:rgba(20,12,4,.4); display:flex; align-items:flex-end; animation:edfade var(--dur-md) var(--ease-out); }
+.ed-sheet { width:100%; max-height:78%; background:var(--bg-card); border-radius:var(--r-2xl) var(--r-2xl) 0 0; box-shadow:var(--shadow-drawer);
+  display:flex; flex-direction:column; overflow:hidden; animation:edsheet var(--dur-md) var(--ease-spring); }
+@keyframes edsheet { from{ transform:translateY(100%); } to{ transform:none; } }
+.ed-sheet .grab { width:38px; height:4px; border-radius:var(--r-pill); background:var(--border-strong); margin:9px auto 4px; }
+.ed-sheet .sh { display:flex; align-items:center; gap:8px; padding:6px 16px 10px; border-bottom:1px solid var(--border); }
+.ed-sheet .sb { flex:1; overflow-y:auto; padding:16px; display:flex; justify-content:center; }
+
+/* mobile adaptations */
+.ed-app.is-mobile .ed-split { display:flex; }
+.ed-app.is-mobile .ed-pane.right { display:none; }
+.ed-app.is-mobile .ed-pane.left { flex:1; }
+.ed-app.is-mobile .ed-lhead { padding:9px 12px; gap:8px; }
+.ed-app.is-mobile .ed-toolbar { flex-wrap:wrap; }
+.ed-app.is-mobile .ed-search { flex:1 1 100%; min-width:0; order:-1; }
+.ed-app.is-mobile .ed-footer .grow { display:none; }
+.ed-app.is-mobile .ed-fbtn.hideM { display:none; }
+.ed-app.is-mobile .ed-publish { flex:1; justify-content:center; }
+.ed-app.is-mobile .ed-toast { bottom:88px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ed-pill .pulse, .ed-savebar, .ed-sk, .ed-spin, .ed-saveveil { animation:none; }
+}
+`;
+
+/* ──────────────────────────────────────────────────────────
+   RuleSpec di Catan — array flat di RuleAtom (dati realistici IT)
+   ────────────────────────────────────────────────────────── */
+const SECTIONS = ['Preparazione', 'Produzione risorse', 'Costruzione', 'Commercio', 'Punti vittoria'];
+const BASE_ATOMS = [
+  { id: 'a1', section: 'Preparazione', text: 'Disponi i 19 esagoni terreno in modo casuale per formare l’isola al centro del tavolo.', page: 4, sec: '1.1' },
+  { id: 'a2', section: 'Preparazione', text: 'Posiziona i gettoni numero sugli esagoni seguendo l’ordine alfabetico delle lettere A–R.', page: 4, sec: '1.2' },
+  { id: 'a3', section: 'Preparazione', text: 'Ogni giocatore piazza a turno 2 strade e 2 insediamenti iniziali sugli incroci.', page: 4, sec: '1.3' },
+  { id: 'a4', section: 'Produzione risorse', text: 'All’inizio del turno tira due dadi: la somma attiva tutti gli esagoni con quel numero.', page: 5, sec: '2.1' },
+  { id: 'a5', section: 'Produzione risorse', text: 'Ogni insediamento adiacente a un esagono attivato produce 1 risorsa del suo tipo; le città ne producono 2.', page: 5, sec: '2.2' },
+  { id: 'a6', section: 'Produzione risorse', text: 'Se esce 7 nessuno produce: si sposta il ladro e si ruba una carta a un avversario adiacente.', page: 6, sec: '2.3' },
+  { id: 'a7', section: 'Costruzione', text: 'Strada: costa 1 legno + 1 mattone. Deve collegarsi a una tua struttura esistente.', page: 7, sec: '3.1' },
+  { id: 'a8', section: 'Costruzione', text: 'Insediamento: costa 1 legno + 1 mattone + 1 lana + 1 grano. Vale 1 punto vittoria.', page: 7, sec: '3.2' },
+  { id: 'a9', section: 'Costruzione', text: 'Città: costa 2 grano + 3 minerale e sostituisce un insediamento. Vale 2 punti vittoria.', page: 8, sec: '3.3' },
+  { id: 'a10', section: 'Commercio', text: 'Commercio marittimo 4:1 con la banca, oppure 3:1 / 2:1 usando i porti.', page: 9, sec: '4.1' },
+  { id: 'a11', section: 'Commercio', text: 'Commercio tra giocatori: libero durante la fase di commercio, prima di costruire.', page: 9, sec: '4.2' },
+  { id: 'a12', section: 'Punti vittoria', text: 'Vince chi raggiunge per primo 10 punti vittoria nel proprio turno.', page: 10, sec: '5.1' },
+];
+
+const PDF_PARAS = [
+  { sec: '1.1', h: '1.1 — Preparazione dell’isola', t: 'I diciannove esagoni di terreno vengono disposti in modo casuale a comporre l’isola. La cornice di mare con i porti circonda il tavoliere. Si raccomanda, per le prime partite, la disposizione fissa illustrata nel regolamento.' },
+  { sec: '1.2', h: '1.2 — Gettoni numero', t: 'I gettoni numero recano le lettere A–R. Vanno collocati sugli esagoni terra seguendo l’ordine alfabetico in senso antiorario, partendo da un angolo qualsiasi. Il deserto non riceve alcun gettone e ospita inizialmente il ladro.' },
+  { sec: '2.1', h: '2.1 — Lancio dei dadi', t: 'All’inizio di ogni turno il giocatore attivo lancia i due dadi. La somma ottenuta determina quali esagoni producono risorse in questo turno: tutti gli esagoni contrassegnati con quel numero si attivano simultaneamente.' },
+  { sec: '3.1', h: '3.1 — Costruire strade', t: 'Una strada costa una carta legno e una carta mattone. Ogni strada deve connettersi a una propria strada, a un proprio insediamento o a una propria città. Due strade non possono occupare lo stesso bordo.' },
+  { sec: '4.1', h: '4.1 — Commercio con la banca', t: 'Durante la propria fase di commercio è sempre possibile scambiare quattro carte risorsa identiche con una carta risorsa qualsiasi dalla banca. I porti riducono il rapporto a 3:1 o, per i porti specializzati, a 2:1.' },
+];
+
+/* ──────────────────────────────────────────────────────────
+   Scenari (11 stati)
+   ────────────────────────────────────────────────────────── */
+const SCENARIOS = {
+  'default':            { sel: 'a1',  edit: null, save: 'saved',   valid: true,  banner: null, toast: false, modal: false, loadVeil: false, readonly: false, empty: false, loading: false, versions: false, veil: false },
+  'editing':            { sel: 'a2',  edit: 'a2', save: 'unsaved', valid: true,  banner: null, toast: false, modal: false, loadVeil: false, readonly: false, empty: false, loading: false, versions: false, veil: false },
+  'saving':             { sel: 'a1',  edit: null, save: 'saving',  valid: true,  banner: null, toast: false, modal: false, loadVeil: false, readonly: false, empty: false, loading: false, versions: false, veil: true },
+  'saved':              { sel: 'a1',  edit: null, save: 'saved',   valid: true,  banner: null, toast: true,  modal: false, loadVeil: false, readonly: false, empty: false, loading: false, versions: false, veil: false },
+  'validation-error':   { sel: 'aX',  edit: 'aX', save: 'unsaved', valid: false, banner: null, toast: false, modal: false, loadVeil: false, readonly: false, empty: false, loading: false, versions: false, veil: false },
+  'conflict-detected':  { sel: 'a1',  edit: null, save: 'conflict',valid: true,  banner: null, toast: false, modal: true,  loadVeil: false, readonly: false, empty: false, loading: false, versions: false, veil: false },
+  'published':          { sel: 'a1',  edit: null, save: 'saved',   valid: true,  banner: 'pub',toast: false, modal: false, loadVeil: false, readonly: false, empty: false, loading: false, versions: true,  veil: false },
+  'lock-acquiring':     { sel: 'a1',  edit: null, save: 'saved',   valid: true,  banner: null, toast: false, modal: false, loadVeil: true,  readonly: true,  empty: false, loading: false, versions: false, veil: false },
+  'lock-held-by-other': { sel: 'a1',  edit: null, save: 'saved',   valid: true,  banner: 'lock',toast: false,modal: false, loadVeil: false, readonly: true,  empty: false, loading: false, versions: false, veil: false },
+  'loading':            { sel: null,  edit: null, save: 'saved',   valid: true,  banner: null, toast: false, modal: false, loadVeil: false, readonly: true,  empty: false, loading: true,  versions: false, veil: false },
+  'empty':              { sel: null,  edit: null, save: 'saved',   valid: true,  banner: null, toast: false, modal: false, loadVeil: false, readonly: true,  empty: true,  loading: false, versions: false, veil: false },
+};
+const STATE_LIST = [
+  ['default', 'Default'], ['editing', 'Editing'], ['saving', 'Saving'], ['saved', 'Saved'],
+  ['validation-error', 'Validation error'], ['conflict-detected', 'Conflict'], ['published', 'Published'],
+  ['lock-acquiring', 'Lock acquiring'], ['lock-held-by-other', 'Lock altrui'], ['loading', 'Loading'], ['empty', 'Empty'],
+];
+
+/* ──────────────────────────────────────────────────────────
+   Sub-components
+   ────────────────────────────────────────────────────────── */
+function SaveStatus({ save }) {
+  const map = {
+    saved:    ['ok', <>✓ Salvato 30s fa</>],
+    unsaved:  ['warn', <><span className="dot" /> Modifiche non salvate</>],
+    saving:   ['warn', <><span className="pulse" /> Salvataggio…</>],
+    conflict: ['danger', <><span className="dot" /> Conflitto rilevato</>],
+  };
+  const [cls, content] = map[save] || map.saved;
+  return <span className={'ed-pill ' + cls} role="status" aria-live="polite">{content}</span>;
+}
+
+function LeftHeader({ sc, canPublish }) {
+  return (
+    <header className="ed-lhead">
+      <div className="ed-brand">M</div>
+      <button className="ed-gamesel" aria-haspopup="listbox" aria-label="Seleziona gioco — attuale: Catan">
+        🎲 Catan <span className="chev">▼</span>
+      </button>
+      <div className="ed-title">Editor regole</div>
+      <div className="grow" />
+      <SaveStatus save={sc.save} />
+      {sc.valid
+        ? <span className="ed-pill ok btn" title="Nessun problema">✓ Valido</span>
+        : <span className="ed-pill warn btn" title="1 problema — vai all’atom">⚠ 1 problema</span>}
+      <button className="ed-publish" disabled={!canPublish} title="Pubblica — Ctrl+Enter">
+        🚀 {sc.banner === 'pub' ? 'Pubblicato' : 'Pubblica'}
+      </button>
+    </header>
+  );
+}
+
+function Toolbar({ search, setSearch, sectionFilter, setSectionFilter, viewMode, setViewMode }) {
+  return (
+    <div className="ed-toolbar" role="toolbar" aria-label="Strumenti editor">
+      <div className="ed-search">
+        <span className="ic">🔍</span>
+        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Cerca in testo e sezioni…" aria-label="Cerca atom (Ctrl+F)" />
+      </div>
+      <div className="ed-selectw">
+        <select className="ed-select" value={sectionFilter} onChange={e => setSectionFilter(e.target.value)} aria-label="Filtra per sezione">
+          <option value="">Tutte le sezioni</option>
+          {SECTIONS.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </div>
+      <button className="ed-tbtn" title="Crea nuova sezione (Ctrl+N)">+ Sezione</button>
+      <div className="ed-vtoggle" role="group" aria-label="Vista atom">
+        <button aria-pressed={viewMode === 'accordion'} onClick={() => setViewMode('accordion')} title="Vista accordion" aria-label="Vista accordion">☰</button>
+        <button aria-pressed={viewMode === 'flat'} onClick={() => setViewMode('flat')} title="Vista lista piatta" aria-label="Vista lista piatta">≣</button>
+      </div>
+    </div>
+  );
+}
+
+function AtomCard({ atom, n, selected, editing, invalid, dirty, saving, readonly, onSelect, onEdit, onRefClick }) {
+  const cls = ['ed-atom', selected && 'sel', editing && 'editing', invalid && 'invalid'].filter(Boolean).join(' ');
+  return (
+    <div className={cls} tabIndex={0} role="button" aria-pressed={selected}
+         onClick={() => !readonly && onSelect(atom.id)}
+         onKeyDown={e => { if ((e.key === 'Enter' || e.key === ' ') && !readonly) { e.preventDefault(); onSelect(atom.id); } }}>
+      {dirty && <span className="ed-dirty" title="Modifiche non salvate" />}
+      <span className="num">{n}.</span>
+      <div className="body">
+        {editing ? (
+          <>
+            <textarea className={'ta' + (invalid ? ' bad' : '')} defaultValue={atom.text} autoFocus
+                      aria-label={'Testo atom ' + n} aria-invalid={invalid}
+                      placeholder="Scrivi il testo della regola…" />
+            {invalid && <div className="ed-aerr" role="alert" aria-live="assertive">⚠ Il testo non può essere vuoto</div>}
+            <div className="ed-editrow">
+              <button className="ed-ebtn pri" disabled={invalid}>Salva</button>
+              <button className="ed-ebtn sec">Annulla <span className="ed-kbd" style={{ marginLeft: 4 }}>Esc</span></button>
+            </div>
+          </>
+        ) : (
+          <div className="text">{atom.text || <span style={{ color: 'hsl(var(--c-danger))', fontStyle: 'italic' }}>(testo mancante)</span>}</div>
+        )}
+        {!editing && (
+          <div className="ed-afoot">
+            <span className="ed-aref" title="Vai al PDF" onClick={(e) => { e.stopPropagation(); onRefClick(atom); }}>📄 p.{atom.page} · §{atom.sec}</span>
+            <span className="grow" />
+            {!readonly && <>
+              <button className="ed-aact" aria-label={'Modifica atom ' + n} title="Modifica" onClick={(e) => { e.stopPropagation(); onEdit(atom.id); }}>✏️</button>
+              <button className="ed-aact" aria-label={'Elimina atom ' + n} title="Elimina">🗑</button>
+            </>}
+          </div>
+        )}
+      </div>
+      {saving && <div className="ed-asaving"><span className="lbl"><span className="ed-pill warn" style={{ padding: 0, background: 'none' }}><span className="pulse" /></span> Salvataggio…</span></div>}
+    </div>
+  );
+}
+
+function AtomListBody({ atoms, viewMode, sc, expanded, toggleSection, selId, editId, savingId, readonly, onSelect, onEdit, onRefClick }) {
+  const numberOf = (id) => atoms.findIndex(a => a.id === id) + 1;
+
+  if (viewMode === 'flat') {
+    return (
+      <div className="ed-lbody">
+        <div className="ed-satoms" style={{ paddingLeft: 0 }}>
+          {atoms.map((a) => (
+            <AtomCard key={a.id} atom={a} n={numberOf(a.id)}
+                      selected={a.id === selId} editing={a.id === editId} invalid={a.id === editId && !sc.valid}
+                      dirty={a.id === editId && sc.save === 'unsaved'} saving={a.id === savingId} readonly={readonly}
+                      onSelect={onSelect} onEdit={onEdit} onRefClick={onRefClick} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ed-lbody">
+      {SECTIONS.map(sec => {
+        const list = atoms.filter(a => a.section === sec);
+        if (list.length === 0 && sec !== 'Punti vittoria') return null; // hide empty sections except demo one
+        const open = expanded[sec] !== false;
+        return (
+          <section className="ed-section" key={sec} role="region" aria-label={'Sezione: ' + sec}>
+            <div className="ed-shead" role="button" tabIndex={0} aria-expanded={open}
+                 onClick={() => toggleSection(sec)}
+                 onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleSection(sec); } }}>
+              <span className="ed-caret" style={{ transform: open ? 'none' : 'rotate(-90deg)' }}>▼</span>
+              <span className="ed-sname">{sec}</span>
+              <span className="ed-scount">({list.length} atom)</span>
+              <span className="grow" />
+              {!readonly && <button className="ed-saddbtn" onClick={(e) => { e.stopPropagation(); }} title="Aggiungi atom (Ctrl+N)">+ Atom</button>}
+              {!readonly && <button className="ed-ctx" aria-label={'Azioni sezione ' + sec} title="Rinomina / sposta / elimina">⋮</button>}
+            </div>
+            {open && (
+              <div className="ed-satoms">
+                {list.length === 0 ? (
+                  <div className="ed-sempty">
+                    <div className="tx">Nessun atom in questa sezione</div>
+                    {!readonly && <button className="ed-tbtn" style={{ margin: '0 auto' }}>+ Aggiungi il primo atom</button>}
+                  </div>
+                ) : list.map(a => (
+                  <AtomCard key={a.id} atom={a} n={numberOf(a.id)}
+                            selected={a.id === selId} editing={a.id === editId} invalid={a.id === editId && !sc.valid}
+                            dirty={a.id === editId && sc.save === 'unsaved'} saving={a.id === savingId} readonly={readonly}
+                            onSelect={onSelect} onEdit={onEdit} onRefClick={onRefClick} />
+                ))}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function PdfHeader({ page, sync }) {
+  return (
+    <header className="ed-rhead">
+      <button className="ed-kbpip" title="Apri documento KB" aria-label="Documento sorgente: catan-rules.pdf">📄 catan-rules.pdf</button>
+      <div className="grow" />
+      <div className="ed-pagenav">
+        <button className="ed-navbtn" aria-label="Pagina precedente del PDF" title="PageUp">◀</button>
+        <span className="ed-pagenum">p.{page} / 24</span>
+        <button className="ed-navbtn" aria-label="Pagina successiva del PDF" title="PageDown">▶</button>
+      </div>
+      <div className="ed-zoom">
+        <button className="ed-navbtn" aria-label="Riduci zoom">−</button>
+        <span className="ed-pagenum">100%</span>
+        <button className="ed-navbtn" aria-label="Aumenta zoom">+</button>
+      </div>
+      <button className="ed-iconbtn" aria-label="Apri PDF a schermo intero" title="Schermo intero">⛶</button>
+      <span className={'ed-syncdot ' + (sync ? 'on' : 'off')} title={sync ? 'Sincronizzato con l’atom selezionato' : 'Navigazione manuale'}>
+        <i />{sync ? 'Sync' : 'Manuale'}
+      </span>
+    </header>
+  );
+}
+
+function PdfPage({ page, sec }) {
+  return (
+    <div className="ed-page">
+      <div className="ph">
+        <div className="pt">Le regole di Catan</div>
+        <div className="ps">pagina {page} di 24 · catan-rules.pdf</div>
+      </div>
+      {PDF_PARAS.map(p => (
+        <div className={'ed-para' + (p.sec === sec ? ' hl' : '')} key={p.sec}>
+          <h6>{p.h}</h6>
+          <p>{p.t}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function VersionsPanel() {
+  const rows = [
+    { v: 'v2.4', meta: 'Pubblicata adesso · Marco R.', cur: true },
+    { v: 'v2.3', meta: '2 ore fa · Marco R. · 12 atom' },
+    { v: 'v2.2', meta: 'Ieri · Sara T. · 11 atom' },
+    { v: 'v2.1', meta: '3 giorni fa · importata da PDF' },
+  ];
+  return (
+    <div className="ed-versions">
+      <h5>🕓 Cronologia versioni</h5>
+      {rows.map(r => (
+        <div className={'ed-vrow' + (r.cur ? ' cur' : '')} key={r.v}>
+          <div>
+            <div className="ed-vtag">{r.v}</div>
+            <div className="ed-vmeta">{r.meta}</div>
+          </div>
+          {r.cur ? <span className="ed-vbadge2">Attuale</span> : <button className="ed-vrest">Ripristina</button>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PdfPane({ sc, selAtom, versions }) {
+  return (
+    <aside className="ed-pane right" aria-label="Anteprima PDF">
+      {versions ? (
+        <>
+          <header className="ed-rhead"><span style={{ fontFamily: 'var(--f-display)', fontWeight: 700 }}>Versioni</span></header>
+          <div className="ed-rbody"><VersionsPanel /></div>
+        </>
+      ) : (
+        <>
+          <PdfHeader page={selAtom ? selAtom.page : 4} sync={!!selAtom} />
+          <div className="ed-rbody">
+            {selAtom
+              ? <PdfPage page={selAtom.page} sec={selAtom.sec} />
+              : <div className="ed-rempty"><div className="em">📄</div><div className="tx">Seleziona un atom per vedere la pagina corrispondente del PDF.</div></div>}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}
+
+function Footer({ atomCount, canPublish, mobile }) {
+  return (
+    <footer className="ed-footer">
+      <div className="fl">
+        <div className="ln1">{atomCount} atom in {SECTIONS.length} sezioni · Catan v2.3</div>
+        <div className="ln2">Modificato 30s fa da Marco · <span className="ed-kbd">Ctrl</span> <span className="ed-kbd">S</span> salva · <span className="ed-kbd">Ctrl</span> <span className="ed-kbd">Z</span> annulla</div>
+      </div>
+      <div className="grow" />
+      {!mobile && <button className="ed-fbtn hideM">Annulla</button>}
+      <button className="ed-fbtn hideM">Anteprima diff</button>
+      <button className="ed-publish" disabled={!canPublish}>🚀 Pubblica</button>
+    </footer>
+  );
+}
+
+/* overlays */
+function ConflictModal() {
+  return (
+    <div className="ed-modal-veil">
+      <div className="ed-modal" role="alertdialog" aria-modal="true" aria-labelledby="cfTitle" aria-describedby="cfDesc">
+        <div className="mh">
+          <div className="ic">⚠</div>
+          <div>
+            <h3 id="cfTitle">Conflitto rilevato</h3>
+            <div style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', fontFamily: 'var(--f-mono)' }}>RuleSpec · Catan</div>
+          </div>
+        </div>
+        <div className="mb">
+          <p id="cfDesc">La tua versione diverge da <strong>v2.4</strong>, modificata 2 minuti fa da{' '}
+            <span className="ed-pchip"><span className="av">AL</span> Alice V.</span>. Scegli come procedere.</p>
+        </div>
+        <div className="mf">
+          <button className="ed-cbtn primary">✔ Mantieni la mia <span className="csub">scarta v2.4</span></button>
+          <button className="ed-cbtn">↧ Usa la sua <span className="csub">scarta le mie modifiche</span></button>
+          <button className="ed-cbtn">⤬ Confronta diff <span className="csub">apri confronto a 3 vie</span></button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobilePdfSheet({ atom, onClose }) {
+  return (
+    <div className="ed-sheet-veil" onClick={onClose}>
+      <div className="ed-sheet" role="dialog" aria-label="Anteprima PDF" onClick={e => e.stopPropagation()}>
+        <div className="grab" />
+        <div className="sh">
+          <button className="ed-kbpip">📄 catan-rules.pdf</button>
+          <div style={{ flex: 1 }} />
+          <span className="ed-pagenum" style={{ fontFamily: 'var(--f-mono)', fontSize: 'var(--fs-xs)', color: 'var(--text-sec)' }}>p.{atom.page} / 24</span>
+          <button className="ed-iconbtn" aria-label="Chiudi" onClick={onClose}>✕</button>
+        </div>
+        <div className="sb"><PdfPage page={atom.page} sec={atom.sec} /></div>
+      </div>
+    </div>
+  );
+}
+
+/* loading skeleton */
+function LoadingSkeleton({ mobile }) {
+  return (
+    <div className={'ed-app' + (mobile ? ' is-mobile' : '')} style={{ pointerEvents: 'none' }}>
+      <header className="ed-lhead">
+        <div className="ed-sk" style={{ width: 28, height: 28, borderRadius: 'var(--r-sm)' }} />
+        <div className="ed-sk" style={{ width: 78, height: 28, borderRadius: 'var(--r-pill)' }} />
+        <div className="ed-sk" style={{ width: 110, height: 16 }} />
+        <div className="grow" />
+        <div className="ed-sk" style={{ width: 96, height: 28, borderRadius: 'var(--r-pill)' }} />
+        <div className="ed-sk" style={{ width: 100, height: 32, borderRadius: 'var(--r-md)' }} />
+      </header>
+      <div className="ed-toolbar">
+        <div className="ed-sk" style={{ flex: 1, height: 32, borderRadius: 'var(--r-md)' }} />
+        <div className="ed-sk" style={{ width: 130, height: 32, borderRadius: 'var(--r-md)' }} />
+        <div className="ed-sk" style={{ width: 90, height: 32, borderRadius: 'var(--r-md)' }} />
+      </div>
+      <div className="ed-split">
+        <div className="ed-pane left">
+          <div className="ed-lbody">
+            {[0, 1, 2, 3, 4].map(i => (
+              <div key={i} style={{ marginBottom: 12 }}>
+                <div className="ed-sk" style={{ width: '100%', height: 38, borderRadius: 'var(--r-md)', marginBottom: 8 }} />
+                <div className="ed-sk" style={{ width: '94%', height: 56, borderRadius: 'var(--r-md)', marginLeft: 'auto' }} />
+              </div>
+            ))}
+          </div>
+        </div>
+        {!mobile && (
+          <div className="ed-pane right">
+            <div className="ed-rbody"><div className="ed-sk" style={{ width: '100%', maxWidth: 420, height: 540, borderRadius: 'var(--r-sm)' }} /></div>
+          </div>
+        )}
+      </div>
+      <footer className="ed-footer"><div className="ed-sk" style={{ width: 240, height: 18 }} /><div className="grow" /><div className="ed-sk" style={{ width: 100, height: 32, borderRadius: 'var(--r-md)' }} /></footer>
+    </div>
+  );
+}
+
+/* empty state */
+function LeftHeaderEmpty() {
+  return (
+    <header className="ed-lhead">
+      <div className="ed-brand">M</div>
+      <button className="ed-gamesel" aria-label="Gioco: Catan">🎲 Catan <span className="chev">▼</span></button>
+      <div className="ed-title">Editor regole</div>
+      <div className="grow" />
+      <span className="ed-pill warn">Nessun RuleSpec</span>
+    </header>
+  );
+}
+function EmptyState({ mobile }) {
+  return (
+    <div className={'ed-app' + (mobile ? ' is-mobile' : '')}>
+      <LeftHeaderEmpty />
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 32 }}>
+        <div style={{ textAlign: 'center', maxWidth: 360 }}>
+          <div style={{ fontSize: 46, marginBottom: 12 }}>📋</div>
+          <h3 style={{ fontFamily: 'var(--f-display)', fontSize: 'var(--fs-xl)', marginBottom: 8 }}>Nessuna regola ancora indicizzata</h3>
+          <p style={{ color: 'var(--text-sec)', fontSize: 'var(--fs-md)', lineHeight: 'var(--lh-body)', marginBottom: 20 }}>
+            Catan non ha ancora un RuleSpec. Carica il PDF delle regole per estrarre gli atom automaticamente, oppure creali a mano.
+          </p>
+          <div style={{ display: 'flex', gap: 10, justifyContent: 'center', flexWrap: 'wrap' }}>
+            <button className="ed-publish" style={{ background: 'hsl(var(--c-kb))' }}>📄 Carica PDF regole</button>
+            <button className="ed-tbtn" style={{ padding: '8px 15px' }}>+ Crea manualmente</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   EditorApp — un'istanza per (state × viewport). Remount via key.
+   ────────────────────────────────────────────────────────── */
+function EditorApp({ stateId, mobile }) {
+  const sc = SCENARIOS[stateId];
+
+  const atoms = useMemo(() => {
+    if (stateId === 'validation-error') {
+      return [...BASE_ATOMS, { id: 'aX', section: 'Punti vittoria', text: '', page: 10, sec: '5.2' }];
+    }
+    return BASE_ATOMS;
+  }, [stateId]);
+
+  const [selId, setSelId] = useState(sc.sel);
+  const [editId, setEditId] = useState(sc.edit);
+  const [search, setSearch] = useState('');
+  const [sectionFilter, setSectionFilter] = useState('');
+  const [viewMode, setViewMode] = useState('accordion');
+  const [expanded, setExpanded] = useState({});
+  const [sheetAtom, setSheetAtom] = useState(null);
+
+  if (sc.loading) return <LoadingSkeleton mobile={mobile} />;
+  if (sc.empty) return <EmptyState mobile={mobile} />;
+
+  const readonly = sc.readonly;
+  const savingId = sc.veil ? sc.sel : null;
+
+  const q = search.trim().toLowerCase();
+  const filtered = atoms.filter(a =>
+    (!sectionFilter || a.section === sectionFilter) &&
+    (!q || a.text.toLowerCase().includes(q) || a.section.toLowerCase().includes(q))
+  );
+
+  const selAtom = atoms.find(a => a.id === selId) || null;
+  const atomCount = atoms.length;
+  const canPublish = sc.valid && !readonly && sc.save !== 'saving' && sc.save !== 'conflict' && sc.banner !== 'pub';
+
+  const toggleSection = (s) => setExpanded(e => ({ ...e, [s]: e[s] === false ? true : false }));
+  const onSelect = (id) => setSelId(id);
+  const onEdit = (id) => { setSelId(id); setEditId(id); };
+  const onRefClick = (atom) => { setSelId(atom.id); if (mobile) setSheetAtom(atom); };
+
+  return (
+    <div className={'ed-app' + (mobile ? ' is-mobile' : '')}>
+      {sc.veil && <div className="ed-savebar" />}
+
+      {sc.banner === 'pub' && (
+        <div className="ed-banner pub" role="status">✓ Pubblicato come v2.4 <span className="grow" /><button className="bcta">Vedi changelog</button></div>
+      )}
+      {sc.banner === 'lock' && (
+        <div className="ed-banner lock" role="status">
+          🔒 <span className="ed-pchip"><span className="av">MR</span> Marco R.</span> sta modificando — sola lettura
+          <span className="grow" /><button className="bcta">Richiedi lock</button>
+        </div>
+      )}
+
+      <div className="ed-split">
+        <div className="ed-pane left">
+          <LeftHeader sc={sc} canPublish={canPublish} />
+          <Toolbar search={search} setSearch={setSearch} sectionFilter={sectionFilter} setSectionFilter={setSectionFilter}
+                   viewMode={viewMode} setViewMode={setViewMode} />
+          <AtomListBody atoms={filtered} viewMode={viewMode} sc={sc} expanded={expanded} toggleSection={toggleSection}
+                        selId={selId} editId={editId} savingId={savingId} readonly={readonly}
+                        onSelect={onSelect} onEdit={onEdit} onRefClick={onRefClick} />
+        </div>
+
+        <PdfPane sc={sc} selAtom={selAtom} versions={sc.versions} />
+      </div>
+
+      <Footer atomCount={atomCount} canPublish={canPublish} mobile={mobile} />
+
+      {sc.veil && <div className="ed-saveveil" aria-hidden="true" />}
+      {sc.toast && <div className="ed-toast" role="status" aria-live="polite"><span className="ti">✓</span><div className="tt">Atom aggiornato</div></div>}
+      {sc.modal && <ConflictModal />}
+      {sc.loadVeil && (
+        <div className="ed-loadveil" role="status" aria-live="polite">
+          <div className="ed-spin" />
+          <div className="lt">Acquisendo lock per editing collaborativo…</div>
+        </div>
+      )}
+      {sheetAtom && <MobilePdfSheet atom={sheetAtom} onClose={() => setSheetAtom(null)} />}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   Harness
+   ────────────────────────────────────────────────────────── */
+function Harness() {
+  const [stateId, setStateId] = useState(() => localStorage.getItem('ed-state2') || 'default');
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || 'light');
+
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem('ed-state2', stateId); }, [stateId]);
+
+  return (
+    <div className="ed-stage">
+      <style dangerouslySetInnerHTML={{ __html: EDITOR_CSS }} />
+      <button className="theme-toggle" onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>🌗 <span>{theme === 'dark' ? 'Dark' : 'Light'}</span></button>
+
+      <div className="ed-wrap">
+        <div className="ed-kicker">SP4 · B14 · #1489 — schermata 1 / 5 · REV split-view</div>
+        <h1>Editor <span className="acc">regole</span> — /editor</h1>
+        <p className="ed-lead">
+          Editor del RuleSpec come <b>lista flat di RuleAtom</b> ({'{ id, text, section, page }'}). Niente JSON grezzo:
+          un solo editor leggibile a sinistra, anteprima PDF sorgente a destra, sincronizzati. Autosalvataggio, validazione,
+          lock collaborativo (#2055), conflitti e pubblicazione versionata.
+        </p>
+
+        <div className="ed-notes">
+          <div className="ed-note">
+            <h4>Pattern (locked)</h4>
+            <p><b>Split-view 60/40</b>: pane sinistro = atom-list editor (accordion per <code>section</code>, card editabili inline); pane destro = <b>PDF preview</b> con highlight dell’atom selezionato. Footer sticky con conteggi + Pubblica.</p>
+          </div>
+          <div className="ed-note">
+            <h4>11 stati</h4>
+            <p>Selettore qui sotto: default · editing · saving · saved · validation-error · conflict · published · lock-acquiring · lock altrui · loading · empty.</p>
+          </div>
+          <div className="ed-note">
+            <h4>Mobile & a11y</h4>
+            <p>Mobile = solo atom-list; il ref <code>📄 p.N</code> apre un <b>bottom-sheet</b> col PDF. <code>role=region</code>/<code>aria-expanded</code> sulle sezioni, <code>aria-live</code> sullo stato, <code>alertdialog</code> sul conflitto, scorciatoie in tooltip.</p>
+          </div>
+        </div>
+
+        <div className="ed-rail">
+          <span className="lab">Stato</span>
+          <div className="ed-states" role="group" aria-label="Selettore stato schermata">
+            {STATE_LIST.map(([id, label]) => (
+              <button key={id} className={'ed-sbtn' + (stateId === id ? ' on' : '')} aria-pressed={stateId === id} onClick={() => setStateId(id)}>
+                <span className="pip" />{label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Desktop · 1440 — split 60 / 40</div>
+        <div className="ed-desk">
+          <div className="ed-chrome">
+            <div className="dots"><i /><i /><i /></div>
+            <div className="url">meepleai.app/editor?game=g-catan</div>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <EditorApp key={'d-' + stateId} stateId={stateId} mobile={false} />
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Mobile · 375 — stack + drawer PDF</div>
+        <div className="ed-phone-row">
+          <div className="phone">
+            <div className="phone-sbar"><span>9:41</span><span className="ind">●●● 5G ▮</span></div>
+            <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+              <EditorApp key={'m-' + stateId} stateId={stateId} mobile={true} />
+            </div>
+          </div>
+          <div className="ed-phone-cap">
+            <h4>Layout mobile</h4>
+            <p>Niente split-view: solo l’atom-list. Tocca <code>📄 p.N</code> sotto un atom per aprire un bottom-sheet con la pagina PDF (prova negli stati con atom). La toolbar va a capo su due righe; Pubblica è full-width nel footer.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Harness />);

--- a/admin-mockups/design_files/sp4-editor-proposals-create.html
+++ b/admin-mockups/design_files/sp4-editor-proposals-create.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · B14 editor · #3/5 · Crea typology proposal — /editor/agent-proposals/create</title>
+<!-- route: /editor/agent-proposals/create — Form multi-section per creare typology AI agent proposal -->
+<!--
+  @route /editor/agent-proposals/create
+  @brief B14 (issue #1489) — Editor user-facing (agent proposals)
+  @screen 3 of 5 — sp4-editor-proposals-create
+  @tier M
+  @pattern Form full-page (NO drawer) · 5 sezioni accordion stacked · max-width 880 centered · cards stack mobile
+  @states default-empty · partial-filled · all-valid · validation-errors · saving · draft-saved · submitting · submit-success
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-editor-proposals-create.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-editor-proposals-create.jsx
+++ b/admin-mockups/design_files/sp4-editor-proposals-create.jsx
@@ -1,0 +1,961 @@
+/* sp4-editor-proposals-create.jsx
+   Route: /editor/agent-proposals/create — Crea nuova typology AI agent proposal
+   B14 (issue #1489) · screen 3 of 5 · Tier M
+   Pattern: Form full-page (NO drawer) — 5 sezioni accordion stacked verticalmente, max-width 880 centered.
+            Single-page (NON wizard): l'editor power-user vede tutto il context insieme, salva draft
+            parziale, salta fra sezioni. Riusa pattern field di auth-flow.jsx (label + input + error/hint).
+   Continuity con S1+S2: stesso state-picker UI, theme toggle 🌗 (mai-theme), desktop frame chrome
+            (.ed-desk), phone-row mobile. Entity primaria = --c-agent. CTA primario --c-agent.
+   Loadable standalone via Babel. Injects own component CSS; relies on tokens.css + components.css.
+
+   v2 components surfaced here:
+   /* v2: ProposalCreateForm, FormHeader, FormFooter, SaveStatusPill, SectionCard, ValidationPip,
+          NameField, UniqueCheck, CharCounter, AutoTextarea, IconPicker, ColorPicker, CapabilityGrid,
+          CodeEditor (highlight {var}), PromptToolbar, VarHint, SampleRows, GameScopePicker,
+          ScopeSummary, ConfirmCancelModal, SubmitReviewModal, DraftSavedToast, SubmitSuccessBanner,
+          AuthorChip, EntityChip (game) */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+
+/* ──────────────────────────────────────────────────────────
+   Component CSS — solo token da tokens.css / components.css.
+   .ed-* = harness chrome riusato da S1/S2 (continuity). .cp-* = create-proposal.
+   ────────────────────────────────────────────────────────── */
+const CP_CSS = `
+/* ─── harness (riuso esatto da sp4-editor-proposals-index S2) ─── */
+.ed-stage { min-height:100vh; padding:72px 24px 96px; background:var(--bg); color:var(--text); }
+.ed-wrap { max-width:1380px; margin:0 auto; }
+.ed-kicker { font-family:var(--f-mono); font-size:var(--fs-xs); letter-spacing:.1em; text-transform:uppercase; color:var(--text-muted); }
+.ed-stage h1 { font-size:var(--fs-3xl); margin:8px 0 6px; }
+.ed-stage h1 .acc { color:hsl(var(--c-agent)); }
+.ed-lead { color:var(--text-sec); font-size:var(--fs-md); max-width:820px; line-height:var(--lh-body); }
+.ed-notes { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:22px 0 4px; }
+.ed-note { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:14px 16px; }
+.ed-note h4 { font-family:var(--f-display); font-size:var(--fs-sm); text-transform:uppercase; letter-spacing:.04em; color:hsl(var(--c-agent)); margin-bottom:6px; }
+.ed-note p { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.ed-note p b { color:var(--text); font-weight:var(--fw-bold); }
+.ed-note code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:11px; }
+.ed-rail { position:sticky; top:0; z-index:var(--z-sticky); margin:26px 0 18px; padding:12px 0;
+  background:var(--bg); display:flex; align-items:flex-start; gap:14px; flex-wrap:wrap; border-bottom:1px solid var(--border); }
+.ed-rail .lab { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); padding-top:8px; }
+.ed-states { display:flex; gap:6px; flex-wrap:wrap; flex:1; }
+.ed-sbtn { display:inline-flex; align-items:center; gap:7px; padding:7px 12px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-sbtn:hover { transform:translateY(-1px); border-color:var(--border-strong); }
+.ed-sbtn .pip { width:7px; height:7px; border-radius:50%; background:currentColor; opacity:.6; }
+.ed-sbtn.on { background:hsl(var(--c-agent)); border-color:transparent; color:#fff; }
+.ed-sbtn.on .pip { opacity:1; background:#fff; }
+.ed-vp-label { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em;
+  color:var(--text-muted); margin:30px 0 12px; display:flex; align-items:center; gap:10px; }
+.ed-vp-label::after { content:''; flex:1; height:1px; background:var(--border); }
+.ed-desk { width:100%; max-width:1340px; height:820px; border-radius:var(--r-lg); overflow:hidden;
+  background:var(--bg-card); border:1px solid var(--border); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; }
+.ed-chrome { height:38px; flex-shrink:0; display:flex; align-items:center; gap:8px; padding:0 14px;
+  background:var(--bg-muted); border-bottom:1px solid var(--border); font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ed-chrome .dots { display:flex; gap:6px; }
+.ed-chrome .dots i { width:11px; height:11px; border-radius:50%; display:block; }
+.ed-chrome .dots i:nth-child(1){ background:#ff5f57; } .ed-chrome .dots i:nth-child(2){ background:#febc2e; } .ed-chrome .dots i:nth-child(3){ background:#28c840; }
+.ed-chrome .url { flex:1; text-align:center; background:var(--bg-card); border-radius:var(--r-sm); padding:4px 10px; margin:0 14%; }
+.ed-phone-row { display:flex; gap:28px; align-items:flex-start; flex-wrap:wrap; }
+.ed-phone-cap { font-size:var(--fs-sm); color:var(--text-sec); max-width:300px; line-height:var(--lh-snug); }
+.ed-phone-cap h4 { font-family:var(--f-display); font-size:var(--fs-base); margin-bottom:6px; }
+
+/* ─── form app shell ─── */
+.cp-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+.cp-app :focus-visible { outline:2px solid hsl(var(--c-agent)); outline-offset:2px; border-radius:var(--r-xs); }
+
+/* success banner (top) */
+.cp-banner { flex-shrink:0; display:flex; align-items:center; gap:12px; padding:13px 22px; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:hsl(var(--c-success) / .15); color:hsl(var(--c-success)); border-bottom:1px solid hsl(var(--c-success) / .35); }
+.cp-banner .grow { flex:1; }
+.cp-banner .gocta { display:inline-flex; align-items:center; gap:6px; padding:7px 14px; border-radius:var(--r-md); border:none;
+  background:hsl(var(--c-success)); color:#06250f; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; }
+[data-theme="dark"] .cp-banner .gocta { color:#06250f; }
+
+/* header (sticky) */
+.cp-head { flex-shrink:0; position:sticky; top:0; z-index:var(--z-sticky); background:var(--bg-card); border-bottom:1px solid var(--border); }
+.cp-head .hrow { display:flex; align-items:flex-end; gap:16px; padding:14px 22px 15px; max-width:980px; margin:0 auto; }
+.cp-head .htxt { min-width:0; }
+.cp-bread { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:6px; }
+.cp-bread .sep { opacity:.5; }
+.cp-bread .cur { color:hsl(var(--c-agent)); font-weight:var(--fw-bold); }
+.cp-h1 { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-2xl); letter-spacing:-.01em; line-height:var(--lh-tight); }
+.cp-sub { font-size:var(--fs-sm); color:var(--text-sec); margin-top:4px; max-width:560px; }
+.cp-author { display:inline-flex; align-items:center; gap:6px; margin-top:9px; padding:3px 10px 3px 3px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .14); color:hsl(var(--c-player)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); }
+.cp-author .av { width:18px; height:18px; border-radius:50%; background:hsl(var(--c-player)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:9px; font-weight:var(--fw-ext); }
+.cp-author .lb { color:var(--text-muted); font-weight:var(--fw-semi); }
+.cp-head .grow { flex:1; }
+.cp-headcta { display:flex; align-items:center; gap:9px; flex-shrink:0; }
+
+/* generic buttons */
+.cp-btn { display:inline-flex; align-items:center; gap:7px; padding:9px 15px; border-radius:var(--r-md); border:1px solid transparent;
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); white-space:nowrap; }
+.cp-btn .ic { font-size:13px; line-height:1; }
+.cp-btn.link { background:transparent; color:var(--text-muted); padding:9px 8px; }
+.cp-btn.link:hover { color:var(--text); }
+.cp-btn.ghost { background:var(--bg-card); border-color:var(--border); color:var(--text-sec); }
+.cp-btn.ghost:hover { border-color:var(--border-strong); color:var(--text); transform:translateY(-1px); }
+.cp-btn.primary { background:hsl(var(--c-agent)); color:#3a2400; box-shadow:var(--shadow-xs); }
+.cp-btn.primary:hover:not(:disabled) { transform:translateY(-1px); box-shadow:var(--shadow-sm); filter:brightness(1.03); }
+.cp-btn.primary:disabled { opacity:.45; cursor:not-allowed; }
+.cp-btn.danger { background:hsl(var(--c-danger)); color:#fff; }
+.cp-btn.danger:hover { filter:brightness(1.04); transform:translateY(-1px); }
+
+/* save pill bar (above footer) */
+.cp-savebar { flex-shrink:0; display:flex; justify-content:flex-end; padding:7px 22px; background:var(--bg); }
+.cp-savebar .inner { max-width:980px; width:100%; margin:0 auto; display:flex; justify-content:flex-end; }
+.cp-pill { display:inline-flex; align-items:center; gap:6px; padding:4px 11px; border-radius:var(--r-pill);
+  font-family:var(--f-mono); font-size:var(--fs-xs); font-weight:var(--fw-bold); }
+.cp-pill.unsaved { background:hsl(var(--c-warning) / .14); color:hsl(var(--c-warning)); }
+.cp-pill.saved   { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); }
+.cp-pill.saving  { background:hsl(var(--c-warning) / .14); color:hsl(var(--c-warning)); }
+.cp-pill .dot { width:7px; height:7px; border-radius:50%; background:currentColor; }
+.cp-pill.saving .dot { animation:cppulse 1s var(--ease-in-out) infinite; }
+@keyframes cppulse { 0%,100%{ opacity:1; transform:scale(1);} 50%{ opacity:.3; transform:scale(.55);} }
+
+/* footer (sticky bottom) */
+.cp-foot { flex-shrink:0; background:var(--bg-card); border-top:1px solid var(--border); }
+.cp-foot .frow { display:flex; align-items:center; gap:10px; padding:13px 22px; max-width:980px; margin:0 auto; }
+.cp-foot .grow { flex:1; }
+
+/* scroll body + form column */
+.cp-body { flex:1; overflow:auto; min-height:0; padding:24px 22px 32px; }
+.cp-form { max-width:880px; margin:0 auto; display:flex; flex-direction:column; gap:16px; }
+
+/* section card (accordion) */
+.cp-sec { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); overflow:hidden; transition:border-color var(--dur-sm) var(--ease-out); }
+.cp-sec.has-error { border-color:hsl(var(--c-danger) / .4); }
+.cp-sec.is-valid { border-color:hsl(var(--c-toolkit) / .32); }
+.cp-sechead { display:flex; align-items:center; gap:13px; width:100%; padding:15px 18px; background:transparent; border:none; text-align:left; cursor:pointer; }
+.cp-sechead:hover { background:var(--bg-hover); }
+.cp-secnum { flex-shrink:0; width:26px; height:26px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center;
+  background:hsl(var(--c-agent) / .14); color:hsl(var(--c-agent)); font-family:var(--f-mono); font-weight:var(--fw-ext); font-size:var(--fs-sm); }
+.cp-sectitle { min-width:0; flex:1; }
+.cp-sectitle .t { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-lg); line-height:var(--lh-tight); display:flex; align-items:center; gap:8px; }
+.cp-sectitle .t .opt { font-family:var(--f-mono); font-size:var(--fs-xs); font-weight:var(--fw-bold); color:var(--text-muted); text-transform:uppercase; letter-spacing:.04em;
+  background:var(--bg-muted); padding:2px 7px; border-radius:var(--r-pill); }
+.cp-sectitle .s { font-size:var(--fs-sm); color:var(--text-sec); margin-top:3px; }
+.cp-vpip { flex-shrink:0; display:inline-flex; align-items:center; gap:5px; padding:3px 10px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); white-space:nowrap; }
+.cp-vpip.valid { background:hsl(var(--c-toolkit) / .14); color:hsl(var(--c-toolkit)); }
+.cp-vpip.issues { background:hsl(var(--c-danger) / .14); color:hsl(var(--c-danger)); }
+.cp-vpip.incomplete { background:var(--bg-muted); color:var(--text-muted); }
+.cp-vpip.optional { background:var(--bg-muted); color:var(--text-muted); }
+.cp-caret { flex-shrink:0; color:var(--text-muted); font-size:11px; transition:transform var(--dur-sm) var(--ease-out); width:16px; text-align:center; }
+.cp-sec.open .cp-caret { transform:rotate(90deg); }
+.cp-secbody { padding:4px 18px 20px; border-top:1px solid var(--border-light); }
+
+/* fields (auth-flow heritage) */
+.cp-field { margin-bottom:16px; }
+.cp-field:last-child { margin-bottom:0; }
+.cp-label { display:flex; align-items:center; gap:6px; font-family:var(--f-display); font-size:var(--fs-xs); font-weight:var(--fw-bold);
+  color:var(--text-sec); margin-bottom:7px; text-transform:uppercase; letter-spacing:.05em; }
+.cp-label .req { color:hsl(var(--c-danger)); }
+.cp-label .grow { flex:1; }
+.cp-counter { font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); color:var(--text-muted); text-transform:none; letter-spacing:0; }
+.cp-counter.over { color:hsl(var(--c-danger)); }
+.cp-inwrap { position:relative; }
+.cp-input, .cp-textarea { width:100%; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:var(--fs-base); color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.cp-input:focus, .cp-textarea:focus { border-color:hsl(var(--c-agent) / .55); box-shadow:0 0 0 3px hsl(var(--c-agent) / .14); }
+.cp-input.err, .cp-textarea.err { border-color:hsl(var(--c-danger) / .6); }
+.cp-input.err:focus, .cp-textarea.err:focus { box-shadow:0 0 0 3px hsl(var(--c-danger) / .14); }
+.cp-input[readonly], .cp-textarea[readonly] { background:var(--bg-muted); color:var(--text-sec); cursor:default; }
+.cp-input.haspad { padding-right:110px; }
+.cp-textarea { resize:none; line-height:var(--lh-body); min-height:74px; }
+.cp-unique { position:absolute; right:11px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; gap:5px;
+  font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); white-space:nowrap; }
+.cp-unique.checking { color:hsl(var(--c-info)); }
+.cp-unique.ok { color:hsl(var(--c-toolkit)); }
+.cp-unique.dup { color:hsl(var(--c-danger)); }
+.cp-unique .sp { width:11px; height:11px; border:2px solid currentColor; border-right-color:transparent; border-radius:50%; animation:cpspin .7s linear infinite; }
+@keyframes cpspin { to { transform:rotate(360deg); } }
+.cp-err { display:flex; align-items:center; gap:6px; font-size:var(--fs-xs); color:hsl(var(--c-danger)); font-weight:var(--fw-semi); margin-top:6px; }
+.cp-hint { font-size:var(--fs-xs); color:var(--text-muted); margin-top:6px; line-height:var(--lh-snug); }
+
+/* tip / help box */
+.cp-tip { display:flex; align-items:flex-start; gap:9px; margin-top:14px; padding:10px 13px; border-radius:var(--r-md);
+  background:hsl(var(--c-info) / .08); border:1px solid hsl(var(--c-info) / .18); }
+.cp-tip .ti { font-size:14px; line-height:1.3; flex-shrink:0; }
+.cp-tip .tt { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.cp-tip .tt b { color:var(--text); font-weight:var(--fw-bold); }
+.cp-tip .tt code { font-family:var(--f-mono); font-size:11px; background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); color:hsl(var(--c-game)); }
+
+/* icon picker */
+.cp-icons { display:flex; flex-wrap:wrap; gap:8px; }
+.cp-icon { width:46px; height:46px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card);
+  display:flex; align-items:center; justify-content:center; font-size:21px; cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.cp-icon:hover { border-color:var(--border-strong); transform:translateY(-1px); }
+.cp-icon.on { border-color:hsl(var(--c-agent)); background:hsl(var(--c-agent) / .12); box-shadow:0 0 0 3px hsl(var(--c-agent) / .22); }
+.cp-upload { flex:1; min-width:160px; display:flex; align-items:center; justify-content:center; gap:9px; height:46px; border-radius:var(--r-md);
+  border:1.5px dashed var(--border-strong); background:var(--bg); color:var(--text-muted); cursor:pointer; font-family:var(--f-body); font-size:var(--fs-xs); }
+.cp-upload:hover { border-color:hsl(var(--c-agent) / .5); color:var(--text-sec); background:var(--bg-hover); }
+.cp-upload .ui { font-size:16px; }
+
+/* color picker */
+.cp-colors { display:flex; flex-wrap:wrap; gap:9px; align-items:center; }
+.cp-swatch { width:30px; height:30px; border-radius:var(--r-sm); cursor:pointer; border:2px solid transparent; position:relative; transition:transform var(--dur-sm) var(--ease-out); }
+.cp-swatch:hover { transform:scale(1.08); }
+.cp-swatch.on { border-color:var(--text); box-shadow:0 0 0 2px var(--bg-card), 0 0 0 4px var(--border-strong); }
+.cp-swatch.on::after { content:'✓'; position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:#fff; font-size:13px; font-weight:900; text-shadow:0 1px 2px rgba(0,0,0,.4); }
+.cp-advtoggle { font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); color:hsl(var(--c-agent)); background:none; border:none; cursor:pointer; padding:4px 6px; }
+.cp-hslrow { display:flex; align-items:center; gap:14px; margin-top:12px; padding:12px; border:1px solid var(--border); border-radius:var(--r-md); background:var(--bg); }
+.cp-hslrow .prev { width:40px; height:40px; border-radius:var(--r-sm); flex-shrink:0; }
+.cp-hsl { flex:1; display:flex; flex-direction:column; gap:6px; }
+.cp-hsl label { display:flex; align-items:center; gap:8px; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.cp-hsl label span { width:14px; }
+.cp-hsl input[type=range] { flex:1; accent-color:hsl(var(--c-agent)); }
+.cp-hsl label b { font-family:var(--f-mono); font-size:10px; color:var(--text-sec); width:34px; text-align:right; }
+
+/* capability grid */
+.cp-caps { display:grid; grid-template-columns:repeat(auto-fill, minmax(232px, 1fr)); gap:9px; }
+.cp-cap { display:flex; align-items:flex-start; gap:10px; padding:11px 12px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); cursor:pointer; text-align:left; transition:all var(--dur-sm) var(--ease-out); position:relative; }
+.cp-cap:hover { background:var(--bg-hover); border-color:var(--border-strong); }
+.cp-cap.on { background:hsl(var(--c-agent) / .12); border-color:hsl(var(--c-agent) / .45); }
+.cp-cap .cic { font-size:18px; line-height:1.1; flex-shrink:0; }
+.cp-cap .cbody { display:flex; flex-direction:column; gap:3px; min-width:0; }
+.cp-cap .cbody .ct { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); }
+.cp-cap.on .cbody .ct { color:hsl(var(--c-agent)); }
+.cp-cap .cbody .cd { font-size:var(--fs-xs); color:var(--text-sec); line-height:var(--lh-snug); }
+.cp-cap .ck { position:absolute; top:9px; right:9px; width:17px; height:17px; border-radius:50%; background:hsl(var(--c-agent)); color:#fff;
+  display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:900; opacity:0; transform:scale(.5); transition:all var(--dur-sm) var(--ease-spring); }
+.cp-cap.on .ck { opacity:1; transform:scale(1); }
+.cp-capwarn { display:flex; align-items:center; gap:6px; font-size:var(--fs-xs); color:hsl(var(--c-danger)); font-weight:var(--fw-semi); margin-top:10px; }
+
+/* prompt toolbar + code editor */
+.cp-ptoolbar { display:flex; align-items:center; gap:7px; flex-wrap:wrap; margin-bottom:9px; }
+.cp-ptool { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border-radius:var(--r-sm); border:1px solid var(--border); white-space:nowrap;
+  background:var(--bg-card); color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; transition:all var(--dur-sm); }
+.cp-ptool:hover { background:var(--bg-muted); color:var(--text); border-color:var(--border-strong); }
+.cp-ptool.play { color:hsl(var(--c-tool)); border-color:hsl(var(--c-tool) / .35); background:hsl(var(--c-tool) / .08); }
+.cp-ptool.play:hover { background:hsl(var(--c-tool) / .15); }
+.cp-ptoolbar .grow { flex:1; }
+.cp-code-wrap { position:relative; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-muted); overflow:hidden; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.cp-code-wrap.focus { border-color:hsl(var(--c-agent) / .55); box-shadow:0 0 0 3px hsl(var(--c-agent) / .14); }
+.cp-code-wrap.err { border-color:hsl(var(--c-danger) / .6); }
+.cp-code-layer { margin:0; padding:13px 15px; font-family:var(--f-mono); font-size:13px; line-height:1.6; white-space:pre-wrap; word-break:break-word; }
+.cp-code-hl { position:absolute; inset:0; pointer-events:none; color:var(--text); }
+.cp-code-hl .v { color:hsl(var(--c-game)); font-weight:var(--fw-bold); background:hsl(var(--c-game) / .12); border-radius:3px; padding:0 2px; }
+.cp-code-hl .bt { color:hsl(var(--c-tool)); }
+.cp-code-hl .ph { color:var(--text-muted); }
+.cp-code-ta { position:relative; display:block; width:100%; border:none; outline:none; resize:none; background:transparent;
+  color:transparent; caret-color:hsl(var(--c-agent)); overflow:hidden; }
+.cp-code-ta::selection { background:hsl(var(--c-agent) / .25); }
+.cp-codefoot { display:flex; align-items:center; padding:7px 15px; border-top:1px solid var(--border-light); background:var(--bg); }
+.cp-codefoot .grow { flex:1; }
+
+/* sample rows */
+.cp-samples { display:flex; flex-direction:column; gap:11px; }
+.cp-sample { border:1px solid var(--border); border-radius:var(--r-md); padding:12px; background:var(--bg); position:relative; }
+.cp-sample .shead { display:flex; align-items:center; margin-bottom:9px; }
+.cp-sample .sidx { font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); color:var(--text-muted); flex:1; }
+.cp-sample .sdel { width:28px; height:28px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text-muted); cursor:pointer; font-size:13px; }
+.cp-sample .sdel:hover { color:hsl(var(--c-danger)); border-color:hsl(var(--c-danger) / .4); background:hsl(var(--c-danger) / .08); }
+.cp-sample .sgrid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+.cp-sample .scol .sl { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--text-muted); margin-bottom:5px; }
+.cp-addbtn { display:inline-flex; align-items:center; gap:6px; align-self:flex-start; padding:8px 13px; border-radius:var(--r-md);
+  border:1.5px dashed var(--border-strong); background:transparent; color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; }
+.cp-addbtn:hover { border-color:hsl(var(--c-agent) / .5); color:hsl(var(--c-agent)); background:hsl(var(--c-agent) / .06); }
+.cp-addbtn:disabled { opacity:.45; cursor:not-allowed; }
+
+/* game scope picker */
+.cp-scopsearch { position:relative; }
+.cp-scopsearch .si { position:absolute; left:11px; top:50%; transform:translateY(-50%); opacity:.6; font-size:13px; pointer-events:none; }
+.cp-scopsuggest { margin-top:7px; border:1px solid var(--border); border-radius:var(--r-md); background:var(--bg-card); box-shadow:var(--shadow-md); overflow:hidden; }
+.cp-sugg { display:flex; align-items:center; gap:11px; width:100%; padding:9px 12px; border:none; background:transparent; cursor:pointer; text-align:left; }
+.cp-sugg:not(:last-child) { border-bottom:1px solid var(--border-light); }
+.cp-sugg:hover, .cp-sugg.hi { background:var(--bg-hover); }
+.cp-sugg .th { width:34px; height:34px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center; font-size:17px; color:#fff; flex-shrink:0; }
+.cp-sugg .sm { min-width:0; flex:1; }
+.cp-sugg .sm .gn { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.cp-sugg .sm .gd { font-size:var(--fs-xs); color:var(--text-muted); }
+.cp-sugg .add { font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); color:hsl(var(--c-game)); }
+.cp-sugg.sel .add { color:var(--text-muted); }
+.cp-scochips { display:flex; flex-wrap:wrap; gap:7px; margin-top:11px; }
+.cp-gchip { display:inline-flex; align-items:center; gap:6px; padding:4px 6px 4px 4px; border-radius:var(--r-pill);
+  background:hsl(var(--c-game) / .12); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .25);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); }
+.cp-gchip .ge { font-size:13px; }
+.cp-gchip .gx { width:16px; height:16px; border-radius:50%; border:none; background:hsl(var(--c-game) / .2); color:hsl(var(--c-game)); cursor:pointer; font-size:10px; display:inline-flex; align-items:center; justify-content:center; }
+.cp-gchip .gx:hover { background:hsl(var(--c-game) / .35); }
+.cp-scopsum { display:inline-flex; align-items:center; gap:7px; margin-top:13px; padding:6px 13px; border-radius:var(--r-pill);
+  background:var(--bg-muted); color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.cp-scopsum .pin { color:hsl(var(--c-game)); }
+
+/* overlay (saving) */
+.cp-dim { position:absolute; inset:0; z-index:var(--z-overlay); background:rgba(20,16,10,.18); backdrop-filter:blur(1px); display:flex; align-items:center; justify-content:center; }
+[data-theme="dark"] .cp-dim { background:rgba(0,0,0,.4); }
+.cp-savecard { display:flex; align-items:center; gap:11px; padding:14px 20px; border-radius:var(--r-lg); background:var(--bg-card); border:1px solid var(--border); box-shadow:var(--shadow-lg);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-base); color:var(--text); }
+.cp-savecard .sp { width:18px; height:18px; border:2.5px solid hsl(var(--c-agent)); border-right-color:transparent; border-radius:50%; animation:cpspin .7s linear infinite; }
+
+/* toast */
+.cp-toast { position:absolute; right:18px; bottom:18px; z-index:var(--z-toast); display:flex; align-items:center; gap:10px; padding:12px 16px;
+  border-radius:var(--r-md); background:var(--bg-card); border:1px solid hsl(var(--c-success) / .4); box-shadow:var(--shadow-lg);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); animation:cptoast var(--dur-md) var(--ease-spring); }
+.cp-toast .ck { width:22px; height:22px; border-radius:50%; background:hsl(var(--c-success)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:12px; flex-shrink:0; }
+@keyframes cptoast { from { transform:translateY(14px); } to { transform:translateY(0); } }
+
+/* modal */
+.cp-modal-bd { position:absolute; inset:0; z-index:var(--z-modal); background:rgba(20,16,10,.42); backdrop-filter:blur(2px); display:flex; align-items:center; justify-content:center; padding:24px; }
+[data-theme="dark"] .cp-modal-bd { background:rgba(0,0,0,.6); }
+.cp-modal { width:100%; max-width:440px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg); overflow:hidden; animation:cpmodal var(--dur-md) var(--ease-out); }
+@keyframes cpmodal { from { transform:translateY(10px) scale(.98); } to { transform:none; } }
+.cp-modal .mhead { display:flex; align-items:center; gap:11px; padding:18px 20px 14px; }
+.cp-modal .mhead .mi { width:38px; height:38px; border-radius:var(--r-md); display:flex; align-items:center; justify-content:center; font-size:18px; flex-shrink:0; }
+.cp-modal .mhead .mi.agent { background:hsl(var(--c-agent) / .14); }
+.cp-modal .mhead .mi.warn { background:hsl(var(--c-warning) / .14); }
+.cp-modal .mhead h3 { font-family:var(--f-display); font-size:var(--fs-lg); }
+.cp-modal .mbody { padding:0 20px 16px; font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-body); }
+.cp-modal .msummary { margin-top:13px; border:1px solid var(--border); border-radius:var(--r-md); overflow:hidden; }
+.cp-modal .msrow { display:flex; gap:10px; padding:9px 12px; font-size:var(--fs-sm); }
+.cp-modal .msrow:not(:last-child) { border-bottom:1px solid var(--border-light); }
+.cp-modal .msrow .k { font-family:var(--f-mono); font-size:11px; text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted); width:108px; flex-shrink:0; }
+.cp-modal .msrow .vv { color:var(--text); font-weight:var(--fw-semi); min-width:0; }
+.cp-modal .mfoot { display:flex; gap:9px; padding:14px 20px; background:var(--bg); border-top:1px solid var(--border); }
+.cp-modal .mfoot .grow { flex:1; }
+
+/* mobile */
+.cp-app.is-mobile .cp-head .hrow { flex-wrap:wrap; padding:12px 14px 13px; }
+.cp-app.is-mobile .cp-headcta { display:none; }
+.cp-app.is-mobile .cp-h1 { font-size:var(--fs-xl); }
+.cp-app.is-mobile .cp-body { padding:14px 13px 24px; }
+.cp-app.is-mobile .cp-form { gap:12px; }
+.cp-app.is-mobile .cp-sechead { padding:13px 14px; }
+.cp-app.is-mobile .cp-secbody { padding:4px 14px 16px; }
+.cp-app.is-mobile .cp-sectitle .t { font-size:var(--fs-base); }
+.cp-app.is-mobile .cp-caps { grid-template-columns:1fr; }
+.cp-app.is-mobile .cp-sample .sgrid { grid-template-columns:1fr; }
+.cp-app.is-mobile .cp-foot .frow { padding:11px 13px; gap:7px; }
+.cp-app.is-mobile .cp-foot .cp-btn { flex:1; justify-content:center; padding:11px 8px; }
+.cp-app.is-mobile .cp-foot .cp-btn.link { flex:0 0 auto; }
+.cp-app.is-mobile .cp-savebar { padding:6px 13px; }
+.cp-app.is-mobile .cp-modal { max-width:none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cp-pill.saving .dot, .cp-unique .sp, .cp-savecard .sp, .cp-toast, .cp-modal { animation:none; }
+}
+`;
+
+/* ──────────────────────────────────────────────────────────
+   Static config
+   ────────────────────────────────────────────────────────── */
+const AUTHOR = { name: 'Marco R.', initials: 'MR' };
+
+/* nomi typology già esistenti — usati per il check di unicità (case-insensitive) */
+const EXISTING_NAMES = [
+  'catan rules expert', 'strategy advisor', 'setup tutor', 'wingspan strategy advisor',
+  'codenames spymaster', 'power grid auction helper', 'rules arbiter', 'endgame scorer',
+];
+
+const ICONS = ['🤖', '📋', '🎯', '🧠', '⚔️', '🛡️', '🎓', '🎨'];
+
+const ENTITY_COLORS = [
+  ['game', 25, 95, 45], ['player', 262, 83, 58], ['session', 240, 60, 55],
+  ['agent', 38, 92, 50], ['kb', 174, 60, 40], ['chat', 220, 80, 55],
+  ['event', 350, 89, 60], ['toolkit', 142, 70, 45], ['tool', 195, 80, 50],
+];
+
+const CAPABILITIES = [
+  { id: 'qa',     icon: '💬', label: 'Q&A',         desc: 'Risponde a domande sulle regole dei giochi' },
+  { id: 'stream', icon: '⚡', label: 'Streaming',    desc: 'Risposta token-by-token in tempo reale' },
+  { id: 'tool',   icon: '🔧', label: 'Tool use',     desc: 'Chiama strumenti esterni (punteggi, timer…)' },
+  { id: 'image',  icon: '📸', label: 'Image input',  desc: 'Analizza immagini (stato del tavolo, carte)' },
+  { id: 'web',    icon: '🌐', label: 'Web search',   desc: 'Cerca regole e FAQ ufficiali online' },
+];
+
+const GAMES = (window.DS && window.DS.games) ? window.DS.games : [];
+
+const PROMPT_FULL =
+`Sei un esperto delle regole ufficiali di {game}. Rispondi alle domande del {player} citando sempre il manuale e indicando la pagina di riferimento quando possibile.
+
+Se una regola è ambigua, spiega le interpretazioni più diffuse e segnala quella ufficiale. Mantieni un tono chiaro e amichevole, adatto anche a chi gioca per la prima volta. Non inventare regole non presenti in {rules_kb}.`;
+
+const PROMPT_PARTIAL = `Sei un assistente per Ark Nova. Aiuti a`;
+const PROMPT_SHORT = `Aiuta il giocatore.`;
+
+/* ──────────────────────────────────────────────────────────
+   Scenari (8 stati) — ognuno definisce form precompilato + UI flags
+   ────────────────────────────────────────────────────────── */
+const EMPTY_FORM = { name: '', desc: '', icon: null, color: 'agent', caps: [], prompt: '', samples: [], scope: [] };
+
+const FORM_PARTIAL = {
+  name: 'Ark Nova Zoo Planner', desc: 'Aiuta a pianificare la costruzione dello zoo e l\u2019ordine delle carte azione per massimizzare punti conservazione e appeal.',
+  icon: '🎯', color: 'agent', caps: ['qa', 'stream'], prompt: PROMPT_PARTIAL, samples: [], scope: [],
+};
+const FORM_VALID = {
+  name: 'Brass Routes Coach', desc: 'Consiglia la rete di canali e ferrovie ottimale in Brass: Birmingham, valutando mercati, link e tempistica delle ere.',
+  icon: '🧠', color: 'agent', caps: ['qa', 'tool', 'stream'], prompt: PROMPT_FULL,
+  samples: [
+    { in: 'Conviene costruire un canale verso Birmingham al primo turno?', out: 'Dipende dalle tue industrie iniziali: un canale precoce verso Birmingham aumenta la connettività ma spende denaro utile per il primo livello di industria…' },
+    { in: 'Quando passo dalle ere canale a quella ferrovia?', out: 'L\u2019era ferrovia inizia quando il mazzo si esaurisce la prima volta. Conviene chiudere l\u2019era canale avendo già piazzato le industrie di basso livello…' },
+  ],
+  scope: ['g-brass'],
+};
+const FORM_ERRORS = {
+  name: 'Catan Rules Expert', desc: 'Esperto delle regole di Catan per preparazione, commercio e calcolo dei punti vittoria a fine partita.',
+  icon: '📋', color: 'agent', caps: ['qa'], prompt: PROMPT_SHORT, samples: [], scope: ['g-catan'],
+};
+
+const SCENARIOS = {
+  'default-empty':     { form: EMPTY_FORM,   open: [1, 2, 3, 4, 5], showValidation: false, savePill: null,      ui: {} },
+  'partial-filled':    { form: FORM_PARTIAL, open: [1, 2, 3],       showValidation: true,  savePill: 'unsaved',  ui: {} },
+  'all-valid':         { form: FORM_VALID,   open: [3, 5],          showValidation: true,  savePill: 'saved',    ui: {} },
+  'validation-errors': { form: FORM_ERRORS,  open: [1, 3],          showValidation: true,  savePill: 'unsaved',  ui: {} },
+  'saving':            { form: FORM_VALID,   open: [],              showValidation: true,  savePill: 'saving',   ui: { overlay: true } },
+  'draft-saved':       { form: FORM_PARTIAL, open: [1, 2],          showValidation: true,  savePill: 'saved',    ui: { toast: true } },
+  'submitting':        { form: FORM_VALID,   open: [],              showValidation: true,  savePill: 'saved',    ui: { modal: true } },
+  'submit-success':    { form: FORM_VALID,   open: [],              showValidation: true,  savePill: 'saved',    ui: { banner: true, readonly: true } },
+};
+const STATE_LIST = [
+  ['default-empty', 'Empty'], ['partial-filled', 'Partial'], ['all-valid', 'Valid'],
+  ['validation-errors', 'Errors'], ['saving', 'Saving'], ['draft-saved', 'Draft saved'],
+  ['submitting', 'Submitting'], ['submit-success', 'Success'],
+];
+
+/* ──────────────────────────────────────────────────────────
+   Helpers
+   ────────────────────────────────────────────────────────── */
+function colorTriplet(key) {
+  const c = ENTITY_COLORS.find(x => x[0] === key);
+  return c ? `${c[1]} ${c[2]}% ${c[3]}%` : '38 92% 50%';
+}
+function gameById(id) { return GAMES.find(g => g.id === id); }
+
+/* highlight {var} e `backtick` per il code layer */
+function highlightPrompt(text) {
+  if (!text) return [<span className="ph" key="ph">Definisci il comportamento dell&rsquo;agente… usa {'{game}'} {'{player}'} {'{turn}'} {'{rules_kb}'}</span>];
+  const parts = text.split(/(\{[a-z_]+\}|`[^`]*`)/g);
+  return parts.map((p, i) => {
+    if (/^\{[a-z_]+\}$/.test(p)) return <span className="v" key={i}>{p}</span>;
+    if (/^`[^`]*`$/.test(p)) return <span className="bt" key={i}>{p}</span>;
+    return <React.Fragment key={i}>{p}</React.Fragment>;
+  });
+}
+
+/* ──────────────────────────────────────────────────────────
+   Sub-components
+   ────────────────────────────────────────────────────────── */
+function ValidationPip({ kind, count }) {
+  if (kind === 'valid')      return <span className="cp-vpip valid"><span aria-hidden="true">✓</span> Completa</span>;
+  if (kind === 'issues')     return <span className="cp-vpip issues" role="status"><span aria-hidden="true">⚠</span> {count} {count === 1 ? 'problema' : 'problemi'}</span>;
+  if (kind === 'optional')   return <span className="cp-vpip optional"><span aria-hidden="true">·</span> Opzionale</span>;
+  return <span className="cp-vpip incomplete"><span aria-hidden="true">·</span> Da completare</span>;
+}
+
+function SectionCard({ num, id, title, subtitle, optional, status, statusCount, open, onToggle, children, bodyRef }) {
+  const cls = 'cp-sec' + (open ? ' open' : '') + (status === 'issues' ? ' has-error' : status === 'valid' ? ' is-valid' : '');
+  return (
+    <section className={cls} role="region" aria-labelledby={'sec-' + id + '-t'}>
+      <button className="cp-sechead" aria-expanded={open} aria-controls={'sec-' + id + '-b'} onClick={onToggle}>
+        <span className="cp-secnum" aria-hidden="true">{num}</span>
+        <span className="cp-sectitle">
+          <span className="t" id={'sec-' + id + '-t'}>{title}{optional && <span className="opt">Opzionale</span>}</span>
+          <span className="s">{subtitle}</span>
+        </span>
+        <ValidationPip kind={status} count={statusCount} />
+        <span className="cp-caret" aria-hidden="true">▸</span>
+      </button>
+      {open && <div className="cp-secbody" id={'sec-' + id + '-b'} role="group" ref={bodyRef}>{children}</div>}
+    </section>
+  );
+}
+
+function CharCounter({ value, max }) {
+  const over = value > max;
+  return <span className={'cp-counter' + (over ? ' over' : '')}>{value} / {max}</span>;
+}
+
+function AutoTextarea({ value, onChange, max, minH = 74, readOnly, ...rest }) {
+  const ref = useRef(null);
+  const fit = useCallback(() => { const el = ref.current; if (!el) return; el.style.height = 'auto'; el.style.height = Math.max(minH, el.scrollHeight) + 'px'; }, [minH]);
+  useEffect(() => { fit(); }, [value, fit]);
+  return (
+    <textarea ref={ref} className="cp-textarea" value={value} readOnly={readOnly}
+      onChange={e => { if (!readOnly && (!max || e.target.value.length <= max + 40)) onChange(e.target.value); }} {...rest} />
+  );
+}
+
+function UniqueCheck({ status }) {
+  if (status === 'checking') return <span className="cp-unique checking"><span className="sp" aria-hidden="true" />Verificando…</span>;
+  if (status === 'ok')       return <span className="cp-unique ok" role="status"><span aria-hidden="true">✓</span> Disponibile</span>;
+  if (status === 'dup')      return <span className="cp-unique dup" role="status"><span aria-hidden="true">✗</span> Già in uso</span>;
+  return null;
+}
+
+/* ─── Section 1: Identity ─── */
+function IdentitySection({ form, set, readOnly, uniqueStatus, showValidation }) {
+  const [adv, setAdv] = useState(false);
+  const [hsl, setHsl] = useState({ h: 38, s: 92, l: 50 });
+  const nameTooShort = showValidation && form.name.trim().length > 0 && form.name.trim().length < 3;
+  return (
+    <>
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="f-name">Nome <span className="req">*</span><span className="grow" /><CharCounter value={form.name.length} max={80} /></label>
+        <div className="cp-inwrap">
+          <input id="f-name" className={'cp-input haspad' + (uniqueStatus === 'dup' || nameTooShort ? ' err' : '')} value={form.name} readOnly={readOnly}
+            maxLength={84} placeholder="es. Catan Rules Expert" aria-invalid={uniqueStatus === 'dup'}
+            aria-describedby={uniqueStatus === 'dup' ? 'f-name-err' : undefined}
+            onChange={e => set('name', e.target.value)} />
+          <UniqueCheck status={uniqueStatus} />
+        </div>
+        {uniqueStatus === 'dup' && <div className="cp-err" id="f-name-err"><span aria-hidden="true">⚠️</span> Esiste già una typology con questo nome. Scegline uno diverso prima di inviare.</div>}
+        {nameTooShort && <div className="cp-err"><span aria-hidden="true">⚠️</span> Minimo 3 caratteri.</div>}
+      </div>
+
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="f-desc">Descrizione <span className="req">*</span><span className="grow" /><CharCounter value={form.desc.length} max={500} /></label>
+        <AutoTextarea id="f-desc" value={form.desc} max={500} minH={70} readOnly={readOnly}
+          placeholder="Descrivi cosa fa questa typology e quando usarla…" onChange={v => set('desc', v)} />
+        {showValidation && form.desc.length > 0 && form.desc.length < 20 && <div className="cp-err"><span aria-hidden="true">⚠️</span> Minimo 20 caratteri ({form.desc.length}/20).</div>}
+      </div>
+
+      <div className="cp-field">
+        <label className="cp-label">Icona <span className="req">*</span></label>
+        <div className="cp-icons" role="radiogroup" aria-label="Scegli icona">
+          {ICONS.map(ic => (
+            <button key={ic} type="button" role="radio" aria-checked={form.icon === ic} aria-label={'Icona ' + ic}
+              className={'cp-icon' + (form.icon === ic ? ' on' : '')} onClick={() => !readOnly && set('icon', ic)}>{ic}</button>
+          ))}
+          <div className="cp-upload" role="button" tabIndex={0} aria-label="Carica icona personalizzata">
+            <span className="ui" aria-hidden="true">⬆</span> Carica PNG/SVG · max 50KB
+          </div>
+        </div>
+      </div>
+
+      <div className="cp-field">
+        <label className="cp-label">Colore entity<span className="grow" /><button type="button" className="cp-advtoggle" aria-expanded={adv} onClick={() => setAdv(a => !a)}>{adv ? '− HSL custom' : '+ HSL custom'}</button></label>
+        <div className="cp-colors" role="radiogroup" aria-label="Scegli colore entity">
+          {ENTITY_COLORS.map(([key, h, s, l]) => (
+            <button key={key} type="button" role="radio" aria-checked={form.color === key} aria-label={'Colore ' + key}
+              className={'cp-swatch' + (form.color === key ? ' on' : '')} style={{ background: `hsl(${h} ${s}% ${l}%)` }}
+              onClick={() => !readOnly && set('color', key)} />
+          ))}
+        </div>
+        {adv && (
+          <div className="cp-hslrow">
+            <div className="prev" style={{ background: `hsl(${hsl.h} ${hsl.s}% ${hsl.l}%)` }} />
+            <div className="cp-hsl">
+              <label><span>H</span><input type="range" min="0" max="360" value={hsl.h} onChange={e => setHsl(s => ({ ...s, h: +e.target.value }))} /><b>{hsl.h}</b></label>
+              <label><span>S</span><input type="range" min="0" max="100" value={hsl.s} onChange={e => setHsl(s => ({ ...s, s: +e.target.value }))} /><b>{hsl.s}%</b></label>
+              <label><span>L</span><input type="range" min="0" max="100" value={hsl.l} onChange={e => setHsl(s => ({ ...s, l: +e.target.value }))} /><b>{hsl.l}%</b></label>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+/* ─── Section 2: Capabilities ─── */
+function CapabilitiesSection({ form, set, readOnly, showValidation }) {
+  const toggle = id => { if (readOnly) return; set('caps', form.caps.includes(id) ? form.caps.filter(c => c !== id) : [...form.caps, id]); };
+  const none = showValidation && form.caps.length === 0;
+  return (
+    <>
+      <div className="cp-caps" role="group" aria-label="Seleziona capability">
+        {CAPABILITIES.map(c => {
+          const on = form.caps.includes(c.id);
+          return (
+            <button key={c.id} type="button" className={'cp-cap' + (on ? ' on' : '')} aria-pressed={on} onClick={() => toggle(c.id)}>
+              <span className="cic" aria-hidden="true">{c.icon}</span>
+              <span className="cbody"><span className="ct">{c.label}</span><span className="cd">{c.desc}</span></span>
+              <span className="ck" aria-hidden="true">✓</span>
+            </button>
+          );
+        })}
+      </div>
+      {none && <div className="cp-capwarn" role="alert"><span aria-hidden="true">⚠️</span> Seleziona almeno una capability.</div>}
+      <div className="cp-tip"><span className="ti" aria-hidden="true">💡</span><span className="tt">Le capability sono <b>tassonomia interna</b>: determinano quali tool e modalità l&rsquo;agente potrà usare in chat. Puoi modificarle anche dopo l&rsquo;approvazione.</span></div>
+    </>
+  );
+}
+
+/* ─── Section 3: System prompt ─── */
+function CodeEditor({ value, onChange, readOnly, error }) {
+  const taRef = useRef(null);
+  const hlRef = useRef(null);
+  const [focus, setFocus] = useState(false);
+  const fit = useCallback(() => {
+    const ta = taRef.current; if (!ta) return;
+    ta.style.height = 'auto';
+    const h = Math.min(Math.max(150, ta.scrollHeight), 460);
+    ta.style.height = h + 'px';
+  }, []);
+  useEffect(() => { fit(); }, [value, fit]);
+  const syncScroll = () => { if (hlRef.current && taRef.current) hlRef.current.scrollTop = taRef.current.scrollTop; };
+  return (
+    <div className={'cp-code-wrap' + (focus ? ' focus' : '') + (error ? ' err' : '')}>
+      <pre className="cp-code-layer cp-code-hl" ref={hlRef} aria-hidden="true">{highlightPrompt(value)}</pre>
+      <textarea ref={taRef} className="cp-code-layer cp-code-ta" value={value} readOnly={readOnly} spellCheck={false}
+        aria-label="System prompt" rows={6} onScroll={syncScroll}
+        onFocus={() => setFocus(true)} onBlur={() => setFocus(false)}
+        onChange={e => { if (!readOnly && e.target.value.length <= 4000) onChange(e.target.value); }} />
+    </div>
+  );
+}
+
+function SystemPromptSection({ form, set, readOnly, showValidation }) {
+  const tooShort = showValidation && form.prompt.trim().length > 0 && form.prompt.trim().length < 50;
+  return (
+    <>
+      <div className="cp-ptoolbar">
+        <button type="button" className="cp-ptool" onClick={() => !readOnly && set('prompt', PROMPT_FULL)}><span aria-hidden="true">＋</span> Aggiungi esempio</button>
+        <button type="button" className="cp-ptool"><span aria-hidden="true">▤</span> Templates</button>
+        <span className="grow" />
+        <button type="button" className="cp-ptool play" title="Apri il playground di test (S5)"><span aria-hidden="true">🧪</span> Testa nel playground</button>
+      </div>
+      <CodeEditor value={form.prompt} onChange={v => set('prompt', v)} readOnly={readOnly} error={tooShort} />
+      <div className="cp-codefoot"><span className="grow" /><CharCounter value={form.prompt.length} max={4000} /></div>
+      {tooShort && <div className="cp-err"><span aria-hidden="true">⚠️</span> Il system prompt è troppo corto: minimo 50 caratteri ({form.prompt.trim().length}/50).</div>}
+      <div className="cp-tip"><span className="ti" aria-hidden="true">💡</span><span className="tt">Variabili disponibili: <code>{'{game}'}</code> <code>{'{player}'}</code> <code>{'{turn}'}</code> <code>{'{rules_kb}'}</code>. Vengono sostituite a runtime. Usa <code>\n</code> per newline literali e i <code>`backtick`</code> per i nomi di tool.</span></div>
+    </>
+  );
+}
+
+/* ─── Section 4: Test config ─── */
+function TestConfigSection({ form, set, readOnly }) {
+  const addSample = () => { if (readOnly || form.samples.length >= 3) return; set('samples', [...form.samples, { in: '', out: '' }]); };
+  const delSample = i => { if (readOnly) return; set('samples', form.samples.filter((_, x) => x !== i)); };
+  const editSample = (i, k, v) => { if (readOnly) return; set('samples', form.samples.map((s, x) => x === i ? { ...s, [k]: v } : s)); };
+  return (
+    <>
+      <div className="cp-samples">
+        {form.samples.map((s, i) => (
+          <div className="cp-sample" key={i}>
+            <div className="shead"><span className="sidx">Esempio {i + 1}</span>
+              <button type="button" className="sdel" aria-label={'Elimina esempio ' + (i + 1)} onClick={() => delSample(i)}>🗑</button></div>
+            <div className="sgrid">
+              <div className="scol"><div className="sl">Input utente</div>
+                <AutoTextarea value={s.in} minH={62} readOnly={readOnly} placeholder="es. Quante carte si pescano in setup?" onChange={v => editSample(i, 'in', v)} /></div>
+              <div className="scol"><div className="sl">Output atteso</div>
+                <AutoTextarea value={s.out} minH={62} readOnly={readOnly} placeholder="es. In Catan classico ogni giocatore parte con 2 insediamenti…" onChange={v => editSample(i, 'out', v)} /></div>
+            </div>
+          </div>
+        ))}
+        <button type="button" className="cp-addbtn" disabled={readOnly || form.samples.length >= 3} onClick={addSample}>
+          <span aria-hidden="true">＋</span> Aggiungi esempio {form.samples.length > 0 && `(${form.samples.length}/3)`}
+        </button>
+      </div>
+      <div className="cp-tip"><span className="ti" aria-hidden="true">💡</span><span className="tt">Questi esempi verranno usati nel <b>playground</b> per validare il comportamento dell&rsquo;agente. <b>Non</b> sono training data e non modificano il modello.</span></div>
+    </>
+  );
+}
+
+/* ─── Section 5: Game scope ─── */
+function GameScopeSection({ form, set, readOnly }) {
+  const [q, setQ] = useState('');
+  const selected = form.scope.map(gameById).filter(Boolean);
+  const suggestions = GAMES.filter(g => !q || g.title.toLowerCase().includes(q.toLowerCase()));
+  const toggleGame = id => { if (readOnly) return; set('scope', form.scope.includes(id) ? form.scope.filter(s => s !== id) : [...form.scope, id]); };
+  return (
+    <>
+      <div className="cp-scopsearch cp-scopsearch">
+        <div className="cp-inwrap">
+          <span className="si" aria-hidden="true">🔍</span>
+          <input className="cp-input" style={{ paddingLeft: 32 }} value={q} readOnly={readOnly}
+            placeholder="Cerca un gioco per nome…" aria-label="Cerca gioco" onChange={e => setQ(e.target.value)} />
+        </div>
+        {!readOnly && q && (
+          <div className="cp-scopsuggest" role="listbox" aria-label="Giochi suggeriti">
+            {suggestions.length === 0 && <div className="cp-sugg" aria-disabled="true"><span className="sm"><span className="gd">Nessun gioco trovato per “{q}”</span></span></div>}
+            {suggestions.slice(0, 5).map(g => {
+              const sel = form.scope.includes(g.id);
+              return (
+                <button key={g.id} type="button" role="option" aria-selected={sel} className={'cp-sugg' + (sel ? ' sel' : '')} onClick={() => toggleGame(g.id)}>
+                  <span className="th" style={{ background: g.cover }} aria-hidden="true">{g.coverEmoji}</span>
+                  <span className="sm"><span className="gn">{g.title}</span><span className="gd">{g.author} · {g.year}</span></span>
+                  <span className="add">{sel ? '✓ Aggiunto' : '+ Aggiungi'}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {selected.length > 0 && (
+        <div className="cp-scochips" aria-label="Giochi in scope">
+          {selected.map(g => (
+            <span className="cp-gchip" key={g.id}><span className="ge" aria-hidden="true">🎲</span>{g.title}
+              {!readOnly && <button type="button" className="gx" aria-label={'Rimuovi ' + g.title} onClick={() => toggleGame(g.id)}>✕</button>}</span>
+          ))}
+        </div>
+      )}
+
+      <div className="cp-scopsum">
+        <span className="pin" aria-hidden="true">📍</span>
+        {selected.length === 0 ? 'Scope: tutti i giochi (broad)' : `Scope: ${selected.length} ${selected.length === 1 ? 'gioco' : 'giochi'} (${selected.map(g => g.title).join(', ')})`}
+      </div>
+      {selected.length === 0 && <div className="cp-hint">Lascia vuoto per applicare la typology a tutti i giochi.</div>}
+    </>
+  );
+}
+
+/* ─── Modals / toast / banner ─── */
+function SubmitReviewModal({ form, onClose, onConfirm }) {
+  const scope = form.scope.map(gameById).filter(Boolean);
+  return (
+    <div className="cp-modal-bd" role="dialog" aria-modal="true" aria-labelledby="sub-modal-t" onClick={onClose}>
+      <div className="cp-modal" onClick={e => e.stopPropagation()}>
+        <div className="mhead"><span className="mi agent" aria-hidden="true">⬆️</span><h3 id="sub-modal-t">Conferma invio per review</h3></div>
+        <div className="mbody">
+          La proposal verrà inviata al team di review e non sarà più modificabile finché non riceve un esito. Di solito entro 24h.
+          <div className="msummary">
+            <div className="msrow"><span className="k">Nome</span><span className="vv">{form.icon} {form.name}</span></div>
+            <div className="msrow"><span className="k">Capabilities</span><span className="vv">{form.caps.map(c => CAPABILITIES.find(x => x.id === c).label).join(', ')}</span></div>
+            <div className="msrow"><span className="k">Scope</span><span className="vv">{scope.length ? scope.map(g => g.title).join(', ') : 'Tutti i giochi'}</span></div>
+            <div className="msrow"><span className="k">Esempi test</span><span className="vv">{form.samples.length} configurati</span></div>
+          </div>
+        </div>
+        <div className="mfoot"><button className="cp-btn ghost" onClick={onClose}>Annulla</button><span className="grow" /><button className="cp-btn primary" onClick={onConfirm}><span className="ic" aria-hidden="true">⬆</span> Conferma e invia</button></div>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmCancelModal({ onClose, onConfirm }) {
+  return (
+    <div className="cp-modal-bd" role="dialog" aria-modal="true" aria-labelledby="cnc-t" onClick={onClose}>
+      <div className="cp-modal" onClick={e => e.stopPropagation()}>
+        <div className="mhead"><span className="mi warn" aria-hidden="true">⚠️</span><h3 id="cnc-t">Annullare la creazione?</h3></div>
+        <div className="mbody">Le modifiche non salvate andranno perse. Vuoi davvero uscire senza salvare la bozza?</div>
+        <div className="mfoot"><button className="cp-btn ghost" onClick={onClose}>Continua a modificare</button><span className="grow" /><button className="cp-btn danger" onClick={onConfirm}>Esci senza salvare</button></div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   CreateApp — un'istanza per (state × viewport). Remount via key.
+   ────────────────────────────────────────────────────────── */
+function CreateApp({ stateId, mobile }) {
+  const sc = SCENARIOS[stateId];
+  const [form, setForm] = useState(sc.form);
+  const [open, setOpen] = useState(() => new Set(sc.open));
+  const [savePill, setSavePill] = useState(sc.savePill);
+  const [showValidation, setShowValidation] = useState(sc.showValidation);
+  const [uniqueStatus, setUniqueStatus] = useState(() => {
+    const n = sc.form.name.trim().toLowerCase();
+    if (n.length < 3) return 'idle';
+    return EXISTING_NAMES.includes(n) ? 'dup' : 'ok';
+  });
+  const [cancelModal, setCancelModal] = useState(false);
+  const [submitModal, setSubmitModal] = useState(!!sc.ui.modal);
+  const [toast, setToast] = useState(!!sc.ui.toast);
+  const banner = !!sc.ui.banner;
+  const overlay = !!sc.ui.overlay;
+  const readonly = !!sc.ui.readonly;
+  const uniqueTimer = useRef(null);
+
+  const set = useCallback((key, val) => {
+    setForm(f => ({ ...f, [key]: val }));
+    setShowValidation(true);
+    if (savePill !== 'saving') setSavePill('unsaved');
+  }, [savePill]);
+
+  // live unique check on name
+  useEffect(() => {
+    const n = form.name.trim().toLowerCase();
+    clearTimeout(uniqueTimer.current);
+    if (n.length < 3) { setUniqueStatus('idle'); return; }
+    setUniqueStatus('checking');
+    uniqueTimer.current = setTimeout(() => setUniqueStatus(EXISTING_NAMES.includes(n) ? 'dup' : 'ok'), 650);
+    return () => clearTimeout(uniqueTimer.current);
+  }, [form.name]);
+
+  // auto-dismiss toast
+  useEffect(() => { if (toast) { const t = setTimeout(() => setToast(false), 3600); return () => clearTimeout(t); } }, [toast]);
+
+  // validation per section
+  const v = useMemo(() => {
+    const n = form.name.trim();
+    const s1issues = [];
+    if (n.length < 3) s1issues.push('name'); else if (uniqueStatus === 'dup') s1issues.push('dup');
+    if (form.desc.trim().length < 20) s1issues.push('desc');
+    if (!form.icon) s1issues.push('icon');
+    const s1 = { kind: s1issues.length === 0 ? 'valid' : (showValidation && n.length ? 'issues' : 'incomplete'), count: s1issues.length, ok: s1issues.length === 0 };
+    const s2 = { kind: form.caps.length >= 1 ? 'valid' : (showValidation ? 'issues' : 'incomplete'), count: form.caps.length === 0 ? 1 : 0, ok: form.caps.length >= 1 };
+    const p = form.prompt.trim();
+    const s3 = { kind: p.length >= 50 ? 'valid' : (showValidation && p.length ? 'issues' : 'incomplete'), count: p.length >= 50 ? 0 : 1, ok: p.length >= 50 };
+    const s4 = { kind: 'optional', count: 0, ok: true };
+    const s5 = { kind: 'optional', count: 0, ok: true };
+    return { 1: s1, 2: s2, 3: s3, 4: s4, 5: s5, valid: s1.ok && s2.ok && s3.ok };
+  }, [form, uniqueStatus, showValidation]);
+
+  const toggle = id => setOpen(o => { const n = new Set(o); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  // keyboard: Ctrl+S salva bozza
+  useEffect(() => {
+    const h = e => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') { e.preventDefault(); setSavePill('saved'); setToast(true); }
+      if (e.key === 'Escape' && submitModal) setSubmitModal(false);
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [submitModal]);
+
+  const saveDraft = () => { setSavePill('saving'); setTimeout(() => { setSavePill('saved'); setToast(true); }, 600); };
+
+  const sections = [
+    { num: '1', id: 'identity', title: 'Identità', subtitle: 'Nome, descrizione, icona e colore', optional: false, st: v[1],
+      body: <IdentitySection form={form} set={set} readOnly={readonly} uniqueStatus={uniqueStatus} showValidation={showValidation} /> },
+    { num: '2', id: 'caps', title: 'Capabilities', subtitle: 'Cosa sa fare l\u2019agente (almeno una)', optional: false, st: v[2],
+      body: <CapabilitiesSection form={form} set={set} readOnly={readonly} showValidation={showValidation} /> },
+    { num: '3', id: 'prompt', title: 'System prompt', subtitle: 'Le istruzioni che guidano l\u2019agente', optional: false, st: v[3],
+      body: <SystemPromptSection form={form} set={set} readOnly={readonly} showValidation={showValidation} /> },
+    { num: '4', id: 'test', title: 'Configurazione test', subtitle: 'Esempi input/output per il playground', optional: true, st: v[4],
+      body: <TestConfigSection form={form} set={set} readOnly={readonly} /> },
+    { num: '5', id: 'scope', title: 'Scope giochi', subtitle: 'A quali giochi si applica', optional: true, st: v[5],
+      body: <GameScopeSection form={form} set={set} readOnly={readonly} /> },
+  ];
+
+  const pillEl = savePill && (
+    <span className={'cp-pill ' + savePill} aria-live="polite">
+      <span className="dot" aria-hidden="true" />
+      {savePill === 'unsaved' && 'Modifiche non salvate'}
+      {savePill === 'saved' && '💾 Bozza salvata adesso'}
+      {savePill === 'saving' && 'Salvataggio…'}
+    </span>
+  );
+
+  return (
+    <div className={'cp-app' + (mobile ? ' is-mobile' : '')}>
+      {banner && (
+        <div className="cp-banner" role="status">
+          <span aria-hidden="true">✓</span> Proposal inviata — sarà revisionata entro 24h.
+          <span className="grow" />
+          <button className="gocta"><span aria-hidden="true">→</span> Vai alle mie proposals</button>
+        </div>
+      )}
+
+      <header className="cp-head">
+        <div className="hrow">
+          <div className="htxt">
+            <div className="cp-bread"><span>Editor</span><span className="sep">›</span><span>Agent proposals</span><span className="sep">›</span><span className="cur">Crea nuova</span></div>
+            <h1 className="cp-h1">Crea nuova typology proposal</h1>
+            <div className="cp-sub">Definisci una nuova tipologia di agente AI da sottoporre per approvazione</div>
+            <span className="cp-author"><span className="av" aria-hidden="true">{AUTHOR.initials}</span><span className="lb">Autore:</span> {AUTHOR.name}</span>
+          </div>
+          <span className="grow" />
+          <div className="cp-headcta">
+            <button className="cp-btn link" onClick={() => setCancelModal(true)}>Annulla</button>
+            <button className="cp-btn ghost" onClick={saveDraft} disabled={readonly}><span className="ic" aria-hidden="true">💾</span> Salva bozza</button>
+            <button className="cp-btn primary" disabled={!v.valid || readonly} onClick={() => setSubmitModal(true)}><span className="ic" aria-hidden="true">⬆</span> Invia per review</button>
+          </div>
+        </div>
+      </header>
+
+      <div className="cp-body">
+        <form className="cp-form" aria-label="Form crea typology proposal" onSubmit={e => e.preventDefault()}>
+          {sections.map(s => (
+            <SectionCard key={s.id} num={s.num} id={s.id} title={s.title} subtitle={s.subtitle} optional={s.optional}
+              status={s.st.kind} statusCount={s.st.count} open={open.has(+s.num)} onToggle={() => toggle(+s.num)}>
+              {s.body}
+            </SectionCard>
+          ))}
+        </form>
+      </div>
+
+      <div className="cp-savebar"><div className="inner">{pillEl}</div></div>
+
+      <footer className="cp-foot">
+        <div className="frow">
+          <button className="cp-btn link" onClick={() => setCancelModal(true)}>Annulla</button>
+          <span className="grow" />
+          <button className="cp-btn ghost" onClick={saveDraft} disabled={readonly}><span className="ic" aria-hidden="true">💾</span> Salva bozza</button>
+          <button className="cp-btn primary" disabled={!v.valid || readonly} onClick={() => setSubmitModal(true)}><span className="ic" aria-hidden="true">⬆</span> Invia per review</button>
+        </div>
+      </footer>
+
+      {overlay && <div className="cp-dim" aria-hidden="true"><div className="cp-savecard"><span className="sp" /> Salvataggio in corso…</div></div>}
+      {toast && <div className="cp-toast" role="status"><span className="ck" aria-hidden="true">✓</span> Bozza salvata</div>}
+      {submitModal && <SubmitReviewModal form={form} onClose={() => setSubmitModal(false)} onConfirm={() => setSubmitModal(false)} />}
+      {cancelModal && <ConfirmCancelModal onClose={() => setCancelModal(false)} onConfirm={() => setCancelModal(false)} />}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   Harness — continuity con S1/S2
+   ────────────────────────────────────────────────────────── */
+function Harness() {
+  const [stateId, setStateId] = useState(() => localStorage.getItem('cp-state') || 'default-empty');
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || 'light');
+
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem('cp-state', stateId); }, [stateId]);
+
+  return (
+    <div className="ed-stage">
+      <style dangerouslySetInnerHTML={{ __html: CP_CSS }} />
+      <button className="theme-toggle" onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>🌗 <span>{theme === 'dark' ? 'Dark' : 'Light'}</span></button>
+
+      <div className="ed-wrap">
+        <div className="ed-kicker">SP4 · B14 · #1489 — schermata 3 / 5 · crea typology proposal</div>
+        <h1>Crea <span className="acc">proposal</span> — /editor/agent-proposals/create</h1>
+        <p className="ed-lead">
+          Form full-page per creare una nuova <b>typology AI agent proposal</b>. Niente wizard: l&rsquo;editor power-user vede
+          tutto il context insieme in <b>5 sezioni accordion</b> (Identità · Capabilities · System prompt · Test config · Scope),
+          salva una bozza parziale e salta fra sezioni. Submit → entity in stato <b>Draft</b>, poi <b>Invia per review</b>.
+          Entity primaria <code>--c-agent</code>, scope giochi via EntityChip <code>--c-game</code>.
+        </p>
+
+        <div className="ed-notes">
+          <div className="ed-note">
+            <h4>Pattern</h4>
+            <p><b>Form full-page</b> max-width 880 centered, header + footer sticky con CTA tripla (<b>Annulla · Salva bozza · Invia per review</b>). Ogni sezione è una card collassabile con validation pip realtime.</p>
+          </div>
+          <div className="ed-note">
+            <h4>8 stati</h4>
+            <p>Selettore qui sotto: empty · partial · valid · errors · saving · draft-saved · submitting · success. Validation inline (nome duplicato, prompt corto, capability mancante) + save status pill <code>aria-live</code>.</p>
+          </div>
+          <div className="ed-note">
+            <h4>Mobile & a11y</h4>
+            <p>Mobile = sezioni full-width, footer sticky con CTA. <code>role=region</code> + <code>aria-expanded</code> per sezione, <code>aria-invalid</code> sui field in errore, <code>Ctrl+S</code> salva bozza, <code>Esc</code> chiude modal.</p>
+          </div>
+        </div>
+
+        <div className="ed-rail">
+          <span className="lab">Stato</span>
+          <div className="ed-states" role="group" aria-label="Selettore stato schermata">
+            {STATE_LIST.map(([id, label]) => (
+              <button key={id} className={'ed-sbtn' + (stateId === id ? ' on' : '')} aria-pressed={stateId === id} onClick={() => setStateId(id)}>
+                <span className="pip" />{label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Desktop · 1440 — form 5-section accordion</div>
+        <div className="ed-desk">
+          <div className="ed-chrome">
+            <div className="dots"><i /><i /><i /></div>
+            <div className="url">meepleai.app/editor/agent-proposals/create</div>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <CreateApp key={'d-' + stateId} stateId={stateId} mobile={false} />
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Mobile · 375 — sezioni stack full-width</div>
+        <div className="ed-phone-row">
+          <div className="phone">
+            <div className="phone-sbar"><span>9:41</span><span className="ind">●●● 5G ▮</span></div>
+            <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+              <CreateApp key={'m-' + stateId} stateId={stateId} mobile={true} />
+            </div>
+          </div>
+          <div className="ed-phone-cap">
+            <h4>Layout mobile</h4>
+            <p>Le 5 sezioni accordion vanno a <b>full-width</b>, la capability grid e gli esempi test passano a colonna singola. Header CTA collassano nel <b>footer sticky</b> (Salva bozza · Invia). Modal e toast occupano la larghezza dello schermo.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Harness />);

--- a/admin-mockups/design_files/sp4-editor-proposals-edit.html
+++ b/admin-mockups/design_files/sp4-editor-proposals-edit.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · B14 editor · #4/5 · Edit typology proposal — /editor/agent-proposals/[id]/edit</title>
+<!-- route: /editor/agent-proposals/[id]/edit — Edit typology proposal con status-variant mode (Draft/Pending/Approved/Rejected) + Revisions diff + Audit trail -->
+<!--
+  @route /editor/agent-proposals/[id]/edit
+  @brief B14 (issue #1489) — Editor user-facing (agent proposals)
+  @screen 4 of 5 — sp4-editor-proposals-edit
+  @tier M
+  @pattern Form full-page (5 sezioni S3) + status-variant header/banner + read-only mode + Revisions diff (6) + Audit trail (7) · max-width 880 centered
+  @states draft-edit · draft-edit-dirty · pending-review · approved-readonly · approved-with-stats · rejected-fresh · rejected-addressing · revisions-expanded · audit-trail-expanded · submitting-update
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-editor-proposals-edit.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-editor-proposals-edit.jsx
+++ b/admin-mockups/design_files/sp4-editor-proposals-edit.jsx
@@ -1,0 +1,1331 @@
+/* sp4-editor-proposals-edit.jsx
+   Route: /editor/agent-proposals/[id]/edit — Edit typology AI agent proposal (status-variant mode)
+   B14 (issue #1489) · screen 4 of 5 · Tier M
+   Pattern: Form full-page identico a S3 (5 sezioni accordion) + status-variant header/banner +
+            read-only mode (Pending/Approved) + NUOVA sez. 6 Revisions diff + NUOVA sez. 7 Audit trail.
+            max-width 880 centered. Single-page (NON wizard).
+   Continuity con S1+S2+S3: stesso state-picker UI, theme toggle 🌗 (mai-theme), desktop frame chrome
+            (.ed-desk), phone-row mobile. Entity primaria = --c-agent. Status badge riusa pr-badge (S2).
+   Loadable standalone via Babel. Injects own component CSS; relies on tokens.css + components.css.
+
+   v2 components surfaced here:
+   /* v2: ProposalEditForm, EditHeader, StatusBadge, LiveDot, StatusBanner (Rejected/Pending/Approved),
+          EditFooter, SaveStatusPill, SectionCard (locked/changed/resolved), ValidationPip,
+          Identity/Capabilities/SystemPrompt/TestConfig/GameScope (readOnly), RevisionsSection, DiffRow,
+          AuditTrailSection, AuditEvent, AuthorChip, EntityChip(game), SubmitUpdateModal, ConfirmCancelModal */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+
+/* ──────────────────────────────────────────────────────────
+   Component CSS — solo token da tokens.css / components.css.
+   .ed-* = harness chrome (riuso da S1/S2/S3). .cp-* = form (riuso da S3). .ce-* = edit-specific.
+   ────────────────────────────────────────────────────────── */
+const CE_CSS = `
+/* ─── harness (riuso esatto da S3) ─── */
+.ed-stage { min-height:100vh; padding:72px 24px 96px; background:var(--bg); color:var(--text); }
+.ed-wrap { max-width:1380px; margin:0 auto; }
+.ed-kicker { font-family:var(--f-mono); font-size:var(--fs-xs); letter-spacing:.1em; text-transform:uppercase; color:var(--text-muted); }
+.ed-stage h1 { font-size:var(--fs-3xl); margin:8px 0 6px; }
+.ed-stage h1 .acc { color:hsl(var(--c-agent)); }
+.ed-lead { color:var(--text-sec); font-size:var(--fs-md); max-width:820px; line-height:var(--lh-body); }
+.ed-notes { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:22px 0 4px; }
+.ed-note { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:14px 16px; }
+.ed-note h4 { font-family:var(--f-display); font-size:var(--fs-sm); text-transform:uppercase; letter-spacing:.04em; color:hsl(var(--c-agent)); margin-bottom:6px; }
+.ed-note p { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.ed-note p b { color:var(--text); font-weight:var(--fw-bold); }
+.ed-note code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:11px; }
+.ed-rail { position:sticky; top:0; z-index:var(--z-sticky); margin:26px 0 18px; padding:12px 0;
+  background:var(--bg); display:flex; align-items:flex-start; gap:14px; flex-wrap:wrap; border-bottom:1px solid var(--border); }
+.ed-rail .lab { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); padding-top:8px; }
+.ed-states { display:flex; gap:6px; flex-wrap:wrap; flex:1; }
+.ed-sbtn { display:inline-flex; align-items:center; gap:7px; padding:7px 12px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-sbtn:hover { transform:translateY(-1px); border-color:var(--border-strong); }
+.ed-sbtn .pip { width:7px; height:7px; border-radius:50%; background:currentColor; opacity:.6; }
+.ed-sbtn.on { background:hsl(var(--c-agent)); border-color:transparent; color:#fff; }
+.ed-sbtn.on .pip { opacity:1; background:#fff; }
+.ed-vp-label { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em;
+  color:var(--text-muted); margin:30px 0 12px; display:flex; align-items:center; gap:10px; }
+.ed-vp-label::after { content:''; flex:1; height:1px; background:var(--border); }
+.ed-desk { width:100%; max-width:1340px; height:860px; border-radius:var(--r-lg); overflow:hidden;
+  background:var(--bg-card); border:1px solid var(--border); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; }
+.ed-chrome { height:38px; flex-shrink:0; display:flex; align-items:center; gap:8px; padding:0 14px;
+  background:var(--bg-muted); border-bottom:1px solid var(--border); font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ed-chrome .dots { display:flex; gap:6px; }
+.ed-chrome .dots i { width:11px; height:11px; border-radius:50%; display:block; }
+.ed-chrome .dots i:nth-child(1){ background:#ff5f57; } .ed-chrome .dots i:nth-child(2){ background:#febc2e; } .ed-chrome .dots i:nth-child(3){ background:#28c840; }
+.ed-chrome .url { flex:1; text-align:center; background:var(--bg-card); border-radius:var(--r-sm); padding:4px 10px; margin:0 12%; }
+.ed-phone-row { display:flex; gap:28px; align-items:flex-start; flex-wrap:wrap; }
+.ed-phone-cap { font-size:var(--fs-sm); color:var(--text-sec); max-width:300px; line-height:var(--lh-snug); }
+.ed-phone-cap h4 { font-family:var(--f-display); font-size:var(--fs-base); margin-bottom:6px; }
+
+/* ─── form app shell (riuso da S3) ─── */
+.cp-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+.cp-app :focus-visible { outline:2px solid hsl(var(--c-agent)); outline-offset:2px; border-radius:var(--r-xs); }
+
+/* header (sticky) */
+.cp-head { flex-shrink:0; position:sticky; top:0; z-index:var(--z-sticky); background:var(--bg-card); border-bottom:1px solid var(--border); }
+.cp-head .hrow { display:flex; align-items:flex-start; gap:16px; padding:14px 22px 15px; max-width:980px; margin:0 auto; }
+.cp-head .htxt { min-width:0; }
+.cp-bread { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:6px; }
+.cp-bread .sep { opacity:.5; }
+.cp-bread .cur { color:hsl(var(--c-agent)); font-weight:var(--fw-bold); }
+.ce-titlerow { display:flex; align-items:center; gap:11px; flex-wrap:wrap; }
+.cp-h1 { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-2xl); letter-spacing:-.01em; line-height:var(--lh-tight); }
+.cp-sub { font-size:var(--fs-sm); color:var(--text-sec); margin-top:5px; max-width:620px; }
+.cp-sub b { color:var(--text); font-weight:var(--fw-bold); }
+.ce-metarow { display:flex; align-items:center; gap:9px; flex-wrap:wrap; margin-top:9px; }
+.ce-idchip { display:inline-flex; align-items:center; gap:7px; padding:3px 7px 3px 10px; border-radius:var(--r-pill);
+  background:var(--bg-muted); color:var(--text-muted); font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); }
+.ce-idchip .copy { width:19px; height:19px; border-radius:var(--r-xs); border:none; background:transparent; color:var(--text-muted); cursor:pointer; font-size:11px; display:inline-flex; align-items:center; justify-content:center; }
+.ce-idchip .copy:hover { background:var(--border-strong); color:var(--text); }
+.cp-head .grow { flex:1; }
+.cp-headcta { display:flex; align-items:center; gap:9px; flex-shrink:0; flex-wrap:wrap; justify-content:flex-end; max-width:300px; }
+
+/* author chip (player entity) */
+.ce-author { display:inline-flex; align-items:center; gap:6px; padding:2px 10px 2px 2px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .14); color:hsl(var(--c-player)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); }
+.ce-author .av { width:18px; height:18px; border-radius:50%; background:hsl(var(--c-player)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:9px; font-weight:var(--fw-ext); }
+.ce-author .abadge { font-family:var(--f-mono); font-size:9px; font-weight:var(--fw-ext); text-transform:uppercase; letter-spacing:.04em;
+  background:hsl(var(--c-warning) / .2); color:hsl(var(--c-warning)); padding:1px 5px; border-radius:var(--r-pill); }
+
+/* status badge inline (riuso pr-badge S2) */
+.ce-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 11px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); border:1px solid transparent; white-space:nowrap; }
+.ce-badge .bi { font-size:13px; line-height:1; }
+.ce-badge.draft    { background:var(--bg-muted); border-color:var(--border); color:var(--text-muted); }
+.ce-badge.review   { background:hsl(var(--c-warning) / .14); border-color:hsl(var(--c-warning) / .35); color:hsl(var(--c-warning)); }
+.ce-badge.approved { background:hsl(var(--c-toolkit) / .14); border-color:hsl(var(--c-toolkit) / .35); color:hsl(var(--c-toolkit)); }
+.ce-badge.rejected { background:hsl(var(--c-danger) / .14); border-color:hsl(var(--c-danger) / .35); color:hsl(var(--c-danger)); }
+.ce-live { display:inline-flex; align-items:center; gap:5px; font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); color:hsl(var(--c-success)); }
+.ce-live i { width:8px; height:8px; border-radius:50%; background:hsl(var(--c-success)); animation:celive 2s var(--ease-in-out) infinite; }
+@keyframes celive { 0%,100%{ opacity:1; box-shadow:0 0 0 0 hsl(var(--c-success) / .5);} 50%{ opacity:.6; box-shadow:0 0 0 5px hsl(var(--c-success) / 0);} }
+
+/* generic buttons (riuso da S3) */
+.cp-btn { display:inline-flex; align-items:center; gap:7px; padding:9px 15px; border-radius:var(--r-md); border:1px solid transparent;
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); white-space:nowrap; }
+.cp-btn .ic { font-size:13px; line-height:1; }
+.cp-btn.link { background:transparent; color:var(--text-muted); padding:9px 8px; }
+.cp-btn.link:hover { color:var(--text); }
+.cp-btn.ghost { background:var(--bg-card); border-color:var(--border); color:var(--text-sec); }
+.cp-btn.ghost:hover { border-color:var(--border-strong); color:var(--text); transform:translateY(-1px); }
+.cp-btn.primary { background:hsl(var(--c-agent)); color:#3a2400; box-shadow:var(--shadow-xs); }
+.cp-btn.primary:hover:not(:disabled) { transform:translateY(-1px); box-shadow:var(--shadow-sm); filter:brightness(1.03); }
+.cp-btn.primary:disabled { opacity:.45; cursor:not-allowed; }
+.cp-btn.warn { background:hsl(var(--c-warning)); color:#3a2400; }
+.cp-btn.warn:hover { filter:brightness(1.04); transform:translateY(-1px); }
+.cp-btn.warn-out { background:transparent; border-color:hsl(var(--c-warning) / .5); color:hsl(var(--c-warning)); }
+.cp-btn.warn-out:hover { background:hsl(var(--c-warning) / .1); }
+.cp-btn.toolkit-out { background:transparent; border-color:hsl(var(--c-toolkit) / .5); color:hsl(var(--c-toolkit)); }
+.cp-btn.toolkit-out:hover { background:hsl(var(--c-toolkit) / .1); }
+.cp-btn.info-out { background:transparent; border-color:hsl(var(--c-info) / .5); color:hsl(var(--c-info)); }
+.cp-btn.info-out:hover { background:hsl(var(--c-info) / .1); }
+.cp-btn.danger { background:hsl(var(--c-danger)); color:#fff; }
+.cp-btn.danger:hover { filter:brightness(1.04); transform:translateY(-1px); }
+
+/* ─── status banner area (sotto header, condizionale) ─── */
+.ce-banwrap { flex-shrink:0; padding:14px 22px 0; }
+.ce-banwrap .inner { max-width:980px; margin:0 auto; }
+.ce-banner { border-radius:var(--r-lg); padding:15px 18px; }
+.ce-banner .bhead { display:flex; align-items:center; gap:10px; }
+.ce-banner .bhead .bic { font-size:20px; line-height:1; flex-shrink:0; }
+.ce-banner .bhead .bt { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-base); flex:1; }
+.ce-banner .bhead .bwhen { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ce-bantoggle { flex-shrink:0; width:26px; height:26px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-sec);
+  cursor:pointer; font-size:12px; display:inline-flex; align-items:center; justify-content:center; opacity:.65; transition:opacity var(--dur-sm), background var(--dur-sm); }
+.ce-bantoggle:hover { opacity:1; background:var(--bg-hover); }
+.ce-banner .bpeek { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); white-space:nowrap; }
+.ce-banner.collapsed { padding:11px 18px; }
+.ce-banner.collapsed .bhead .bt { font-size:var(--fs-sm); }
+.ce-banner .bbody { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-body); margin-top:9px; }
+.ce-banner .bbody b { color:var(--text); font-weight:var(--fw-bold); }
+.ce-banner .bsections { display:flex; align-items:center; flex-wrap:wrap; gap:7px; margin-top:11px; }
+.ce-banner .bsec-lab { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); text-transform:uppercase; letter-spacing:.04em; }
+.ce-secchip { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill);
+  background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); border:1px solid hsl(var(--c-danger) / .3);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:11px; cursor:pointer; }
+.ce-secchip:hover { background:hsl(var(--c-danger) / .2); }
+.ce-banner .bacts { display:flex; align-items:center; flex-wrap:wrap; gap:8px; margin-top:14px; }
+.ce-banner .bstats { display:flex; align-items:center; flex-wrap:wrap; gap:14px; margin-top:11px; padding-top:11px; border-top:1px solid var(--border-light); }
+.ce-banner .bstat { display:inline-flex; align-items:center; gap:6px; font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ce-banner .bstat b { color:var(--text); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.ce-banner.rejected  { background:hsl(var(--c-danger) / .08);  border-left:4px solid hsl(var(--c-danger)); }
+.ce-banner.review    { background:hsl(var(--c-warning) / .08); border-left:4px solid hsl(var(--c-warning)); }
+.ce-banner.approved  { background:hsl(var(--c-toolkit) / .08); border-left:4px solid hsl(var(--c-toolkit)); }
+.ce-banner.rejected .bhead .bt { color:hsl(var(--c-danger)); }
+.ce-banner.review .bhead .bt   { color:hsl(var(--c-warning)); }
+.ce-banner.approved .bhead .bt { color:hsl(var(--c-toolkit)); }
+
+/* save pill bar (sopra footer) */
+.cp-savebar { flex-shrink:0; display:flex; justify-content:flex-end; padding:7px 22px; background:var(--bg); }
+.cp-savebar .inner { max-width:980px; width:100%; margin:0 auto; display:flex; justify-content:flex-end; }
+.cp-pill { display:inline-flex; align-items:center; gap:6px; padding:4px 11px; border-radius:var(--r-pill);
+  font-family:var(--f-mono); font-size:var(--fs-xs); font-weight:var(--fw-bold); }
+.cp-pill.unsaved { background:hsl(var(--c-warning) / .14); color:hsl(var(--c-warning)); }
+.cp-pill.saved   { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); }
+.cp-pill.readonly{ background:var(--bg-muted); color:var(--text-muted); }
+.cp-pill.dirty   { background:hsl(var(--c-info) / .14); color:hsl(var(--c-info)); }
+.cp-pill .dot { width:7px; height:7px; border-radius:50%; background:currentColor; }
+.cp-pill.dirty .dot { animation:cppulse 1.1s var(--ease-in-out) infinite; }
+@keyframes cppulse { 0%,100%{ opacity:1; transform:scale(1);} 50%{ opacity:.3; transform:scale(.55);} }
+
+/* footer (sticky bottom) */
+.cp-foot { flex-shrink:0; background:var(--bg-card); border-top:1px solid var(--border); }
+.cp-foot .frow { display:flex; align-items:center; gap:10px; padding:13px 22px; max-width:980px; margin:0 auto; flex-wrap:wrap; }
+.cp-foot .grow { flex:1; }
+
+/* scroll body + form column */
+.cp-body { flex:1; overflow:auto; min-height:0; padding:22px 22px 32px; }
+.cp-form { max-width:880px; margin:0 auto; display:flex; flex-direction:column; gap:16px; }
+
+/* section card (accordion, riuso da S3 + lock/changed/resolved) */
+.cp-sec { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); overflow:hidden; transition:border-color var(--dur-sm) var(--ease-out); }
+.cp-sec.has-error { border-color:hsl(var(--c-danger) / .4); }
+.cp-sec.is-valid { border-color:hsl(var(--c-toolkit) / .32); }
+.cp-sec.affected { border-color:hsl(var(--c-danger) / .45); box-shadow:0 0 0 1px hsl(var(--c-danger) / .15); }
+.cp-sec.resolved { border-color:hsl(var(--c-toolkit) / .4); }
+.cp-sec.locked { background:var(--bg); }
+.cp-sechead { display:flex; align-items:center; gap:13px; width:100%; padding:15px 18px; background:transparent; border:none; text-align:left; cursor:pointer; }
+.cp-sechead:hover { background:var(--bg-hover); }
+.cp-secnum { position:relative; flex-shrink:0; width:26px; height:26px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center;
+  background:hsl(var(--c-agent) / .14); color:hsl(var(--c-agent)); font-family:var(--f-mono); font-weight:var(--fw-ext); font-size:var(--fs-sm); }
+.cp-sec.locked .cp-secnum { background:var(--bg-muted); color:var(--text-muted); }
+.cp-secnum .lock { position:absolute; right:-6px; bottom:-6px; width:15px; height:15px; border-radius:50%; background:var(--bg-card); border:1px solid var(--border);
+  display:flex; align-items:center; justify-content:center; font-size:8px; }
+.cp-sectitle { min-width:0; flex:1; }
+.cp-sectitle .t { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-lg); line-height:var(--lh-tight); display:flex; align-items:center; gap:8px; }
+.cp-sectitle .s { font-size:var(--fs-sm); color:var(--text-sec); margin-top:3px; }
+.cp-vpip { flex-shrink:0; display:inline-flex; align-items:center; gap:5px; padding:3px 10px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); white-space:nowrap; }
+.cp-vpip.valid { background:hsl(var(--c-toolkit) / .14); color:hsl(var(--c-toolkit)); }
+.cp-vpip.issues { background:hsl(var(--c-danger) / .14); color:hsl(var(--c-danger)); }
+.cp-vpip.incomplete { background:var(--bg-muted); color:var(--text-muted); }
+.cp-vpip.optional { background:var(--bg-muted); color:var(--text-muted); }
+.cp-vpip.locked { background:var(--bg-muted); color:var(--text-muted); }
+.cp-vpip.changed { background:hsl(var(--c-info) / .14); color:hsl(var(--c-info)); }
+.cp-vpip.resolved { background:hsl(var(--c-toolkit) / .14); color:hsl(var(--c-toolkit)); }
+.cp-vpip.count { background:var(--bg-muted); color:var(--text-muted); font-family:var(--f-mono); }
+.cp-caret { flex-shrink:0; color:var(--text-muted); font-size:11px; transition:transform var(--dur-sm) var(--ease-out); width:16px; text-align:center; }
+.cp-sec.open .cp-caret { transform:rotate(90deg); }
+.cp-secbody { padding:4px 18px 20px; border-top:1px solid var(--border-light); }
+.cp-sec.locked .cp-secbody { background:var(--bg-muted); }
+
+/* fields (riuso da S3) */
+.cp-field { margin-bottom:16px; }
+.cp-field:last-child { margin-bottom:0; }
+.cp-label { display:flex; align-items:center; gap:6px; font-family:var(--f-display); font-size:var(--fs-xs); font-weight:var(--fw-bold);
+  color:var(--text-sec); margin-bottom:7px; text-transform:uppercase; letter-spacing:.05em; }
+.cp-label .req { color:hsl(var(--c-danger)); }
+.cp-label .grow { flex:1; }
+.cp-label .chgmark { display:inline-flex; align-items:center; gap:4px; font-family:var(--f-mono); font-size:9px; font-weight:var(--fw-ext); text-transform:none; letter-spacing:0;
+  color:hsl(var(--c-warning)); background:hsl(var(--c-warning) / .14); padding:1px 7px; border-radius:var(--r-pill); }
+.cp-counter { font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); color:var(--text-muted); text-transform:none; letter-spacing:0; }
+.cp-counter.over { color:hsl(var(--c-danger)); }
+.cp-inwrap { position:relative; }
+.cp-input, .cp-textarea { width:100%; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:var(--fs-base); color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.cp-input:focus, .cp-textarea:focus { border-color:hsl(var(--c-agent) / .55); box-shadow:0 0 0 3px hsl(var(--c-agent) / .14); }
+.cp-input.err, .cp-textarea.err { border-color:hsl(var(--c-danger) / .6); }
+.cp-input.chg, .cp-textarea.chg { border-color:hsl(var(--c-warning) / .5); }
+.cp-input[readonly], .cp-textarea[readonly] { background:var(--bg-muted); color:var(--text-sec); cursor:not-allowed; opacity:.85; }
+.cp-input.haspad { padding-right:110px; }
+.cp-textarea { resize:none; line-height:var(--lh-body); min-height:74px; }
+.cp-unique { position:absolute; right:11px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; gap:5px;
+  font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); white-space:nowrap; }
+.cp-unique.checking { color:hsl(var(--c-info)); }
+.cp-unique.ok { color:hsl(var(--c-toolkit)); }
+.cp-unique.dup { color:hsl(var(--c-danger)); }
+.cp-unique .sp { width:11px; height:11px; border:2px solid currentColor; border-right-color:transparent; border-radius:50%; animation:cpspin .7s linear infinite; }
+@keyframes cpspin { to { transform:rotate(360deg); } }
+.cp-err { display:flex; align-items:center; gap:6px; font-size:var(--fs-xs); color:hsl(var(--c-danger)); font-weight:var(--fw-semi); margin-top:6px; }
+.cp-hint { font-size:var(--fs-xs); color:var(--text-muted); margin-top:6px; line-height:var(--lh-snug); }
+
+/* tip / help box */
+.cp-tip { display:flex; align-items:flex-start; gap:9px; margin-top:14px; padding:10px 13px; border-radius:var(--r-md);
+  background:hsl(var(--c-info) / .08); border:1px solid hsl(var(--c-info) / .18); }
+.cp-tip .ti { font-size:14px; line-height:1.3; flex-shrink:0; }
+.cp-tip .tt { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.cp-tip .tt b { color:var(--text); font-weight:var(--fw-bold); }
+.cp-tip .tt code { font-family:var(--f-mono); font-size:11px; background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); color:hsl(var(--c-game)); }
+
+/* icon picker / colors */
+.cp-icons { display:flex; flex-wrap:wrap; gap:8px; }
+.cp-icon { width:46px; height:46px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card);
+  display:flex; align-items:center; justify-content:center; font-size:21px; cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.cp-icon:hover { border-color:var(--border-strong); transform:translateY(-1px); }
+.cp-icon.on { border-color:hsl(var(--c-agent)); background:hsl(var(--c-agent) / .12); box-shadow:0 0 0 3px hsl(var(--c-agent) / .22); }
+.cp-icon:disabled { cursor:not-allowed; opacity:.6; }
+.cp-colors { display:flex; flex-wrap:wrap; gap:9px; align-items:center; }
+.cp-swatch { width:30px; height:30px; border-radius:var(--r-sm); cursor:pointer; border:2px solid transparent; position:relative; transition:transform var(--dur-sm) var(--ease-out); }
+.cp-swatch:hover { transform:scale(1.08); }
+.cp-swatch.on { border-color:var(--text); box-shadow:0 0 0 2px var(--bg-card), 0 0 0 4px var(--border-strong); }
+.cp-swatch.on::after { content:'✓'; position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:#fff; font-size:13px; font-weight:900; text-shadow:0 1px 2px rgba(0,0,0,.4); }
+.cp-swatch:disabled { cursor:not-allowed; }
+
+/* capability grid */
+.cp-caps { display:grid; grid-template-columns:repeat(auto-fill, minmax(232px, 1fr)); gap:9px; }
+.cp-cap { display:flex; align-items:flex-start; gap:10px; padding:11px 12px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); cursor:pointer; text-align:left; transition:all var(--dur-sm) var(--ease-out); position:relative; }
+.cp-cap:hover { background:var(--bg-hover); border-color:var(--border-strong); }
+.cp-cap.on { background:hsl(var(--c-agent) / .12); border-color:hsl(var(--c-agent) / .45); }
+.cp-cap:disabled { cursor:not-allowed; }
+.cp-cap:disabled:hover { background:var(--bg-card); border-color:var(--border); }
+.cp-cap.on:disabled:hover { background:hsl(var(--c-agent) / .12); border-color:hsl(var(--c-agent) / .45); }
+.cp-cap .cic { font-size:18px; line-height:1.1; flex-shrink:0; }
+.cp-cap .cbody { display:flex; flex-direction:column; gap:3px; min-width:0; }
+.cp-cap .cbody .ct { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); }
+.cp-cap.on .cbody .ct { color:hsl(var(--c-agent)); }
+.cp-cap .cbody .cd { font-size:var(--fs-xs); color:var(--text-sec); line-height:var(--lh-snug); }
+.cp-cap .ck { position:absolute; top:9px; right:9px; width:17px; height:17px; border-radius:50%; background:hsl(var(--c-agent)); color:#fff;
+  display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:900; opacity:0; transform:scale(.5); transition:all var(--dur-sm) var(--ease-spring); }
+.cp-cap.on .ck { opacity:1; transform:scale(1); }
+.cp-capwarn { display:flex; align-items:center; gap:6px; font-size:var(--fs-xs); color:hsl(var(--c-danger)); font-weight:var(--fw-semi); margin-top:10px; }
+
+/* prompt toolbar + code editor */
+.cp-ptoolbar { display:flex; align-items:center; gap:7px; flex-wrap:wrap; margin-bottom:9px; }
+.cp-ptool { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border-radius:var(--r-sm); border:1px solid var(--border); white-space:nowrap;
+  background:var(--bg-card); color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; transition:all var(--dur-sm); }
+.cp-ptool:hover { background:var(--bg-muted); color:var(--text); border-color:var(--border-strong); }
+.cp-ptool.play { color:hsl(var(--c-tool)); border-color:hsl(var(--c-tool) / .35); background:hsl(var(--c-tool) / .08); }
+.cp-ptool.play:hover { background:hsl(var(--c-tool) / .15); }
+.cp-ptoolbar .grow { flex:1; }
+.cp-code-wrap { position:relative; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-muted); overflow:hidden; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.cp-code-wrap.focus { border-color:hsl(var(--c-agent) / .55); box-shadow:0 0 0 3px hsl(var(--c-agent) / .14); }
+.cp-code-wrap.err { border-color:hsl(var(--c-danger) / .6); }
+.cp-code-wrap.chg { border-color:hsl(var(--c-warning) / .5); }
+.cp-code-layer { margin:0; padding:13px 15px; font-family:var(--f-mono); font-size:13px; line-height:1.6; white-space:pre-wrap; word-break:break-word; }
+.cp-code-hl { position:absolute; inset:0; pointer-events:none; color:var(--text); }
+.cp-code-hl .v { color:hsl(var(--c-game)); font-weight:var(--fw-bold); background:hsl(var(--c-game) / .12); border-radius:3px; padding:0 2px; }
+.cp-code-hl .bt { color:hsl(var(--c-tool)); }
+.cp-code-hl .ph { color:var(--text-muted); }
+.cp-code-ta { position:relative; display:block; width:100%; border:none; outline:none; resize:none; background:transparent;
+  color:transparent; caret-color:hsl(var(--c-agent)); overflow:hidden; }
+.cp-code-ta:read-only { caret-color:transparent; cursor:not-allowed; }
+.cp-code-ta::selection { background:hsl(var(--c-agent) / .25); }
+.cp-codefoot { display:flex; align-items:center; padding:7px 15px; border-top:1px solid var(--border-light); background:var(--bg); }
+.cp-codefoot .grow { flex:1; }
+
+/* sample rows */
+.cp-samples { display:flex; flex-direction:column; gap:11px; }
+.cp-sample { border:1px solid var(--border); border-radius:var(--r-md); padding:12px; background:var(--bg); position:relative; }
+.cp-sample .shead { display:flex; align-items:center; margin-bottom:9px; }
+.cp-sample .sidx { font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); color:var(--text-muted); flex:1; }
+.cp-sample .sdel { width:28px; height:28px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text-muted); cursor:pointer; font-size:13px; }
+.cp-sample .sdel:hover { color:hsl(var(--c-danger)); border-color:hsl(var(--c-danger) / .4); background:hsl(var(--c-danger) / .08); }
+.cp-sample .sgrid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+.cp-sample .scol .sl { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--text-muted); margin-bottom:5px; }
+.cp-addbtn { display:inline-flex; align-items:center; gap:6px; align-self:flex-start; padding:8px 13px; border-radius:var(--r-md);
+  border:1.5px dashed var(--border-strong); background:transparent; color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; }
+.cp-addbtn:hover { border-color:hsl(var(--c-agent) / .5); color:hsl(var(--c-agent)); background:hsl(var(--c-agent) / .06); }
+.cp-addbtn:disabled { opacity:.45; cursor:not-allowed; }
+
+/* game scope picker */
+.cp-scopsearch { position:relative; }
+.cp-scopsuggest { margin-top:7px; border:1px solid var(--border); border-radius:var(--r-md); background:var(--bg-card); box-shadow:var(--shadow-md); overflow:hidden; }
+.cp-sugg { display:flex; align-items:center; gap:11px; width:100%; padding:9px 12px; border:none; background:transparent; cursor:pointer; text-align:left; }
+.cp-sugg:not(:last-child) { border-bottom:1px solid var(--border-light); }
+.cp-sugg:hover, .cp-sugg.hi { background:var(--bg-hover); }
+.cp-sugg .th { width:34px; height:34px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center; font-size:17px; color:#fff; flex-shrink:0; }
+.cp-sugg .sm { min-width:0; flex:1; }
+.cp-sugg .sm .gn { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.cp-sugg .sm .gd { font-size:var(--fs-xs); color:var(--text-muted); }
+.cp-sugg .add { font-family:var(--f-mono); font-size:11px; font-weight:var(--fw-bold); color:hsl(var(--c-game)); }
+.cp-sugg.sel .add { color:var(--text-muted); }
+.cp-scochips { display:flex; flex-wrap:wrap; gap:7px; margin-top:11px; }
+.cp-gchip { display:inline-flex; align-items:center; gap:6px; padding:4px 6px 4px 4px; border-radius:var(--r-pill);
+  background:hsl(var(--c-game) / .12); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .25);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); }
+.cp-gchip .ge { font-size:13px; }
+.cp-gchip .gx { width:16px; height:16px; border-radius:50%; border:none; background:hsl(var(--c-game) / .2); color:hsl(var(--c-game)); cursor:pointer; font-size:10px; display:inline-flex; align-items:center; justify-content:center; }
+.cp-gchip .gx:hover { background:hsl(var(--c-game) / .35); }
+.cp-scopsum { display:inline-flex; align-items:center; gap:7px; margin-top:13px; padding:6px 13px; border-radius:var(--r-pill);
+  background:var(--bg-muted); color:var(--text-sec); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.cp-scopsum .pin { color:hsl(var(--c-game)); }
+
+/* ─── Sezione 6: Revisions diff ─── */
+.ce-comparebar { display:flex; align-items:center; gap:11px; flex-wrap:wrap; padding:10px 13px; border-radius:var(--r-md); background:var(--bg-muted); margin-bottom:14px; }
+.ce-comparebar .cl { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); text-transform:uppercase; letter-spacing:.04em; }
+.ce-cmpsel { display:inline-flex; align-items:center; gap:6px; padding:5px 10px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); color:var(--text); cursor:pointer; }
+.ce-cmpsel .vv { color:var(--text-muted); font-family:var(--f-mono); font-weight:var(--fw-bold); }
+.ce-cmpsel .car { font-size:9px; color:var(--text-muted); }
+.ce-cmparrow { color:var(--text-muted); font-size:13px; }
+.ce-difflist { display:flex; flex-direction:column; gap:13px; }
+.ce-diff { border:1px solid var(--border); border-radius:var(--r-md); overflow:hidden; background:var(--bg-card); }
+.ce-diffhead { display:flex; align-items:center; gap:9px; padding:10px 13px; background:var(--bg); border-bottom:1px solid var(--border-light); }
+.ce-diffhead .df { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.ce-diffhead .dref { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.ce-diffhead .grow { flex:1; }
+.ce-diffhead .goto { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); color:hsl(var(--c-agent)); background:none; border:none; cursor:pointer; padding:3px 6px; border-radius:var(--r-xs); }
+.ce-diffhead .goto:hover { background:hsl(var(--c-agent) / .1); }
+.ce-diffbody { font-family:var(--f-mono); font-size:13px; line-height:1.55; padding:8px 0; }
+.ce-dline { display:flex; gap:9px; padding:1px 13px; white-space:pre-wrap; word-break:break-word; }
+.ce-dline .pfx { flex-shrink:0; width:11px; text-align:center; font-weight:var(--fw-bold); opacity:.8; user-select:none; }
+.ce-dline.ctx { color:var(--text-muted); }
+.ce-dline.add { background:hsl(var(--c-toolkit) / .15); border-left:3px solid hsl(var(--c-toolkit)); }
+.ce-dline.add .pfx, .ce-dline.add { color:hsl(var(--c-toolkit)); }
+.ce-dline.del { background:hsl(var(--c-danger) / .1); border-left:3px solid hsl(var(--c-danger)); }
+.ce-dline.del .pfx, .ce-dline.del { color:hsl(var(--c-danger)); }
+.ce-diffsum { display:flex; align-items:center; gap:8px; margin-top:14px; padding:11px 13px; border-radius:var(--r-md); background:var(--bg-muted);
+  font-size:var(--fs-sm); color:var(--text-sec); }
+.ce-diffsum b { color:var(--text); font-weight:var(--fw-bold); }
+.ce-difftoggle { display:flex; align-items:center; gap:10px; margin-top:13px; padding:11px 13px; border-radius:var(--r-md); border:1px solid var(--border); }
+.ce-difftoggle .dtt { flex:1; }
+.ce-difftoggle .dtt .dtl { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.ce-difftoggle .dtt .dts { font-size:var(--fs-xs); color:var(--text-muted); margin-top:2px; }
+.ce-switch { flex-shrink:0; width:42px; height:24px; border-radius:var(--r-pill); border:none; background:var(--border-strong); position:relative; cursor:pointer; transition:background var(--dur-sm) var(--ease-out); }
+.ce-switch::after { content:''; position:absolute; top:3px; left:3px; width:18px; height:18px; border-radius:50%; background:#fff; box-shadow:var(--shadow-xs); transition:transform var(--dur-sm) var(--ease-spring); }
+.ce-switch.on { background:hsl(var(--c-warning)); }
+.ce-switch.on::after { transform:translateX(18px); }
+.ce-diffempty { text-align:center; padding:24px; color:var(--text-muted); font-size:var(--fs-sm); }
+.ce-diffempty .em { font-size:28px; opacity:.7; display:block; margin-bottom:8px; }
+
+/* ─── Sezione 7: Audit trail ─── */
+.ce-timeline { display:flex; flex-direction:column; }
+.ce-event { display:flex; gap:13px; }
+.ce-evcol { display:flex; flex-direction:column; align-items:center; flex-shrink:0; }
+.ce-evdot { width:26px; height:26px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:12px; flex-shrink:0; z-index:1;
+  border:2px solid var(--bg-card); }
+.ce-evdot.created  { background:hsl(var(--c-success) / .18); color:hsl(var(--c-success)); }
+.ce-evdot.submit   { background:hsl(var(--c-agent) / .18); color:hsl(var(--c-agent)); }
+.ce-evdot.review   { background:hsl(var(--c-warning) / .18); color:hsl(var(--c-warning)); }
+.ce-evdot.approved { background:hsl(var(--c-toolkit) / .18); color:hsl(var(--c-toolkit)); }
+.ce-evdot.rejected { background:hsl(var(--c-danger) / .18); color:hsl(var(--c-danger)); }
+.ce-evdot.edited   { background:hsl(var(--c-info) / .18); color:hsl(var(--c-info)); }
+.ce-evline { flex:1; width:0; border-left:2px dashed var(--border); margin:2px 0; min-height:14px; }
+.ce-event:last-child .ce-evline { display:none; }
+.ce-evbody { flex:1; min-width:0; padding-bottom:16px; }
+.ce-event:last-child .ce-evbody { padding-bottom:0; }
+.ce-evtop { display:flex; align-items:baseline; gap:9px; flex-wrap:wrap; }
+.ce-evlabel { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); }
+.ce-evwhen { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.ce-evmeta { display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:7px; }
+.ce-evreason { margin-top:8px; padding:8px 11px; border-radius:var(--r-sm); background:hsl(var(--c-danger) / .07); border-left:3px solid hsl(var(--c-danger) / .6);
+  font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.ce-evreason b { color:hsl(var(--c-danger)); font-weight:var(--fw-bold); }
+.ce-evreason a { color:hsl(var(--c-danger)); text-decoration:underline; font-weight:var(--fw-bold); cursor:pointer; white-space:nowrap; }
+
+/* overlay + modal (riuso da S3) */
+.cp-modal-bd { position:absolute; inset:0; z-index:var(--z-modal); background:rgba(20,16,10,.42); backdrop-filter:blur(2px); display:flex; align-items:center; justify-content:center; padding:24px; }
+[data-theme="dark"] .cp-modal-bd { background:rgba(0,0,0,.6); }
+.cp-modal { width:100%; max-width:460px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg); overflow:hidden; animation:cpmodal var(--dur-md) var(--ease-out); }
+@keyframes cpmodal { from { transform:translateY(10px) scale(.98); } to { transform:none; } }
+.cp-modal .mhead { display:flex; align-items:center; gap:11px; padding:18px 20px 14px; }
+.cp-modal .mhead .mi { width:38px; height:38px; border-radius:var(--r-md); display:flex; align-items:center; justify-content:center; font-size:18px; flex-shrink:0; }
+.cp-modal .mhead .mi.agent { background:hsl(var(--c-agent) / .14); }
+.cp-modal .mhead .mi.warn { background:hsl(var(--c-warning) / .14); }
+.cp-modal .mhead h3 { font-family:var(--f-display); font-size:var(--fs-lg); }
+.cp-modal .mbody { padding:0 20px 16px; font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-body); }
+.cp-modal .msummary { margin-top:13px; border:1px solid var(--border); border-radius:var(--r-md); overflow:hidden; }
+.cp-modal .msrow { display:flex; gap:10px; padding:9px 12px; font-size:var(--fs-sm); }
+.cp-modal .msrow:not(:last-child) { border-bottom:1px solid var(--border-light); }
+.cp-modal .msrow .k { font-family:var(--f-mono); font-size:11px; text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted); width:120px; flex-shrink:0; }
+.cp-modal .msrow .vv { color:var(--text); font-weight:var(--fw-semi); min-width:0; }
+.cp-modal .msrow .vv.add { color:hsl(var(--c-toolkit)); }
+.cp-modal .mfoot { display:flex; gap:9px; padding:14px 20px; background:var(--bg); border-top:1px solid var(--border); }
+.cp-modal .mfoot .grow { flex:1; }
+
+/* ─── mobile ─── */
+.cp-app.is-mobile .cp-head .hrow { flex-wrap:wrap; padding:12px 14px 13px; }
+.cp-app.is-mobile .cp-headcta { display:none; }
+.cp-app.is-mobile .cp-h1 { font-size:var(--fs-xl); }
+.cp-app.is-mobile .ce-banwrap { padding:12px 13px 0; }
+.cp-app.is-mobile .cp-body { padding:14px 13px 24px; }
+.cp-app.is-mobile .cp-form { gap:12px; }
+.cp-app.is-mobile .cp-sechead { padding:13px 14px; }
+.cp-app.is-mobile .cp-secbody { padding:4px 14px 16px; }
+.cp-app.is-mobile .cp-sectitle .t { font-size:var(--fs-base); }
+.cp-app.is-mobile .cp-caps { grid-template-columns:1fr; }
+.cp-app.is-mobile .cp-sample .sgrid { grid-template-columns:1fr; }
+.cp-app.is-mobile .cp-foot .frow { padding:11px 13px; gap:7px; }
+.cp-app.is-mobile .cp-foot .cp-btn { flex:1; justify-content:center; padding:11px 8px; }
+.cp-app.is-mobile .cp-foot .cp-btn.link { flex:0 0 auto; }
+.cp-app.is-mobile .cp-savebar { padding:6px 13px; }
+.cp-app.is-mobile .cp-modal { max-width:none; }
+.cp-app.is-mobile .ce-comparebar { gap:7px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ce-live i, .cp-pill.dirty .dot, .cp-unique .sp, .cp-modal, .ce-switch::after { animation:none; transition:none; }
+}
+`;
+
+/* ──────────────────────────────────────────────────────────
+   Static config (riuso da S3)
+   ────────────────────────────────────────────────────────── */
+const AUTHOR = { name: 'Marco R.', initials: 'MR' };
+const ADMIN = { name: 'Sara T.', initials: 'ST' };
+
+const ICONS = ['🤖', '📋', '🎯', '🧠', '⚔️', '🛡️', '🎓', '🎨'];
+
+const ENTITY_COLORS = [
+  ['game', 25, 95, 45], ['player', 262, 83, 58], ['session', 240, 60, 55],
+  ['agent', 38, 92, 50], ['kb', 174, 60, 40], ['chat', 220, 80, 55],
+  ['event', 350, 89, 60], ['toolkit', 142, 70, 45], ['tool', 195, 80, 50],
+];
+
+const CAPABILITIES = [
+  { id: 'qa',     icon: '💬', label: 'Q&A',         desc: 'Risponde a domande sulle regole dei giochi' },
+  { id: 'stream', icon: '⚡', label: 'Streaming',    desc: 'Risposta token-by-token in tempo reale' },
+  { id: 'tool',   icon: '🔧', label: 'Tool use',     desc: 'Chiama strumenti esterni (punteggi, timer…)' },
+  { id: 'image',  icon: '📸', label: 'Image input',  desc: 'Analizza immagini (stato del tavolo, carte)' },
+  { id: 'web',    icon: '🌐', label: 'Web search',   desc: 'Cerca regole e FAQ ufficiali online' },
+];
+
+const GAMES = (window.DS && window.DS.games) ? window.DS.games : [];
+
+/* prompt v3 (bozza corrente, generalizzato) */
+const PROMPT_V3 =
+`Sei un esperto delle regole ufficiali di {game}. Rispondi alle domande del {player} citando sempre il manuale e indicando la pagina di riferimento quando possibile.
+
+Adatta le risposte all'archetipo euro-game: gestione risorse, piazzamento e ottimizzazione del punteggio. Se una regola è ambigua, spiega le interpretazioni più diffuse e segnala quella ufficiale. Mantieni un tono chiaro e amichevole, adatto anche a chi gioca per la prima volta. Non inventare regole non presenti in {rules_kb}.`;
+
+/* ──────────────────────────────────────────────────────────
+   Base proposal (Catan Rules Expert · v3) + meta
+   ────────────────────────────────────────────────────────── */
+const BASE_FORM = {
+  name: 'Catan Rules Expert',
+  desc: 'Esperto delle regole ufficiali di Catan: risponde su preparazione, commercio, ladrone e calcolo dei punti vittoria citando sempre il manuale.',
+  icon: '📋', color: 'agent',
+  caps: ['qa', 'stream', 'web'],
+  prompt: PROMPT_V3,
+  samples: [
+    { in: 'Quante carte risorsa si pescano durante il setup?', out: 'Nel setup ogni giocatore riceve risorse dai terreni adiacenti al suo secondo insediamento, una carta per ciascun terreno (escluso il deserto).' },
+    { in: 'Il ladrone blocca anche la produzione del 7?', out: 'Il ladrone non blocca un numero: quando esce il 7 nessuno produce, si attiva il ladrone e si scartano le carte oltre le 7 in mano.' },
+  ],
+  scope: ['g-catan'],
+};
+const META = {
+  id: 'tp-catan-rules-3',
+  version: 3,
+  createdAgo: '5 giorni fa', createdAbs: '28 mag 2026, 09:12',
+  modAgo: '2 ore fa', modAbs: '2 giu 2026, 16:04',
+};
+
+/* feedback admin (per Rejected) */
+const REJECT_FEEDBACK = {
+  ago: '2 giorni fa', abs: '31 mag 2026, 11:40',
+  body: 'Il prompt sistema include riferimenti a giochi specifici che non sono nello scope. Generalizza per coprire l\u2019archetipo "euro-game" invece di nominare Catan esplicitamente nelle istruzioni base.',
+  sections: [['System prompt', 3, 'prompt'], ['Scope giochi', 5, 'scope']],
+};
+
+/* ──────────────────────────────────────────────────────────
+   Revisions diff — v3 (bozza) vs v2 (approvata 28 mag)
+   ────────────────────────────────────────────────────────── */
+const REVISIONS = [
+  { id: 'r1', field: 'System prompt', section: 3, sectionId: 'prompt',
+    lines: [
+      ['del', 'Sei un esperto delle regole di Catan e dei giochi di piazzamento tedeschi.'],
+      ['add', 'Sei un esperto delle regole ufficiali di {game}. Rispondi alle domande del {player}'],
+      ['add', 'citando sempre il manuale e indicando la pagina di riferimento quando possibile.'],
+      ['ctx', 'Se una regola è ambigua, spiega le interpretazioni più diffuse.'],
+    ] },
+  { id: 'r2', field: 'System prompt', section: 3, sectionId: 'prompt',
+    lines: [
+      ['ctx', 'Mantieni un tono chiaro e amichevole.'],
+      ['del', 'Concentrati sulle meccaniche specifiche di Catan: commercio e ladrone.'],
+      ['add', "Adatta le risposte all'archetipo euro-game: gestione risorse, piazzamento"],
+      ['add', 'e ottimizzazione del punteggio.'],
+    ] },
+  { id: 'r3', field: 'Scope giochi', section: 5, sectionId: 'scope',
+    lines: [
+      ['del', 'Scope: Catan, Power Grid (2 giochi)'],
+      ['add', 'Scope: Catan (1 gioco)'],
+    ] },
+];
+
+/* ──────────────────────────────────────────────────────────
+   Audit trail — 8 eventi (storia v2→v3)
+   ────────────────────────────────────────────────────────── */
+const AUDIT = [
+  { id: 'a1', type: 'created',  label: 'Creata',                  ago: '7 giorni fa', iso: '2026-05-26T20:05', who: AUTHOR },
+  { id: 'a2', type: 'submit',   label: 'Inviata per review (v2)', ago: '6 giorni fa', iso: '2026-05-27T10:30', who: AUTHOR },
+  { id: 'a3', type: 'review',   label: 'In review',               ago: '6 giorni fa', iso: '2026-05-27T10:31', who: { name: 'Sistema', initials: 'SY', system: true } },
+  { id: 'a4', type: 'approved', label: 'Approvata · v2 live',     ago: '5 giorni fa', iso: '2026-05-28T09:12', who: ADMIN, admin: true },
+  { id: 'a5', type: 'edited',   label: 'Nuova versione v3 (clone)', ago: '3 giorni fa', iso: '2026-05-30T18:48', who: AUTHOR },
+  { id: 'a6', type: 'submit',   label: 'Inviata per review (v3)', ago: '3 giorni fa', iso: '2026-05-30T19:02', who: AUTHOR },
+  { id: 'a7', type: 'rejected', label: 'Rifiutata',               ago: '2 giorni fa', iso: '2026-05-31T11:40', who: ADMIN, admin: true,
+    reason: 'Prompt include riferimenti specifici a Catan fuori scope. Generalizza per l\u2019archetipo euro-game.' },
+  { id: 'a8', type: 'edited',   label: 'Edit ripreso',            ago: '1 ora fa',    iso: '2026-06-02T15:10', who: AUTHOR },
+];
+
+/* ──────────────────────────────────────────────────────────
+   Scenari (10 stati)
+   status ∈ Draft · PendingReview · Approved · Rejected
+   ────────────────────────────────────────────────────────── */
+const SCENARIOS = {
+  'draft-edit':          { status: 'Draft',         open: [1, 2, 3, 4, 5], savePill: 'saved',    addressed: [], dirty: false, ui: {} },
+  'draft-edit-dirty':    { status: 'Draft',         open: [1, 3],          savePill: 'unsaved',  addressed: [], dirty: true,  ui: {} },
+  'pending-review':      { status: 'PendingReview', open: [1, 2, 3],       savePill: 'readonly', addressed: [], dirty: false, ui: {} },
+  'approved-readonly':   { status: 'Approved',      open: [1, 3],          savePill: 'readonly', addressed: [], dirty: false, ui: {} },
+  'approved-with-stats': { status: 'Approved',      open: [1],             savePill: 'readonly', addressed: [], dirty: false, ui: { stats: true } },
+  'rejected-fresh':      { status: 'Rejected',      open: [3, 5],          savePill: 'saved',    addressed: [], dirty: false, ui: {} },
+  'rejected-addressing': { status: 'Rejected',      open: [3, 5],          savePill: 'dirty',    addressed: ['prompt'], dirty: true, ui: {} },
+  'revisions-expanded':  { status: 'Rejected',      open: [6],             savePill: 'dirty',    addressed: ['prompt'], dirty: true, ui: { diffInline: false } },
+  'audit-trail-expanded':{ status: 'Rejected',      open: [7],             savePill: 'saved',    addressed: [], dirty: false, ui: {} },
+  'submitting-update':   { status: 'Rejected',      open: [],              savePill: 'dirty',    addressed: ['prompt', 'scope'], dirty: true, ui: { modal: true } },
+};
+const STATE_LIST = [
+  ['draft-edit', 'Draft'], ['draft-edit-dirty', 'Draft · dirty'], ['pending-review', 'Pending'],
+  ['approved-readonly', 'Approved'], ['approved-with-stats', 'Approved · stats'],
+  ['rejected-fresh', 'Rejected'], ['rejected-addressing', 'Rejected · addressing'],
+  ['revisions-expanded', 'Revisions'], ['audit-trail-expanded', 'Audit trail'], ['submitting-update', 'Submitting'],
+];
+
+const STATUS_META = {
+  Draft:         { cls: 'draft',    icon: '📝', label: 'Draft' },
+  PendingReview: { cls: 'review',   icon: '⏳', label: 'In review' },
+  Approved:      { cls: 'approved', icon: '✓', label: 'Approvata' },
+  Rejected:      { cls: 'rejected', icon: '✗', label: 'Rifiutata' },
+};
+
+/* ──────────────────────────────────────────────────────────
+   Helpers
+   ────────────────────────────────────────────────────────── */
+function gameById(id) { return GAMES.find(g => g.id === id); }
+function highlightPrompt(text) {
+  if (!text) return [<span className="ph" key="ph">Definisci il comportamento dell&rsquo;agente…</span>];
+  const parts = text.split(/(\{[a-z_]+\}|`[^`]*`)/g);
+  return parts.map((p, i) => {
+    if (/^\{[a-z_]+\}$/.test(p)) return <span className="v" key={i}>{p}</span>;
+    if (/^`[^`]*`$/.test(p)) return <span className="bt" key={i}>{p}</span>;
+    return <React.Fragment key={i}>{p}</React.Fragment>;
+  });
+}
+
+/* ──────────────────────────────────────────────────────────
+   Shared sub-components
+   ────────────────────────────────────────────────────────── */
+function AuthorChip({ who, admin }) {
+  return (
+    <span className="ce-author" title={'Autore: ' + who.name}>
+      <span className="av" aria-hidden="true">{who.initials}</span>{who.name}
+      {admin && <span className="abadge">admin</span>}
+    </span>
+  );
+}
+
+function CharCounter({ value, max }) {
+  const over = value > max;
+  return <span className={'cp-counter' + (over ? ' over' : '')}>{value} / {max}</span>;
+}
+
+function AutoTextarea({ value, onChange, max, minH = 74, readOnly, changed, ...rest }) {
+  const ref = useRef(null);
+  const fit = useCallback(() => { const el = ref.current; if (!el) return; el.style.height = 'auto'; el.style.height = Math.max(minH, el.scrollHeight) + 'px'; }, [minH]);
+  useEffect(() => { fit(); }, [value, fit]);
+  return (
+    <textarea ref={ref} className={'cp-textarea' + (changed ? ' chg' : '')} value={value} readOnly={readOnly}
+      onChange={e => { if (!readOnly && (!max || e.target.value.length <= max + 40)) onChange(e.target.value); }} {...rest} />
+  );
+}
+
+function UniqueCheck({ status }) {
+  if (status === 'ok') return <span className="cp-unique ok" role="status"><span aria-hidden="true">✓</span> Disponibile</span>;
+  if (status === 'dup') return <span className="cp-unique dup" role="status"><span aria-hidden="true">✗</span> Già in uso</span>;
+  return null;
+}
+
+function ChangedMark() { return <span className="chgmark"><span aria-hidden="true">●</span> modificato dopo feedback</span>; }
+
+/* section card (accordion) — locked / changed / resolved / affected */
+function SectionCard({ num, id, title, subtitle, locked, status, statusCount, affected, changed, resolved, open, onToggle, children, bodyRef }) {
+  let cls = 'cp-sec' + (open ? ' open' : '');
+  if (locked) cls += ' locked';
+  else if (resolved) cls += ' resolved';
+  else if (affected) cls += ' affected';
+  else if (status === 'issues') cls += ' has-error';
+  else if (status === 'valid') cls += ' is-valid';
+
+  let pip;
+  if (locked) pip = <span className="cp-vpip locked"><span aria-hidden="true">🔒</span> Sola lettura</span>;
+  else if (resolved) pip = <span className="cp-vpip resolved"><span aria-hidden="true">✓</span> Risolta</span>;
+  else if (changed) pip = <span className="cp-vpip changed"><span aria-hidden="true">●</span> Modificata</span>;
+  else if (typeof statusCount === 'string') pip = <span className="cp-vpip count">{statusCount}</span>;
+  else if (status === 'valid') pip = <span className="cp-vpip valid"><span aria-hidden="true">✓</span> Completa</span>;
+  else if (status === 'issues') pip = <span className="cp-vpip issues" role="status"><span aria-hidden="true">⚠</span> {statusCount} {statusCount === 1 ? 'problema' : 'problemi'}</span>;
+  else if (status === 'optional') pip = <span className="cp-vpip optional"><span aria-hidden="true">·</span> Opzionale</span>;
+  else pip = <span className="cp-vpip incomplete"><span aria-hidden="true">·</span> Da completare</span>;
+
+  return (
+    <section className={cls} role="region" aria-labelledby={'sec-' + id + '-t'}>
+      <button className="cp-sechead" aria-expanded={open} aria-controls={'sec-' + id + '-b'} onClick={onToggle}>
+        <span className="cp-secnum" aria-hidden="true">{num}{locked && <span className="lock">🔒</span>}</span>
+        <span className="cp-sectitle">
+          <span className="t" id={'sec-' + id + '-t'}>{title}</span>
+          <span className="s">{subtitle}</span>
+        </span>
+        {pip}
+        <span className="cp-caret" aria-hidden="true">▸</span>
+      </button>
+      {open && <div className="cp-secbody" id={'sec-' + id + '-b'} role="group" ref={bodyRef}>{children}</div>}
+    </section>
+  );
+}
+
+/* ─── Section 1: Identity (riuso S3) ─── */
+function IdentitySection({ form, set, readOnly, uniqueStatus, showValidation }) {
+  return (
+    <>
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="f-name">Nome <span className="req">*</span><span className="grow" /><CharCounter value={form.name.length} max={80} /></label>
+        <div className="cp-inwrap">
+          <input id="f-name" className="cp-input haspad" value={form.name} readOnly={readOnly}
+            maxLength={84} placeholder="es. Catan Rules Expert" onChange={e => set('name', e.target.value)} />
+          {!readOnly && <UniqueCheck status={uniqueStatus} />}
+        </div>
+      </div>
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="f-desc">Descrizione <span className="req">*</span><span className="grow" /><CharCounter value={form.desc.length} max={500} /></label>
+        <AutoTextarea id="f-desc" value={form.desc} max={500} minH={70} readOnly={readOnly}
+          placeholder="Descrivi cosa fa questa typology e quando usarla…" onChange={v => set('desc', v)} />
+      </div>
+      <div className="cp-field">
+        <label className="cp-label">Icona <span className="req">*</span></label>
+        <div className="cp-icons" role="radiogroup" aria-label="Scegli icona">
+          {ICONS.map(ic => (
+            <button key={ic} type="button" role="radio" aria-checked={form.icon === ic} aria-label={'Icona ' + ic} disabled={readOnly}
+              className={'cp-icon' + (form.icon === ic ? ' on' : '')} onClick={() => !readOnly && set('icon', ic)}>{ic}</button>
+          ))}
+        </div>
+      </div>
+      <div className="cp-field">
+        <label className="cp-label">Colore entity</label>
+        <div className="cp-colors" role="radiogroup" aria-label="Scegli colore entity">
+          {ENTITY_COLORS.map(([key, h, s, l]) => (
+            <button key={key} type="button" role="radio" aria-checked={form.color === key} aria-label={'Colore ' + key} disabled={readOnly}
+              className={'cp-swatch' + (form.color === key ? ' on' : '')} style={{ background: `hsl(${h} ${s}% ${l}%)` }}
+              onClick={() => !readOnly && set('color', key)} />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+/* ─── Section 2: Capabilities (riuso S3) ─── */
+function CapabilitiesSection({ form, set, readOnly }) {
+  const toggle = id => { if (readOnly) return; set('caps', form.caps.includes(id) ? form.caps.filter(c => c !== id) : [...form.caps, id]); };
+  return (
+    <>
+      <div className="cp-caps" role="group" aria-label="Seleziona capability">
+        {CAPABILITIES.map(c => {
+          const on = form.caps.includes(c.id);
+          return (
+            <button key={c.id} type="button" className={'cp-cap' + (on ? ' on' : '')} aria-pressed={on} disabled={readOnly} onClick={() => toggle(c.id)}>
+              <span className="cic" aria-hidden="true">{c.icon}</span>
+              <span className="cbody"><span className="ct">{c.label}</span><span className="cd">{c.desc}</span></span>
+              <span className="ck" aria-hidden="true">✓</span>
+            </button>
+          );
+        })}
+      </div>
+      {!readOnly && <div className="cp-tip"><span className="ti" aria-hidden="true">💡</span><span className="tt">Le capability sono <b>tassonomia interna</b>: determinano quali tool e modalità l&rsquo;agente potrà usare in chat.</span></div>}
+    </>
+  );
+}
+
+/* ─── Section 3: System prompt (riuso S3) ─── */
+function CodeEditor({ value, onChange, readOnly, changed }) {
+  const taRef = useRef(null);
+  const hlRef = useRef(null);
+  const [focus, setFocus] = useState(false);
+  const fit = useCallback(() => {
+    const ta = taRef.current; if (!ta) return;
+    ta.style.height = 'auto';
+    ta.style.height = Math.min(Math.max(150, ta.scrollHeight), 460) + 'px';
+  }, []);
+  useEffect(() => { fit(); }, [value, fit]);
+  const syncScroll = () => { if (hlRef.current && taRef.current) hlRef.current.scrollTop = taRef.current.scrollTop; };
+  return (
+    <div className={'cp-code-wrap' + (focus ? ' focus' : '') + (changed ? ' chg' : '')}>
+      <pre className="cp-code-layer cp-code-hl" ref={hlRef} aria-hidden="true">{highlightPrompt(value)}</pre>
+      <textarea ref={taRef} className="cp-code-layer cp-code-ta" value={value} readOnly={readOnly} spellCheck={false}
+        aria-label="System prompt" rows={6} onScroll={syncScroll}
+        onFocus={() => setFocus(true)} onBlur={() => setFocus(false)}
+        onChange={e => { if (!readOnly && e.target.value.length <= 4000) onChange(e.target.value); }} />
+    </div>
+  );
+}
+
+function SystemPromptSection({ form, set, readOnly, changed }) {
+  return (
+    <>
+      {!readOnly && (
+        <div className="cp-ptoolbar">
+          <button type="button" className="cp-ptool"><span aria-hidden="true">▤</span> Templates</button>
+          <span className="grow" />
+          <button type="button" className="cp-ptool play" title="Apri il playground di test (S5)"><span aria-hidden="true">🧪</span> Testa nel playground</button>
+        </div>
+      )}
+      {changed && !readOnly && <div className="cp-label" style={{ marginBottom: 8 }}><span className="grow" /><ChangedMark /></div>}
+      <CodeEditor value={form.prompt} onChange={v => set('prompt', v)} readOnly={readOnly} changed={changed} />
+      <div className="cp-codefoot"><span className="grow" /><CharCounter value={form.prompt.length} max={4000} /></div>
+      {!readOnly && <div className="cp-tip"><span className="ti" aria-hidden="true">💡</span><span className="tt">Variabili: <code>{'{game}'}</code> <code>{'{player}'}</code> <code>{'{turn}'}</code> <code>{'{rules_kb}'}</code>. Sostituite a runtime.</span></div>}
+    </>
+  );
+}
+
+/* ─── Section 4: Test config (riuso S3) ─── */
+function TestConfigSection({ form, set, readOnly }) {
+  const addSample = () => { if (readOnly || form.samples.length >= 3) return; set('samples', [...form.samples, { in: '', out: '' }]); };
+  const delSample = i => { if (readOnly) return; set('samples', form.samples.filter((_, x) => x !== i)); };
+  const editSample = (i, k, v) => { if (readOnly) return; set('samples', form.samples.map((s, x) => x === i ? { ...s, [k]: v } : s)); };
+  return (
+    <>
+      <div className="cp-samples">
+        {form.samples.map((s, i) => (
+          <div className="cp-sample" key={i}>
+            <div className="shead"><span className="sidx">Esempio {i + 1}</span>
+              {!readOnly && <button type="button" className="sdel" aria-label={'Elimina esempio ' + (i + 1)} onClick={() => delSample(i)}>🗑</button>}</div>
+            <div className="sgrid">
+              <div className="scol"><div className="sl">Input utente</div>
+                <AutoTextarea value={s.in} minH={62} readOnly={readOnly} placeholder="es. Quante carte si pescano in setup?" onChange={v => editSample(i, 'in', v)} /></div>
+              <div className="scol"><div className="sl">Output atteso</div>
+                <AutoTextarea value={s.out} minH={62} readOnly={readOnly} placeholder="es. In Catan classico ogni giocatore parte con 2 insediamenti…" onChange={v => editSample(i, 'out', v)} /></div>
+            </div>
+          </div>
+        ))}
+        {!readOnly && (
+          <button type="button" className="cp-addbtn" disabled={form.samples.length >= 3} onClick={addSample}>
+            <span aria-hidden="true">＋</span> Aggiungi esempio {form.samples.length > 0 && `(${form.samples.length}/3)`}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+/* ─── Section 5: Game scope (riuso S3) ─── */
+function GameScopeSection({ form, set, readOnly, changed }) {
+  const [q, setQ] = useState('');
+  const selected = form.scope.map(gameById).filter(Boolean);
+  const suggestions = GAMES.filter(g => !q || g.title.toLowerCase().includes(q.toLowerCase()));
+  const toggleGame = id => { if (readOnly) return; set('scope', form.scope.includes(id) ? form.scope.filter(s => s !== id) : [...form.scope, id]); };
+  return (
+    <>
+      {!readOnly && (
+        <div className="cp-scopsearch">
+          <div className="cp-inwrap">
+            <span style={{ position: 'absolute', left: 11, top: '50%', transform: 'translateY(-50%)', opacity: .6, fontSize: 13, pointerEvents: 'none' }} aria-hidden="true">🔍</span>
+            <input className="cp-input" style={{ paddingLeft: 32 }} value={q}
+              placeholder="Cerca un gioco per nome…" aria-label="Cerca gioco" onChange={e => setQ(e.target.value)} />
+          </div>
+          {q && (
+            <div className="cp-scopsuggest" role="listbox" aria-label="Giochi suggeriti">
+              {suggestions.length === 0 && <div className="cp-sugg" aria-disabled="true"><span className="sm"><span className="gd">Nessun gioco trovato per “{q}”</span></span></div>}
+              {suggestions.slice(0, 5).map(g => {
+                const sel = form.scope.includes(g.id);
+                return (
+                  <button key={g.id} type="button" role="option" aria-selected={sel} className={'cp-sugg' + (sel ? ' sel' : '')} onClick={() => toggleGame(g.id)}>
+                    <span className="th" style={{ background: g.cover }} aria-hidden="true">{g.coverEmoji}</span>
+                    <span className="sm"><span className="gn">{g.title}</span><span className="gd">{g.author} · {g.year}</span></span>
+                    <span className="add">{sel ? '✓ Aggiunto' : '+ Aggiungi'}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+      {changed && !readOnly && <div className="cp-label" style={{ margin: '4px 0 0' }}><span className="grow" /><ChangedMark /></div>}
+      {selected.length > 0 && (
+        <div className="cp-scochips" aria-label="Giochi in scope">
+          {selected.map(g => (
+            <span className="cp-gchip" key={g.id}><span className="ge" aria-hidden="true">🎲</span>{g.title}
+              {!readOnly && <button type="button" className="gx" aria-label={'Rimuovi ' + g.title} onClick={() => toggleGame(g.id)}>✕</button>}</span>
+          ))}
+        </div>
+      )}
+      <div className="cp-scopsum">
+        <span className="pin" aria-hidden="true">📍</span>
+        {selected.length === 0 ? 'Scope: tutti i giochi (broad)' : `Scope: ${selected.length} ${selected.length === 1 ? 'gioco' : 'giochi'} (${selected.map(g => g.title).join(', ')})`}
+      </div>
+    </>
+  );
+}
+
+/* ─── Section 6: Revisions diff ─── */
+function DiffRow({ rev, onGoto }) {
+  return (
+    <div className="ce-diff" role="group" aria-label={'Diff ' + rev.field}>
+      <div className="ce-diffhead">
+        <span className="df">{rev.field}</span>
+        <span className="dref">→ Sezione {rev.section}</span>
+        <span className="grow" />
+        <button className="goto" onClick={() => onGoto(rev.sectionId)}>Vai alla sezione ↗</button>
+      </div>
+      <div className="ce-diffbody">
+        {rev.lines.map((l, i) => (
+          <div className={'ce-dline ' + l[0]} key={i}>
+            <span className="pfx" aria-hidden="true">{l[0] === 'add' ? '+' : l[0] === 'del' ? '−' : ' '}</span>
+            <span>{l[1]}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RevisionsSection({ onGoto, diffInline, setDiffInline }) {
+  return (
+    <div role="region" aria-label="Differenze rispetto a versione approvata">
+      <div className="ce-comparebar">
+        <span className="cl">Confronto</span>
+        <button className="ce-cmpsel">v3 <span className="vv">bozza</span> <span className="car">▾</span></button>
+        <span className="ce-cmparrow" aria-hidden="true">vs</span>
+        <button className="ce-cmpsel">v2 <span className="vv">approvata 28 mag</span> <span className="car">▾</span></button>
+      </div>
+      <div className="ce-difflist">
+        {REVISIONS.map(rev => <DiffRow key={rev.id} rev={rev} onGoto={onGoto} />)}
+      </div>
+      <div className="ce-diffsum">
+        <span aria-hidden="true">📊</span>
+        <span><b>3 modifiche:</b> 2 in System prompt, 1 in Scope giochi. Capabilities invariate.</span>
+      </div>
+      <div className="ce-difftoggle">
+        <div className="dtt">
+          <div className="dtl">Mostra modifiche inline</div>
+          <div className="dts">Evidenzia i campi cambiati direttamente nelle sezioni del form</div>
+        </div>
+        <button className={'ce-switch' + (diffInline ? ' on' : '')} role="switch" aria-checked={diffInline} aria-label="Mostra modifiche inline" onClick={() => setDiffInline(v => !v)} />
+      </div>
+    </div>
+  );
+}
+
+/* ─── Section 7: Audit trail ─── */
+const AUDIT_ICON = { created: '🟢', submit: '🔵', review: '🟡', approved: '✅', rejected: '❌', edited: '✏️' };
+function AuditEvent({ ev }) {
+  return (
+    <li className="ce-event">
+      <div className="ce-evcol">
+        <span className={'ce-evdot ' + ev.type} aria-label={ev.label}>{AUDIT_ICON[ev.type]}</span>
+        <span className="ce-evline" aria-hidden="true" />
+      </div>
+      <div className="ce-evbody">
+        <div className="ce-evtop">
+          <span className="ce-evlabel">{ev.label}</span>
+          <time className="ce-evwhen" dateTime={ev.iso} title={ev.iso.replace('T', ' ')}>{ev.ago}</time>
+        </div>
+        <div className="ce-evmeta">
+          <AuthorChip who={ev.who} admin={ev.admin} />
+        </div>
+        {ev.reason && (
+          <div className="ce-evreason"><b>Motivo:</b> “{ev.reason}” <a tabIndex={0} role="button">Vedi</a></div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function AuditTrailSection() {
+  return (
+    <ol className="ce-timeline" role="list" aria-label="Storico azioni">
+      {AUDIT.map(ev => <AuditEvent key={ev.id} ev={ev} />)}
+    </ol>
+  );
+}
+
+/* ─── Status banner ─── */
+function StatusBanner({ status, stats, onGoto }) {
+  const [open, setOpen] = useState(true);
+  const toggle = (
+    <button className="ce-bantoggle" aria-expanded={open} aria-label={open ? 'Riduci banner' : 'Espandi banner'}
+      title={open ? 'Riduci' : 'Espandi'} onClick={() => setOpen(o => !o)}>
+      <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+    </button>
+  );
+
+  if (status === 'Rejected') {
+    return (
+      <div className={'ce-banner rejected' + (open ? '' : ' collapsed')} role="alert" aria-labelledby="rej-t">
+        <div className="bhead">
+          <span className="bic" aria-hidden="true">⚠️</span>
+          <span className="bt" id="rej-t">Feedback admin</span>
+          <span className="bwhen">· {REJECT_FEEDBACK.ago}</span>
+          {!open && <span className="bpeek">2 sezioni da rivedere</span>}
+          {toggle}
+        </div>
+        {open && (
+          <>
+            <div className="bbody">{REJECT_FEEDBACK.body}</div>
+            <div className="bsections">
+              <span className="bsec-lab">Sezioni da rivedere</span>
+              {REJECT_FEEDBACK.sections.map(([label, n, id]) => (
+                <button key={id} className="ce-secchip" onClick={() => onGoto(id)}>{label} ({n})</button>
+              ))}
+            </div>
+            <div className="bacts">
+              <button className="cp-btn ghost"><span className="ic" aria-hidden="true">👁</span> Vedi feedback completo</button>
+              <button className="cp-btn toolkit-out"><span className="ic" aria-hidden="true">✓</span> Marca come risolto</button>
+              <button className="cp-btn primary"><span className="ic" aria-hidden="true">↻</span> Riinvia per review</button>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+  if (status === 'PendingReview') {
+    return (
+      <div className={'ce-banner review' + (open ? '' : ' collapsed')} role="status">
+        <div className="bhead">
+          <span className="bic" aria-hidden="true">⏳</span>
+          <span className="bt">In review da 3 giorni</span>
+          <span className="bwhen">· Sottomesso il 30 mag 2026</span>
+          {toggle}
+        </div>
+        {open && (
+          <>
+            <div className="bbody">La proposal è <b>bloccata</b> fino al verdetto admin. Non è modificabile in questo stato.</div>
+            <div className="bacts">
+              <button className="cp-btn warn-out"><span className="ic" aria-hidden="true">↩</span> Ritira dalla review</button>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+  if (status === 'Approved') {
+    return (
+      <div className={'ce-banner approved' + (open ? '' : ' collapsed')} role="status">
+        <div className="bhead">
+          <span className="bic" aria-hidden="true">✓</span>
+          <span className="bt">Approvata il 28 mag 2026 da Admin</span>
+          <span className="bwhen">· Live da 5 giorni</span>
+          {toggle}
+        </div>
+        {open && (
+          <>
+            <div className="bbody">Questa versione è <b>attiva in produzione</b>. Per modificarla crea una nuova versione (clone in nuovo Draft).</div>
+            {stats && (
+              <div className="bstats">
+                <span className="bstat"><span aria-hidden="true">🎯</span> <b>234</b> conversazioni</span>
+                <span className="bstat"><span aria-hidden="true">👍</span> <b>92%</b> feedback positivo</span>
+                <span className="bstat"><span aria-hidden="true">⚡</span> <b>0.9s</b> latenza media</span>
+              </div>
+            )}
+            <div className="bacts">
+              <button className="cp-btn primary"><span className="ic" aria-hidden="true">⎘</span> Crea versione successiva</button>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+  return null;
+}
+
+/* ─── Modals ─── */
+function SubmitUpdateModal({ form, onClose, onConfirm }) {
+  const scope = form.scope.map(gameById).filter(Boolean);
+  return (
+    <div className="cp-modal-bd" role="dialog" aria-modal="true" aria-labelledby="sub-modal-t" onClick={onClose}>
+      <div className="cp-modal" onClick={e => e.stopPropagation()}>
+        <div className="mhead"><span className="mi agent" aria-hidden="true">↻</span><h3 id="sub-modal-t">Conferma reinvio per review</h3></div>
+        <div className="mbody">
+          La versione aggiornata verrà reinviata al team di review. Verranno incluse le modifiche fatte dopo il feedback del <b>{REJECT_FEEDBACK.ago}</b>.
+          <div className="msummary">
+            <div className="msrow"><span className="k">Modifiche</span><span className="vv add">3 campi cambiati vs v2</span></div>
+            <div className="msrow"><span className="k">System prompt</span><span className="vv">Generalizzato per euro-game</span></div>
+            <div className="msrow"><span className="k">Scope</span><span className="vv">{scope.map(g => g.title).join(', ')} (ristretto)</span></div>
+            <div className="msrow"><span className="k">Feedback</span><span className="vv add">2 sezioni risolte</span></div>
+          </div>
+        </div>
+        <div className="mfoot"><button className="cp-btn ghost" onClick={onClose}>Annulla</button><span className="grow" /><button className="cp-btn primary" onClick={onConfirm}><span className="ic" aria-hidden="true">↻</span> Conferma e reinvia</button></div>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmCancelModal({ onClose, onConfirm }) {
+  return (
+    <div className="cp-modal-bd" role="dialog" aria-modal="true" aria-labelledby="cnc-t" onClick={onClose}>
+      <div className="cp-modal" onClick={e => e.stopPropagation()}>
+        <div className="mhead"><span className="mi warn" aria-hidden="true">⚠️</span><h3 id="cnc-t">Annullare le modifiche?</h3></div>
+        <div className="mbody">Le modifiche non salvate andranno perse. Vuoi davvero uscire senza salvare?</div>
+        <div className="mfoot"><button className="cp-btn ghost" onClick={onClose}>Continua a modificare</button><span className="grow" /><button className="cp-btn danger" onClick={onConfirm}>Esci senza salvare</button></div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   EditApp — un'istanza per (state × viewport). Remount via key.
+   ────────────────────────────────────────────────────────── */
+function EditApp({ stateId, mobile }) {
+  const sc = SCENARIOS[stateId];
+  const status = sc.status;
+  const readOnly = status === 'PendingReview' || status === 'Approved';
+  const [form, setForm] = useState(BASE_FORM);
+  const [open, setOpen] = useState(() => new Set(sc.open));
+  const [savePill] = useState(sc.savePill);
+  const [diffInline, setDiffInline] = useState(!!sc.ui.diffInline);
+  const [submitModal, setSubmitModal] = useState(!!sc.ui.modal);
+  const [cancelModal, setCancelModal] = useState(false);
+  const bodyRef = useRef(null);
+  const sectionRefs = useRef({});
+
+  const addressed = sc.addressed || [];
+  const affectedSet = new Set(REJECT_FEEDBACK.sections.map(s => s[2])); // prompt, scope
+  const showStats = !!sc.ui.stats;
+  const showInlineMarkers = diffInline || addressed.length > 0;
+
+  const set = useCallback((key, val) => { if (readOnly) return; setForm(f => ({ ...f, [key]: val })); }, [readOnly]);
+  const toggle = id => setOpen(o => { const n = new Set(o); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  const gotoSection = useCallback(id => {
+    const num = { identity: 1, caps: 2, prompt: 3, test: 4, scope: 5, revisions: 6, audit: 7 }[id];
+    if (!num) return;
+    setOpen(o => { const n = new Set(o); n.add(num); return n; });
+    requestAnimationFrame(() => {
+      const el = sectionRefs.current[num];
+      if (el && bodyRef.current) bodyRef.current.scrollTo({ top: el.offsetTop - 12, behavior: 'smooth' });
+    });
+  }, []);
+
+  // section flags
+  const isAffected = id => status === 'Rejected' && affectedSet.has(id) && !addressed.includes(id);
+  const isResolved = id => status === 'Rejected' && addressed.includes(id);
+  const isChanged = id => showInlineMarkers && affectedSet.has(id) && (diffInline || addressed.includes(id)) && !readOnly;
+
+  const sections = [
+    { num: 1, id: 'identity', title: 'Identità', subtitle: 'Nome, descrizione, icona e colore',
+      body: <IdentitySection form={form} set={set} readOnly={readOnly} uniqueStatus="ok" /> },
+    { num: 2, id: 'caps', title: 'Capabilities', subtitle: 'Cosa sa fare l\u2019agente',
+      body: <CapabilitiesSection form={form} set={set} readOnly={readOnly} /> },
+    { num: 3, id: 'prompt', title: 'System prompt', subtitle: 'Le istruzioni che guidano l\u2019agente',
+      body: <SystemPromptSection form={form} set={set} readOnly={readOnly} changed={isChanged('prompt')} /> },
+    { num: 4, id: 'test', title: 'Configurazione test', subtitle: 'Esempi input/output per il playground',
+      body: <TestConfigSection form={form} set={set} readOnly={readOnly} /> },
+    { num: 5, id: 'scope', title: 'Scope giochi', subtitle: 'A quali giochi si applica',
+      body: <GameScopeSection form={form} set={set} readOnly={readOnly} changed={isChanged('scope')} /> },
+  ];
+
+  // keyboard shortcuts
+  useEffect(() => {
+    const h = e => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') { e.preventDefault(); }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && (status === 'Draft' || status === 'Rejected')) { e.preventDefault(); setSubmitModal(true); }
+      if (e.key === 'Escape') { setSubmitModal(false); setCancelModal(false); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [status]);
+
+  const m = STATUS_META[status];
+
+  /* footer CTAs per status */
+  let footerCtas;
+  if (status === 'Draft') {
+    footerCtas = <>
+      <button className="cp-btn link" onClick={() => setCancelModal(true)}>Annulla</button>
+      <span className="grow" />
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">💾</span> Salva bozza</button>
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">👁</span> Anteprima</button>
+      <button className="cp-btn primary" onClick={() => setSubmitModal(true)}><span className="ic" aria-hidden="true">⬆</span> Invia per review</button>
+    </>;
+  } else if (status === 'Rejected') {
+    footerCtas = <>
+      <button className="cp-btn link" onClick={() => setCancelModal(true)}>Annulla modifiche</button>
+      <span className="grow" />
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">💾</span> Salva bozza</button>
+      <button className="cp-btn warn-out"><span className="ic" aria-hidden="true">⇄</span> Confronta con feedback</button>
+      <button className="cp-btn primary" onClick={() => setSubmitModal(true)}><span className="ic" aria-hidden="true">↻</span> Riinvia per review</button>
+    </>;
+  } else if (status === 'PendingReview') {
+    footerCtas = <>
+      <span className="grow" />
+      <button className="cp-btn toolkit-out"><span className="ic" aria-hidden="true">↗</span> Visualizza in production</button>
+      <button className="cp-btn warn"><span className="ic" aria-hidden="true">↩</span> Annulla invio (ritira)</button>
+    </>;
+  } else { // Approved
+    footerCtas = <>
+      <span className="grow" />
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">⇄</span> Diff vs versione precedente</button>
+      <button className="cp-btn info-out"><span className="ic" aria-hidden="true">📊</span> Stats production</button>
+      <button className="cp-btn primary"><span className="ic" aria-hidden="true">⎘</span> Crea versione successiva</button>
+    </>;
+  }
+
+  /* header CTAs per status */
+  let headerCtas;
+  if (status === 'Draft') {
+    headerCtas = <>
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">💾</span> Salva bozza</button>
+      <button className="cp-btn primary" onClick={() => setSubmitModal(true)}><span className="ic" aria-hidden="true">⬆</span> Invia per review</button>
+    </>;
+  } else if (status === 'Rejected') {
+    headerCtas = <>
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">💾</span> Salva bozza</button>
+      <button className="cp-btn primary" onClick={() => setSubmitModal(true)}><span className="ic" aria-hidden="true">↻</span> Riinvia per review</button>
+    </>;
+  } else if (status === 'PendingReview') {
+    headerCtas = <button className="cp-btn warn-out"><span className="ic" aria-hidden="true">↩</span> Annulla invio (ritira)</button>;
+  } else {
+    headerCtas = <>
+      <button className="cp-btn ghost"><span className="ic" aria-hidden="true">⇄</span> Visualizza diff</button>
+      <button className="cp-btn primary"><span className="ic" aria-hidden="true">⎘</span> Crea versione successiva</button>
+    </>;
+  }
+
+  const pillEl = (
+    <span className={'cp-pill ' + savePill} aria-live="polite">
+      <span className="dot" aria-hidden="true" />
+      {savePill === 'unsaved' && 'Modifiche non salvate'}
+      {savePill === 'saved' && '💾 Bozza salvata 2m fa'}
+      {savePill === 'readonly' && '🔒 Read-only'}
+      {savePill === 'dirty' && '● Modifiche dopo feedback'}
+    </span>
+  );
+
+  return (
+    <div className={'cp-app' + (mobile ? ' is-mobile' : '')}>
+      <header className="cp-head">
+        <div className="hrow">
+          <div className="htxt">
+            <div className="cp-bread"><span>Editor</span><span className="sep">›</span><span>Agent proposals</span><span className="sep">›</span><span className="cur">{form.name}</span></div>
+            <div className="ce-titlerow">
+              <h1 className="cp-h1">{form.icon} {form.name}</h1>
+              <span className={'ce-badge ' + m.cls} aria-label={'Stato: ' + m.label}><span className="bi" aria-hidden="true">{m.icon}</span>{m.label}</span>
+              {status === 'Approved' && <span className="ce-live"><i />Live</span>}
+            </div>
+            <div className="cp-sub">Versione {META.version} · Creata {META.createdAgo} da <b>{AUTHOR.name}</b> · Ultima modifica {META.modAgo}</div>
+            <div className="ce-metarow">
+              <span className="ce-idchip">ID: {META.id}<button className="copy" aria-label="Copia ID" title="Copia ID">⧉</button></span>
+              <AuthorChip who={AUTHOR} />
+            </div>
+          </div>
+          <span className="grow" />
+          <div className="cp-headcta">{headerCtas}</div>
+        </div>
+      </header>
+
+      {status !== 'Draft' && (
+        <div className="ce-banwrap"><div className="inner"><StatusBanner status={status} stats={showStats} onGoto={gotoSection} /></div></div>
+      )}
+
+      <div className="cp-body" ref={bodyRef}>
+        <form className="cp-form" aria-label="Form modifica typology proposal" aria-readonly={readOnly} onSubmit={e => e.preventDefault()}>
+          {sections.map(s => (
+            <div key={s.id} ref={el => { sectionRefs.current[s.num] = el; }}>
+              <SectionCard num={s.num} id={s.id} title={s.title} subtitle={s.subtitle}
+                locked={readOnly} affected={isAffected(s.id)} resolved={isResolved(s.id)} changed={isChanged(s.id)}
+                status="optional" statusCount={0}
+                open={open.has(s.num)} onToggle={() => toggle(s.num)}>
+                {s.body}
+              </SectionCard>
+            </div>
+          ))}
+
+          {/* Sezione 6 — Revisions diff */}
+          <div ref={el => { sectionRefs.current[6] = el; }}>
+            <SectionCard num={6} id="revisions" title="Revisions" subtitle="Differenze rispetto alla versione approvata in produzione"
+              statusCount="3 modifiche" open={open.has(6)} onToggle={() => toggle(6)}>
+              <RevisionsSection onGoto={gotoSection} diffInline={diffInline} setDiffInline={setDiffInline} />
+            </SectionCard>
+          </div>
+
+          {/* Sezione 7 — Audit trail */}
+          <div ref={el => { sectionRefs.current[7] = el; }}>
+            <SectionCard num={7} id="audit" title="Storico azioni" subtitle="Log delle azioni e decisioni"
+              statusCount={AUDIT.length + ' eventi'} open={open.has(7)} onToggle={() => toggle(7)}>
+              <AuditTrailSection />
+            </SectionCard>
+          </div>
+        </form>
+      </div>
+
+      <div className="cp-savebar"><div className="inner">{pillEl}</div></div>
+
+      <footer className="cp-foot">
+        <div className="frow">{footerCtas}</div>
+      </footer>
+
+      {submitModal && <SubmitUpdateModal form={form} onClose={() => setSubmitModal(false)} onConfirm={() => setSubmitModal(false)} />}
+      {cancelModal && <ConfirmCancelModal onClose={() => setCancelModal(false)} onConfirm={() => setCancelModal(false)} />}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   Harness — continuity con S1/S2/S3
+   ────────────────────────────────────────────────────────── */
+function Harness() {
+  const [stateId, setStateId] = useState(() => localStorage.getItem('ce-state') || 'rejected-fresh');
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || 'light');
+
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem('ce-state', stateId); }, [stateId]);
+
+  return (
+    <div className="ed-stage">
+      <style dangerouslySetInnerHTML={{ __html: CE_CSS }} />
+      <button className="theme-toggle" onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>🌗 <span>{theme === 'dark' ? 'Dark' : 'Light'}</span></button>
+
+      <div className="ed-wrap">
+        <div className="ed-kicker">SP4 · B14 · #1489 — schermata 4 / 5 · edit typology proposal</div>
+        <h1>Edit <span className="acc">proposal</span> — /editor/agent-proposals/[id]/edit</h1>
+        <p className="ed-lead">
+          Form di modifica di una <b>typology proposal</b> esistente, con <b>comportamento variabile per status</b>:
+          <b> Draft</b> editable, <b>PendingReview</b> e <b>Approved</b> in read-only (lock), <b>Rejected</b> con alert feedback
+          e campi editabili per la risottomissione. Riusa le 5 sezioni di S3 e aggiunge <b>Revisions diff</b> (6) e
+          <b> Audit trail</b> (7). Entity primaria <code>--c-agent</code>, autore via EntityChip <code>--c-player</code>.
+        </p>
+
+        <div className="ed-notes">
+          <div className="ed-note">
+            <h4>Status variants</h4>
+            <p><b>Draft</b> tutto editable · <b>Pending</b> banner giallo + lock · <b>Approved</b> banner verde + Live + lock · <b>Rejected</b> alert rosso + campi editabili + marker “modifiche dopo feedback”.</p>
+          </div>
+          <div className="ed-note">
+            <h4>10 stati · 7 sezioni</h4>
+            <p>Selettore qui sotto. Sezioni 1-5 riusate da S3, <b>6 Revisions</b> (diff inline +/−) e <b>7 Audit trail</b> (timeline 8 eventi entity-colored). Save pill <code>aria-live</code> per status.</p>
+          </div>
+          <div className="ed-note">
+            <h4>Mobile & a11y</h4>
+            <p>Mobile = sezioni full-width, banner full-width, timeline compatta. <code>role=alert/status</code> sui banner, <code>aria-readonly</code> sul form lock, <code>role=list</code> sull’audit, <code>Ctrl+S</code> / <code>Ctrl+Enter</code> / <code>Esc</code>.</p>
+          </div>
+        </div>
+
+        <div className="ed-rail">
+          <span className="lab">Stato</span>
+          <div className="ed-states" role="group" aria-label="Selettore stato schermata">
+            {STATE_LIST.map(([id, label]) => (
+              <button key={id} className={'ed-sbtn' + (stateId === id ? ' on' : '')} aria-pressed={stateId === id} onClick={() => setStateId(id)}>
+                <span className="pip" />{label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Desktop · 1440 — form + status banner + revisions/audit</div>
+        <div className="ed-desk">
+          <div className="ed-chrome">
+            <div className="dots"><i /><i /><i /></div>
+            <div className="url">meepleai.app/editor/agent-proposals/{META.id}/edit</div>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <EditApp key={'d-' + stateId} stateId={stateId} mobile={false} />
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Mobile · 375 — sezioni stack, banner full-width</div>
+        <div className="ed-phone-row">
+          <div className="phone">
+            <div className="phone-sbar"><span>9:41</span><span className="ind">●●● 5G ▮</span></div>
+            <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+              <EditApp key={'m-' + stateId} stateId={stateId} mobile={true} />
+            </div>
+          </div>
+          <div className="ed-phone-cap">
+            <h4>Layout mobile</h4>
+            <p>Le sezioni vanno a <b>full-width</b>, lo status banner occupa tutta la larghezza, header CTA collassano nel <b>footer sticky</b>. La timeline audit resta verticale ma compatta; il diff scrolla in orizzontale dentro la card.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Harness />);

--- a/admin-mockups/design_files/sp4-editor-proposals-index.html
+++ b/admin-mockups/design_files/sp4-editor-proposals-index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · B14 editor · #2/5 · Typology proposals — /editor/agent-proposals</title>
+<!-- route: /editor/agent-proposals — Typology proposals list con filtri e badges -->
+<!--
+  @route /editor/agent-proposals
+  @brief B14 (issue #1489) — Editor user-facing (agent proposals)
+  @screen 2 of 5 — sp4-editor-proposals-index
+  @tier S
+  @pattern Hero+body con tabella filtrabile (list view + filtri + search) · cards stack mobile
+  @states default · empty-all · loading · error · filter-search · filter-status · filter-empty · rejected-row-expanded · mobile-cards
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-editor-proposals-index.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-editor-proposals-index.jsx
+++ b/admin-mockups/design_files/sp4-editor-proposals-index.jsx
@@ -1,0 +1,780 @@
+/* sp4-editor-proposals-index.jsx
+   Route: /editor/agent-proposals — Typology proposals list (filtri + status badges)
+   B14 (issue #1489) · screen 2 of 5 · Tier S
+   Pattern: Hero + body con tabella filtrabile (list view come sp4-library-desktop) +
+            status badges (pattern sp4-toolkit-detail). Desktop = table, mobile = cards stack.
+   Continuity con sp4-editor-index (S1): stesso state-picker UI, theme toggle 🌗 (mai-theme),
+   desktop frame chrome (.ed-desk) e phone-row pattern. Entity primaria = --c-agent (typology).
+   Loadable standalone via Babel. Injects own component CSS; relies on tokens.css + components.css.
+
+   v2 components surfaced here (annotate at implementation time):
+   /* v2: ProposalsList, ProposalsTable, ProposalsTableRow, ProposalsCards, ProposalsFilters,
+          ProposalsSearchBox, StatusFilterChips, StatusBadge, CapabilityStrip, GameScopePip,
+          AuthorChip, RejectionReasonAlert, ProposalActions, ProposalsEmpty, ProposalsSkeleton */
+
+const { useState, useEffect, useMemo, useRef } = React;
+
+/* ──────────────────────────────────────────────────────────
+   Component CSS — solo token da tokens.css / components.css.
+   .ed-* = harness chrome riusato da S1 (continuity). .pr-* = proposals.
+   ────────────────────────────────────────────────────────── */
+const PROP_CSS = `
+/* ─── harness (riuso esatto da sp4-editor-index S1) ─── */
+.ed-stage { min-height:100vh; padding:72px 24px 96px; background:var(--bg); color:var(--text); }
+.ed-wrap { max-width:1380px; margin:0 auto; }
+.ed-kicker { font-family:var(--f-mono); font-size:var(--fs-xs); letter-spacing:.1em; text-transform:uppercase; color:var(--text-muted); }
+.ed-stage h1 { font-size:var(--fs-3xl); margin:8px 0 6px; }
+.ed-stage h1 .acc { color:hsl(var(--c-agent)); }
+.ed-lead { color:var(--text-sec); font-size:var(--fs-md); max-width:820px; line-height:var(--lh-body); }
+.ed-notes { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:22px 0 4px; }
+.ed-note { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:14px 16px; }
+.ed-note h4 { font-family:var(--f-display); font-size:var(--fs-sm); text-transform:uppercase; letter-spacing:.04em; color:hsl(var(--c-agent)); margin-bottom:6px; }
+.ed-note p { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.ed-note p b { color:var(--text); font-weight:var(--fw-bold); }
+.ed-note code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:11px; }
+.ed-rail { position:sticky; top:0; z-index:var(--z-sticky); margin:26px 0 18px; padding:12px 0;
+  background:var(--bg); display:flex; align-items:flex-start; gap:14px; flex-wrap:wrap; border-bottom:1px solid var(--border); }
+.ed-rail .lab { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); padding-top:8px; }
+.ed-states { display:flex; gap:6px; flex-wrap:wrap; flex:1; }
+.ed-sbtn { display:inline-flex; align-items:center; gap:7px; padding:7px 12px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-sbtn:hover { transform:translateY(-1px); border-color:var(--border-strong); }
+.ed-sbtn .pip { width:7px; height:7px; border-radius:50%; background:currentColor; opacity:.6; }
+.ed-sbtn.on { background:hsl(var(--c-agent)); border-color:transparent; color:#fff; }
+.ed-sbtn.on .pip { opacity:1; background:#fff; }
+.ed-vp-label { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em;
+  color:var(--text-muted); margin:30px 0 12px; display:flex; align-items:center; gap:10px; }
+.ed-vp-label::after { content:''; flex:1; height:1px; background:var(--border); }
+.ed-desk { width:100%; max-width:1340px; height:792px; border-radius:var(--r-lg); overflow:hidden;
+  background:var(--bg-card); border:1px solid var(--border); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; }
+.ed-chrome { height:38px; flex-shrink:0; display:flex; align-items:center; gap:8px; padding:0 14px;
+  background:var(--bg-muted); border-bottom:1px solid var(--border); font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ed-chrome .dots { display:flex; gap:6px; }
+.ed-chrome .dots i { width:11px; height:11px; border-radius:50%; display:block; }
+.ed-chrome .dots i:nth-child(1){ background:#ff5f57; } .ed-chrome .dots i:nth-child(2){ background:#febc2e; } .ed-chrome .dots i:nth-child(3){ background:#28c840; }
+.ed-chrome .url { flex:1; text-align:center; background:var(--bg-card); border-radius:var(--r-sm); padding:4px 10px; margin:0 14%; }
+.ed-phone-row { display:flex; gap:28px; align-items:flex-start; flex-wrap:wrap; }
+.ed-phone-cap { font-size:var(--fs-sm); color:var(--text-sec); max-width:300px; line-height:var(--lh-snug); }
+.ed-phone-cap h4 { font-family:var(--f-display); font-size:var(--fs-base); margin-bottom:6px; }
+
+/* ─── proposals app shell ─── */
+.pr-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+.pr-app :focus-visible { outline:2px solid hsl(var(--c-agent)); outline-offset:2px; border-radius:var(--r-xs); }
+
+/* error banner (top) */
+.pr-errbar { flex-shrink:0; display:flex; align-items:center; gap:11px; padding:11px 18px; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:hsl(var(--c-danger) / .14); color:hsl(var(--c-danger)); border-bottom:1px solid hsl(var(--c-danger) / .3); }
+.pr-errbar .grow { flex:1; }
+.pr-errbar .retry { display:inline-flex; align-items:center; gap:6px; padding:5px 12px; border-radius:var(--r-md); border:1px solid hsl(var(--c-danger) / .4);
+  background:var(--bg-card); color:hsl(var(--c-danger)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; }
+
+/* header (sticky) */
+.pr-head { flex-shrink:0; position:sticky; top:0; z-index:var(--z-sticky); background:var(--bg-card); border-bottom:1px solid var(--border);
+  display:flex; align-items:flex-end; gap:16px; padding:14px 22px 16px; }
+.pr-head .htxt { min-width:0; }
+.pr-bread { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:6px; }
+.pr-bread .sep { opacity:.5; }
+.pr-bread .cur { color:hsl(var(--c-agent)); }
+.pr-h1 { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-2xl); letter-spacing:-.01em; line-height:var(--lh-tight); }
+.pr-sub { font-size:var(--fs-base); color:var(--text-sec); margin-top:4px; }
+.pr-head .grow { flex:1; }
+.pr-newbtn { flex-shrink:0; display:inline-flex; align-items:center; gap:7px; padding:9px 16px; border-radius:var(--r-md); border:none;
+  background:hsl(var(--c-agent)); color:#3a2400; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  box-shadow:var(--shadow-xs); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); white-space:nowrap; }
+.pr-newbtn:hover { transform:translateY(-1px); box-shadow:var(--shadow-sm); filter:brightness(1.03); }
+.pr-newbtn .ic { font-size:14px; line-height:1; }
+
+/* toolbar */
+.pr-toolbar { flex-shrink:0; display:flex; align-items:center; gap:12px; padding:11px 22px; background:var(--bg); border-bottom:1px solid var(--border); }
+.pr-search { flex:0 0 38%; max-width:38%; position:relative; }
+.pr-search .ic { position:absolute; left:11px; top:50%; transform:translateY(-50%); font-size:13px; opacity:.6; pointer-events:none; }
+.pr-search input { width:100%; padding:8px 64px 8px 32px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:var(--fs-sm); color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.pr-search input:focus, .pr-search.active input { border-color:hsl(var(--c-agent) / .55); box-shadow:0 0 0 3px hsl(var(--c-agent) / .14); }
+.pr-search .clear { position:absolute; right:9px; top:50%; transform:translateY(-50%); width:20px; height:20px; border-radius:var(--r-pill);
+  border:none; background:var(--bg-muted); color:var(--text-sec); cursor:pointer; font-size:12px; display:inline-flex; align-items:center; justify-content:center; }
+.pr-search .clear:hover { background:var(--border-strong); color:var(--text); }
+.pr-search .busy { position:absolute; right:34px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; gap:5px;
+  font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-info)); white-space:nowrap; }
+.pr-search .busy i { width:6px; height:6px; border-radius:50%; background:currentColor; animation:prpulse 1s var(--ease-in-out) infinite; }
+@keyframes prpulse { 0%,100%{ opacity:1; transform:scale(1);} 50%{ opacity:.3; transform:scale(.6);} }
+
+.pr-chips { flex:1; display:flex; align-items:center; gap:7px; overflow-x:auto; scrollbar-width:none; padding:2px; }
+.pr-chips::-webkit-scrollbar { display:none; }
+.pr-chip { display:inline-flex; align-items:center; gap:7px; padding:6px 12px; border-radius:var(--r-pill); white-space:nowrap;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.pr-chip:hover { background:var(--bg-hover); }
+.pr-chip .cdot { width:8px; height:8px; border-radius:50%; flex-shrink:0; }
+.pr-chip .ccount { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.pr-chip.all .cdot { background:var(--text-muted); }
+.pr-chip[data-st="Draft"] .cdot { background:var(--text-muted); }
+.pr-chip[data-st="PendingReview"] .cdot { background:hsl(var(--c-warning)); }
+.pr-chip[data-st="Approved"] .cdot { background:hsl(var(--c-toolkit)); }
+.pr-chip[data-st="Rejected"] .cdot { background:hsl(var(--c-danger)); }
+.pr-chip.on { color:var(--text); background:var(--bg-muted); border-color:var(--border-strong); }
+.pr-chip.on .ccount { color:var(--text-sec); }
+.pr-chip[data-st="PendingReview"].on { background:hsl(var(--c-warning) / .14); border-color:hsl(var(--c-warning) / .4); color:hsl(var(--c-warning)); }
+.pr-chip[data-st="Approved"].on { background:hsl(var(--c-toolkit) / .14); border-color:hsl(var(--c-toolkit) / .4); color:hsl(var(--c-toolkit)); }
+.pr-chip[data-st="Rejected"].on { background:hsl(var(--c-danger) / .14); border-color:hsl(var(--c-danger) / .4); color:hsl(var(--c-danger)); }
+.pr-chip[data-st="PendingReview"].on .ccount, .pr-chip[data-st="Approved"].on .ccount, .pr-chip[data-st="Rejected"].on .ccount { color:currentColor; opacity:.8; }
+
+.pr-vtoggle { flex-shrink:0; display:inline-flex; padding:3px; gap:2px; background:var(--bg-muted); border-radius:var(--r-md); border:1px solid var(--border); }
+.pr-vtoggle button { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; }
+.pr-vtoggle button[aria-pressed="true"] { background:var(--bg-card); color:hsl(var(--c-agent)); box-shadow:var(--shadow-xs); }
+
+/* table */
+.pr-body { flex:1; overflow:auto; min-height:0; }
+.pr-table { --cols: minmax(150px,1.35fr) minmax(190px,2fr) 152px 158px 102px 116px 146px; min-width:1060px; }
+.pr-thead { position:sticky; top:0; z-index:2; display:grid; grid-template-columns:var(--cols); gap:14px; align-items:center;
+  padding:10px 22px; background:var(--bg-sunken); border-bottom:1px solid var(--border); }
+.pr-th { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); display:flex; align-items:center; gap:5px; }
+.pr-th.sortable { cursor:pointer; }
+.pr-th.sortable:hover { color:var(--text-sec); }
+.pr-th .arr { font-size:9px; opacity:0; transition:opacity var(--dur-sm); }
+.pr-th[aria-sort="ascending"] .arr, .pr-th[aria-sort="descending"] .arr { opacity:1; color:hsl(var(--c-agent)); }
+.pr-th.right { justify-content:flex-end; }
+
+.pr-row { border-bottom:1px solid var(--border-light); cursor:pointer; transition:background var(--dur-sm) var(--ease-out); }
+.pr-row:hover { background:var(--bg-hover); }
+.pr-row.rejected:hover { background:hsl(var(--c-danger) / .04); }
+.pr-rowmain { display:grid; grid-template-columns:var(--cols); gap:14px; align-items:center; padding:14px 22px; }
+.pr-cell { min-width:0; }
+.pr-name { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-snug); }
+.pr-name .av-row { display:flex; align-items:center; gap:7px; margin-top:6px; }
+.pr-desc { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.pr-upd { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+
+/* author EntityChip (player) */
+.pr-author { display:inline-flex; align-items:center; gap:5px; padding:2px 9px 2px 2px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .14); color:hsl(var(--c-player)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; }
+.pr-author .av { width:17px; height:17px; border-radius:50%; background:hsl(var(--c-player)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:9px; font-weight:var(--fw-ext); }
+
+/* status badge (pattern toolkit-detail) */
+.pr-status { display:flex; flex-direction:column; gap:5px; align-items:flex-start; }
+.pr-badge { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); border:1px solid transparent; white-space:nowrap; }
+.pr-badge .bi { font-size:12px; line-height:1; }
+.pr-badge.draft    { background:var(--bg-muted); border-color:var(--border); color:var(--text-muted); }
+.pr-badge.review   { background:hsl(var(--c-warning) / .14); border-color:hsl(var(--c-warning) / .35); color:hsl(var(--c-warning)); }
+.pr-badge.approved { background:hsl(var(--c-toolkit) / .14); border-color:hsl(var(--c-toolkit) / .35); color:hsl(var(--c-toolkit)); }
+.pr-badge.rejected { background:hsl(var(--c-danger) / .14); border-color:hsl(var(--c-danger) / .35); color:hsl(var(--c-danger)); }
+.pr-since { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.pr-live { display:inline-flex; align-items:center; gap:5px; font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); color:hsl(var(--c-success)); }
+.pr-live i { width:7px; height:7px; border-radius:50%; background:hsl(var(--c-success)); animation:prlive 2s var(--ease-in-out) infinite; }
+@keyframes prlive { 0%,100%{ opacity:1; box-shadow:0 0 0 0 hsl(var(--c-success) / .5);} 50%{ opacity:.6; box-shadow:0 0 0 4px hsl(var(--c-success) / 0);} }
+
+/* capability strip (internal taxonomy, agent-tinted) */
+.pr-caps { display:flex; flex-wrap:wrap; gap:5px; }
+.pr-cap { padding:2px 7px; border-radius:var(--r-sm); background:hsl(var(--c-agent) / .12); color:hsl(var(--c-agent));
+  font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); white-space:nowrap; }
+.pr-cap.more { background:var(--bg-muted); color:var(--text-muted); }
+
+/* game scope EntityPip (--c-game) + tooltip */
+.pr-scope { position:relative; display:inline-flex; align-items:center; gap:6px; padding:3px 10px 3px 3px; border-radius:var(--r-pill);
+  background:hsl(var(--c-game) / .12); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .22);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:default; }
+.pr-scope .pin { width:18px; height:18px; border-radius:50%; background:hsl(var(--c-game)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:10px; }
+.pr-scope .tip { position:absolute; bottom:calc(100% + 8px); left:50%; transform:translateX(-50%) translateY(4px); opacity:0; pointer-events:none;
+  background:var(--text); color:var(--bg-card); padding:7px 11px; border-radius:var(--r-sm); box-shadow:var(--shadow-lg); white-space:nowrap;
+  font-family:var(--f-body); font-weight:var(--fw-semi); font-size:var(--fs-xs); transition:opacity var(--dur-sm), transform var(--dur-sm); z-index:var(--z-tooltip); }
+.pr-scope .tip::after { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:5px solid transparent; border-top-color:var(--text); }
+.pr-scope:hover .tip, .pr-scope:focus-within .tip { opacity:1; transform:translateX(-50%) translateY(0); }
+
+/* actions */
+.pr-acts { display:flex; align-items:center; gap:4px; justify-content:flex-end; }
+.pr-act { width:30px; height:30px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text-sec);
+  display:inline-flex; align-items:center; justify-content:center; cursor:pointer; font-size:13px; transition:all var(--dur-sm) var(--ease-out); }
+.pr-act:hover { background:var(--bg-muted); color:var(--text); border-color:var(--border-strong); }
+.pr-act.submit:hover { color:hsl(var(--c-agent)); border-color:hsl(var(--c-agent) / .4); background:hsl(var(--c-agent) / .1); }
+
+/* rejection reason inline alert */
+.pr-reject { display:flex; align-items:flex-start; gap:8px; margin:0 22px 14px; padding:8px 14px; border-radius:var(--r-sm);
+  background:hsl(var(--c-danger) / .08); border-left:3px solid hsl(var(--c-danger)); }
+.pr-reject .ri { font-size:13px; line-height:1.4; flex-shrink:0; }
+.pr-reject .rt { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.pr-reject .rt b { color:hsl(var(--c-danger)); font-weight:var(--fw-bold); }
+.pr-reject .rt a { color:hsl(var(--c-danger)); text-decoration:underline; font-weight:var(--fw-bold); cursor:pointer; white-space:nowrap; }
+
+/* empty / filter-empty / skeleton */
+.pr-pad { flex:1; display:flex; align-items:center; justify-content:center; padding:40px 24px; }
+.pr-empty { text-align:center; max-width:380px; border:1.5px dashed var(--border-strong); border-radius:var(--r-xl); padding:48px 32px; }
+.pr-empty .em { font-size:40px; opacity:.7; }
+.pr-empty h3 { font-family:var(--f-display); font-size:var(--fs-lg); margin:14px 0 6px; }
+.pr-empty p { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-body); margin-bottom:20px; }
+.pr-empty .cta { display:inline-flex; align-items:center; gap:7px; padding:9px 16px; border-radius:var(--r-md); border:none;
+  background:hsl(var(--c-agent)); color:#3a2400; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; }
+.pr-empty .cta.ghost { background:transparent; border:1px solid var(--border-strong); color:var(--text-sec); }
+
+@keyframes prshimmer { 0%{ background-position:-400px 0; } 100%{ background-position:400px 0; } }
+.pr-sk { border-radius:var(--r-sm); background:linear-gradient(90deg,var(--bg-muted) 25%,var(--bg-hover) 37%,var(--bg-muted) 63%); background-size:800px 100%; animation:prshimmer 1.4s linear infinite; }
+
+/* ─── mobile cards ─── */
+.pr-cards { display:flex; flex-direction:column; gap:11px; padding:14px; }
+.pr-card { position:relative; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:13px 14px; cursor:pointer;
+  transition:border-color var(--dur-sm) var(--ease-out); }
+.pr-card:hover, .pr-card:focus-visible { border-color:var(--border-strong); }
+.pr-card.rejected { border-left:3px solid hsl(var(--c-danger) / .5); }
+.pr-card .chead { display:flex; align-items:flex-start; gap:10px; }
+.pr-card .cname { flex:1; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-base); line-height:var(--lh-snug); }
+.pr-card .cmenu { width:28px; height:28px; flex-shrink:0; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted); cursor:pointer; font-size:16px; }
+.pr-card .cmenu:hover { background:var(--bg-muted); color:var(--text); }
+.pr-card .cdesc { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); margin:9px 0 11px;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.pr-card .cfoot { display:flex; align-items:center; flex-wrap:wrap; gap:8px; }
+.pr-card .cfoot .grow { flex:1; }
+.pr-card .creject { margin-top:11px; }
+.pr-menu { position:absolute; top:40px; right:10px; z-index:var(--z-overlay); background:var(--bg-card); border:1px solid var(--border);
+  border-radius:var(--r-md); box-shadow:var(--shadow-lg); padding:5px; min-width:170px; display:flex; flex-direction:column; gap:2px; }
+.pr-menu button { display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:var(--r-sm); border:none; background:transparent;
+  color:var(--text); font-family:var(--f-body); font-weight:var(--fw-semi); font-size:var(--fs-sm); cursor:pointer; text-align:left; }
+.pr-menu button:hover { background:var(--bg-muted); }
+
+/* mobile adaptations */
+.pr-app.is-mobile .pr-head { padding:12px 14px 13px; flex-wrap:wrap; gap:10px; }
+.pr-app.is-mobile .pr-h1 { font-size:var(--fs-xl); }
+.pr-app.is-mobile .pr-newbtn { width:100%; justify-content:center; order:3; }
+.pr-app.is-mobile .pr-toolbar { flex-wrap:wrap; padding:11px 14px; gap:10px; }
+.pr-app.is-mobile .pr-search { flex:1 1 100%; max-width:100%; }
+.pr-app.is-mobile .pr-chips { flex:1 1 100%; flex-wrap:wrap; overflow-x:visible; }
+.pr-app.is-mobile .pr-body { overflow-x:hidden; }
+.pr-app.is-mobile .pr-vtoggle { display:none; }
+.pr-app.is-mobile .pr-empty { padding:34px 22px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .pr-live i, .pr-search .busy i, .pr-sk { animation:none; }
+}
+`;
+
+/* ──────────────────────────────────────────────────────────
+   Dataset — 12 typology proposals (dati realistici IT).
+   Game scope: Catan, Power Grid, Codenames, Wingspan, Ark Nova, Brass.
+   Author: Marco R. / Sara T. — caps = internal taxonomy.
+   ────────────────────────────────────────────────────────── */
+const AUTHORS = {
+  marco: { name: 'Marco R.', initials: 'MR' },
+  sara:  { name: 'Sara T.',  initials: 'ST' },
+};
+
+const PROPOSALS = [
+  { id: 'tp-catan-rules', name: 'Catan Rules Expert', status: 'Approved', live: true, author: 'marco',
+    desc: 'Esperto delle regole ufficiali di Catan: risponde su preparazione, commercio, ladrone e calcolo dei punti citando il manuale.',
+    caps: ['Q&A', 'Streaming', 'Web'], scope: ['Catan'], updated: '2 ore fa', updatedAbs: '2 giu 2026, 16:04' },
+
+  { id: 'tp-strategy-advisor', name: 'Strategy Advisor', status: 'Draft', author: 'sara',
+    desc: 'Consiglia mosse di apertura e gestione delle risorse nei gestionali economici, analizzando il tempo di gioco residuo.',
+    caps: ['Q&A', 'Tool'], scope: ['Power Grid', 'Brass'], updated: '5 ore fa', updatedAbs: '2 giu 2026, 13:20' },
+
+  { id: 'tp-setup-tutor', name: 'Setup Tutor', status: 'Draft', author: 'marco',
+    desc: 'Guida passo-passo alla preparazione del tavolo: piazzamento iniziale, mazzi e plance per ciascun giocatore.',
+    caps: ['Q&A', 'Image'], scope: ['Wingspan', 'Catan', 'Ark Nova'], updated: 'Ieri', updatedAbs: '1 giu 2026, 21:42' },
+
+  { id: 'tp-wing-strategy', name: 'Wingspan Strategy Advisor', status: 'PendingReview', author: 'sara', reviewSince: 'Da 2 giorni in review',
+    desc: 'Suggerisce combinazioni di uccelli e ottimizzazione degli habitat per massimizzare i punti a fine partita.',
+    caps: ['Q&A', 'Streaming'], scope: ['Wingspan'], updated: '2 giorni fa', updatedAbs: '31 mag 2026, 10:15' },
+
+  { id: 'tp-codenames-spy', name: 'Codenames Spymaster', status: 'PendingReview', author: 'marco', reviewSince: 'Da 3 giorni in review',
+    desc: 'Genera indizi a tema e valuta il rischio delle parole avversarie per la squadra rossa o blu.',
+    caps: ['Q&A'], scope: ['Codenames'], updated: '3 giorni fa', updatedAbs: '30 mag 2026, 18:00' },
+
+  { id: 'tp-powergrid-auction', name: 'Power Grid Auction Helper', status: 'Approved', live: true, author: 'sara',
+    desc: 'Calcola l\u2019offerta ottimale nelle aste delle centrali in base a risorse disponibili e turno di gioco.',
+    caps: ['Q&A', 'Tool', 'Streaming'], scope: ['Power Grid'], updated: '4 giorni fa', updatedAbs: '29 mag 2026, 09:30' },
+
+  { id: 'tp-rules-arbiter', name: 'Rules Arbiter', status: 'Rejected', author: 'marco',
+    desc: 'Arbitro imparziale per dispute sulle regole durante la partita, con riferimento al regolamento ufficiale.',
+    caps: ['Q&A', 'Web'], scope: ['Catan', 'Codenames'], updated: '5 giorni fa', updatedAbs: '28 mag 2026, 14:11',
+    rejection: 'Sovrapposizione troppo ampia con \u201CCatan Rules Expert\u201D. Restringi lo scope a un singolo gioco prima di risottomettere.' },
+
+  { id: 'tp-onboarding-coach', name: 'Onboarding Coach', status: 'Draft', author: 'sara',
+    desc: 'Insegna le basi a chi gioca per la prima volta, con esempi visivi e brevi quiz di verifica.',
+    caps: ['Q&A', 'Image'], scope: ['Wingspan'], updated: '6 giorni fa', updatedAbs: '27 mag 2026, 11:48' },
+
+  { id: 'tp-catan-negotiate', name: 'Catan Negotiation Bot', status: 'Draft', author: 'marco',
+    desc: 'Simula trattative commerciali e suggerisce scambi equi tra giocatori durante la fase di commercio.',
+    caps: ['Q&A', 'Streaming'], scope: ['Catan'], updated: '1 settimana fa', updatedAbs: '26 mag 2026, 20:05' },
+
+  { id: 'tp-tournament-judge', name: 'Tournament Judge', status: 'PendingReview', author: 'sara', reviewSince: 'Da 1 giorno in review',
+    desc: 'Applica i regolamenti da torneo e tiene traccia delle penalità ufficiali per ogni giocatore.',
+    caps: ['Q&A', 'Tool', 'Web'], scope: ['Power Grid', 'Wingspan', 'Catan'], updated: '1 settimana fa', updatedAbs: '25 mag 2026, 15:33' },
+
+  { id: 'tp-codenames-guess', name: 'Codenames Guesser Aid', status: 'Approved', live: true, author: 'marco',
+    desc: 'Aiuta a interpretare gli indizi del capospia minimizzando i tocchi sulle parole avversarie.',
+    caps: ['Q&A', 'Streaming'], scope: ['Codenames'], updated: '2 settimane fa', updatedAbs: '19 mag 2026, 12:00' },
+
+  { id: 'tp-endgame-scorer', name: 'Endgame Scorer', status: 'Approved', author: 'sara',
+    desc: 'Calcola il punteggio finale gestendo bonus, obiettivi di fine partita e criteri di spareggio.',
+    caps: ['Q&A', 'Tool'], scope: ['Wingspan', 'Ark Nova'], updated: '3 settimane fa', updatedAbs: '12 mag 2026, 17:22' },
+];
+
+const STATUS_META = {
+  Draft:         { cls: 'draft',    icon: '\uD83D\uDCDD', label: 'Draft' },
+  PendingReview: { cls: 'review',   icon: '\u23F3', label: 'In review' },
+  Approved:      { cls: 'approved', icon: '\u2713', label: 'Approvata' },
+  Rejected:      { cls: 'rejected', icon: '\u2717', label: 'Rifiutata' },
+};
+
+const STATUS_ORDER = ['Draft', 'PendingReview', 'Approved', 'Rejected'];
+
+function actionsFor(status) {
+  switch (status) {
+    case 'Draft':         return [['edit', '\u270F\uFE0F', 'Modifica'], ['test', '\uD83E\uDDEA', 'Testa nel playground'], ['submit', '\u2B06\uFE0F', 'Sottometti per review', 'submit']];
+    case 'PendingReview': return [['view', '\uD83D\uDC41\uFE0F', 'Vedi dettaglio']];
+    case 'Approved':      return [['view', '\uD83D\uDC41\uFE0F', 'Vedi dettaglio'], ['test', '\uD83E\uDDEA', 'Testa nel playground']];
+    case 'Rejected':      return [['edit', '\u270F\uFE0F', 'Riprendi e modifica'], ['feedback', '\uD83D\uDC41\uFE0F', 'Vedi feedback admin']];
+    default:              return [];
+  }
+}
+
+/* ──────────────────────────────────────────────────────────
+   Scenari (9 stati)
+   ────────────────────────────────────────────────────────── */
+const SCENARIOS = {
+  'default':            { loading: false, error: false, empty: false, search: '', status: [], view: 'table', expandRejected: false },
+  'empty-all':          { loading: false, error: false, empty: true,  search: '', status: [], view: 'table', expandRejected: false },
+  'loading':            { loading: true,  error: false, empty: false, search: '', status: [], view: 'table', expandRejected: false },
+  'error':              { loading: false, error: true,  empty: false, search: '', status: [], view: 'table', expandRejected: false },
+  'filter-search':      { loading: false, error: false, empty: false, search: 'Catan', status: [], view: 'table', expandRejected: false },
+  'filter-status':      { loading: false, error: false, empty: false, search: '', status: ['Rejected'], view: 'table', expandRejected: true },
+  'filter-empty':       { loading: false, error: false, empty: false, search: 'Monopoly', status: [], view: 'table', expandRejected: false },
+  'rejected-expanded':  { loading: false, error: false, empty: false, search: '', status: [], view: 'table', expandRejected: true },
+  'mobile-cards':       { loading: false, error: false, empty: false, search: '', status: [], view: 'cards', expandRejected: false },
+};
+const STATE_LIST = [
+  ['default', 'Default'], ['empty-all', 'Empty'], ['loading', 'Loading'], ['error', 'Error'],
+  ['filter-search', 'Filter · search'], ['filter-status', 'Filter · status'], ['filter-empty', 'Filter · 0 match'],
+  ['rejected-expanded', 'Rejected row'], ['mobile-cards', 'Cards view'],
+];
+
+/* ──────────────────────────────────────────────────────────
+   Sub-components
+   ────────────────────────────────────────────────────────── */
+function StatusBadge({ status, live, reviewSince }) {
+  const m = STATUS_META[status];
+  return (
+    <div className="pr-status">
+      <span className={'pr-badge ' + m.cls} aria-label={'Stato: ' + m.label}>
+        <span className="bi" aria-hidden="true">{m.icon}</span>{m.label}
+      </span>
+      {live && <span className="pr-live"><i />Live</span>}
+      {reviewSince && <span className="pr-since">{reviewSince}</span>}
+    </div>
+  );
+}
+
+function CapStrip({ caps }) {
+  const visible = caps.slice(0, 3);
+  const extra = caps.length - visible.length;
+  return (
+    <div className="pr-caps" aria-label={'Capacità: ' + caps.join(', ')}>
+      {visible.map(c => <span className="pr-cap" key={c}>{c}</span>)}
+      {extra > 0 && <span className="pr-cap more">+{extra}</span>}
+    </div>
+  );
+}
+
+function ScopePip({ scope }) {
+  return (
+    <span className="pr-scope" tabIndex={0} aria-label={'Scope: ' + scope.length + ' giochi — ' + scope.join(', ')}>
+      <span className="pin" aria-hidden="true">🎲</span>
+      {scope.length} {scope.length === 1 ? 'gioco' : 'giochi'}
+      <span className="tip" role="tooltip">{scope.join(' · ')}</span>
+    </span>
+  );
+}
+
+function AuthorChip({ author }) {
+  const a = AUTHORS[author];
+  return (
+    <span className="pr-author" title={'Autore: ' + a.name}>
+      <span className="av" aria-hidden="true">{a.initials}</span>{a.name}
+    </span>
+  );
+}
+
+function ProposalActions({ status }) {
+  return (
+    <div className="pr-acts" role="group" aria-label="Azioni proposal">
+      {actionsFor(status).map(([key, icon, label, mod]) => (
+        <button key={key} className={'pr-act' + (mod ? ' ' + mod : '')} aria-label={label} title={label}
+                onClick={e => e.stopPropagation()}>{icon}</button>
+      ))}
+    </div>
+  );
+}
+
+function RejectionAlert({ reason, margin = true }) {
+  return (
+    <div className={'pr-reject' + (margin ? '' : ' nomargin')} style={margin ? null : { margin: '11px 0 0' }} role="note">
+      <span className="ri" aria-hidden="true">⚠️</span>
+      <div className="rt"><b>Feedback admin:</b> {reason} <a tabIndex={0} role="button">Vedi feedback completo</a></div>
+    </div>
+  );
+}
+
+/* ─── desktop table ─── */
+function TableHeader({ sortKey, sortDir, onSort }) {
+  const sortAttr = k => sortKey === k ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none';
+  return (
+    <div className="pr-thead" role="row">
+      <div className="pr-th sortable" role="columnheader" aria-sort={sortAttr('name')} tabIndex={0}
+           onClick={() => onSort('name')} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort('name'); } }}>
+        Name <span className="arr">{sortKey === 'name' && sortDir === 'desc' ? '▼' : '▲'}</span>
+      </div>
+      <div className="pr-th" role="columnheader">Descrizione</div>
+      <div className="pr-th" role="columnheader">Status</div>
+      <div className="pr-th" role="columnheader">Capabilities</div>
+      <div className="pr-th" role="columnheader">Scope</div>
+      <div className="pr-th sortable" role="columnheader" aria-sort={sortAttr('updated')} tabIndex={0}
+           onClick={() => onSort('updated')} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort('updated'); } }}>
+        Updated <span className="arr">{sortKey === 'updated' && sortDir === 'desc' ? '▼' : '▲'}</span>
+      </div>
+      <div className="pr-th right" role="columnheader">Azioni</div>
+    </div>
+  );
+}
+
+function TableRow({ p, expandRejected, rowRef }) {
+  const showReject = p.status === 'Rejected' && p.rejection && expandRejected;
+  return (
+    <div className={'pr-row' + (p.status === 'Rejected' ? ' rejected' : '')} role="row" tabIndex={0} ref={rowRef}
+         onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); /* naviga a /edit */ } }}>
+      <div className="pr-rowmain">
+        <div className="pr-cell">
+          <div className="pr-name">{p.name}</div>
+          <div className="av-row"><AuthorChip author={p.author} /></div>
+        </div>
+        <div className="pr-cell"><div className="pr-desc">{p.desc}</div></div>
+        <div className="pr-cell" role="cell"><StatusBadge status={p.status} live={p.live} reviewSince={p.reviewSince} /></div>
+        <div className="pr-cell" role="cell"><CapStrip caps={p.caps} /></div>
+        <div className="pr-cell" role="cell"><ScopePip scope={p.scope} /></div>
+        <div className="pr-cell" role="cell"><span className="pr-upd" title={p.updatedAbs}>{p.updated}</span></div>
+        <div className="pr-cell" role="cell"><ProposalActions status={p.status} /></div>
+      </div>
+      {showReject && <RejectionAlert reason={p.rejection} />}
+    </div>
+  );
+}
+
+function ProposalsTable({ rows, expandRejected, sortKey, sortDir, onSort, firstRowRef }) {
+  return (
+    <div className="pr-table" role="table" aria-label="Typology proposals">
+      <TableHeader sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
+      <div role="rowgroup">
+        {rows.map((p, i) => <TableRow key={p.id} p={p} expandRejected={expandRejected} rowRef={i === 0 ? firstRowRef : null} />)}
+      </div>
+    </div>
+  );
+}
+
+/* ─── mobile cards ─── */
+function ProposalCard({ p, expandRejected }) {
+  const [menu, setMenu] = useState(false);
+  const showReject = p.status === 'Rejected' && p.rejection && expandRejected;
+  return (
+    <div className={'pr-card' + (p.status === 'Rejected' ? ' rejected' : '')} role="button" tabIndex={0}>
+      <div className="chead">
+        <div className="cname">{p.name}</div>
+        <StatusBadge status={p.status} live={p.live} reviewSince={p.reviewSince} />
+        <button className="cmenu" aria-label="Azioni proposal" aria-haspopup="menu" aria-expanded={menu}
+                onClick={e => { e.stopPropagation(); setMenu(m => !m); }}>⋮</button>
+      </div>
+      <div className="cdesc">{p.desc}</div>
+      <div className="cfoot">
+        <CapStrip caps={p.caps} />
+        <span className="grow" />
+        <ScopePip scope={p.scope} />
+        <span className="pr-upd" title={p.updatedAbs}>{p.updated}</span>
+      </div>
+      <div className="cfoot" style={{ marginTop: 9 }}><AuthorChip author={p.author} /></div>
+      {showReject && <div className="creject"><RejectionAlert reason={p.rejection} margin={false} /></div>}
+      {menu && (
+        <div className="pr-menu" role="menu" onClick={e => e.stopPropagation()}>
+          {actionsFor(p.status).map(([key, icon, label]) => (
+            <button key={key} role="menuitem" onClick={() => setMenu(false)}><span aria-hidden="true">{icon}</span>{label}</button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProposalsCards({ rows, expandRejected }) {
+  return <div className="pr-cards">{rows.map(p => <ProposalCard key={p.id} p={p} expandRejected={expandRejected} />)}</div>;
+}
+
+/* ─── empty / filter-empty / skeleton ─── */
+function EmptyAll() {
+  return (
+    <div className="pr-pad">
+      <div className="pr-empty">
+        <div className="em" aria-hidden="true">🤖</div>
+        <h3>Nessuna proposal ancora</h3>
+        <p>Inizia creando la tua prima typology AI: definisci nome, capacità e i giochi su cui sarà esperta.</p>
+        <button className="cta"><span aria-hidden="true">+</span> Crea la prima proposal</button>
+      </div>
+    </div>
+  );
+}
+
+function FilterEmpty({ onClear }) {
+  return (
+    <div className="pr-pad" aria-live="polite">
+      <div className="pr-empty">
+        <div className="em" aria-hidden="true">🔍</div>
+        <h3>Nessuna proposal corrisponde ai filtri</h3>
+        <p>Prova a modificare la ricerca o a rimuovere i filtri di stato attivi.</p>
+        <button className="cta ghost" onClick={onClear}>Rimuovi filtri</button>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonTable({ mobile }) {
+  if (mobile) {
+    return (
+      <div className="pr-cards" aria-busy="true">
+        {[0, 1, 2, 3].map(i => (
+          <div className="pr-card" key={i}>
+            <div className="chead"><div className="pr-sk" style={{ flex: 1, height: 16 }} /><div className="pr-sk" style={{ width: 78, height: 22, borderRadius: 'var(--r-pill)' }} /></div>
+            <div className="pr-sk" style={{ width: '100%', height: 13, margin: '11px 0 6px' }} />
+            <div className="pr-sk" style={{ width: '72%', height: 13, marginBottom: 11 }} />
+            <div className="pr-sk" style={{ width: 130, height: 20, borderRadius: 'var(--r-pill)' }} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="pr-table" aria-busy="true">
+      <div className="pr-thead">
+        {['name', 'desc', 'st', 'cap', 'sc', 'up', 'ac'].map(k => <div key={k} className="pr-sk" style={{ height: 11, width: k === 'desc' ? '60%' : '50%' }} />)}
+      </div>
+      {[0, 1, 2, 3].map(i => (
+        <div className="pr-rowmain" key={i} style={{ borderBottom: '1px solid var(--border-light)' }}>
+          <div><div className="pr-sk" style={{ width: '80%', height: 14, marginBottom: 8 }} /><div className="pr-sk" style={{ width: 70, height: 17, borderRadius: 'var(--r-pill)' }} /></div>
+          <div><div className="pr-sk" style={{ width: '100%', height: 12, marginBottom: 6 }} /><div className="pr-sk" style={{ width: '70%', height: 12 }} /></div>
+          <div className="pr-sk" style={{ width: 84, height: 22, borderRadius: 'var(--r-pill)' }} />
+          <div className="pr-sk" style={{ width: '90%', height: 18, borderRadius: 'var(--r-sm)' }} />
+          <div className="pr-sk" style={{ width: 78, height: 24, borderRadius: 'var(--r-pill)' }} />
+          <div className="pr-sk" style={{ width: 60, height: 12 }} />
+          <div className="pr-sk" style={{ width: 96, height: 30, borderRadius: 'var(--r-sm)', marginLeft: 'auto' }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─── Toolbar ─── */
+function Toolbar({ search, setSearch, typing, status, toggleStatus, counts, view, setView, searchRef, onClearSearch }) {
+  return (
+    <div className="pr-toolbar">
+      <div className={'pr-search' + (search ? ' active' : '')}>
+        <span className="ic" aria-hidden="true">🔍</span>
+        <input ref={searchRef} value={search} onChange={e => setSearch(e.target.value)} role="searchbox"
+               aria-label="Cerca proposals" placeholder="Cerca per nome o descrizione…"
+               onKeyDown={e => { if (e.key === 'Escape') onClearSearch(); }} />
+        {typing && <span className="busy" aria-hidden="true"><i />Cercando…</span>}
+        {search && <button className="clear" aria-label="Cancella ricerca" onClick={onClearSearch}>✕</button>}
+      </div>
+      <div className="pr-chips" role="group" aria-label="Filtra per stato">
+        <button className={'pr-chip all' + (status.length === 0 ? ' on' : '')} aria-pressed={status.length === 0} onClick={() => toggleStatus(null)}>
+          <span className="cdot" />Tutti <span className="ccount">({counts.all})</span>
+        </button>
+        {STATUS_ORDER.map(st => (
+          <button key={st} className={'pr-chip' + (status.includes(st) ? ' on' : '')} data-st={st} aria-pressed={status.includes(st)} onClick={() => toggleStatus(st)}>
+            <span className="cdot" />{st} <span className="ccount">({counts[st]})</span>
+          </button>
+        ))}
+      </div>
+      <div className="pr-vtoggle" role="group" aria-label="Vista">
+        <button aria-pressed={view === 'table'} onClick={() => setView('table')} title="Vista tabella">☰ Table</button>
+        <button aria-pressed={view === 'cards'} onClick={() => setView('cards')} title="Vista cards">▦ Cards</button>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   ProposalsApp — un'istanza per (state × viewport). Remount via key.
+   ────────────────────────────────────────────────────────── */
+function ProposalsApp({ stateId, mobile }) {
+  const sc = SCENARIOS[stateId];
+  const [search, setSearch] = useState(sc.search);
+  const [status, setStatus] = useState(sc.status);
+  const [view, setView] = useState(sc.view);
+  const [sortKey, setSortKey] = useState('name');
+  const [sortDir, setSortDir] = useState('asc');
+  const [typing, setTyping] = useState(false);
+  const searchRef = useRef(null);
+  const firstRowRef = useRef(null);
+  const typingTimer = useRef(null);
+
+  // debounce visual
+  useEffect(() => {
+    if (!search) { setTyping(false); return; }
+    setTyping(true);
+    clearTimeout(typingTimer.current);
+    typingTimer.current = setTimeout(() => setTyping(false), 650);
+    return () => clearTimeout(typingTimer.current);
+  }, [search]);
+
+  // Ctrl+F → focus search
+  useEffect(() => {
+    const h = e => { if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f') { e.preventDefault(); searchRef.current && searchRef.current.focus(); } };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, []);
+
+  const counts = useMemo(() => {
+    const c = { all: PROPOSALS.length };
+    STATUS_ORDER.forEach(s => { c[s] = PROPOSALS.filter(p => p.status === s).length; });
+    return c;
+  }, []);
+
+  const toggleStatus = st => {
+    if (st === null) { setStatus([]); return; }
+    setStatus(prev => prev.includes(st) ? prev.filter(s => s !== st) : [...prev, st]);
+  };
+  const clearFilters = () => { setSearch(''); setStatus([]); };
+  const onClearSearch = () => { setSearch(''); searchRef.current && searchRef.current.focus(); };
+  const onSort = key => {
+    if (sortKey === key) setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    else { setSortKey(key); setSortDir('asc'); }
+  };
+
+  const q = search.trim().toLowerCase();
+  let rows = PROPOSALS.filter(p =>
+    (status.length === 0 || status.includes(p.status)) &&
+    (!q || p.name.toLowerCase().includes(q) || p.desc.toLowerCase().includes(q) || p.scope.some(g => g.toLowerCase().includes(q)))
+  );
+  const UPD_RANK = id => PROPOSALS.findIndex(p => p.id === id); // array già in ordine cronologico desc
+  rows = [...rows].sort((a, b) => {
+    let r;
+    if (sortKey === 'name') r = a.name.localeCompare(b.name);
+    else r = UPD_RANK(a.id) - UPD_RANK(b.id);
+    return sortDir === 'asc' ? r : -r;
+  });
+
+  const expandRejected = sc.expandRejected;
+  const filtersActive = status.length > 0 || q.length > 0;
+
+  let bodyEl;
+  if (sc.empty) bodyEl = <EmptyAll />;
+  else if (sc.loading) bodyEl = <SkeletonTable mobile={mobile} />;
+  else if (rows.length === 0) bodyEl = <FilterEmpty onClear={clearFilters} />;
+  else if (mobile || view === 'cards') bodyEl = <ProposalsCards rows={rows} expandRejected={expandRejected} />;
+  else bodyEl = <ProposalsTable rows={rows} expandRejected={expandRejected} sortKey={sortKey} sortDir={sortDir} onSort={onSort} firstRowRef={firstRowRef} />;
+
+  return (
+    <div className={'pr-app' + (mobile ? ' is-mobile' : '')}>
+      {sc.error && (
+        <div className="pr-errbar" role="alert">
+          <span aria-hidden="true">⚠️</span> Impossibile caricare le proposals — riprova.
+          <span className="grow" />
+          <button className="retry"><span aria-hidden="true">↻</span> Riprova</button>
+        </div>
+      )}
+
+      <header className="pr-head">
+        <div className="htxt">
+          <div className="pr-bread"><span>Editor</span><span className="sep">›</span><span className="cur">Agent proposals</span></div>
+          <h1 className="pr-h1">Le mie typology proposals</h1>
+          <div className="pr-sub">Crea, testa e sottometti tipologie AI agent per l’approvazione</div>
+        </div>
+        <span className="grow" />
+        <button className="pr-newbtn"><span className="ic" aria-hidden="true">+</span> Crea proposal</button>
+      </header>
+
+      {!sc.error && (
+        <Toolbar search={search} setSearch={setSearch} typing={typing} status={status} toggleStatus={toggleStatus}
+                 counts={counts} view={view} setView={setView} searchRef={searchRef} onClearSearch={onClearSearch} />
+      )}
+
+      <div className="pr-body">{bodyEl}</div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────
+   Harness — continuity con S1
+   ────────────────────────────────────────────────────────── */
+function Harness() {
+  const [stateId, setStateId] = useState(() => localStorage.getItem('pr-state') || 'default');
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || 'light');
+
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem('pr-state', stateId); }, [stateId]);
+
+  return (
+    <div className="ed-stage">
+      <style dangerouslySetInnerHTML={{ __html: PROP_CSS }} />
+      <button className="theme-toggle" onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>🌗 <span>{theme === 'dark' ? 'Dark' : 'Light'}</span></button>
+
+      <div className="ed-wrap">
+        <div className="ed-kicker">SP4 · B14 · #1489 — schermata 2 / 5 · typology proposals list</div>
+        <h1>Typology <span className="acc">proposals</span> — /editor/agent-proposals</h1>
+        <p className="ed-lead">
+          Lista delle <b>typology proposals</b> dell’editor: ogni proposal è un nuovo tipo di agente AI con un lifecycle
+          (<b>Draft → PendingReview → Approved → Rejected</b>). Pattern hero + tabella filtrabile con search e status chip;
+          table su desktop, cards stack su mobile. Entity primaria <code>--c-agent</code>, scope giochi via EntityPip <code>--c-game</code>.
+        </p>
+
+        <div className="ed-notes">
+          <div className="ed-note">
+            <h4>Pattern</h4>
+            <p><b>Hero + body</b>: header sticky con breadcrumb/title/CTA, toolbar (search 38% · status chip · view toggle), body <b>table desktop</b> / <b>cards mobile</b>. Badge status entity-colored riusati da toolkit-detail.</p>
+          </div>
+          <div className="ed-note">
+            <h4>9 stati</h4>
+            <p>Selettore qui sotto: default · empty · loading · error · filter-search · filter-status · filter-0-match · rejected-row · cards-view. Action button per-status (Edit / Test / Submit / View).</p>
+          </div>
+          <div className="ed-note">
+            <h4>Mobile & a11y</h4>
+            <p>Mobile = cards stack, chip a capo, menu <code>⋮</code> per azioni. <code>role=table/row/cell</code>, <code>aria-sort</code> sulle colonne, <code>aria-pressed</code> sui chip, <code>searchbox</code>, <code>Ctrl+F</code> / <code>Esc</code>.</p>
+          </div>
+        </div>
+
+        <div className="ed-rail">
+          <span className="lab">Stato</span>
+          <div className="ed-states" role="group" aria-label="Selettore stato schermata">
+            {STATE_LIST.map(([id, label]) => (
+              <button key={id} className={'ed-sbtn' + (stateId === id ? ' on' : '')} aria-pressed={stateId === id} onClick={() => setStateId(id)}>
+                <span className="pip" />{label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Desktop · 1440 — hero + table</div>
+        <div className="ed-desk">
+          <div className="ed-chrome">
+            <div className="dots"><i /><i /><i /></div>
+            <div className="url">meepleai.app/editor/agent-proposals</div>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <ProposalsApp key={'d-' + stateId} stateId={stateId} mobile={false} />
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Mobile · 375 — cards stack</div>
+        <div className="ed-phone-row">
+          <div className="phone">
+            <div className="phone-sbar"><span>9:41</span><span className="ind">●●● 5G ▮</span></div>
+            <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+              <ProposalsApp key={'m-' + stateId} stateId={stateId} mobile={true} />
+            </div>
+          </div>
+          <div className="ed-phone-cap">
+            <h4>Layout mobile</h4>
+            <p>Niente table: stack di <b>cards</b>. Status badge in alto a destra, menu <code>⋮</code> per le azioni (drawer-style), chip di stato che vanno a capo senza scroll orizzontale. Le righe Rejected mostrano l’alert feedback inline (stato <code>rejected-row</code>).</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Harness />);

--- a/admin-mockups/design_files/sp4-editor-proposals-test.html
+++ b/admin-mockups/design_files/sp4-editor-proposals-test.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · B14 editor · #5/5 · Test playground — /editor/agent-proposals/[id]/test</title>
+<!-- route: /editor/agent-proposals/[id]/test — Playground streaming FSM per testare typology pre-submit con trace dettagliato + compare mode -->
+<!--
+  @route /editor/agent-proposals/[id]/test
+  @brief B14 (issue #1489) — Editor user-facing (agent proposals)
+  @screen 5 of 5 — sp4-editor-proposals-test (ULTIMA del cluster)
+  @tier M
+  @pattern Split-view asimmetrico (config sidebar sx 320px + chat body dx) + optional trace drawer (380px)
+  @fsm streaming 4-stati: idle · streaming · completed · error (cursor BLINK animato CSS)
+  @states idle-empty · typing-input · streaming-active · streaming-stop-clicked · completed-single ·
+          completed-multi · error-rate-limit · error-timeout · error-network · trace-drawer-open ·
+          compare-mode · mobile-stack
+  @continuity S1 (split-view) · S2 (pr-badge) · S4 (ce-author chip, breadcrumb header) — entity --c-agent
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-editor-proposals-test.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-editor-proposals-test.jsx
+++ b/admin-mockups/design_files/sp4-editor-proposals-test.jsx
@@ -1,0 +1,1045 @@
+/* sp4-editor-proposals-test.jsx
+   Route: /editor/agent-proposals/[id]/test — Playground streaming per testare una typology PRE-submit.
+   B14 (issue #1489) · screen 5 of 5 (ULTIMA del cluster) · Tier M
+   Pattern: Split-view asimmetrico — config sidebar sx (320px) + chat body dx (fluid) + optional trace drawer (380px).
+   Mobile: config collassa in header-drawer top + chat full-width + trace in bottom-sheet.
+   Continuity: S1 split-view · S2 pr-badge (status) · S4 ce-author chip + breadcrumb header. Entity primaria --c-agent,
+   user message --c-player, accenti sessione --c-chat, KB sources --c-kb, game scope --c-game.
+   FSM streaming 4-stati: idle · streaming (cursor BLINK + typewriter) · completed · error.
+   Loadable standalone via Babel. Injects own component CSS; relies on tokens.css + components.css.
+   v2 components surfaced here:
+   /* v2: TestPlaygroundSplit, ConfigSidebar, TypologySummaryCard, SampleInputsPanel, SessionConfigPanel,
+          TraceSummaryMini, ChatBody, ChatStreamHeader, MessageList, UserBubble, AgentBubble (fsm),
+          StreamingCursor, MessageActions, SystemNotice, ChatComposer, ComposerToolbar, StopButton,
+          TraceDrawer, TraceBlock, CompareColumns, MobileConfigDrawer */
+
+const { useState, useEffect, useMemo, useRef } = React;
+
+/* ══════════════════════════════════════════════════════════
+   Component CSS — solo token da tokens.css / components.css.
+   ══════════════════════════════════════════════════════════ */
+const PT_CSS = `
+/* ─── harness chrome (continuity S1/S4) ─── */
+.ed-stage { min-height:100vh; padding:72px 24px 96px; background:var(--bg); color:var(--text); }
+.ed-wrap { max-width:1380px; margin:0 auto; }
+.ed-kicker { font-family:var(--f-mono); font-size:var(--fs-xs); letter-spacing:.1em; text-transform:uppercase; color:var(--text-muted); }
+.ed-stage h1 { font-size:var(--fs-3xl); margin:8px 0 6px; }
+.ed-stage h1 .acc { color:hsl(var(--c-agent)); }
+.ed-lead { color:var(--text-sec); font-size:var(--fs-md); max-width:820px; line-height:var(--lh-body); }
+.ed-lead code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:12px; font-family:var(--f-mono); }
+.ed-notes { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:22px 0 4px; }
+.ed-note { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:14px 16px; }
+.ed-note h4 { font-family:var(--f-display); font-size:var(--fs-sm); text-transform:uppercase; letter-spacing:.04em; color:hsl(var(--c-agent)); margin-bottom:6px; }
+.ed-note p { font-size:var(--fs-sm); color:var(--text-sec); line-height:var(--lh-snug); }
+.ed-note p b { color:var(--text); font-weight:var(--fw-bold); }
+.ed-note code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:11px; font-family:var(--f-mono); }
+
+.ed-rail { position:sticky; top:0; z-index:var(--z-sticky); margin:26px 0 18px; padding:12px 0;
+  background:var(--bg); display:flex; align-items:flex-start; gap:14px; flex-wrap:wrap; border-bottom:1px solid var(--border); }
+.ed-rail .lab { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); padding-top:8px; }
+.ed-states { display:flex; gap:6px; flex-wrap:wrap; flex:1; }
+.ed-sbtn { display:inline-flex; align-items:center; gap:7px; padding:7px 12px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm);
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.ed-sbtn:hover { transform:translateY(-1px); border-color:var(--border-strong); }
+.ed-sbtn .pip { width:7px; height:7px; border-radius:50%; background:currentColor; opacity:.6; }
+.ed-sbtn.on { background:hsl(var(--c-agent)); border-color:transparent; color:#3a2400; }
+.ed-sbtn.on .pip { opacity:1; background:#3a2400; }
+
+.ed-vp-label { font-family:var(--f-mono); font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:.08em;
+  color:var(--text-muted); margin:30px 0 12px; display:flex; align-items:center; gap:10px; }
+.ed-vp-label::after { content:''; flex:1; height:1px; background:var(--border); }
+
+.ed-desk { width:100%; max-width:1340px; height:880px; border-radius:var(--r-lg); overflow:hidden;
+  background:var(--bg-card); border:1px solid var(--border); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; }
+.ed-chrome { height:38px; flex-shrink:0; display:flex; align-items:center; gap:8px; padding:0 14px;
+  background:var(--bg-muted); border-bottom:1px solid var(--border); font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); }
+.ed-chrome .dots { display:flex; gap:6px; }
+.ed-chrome .dots i { width:11px; height:11px; border-radius:50%; display:block; }
+.ed-chrome .dots i:nth-child(1){ background:#ff5f57; } .ed-chrome .dots i:nth-child(2){ background:#febc2e; } .ed-chrome .dots i:nth-child(3){ background:#28c840; }
+.ed-chrome .url { flex:1; text-align:center; background:var(--bg-card); border-radius:var(--r-sm); padding:4px 10px; margin:0 11%; }
+.ed-phone-row { display:flex; gap:28px; align-items:flex-start; flex-wrap:wrap; }
+.ed-phone-cap { font-size:var(--fs-sm); color:var(--text-sec); max-width:300px; line-height:var(--lh-snug); }
+.ed-phone-cap h4 { font-family:var(--f-display); font-size:var(--fs-base); margin-bottom:6px; }
+.ed-phone-cap code { background:var(--bg-muted); padding:1px 5px; border-radius:var(--r-xs); font-size:11px; font-family:var(--f-mono); }
+
+/* ─── app shell ─── */
+.pt-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+.pt-app :focus-visible { outline:2px solid hsl(var(--c-agent)); outline-offset:2px; border-radius:var(--r-xs); }
+
+/* header (sticky, esteso da S4) */
+.pt-head { flex-shrink:0; background:var(--bg-card); border-bottom:1px solid var(--border); }
+.pt-head .hrow { display:flex; align-items:flex-start; gap:16px; padding:13px 20px 14px; }
+.pt-head .htxt { min-width:0; }
+.pt-bread { font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text-muted); letter-spacing:.03em; display:flex; align-items:center; gap:6px; margin-bottom:6px; flex-wrap:wrap; }
+.pt-bread .sep { opacity:.5; }
+.pt-bread .cur { color:hsl(var(--c-agent)); font-weight:var(--fw-bold); }
+.pt-titlerow { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+.pt-h1 { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-2xl); letter-spacing:-.01em; line-height:var(--lh-tight); }
+.pt-sub { font-size:var(--fs-sm); color:var(--text-sec); margin-top:6px; }
+.pt-sub b { color:var(--text); }
+.pt-livechip { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill);
+  background:hsl(var(--c-toolkit) / .14); color:hsl(var(--c-toolkit)); font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); border:1px solid hsl(var(--c-toolkit) / .3); }
+.pt-livechip i { width:7px; height:7px; border-radius:50%; background:hsl(var(--c-toolkit)); animation:ptpulse 2s var(--ease-in-out) infinite; }
+.pt-head .grow { flex:1; }
+.pt-headcta { display:flex; align-items:center; gap:8px; flex-shrink:0; flex-wrap:wrap; justify-content:flex-end; }
+
+/* status badge inline (riuso pr-badge S2) */
+.ce-badge { display:inline-flex; align-items:center; gap:5px; padding:4px 11px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); border:1px solid transparent; white-space:nowrap; }
+.ce-badge .bi { font-size:13px; line-height:1; }
+.ce-badge.draft    { background:var(--bg-muted); border-color:var(--border); color:var(--text-muted); }
+.ce-badge.rejected { background:hsl(var(--c-danger) / .14); border-color:hsl(var(--c-danger) / .35); color:hsl(var(--c-danger)); }
+
+/* author chip (player entity, riuso S4) */
+.ce-author { display:inline-flex; align-items:center; gap:6px; padding:2px 10px 2px 2px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .14); color:hsl(var(--c-player)); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); }
+.ce-author .av { width:18px; height:18px; border-radius:50%; background:hsl(var(--c-player)); color:#fff; display:flex; align-items:center; justify-content:center; font-size:9px; font-weight:var(--fw-ext); }
+
+/* generic buttons */
+.pt-btn { display:inline-flex; align-items:center; gap:6px; padding:8px 13px; border-radius:var(--r-md); border:1px solid transparent;
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); white-space:nowrap; }
+.pt-btn .ic { font-size:13px; line-height:1; }
+.pt-btn.link { background:transparent; color:var(--text-sec); padding:8px 6px; }
+.pt-btn.link:hover { color:var(--text); }
+.pt-btn.sec { background:var(--bg-card); border-color:var(--border); color:var(--text-sec); }
+.pt-btn.sec:hover { border-color:var(--border-strong); color:var(--text); transform:translateY(-1px); }
+.pt-btn.info-out { background:transparent; border-color:hsl(var(--c-info) / .5); color:hsl(var(--c-info)); }
+.pt-btn.info-out:hover { background:hsl(var(--c-info) / .1); }
+.pt-btn.agent { background:hsl(var(--c-agent)); color:#3a2400; box-shadow:var(--shadow-xs); }
+.pt-btn.agent:hover:not(:disabled) { transform:translateY(-1px); box-shadow:var(--shadow-sm); filter:brightness(1.03); }
+.pt-btn.agent:disabled { opacity:.45; cursor:not-allowed; }
+.pt-btn.danger-out { background:transparent; border-color:hsl(var(--c-danger) / .5); color:hsl(var(--c-danger)); }
+.pt-btn.danger-out:hover { background:hsl(var(--c-danger) / .1); }
+.pt-btn.danger { background:hsl(var(--c-danger)); color:#fff; }
+.pt-btn.danger:hover { filter:brightness(1.04); transform:translateY(-1px); }
+
+/* ─── split ─── */
+.pt-split { flex:1; display:grid; grid-template-columns:320px minmax(0,1fr); overflow:hidden; min-height:0; }
+.pt-split.has-trace { grid-template-columns:300px minmax(0,1fr) 360px; }
+.pt-split.compare { grid-template-columns:300px minmax(0,1fr); }
+
+/* ─── config sidebar ─── */
+.pt-config { background:var(--bg-muted); border-right:1px solid var(--border); overflow-y:auto; padding:14px; display:flex; flex-direction:column; gap:12px; min-height:0; }
+.pt-cfg-card { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:13px 14px; }
+.pt-cfg-card > h4 { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.07em; color:var(--text-muted); margin-bottom:10px; display:flex; align-items:center; gap:6px; }
+.pt-cfg-card > h4 .ct { color:var(--text-sec); font-weight:var(--fw-bold); }
+
+/* typology summary */
+.pt-tysum .row1 { display:flex; align-items:center; gap:10px; margin-bottom:11px; }
+.pt-tyav { width:40px; height:40px; border-radius:50%; flex-shrink:0; background:hsl(var(--c-agent) / .16); color:hsl(var(--c-agent)); display:flex; align-items:center; justify-content:center; font-size:20px; }
+.pt-tysum .nm { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-md); }
+.pt-tysum .vr { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-top:2px; }
+.pt-chipstrip { display:flex; flex-wrap:wrap; gap:5px; margin-bottom:10px; }
+.pt-cap { display:inline-flex; align-items:center; gap:4px; padding:3px 8px; border-radius:var(--r-pill); font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold);
+  background:hsl(var(--c-agent) / .12); color:hsl(var(--c-agent)); }
+.pt-cap.off { background:var(--bg-muted); color:var(--text-muted); opacity:.7; }
+.pt-gchip { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill); font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs);
+  background:hsl(var(--c-game) / .14); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .25); cursor:pointer; }
+.pt-cfg-lbl { font-family:var(--f-mono); font-size:9px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); margin:4px 0 6px; }
+.pt-tysum .foot { display:flex; align-items:center; justify-content:space-between; gap:8px; margin-top:11px; padding-top:10px; border-top:1px dashed var(--border); }
+.pt-cfg-link { background:none; border:none; cursor:pointer; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); color:hsl(var(--c-agent)); padding:0; }
+.pt-cfg-link:hover { text-decoration:underline; }
+.pt-cfg-link.muted { color:var(--text-muted); }
+
+/* sample inputs */
+.pt-sample { display:flex; flex-direction:column; gap:7px; padding:10px 11px; border-radius:var(--r-md); background:var(--bg); border:1px solid var(--border-light); cursor:pointer; transition:all var(--dur-sm) var(--ease-out); margin-bottom:6px; }
+.pt-sample:hover { background:var(--bg-hover); border-color:hsl(var(--c-agent) / .4); }
+.pt-sample:focus-visible { border-color:hsl(var(--c-agent)); }
+.pt-sample .q { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-snug); display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.pt-sample .meta { display:flex; align-items:center; gap:6px; }
+.pt-sample .tmpl { display:inline-flex; align-items:center; gap:3px; font-family:var(--f-mono); font-size:9px; color:hsl(var(--c-kb)); background:hsl(var(--c-kb) / .1); padding:1px 6px; border-radius:var(--r-pill); }
+.pt-sample .fill { margin-left:auto; font-family:var(--f-mono); font-size:9px; color:var(--text-muted); }
+
+/* session config controls */
+.pt-field { margin-bottom:11px; }
+.pt-field:last-child { margin-bottom:0; }
+.pt-selectw { position:relative; }
+.pt-select { width:100%; padding:7px 28px 7px 10px; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg);
+  font-family:var(--f-mono); font-weight:var(--fw-bold); font-size:var(--fs-xs); color:var(--text); cursor:pointer; appearance:none; outline:none; }
+.pt-selectw::after { content:'▾'; position:absolute; right:11px; top:50%; transform:translateY(-50%); font-size:9px; color:var(--text-muted); pointer-events:none; }
+.pt-rangerow { display:flex; align-items:center; gap:10px; }
+.pt-range { flex:1; -webkit-appearance:none; appearance:none; height:4px; border-radius:var(--r-pill); background:var(--bg-sunken); outline:none; }
+.pt-range::-webkit-slider-thumb { -webkit-appearance:none; appearance:none; width:15px; height:15px; border-radius:50%; background:hsl(var(--c-agent)); cursor:pointer; box-shadow:var(--shadow-xs); }
+.pt-range::-moz-range-thumb { width:15px; height:15px; border:none; border-radius:50%; background:hsl(var(--c-agent)); cursor:pointer; }
+.pt-rangeval { font-family:var(--f-mono); font-size:var(--fs-xs); font-weight:var(--fw-bold); color:var(--text); min-width:26px; text-align:right; }
+.pt-num { width:100%; padding:7px 10px; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg); font-family:var(--f-mono); font-size:var(--fs-xs); color:var(--text); outline:none; }
+.pt-num:focus, .pt-select:focus { border-color:hsl(var(--c-agent) / .5); }
+.pt-togrow { display:flex; align-items:center; gap:9px; padding:6px 0; }
+.pt-togrow .tl { font-size:var(--fs-sm); color:var(--text); flex:1; }
+.pt-togrow .ts { font-size:10px; color:var(--text-muted); }
+.pt-toggle { width:38px; height:22px; border-radius:var(--r-pill); border:none; background:var(--bg-sunken); position:relative; cursor:pointer; flex-shrink:0; transition:background var(--dur-sm) var(--ease-out); }
+.pt-toggle i { position:absolute; top:3px; left:3px; width:16px; height:16px; border-radius:50%; background:#fff; box-shadow:var(--shadow-xs); transition:transform var(--dur-sm) var(--ease-out); }
+.pt-toggle.on { background:hsl(var(--c-agent)); }
+.pt-toggle.on i { transform:translateX(16px); }
+.pt-resetlink { background:none; border:none; cursor:pointer; font-family:var(--f-display); font-weight:var(--fw-bold); font-size:10px; color:hsl(var(--c-warning)); padding:6px 0 0; }
+.pt-resetlink:hover { text-decoration:underline; }
+
+/* trace summary mini */
+.pt-tracemini { display:flex; align-items:center; gap:9px; padding:11px 13px; }
+.pt-tracemini .tx { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); line-height:1.5; flex:1; }
+.pt-tracemini .tx b { color:var(--text-sec); }
+.pt-tracemini .exp { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:10px; color:hsl(var(--c-agent)); background:hsl(var(--c-agent) / .1); border:none; padding:5px 9px; border-radius:var(--r-sm); cursor:pointer; white-space:nowrap; }
+
+/* ─── chat body ─── */
+.pt-chat { display:flex; flex-direction:column; min-height:0; overflow:hidden; background:var(--bg); }
+.pt-chathead { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:11px 16px; border-bottom:1px solid var(--border); background:var(--bg-card); }
+.pt-session-ind { display:inline-flex; align-items:center; gap:6px; font-family:var(--f-mono); font-size:var(--fs-xs); font-weight:var(--fw-bold); color:hsl(var(--c-success)); }
+.pt-session-ind i { width:8px; height:8px; border-radius:50%; background:hsl(var(--c-success)); animation:ptpulse 1.6s var(--ease-in-out) infinite; }
+.pt-session-ind.idle { color:var(--text-muted); } .pt-session-ind.idle i { background:var(--text-muted); animation:none; }
+.pt-chathead .grow { flex:1; }
+.pt-icbtn { width:30px; height:30px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg); color:var(--text-sec); cursor:pointer; font-size:14px; display:inline-flex; align-items:center; justify-content:center; }
+.pt-icbtn:hover { background:var(--bg-muted); color:var(--text); }
+.pt-icbtn.on { background:hsl(var(--c-agent) / .14); color:hsl(var(--c-agent)); border-color:hsl(var(--c-agent) / .35); }
+
+.pt-msgs { flex:1; overflow-y:auto; padding:18px 20px 8px; min-height:0; display:flex; flex-direction:column; gap:16px; }
+
+/* message row */
+.pt-row { display:flex; gap:10px; align-items:flex-start; max-width:760px; width:100%; }
+.pt-row.user { flex-direction:row-reverse; margin-left:auto; }
+.pt-mav { width:30px; height:30px; border-radius:50%; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:14px; font-weight:var(--fw-ext); }
+.pt-row.user .pt-mav { background:hsl(var(--c-player)); color:#fff; font-size:10px; }
+.pt-row.agent .pt-mav { background:hsl(var(--c-agent) / .16); color:hsl(var(--c-agent)); }
+.pt-mcol { min-width:0; display:flex; flex-direction:column; gap:4px; }
+.pt-row.user .pt-mcol { align-items:flex-end; }
+
+.pt-bubble { padding:11px 15px; border-radius:var(--r-lg); font-size:var(--fs-md); line-height:var(--lh-body); position:relative; }
+.pt-row.user .pt-bubble { background:hsl(var(--c-player) / .14); border:1px solid hsl(var(--c-player) / .3); color:var(--text); border-bottom-right-radius:var(--r-sm); }
+.pt-row.agent .pt-bubble { background:hsl(var(--c-agent) / .10); border:1px solid hsl(var(--c-agent) / .25); color:var(--text); border-bottom-left-radius:var(--r-sm); }
+.pt-bubble.err { background:hsl(var(--c-danger) / .05); border-color:hsl(var(--c-danger) / .5); }
+.pt-bubble b { font-weight:var(--fw-bold); }
+.pt-bubble p { margin:0 0 8px; } .pt-bubble p:last-child { margin-bottom:0; }
+.pt-streamhint { display:flex; align-items:center; gap:7px; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-bottom:7px; }
+.pt-streamhint .tk { color:hsl(var(--c-agent)); font-weight:var(--fw-bold); }
+
+.pt-pre { background:var(--bg-sunken); border:1px solid var(--border); border-radius:var(--r-sm); padding:9px 11px; font-family:var(--f-mono); font-size:var(--fs-sm); line-height:1.5; overflow-x:auto; margin:8px 0; color:var(--text-sec); }
+.pt-pre .kw { color:hsl(var(--c-agent)); } .pt-pre .st { color:hsl(var(--c-toolkit)); } .pt-pre .nm { color:hsl(var(--c-chat)); }
+.pt-quote { border-left:3px solid hsl(var(--c-kb)); padding:4px 0 4px 12px; margin:8px 0; font-size:var(--fs-sm); font-style:italic; color:var(--text-sec); }
+.pt-quote .src { display:block; font-style:normal; font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-kb)); margin-top:4px; }
+
+.pt-cursor { display:inline-block; width:7px; height:16px; background:hsl(var(--c-agent)); margin-left:2px; vertical-align:text-bottom; animation:ptblink .9s step-end infinite; }
+@keyframes ptblink { 50% { opacity:0; } }
+@keyframes ptpulse { 0%,100%{ opacity:1; transform:scale(1);} 50%{ opacity:.4; transform:scale(.7);} }
+
+.pt-mhead { display:flex; align-items:center; gap:7px; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.pt-mhead .nm { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); color:var(--text-sec); }
+.pt-mhead .writing { color:hsl(var(--c-agent)); font-weight:var(--fw-bold); display:inline-flex; align-items:center; gap:4px; }
+.pt-mhead .writing i { width:6px; height:6px; border-radius:50%; background:hsl(var(--c-agent)); animation:ptpulse 1.2s var(--ease-in-out) infinite; }
+.pt-mhead .dur { color:var(--text-muted); }
+.pt-mhead .errt { color:hsl(var(--c-danger)); font-weight:var(--fw-bold); }
+.pt-ts { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+
+/* message action footer */
+.pt-mact { display:flex; align-items:center; gap:5px; flex-wrap:wrap; margin-top:8px; padding-top:8px; border-top:1px dashed hsl(var(--c-agent) / .2); }
+.pt-actbtn { display:inline-flex; align-items:center; gap:4px; padding:3px 8px; border-radius:var(--r-sm); border:1px solid transparent; background:var(--bg-card); color:var(--text-sec);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:10px; cursor:pointer; }
+.pt-actbtn:hover { background:var(--bg-muted); color:var(--text); }
+.pt-actbtn.on.up { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); }
+.pt-actbtn.on.down { background:hsl(var(--c-danger) / .14); color:hsl(var(--c-danger)); }
+.pt-mact .grow { flex:1; }
+
+/* error footer CTAs */
+.pt-errfoot { display:flex; align-items:center; gap:7px; flex-wrap:wrap; margin-top:9px; }
+.pt-interrupt-suffix { display:inline-block; margin-top:6px; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); font-style:italic; }
+
+/* system notice */
+.pt-notice { align-self:center; display:inline-flex; align-items:center; gap:7px; padding:6px 14px; border-radius:var(--r-pill);
+  background:var(--bg-muted); color:var(--text-muted); font-family:var(--f-mono); font-size:var(--fs-xs); }
+.pt-notice.warn { background:hsl(var(--c-warning) / .12); color:hsl(var(--c-warning)); }
+
+/* empty / idle state */
+.pt-idle { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; gap:10px; padding:30px; }
+.pt-idle .em { font-size:48px; color:hsl(var(--c-agent)); }
+.pt-idle h3 { font-family:var(--f-display); font-size:var(--fs-xl); }
+.pt-idle p { color:var(--text-sec); font-size:var(--fs-sm); max-width:340px; line-height:var(--lh-body); }
+.pt-idle .quick { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; margin-top:6px; }
+.pt-qcta { padding:7px 13px; border-radius:var(--r-pill); border:1px solid hsl(var(--c-agent) / .35); background:hsl(var(--c-agent) / .08); color:hsl(var(--c-agent));
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); cursor:pointer; }
+.pt-qcta:hover { background:hsl(var(--c-agent) / .16); }
+
+/* ─── composer ─── */
+.pt-composer { flex-shrink:0; border-top:1px solid var(--border); background:var(--bg-card); padding:10px 16px 12px; }
+.pt-comp-tools { display:flex; align-items:center; gap:6px; margin-bottom:8px; }
+.pt-tool { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border-radius:var(--r-pill); border:1px solid var(--border); background:var(--bg); color:var(--text-sec);
+  font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-xs); cursor:pointer; }
+.pt-tool:hover { background:var(--bg-muted); color:var(--text); }
+.pt-tool.on { background:hsl(var(--c-chat) / .12); color:hsl(var(--c-chat)); border-color:hsl(var(--c-chat) / .35); }
+.pt-comp-tools .grow { flex:1; }
+.pt-charcount { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.pt-comp-row { display:flex; align-items:flex-end; gap:9px; }
+.pt-ta { flex:1; resize:none; padding:10px 12px; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg);
+  font-family:var(--f-body); font-size:var(--fs-md); line-height:var(--lh-body); color:var(--text); outline:none; min-height:46px; max-height:160px; }
+.pt-ta:focus { border-color:hsl(var(--c-agent) / .5); box-shadow:0 0 0 3px hsl(var(--c-agent) / .12); }
+.pt-ta:disabled { background:var(--bg-muted); color:var(--text-muted); cursor:not-allowed; }
+.pt-comp-fail { display:inline-flex; align-items:center; gap:5px; margin-bottom:8px; padding:3px 9px; border-radius:var(--r-pill); background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); font-family:var(--f-mono); font-size:10px; font-weight:var(--fw-bold); }
+.pt-kbd { font-family:var(--f-mono); font-size:9px; background:var(--bg-muted); border:1px solid var(--border); border-bottom-width:2px; border-radius:var(--r-xs); padding:1px 4px; color:var(--text-sec); }
+
+/* ─── trace drawer ─── */
+.pt-trace { background:var(--bg-card); border-left:1px solid var(--border); display:flex; flex-direction:column; min-height:0; overflow:hidden; animation:pttracein var(--dur-md) var(--ease-out); }
+@keyframes pttracein { from { opacity:0; transform:translateX(12px); } to { opacity:1; transform:none; } }
+.pt-trace-head { flex-shrink:0; display:flex; align-items:center; gap:8px; padding:12px 14px; border-bottom:1px solid var(--border); }
+.pt-trace-head h3 { font-family:var(--f-display); font-size:var(--fs-md); }
+.pt-trace-head .grow { flex:1; }
+.pt-trace-body { flex:1; overflow-y:auto; padding:14px 14px 28px; min-height:0; display:flex; flex-direction:column; gap:12px; }
+.pt-tblock { border:1px solid var(--border); border-radius:var(--r-md); overflow:hidden; flex-shrink:0; }
+.pt-tblock-h { width:100%; display:flex; align-items:center; gap:8px; padding:9px 11px; background:var(--bg-muted); border:none; cursor:pointer; text-align:left;
+  font-family:var(--f-mono); font-size:9px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); }
+.pt-tblock-h:hover { background:var(--bg-sunken); }
+.pt-tblock.open .pt-tblock-h { border-bottom:1px solid var(--border); }
+.pt-tblock-h .t { flex:1; font-weight:var(--fw-bold); }
+.pt-tblock-h .cv { font-size:8px; color:hsl(var(--c-agent)); transition:transform var(--dur-sm) var(--ease-out); }
+.pt-tblock.collapsed .pt-tblock-h .cv { transform:rotate(-90deg); }
+.pt-tgrid { display:grid; grid-template-columns:auto 1fr; gap:6px 12px; padding:10px 11px; font-family:var(--f-mono); font-size:11px; }
+.pt-tgrid .k { color:var(--text-muted); } .pt-tgrid .v { color:var(--text); font-weight:var(--fw-bold); text-align:right; }
+.pt-trow { display:flex; gap:8px; padding:8px 11px; border-top:1px solid var(--border-light); font-size:var(--fs-xs); align-items:flex-start; }
+.pt-trow:first-child { border-top:none; }
+.pt-trow .ti { flex-shrink:0; }
+.pt-trow .tc { min-width:0; }
+.pt-trow .tc .l1 { font-family:var(--f-mono); font-size:11px; color:var(--text); word-break:break-word; }
+.pt-trow .tc .l2 { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-top:2px; }
+.pt-kbsrc { cursor:pointer; } .pt-kbsrc:hover { background:hsl(var(--c-kb) / .07); }
+.pt-kbsrc .l1 { color:hsl(var(--c-kb)); }
+.pt-score { margin-left:auto; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); flex-shrink:0; }
+.pt-twarn { padding:10px 11px; background:hsl(var(--c-warning) / .08); border-top:1px solid hsl(var(--c-warning) / .3); display:flex; gap:8px; font-size:var(--fs-xs); color:hsl(var(--c-warning)); }
+
+/* ─── compare mode ─── */
+.pt-compare { flex:1; display:grid; grid-template-columns:1fr 1fr; min-height:0; overflow:hidden; }
+.pt-ccol { display:flex; flex-direction:column; min-height:0; overflow:hidden; }
+.pt-ccol:first-child { border-right:1px solid var(--border); }
+.pt-chead { flex-shrink:0; display:flex; align-items:center; gap:8px; padding:9px 14px; border:none; width:100%; text-align:left; cursor:pointer; color:var(--text); font-family:inherit; background:var(--bg-muted); border-bottom:1px solid var(--border); position:sticky; top:0; z-index:1; }
+.pt-chead:hover { background:var(--bg-sunken); }
+.pt-cv { margin-left:8px; font-size:9px; color:var(--text-muted); transition:transform var(--dur-sm) var(--ease-out); flex-shrink:0; }
+.pt-ccol.collapsed .pt-cv { transform:rotate(-90deg); }
+.pt-ccol.collapsed { flex:0 0 auto; }
+.pt-chead .ttl { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); }
+.pt-cmsgs { flex:1; overflow-y:auto; padding:14px; min-height:0; display:flex; flex-direction:column; gap:13px; }
+.pt-cmsgs .pt-row { max-width:none; }
+
+/* ─── mobile ─── */
+.pt-app.is-mobile .pt-head .hrow { flex-direction:column; align-items:stretch; gap:9px; padding:11px 13px; }
+.pt-app.is-mobile .pt-head .htxt { width:100%; min-width:0; }
+.pt-app.is-mobile .pt-head .grow { display:none; }
+.pt-app.is-mobile .pt-bread { font-size:10px; }
+.pt-app.is-mobile .pt-h1 { font-size:var(--fs-lg); }
+.pt-app.is-mobile .pt-sub { font-size:var(--fs-xs); }
+.pt-app.is-mobile .pt-headcta { display:none; }
+.pt-app.is-mobile .pt-kbdhint { display:none; }
+.pt-app.is-mobile .pt-split, .pt-app.is-mobile .pt-split.has-trace, .pt-app.is-mobile .pt-split.compare { display:flex; flex-direction:column; }
+.pt-app.is-mobile .pt-chat { flex:1; min-height:0; }
+.pt-app.is-mobile .pt-config { display:none; }
+.pt-mcfg { display:none; }
+.pt-app.is-mobile .pt-mcfg { display:block; flex-shrink:0; border-bottom:1px solid var(--border); background:var(--bg-muted); }
+.pt-mcfg-head { display:flex; align-items:center; gap:8px; padding:10px 13px; cursor:pointer; background:none; border:none; width:100%; text-align:left; color:var(--text); }
+.pt-mcfg-head:hover { background:var(--bg-sunken); }
+.pt-mcfg-head .ttl { font-family:var(--f-display); font-weight:var(--fw-bold); font-size:var(--fs-sm); flex:1; }
+.pt-mcfg-head .cv { font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-agent)); font-weight:var(--fw-bold); }
+.pt-app.is-mobile .pt-fsbtn { display:none; }
+.pt-app.is-mobile .pt-compare { display:flex; flex-direction:column; overflow-y:auto; min-height:0; }
+.pt-app.is-mobile .pt-ccol { flex:0 0 auto; overflow:visible; }
+.pt-app.is-mobile .pt-cmsgs { overflow:visible; flex:0 0 auto; }
+.pt-app.is-mobile .pt-ccol:first-child { border-right:none; border-bottom:1px solid var(--border); }
+.pt-app.is-mobile .pt-row { max-width:none; }
+.pt-app.is-mobile .pt-composer { padding:9px 12px 11px; }
+
+/* mobile trace bottom-sheet */
+.pt-sheet-veil { position:absolute; inset:0; z-index:var(--z-modal); background:rgba(20,12,4,.5); display:flex; align-items:stretch; animation:ptfade var(--dur-md) var(--ease-out); }
+@keyframes ptfade { from { opacity:0; } to { opacity:1; } }
+.pt-sheet { width:100%; height:100%; max-height:100%; background:var(--bg-card); border-radius:0; box-shadow:var(--shadow-drawer); display:flex; flex-direction:column; overflow:hidden; animation:ptsheet var(--dur-md) var(--ease-out); }
+@keyframes ptsheet { from { transform:translateY(24px); opacity:.4; } to { transform:none; opacity:1; } }
+.pt-sheet .grab { width:38px; height:4px; border-radius:var(--r-pill); background:var(--border-strong); margin:9px auto 4px; }
+.pt-sheet-head { display:flex; align-items:center; gap:8px; padding:4px 14px 10px; border-bottom:1px solid var(--border); flex-shrink:0; }
+.pt-sheet-head h3 { font-family:var(--f-display); font-size:var(--fs-md); }
+.pt-sheet-head .grow { flex:1; }
+.pt-sheet-body { overflow-y:auto; padding:12px 13px 16px; display:flex; flex-direction:column; gap:11px; min-height:0; }
+.pt-app.is-mobile .pt-sheet .pt-trace { display:flex; flex:1; min-height:0; border-left:none; animation:none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .pt-cursor, .pt-session-ind i, .pt-livechip i, .pt-mhead .writing i, .pt-trace { animation:none; }
+}
+`;
+
+/* ══════════════════════════════════════════════════════════
+   Dati — typology "Catan Rules Expert v3 (Draft)" + sessione test (IT)
+   ══════════════════════════════════════════════════════════ */
+const TYPOLOGY = {
+  id: 'tp-catan-rules-3', name: 'Catan Rules Expert', version: 'v3 (Draft)', icon: '🤖',
+  caps: [['Q&A', true], ['Streaming', true], ['Tool', true], ['Image', false], ['Web', true]],
+  game: 'Catan', author: { name: 'Marco R.', initials: 'MR' }, model: 'gpt-4o-mini',
+};
+
+const SAMPLES = [
+  { q: 'Quante carte risorsa pesca ogni giocatore a inizio partita?', tmpl: 'Conteggio + fonte' },
+  { q: 'Cosa succede quando esce un 7 con i dadi?', tmpl: 'Regola ladro' },
+  { q: 'Come si imposta una partita per 3 giocatori?', tmpl: 'Setup passo-passo' },
+];
+
+/* singola risposta agent renderizzata con quote RAG + (opz) code block */
+const AGENT_A1 = {
+  blocks: [
+    { t: 'p', html: 'A inizio partita ogni giocatore riceve le risorse dei terreni adiacenti al <b>secondo</b> insediamento piazzato: <b>una carta risorsa per ogni esagono confinante</b>. Il deserto non produce nulla.' },
+    { t: 'quote', html: '«Dopo aver piazzato il secondo insediamento, ciascun giocatore prende una carta risorsa per ogni esagono adiacente a quell’insediamento.»', src: '📄 catan-rules.pdf · p.4 §1.3 · score 0.91' },
+    { t: 'p', html: 'Quindi tipicamente <b>3 carte</b>, ma possono essere 2 se l’insediamento tocca un esagono deserto o un porto di mare.' },
+  ],
+};
+const AGENT_A2 = {
+  blocks: [
+    { t: 'p', html: 'Quando esce <b>7</b> nessun terreno produce risorse. La sequenza è:' },
+    { t: 'pre', code: [
+      { txt: '1. ', cls: '' }, { txt: 'scarto', cls: 'kw' }, { txt: ' → chi ha >7 carte ne scarta metà (arrot. difetto)\n', cls: '' },
+      { txt: '2. ', cls: '' }, { txt: 'ladro', cls: 'kw' }, { txt: '  → il giocatore di turno lo sposta su un esagono\n', cls: '' },
+      { txt: '3. ', cls: '' }, { txt: 'furto', cls: 'kw' }, { txt: '  → ruba ', cls: '' }, { txt: '1', cls: 'nm' }, { txt: ' carta a un avversario adiacente', cls: '' },
+    ] },
+    { t: 'p', html: 'L’esagono col ladro resta bloccato finché un nuovo 7 (o un cavaliere) non lo sposta.' },
+  ],
+};
+const AGENT_A3 = {
+  blocks: [{ t: 'p', html: 'Con <b>3 giocatori</b> si usa il tabellone base completo. Ogni giocatore riceve 5 insediamenti, 4 città e 15 strade. Si piazzano 2 insediamenti + 2 strade a testa in ordine, poi a ritroso.' }],
+};
+
+const ROUNDS = [
+  { id: 'r1', q: SAMPLES[0].q, a: AGENT_A1, ts: '15:38', dur: '1.8s', tokens: 312 },
+  { id: 'r2', q: SAMPLES[1].q, a: AGENT_A2, ts: '15:40', dur: '2.3s', tokens: 287 },
+  { id: 'r3', q: 'Posso costruire una strada non collegata alle mie?', a: AGENT_A3, ts: '15:41', dur: '1.4s', tokens: 198 },
+  { id: 'r4', q: SAMPLES[2].q, a: AGENT_A3, ts: '15:43', dur: '1.9s', tokens: 241 },
+];
+
+/* testo parziale per lo stato streaming (typewriter) */
+const STREAM_PARTIAL = 'I malus di ferita si cumulano solo con i malus situazionali. Quando esce 7 il ladro va spostato e il giocatore di turno ruba una carta a un avversario adiacente all’esagono';
+
+const TRACE = {
+  model: 'gpt-4o-mini', ttft: '240ms', total: '1.8s',
+  tokIn: 145, tokOut: 312, tokTot: 457, cost: '$0.0023',
+  tools: [{ name: "search_rules(query='Catan distribuzione iniziale')", meta: '180ms · 3 risultati' }],
+  rag: [
+    { doc: 'catan-rules.pdf · p.4 §1.3', meta: 'Distribuzione iniziale risorse', score: '0.91' },
+    { doc: 'catan-faq.md · §setup', meta: 'FAQ ufficiale Kosmos', score: '0.78' },
+  ],
+  web: [{ q: "'catan setup ufficiale regole'", meta: '→ 5 risultati' }],
+};
+
+/* ══════════════════════════════════════════════════════════
+   Scenari (12 stati)
+   ══════════════════════════════════════════════════════════ */
+const SC = {
+  'idle-empty':          { chat: 'idle', rounds: 0, fsm: null, input: 'empty', trace: false, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+  'typing-input':        { chat: 'idle', rounds: 0, fsm: null, input: 'typing', trace: false, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+  'streaming-active':    { chat: 'active', rounds: 1, fsm: 'streaming', input: 'disabled', trace: false, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+  'streaming-stop-clicked': { chat: 'active', rounds: 1, fsm: 'stopped', input: 'empty', trace: false, compare: false, stopped: true, notice: null, err: null, status: 'Draft' },
+  'completed-single':    { chat: 'active', rounds: 1, fsm: 'completed', input: 'empty', trace: false, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+  'completed-multi':     { chat: 'active', rounds: 4, fsm: 'completed', input: 'empty', trace: false, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+  'error-rate-limit':    { chat: 'active', rounds: 1, fsm: 'error', input: 'empty', trace: false, compare: false, stopped: false, notice: null, err: 'rate-limit', status: 'Draft' },
+  'error-timeout':       { chat: 'active', rounds: 1, fsm: 'error', input: 'empty', trace: false, compare: false, stopped: false, notice: null, err: 'timeout', status: 'Draft' },
+  'error-network':       { chat: 'active', rounds: 2, fsm: 'error', input: 'failed', trace: false, compare: false, stopped: false, notice: 'network', err: 'network', status: 'Draft' },
+  'trace-drawer-open':   { chat: 'active', rounds: 1, fsm: 'completed', input: 'empty', trace: true, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+  'compare-mode':        { chat: 'active', rounds: 1, fsm: 'completed', input: 'empty', trace: false, compare: true, stopped: false, notice: null, err: null, status: 'Draft' },
+  'mobile-stack':        { chat: 'active', rounds: 1, fsm: 'completed', input: 'empty', trace: false, compare: false, stopped: false, notice: null, err: null, status: 'Draft' },
+};
+const STATE_LIST = [
+  ['idle-empty', 'Idle empty'], ['typing-input', 'Typing input'], ['streaming-active', 'Streaming'],
+  ['streaming-stop-clicked', 'Stop clicked'], ['completed-single', 'Completed'], ['completed-multi', 'Multi-turn'],
+  ['error-rate-limit', 'Err · rate limit'], ['error-timeout', 'Err · timeout'], ['error-network', 'Err · network'],
+  ['trace-drawer-open', 'Trace drawer'], ['compare-mode', 'Compare'], ['mobile-stack', 'Mobile stack'],
+];
+const ERR_META = {
+  'rate-limit': { title: '⚠ Errore streaming · Rate limit', body: 'Limite di richieste raggiunto sul modello gpt-4o-mini. Riprova tra', countdown: '30s', reason: 'Rate limit reached' },
+  'timeout':    { title: '⚠ Errore streaming · Timeout', body: 'Il modello non ha risposto entro 15 secondi (hard timeout). La richiesta è stata interrotta.', countdown: null, reason: 'Model timeout (15s)' },
+  'network':    { title: '⚠ Errore streaming · Connessione persa', body: 'Connessione interrotta durante lo streaming. L’ultima richiesta non è stata completata.', countdown: null, reason: 'Network lost' },
+};
+
+/* ══════════════════════════════════════════════════════════
+   Sub-components
+   ══════════════════════════════════════════════════════════ */
+function AuthorChip({ who }) {
+  return <span className="ce-author" title={'Autore: ' + who.name}><span className="av" aria-hidden="true">{who.initials}</span>{who.name}</span>;
+}
+
+function TestHeader({ sc, mobile }) {
+  const m = sc.status === 'Rejected' ? { cls: 'rejected', icon: '✕', label: 'Rejected' } : { cls: 'draft', icon: '✎', label: 'Draft' };
+  return (
+    <header className="pt-head">
+      <div className="hrow">
+        <div className="htxt">
+          <nav className="pt-bread" aria-label="Breadcrumb">
+            <span>Editor</span><span className="sep">›</span><span>Agent proposals</span><span className="sep">›</span>
+            <span>Catan Rules Expert</span><span className="sep">›</span><span className="cur">Test playground</span>
+          </nav>
+          <div className="pt-titlerow">
+            <h1 className="pt-h1">{TYPOLOGY.icon} {TYPOLOGY.name} · {TYPOLOGY.version}</h1>
+            <span className={'ce-badge ' + m.cls} aria-label={'Stato: ' + m.label}><span className="bi" aria-hidden="true">{m.icon}</span>{m.label}</span>
+            <span className="pt-livechip" title="Esiste una versione in produzione"><i aria-hidden="true" />v2 live</span>
+          </div>
+          <div className="pt-sub">Modalità <b>test playground</b> · sessione effimera, non salvata · testato da <AuthorChip who={TYPOLOGY.author} /></div>
+        </div>
+        <span className="grow" />
+        <div className="pt-headcta">
+          <button className="pt-btn link"><span className="ic" aria-hidden="true">←</span> Torna a edit</button>
+          <button className="pt-btn sec"><span className="ic" aria-hidden="true">🔄</span> Reset session</button>
+          <button className="pt-btn info-out"><span className="ic" aria-hidden="true">📊</span> Confronta versioni</button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/* ─── config sidebar sections ─── */
+function TypologySummary() {
+  return (
+    <div className="pt-cfg-card pt-tysum">
+      <h4>Typology in test</h4>
+      <div className="row1">
+        <div className="pt-tyav" aria-hidden="true">{TYPOLOGY.icon}</div>
+        <div><div className="nm">{TYPOLOGY.name}</div><div className="vr">{TYPOLOGY.version} · {TYPOLOGY.id}</div></div>
+      </div>
+      <div className="pt-cfg-lbl">Capabilities</div>
+      <div className="pt-chipstrip">
+        {TYPOLOGY.caps.map(([c, on]) => <span key={c} className={'pt-cap' + (on ? '' : ' off')}>{on ? '✓' : '–'} {c}</span>)}
+      </div>
+      <div className="pt-cfg-lbl">Game scope</div>
+      <div className="pt-chipstrip"><button className="pt-gchip" title="Apri scheda gioco">🎲 {TYPOLOGY.game}</button></div>
+      <div className="foot">
+        <AuthorChip who={TYPOLOGY.author} />
+        <button className="pt-cfg-link muted">📝 Modifica config</button>
+      </div>
+    </div>
+  );
+}
+
+function SampleInputs({ onFill }) {
+  return (
+    <div className="pt-cfg-card">
+      <h4>Esempi rapidi <span className="ct">({SAMPLES.length} disponibili)</span></h4>
+      {SAMPLES.map((s, i) => (
+        <div key={i} className="pt-sample" role="button" tabIndex={0} onClick={() => onFill(s.q)}
+             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onFill(s.q); } }}
+             title="Click per autofill nell’input (non invia)">
+          <div className="q">{s.q}</div>
+          <div className="meta"><span className="tmpl">▦ {s.tmpl}</span><span className="fill">↧ autofill</span></div>
+        </div>
+      ))}
+      <button className="pt-cfg-link" style={{ marginTop: 4 }}>+ Crea nuovo esempio</button>
+    </div>
+  );
+}
+
+function SessionConfig({ cfg, setCfg }) {
+  return (
+    <div className="pt-cfg-card">
+      <h4>Config sessione</h4>
+      <div className="pt-field">
+        <div className="pt-cfg-lbl">Model</div>
+        <div className="pt-selectw">
+          <select className="pt-select" value={cfg.model} onChange={e => setCfg({ ...cfg, model: e.target.value })} aria-label="Modello">
+            <option>gpt-4o-mini</option><option>gpt-4o</option><option>claude-3-5-sonnet</option>
+          </select>
+        </div>
+      </div>
+      <div className="pt-field">
+        <div className="pt-cfg-lbl">Temperature</div>
+        <div className="pt-rangerow">
+          <input className="pt-range" type="range" min="0" max="1" step="0.1" value={cfg.temp}
+                 onChange={e => setCfg({ ...cfg, temp: parseFloat(e.target.value) })} aria-label="Temperature" />
+          <span className="pt-rangeval">{cfg.temp.toFixed(1)}</span>
+        </div>
+      </div>
+      <div className="pt-field">
+        <div className="pt-cfg-lbl">Max tokens</div>
+        <input className="pt-num" type="number" value={cfg.maxTok} onChange={e => setCfg({ ...cfg, maxTok: e.target.value })} aria-label="Max tokens" />
+      </div>
+      <div className="pt-togrow">
+        <div className="tl">Streaming <div className="ts">token-by-token vs full response</div></div>
+        <button className={'pt-toggle' + (cfg.streaming ? ' on' : '')} role="switch" aria-checked={cfg.streaming} aria-label="Streaming"
+                onClick={() => setCfg({ ...cfg, streaming: !cfg.streaming })}><i /></button>
+      </div>
+      <div className="pt-togrow">
+        <div className="tl">Show trace panel <div className="ts">apre il drawer destro</div></div>
+        <button className={'pt-toggle' + (cfg.trace ? ' on' : '')} role="switch" aria-checked={cfg.trace} aria-label="Mostra pannello trace"
+                onClick={() => setCfg({ ...cfg, trace: !cfg.trace })}><i /></button>
+      </div>
+      <button className="pt-resetlink">↺ Ripristina default</button>
+    </div>
+  );
+}
+
+function TraceSummaryMini({ rounds, onOpen }) {
+  const msgs = rounds * 2;
+  return (
+    <div className="pt-cfg-card" style={{ padding: 0 }}>
+      <div className="pt-tracemini">
+        <div className="tx">Sessione: <b>{msgs} messaggi</b> · <b>12.4k tokens</b> · <b>$0.18</b> stimato</div>
+        <button className="exp" onClick={onOpen} title="Apri trace completo">🐛 Trace</button>
+      </div>
+    </div>
+  );
+}
+
+function ConfigSidebar({ cfg, setCfg, rounds, onFill, onOpenTrace }) {
+  return (
+    <aside className="pt-config" aria-label="Configurazione sessione test">
+      <TypologySummary />
+      <SampleInputs onFill={onFill} />
+      <SessionConfig cfg={cfg} setCfg={setCfg} />
+      <TraceSummaryMini rounds={rounds} onOpen={onOpenTrace} />
+    </aside>
+  );
+}
+
+/* ─── messages ─── */
+function AgentBlocks({ a }) {
+  return a.blocks.map((b, i) => {
+    if (b.t === 'p') return <p key={i} dangerouslySetInnerHTML={{ __html: b.html }} />;
+    if (b.t === 'quote') return <div className="pt-quote" key={i}>{b.html}<span className="src">{b.src}</span></div>;
+    if (b.t === 'pre') return <pre className="pt-pre" key={i}>{b.code.map((s, j) => <span key={j} className={s.cls}>{s.txt}</span>)}</pre>;
+    return null;
+  });
+}
+
+function MessageActions({ fb, setFb, onTrace }) {
+  return (
+    <div className="pt-mact">
+      <button className={'pt-actbtn up' + (fb === 'up' ? ' on' : '')} aria-pressed={fb === 'up'} onClick={() => setFb(fb === 'up' ? null : 'up')}>👍 Buono</button>
+      <button className={'pt-actbtn down' + (fb === 'down' ? ' on' : '')} aria-pressed={fb === 'down'} onClick={() => setFb(fb === 'down' ? null : 'down')}>👎 Sbagliato</button>
+      <button className="pt-actbtn">📋 Copia</button>
+      <button className="pt-actbtn">🔄 Rigenera</button>
+      <span className="grow" />
+      <button className="pt-actbtn" onClick={onTrace}>🐛 Trace</button>
+    </div>
+  );
+}
+
+function UserMessage({ q }) {
+  return (
+    <div className="pt-row user">
+      <div className="pt-mav" aria-hidden="true">{TYPOLOGY.author.initials}</div>
+      <div className="pt-mcol">
+        <div className="pt-bubble">{q}</div>
+        <div className="pt-ts">{TYPOLOGY.author.name} · 15:42</div>
+      </div>
+    </div>
+  );
+}
+
+/* typewriter hook per lo stato streaming */
+function useTypewriter(text, active, speed) {
+  const [n, setN] = useState(active ? 0 : text.length);
+  useEffect(() => {
+    if (!active) { setN(text.length); return; }
+    setN(0);
+    let i = 0;
+    const id = setInterval(() => { i += 2; setN(i); if (i >= text.length) clearInterval(id); }, speed || 24);
+    return () => clearInterval(id);
+  }, [text, active, speed]);
+  return active ? text.slice(0, n) : text;
+}
+
+function StreamingAgent() {
+  const shown = useTypewriter(STREAM_PARTIAL, true, 22);
+  return (
+    <div className="pt-row agent">
+      <div className="pt-mav" aria-hidden="true">{TYPOLOGY.icon}</div>
+      <div className="pt-mcol" style={{ width: '100%' }}>
+        <div className="pt-bubble" aria-busy="true" aria-live="polite">
+          <div className="pt-mhead"><span className="nm">{TYPOLOGY.name}</span><span className="writing"><i aria-hidden="true" />⚡ Sta scrivendo…</span></div>
+          <div className="pt-streamhint">TTFT <span className="tk">240ms</span> · <span className="tk">23 tokens/s</span></div>
+          <p style={{ marginBottom: 0 }}>{shown}<span className="pt-cursor" aria-hidden="true" /></p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompletedAgent({ round, stopped, onTrace }) {
+  const [fb, setFb] = useState(null);
+  return (
+    <div className="pt-row agent">
+      <div className="pt-mav" aria-hidden="true">{TYPOLOGY.icon}</div>
+      <div className="pt-mcol" style={{ width: '100%' }}>
+        <div className="pt-bubble" aria-busy="false">
+          <div className="pt-mhead"><span className="nm">{TYPOLOGY.name}</span><span>· {round.ts}</span><span className="dur">📊 {round.dur} · {round.tokens} tokens</span></div>
+          <div style={{ marginTop: 7 }}><AgentBlocks a={round.a} /></div>
+          {stopped && <span className="pt-interrupt-suffix">[Interrotto dall’utente]</span>}
+          <MessageActions fb={fb} setFb={setFb} onTrace={onTrace} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ErrorAgent({ err, onTrace }) {
+  const m = ERR_META[err];
+  return (
+    <div className="pt-row agent">
+      <div className="pt-mav" aria-hidden="true">{TYPOLOGY.icon}</div>
+      <div className="pt-mcol" style={{ width: '100%' }}>
+        <div className="pt-bubble err" role="alert">
+          <div className="pt-mhead"><span className="nm">{TYPOLOGY.name}</span><span className="errt">{m.title}</span></div>
+          <p style={{ marginTop: 7 }}>{m.body}{m.countdown && <b> {m.countdown}</b>}{m.countdown && '.'}</p>
+          <div className="pt-errfoot">
+            <button className="pt-btn danger"><span className="ic" aria-hidden="true">🔄</span> Riprova</button>
+            <button className="pt-btn danger-out" onClick={onTrace}><span className="ic" aria-hidden="true">🐛</span> Trace error</button>
+            <span className="pt-ts" style={{ marginLeft: 'auto' }}>reason: {m.reason}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IdleBody({ onFill }) {
+  return (
+    <div className="pt-idle" role="status">
+      <div className="em" aria-hidden="true">{TYPOLOGY.icon}</div>
+      <h3>👋 Invia un messaggio per testare l’agent</h3>
+      <p>Usa gli esempi nella sidebar per partire velocemente, oppure scrivi una domanda di test qui sotto.</p>
+      <div className="quick">
+        <button className="pt-qcta" onClick={() => onFill('Quali sono le regole base di una domanda?')}>Domanda regole</button>
+        <button className="pt-qcta" onClick={() => onFill('Dammi un consiglio strategico per l’apertura.')}>Strategy advice</button>
+        <button className="pt-qcta" onClick={() => onFill('Come si imposta la partita passo-passo?')}>Setup tutorial</button>
+      </div>
+    </div>
+  );
+}
+
+/* ─── chat body ─── */
+function ChatHeader({ sc, onFullscreen, onTrace }) {
+  const active = sc.chat === 'active';
+  const msgs = sc.rounds * 2 + (sc.fsm === 'streaming' || sc.fsm === 'error' ? 1 : 0);
+  return (
+    <div className="pt-chathead">
+      <span className={'pt-session-ind' + (active ? '' : ' idle')}>
+        <i aria-hidden="true" />{active ? `🟢 Sessione attiva · ${msgs} messaggi` : 'Sessione non avviata'}
+      </span>
+      <span className="grow" />
+      <button className="pt-icbtn" aria-label="Apri trace" title="Trace" onClick={onTrace}>🐛</button>
+      <button className="pt-icbtn pt-fsbtn" aria-label="Schermo intero — nascondi sidebar" title="Schermo intero" onClick={onFullscreen}>⛶</button>
+    </div>
+  );
+}
+
+function MessageList({ sc, onTrace }) {
+  if (sc.chat === 'idle') return <div className="pt-msgs"><IdleBody onFill={() => {}} /></div>;
+  const visible = ROUNDS.slice(0, sc.rounds);
+  return (
+    <div className="pt-msgs" role="log" aria-live="polite" aria-relevant="additions" aria-label="Messaggi sessione test">
+      {visible.map((r, i) => {
+        const isLast = i === visible.length - 1;
+        return (
+          <React.Fragment key={r.id}>
+            <UserMessage q={r.q} />
+            {!(isLast && (sc.fsm === 'streaming' || sc.fsm === 'error'))
+              ? <CompletedAgent round={r} stopped={isLast && sc.stopped} onTrace={onTrace} />
+              : null}
+          </React.Fragment>
+        );
+      })}
+      {sc.fsm === 'streaming' && <StreamingAgent />}
+      {sc.notice === 'network' && <div className="pt-notice warn" role="status">⚠️ Connessione persa, riconnessione…</div>}
+      {sc.fsm === 'error' && <ErrorAgent err={sc.err} onTrace={onTrace} />}
+    </div>
+  );
+}
+
+function Composer({ sc, draft, setDraft, onFullWidthStop }) {
+  const disabled = sc.input === 'disabled';
+  const streaming = sc.fsm === 'streaming';
+  const failed = sc.input === 'failed';
+  const count = draft.length;
+  const caps = TYPOLOGY.caps;
+  const hasImg = caps.find(c => c[0] === 'Image')[1];
+  const hasWeb = caps.find(c => c[0] === 'Web')[1];
+  return (
+    <div className="pt-composer">
+      {failed && <div className="pt-comp-fail">⚠ Ultima richiesta fallita</div>}
+      <div className="pt-comp-tools">
+        <button className="pt-tool" disabled={disabled}>🎴 Sample</button>
+        <button className="pt-tool" disabled={disabled || !hasImg} title={hasImg ? 'Allega immagine' : 'Image capability disabilitata'}>📎 Allega</button>
+        <button className={'pt-tool' + (hasWeb ? '' : '')} disabled={disabled || !hasWeb} title={hasWeb ? 'Web search' : 'Web capability disabilitata'}>🌐 Web</button>
+        <span className="grow" />
+        <span className="pt-charcount">{count} / 4000</span>
+      </div>
+      <div className="pt-comp-row">
+        <textarea className="pt-ta" rows={sc.input === 'typing' ? 5 : 3} value={draft} disabled={disabled}
+                  onChange={e => setDraft(e.target.value)} aria-label="Messaggio di test" aria-multiline="true"
+                  placeholder="Scrivi un messaggio di test… (Ctrl+Enter per inviare)" />
+        {streaming
+          ? <button className="pt-btn danger-out" onClick={onFullWidthStop} aria-label="Interrompi streaming"><span className="ic" aria-hidden="true">⏹</span> Interrompi</button>
+          : <button className="pt-btn agent" disabled={disabled || count === 0} aria-label="Invia messaggio di test">Invia <span className="ic" aria-hidden="true">→</span></button>}
+      </div>
+      <div className="pt-kbdhint" style={{ marginTop: 7 }}>
+        <span className="pt-charcount"><span className="pt-kbd">Ctrl</span> <span className="pt-kbd">↵</span> invia · <span className="pt-kbd">Esc</span> interrompi · <span className="pt-kbd">Ctrl</span> <span className="pt-kbd">T</span> trace</span>
+      </div>
+    </div>
+  );
+}
+
+function ChatBody({ sc, draft, setDraft, onTrace, onFullscreen }) {
+  return (
+    <section className="pt-chat" aria-label="Chat di test">
+      <ChatHeader sc={sc} onFullscreen={onFullscreen} onTrace={onTrace} />
+      <MessageList sc={sc} onTrace={onTrace} />
+      <Composer sc={sc} draft={draft} setDraft={setDraft} onFullWidthStop={() => {}} />
+    </section>
+  );
+}
+
+/* ─── trace drawer ─── */
+function TBlock({ title, count, defaultOpen, children }) {
+  const [open, setOpen] = useState(defaultOpen !== false);
+  return (
+    <div className={'pt-tblock' + (open ? ' open' : ' collapsed')}>
+      <button className="pt-tblock-h" aria-expanded={open} onClick={() => setOpen(o => !o)}>
+        <span className="t">{title}{count != null ? ' · ' + count : ''}</span>
+        <span className="cv" aria-hidden="true">▼</span>
+      </button>
+      {open && <div className="pt-tblock-c">{children}</div>}
+    </div>
+  );
+}
+
+function TraceDrawer({ onClose }) {
+  return (
+    <aside className="pt-trace" role="complementary" aria-labelledby="pt-trace-title">
+      <div className="pt-trace-head">
+        <h3 id="pt-trace-title">🐛 Trace</h3>
+        <span className="pt-ts">msg #2 · agent</span>
+        <span className="grow" />
+        <button className="pt-icbtn" aria-label="Chiudi trace" onClick={onClose}>✕</button>
+      </div>
+      <div className="pt-trace-body">
+        <TBlock title="Modello & latenza">
+          <div className="pt-tgrid">
+            <span className="k">Model</span><span className="v">{TRACE.model}</span>
+            <span className="k">TTFT</span><span className="v">{TRACE.ttft}</span>
+            <span className="k">Total</span><span className="v">{TRACE.total}</span>
+          </div>
+        </TBlock>
+        <TBlock title="Tokens & costo">
+          <div className="pt-tgrid">
+            <span className="k">Input</span><span className="v">{TRACE.tokIn}</span>
+            <span className="k">Output</span><span className="v">{TRACE.tokOut}</span>
+            <span className="k">Total</span><span className="v">{TRACE.tokTot}</span>
+            <span className="k">Cost</span><span className="v">{TRACE.cost}</span>
+          </div>
+        </TBlock>
+        <TBlock title="Tool calls" count={TRACE.tools.length}>
+          {TRACE.tools.map((t, i) => (
+            <div className="pt-trow" key={i}><span className="ti">🔧</span><div className="tc"><div className="l1">{t.name}</div><div className="l2">{t.meta}</div></div></div>
+          ))}
+        </TBlock>
+        <TBlock title="RAG sources" count={TRACE.rag.length}>
+          {TRACE.rag.map((r, i) => (
+            <div className="pt-trow pt-kbsrc" key={i} role="button" tabIndex={0} title="Apri PDF preview"><span className="ti">📄</span>
+              <div className="tc"><div className="l1">{r.doc}</div><div className="l2">{r.meta}</div></div><span className="pt-score">score {r.score}</span></div>
+          ))}
+        </TBlock>
+        <TBlock title="Web searches" count={TRACE.web.length}>
+          {TRACE.web.map((w, i) => (
+            <div className="pt-trow" key={i}><span className="ti">🌐</span><div className="tc"><div className="l1">{w.q}</div><div className="l2">{w.meta}</div></div></div>
+          ))}
+        </TBlock>
+        <TBlock title="Warnings" defaultOpen={false}>
+          <div className="pt-twarn">⚠ Output vicino al limite max_tokens (312/2048 · 15%). Considera un prompt più conciso.</div>
+        </TBlock>
+      </div>
+    </aside>
+  );
+}
+
+/* ─── compare mode ─── */
+function CompareColumn({ title, badgeCls, badge, round, defaultOpen }) {
+  const [open, setOpen] = useState(defaultOpen !== false);
+  return (
+    <div className={'pt-ccol' + (open ? '' : ' collapsed')}>
+      <button className="pt-chead" aria-expanded={open} onClick={() => setOpen(o => !o)} title={open ? 'Comprimi' : 'Espandi'}>
+        <span className="pt-tyav" style={{ width: 26, height: 26, fontSize: 14 }} aria-hidden="true">{TYPOLOGY.icon}</span>
+        <span className="ttl">{title}</span>
+        <span className={'ce-badge ' + badgeCls} style={{ marginLeft: 'auto', padding: '2px 8px', fontSize: 11 }}>{badge}</span>
+        <span className="pt-cv" aria-hidden="true">▼</span>
+      </button>
+      {open && (
+      <div className="pt-cmsgs">
+        <div className="pt-row agent">
+          <div className="pt-mav" aria-hidden="true">{TYPOLOGY.icon}</div>
+          <div className="pt-mcol" style={{ width: '100%' }}>
+            <div className="pt-bubble">
+              <div className="pt-mhead"><span className="nm">{title}</span><span className="dur">📊 {round.dur} · {round.tokens} tok</span></div>
+              <div style={{ marginTop: 7 }}><AgentBlocks a={round.a} /></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      )}
+    </div>
+  );
+}
+
+function CompareMode({ draft, setDraft, mobile }) {
+  return (
+    <>
+      <div className="pt-chathead">
+        <span className="pt-session-ind"><i aria-hidden="true" />⚖ Compare mode · stesso prompt → 2 versioni</span>
+        <span className="grow" />
+        <button className="pt-icbtn on" aria-label="Esci da compare" title="Chiudi confronto">✕</button>
+      </div>
+      <div className="pt-compare">
+        <CompareColumn title="v3 (Draft)" badgeCls="draft" badge="✎ Draft" round={ROUNDS[0]} defaultOpen={true} />
+        <CompareColumn title="v2 (Approved)" badgeCls="" badge="✓ Live" round={ROUNDS[3]} defaultOpen={!mobile} />
+      </div>
+      <Composer sc={SC['completed-single']} draft={draft} setDraft={setDraft} onFullWidthStop={() => {}} />
+    </>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════
+   TestApp — un'istanza per (state × viewport). Remount via key.
+   ══════════════════════════════════════════════════════════ */
+function TestApp({ stateId, mobile }) {
+  const sc = SC[stateId];
+  const [cfg, setCfg] = useState({ model: TYPOLOGY.model, temp: 0.7, maxTok: 2048, streaming: true, trace: sc.trace });
+  const [draft, setDraft] = useState(sc.input === 'typing' ? 'Se ho 2 ferite, il malus −2 si cumula con quello del ladro o no?' : '');
+  const [traceOpen, setTraceOpen] = useState(sc.trace);
+  const [mcfgOpen, setMcfgOpen] = useState(false);
+  const [sheet, setSheet] = useState(mobile && sc.trace);
+
+  const openTrace = () => { if (mobile) setSheet(true); else { setTraceOpen(true); setCfg(c => ({ ...c, trace: true })); } };
+  const closeTrace = () => { setTraceOpen(false); setCfg(c => ({ ...c, trace: false })); };
+  const showTrace = !mobile && traceOpen && !sc.compare;
+
+  const splitCls = 'pt-split' + (sc.compare ? ' compare' : showTrace ? ' has-trace' : '');
+
+  return (
+    <div className={'pt-app' + (mobile ? ' is-mobile' : '')}>
+      <TestHeader sc={sc} mobile={mobile} />
+
+      {/* mobile: config come bottom-sheet (non spinge/collassa la chat) */}
+      <div className="pt-mcfg">
+        <button className="pt-mcfg-head" aria-expanded={mcfgOpen} aria-haspopup="dialog" onClick={() => setMcfgOpen(true)}>
+          <span aria-hidden="true">⚙️</span><span className="ttl">Config sessione · {TYPOLOGY.model}</span><span className="cv" aria-hidden="true">▸ apri</span>
+        </button>
+      </div>
+
+      <div className={splitCls}>
+        {!mobile && !sc.compare && (
+          <ConfigSidebar cfg={cfg} setCfg={setCfg} rounds={Math.max(sc.rounds, 1)} onFill={setDraft} onOpenTrace={openTrace} />
+        )}
+        {!mobile && sc.compare && (
+          <ConfigSidebar cfg={cfg} setCfg={setCfg} rounds={Math.max(sc.rounds, 1)} onFill={setDraft} onOpenTrace={openTrace} />
+        )}
+
+        {sc.compare
+          ? <section className="pt-chat" aria-label="Confronto versioni"><CompareMode draft={draft} setDraft={setDraft} mobile={mobile} /></section>
+          : <ChatBody sc={sc} draft={draft} setDraft={setDraft} onTrace={openTrace} onFullscreen={() => {}} />}
+
+        {showTrace && <TraceDrawer onClose={closeTrace} />}
+      </div>
+
+      {mobile && mcfgOpen && (
+        <div className="pt-sheet-veil" onClick={() => setMcfgOpen(false)}>
+          <div className="pt-sheet" role="dialog" aria-label="Config sessione" onClick={e => e.stopPropagation()}>
+            <div className="grab" />
+            <div className="pt-sheet-head">
+              <h3>⚙️ Config sessione</h3>
+              <span className="grow" />
+              <button className="pt-icbtn" aria-label="Chiudi config" onClick={() => setMcfgOpen(false)}>✕</button>
+            </div>
+            <div className="pt-sheet-body">
+              <TypologySummary />
+              <SampleInputs onFill={(q) => { setDraft(q); setMcfgOpen(false); }} />
+              <SessionConfig cfg={cfg} setCfg={setCfg} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {mobile && sheet && (
+        <div className="pt-sheet-veil" onClick={() => setSheet(false)}>
+          <div className="pt-sheet" role="dialog" aria-label="Trace dettaglio" onClick={e => e.stopPropagation()}>
+            <div className="grab" />
+            <TraceDrawer onClose={() => setSheet(false)} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════
+   Harness — continuity con S1/S2/S3/S4
+   ══════════════════════════════════════════════════════════ */
+function Harness() {
+  const [stateId, setStateId] = useState(() => localStorage.getItem('pt-state') || 'completed-single');
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || 'light');
+
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem('pt-state', stateId); }, [stateId]);
+
+  return (
+    <div className="ed-stage">
+      <style dangerouslySetInnerHTML={{ __html: PT_CSS }} />
+      <button className="theme-toggle" onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>🌗 <span>{theme === 'dark' ? 'Dark' : 'Light'}</span></button>
+
+      <div className="ed-wrap">
+        <div className="ed-kicker">SP4 · B14 · #1489 — schermata 5 / 5 · test playground (ultima del cluster)</div>
+        <h1>Test <span className="acc">playground</span> — /editor/agent-proposals/[id]/test</h1>
+        <p className="ed-lead">
+          Playground streaming per testare una <b>typology proposal</b> PRIMA del submit. L’editor invia messaggi di test
+          all’agent (configurato con system prompt + capabilities dalla typology) e vede la risposta in tempo reale.
+          Split-view asimmetrico: <code>config sidebar 320px</code> a sinistra + <code>chat body</code> a destra, con trace
+          drawer opzionale. Sessione <b>effimera</b>, non salvata. FSM streaming a 4 stati con cursor blink animato.
+        </p>
+
+        <div className="ed-notes">
+          <div className="ed-note">
+            <h4>FSM streaming · 4 stati</h4>
+            <p><b>idle</b> empty body + CTA · <b>streaming</b> typewriter + cursor <code>▎</code> blink + “Interrompi” · <b>completed</b> footer azioni + trace · <b>error</b> bubble bordo rosso + retry.</p>
+          </div>
+          <div className="ed-note">
+            <h4>12 stati · trace + compare</h4>
+            <p>Selettore qui sotto. Trace drawer (380px) con model/latency/tokens/cost/tool/RAG/web. <b>Compare mode</b>: v3 Draft vs v2 Approved, stesso prompt a due colonne.</p>
+          </div>
+          <div className="ed-note">
+            <h4>Mobile & a11y</h4>
+            <p>Mobile = config in <b>drawer top collassabile</b>, chat full-width, trace in <b>bottom-sheet</b>. <code>role=log</code> + <code>aria-live</code> sui messaggi, <code>aria-busy</code> sullo streaming, <code>role=alert</code> sugli errori.</p>
+          </div>
+        </div>
+
+        <div className="ed-rail">
+          <span className="lab">Stato</span>
+          <div className="ed-states" role="group" aria-label="Selettore stato schermata">
+            {STATE_LIST.map(([id, label]) => (
+              <button key={id} className={'ed-sbtn' + (stateId === id ? ' on' : '')} aria-pressed={stateId === id} onClick={() => setStateId(id)}>
+                <span className="pip" />{label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Desktop · 1440 — split-view config 320 / chat fluid / trace 380</div>
+        <div className="ed-desk">
+          <div className="ed-chrome">
+            <div className="dots"><i /><i /><i /></div>
+            <div className="url">meepleai.app/editor/agent-proposals/{TYPOLOGY.id}/test</div>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <TestApp key={'d-' + stateId} stateId={stateId} mobile={false} />
+          </div>
+        </div>
+
+        <div className="ed-vp-label">Mobile · 375 — config in drawer top, chat full-width, trace bottom-sheet</div>
+        <div className="ed-phone-row">
+          <div className="phone">
+            <div className="phone-sbar"><span>9:41</span><span className="ind">●●● 5G ▮</span></div>
+            <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+              <TestApp key={'m-' + stateId} stateId={stateId} mobile={true} />
+            </div>
+          </div>
+          <div className="ed-phone-cap">
+            <h4>Layout mobile</h4>
+            <p>La config sidebar collassa in un <b>drawer in alto</b> (tocca <code>⚙️ Config sessione</code> per espandere typology, esempi e parametri). La chat occupa tutta la larghezza; il <code>🐛 Trace</code> apre un <b>bottom-sheet</b> invece del drawer laterale.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Harness />);

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -102,21 +102,17 @@ sub-pages · nodi architetturali N4/N6/N7.
 
 ## P1 — Gap nuovi bloccanti sprint corrente
 
-### Gap N1 — `/editor/agent-proposals/*`
+### Gap N1 — `/editor/agent-proposals/*` ✅ CLOSED 2026-06-02 (PR pending, #1489)
 
-- **Route impattate** (5):
-  - `/editor` — index editor user-facing
-  - `/editor/agent-proposals` — index proposals
-  - `/editor/agent-proposals/create` — create flow
-  - `/editor/agent-proposals/[id]/edit` — edit detail
-  - `/editor/agent-proposals/[id]/test` — playground test
-- **Impatto**: feature attiva (Epic AI Agent System) senza UX spec → impl
-  scollegato dal design system.
-- **Existing**: nessuna issue dedicata. Search "mockup editor / agent-proposals"
-  → 0 hit.
-- **Tier suggerito**: M (proposal index = S, create/edit = M, test = M con stream).
-- **Recommendation**: aprire `[Design v1 · B14] Mockup Editor user-facing
-  (agent proposals)`.
+- **Route impattate** (5) — TUTTE coperte:
+  - `/editor` → `sp4-editor-index.html` + `.jsx` (S1, RuleSpec atom editor split-view + PDF preview, 11 stati)
+  - `/editor/agent-proposals` → `sp4-editor-proposals-index.html` + `.jsx` (S2, typology list, 5 status badge, 9 stati)
+  - `/editor/agent-proposals/create` → `sp4-editor-proposals-create.html` + `.jsx` (S3, form 5-section, 8 stati)
+  - `/editor/agent-proposals/[id]/edit` → `sp4-editor-proposals-edit.html` + `.jsx` (S4, status-variant + Revisions diff + Audit trail, 10 stati)
+  - `/editor/agent-proposals/[id]/test` → `sp4-editor-proposals-test.html` + `.jsx` (S5, playground FSM streaming + Trace + Compare, 12 stati)
+- **Issue tracker**: [#1489 Design v1 · B14] Mockup Editor user-facing — opened 2026-05-22, mockup shipped 2026-06-02 via Claude Design web canvas.
+- **Closing PR**: `feature/issue-1489-mockup-editor-user-facing` → `main-dev`.
+- **Updates correlati**: `00-hub.html` (5 nuove card SP4), `v2-migration-matrix.md` (5 row /editor/** flipped a `done`).
 
 ### Gap N2 — `/play-records/*`
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -778,7 +778,11 @@ instead.
 
 | Route | Mockup | Note |
 |-------|--------|------|
-| `/editor` · `/editor/agent-proposals/*` (4 sub-route) | `sp4-agents-index.html` [partial] | UX editor proposte mancante |
+| `/editor` | `sp4-editor-index.html` [done] | B14 #1489 5/5 · RuleSpec atom editor split-view + PDF preview, 11 stati |
+| `/editor/agent-proposals` | `sp4-editor-proposals-index.html` [done] | B14 #1489 · Typology list, 5 status badge, 9 stati |
+| `/editor/agent-proposals/create` | `sp4-editor-proposals-create.html` [done] | B14 #1489 · Form multi-section 5 sezioni, 8 stati |
+| `/editor/agent-proposals/[id]/edit` | `sp4-editor-proposals-edit.html` [done] | B14 #1489 · Edit + 4 status variants + Revisions diff + Audit trail, 10 stati |
+| `/editor/agent-proposals/[id]/test` | `sp4-editor-proposals-test.html` [done] | B14 #1489 · Playground FSM streaming + Trace + Compare, 12 stati |
 | `/pipeline-builder` | — | gap |
 | `/n8n` | — | gap (integration UI) |
 


### PR DESCRIPTION
## Summary

Chiude **gap B14** (issue #1489 "Design v1 — Editor user-facing agent proposals"). 5 mockup user-facing per `apps/web/src/app/(authenticated)/editor/**`, prodotti via Claude Design web canvas (sessione handoff: `claudedocs/handoff-1489-editor-mockup.md`).

## Schermate (5/5 done)

| # | Route | File | Stati | Tier |
|---|---|---|---|---|
| **S1** | `/editor` | `sp4-editor-index.html` + `.jsx` | 11 | S |
| **S2** | `/editor/agent-proposals` | `sp4-editor-proposals-index.html` + `.jsx` | 9 | S |
| **S3** | `/editor/agent-proposals/create` | `sp4-editor-proposals-create.html` + `.jsx` | 8 | M |
| **S4** | `/editor/agent-proposals/[id]/edit` | `sp4-editor-proposals-edit.html` + `.jsx` | 10 | M |
| **S5** | `/editor/agent-proposals/[id]/test` | `sp4-editor-proposals-test.html` + `.jsx` | 12 | M |

**Totale**: 10 file (5 HTML scaffold + 5 JSX) · ~5 KB HTML + ~340 KB JSX · **49 stati totali** · 4 status badge variants · 5 sezioni form reusable cross-screen.

## Highlights

- **S1**: RuleSpec atom editor con pattern split-view 60/40 (lista atom raggruppati per section + PDF preview con highlight overlay sync). Mobile bottom-sheet drawer PDF.
- **S2**: typology list con filtri (search + 5 status chips), table desktop / cards mobile, status badges entity-colored (Draft/PendingReview/Approved/Rejected/Live).
- **S3**: form 5-section accordion (Identità / Capabilities / System prompt con highlight `{var}` / Test config / Game scope), validation realtime, unique-name check inline.
- **S4**: form S3 reuse + 4 status variants profondi (Draft editable / PendingReview locked / Approved live read-only / Rejected con alert feedback admin) + Revisions diff inline + Audit trail timeline.
- **S5**: playground FSM streaming (idle / streaming con cursor blink CSS / completed / error con 3 variant rate-limit / timeout / network), Trace drawer (model / latency / tokens / cost / tool calls / RAG sources), Compare mode v3 Draft vs v2 Approved.

## Quality bullets (DoD per ogni mockup, verificato)

- [x] Solo CSS variables da `tokens.css` (no hardcoded colors/spacing)
- [x] Light + dark mode parity
- [x] Mobile 375 + desktop 1440 responsive
- [x] State picker UI consistency cross-screen (continuity S1→S5)
- [x] Theme toggle 🌗 persistito localStorage `mai-theme`
- [x] EntityChip / EntityPip per ogni cross-entity reference
- [x] ARIA essenziale (`role="region/log/alert/status"`, `aria-live/busy/expanded/labelledby`, focus visible)
- [x] Reduced motion CSS (`@media (prefers-reduced-motion: reduce)`)
- [x] Testo IT + dati realistici da `data.js` (Catan, Wingspan, Power Grid, Marco R., Sara T.)
- [x] Header comment ogni file con route + brief + screen + tier + pattern + states

## Updates correlati

- **`00-hub.html`**: 5 nuove card sezione SP4 con pattern `.arrow/.num/h3/p/.tags` coerente con card adiacenti pre-esistenti (343+ righe preservate, NON sostituite)
- **`v2-migration-matrix.md`**: 5 row `/editor/**` flipped da `pending` a `done` con link a sp4-editor-*
- **`2026-05-22-mockup-gaps.md`**: gap **N1 (B14) marked CLOSED** con dettaglio routes coperte + link issue

## Note sul workflow Claude Design

Claude Design (claude.ai web canvas) ha sistematicamente riscritto `00-hub.html` da zero in tutti 5 turni (76→103 righe vs 343 originali), nonostante istruzione critica nel prompt. Workaround: ho ignorato il file consegnato e applicato merge manuale aggiungendo solo la card di ogni screen. Pattern card del file locale (`.arrow/.num/h3/p/.tags`) onorato.

Sessione design + validazione: ~3.5 ore.

## Test plan

- [ ] Visual smoke test browser: `cd admin-mockups/design_files && python -m http.server 8765` → verifica ogni `sp4-editor-*.html` su `:8765/<file>.html` (default light + toggle dark via 🌗)
- [ ] Verifica responsive 375 / 1440 via devtools per ogni screen
- [ ] Verifica state picker funzionante su ogni mockup (12 stati S5, 11 S1, ecc.)
- [ ] Verifica `00-hub.html` mostra 5 nuove card SP4 (sezione "SP4 · Entity desktop & editor")
- [ ] Verifica gap N1 in `2026-05-22-mockup-gaps.md` marked CLOSED
- [ ] Verifica matrix `/editor/**` rows flipped a `done`

## Closes

Closes #1489 (gap B14 / Design v1 · Editor user-facing — agent proposals)

## Out of scope (deferred a follow-up issues separate)

- Implementation FE delle 5 route `apps/web/src/app/(authenticated)/editor/**` (richiede follow-up issue per ciascuna o bundle)
- Backend AI Agent System (epic separato)

## Next mockup gaps (epic #1475 Phase D residue)

Restano 3 mockup gap user-facing in Phase D, tutti designer-led:

- #1490 B15 Toolkit sub-pages (P1, 4 routes)
- #1491 B16 Library Wishlist (P2, 1-2 screens)
- #1492 B17 Sessions sub-pages (P2, ADR + 1-8 files)

Epic #1475 user-facing UI passerà da 22/26 (85%) a **23/26 (88%)** dopo merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)