### PR TITLE
fix(chat): #1814 — surface SSE Error event errorMessage in chat surface

### DIFF
--- a/apps/web/src/components/chat-unified/ChatMobile.tsx
+++ b/apps/web/src/components/chat-unified/ChatMobile.tsx
@@ -42,6 +42,8 @@ interface LocalMessage {
   inlineCitations?: InlineCitationMatch[];
   snippets?: Array<{ text: string; source: string; page: number; line: number; score: number }>;
   continuationToken?: string;
+  /** True when this assistant message was set from an SSE Error event (#1814). */
+  isError?: boolean;
 }
 
 interface CitationItem {
@@ -83,7 +85,9 @@ function MessageBubble({
           'max-w-[85%] rounded-2xl px-4 py-2.5 text-sm font-nunito',
           isUser
             ? 'bg-[var(--bg-card)] text-white rounded-br-md'
-            : 'bg-[var(--glass-bg)] backdrop-blur-sm border border-[var(--glass-border)] text-[var(--text)] rounded-bl-md'
+            : message.isError
+              ? 'bg-red-500/10 border border-red-500/30 text-red-400 rounded-bl-md'
+              : 'bg-[var(--glass-bg)] backdrop-blur-sm border border-[var(--glass-border)] text-[var(--text)] rounded-bl-md'
         )}
       >
         {!isUser && message.inlineCitations && message.inlineCitations.length > 0 ? (
@@ -435,15 +439,24 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
                   break;
                 }
                 case QA_EVENT_TYPES.ERROR: {
-                  const errData = event.data as { message?: string };
+                  // BE sends `{ errorMessage, errorCode }` (Models/Contracts.cs StreamingErrorEvent).
+                  // Read both names defensively in case future emitters use the shorter `message`.
+                  // #1814: previously fell through to the post-loop finalize block which overwrote
+                  // `content` with the empty `finalAnswer`, hiding the error from the user.
+                  const errData = event.data as {
+                    errorMessage?: string;
+                    errorCode?: string;
+                    message?: string;
+                  };
+                  const errorMsg =
+                    errData?.errorMessage ?? errData?.message ?? 'Errore nella risposta';
                   setMessages(prev =>
                     prev.map(m =>
-                      m.id === assistantMsgId
-                        ? { ...m, content: errData?.message ?? 'Errore nella risposta' }
-                        : m
+                      m.id === assistantMsgId ? { ...m, content: errorMsg, isError: true } : m
                     )
                   );
-                  break;
+                  abortController.abort();
+                  return;
                 }
               }
             }

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -431,9 +431,14 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                 break;
               }
               case 5: {
-                // Error
-                const data = event.data as { message?: string };
-                setError(data?.message ?? 'Errore nella risposta AI');
+                // Error — BE sends `{ errorMessage, errorCode }` (StreamingErrorEvent).
+                // Read both names defensively. #1814.
+                const data = event.data as {
+                  errorMessage?: string;
+                  errorCode?: string;
+                  message?: string;
+                };
+                setError(data?.errorMessage ?? data?.message ?? 'Errore nella risposta AI');
                 abortController.abort();
                 return;
               }

--- a/apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
@@ -422,6 +422,44 @@ describe('ChatThreadView — thread-message invariants (characterization)', () =
   });
 
   // -------------------------------------------------------------------------
+  // Invariant 4b — Error event surfaces the BE `errorMessage` field (#1814)
+  //
+  // The BE serializes `StreamingErrorEvent` with `{ errorMessage, errorCode }`
+  // (apps/api/src/Api/Models/Contracts.cs). Pre-#1814 the FE only read
+  // `data.message` and silently fell back to a generic string, hiding the
+  // actual reason from the user (e.g. "No relevant information found in the
+  // rulebook.", "Rate limited", "Provider unavailable"). This guard pins the
+  // BE-shaped path so a future refactor cannot regress to swallowing it.
+  // -------------------------------------------------------------------------
+
+  it('invariant 4b: surfaces BE `errorMessage` field verbatim (#1814)', async () => {
+    setQaStreamScript([
+      {
+        type: QA_EVENT_TYPES_REAL.ERROR,
+        data: {
+          errorMessage: 'No relevant information found in the rulebook.',
+          errorCode: 'NO_RESULTS',
+        },
+      },
+    ]);
+
+    const user = userEvent.setup();
+    await renderView();
+    await waitFor(() => expect(screen.getByTestId('message-input')).toBeInTheDocument());
+
+    await user.type(screen.getByTestId('message-input'), 'asks something');
+    await user.click(screen.getByTestId('send-btn'));
+
+    // The BE-supplied error text must appear in the UI (via the page-level
+    // error banner rendered by ChatThreadView on `setError`).
+    await waitFor(() => {
+      expect(
+        screen.getByText('No relevant information found in the rulebook.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Invariant 5 — Hydration aborts stream
   //
   // After `useThreadMessages` extraction (Task 7): the hydration effect in


### PR DESCRIPTION
## Summary

Fixes #1814 — when the chat SSE backend emits a \`StreamingErrorEvent\` (e.g. \`NO_RESULTS\`, \`rate_limited\`, \`provider_unavailable\`), the user previously saw **nothing**: no spinner, no error banner, the message bubble stayed blank.

## Root cause

The BE serializes \`StreamingErrorEvent\` as \`{ errorMessage, errorCode }\` (\`apps/api/src/Api/Models/Contracts.cs\`), but both QA-stream consumers read \`data.message\` and fell back to a generic string.

Worse, **ChatMobile** ran the post-loop finalize block after handling the error, which overwrote the assistant bubble \`content\` with the empty \`finalAnswer\` (no \`COMPLETE\` event arrived → \`finalAnswer = ''\`), silently hiding the error from the user.

Repro on staging (2026-06-02, mobile 390×844):
1. Add Catan from catalog → \`/library/<gameId>/kb\` shows the rulebook PDF but KB Coverage is 0%
2. Open chat → ask "Test"
3. SSE responds with \`{ "type": 5, "data": { "errorMessage": "No relevant information found in the rulebook.", "errorCode": "NO_RESULTS" } }\`
4. Chat surface stays empty for 27+s

## Fix

**ChatMobile** (\`apps/web/src/components/chat-unified/ChatMobile.tsx\`):
- Read \`errorMessage\` (BE shape) with \`message\` fallback
- Mark the assistant bubble \`isError: true\` → renders in destructive variant (red bg + border + text)
- Abort the controller and \`return\` so the finalize block does not overwrite

**ChatThreadView** (\`apps/web/src/components/chat-unified/ChatThreadView.tsx\`):
- Same BE-shaped read; the existing abort + return already exits cleanly so the page-level error banner stays visible

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`ChatThreadView.invariants.test.tsx\` 7/7 pass, including new invariant 4b that pins the BE \`{ errorMessage, errorCode }\` path
- [x] \`ChatThreadView.test.tsx\` 29/29 still green
- [ ] Post-merge staging smoke: re-run the repro and verify the assistant bubble shows the BE message in red

## Out of scope

- KB indexing inconsistency (\`/library/<gameId>/kb\` shows the PDF but stats say 0 docs) — tracked under umbrella #1816 as a P3 follow-up
- E2E mobile golden-path spec — tracked separately
- Adding the \`message-input\` testid to the mobile textarea — tracked under #1816

## References

- Audit: \`docs/for-developers/audits/2026-06-02-mobile-golden-path-audit.md\` § Chat SSE
- BE contract: \`apps/api/src/Api/Models/Contracts.cs\` \`StreamingErrorEvent\`

Closes #1814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)