### PR TITLE
docs(design): #1490 add sp4-toolkit sub-pages mockup bundle (B15)

### DIFF
--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -315,6 +315,38 @@
     <div class="tags"><span class="tag">12 stati</span><span class="tag">FSM streaming</span><span class="tag">Trace + Compare</span></div>
   </a>
 
+  <a class="hub-card e-toolkit" href="sp4-toolkit-stats.html">
+    <div class="arrow">→</div>
+    <div class="num">B15 · #1490 · 1/4</div>
+    <h3>Toolkit stats — KPI dashboard</h3>
+    <p>Dashboard analytics cross-game (/toolkit/stats): 3 KPI card (sessioni · giochi · durata media con trend YoY), Most Played top-N con progress bar, Monthly Activity bar chart 12 mesi (toggle sessioni/durata + tooltip), Recent Score Trends con variance vs media gioco. 8 stati con state picker: default / empty-no-sessions / empty-partial / loading / error / range-3m / range-all (24 barre) / mobile-stack.</p>
+    <div class="tags"><span class="tag">8 stati</span><span class="tag">KPI cards</span><span class="tag">Bar chart</span></div>
+  </a>
+
+  <a class="hub-card e-toolkit" href="sp4-toolkit-history.html">
+    <div class="arrow">→</div>
+    <div class="num">B15 · #1490 · 2/4</div>
+    <h3>Toolkit history — lista sessioni</h3>
+    <p>Storico paginato cross-game (/toolkit/history): tabella desktop + cards mobile, filtri search · giochi (multi-select) · date range · vincitore, sort + view toggle, detail modal (classifica · timeline · note · stats partita), pagination 156 sessioni / 8 pagine. 9 stati: default / filter-game / filter-multi / filter-0-match / pagination-p3 / modal-detail / loading / error / mobile-cards.</p>
+    <div class="tags"><span class="tag">9 stati</span><span class="tag">Table+Cards</span><span class="tag">Detail modal</span></div>
+  </a>
+
+  <a class="hub-card e-toolkit" href="sp4-toolkit-templates.html">
+    <div class="arrow">→</div>
+    <div class="num">B15 · #1490 · 3/4</div>
+    <h3>Toolkit templates — gallery</h3>
+    <p>Gallery dei preset toolkit approvati (/toolkit/templates): grid 4-col con card composizione tool (dadi · carte · timer · contatori), filtro categoria single-select (Strategy · Party · Card Games · Cooperative), search con debounce, sort + view toggle, rating a stelle, varianti card (ufficiale · popolare · nuovo · in approvazione) e clone modal con gioco target. 8 stati: default / filter-strategy / filter-0-match / tablet-3col / clone-modal / loading / error / mobile-stack.</p>
+    <div class="tags"><span class="tag">8 stati</span><span class="tag">Gallery grid</span><span class="tag">Clone CTA</span></div>
+  </a>
+
+  <a class="hub-card e-toolkit" href="sp4-toolkit-play.html">
+    <div class="arrow">→</div>
+    <div class="num">B15 · #1490 · 4/4</div>
+    <h3>Toolkit play — live session panel</h3>
+    <p>Toolkit standalone live (/toolkit/play) per assistere le partite fisiche al tavolo: 4 tool widget interattivi — un <strong>Dice Builder</strong> completo (preset, builder visivo tipo/quantità/modificatore, modificatori avanzati khN/klN/csN/rN/esplosivi, parser formula con feedback live e storico ri-tirabile), contatori +/− con pop, timer countdown/turno con FSM (running/pause/finishing/expired) e randomizer con estrazione a decay — più un log streaming cross-tool con filtri, sort e clear. Actor chip --c-player, keyframes per ogni animazione. 16 stati incl. 7 dice-* (idle / building / preset / formula / rolling / result / invalid) + timer-running / timer-expired / counter+1 / randomizer-picking / filter-log / clear-log / mobile-stack.</p>
+    <div class="tags"><span class="tag">16 stati</span><span class="tag">Dice Builder</span><span class="tag">FSM + Live log</span></div>
+  </a>
+
   <a class="hub-card e-event" href="sp7-game-night-live.html">
     <div class="arrow">→</div>
     <div class="num">SP7 · K · #487</div>

--- a/admin-mockups/design_files/sp4-toolkit-history-ui.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-history-ui.jsx
@@ -1,0 +1,857 @@
+/* sp4-toolkit-history-ui.jsx — components + interactive app + harness (loads after sp4-toolkit-history.jsx)
+   Route: /toolkit/history — vedi header comment del file foundation. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const DS = window.DS;
+const T = window.__TH;
+const {
+  eHsl, sem, SESSIONS, TOTAL, PAGE_SIZE, GAME_COUNTS, WINNER_COUNTS, N_GAMES,
+  fmtDate, fmtTime, fmtDur, relDate, NOW, MONTHS_FULL, genTimeline, GAME_IDS,
+} = T;
+
+const pColor = (h, l = 52, s = 58) => `hsl(${h}, ${s}%, ${l}%)`;
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const GameChip = ({ s, onClick }) => (
+  <button type="button" className="th-egame" title={`Apri ${s.gameName} in libreria`}
+    onClick={e => { e.stopPropagation(); onClick && onClick(); }}>
+    <span className="cov" aria-hidden="true" style={{ background: s.cover }}>{s.coverEmoji}</span>
+    <span className="gt">{s.gameName}</span>
+  </button>
+);
+
+const AvatarStack = ({ players, max = 3 }) => {
+  const shown = players.slice(0, max);
+  const extra = players.length - shown.length;
+  const label = `${players.length} giocatori: ${players.map(p => p.name).join(', ')}`;
+  return (
+    <span className="th-avs" role="img" aria-label={label}>
+      {shown.map((p, i) => (
+        <span key={p.pid} className="th-av" style={{ background: pColor(p.color), zIndex: max - i }} aria-hidden="true">{p.initials}</span>
+      ))}
+      {extra > 0 && <span className="th-av more" aria-hidden="true">+{extra}</span>}
+    </span>
+  );
+};
+
+const WinnerCell = ({ s }) => {
+  if (s.coop) return <span className="th-coop"><span aria-hidden="true">🤝</span>Cooperativa</span>;
+  if (!s.winner) return <span className="th-nowin" aria-label="Senza vincitore">—</span>;
+  return (
+    <span className="th-win" title={`Vincitore: ${s.winner}`}>
+      <span aria-hidden="true">🏆</span><span className="wt">{s.winner}</span>
+    </span>
+  );
+};
+
+// click-outside hook
+function useOutside(onClose) {
+  const ref = useRef(null);
+  useEffect(() => {
+    const onDoc = e => { if (ref.current && !ref.current.contains(e.target)) onClose(); };
+    const onEsc = e => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onEsc);
+    return () => { document.removeEventListener('mousedown', onDoc); document.removeEventListener('keydown', onEsc); };
+  }, [onClose]);
+  return ref;
+}
+
+// ═══════════════════════════════════════════════════════
+// ─── TOOLBAR ────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const MultiDropdown = ({ open, setOpen, label, icon, tint, count, headLabel, options, selected, onToggle, onClear, more }) => {
+  const ref = useOutside(() => setOpen(false));
+  const [showAll, setShowAll] = useState(false);
+  const visible = (more && !showAll) ? options.slice(0, more) : options;
+  return (
+    <div className="th-fgroup" ref={ref}>
+      <button type="button" className={'th-chip ' + tint + (count > 0 ? ' on' : '')} aria-haspopup="listbox" aria-expanded={open}
+        onClick={() => setOpen(o => !o)}>
+        <span aria-hidden="true">{icon}</span>{label}{count > 0 && <span className="ccount">({count})</span>}
+        <span aria-hidden="true" style={{ fontSize: 8, opacity: .7 }}>▼</span>
+      </button>
+      {open && (
+        <div className="th-pop" role="listbox" aria-label={headLabel}>
+          <div className="th-pophead">{headLabel}</div>
+          <button type="button" className={'th-popitem' + (count === 0 ? ' sel' : '')} role="option" aria-selected={count === 0} onClick={onClear}>
+            <span className="check" aria-hidden="true">{count === 0 ? '✓' : ''}</span>
+            <span className="lbl">Tutti</span>
+          </button>
+          {visible.map(o => {
+            const on = selected.includes(o.value);
+            return (
+              <button key={o.value} type="button" className={'th-popitem' + (on ? ' sel' : '')} role="option" aria-selected={on} onClick={() => onToggle(o.value)}>
+                <span className="check" aria-hidden="true">{on ? '✓' : ''}</span>
+                {o.swatch && <span style={{ width: 16, height: 16, borderRadius: 4, background: o.swatch, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 9 }}>{o.emoji}</span>}
+                {o.avatar && <span className="th-av" style={{ background: o.avatar, margin: 0, width: 18, height: 18, border: 'none' }}>{o.initials}</span>}
+                <span className="lbl">{o.label}</span>
+                <span className="cnt">{o.count}</span>
+              </button>
+            );
+          })}
+          {more && options.length > more && (
+            <button type="button" className="th-popmore" onClick={() => setShowAll(a => !a)}>
+              {showAll ? 'Mostra meno' : `Mostra altri ${options.length - more}`}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DATE_OPTS = [
+  { id: 'all', label: 'Tutte le date' },
+  { id: '30', label: 'Ultimi 30 giorni' },
+  { id: '90', label: 'Ultimi 90 giorni' },
+  { id: '365', label: 'Ultimo anno' },
+  { id: 'custom', label: 'Date custom' },
+];
+const SORT_OPTS = [
+  { id: 'recent', label: 'Più recente' },
+  { id: 'oldest', label: 'Più antica' },
+  { id: 'longest', label: 'Più lunga' },
+  { id: 'score', label: 'Score più alto' },
+];
+
+const Toolbar = ({ st, set, typing, searchRef, counts }) => {
+  const [openGame, setOpenGame] = useState(false);
+  const [openWin, setOpenWin] = useState(false);
+  const [openDate, setOpenDate] = useState(false);
+  const [openSort, setOpenSort] = useState(false);
+  const [customMode, setCustomMode] = useState(st.date === 'custom');
+  const [cfrom, setCfrom] = useState(st.customFrom || '');
+  const [cto, setCto] = useState(st.customTo || '');
+  const shortD = iso => { if (!iso) return ''; const [y, m, d] = iso.split('-').map(Number); return `${d} ${['gen','feb','mar','apr','mag','giu','lug','ago','set','ott','nov','dic'][m - 1]}`; };
+  const dateLabel = (st.date === 'custom' && st.customFrom && st.customTo) ? `${shortD(st.customFrom)} – ${shortD(st.customTo)}` : DATE_OPTS.find(d => d.id === st.date).label;
+
+  const gameOpts = GAME_COUNTS.map(g => ({ value: g.id, label: DS.byId[g.id].title, count: g.count, swatch: DS.byId[g.id].cover, emoji: DS.byId[g.id].coverEmoji }));
+  const winOpts = [
+    ...WINNER_COUNTS.players.map(w => ({ value: w.name, label: `${w.name} (vinto)`, count: w.count, avatar: pColor(playerHue(w.name)), initials: initialsOf(w.name) })),
+    { value: '__nowin__', label: 'Senza vincitore', count: WINNER_COUNTS.noWin },
+  ];
+  const winCount = st.winners.length;
+  const dateRef = useOutside(() => setOpenDate(false));
+  const sortRef = useOutside(() => setOpenSort(false));
+
+  return (
+    <div className="th-toolbar">
+      {/* search */}
+      <div className={'th-search' + (st.search ? ' active' : '')}>
+        <span className="ic" aria-hidden="true">🔍</span>
+        <input ref={searchRef} value={st.search} onChange={e => set({ search: e.target.value, page: 1 })} role="searchbox"
+          aria-label="Cerca per gioco o vincitore" placeholder="Cerca per gioco o vincitore…"
+          onKeyDown={e => { if (e.key === 'Escape') { set({ search: '' }); } }} />
+        {typing && <span className="busy" aria-hidden="true"><i />Cercando…</span>}
+        {st.search && <button className="clear" aria-label="Cancella ricerca" onClick={() => { set({ search: '', page: 1 }); searchRef.current && searchRef.current.focus(); }}>✕</button>}
+      </div>
+
+      {/* filters row */}
+      <div className="th-filters" role="group" aria-label="Filtri">
+        <MultiDropdown open={openGame} setOpen={setOpenGame} label="Giochi" icon="🎲" tint="game" count={st.games.length}
+          headLabel="Filtra per gioco" options={gameOpts} selected={st.games} more={4}
+          onToggle={v => set({ games: st.games.includes(v) ? st.games.filter(x => x !== v) : [...st.games, v], page: 1 })}
+          onClear={() => set({ games: [], page: 1 })} />
+
+        <span className="th-fdiv" />
+
+        {/* date range */}
+        <div className="th-fgroup" ref={dateRef}>
+          <button type="button" className={'th-chip tk' + (st.date !== 'all' ? ' on' : '')} aria-haspopup="listbox" aria-expanded={openDate} onClick={() => setOpenDate(o => !o)}>
+            <span aria-hidden="true">🗓</span>{dateLabel}
+            <span aria-hidden="true" style={{ fontSize: 8, opacity: .7 }}>▼</span>
+          </button>
+          {openDate && (
+            <div className="th-pop" role="listbox" aria-label="Intervallo date">
+              <div className="th-pophead">Intervallo date</div>
+              {DATE_OPTS.map(d => {
+                const on = d.id === 'custom' ? (customMode || st.date === 'custom') : st.date === d.id;
+                return (
+                  <button key={d.id} type="button" className={'th-popitem radio' + (on ? ' sel' : '')} role="option" aria-selected={on}
+                    onClick={() => {
+                      if (d.id === 'custom') { setCustomMode(true); }
+                      else { set({ date: d.id, page: 1 }); setCustomMode(false); setOpenDate(false); }
+                    }}>
+                    <span className="check" aria-hidden="true">{on ? '•' : ''}</span>
+                    <span className="lbl">{d.label}</span>
+                  </button>
+                );
+              })}
+              {customMode && (
+                <div className="th-daterange">
+                  <div className="r2">
+                    <label>Da<input type="date" value={cfrom} max={cto || undefined} onChange={e => setCfrom(e.target.value)} aria-label="Data inizio" /></label>
+                    <label>A<input type="date" value={cto} min={cfrom || undefined} onChange={e => setCto(e.target.value)} aria-label="Data fine" /></label>
+                  </div>
+                  <button type="button" className="apply" disabled={!cfrom || !cto}
+                    onClick={() => { set({ date: 'custom', customFrom: cfrom, customTo: cto, page: 1 }); setOpenDate(false); }}>Applica intervallo</button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <span className="th-fdiv" />
+
+        <MultiDropdown open={openWin} setOpen={setOpenWin} label="Vincitori" icon="🏆" tint="win" count={winCount}
+          headLabel="Filtra per vincitore" options={winOpts} selected={st.winners} more={5}
+          onToggle={v => set({ winners: st.winners.includes(v) ? st.winners.filter(x => x !== v) : [...st.winners, v], page: 1 })}
+          onClear={() => set({ winners: [], page: 1 })} />
+      </div>
+
+      {/* view + sort */}
+      <div className="th-right">
+        <div className="th-fgroup" ref={sortRef}>
+          <button type="button" className="th-chip" aria-haspopup="listbox" aria-expanded={openSort} onClick={() => setOpenSort(o => !o)}>
+            <span aria-hidden="true">↕</span>{SORT_OPTS.find(s => s.id === st.sort).label}
+            <span aria-hidden="true" style={{ fontSize: 8, opacity: .7 }}>▼</span>
+          </button>
+          {openSort && (
+            <div className="th-pop right" role="listbox" aria-label="Ordina">
+              <div className="th-pophead">Ordina per</div>
+              {SORT_OPTS.map(o => (
+                <button key={o.id} type="button" className={'th-popitem radio' + (st.sort === o.id ? ' sel' : '')} role="option" aria-selected={st.sort === o.id}
+                  onClick={() => { set({ sort: o.id }); setOpenSort(false); }}>
+                  <span className="check" aria-hidden="true">{st.sort === o.id ? '•' : ''}</span>
+                  <span className="lbl">{o.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="th-vtoggle" role="group" aria-label="Vista">
+          <button aria-pressed={st.view === 'table'} onClick={() => set({ view: 'table' })} title="Vista tabella" aria-label="Vista tabella">☰</button>
+          <button aria-pressed={st.view === 'cards'} onClick={() => set({ view: 'cards' })} title="Vista cards" aria-label="Vista cards">▦</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function playerHue(name) { const p = DS.players.find(x => x.title === name); return p ? p.color : 262; }
+function initialsOf(name) { const p = DS.players.find(x => x.title === name); return p ? p.initials : name.slice(0, 2).toUpperCase(); }
+
+// ═══════════════════════════════════════════════════════
+// ─── TABLE (desktop) ────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TH = ({ label, k, sort, onSort, align }) => {
+  const active = sort.key === k;
+  const aria = active ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none';
+  return (
+    <div className={'th-th' + (k ? ' sortable' : '') + (align ? ' ' + align : '')} role="columnheader" aria-sort={k ? aria : undefined}
+      tabIndex={k ? 0 : undefined} onClick={k ? () => onSort(k) : undefined}
+      onKeyDown={k ? e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(k); } } : undefined}>
+      {label}{k && <span className="arr">{active && sort.dir === 'asc' ? '▲' : '▼'}</span>}
+    </div>
+  );
+};
+
+const Row = ({ s, selected, onOpen, rowRef }) => (
+  <div className={'th-row' + (s.mine ? ' mine' : '') + (selected ? ' sel' : '')} role="row" tabIndex={0} ref={rowRef}
+    onClick={() => onOpen(s)} onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); onOpen(s); } }}>
+    <div className="th-rowmain">
+      <div className="th-cell" role="cell">
+        <div className="th-dt">{fmtDate(s.date)} · {fmtTime(s.date)}<span className="rel">{relDate(s.date, NOW)}</span></div>
+      </div>
+      <div className="th-cell" role="cell"><GameChip s={s} /></div>
+      <div className="th-cell" role="cell"><span className="th-durpill"><span aria-hidden="true">⏱</span>{fmtDur(s.durationMinutes)}</span></div>
+      <div className="th-cell" role="cell"><AvatarStack players={s.players} /></div>
+      <div className="th-cell" role="cell"><WinnerCell s={s} /></div>
+      <div className="th-cell" role="cell">
+        {s.coop ? <span className="th-score coop">co-op</span> : <span className="th-score" title="Punteggio vincitore">{s.winScore}</span>}
+      </div>
+      <div className="th-cell" role="cell" style={{ textAlign: 'center' }}>
+        <button type="button" className={'th-noteic' + (s.notes ? '' : ' empty')} title={s.notes || 'Nessuna nota'}
+          aria-label={s.notes ? 'Nota presente' : 'Nessuna nota'} onClick={e => { e.stopPropagation(); if (s.notes) onOpen(s); }}>📝</button>
+      </div>
+      <div className="th-cell" role="cell">
+        <div className="th-acts">
+          <button type="button" className="th-act see" aria-label="Vedi dettagli" title="Dettagli" onClick={e => { e.stopPropagation(); onOpen(s); }}>👁</button>
+          <button type="button" className="th-act" aria-label="Stats del gioco" title="Stats gioco" onClick={e => e.stopPropagation()}>📊</button>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const Table = ({ rows, selectedId, onOpen, sort, onSort, firstRef }) => (
+  <div className="th-table" role="table" aria-label="Storico sessioni">
+    <div className="th-thead" role="row">
+      <TH label="Data" k="recent" sort={sort} onSort={onSort} />
+      <TH label="Gioco" k="game" sort={sort} onSort={onSort} />
+      <TH label="Durata" k="longest" sort={sort} onSort={onSort} />
+      <div className="th-th" role="columnheader">Giocatori</div>
+      <div className="th-th" role="columnheader">Vincitore</div>
+      <TH label="Score" k="score" sort={sort} onSort={onSort} />
+      <div className="th-th center" role="columnheader">Note</div>
+      <div className="th-th right" role="columnheader">Azioni</div>
+    </div>
+    <div role="rowgroup">
+      {rows.map((s, i) => <Row key={s.id} s={s} selected={s.id === selectedId} onOpen={onOpen} rowRef={i === 0 ? firstRef : null} />)}
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── CARDS (mobile) ─────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const SessionCard = ({ s, onOpen }) => (
+  <div className={'th-card' + (s.mine ? ' mine' : '')} role="button" tabIndex={0}
+    onClick={() => onOpen(s)} onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); onOpen(s); } }}>
+    <div className="chead">
+      <GameChip s={s} />
+      <span className="grow" />
+      <span className="cdate">{relDate(s.date, NOW)}</span>
+    </div>
+    <div className="cmid">
+      <AvatarStack players={s.players} />
+      <WinnerCell s={s} />
+      <span className="th-durpill"><span aria-hidden="true">⏱</span>{fmtDur(s.durationMinutes)}</span>
+    </div>
+    <div className="cfoot">
+      {s.coop
+        ? <span className="th-cscore" style={{ background: 'var(--bg-muted)', color: 'var(--text-muted)' }}><span aria-hidden="true">🤝</span>Co-op</span>
+        : <span className="th-cscore"><span aria-hidden="true">🏆</span>{s.winScore}</span>}
+      <span className="grow" />
+      {s.notes && <span className="th-noteic" title={s.notes} aria-label="Nota presente">📝</span>}
+      <span className="cdate">{fmtDate(s.date)}</span>
+    </div>
+  </div>
+);
+
+const Cards = ({ rows, onOpen }) => (
+  <div className="th-cards">{rows.map(s => <SessionCard key={s.id} s={s} onOpen={onOpen} />)}</div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── DETAIL MODAL ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+function gameStats(s) {
+  const scores = s.players.map(p => p.score);
+  const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const sigma = Math.sqrt(scores.reduce((a, b) => a + (b - mean) ** 2, 0) / scores.length);
+  const sameGame = SESSIONS.filter(x => x.gameId === s.gameId && !x.coop);
+  const best = sameGame.length ? Math.max(...sameGame.map(x => x.winScore)) : s.winScore;
+  let highlights;
+  if (s.id === SESSIONS[0].id) highlights = ['🛣️ Strada più lunga ×2', '⚔️ Armata più grande ×1'];
+  else if (s.coop) highlights = ['🤝 Vittoria cooperativa', '🌋 Spiriti in sinergia'];
+  else if (sigma < (mean * 0.12)) highlights = ['⚖️ Partita equilibrata'];
+  else highlights = ['🚀 Vittoria netta'];
+  return { sigma: sigma.toFixed(1), best, mine: s.winScore === best && s.gameId === s.gameId };
+}
+
+const DetailModal = ({ s, mobile, onClose }) => {
+  const closeRef = useRef(null);
+  const modalRef = useRef(null);
+  const [tlOpen, setTlOpen] = useState(true);
+  useEffect(() => { closeRef.current && closeRef.current.focus(); }, []);
+  useEffect(() => {
+    const onKey = e => {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key === 'Tab' && modalRef.current) {
+        const f = modalRef.current.querySelectorAll('button, textarea, [tabindex]:not([tabindex="-1"])');
+        if (!f.length) return;
+        const first = f[0], last = f[f.length - 1];
+        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const leaderboard = [...s.players].sort((a, b) => b.score - a.score);
+  const tl = genTimeline(s);
+  const gs = gameStats(s);
+
+  return (
+    <div className="th-overlay" onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="th-modal" ref={modalRef} role="dialog" aria-modal="true" aria-labelledby="th-mtitle">
+        <div className="th-mhead">
+          <span className="mcov" aria-hidden="true" style={{ background: s.cover }}>{s.coverEmoji}</span>
+          <div className="th-mhtxt">
+            <div className="th-mtitle" id="th-mtitle">{s.gameName} · {fmtDate(s.date)}</div>
+            <div className="th-msub">Durata {fmtDur(s.durationMinutes)} · {s.players.length} giocatori · {fmtTime(s.date)}</div>
+          </div>
+          <button type="button" className="th-mclose" ref={closeRef} aria-label="Chiudi" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="th-mbody">
+          {/* leaderboard */}
+          <div className="th-msec">
+            <h4>Classifica finale<span className="gr" /></h4>
+            <div className="th-lb">
+              {leaderboard.map((p, i) => (
+                <div key={p.pid} className={'th-lbrow' + (i === 0 && !s.coop ? ' first' : '')}>
+                  <span className="th-lbrank">{s.coop ? '·' : `#${i + 1}`}</span>
+                  <span className="th-lbplayer">
+                    <span className="th-av" style={{ background: pColor(p.color), margin: 0 }} aria-hidden="true">{p.initials}</span>
+                    <span className="nm">{p.name}{p.name === 'Marco R.' && <span className="th-lbtag"> · tu</span>}</span>
+                  </span>
+                  <span className="th-lbscore">{s.coop ? '—' : p.score}{i === 0 && !s.coop && <span aria-hidden="true" style={{ marginLeft: 6 }}>🏆</span>}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* timeline */}
+          <div className="th-msec">
+            <button type="button" className="th-tl-toggle" aria-expanded={tlOpen} onClick={() => setTlOpen(o => !o)}>
+              <span className="car" style={{ transform: tlOpen ? 'rotate(90deg)' : 'none' }} aria-hidden="true">▶</span>
+              Timeline eventi<span className="gr" />
+            </button>
+            {tlOpen && (
+              <ul className="th-tl">
+                {tl.map((ev, i) => (
+                  <li key={i} className="th-tlrow">
+                    <span className="th-tltime">{ev.t}</span>
+                    <span className="th-tldot" aria-hidden="true">{ev.icon}</span>
+                    <span className="th-tle">{ev.e}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* notes */}
+          <div className="th-msec">
+            <h4>Note<span className="gr" /></h4>
+            {s.notes
+              ? <textarea className="th-noteta" readOnly value={s.notes} aria-label="Note della sessione" />
+              : <p className="th-noteempty">Nessuna nota per questa sessione.</p>}
+          </div>
+
+          {/* game stats */}
+          <div className="th-msec">
+            <h4>Statistiche partita<span className="gr" /></h4>
+            <div className="th-gstats">
+              <div className="th-gstat"><div className="gl">Turni totali</div><div className="gv">{s.turns}</div></div>
+              <div className="th-gstat"><div className="gl">Score vincitore</div><div className="gv">{s.coop ? '—' : <>{s.winScore} <small>· best {gs.best}</small></>}</div></div>
+              <div className="th-gstat"><div className="gl">Varianza score</div><div className="gv">σ {gs.sigma}</div></div>
+              <div className="th-gstat"><div className="gl">Highlights</div>
+                <div className="th-hl">{highlightsFor(s).map((h, i) => <span key={i} className="th-hlchip">{h}</span>)}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="th-mfoot">
+          <button type="button" className="th-mbtn tk"><span aria-hidden="true">📊</span>Stats gioco</button>
+          <button type="button" className="th-mbtn game"><span aria-hidden="true">🎮</span>{mobile ? 'Rigioca' : 'Gioca di nuovo'}</button>
+          <span className="grow" />
+          {!mobile && <button type="button" className="th-mbtn"><span aria-hidden="true">📝</span>Modifica note</button>}
+          <button type="button" className="th-mbtn danger"><span aria-hidden="true">🗑</span>Elimina</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+function highlightsFor(s) {
+  if (s.id === SESSIONS[0].id) return ['🛣️ Strada più lunga ×2', '⚔️ Armata più grande ×1'];
+  if (s.coop) return ['🤝 Vittoria cooperativa'];
+  const scores = s.players.map(p => p.score);
+  const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const sigma = Math.sqrt(scores.reduce((a, b) => a + (b - mean) ** 2, 0) / scores.length);
+  return sigma < mean * 0.12 ? ['⚖️ Partita equilibrata'] : ['🚀 Vittoria netta'];
+}
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / LOADING / ERROR ────────────────────────
+// ═══════════════════════════════════════════════════════
+const EmptyAll = () => (
+  <div className="th-pad">
+    <div className="th-empty tk">
+      <div className="em" aria-hidden="true">📜</div>
+      <h3>Nessuna sessione ancora</h3>
+      <p>Le partite finalizzate appariranno qui: filtra per gioco, data o vincitore e apri il dettaglio di ognuna.</p>
+      <button className="cta"><span aria-hidden="true">🎮</span>Crea prima sessione</button>
+    </div>
+  </div>
+);
+const FilterEmpty = ({ onClear }) => (
+  <div className="th-pad" aria-live="polite">
+    <div className="th-empty warn">
+      <div className="em" aria-hidden="true">🔍</div>
+      <h3>Nessuna sessione corrisponde ai filtri</h3>
+      <p>Prova a modificare la ricerca o a rimuovere i filtri di gioco, data o vincitore attivi.</p>
+      <button className="cta warn" onClick={onClear}>Rimuovi filtri</button>
+    </div>
+  </div>
+);
+const Sk = ({ w, h, r = 'var(--r-sm)', style }) => <div className="th-sk th-shimmer" style={{ width: w, height: h, borderRadius: r, ...style }} />;
+const Skeleton = ({ mobile }) => {
+  if (mobile) return (
+    <div className="th-cards" aria-busy="true">
+      {[0, 1, 2, 3].map(i => (
+        <div className="th-card" key={i}>
+          <div className="chead"><Sk w={130} h={22} r="var(--r-pill)" /><span style={{ flex: 1 }} /><Sk w={50} h={12} /></div>
+          <div className="cmid"><Sk w={90} h={26} r="var(--r-pill)" /><Sk w={110} h={22} r="var(--r-pill)" /></div>
+          <div className="cfoot"><Sk w={70} h={28} r="var(--r-md)" /></div>
+        </div>
+      ))}
+    </div>
+  );
+  return (
+    <div className="th-table" aria-busy="true">
+      <div className="th-thead">{['Data', 'Gioco', 'Durata', 'Gioc.', 'Vinc.', 'Score', 'N', 'Az'].map((k, i) => <Sk key={i} h={11} w={i === 1 ? '60%' : '52%'} />)}</div>
+      {[0, 1, 2, 3, 4, 5].map(i => (
+        <div className="th-rowmain" key={i} style={{ borderBottom: '1px solid var(--border-light)' }}>
+          <div><Sk w="86%" h={13} style={{ marginBottom: 6 }} /><Sk w="50%" h={10} /></div>
+          <Sk w="90%" h={26} r="var(--r-pill)" />
+          <Sk w={52} h={13} />
+          <Sk w={86} h={26} r="var(--r-pill)" />
+          <Sk w="78%" h={24} r="var(--r-pill)" />
+          <Sk w={32} h={16} />
+          <Sk w={24} h={24} r="var(--r-sm)" style={{ margin: '0 auto' }} />
+          <Sk w={70} h={30} r="var(--r-sm)" style={{ marginLeft: 'auto' }} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGINATION ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+function pageList(cur, total) {
+  const out = [];
+  const add = n => out.push(n);
+  if (total <= 7) { for (let i = 1; i <= total; i++) add(i); return out; }
+  add(1);
+  let lo = Math.max(2, cur - 1), hi = Math.min(total - 1, cur + 1);
+  if (cur <= 3) { lo = 2; hi = 4; }
+  if (cur >= total - 2) { lo = total - 3; hi = total - 1; }
+  if (lo > 2) add('…l');
+  for (let i = lo; i <= hi; i++) add(i);
+  if (hi < total - 1) add('…r');
+  add(total);
+  return out;
+}
+const Pagination = ({ page, pages, total, count, pageSize, from, to, onPage, onSize, mobile }) => {
+  if (mobile) return (
+    <nav className="th-pag" role="navigation" aria-label="Pagine storico sessioni">
+      <button className="th-pagbtn ar" disabled={page <= 1} onClick={() => onPage(page - 1)} aria-label="Pagina precedente">←</button>
+      <span className="th-pagmeta">Pag. <b>{page}</b> di {pages} · {total} sess.</span>
+      <button className="th-pagbtn ar" disabled={page >= pages} onClick={() => onPage(page + 1)} aria-label="Pagina successiva">→</button>
+    </nav>
+  );
+  return (
+    <nav className="th-pag" role="navigation" aria-label="Pagine storico sessioni">
+      <button className="th-pagbtn" disabled={page <= 1} onClick={() => onPage(page - 1)} aria-label="Pagina precedente"><span aria-hidden="true">←</span> Prec.</button>
+      <div className="th-pagnums">
+        {pageList(page, pages).map((p, i) => typeof p === 'number'
+          ? <button key={i} className={'th-pagnum' + (p === page ? ' on' : '')} aria-current={p === page ? 'page' : undefined} onClick={() => onPage(p)}>{p}</button>
+          : <span key={i} className="th-pagell" aria-hidden="true">···</span>)}
+      </div>
+      <button className="th-pagbtn" disabled={page >= pages} onClick={() => onPage(page + 1)} aria-label="Pagina successiva">Succ. <span aria-hidden="true">→</span></button>
+      <span className="grow" />
+      <span className="th-pagmeta">{count ? `${from}–${to} di ${total} sessioni` : '0 sessioni'}</span>
+      <label className="th-pagsize">Per pagina
+        <select value={pageSize} onChange={e => onSize(Number(e.target.value))} aria-label="Sessioni per pagina">
+          {[10, 20, 50, 100].map(n => <option key={n} value={n}>{n}</option>)}
+        </select>
+      </label>
+    </nav>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HEADER (sticky + tabs) ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const TABS = [
+  { id: 'stats', icon: '📊', label: 'Stats', href: 'sp4-toolkit-stats.html' },
+  { id: 'history', icon: '📜', label: 'History', href: null },
+  { id: 'templates', icon: '🎨', label: 'Templates', href: null },
+  { id: 'play', icon: '🎮', label: 'Play', href: null },
+];
+const Header = ({ mobile }) => (
+  <header className="th-head">
+    <div className="th-htop">
+      <div className="th-htxt">
+        <div className="th-bread"><span>Toolkit</span><span className="sep" aria-hidden="true">›</span><span className="cur">History</span></div>
+        <div className="th-titlerow">
+          <span className="th-ico" aria-hidden="true">🧰</span>
+          <h1 className="th-h1">Storico sessioni</h1>
+        </div>
+        {!mobile && <p className="th-sub">Tutte le partite finalizzate, filtrabili per gioco, data e vincitore.</p>}
+      </div>
+      <div className="th-hright">
+        <span className="th-qstat"><b>{TOTAL}</b> sessioni<span aria-hidden="true">·</span><b>{N_GAMES}</b> giochi<span aria-hidden="true">·</span><b>{WINNER_COUNTS.players.length}</b> vincitori</span>
+        <button type="button" className="th-export"><span aria-hidden="true">📊</span>{mobile ? 'CSV' : 'Esporta CSV'}</button>
+      </div>
+    </div>
+    <nav className="th-tabs" role="tablist" aria-label="Sezioni toolkit">
+      {TABS.map(t => (
+        <button key={t.id} type="button" role="tab" aria-selected={t.id === 'history'} className={'th-tab' + (t.id === 'history' ? ' on' : '')}>
+          <span aria-hidden="true">{t.icon}</span>{t.label}
+        </button>
+      ))}
+    </nav>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HISTORY APP (interactive, one per state×viewport) ─
+// ═══════════════════════════════════════════════════════
+const DEFAULT_ST = { search: '', games: [], date: 'all', customFrom: '', customTo: '', winners: [], sort: 'recent', view: 'table', page: 1, pageSize: PAGE_SIZE };
+
+const HistoryApp = ({ scenario, mobile }) => {
+  const sc = scenario.sc || {};
+  const [st, setSt] = useState({ ...DEFAULT_ST, ...sc, view: mobile ? 'cards' : (sc.view || 'table') });
+  const [sortState, setSortState] = useState({ key: sc.sort || 'recent', dir: sc.sort === 'oldest' ? 'asc' : 'desc' });
+  const [openSession, setOpenSession] = useState(sc.openId ? SESSIONS.find(s => s.id === sc.openId) : null);
+  const [typing, setTyping] = useState(false);
+  const searchRef = useRef(null);
+  const firstRef = useRef(null);
+  const typingTimer = useRef(null);
+  const loading = sc.loading, error = sc.error, emptyAll = sc.empty;
+
+  const set = patch => setSt(prev => ({ ...prev, ...patch }));
+
+  // debounce visual
+  useEffect(() => {
+    if (!st.search) { setTyping(false); return; }
+    setTyping(true);
+    clearTimeout(typingTimer.current);
+    typingTimer.current = setTimeout(() => setTyping(false), 650);
+    return () => clearTimeout(typingTimer.current);
+  }, [st.search]);
+
+  // "/" focus search (desktop)
+  useEffect(() => {
+    if (mobile) return;
+    const h = e => {
+      if (e.key === '/' && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+        e.preventDefault(); searchRef.current && searchRef.current.focus();
+      }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mobile]);
+
+  const onSort = key => {
+    setSortState(s => s.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: key === 'recent' ? 'desc' : 'desc' });
+    set({ sort: key });
+  };
+
+  // ── filter ──
+  const filtered = useMemo(() => {
+    const q = st.search.trim().toLowerCase();
+    const cutoff = st.date === 'all' || st.date === 'custom' ? null : new Date(NOW.getTime() - Number(st.date) * 86400000);
+    let rows = SESSIONS.filter(s => {
+      if (st.games.length && !st.games.includes(s.gameId)) return false;
+      if (cutoff && s.date < cutoff) return false;
+      if (st.date === 'custom' && st.customFrom && st.customTo) {
+        const from = new Date(st.customFrom + 'T00:00:00'), to = new Date(st.customTo + 'T23:59:59');
+        if (s.date < from || s.date > to) return false;
+      }
+      if (st.winners.length) {
+        const wantNoWin = st.winners.includes('__nowin__');
+        const matchWin = s.winner && st.winners.includes(s.winner);
+        if (!(matchWin || (wantNoWin && !s.winner))) return false;
+      }
+      if (q && !(s.gameName.toLowerCase().includes(q) || (s.winner && s.winner.toLowerCase().includes(q)) || s.players.some(p => p.name.toLowerCase().includes(q)))) return false;
+      return true;
+    });
+    const dir = sortState.dir === 'asc' ? 1 : -1;
+    rows = [...rows].sort((a, b) => {
+      let r;
+      if (sortState.key === 'game') r = a.gameName.localeCompare(b.gameName);
+      else if (sortState.key === 'longest') r = a.durationMinutes - b.durationMinutes;
+      else if (sortState.key === 'score') r = (a.winScore || 0) - (b.winScore || 0);
+      else r = a.date - b.date; // recent/oldest
+      return r * dir;
+    });
+    return rows;
+  }, [st.search, st.games, st.date, st.customFrom, st.customTo, st.winners, sortState]);
+
+  const total = filtered.length;
+  const pages = Math.max(1, Math.ceil(total / st.pageSize));
+  const page = Math.min(st.page, pages);
+  const from = total ? (page - 1) * st.pageSize + 1 : 0;
+  const to = Math.min(total, page * st.pageSize);
+  const pageRows = filtered.slice((page - 1) * st.pageSize, page * st.pageSize);
+
+  const nActive = (st.games.length ? 1 : 0) + (st.date !== 'all' ? 1 : 0) + (st.winners.length ? 1 : 0) + (st.search.trim() ? 1 : 0);
+  const clearAll = () => set({ search: '', games: [], date: 'all', winners: [], page: 1 });
+
+  let body;
+  if (loading) body = <Skeleton mobile={mobile} />;
+  else if (emptyAll) body = <EmptyAll />;
+  else if (total === 0) body = <FilterEmpty onClear={clearAll} />;
+  else if (mobile || st.view === 'cards') body = <Cards rows={pageRows} onOpen={setOpenSession} />;
+  else body = <Table rows={pageRows} selectedId={openSession && openSession.id} onOpen={setOpenSession} sort={sortState} onSort={onSort} firstRef={firstRef} />;
+
+  return (
+    <div className={'th-app' + (mobile ? ' is-mobile' : '')}>
+      {error && (
+        <div className="th-errbar" role="alert">
+          <span aria-hidden="true">⚠</span>Impossibile caricare lo storico — riprova.
+          <span className="grow" />
+          <button className="retry"><span aria-hidden="true">↻</span> Riprova</button>
+        </div>
+      )}
+      <Header mobile={mobile} />
+      {!error && !emptyAll && <Toolbar st={st} set={set} typing={typing} searchRef={searchRef} />}
+      {!error && !emptyAll && !loading && nActive > 0 && (
+        <div className="th-fsum">
+          <span className="badge"><span aria-hidden="true">⚑</span>{nActive} {nActive === 1 ? 'filtro attivo' : 'filtri attivi'}</span>
+          <span>·</span>
+          <span>{total} {total === 1 ? 'sessione' : 'sessioni'} su {TOTAL}</span>
+          <span className="grow" />
+          <button className="clear" onClick={clearAll}>Cancella tutto</button>
+        </div>
+      )}
+      <div className="th-body" aria-busy={loading ? 'true' : undefined}>{body}</div>
+      {!error && !emptyAll && !loading && total > 0 && (
+        <Pagination page={page} pages={pages} total={total} count={total} pageSize={st.pageSize} from={from} to={to} mobile={mobile}
+          onPage={p => set({ page: p })} onSize={n => set({ pageSize: n, page: 1 })} />
+      )}
+      {openSession && <DetailModal s={openSession} mobile={mobile} onClose={() => setOpenSession(null)} />}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES (desktop chrome + phone) ────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ children }) => (
+  <div style={{
+    width: '100%', borderRadius: 'var(--r-xl)', border: '1px solid var(--border)',
+    background: 'var(--bg-card)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)',
+  }}>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: '9px 14px',
+      background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)',
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840' }} />
+      <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.04em' }}>meepleai.app/toolkit/history</span>
+    </div>
+    <div style={{ height: 686 }}>{children}</div>
+  </div>
+);
+
+const PhoneFrame = ({ children }) => (
+  <div className="phone" style={{ width: 375, height: 760 }}>
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>14:32</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+    <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>{children}</div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE PICKER + ROOT ────────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATES = [
+  { id: 'default',      label: 'Default',            view: 'both',    sc: {}, desc: 'Pagina 1 di 8 · 20 sessioni · nessun filtro attivo · ordinamento "più recente".' },
+  { id: 'filter-game',  label: 'Filter · gioco',     view: 'desktop', sc: { games: ['g-catan'] }, desc: 'Game filter "Catan" attivo → badge "1 filtro attivo", solo sessioni Catan.' },
+  { id: 'filter-multi', label: 'Filter · multi',     view: 'desktop', sc: { games: ['g-catan'], date: '30', winners: ['Marco R.'] }, desc: 'Game (Catan) + Data (ultimi 30gg) + Vincitore (Marco R.) → badge "3 filtri attivi · Cancella tutto".' },
+  { id: 'filter-empty', label: 'Filter · 0 match',   view: 'desktop', sc: { search: 'Monopoly' }, desc: 'Ricerca senza corrispondenze → empty state filtrato con CTA "Rimuovi filtri".' },
+  { id: 'pagination-3', label: 'Pagination · p3',    view: 'desktop', sc: { page: 3 }, desc: 'Su pagina 3 di 8: prev/next attivi, items 41–60 di 156, page button compatto con ellissi.' },
+  { id: 'modal-detail', label: 'Modal detail',       view: 'desktop', sc: { openId: SESSIONS[0].id }, desc: 'Modal dettaglio Catan: classifica + timeline + note + statistiche partita, tabella dimmed dietro.' },
+  { id: 'loading',      label: 'Loading',            view: 'desktop', sc: { loading: true }, desc: 'Skeleton shimmer: header + toolbar + tabella 6 righe.' },
+  { id: 'error',        label: 'Error',              view: 'desktop', sc: { error: true }, desc: 'Banner danger in alto + Riprova; toolbar e body nascosti.' },
+  { id: 'mobile-cards', label: 'Mobile · cards',     view: 'mobile',  sc: { view: 'cards' }, desc: 'Vista 375px: stack di cards, filtri con scroll orizzontale, modal come bottom-sheet.' },
+];
+const SKEY = 'th-state';
+
+const VpLabel = ({ children }) => (
+  <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>{children}</div>
+);
+
+const App = () => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || document.documentElement.getAttribute('data-theme') || 'light');
+  const [active, setActive] = useState(() => {
+    const s = localStorage.getItem(SKEY);
+    return STATES.some(x => x.id === s) ? s : 'default';
+  });
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem(SKEY, active); }, [active]);
+
+  const cur = STATES.find(s => s.id === active) || STATES[0];
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', padding: '20px 20px 80px' }}>
+      <style dangerouslySetInnerHTML={{ __html: window.__TH_CSS }} />
+
+      {/* state picker bar */}
+      <header style={{
+        position: 'sticky', top: 12, zIndex: 50, maxWidth: 1280, margin: '0 auto 24px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(16px)',
+        border: '1px solid var(--border)', borderRadius: 'var(--r-xl)',
+        boxShadow: 'var(--shadow-md)', padding: '12px 16px',
+        display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <div style={{
+            width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+            background: `linear-gradient(135deg, ${eHsl('toolkit')}, ${eHsl('session')})`,
+            color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 800, fontFamily: 'var(--f-display)', fontSize: 14,
+          }}>S</div>
+          <div>
+            <div style={{ fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 14, lineHeight: 1.1 }}>Toolkit History</div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)' }}>#1490 · 2/4 · /toolkit/history</div>
+          </div>
+        </div>
+
+        <div role="tablist" aria-label="Stati schermata" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
+          {STATES.map(s => {
+            const on = s.id === active;
+            return (
+              <button key={s.id} type="button" role="tab" aria-selected={on} onClick={() => setActive(s.id)} style={{
+                padding: '7px 12px', borderRadius: 'var(--r-pill)', cursor: 'pointer',
+                background: on ? eHsl('toolkit') : 'var(--bg-muted)',
+                border: on ? 'none' : '1px solid var(--border)',
+                color: on ? '#fff' : 'var(--text-sec)',
+                fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, whiteSpace: 'nowrap',
+                boxShadow: on ? `0 3px 10px ${eHsl('toolkit', 0.35)}` : 'none',
+              }}>{s.label}</button>
+            );
+          })}
+        </div>
+
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{
+          padding: '8px 14px', borderRadius: 'var(--r-md)', flexShrink: 0,
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer',
+        }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* active state description */}
+      <div style={{ maxWidth: 1280, margin: '0 auto 18px', padding: '0 4px', fontFamily: 'var(--f-mono)', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <strong style={{ color: eHsl('toolkit') }}>{cur.label}</strong> — {cur.desc}
+      </div>
+
+      {/* render area */}
+      <div style={{ maxWidth: 1280, margin: '0 auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 36 }}>
+        {(cur.view === 'both' || cur.view === 'desktop') && (
+          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Desktop · 1440 — hero + table + pagination</VpLabel>
+            <DesktopFrame>
+              <HistoryApp key={'d-' + cur.id} scenario={cur} mobile={false} />
+            </DesktopFrame>
+          </div>
+        )}
+        {(cur.view === 'both' || cur.view === 'mobile') && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Mobile · 375 — cards stack + bottom-sheet</VpLabel>
+            <PhoneFrame>
+              <HistoryApp key={'m-' + cur.id} scenario={cur} mobile={true} />
+            </PhoneFrame>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-toolkit-history.html
+++ b/admin-mockups/design_files/sp4-toolkit-history.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<!-- route: /toolkit/history — Paginated sessions list cross-game con filtri (game/date/winner) + detail modal + pagination -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /toolkit/history — Storico sessioni</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ─── Helper classes (continuity con cluster #1489 + #1490 S1) ─── */
+  @keyframes th-shimmer { 0% { background-position: -400px 0; } 100% { background-position: 400px 0; } }
+  .th-shimmer {
+    background: linear-gradient(90deg, var(--bg-muted) 25%, var(--bg-sunken) 37%, var(--bg-muted) 63%);
+    background-size: 800px 100%;
+    animation: th-shimmer 1.4s linear infinite;
+  }
+  @keyframes th-typedot { 0%,100% { opacity: 1; transform: scale(1); } 50% { opacity: .3; transform: scale(.6); } }
+  @keyframes th-live { 0%,100% { opacity: 1; box-shadow: 0 0 0 0 hsl(var(--c-success) / .5); } 50% { opacity: .6; box-shadow: 0 0 0 4px hsl(var(--c-success) / 0); } }
+  @keyframes th-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes th-modal-in { from { opacity: 0; transform: translateY(14px) scale(.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
+  @keyframes th-sheet-in { from { transform: translateY(100%); } to { transform: translateY(0); } }
+
+  /* Focus ring — keyboard only, toolkit entity */
+  a:focus-visible, button:focus-visible, input:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid hsl(var(--c-toolkit));
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .th-shimmer, [class*="th-pulse"] { animation: none !important; }
+    .th-overlay, .th-modal, .th-sheet { animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-toolkit-history.jsx?v=5"></script>
+<script type="text/babel" src="sp4-toolkit-history-ui.jsx?v=5"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-toolkit-history.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-history.jsx
@@ -1,0 +1,487 @@
+/* MeepleAI SP4 wave 4 — S · #1490 · 2/4 — sp4-toolkit-history
+   Route: /toolkit/history — Lista paginata di sessioni finalizzate cross-game con filtri
+          (game / date range / winner) + detail modal + pagination.
+   File: admin-mockups/design_files/sp4-toolkit-history.{html,jsx}
+   Pattern: Hero + body con tabella filtrabile (riusa list view sp4-library-desktop +
+            filter chips / status badge da sp4-editor-proposals-index #1489) + detail modal.
+            NO sidebar, NO split-view. Desktop = table, mobile = cards stack + bottom-sheet modal.
+
+   Source restyle (NO ridisegnare logica): apps/web/src/app/(authenticated)/toolkit/history/client.tsx
+   API: api.sessions.getHistory({ gameId?, startDate?, endDate? }) →
+        { sessions[{id,gameId,gameName,date,durationMinutes,players[{name,score,isWinner}],winner,notes}],
+          totalCount, pageSize:20, currentPage }
+
+   Entity: --c-toolkit (verde, continuity con S1) primaria · --c-game per i giochi (EntityChip 🎲) ·
+           --c-player per i giocatori (avatar) · --c-success per il winner (🏆).
+
+   9 stati (state picker continuity con #1489 + #1490 S1, persistito localStorage `th-state`):
+   default · filter-game · filter-multi · filter-empty · pagination-3 · modal-detail · loading · error · mobile-cards
+
+   Deviazioni flaggate: punteggi Catan nel modal riportati su scala realistica del gioco (~10-13 VP,
+   coerente con data.js avgScore:9) invece del valore 87 del brief — mantiene "dati realistici" (_common.md).
+*/
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const DS = window.DS;
+
+const eHsl = (type, a) => {
+  const c = DS.EC[type] || DS.EC.toolkit;
+  return a !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${a})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+const sem = (name, a) => a !== undefined ? `hsl(var(--c-${name}) / ${a})` : `hsl(var(--c-${name}))`;
+
+const MONTHS_SHORT = ['gen','feb','mar','apr','mag','giu','lug','ago','set','ott','nov','dic'];
+const MONTHS_FULL  = ['gennaio','febbraio','marzo','aprile','maggio','giugno','luglio','agosto','settembre','ottobre','novembre','dicembre'];
+const PAD = n => String(n).padStart(2, '0');
+const fmtDate = d => `${d.getDate()} ${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`;
+const fmtTime = d => `${PAD(d.getHours())}:${PAD(d.getMinutes())}`;
+const fmtDur = m => { const h = Math.floor(m / 60), mm = m % 60; return h ? (mm ? `${h}h ${mm}m` : `${h}h`) : `${mm}m`; };
+function relDate(d, now) {
+  const days = Math.round((now - d) / 86400000);
+  if (days <= 0) return 'oggi';
+  if (days === 1) return 'ieri';
+  if (days < 7) return `${days} giorni fa`;
+  if (days < 30) return `${Math.floor(days / 7)} settimane fa`;
+  if (days < 365) return `${Math.floor(days / 30)} mesi fa`;
+  return `${Math.floor(days / 365)} anni fa`;
+}
+
+// ═══════════════════════════════════════════════════════
+// ─── FIXTURE — 156 sessioni deterministiche (cross-ref data.js) ──
+// ═══════════════════════════════════════════════════════
+const NOW = new Date(2026, 4, 28, 16, 5); // 28 mag 2026
+const PLAYER_POOL = ['p-marco', 'p-sara', 'p-luca', 'p-giulia', 'p-andrea'];
+const ME = 'Marco R.';
+
+// score range realistico per gioco (coerente con data.js avgScore)
+const GAME_CFG = {
+  'g-catan':    { w: 22, range: [7, 14],    dur: [62, 128], coop: false },
+  'g-wingspan': { w: 18, range: [62, 102],  dur: [44, 78],  coop: false },
+  'g-azul':     { w: 16, range: [48, 95],   dur: [28, 52],  coop: false },
+  'g-7wonders': { w: 14, range: [44, 82],   dur: [26, 38],  coop: false },
+  'g-brass':    { w: 11, range: [104, 162], dur: [88, 142], coop: false },
+  'g-arknova':  { w: 8,  range: [88, 142],  dur: [96, 152], coop: false },
+  'g-spirit':   { w: 6,  range: [0, 0],     dur: [92, 124], coop: true },
+};
+const GAME_IDS = Object.keys(GAME_CFG);
+// weighted bag for deterministic distribution
+const GAME_BAG = GAME_IDS.flatMap(id => Array(GAME_CFG[id].w).fill(id));
+
+const NOTE_SNIPS = [
+  'Partita combattutissima fino all’ultimo turno.',
+  'Apertura aggressiva ripagata nel finale.',
+  'Da rivedere la gestione delle risorse a metà partita.',
+  'Vittoria di misura, scarto minimo in classifica.',
+  'Bella rimonta nel secondo tempo.',
+  'Setup lento ma finale spettacolare.',
+  'Buon equilibrio tra i giocatori, decisa ai tie-break.',
+  'Partita di rodaggio con un nuovo giocatore al tavolo.',
+];
+
+// PRNG deterministico (mulberry32)
+function mk(seed) { return () => { seed |= 0; seed = (seed + 0x6D2B79F5) | 0; let t = Math.imul(seed ^ (seed >>> 15), 1 | seed); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; }
+
+function buildSessions() {
+  const rng = mk(20260528);
+  const out = [];
+  let cursor = new Date(NOW.getTime() - 4 * 3600000); // most recent ~ 4h ago
+  for (let i = 0; i < 156; i++) {
+    const gameId = i === 0 ? 'g-catan' : GAME_BAG[Math.floor(rng() * GAME_BAG.length)];
+    const cfg = GAME_CFG[gameId];
+    const g = DS.byId[gameId];
+    // step back 0.4–4 days between sessions
+    if (i > 0) cursor = new Date(cursor.getTime() - (0.4 + rng() * 3.6) * 86400000);
+    const date = new Date(cursor);
+
+    let nP = i === 0 ? 4 : 2 + Math.floor(rng() * 3); // 2–4
+    if (gameId === 'g-7wonders') nP = 2; // duel
+    if (gameId === 'g-arknova' && nP > 4) nP = 4;
+    // pick distinct players, Marco present ~65%
+    const pool = [...PLAYER_POOL];
+    const picks = [];
+    const marcoIn = i === 0 ? true : rng() < 0.62;
+    if (marcoIn) { picks.push('p-marco'); pool.splice(pool.indexOf('p-marco'), 1); }
+    while (picks.length < nP && pool.length) picks.push(pool.splice(Math.floor(rng() * pool.length), 1)[0]);
+
+    const [lo, hi] = cfg.range;
+    const players = picks.map(pid => ({
+      pid, name: DS.byId[pid].title, initials: DS.byId[pid].initials, color: DS.byId[pid].color,
+      score: cfg.coop ? 0 : lo + Math.floor(rng() * (hi - lo + 1)),
+    }));
+    if (i === 0) {
+      // sessione Catan in evidenza: Marco R. vince con 12 PV (coerente con timeline + note del modal)
+      const fixed = [['p-marco', 12], ['p-sara', 10], ['p-luca', 9], ['p-giulia', 8]];
+      players.length = 0;
+      fixed.forEach(([pid, sc]) => players.push({ pid, name: DS.byId[pid].title, initials: DS.byId[pid].initials, color: DS.byId[pid].color, score: sc }));
+    }
+    let winner = null, winScore = null;
+    if (!cfg.coop) {
+      let best = players[0];
+      players.forEach(p => { if (p.score > best.score) best = p; });
+      best.isWinner = true; winner = best.name; winScore = best.score;
+    }
+    const dur = cfg.dur[0] + Math.floor(rng() * (cfg.dur[1] - cfg.dur[0] + 1));
+    const hasNote = i === 0 || rng() < 0.34;
+    const note = i === 0
+      ? 'Ottima partita! Marco si è difeso bene dal ladro. Da ripetere in 4 giocatori.'
+      : hasNote ? NOTE_SNIPS[Math.floor(rng() * NOTE_SNIPS.length)] : null;
+
+    out.push({
+      id: `s-${PAD(i)}-${gameId.slice(2)}`,
+      gameId, gameName: g.title, cover: g.cover, coverEmoji: g.coverEmoji,
+      date, durationMinutes: dur, players, winner, winScore,
+      coop: cfg.coop, notes: note, mine: winner === ME,
+      turns: 8 + Math.floor(rng() * 14),
+    });
+  }
+  return out;
+}
+const SESSIONS = buildSessions();
+const TOTAL = SESSIONS.length;
+const PAGE_SIZE = 20;
+
+// derived counts for filters
+const GAME_COUNTS = GAME_IDS.map(id => ({ id, count: SESSIONS.filter(s => s.gameId === id).length }))
+  .sort((a, b) => b.count - a.count);
+const WINNER_COUNTS = (() => {
+  const m = {};
+  SESSIONS.forEach(s => { if (s.winner) m[s.winner] = (m[s.winner] || 0) + 1; });
+  const noWin = SESSIONS.filter(s => !s.winner).length;
+  const arr = Object.entries(m).map(([name, count]) => ({ name, count })).sort((a, b) => b.count - a.count);
+  return { players: arr.slice(0, 4), noWin };
+})();
+const N_GAMES = GAME_IDS.length;
+
+// timeline IT per il modal (bespoke per sessione 0 = Catan, generico per le altre)
+const CATAN_TL = [
+  { t: '15:42', icon: '🎲', e: 'Setup completato · 4 giocatori al tavolo' },
+  { t: '15:48', icon: '🏘️', e: 'Marco R. costruisce la prima città' },
+  { t: '16:23', icon: '🃏', e: 'Sara T. attiva una carta sviluppo' },
+  { t: '17:06', icon: '🦹', e: 'Luca B. ruba 2 carte risorsa (ladro)' },
+  { t: '17:08', icon: '🏁', e: 'Fine partita · Marco R. raggiunge 12 PV' },
+];
+function genTimeline(s) {
+  if (s.id === SESSIONS[0].id) return CATAN_TL;
+  const start = new Date(s.date.getTime());
+  const end = new Date(start.getTime() + s.durationMinutes * 60000);
+  const mid = new Date(start.getTime() + s.durationMinutes * 0.5 * 60000);
+  const lead = s.players[0], second = s.players[1] || s.players[0];
+  return [
+    { t: fmtTime(start), icon: '🎲', e: `Setup completato · ${s.players.length} giocatori` },
+    { t: fmtTime(new Date(start.getTime() + 8 * 60000)), icon: '▶️', e: `${lead.name} apre la partita` },
+    { t: fmtTime(mid), icon: '⚡', e: `${second.name} prende il vantaggio a metà partita` },
+    { t: fmtTime(end), icon: '🏁', e: s.coop ? 'Fine partita · risultato cooperativo' : `Fine partita · vince ${s.winner}` },
+  ];
+}
+
+// ═══════════════════════════════════════════════════════
+// ─── COMPONENT CSS (inject) — solo token da tokens.css ──
+// ═══════════════════════════════════════════════════════
+const TH_CSS = `
+.th-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+
+/* ─ error banner ─ */
+.th-errbar { flex-shrink:0; display:flex; align-items:center; gap:11px; padding:11px 18px; font-family:var(--f-display); font-weight:700; font-size:13px;
+  background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); border-bottom:1px solid hsl(var(--c-danger) / .3); }
+.th-errbar .grow { flex:1; }
+.th-errbar .retry { display:inline-flex; align-items:center; gap:6px; padding:6px 13px; border-radius:var(--r-md); border:1px solid hsl(var(--c-danger) / .4);
+  background:var(--bg-card); color:hsl(var(--c-danger)); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; }
+
+/* ─ header (sticky) ─ */
+.th-head { flex-shrink:0; position:sticky; top:0; z-index:12; background:var(--glass-bg); backdrop-filter:blur(14px); border-bottom:1px solid var(--border); padding:14px 22px 0; }
+.th-htop { display:flex; align-items:flex-start; gap:16px; }
+.th-htxt { min-width:0; flex:1; }
+.th-bread { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:7px; }
+.th-bread .sep { opacity:.5; }
+.th-bread .cur { color:var(--text-sec); font-weight:700; }
+.th-titlerow { display:flex; align-items:center; gap:10px; }
+.th-ico { width:34px; height:34px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-toolkit) / .16); color:hsl(var(--c-toolkit));
+  display:inline-flex; align-items:center; justify-content:center; font-size:18px; }
+.th-h1 { font-family:var(--f-display); font-weight:800; font-size:30px; letter-spacing:-.02em; line-height:1.1; color:var(--text); white-space:nowrap; }
+.th-sub { font-size:14px; color:var(--text-sec); margin-top:5px; max-width:560px; }
+.th-hright { display:flex; flex-direction:column; align-items:flex-end; gap:10px; flex-shrink:0; }
+.th-qstat { display:inline-flex; align-items:center; gap:7px; font-family:var(--f-mono); font-size:11px; color:var(--text-muted); white-space:nowrap; }
+.th-qstat b { color:var(--text-sec); font-weight:700; }
+.th-export { display:inline-flex; align-items:center; gap:7px; padding:8px 14px; border-radius:var(--r-md); background:var(--bg-card);
+  border:1px solid var(--border-strong); color:var(--text); font-family:var(--f-display); font-weight:800; font-size:13px; cursor:pointer; white-space:nowrap;
+  transition:all var(--dur-sm) var(--ease-out); }
+.th-export:hover { border-color:hsl(var(--c-toolkit) / .5); color:hsl(var(--c-toolkit)); }
+
+/* ─ tabs nav ─ */
+.th-tabs { display:flex; gap:4px; margin-top:14px; overflow-x:auto; scrollbar-width:none; }
+.th-tabs::-webkit-scrollbar { display:none; }
+.th-tab { display:inline-flex; align-items:center; gap:6px; padding:9px 14px 11px; border:none; background:transparent; cursor:pointer; white-space:nowrap;
+  border-bottom:2px solid transparent; color:var(--text-muted); font-family:var(--f-display); font-weight:700; font-size:13px; transition:color var(--dur-sm); }
+.th-tab:hover { color:var(--text-sec); }
+.th-tab.on { color:hsl(var(--c-toolkit)); border-bottom-color:hsl(var(--c-toolkit)); }
+
+/* ─ toolbar ─ */
+.th-toolbar { flex-shrink:0; display:flex; align-items:center; gap:12px; padding:11px 22px; background:var(--bg); border-bottom:1px solid var(--border); flex-wrap:wrap; row-gap:10px; }
+.th-search { flex:1 1 210px; max-width:290px; min-width:150px; position:relative; }
+.th-search .ic { position:absolute; left:11px; top:50%; transform:translateY(-50%); font-size:13px; opacity:.6; pointer-events:none; }
+.th-search input { width:100%; padding:8px 64px 8px 32px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:13px; color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.th-search input::placeholder { color:var(--text-muted); }
+.th-search input:focus, .th-search.active input { border-color:hsl(var(--c-toolkit) / .6); box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .14); }
+.th-search .clear { position:absolute; right:9px; top:50%; transform:translateY(-50%); width:20px; height:20px; border-radius:var(--r-pill);
+  border:none; background:var(--bg-muted); color:var(--text-sec); cursor:pointer; font-size:11px; display:inline-flex; align-items:center; justify-content:center; }
+.th-search .clear:hover { background:var(--border-strong); color:var(--text); }
+.th-search .busy { position:absolute; right:34px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; gap:5px;
+  font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-info)); white-space:nowrap; }
+.th-search .busy i { width:6px; height:6px; border-radius:50%; background:currentColor; animation:th-typedot 1s var(--ease-in-out) infinite; }
+
+.th-filters { flex:1 1 auto; display:flex; align-items:center; gap:8px; flex-wrap:wrap; row-gap:8px; padding:2px; min-width:0; }
+.th-filters::-webkit-scrollbar { display:none; }
+.th-fgroup { position:relative; display:flex; align-items:center; gap:6px; flex-shrink:0; }
+.th-fdiv { width:1px; height:22px; background:var(--border); flex-shrink:0; }
+
+/* generic filter chip */
+.th-chip { display:inline-flex; align-items:center; gap:7px; padding:6px 12px; border-radius:var(--r-pill); white-space:nowrap; flex-shrink:0;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out);
+  font-family:var(--f-display); font-weight:700; font-size:12px; }
+.th-chip:hover { background:var(--bg-hover); }
+.th-chip .cdot { width:8px; height:8px; border-radius:50%; flex-shrink:0; background:var(--text-muted); }
+.th-chip .ccount { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.th-chip .cav { width:16px; height:16px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:8px; font-weight:800; color:#fff; }
+.th-chip.on { color:var(--text); background:var(--bg-muted); border-color:var(--border-strong); }
+.th-chip.on .ccount { color:var(--text-sec); }
+/* game-tinted */
+.th-chip.game.on { background:hsl(var(--c-game) / .14); border-color:hsl(var(--c-game) / .4); color:hsl(var(--c-game)); }
+.th-chip.game .cdot { background:hsl(var(--c-game)); }
+/* toolkit-tinted (date) */
+.th-chip.tk.on { background:hsl(var(--c-toolkit) / .14); border-color:hsl(var(--c-toolkit) / .4); color:hsl(var(--c-toolkit)); }
+/* success-tinted (winner) */
+.th-chip.win.on { background:hsl(var(--c-success) / .14); border-color:hsl(var(--c-success) / .4); color:hsl(var(--c-success)); }
+.th-chip.on .ccount { color:currentColor; opacity:.85; }
+
+/* dropdown chip (game / winner multi-select + sort) */
+.th-pop { position:absolute; top:calc(100% + 6px); left:0; z-index:30; background:var(--bg-card); border:1px solid var(--border);
+  border-radius:var(--r-md); box-shadow:var(--shadow-lg); padding:6px; min-width:230px; display:flex; flex-direction:column; gap:2px; max-height:400px; overflow-y:auto; }
+.th-pop.right { left:auto; right:0; min-width:190px; }
+.th-pophead { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); padding:4px 8px 6px; }
+.th-popitem { display:flex; align-items:center; gap:9px; width:100%; padding:8px 10px; border-radius:var(--r-sm); border:none; background:transparent; cursor:pointer;
+  color:var(--text); font-family:var(--f-display); font-weight:600; font-size:13px; text-align:left; }
+.th-popitem:hover { background:var(--bg-muted); }
+.th-popitem .check { width:16px; height:16px; border-radius:var(--r-xs); border:1.5px solid var(--border-strong); flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; font-size:10px; color:#fff; }
+.th-popitem.sel .check { background:hsl(var(--c-toolkit)); border-color:hsl(var(--c-toolkit)); }
+.th-popitem.radio .check { border-radius:50%; }
+.th-popitem .lbl { flex:1; }
+.th-popitem .cnt { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.th-popmore { font-family:var(--f-display); font-weight:700; font-size:12px; color:hsl(var(--c-toolkit)); background:transparent; border:none; cursor:pointer; padding:7px 10px; text-align:left; }
+.th-daterange { display:flex; flex-direction:column; gap:8px; padding:10px 8px 6px; border-top:1px solid var(--border-light); margin-top:4px; }
+.th-daterange .r2 { display:flex; gap:8px; }
+.th-daterange label { flex:1; font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--text-muted); display:flex; flex-direction:column; gap:4px; }
+.th-daterange input { font-family:var(--f-body); font-size:12px; padding:7px 9px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text); color-scheme:light dark; }
+.th-daterange input:focus { outline:none; border-color:hsl(var(--c-toolkit) / .55); box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .12); }
+.th-daterange .apply { padding:8px 12px; border-radius:var(--r-sm); border:none; background:hsl(var(--c-toolkit)); color:#fff; font-family:var(--f-display); font-weight:700; font-size:12px; cursor:pointer; }
+.th-daterange .apply:disabled { opacity:.45; cursor:default; }
+
+.th-right { flex-shrink:0; display:flex; align-items:center; gap:10px; }
+.th-vtoggle { display:inline-flex; padding:3px; gap:2px; background:var(--bg-muted); border-radius:var(--r-md); border:1px solid var(--border); }
+.th-vtoggle button { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted);
+  font-family:var(--f-display); font-weight:700; font-size:11px; cursor:pointer; }
+.th-vtoggle button[aria-pressed="true"] { background:var(--bg-card); color:hsl(var(--c-toolkit)); box-shadow:var(--shadow-xs); }
+
+/* active filter summary bar */
+.th-fsum { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:8px 22px; background:var(--bg-sunken); border-bottom:1px solid var(--border-light);
+  font-family:var(--f-mono); font-size:11px; color:var(--text-sec); }
+.th-fsum .badge { display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:var(--r-pill); background:hsl(var(--c-toolkit) / .14); color:hsl(var(--c-toolkit)); font-weight:700; }
+.th-fsum .clear { background:transparent; border:none; cursor:pointer; color:hsl(var(--c-warning)); font-family:var(--f-display); font-weight:800; font-size:12px; }
+.th-fsum .grow { flex:1; }
+
+/* ─ table ─ */
+.th-body { flex:1; overflow:auto; min-height:0; position:relative; }
+.th-table { --cols: 168px minmax(150px,1.3fr) 92px minmax(118px,1fr) minmax(140px,1.2fr) 72px 40px 88px; min-width:1080px; }
+.th-thead { position:sticky; top:0; z-index:5; display:grid; grid-template-columns:var(--cols); gap:14px; align-items:center;
+  padding:10px 22px; background:var(--bg-sunken); border-bottom:1px solid var(--border); }
+.th-th { font-family:var(--f-mono); font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); display:flex; align-items:center; gap:5px; }
+.th-th.sortable { cursor:pointer; }
+.th-th.sortable:hover { color:var(--text-sec); }
+.th-th .arr { font-size:9px; opacity:0; transition:opacity var(--dur-sm); }
+.th-th[aria-sort="ascending"] .arr, .th-th[aria-sort="descending"] .arr { opacity:1; color:hsl(var(--c-toolkit)); }
+.th-th.right { justify-content:flex-end; }
+.th-th.center { justify-content:center; }
+
+.th-row { border-bottom:1px solid var(--border-light); cursor:pointer; transition:background var(--dur-sm) var(--ease-out); }
+.th-row:hover { background:var(--bg-hover); }
+.th-row.mine { background:hsl(var(--c-success) / .045); }
+.th-row.mine:hover { background:hsl(var(--c-success) / .08); }
+.th-row.sel { background:hsl(var(--c-toolkit) / .07); box-shadow:inset 3px 0 0 hsl(var(--c-toolkit)); }
+.th-rowmain { display:grid; grid-template-columns:var(--cols); gap:14px; align-items:center; padding:12px 22px; }
+.th-cell { min-width:0; }
+.th-dt { font-family:var(--f-mono); font-size:12px; color:var(--text); font-weight:600; }
+.th-dt .rel { display:block; font-size:10px; color:var(--text-muted); margin-top:2px; }
+.th-durpill { display:inline-flex; align-items:center; gap:5px; font-family:var(--f-mono); font-size:12px; color:var(--text-sec); font-variant-numeric:tabular-nums; }
+.th-score { font-family:var(--f-mono); font-size:14px; font-weight:800; color:var(--text); font-variant-numeric:tabular-nums; text-align:left; }
+.th-score.coop { color:var(--text-muted); font-size:12px; font-weight:600; }
+.th-noteic { width:26px; height:26px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted); cursor:pointer; font-size:13px; display:inline-flex; align-items:center; justify-content:center; position:relative; }
+.th-noteic:hover { background:var(--bg-muted); color:var(--text-sec); }
+.th-noteic.empty { opacity:.28; cursor:default; }
+
+/* EntityChip game */
+.th-egame { display:inline-flex; align-items:center; gap:6px; max-width:100%; overflow:hidden; padding:3px 10px 3px 3px; border-radius:var(--r-pill);
+  background:hsl(var(--c-game) / .12); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .22);
+  font-family:var(--f-display); font-weight:800; font-size:12px; cursor:pointer; white-space:nowrap; }
+.th-egame .cov { width:20px; height:20px; border-radius:var(--r-xs); flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; font-size:11px; color:rgba(255,255,255,.95); }
+.th-egame .gt { overflow:hidden; text-overflow:ellipsis; min-width:0; }
+
+/* avatar stack */
+.th-avs { display:inline-flex; align-items:center; }
+.th-av { width:26px; height:26px; border-radius:50%; border:2px solid var(--bg-card); margin-left:-7px; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--f-display); font-size:9px; font-weight:800; color:#fff; flex-shrink:0; }
+.th-av:first-child { margin-left:0; }
+.th-av.more { background:var(--bg-muted); color:var(--text-sec); border-color:var(--bg-card); }
+.th-row.mine .th-av { border-color:#fffaf2; }
+[data-theme="dark"] .th-row.mine .th-av { border-color:#1c2018; }
+
+/* winner chip */
+.th-win { display:inline-flex; align-items:center; gap:6px; max-width:100%; overflow:hidden; padding:3px 10px 3px 4px; border-radius:var(--r-pill);
+  background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); font-family:var(--f-display); font-weight:800; font-size:12px; white-space:nowrap; }
+.th-win .wt { overflow:hidden; text-overflow:ellipsis; min-width:0; }
+.th-coop { display:inline-flex; align-items:center; gap:6px; padding:3px 10px; border-radius:var(--r-pill); background:var(--bg-muted); color:var(--text-muted);
+  font-family:var(--f-mono); font-size:11px; font-weight:700; white-space:nowrap; }
+.th-nowin { color:var(--text-muted); font-family:var(--f-mono); font-size:13px; }
+
+/* row actions */
+.th-acts { display:flex; align-items:center; gap:4px; justify-content:flex-end; }
+.th-act { width:30px; height:30px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text-sec);
+  display:inline-flex; align-items:center; justify-content:center; cursor:pointer; font-size:13px; transition:all var(--dur-sm) var(--ease-out); }
+.th-act:hover { background:var(--bg-muted); color:var(--text); border-color:var(--border-strong); }
+.th-act.see:hover { color:hsl(var(--c-toolkit)); border-color:hsl(var(--c-toolkit) / .4); background:hsl(var(--c-toolkit) / .1); }
+
+/* ─ pagination ─ */
+.th-pag { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:12px 22px; border-top:1px solid var(--border); background:var(--bg-card); flex-wrap:nowrap; }
+.th-pagbtn { display:inline-flex; align-items:center; gap:6px; padding:7px 13px; border-radius:var(--r-md); border:1px solid var(--border-strong); background:var(--bg-card);
+  color:var(--text); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.th-pagbtn:hover:not(:disabled) { border-color:hsl(var(--c-toolkit) / .5); color:hsl(var(--c-toolkit)); }
+.th-pagbtn:disabled { opacity:.4; cursor:default; }
+.th-pagbtn.ar { padding:8px 15px; font-size:15px; flex-shrink:0; }
+.th-pagnums { display:flex; align-items:center; gap:4px; }
+.th-pagnum { min-width:32px; height:32px; padding:0 6px; border-radius:var(--r-pill); border:none; background:transparent; color:var(--text-sec);
+  font-family:var(--f-mono); font-size:13px; font-weight:700; cursor:pointer; }
+.th-pagnum:hover { background:var(--bg-muted); color:var(--text); }
+.th-pagnum.on { background:hsl(var(--c-toolkit)); color:#fff; box-shadow:0 3px 10px hsl(var(--c-toolkit) / .35); }
+.th-pagell { color:var(--text-muted); padding:0 2px; font-family:var(--f-mono); }
+.th-pag .grow { flex:1; }
+.th-pagmeta { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); white-space:nowrap; min-width:0; overflow:hidden; text-overflow:ellipsis; }
+.th-pagsize { display:inline-flex; align-items:center; gap:7px; font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.th-pagsize select { font-family:var(--f-mono); font-size:11px; padding:5px 8px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text); cursor:pointer; }
+
+/* ─ empty / loading ─ */
+.th-pad { flex:1; display:flex; align-items:center; justify-content:center; padding:48px 24px; }
+.th-empty { text-align:center; max-width:400px; border:1.5px dashed var(--border-strong); border-radius:var(--r-xl); padding:50px 34px;
+  display:flex; flex-direction:column; align-items:center; }
+.th-empty .em { width:72px; height:72px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:32px; margin-bottom:18px; }
+.th-empty.tk .em { background:hsl(var(--c-toolkit) / .12); color:hsl(var(--c-toolkit)); }
+.th-empty.warn .em { background:hsl(var(--c-warning) / .12); }
+.th-empty h3 { font-family:var(--f-display); font-size:20px; font-weight:800; margin:0 0 8px; }
+.th-empty p { font-size:14px; color:var(--text-sec); line-height:1.55; margin:0 0 22px; }
+.th-empty .cta { display:inline-flex; align-items:center; gap:8px; padding:11px 20px; border-radius:var(--r-md); border:none;
+  background:hsl(var(--c-toolkit)); color:#fff; font-family:var(--f-display); font-weight:800; font-size:14px; cursor:pointer; box-shadow:0 4px 14px hsl(var(--c-toolkit) / .4); }
+.th-empty .cta.warn { background:transparent; border:1px solid hsl(var(--c-warning) / .5); color:hsl(var(--c-warning)); box-shadow:none; }
+
+.th-sk { border-radius:var(--r-sm); }
+
+/* ─ modal ─ */
+.th-overlay { position:absolute; inset:0; z-index:50; background:rgba(20,12,4,.46); backdrop-filter:blur(3px); display:flex; align-items:center; justify-content:center; padding:28px; animation:th-overlay-in var(--dur-md) var(--ease-out); }
+[data-theme="dark"] .th-overlay { background:rgba(0,0,0,.62); }
+.th-modal { width:min(580px, 100%); max-height:100%; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg);
+  display:flex; flex-direction:column; overflow:hidden; animation:th-modal-in var(--dur-md) var(--ease-spring); }
+.th-mhead { flex-shrink:0; display:flex; align-items:flex-start; gap:14px; padding:18px 20px; border-bottom:1px solid var(--border); background:var(--bg-card); }
+.th-mhead .mcov { width:42px; height:42px; border-radius:var(--r-md); flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; font-size:21px; color:rgba(255,255,255,.95); }
+.th-mhtxt { flex:1; min-width:0; }
+.th-mtitle { font-family:var(--f-display); font-weight:800; font-size:20px; letter-spacing:-.01em; color:var(--text); }
+.th-msub { font-family:var(--f-mono); font-size:12px; color:var(--text-sec); margin-top:4px; }
+.th-mclose { width:32px; height:32px; flex-shrink:0; border-radius:var(--r-sm); border:none; background:var(--bg-muted); color:var(--text-muted); cursor:pointer; font-size:16px; }
+.th-mclose:hover { background:var(--border-strong); color:var(--text); }
+.th-mbody { flex:1; overflow-y:auto; padding:18px 20px; display:flex; flex-direction:column; gap:20px; }
+.th-msec h4 { font-family:var(--f-mono); font-size:11px; text-transform:uppercase; letter-spacing:.07em; color:var(--text-muted); margin:0 0 10px; display:flex; align-items:center; gap:8px; }
+.th-msec h4 .gr { flex:1; height:1px; background:var(--border-light); }
+
+/* leaderboard */
+.th-lb { display:flex; flex-direction:column; gap:4px; }
+.th-lbrow { display:grid; grid-template-columns:34px 1fr auto; gap:11px; align-items:center; padding:9px 11px; border-radius:var(--r-md); }
+.th-lbrow.first { background:hsl(var(--c-success) / .1); }
+.th-lbrank { font-family:var(--f-mono); font-size:13px; font-weight:800; color:var(--text-muted); text-align:center; }
+.th-lbrow.first .th-lbrank { color:hsl(var(--c-success)); }
+.th-lbplayer { display:flex; align-items:center; gap:9px; min-width:0; }
+.th-lbplayer .nm { font-family:var(--f-display); font-weight:700; font-size:14px; color:var(--text); overflow:hidden; text-overflow:ellipsis; }
+.th-lbscore { font-family:var(--f-mono); font-size:16px; font-weight:800; color:var(--text); font-variant-numeric:tabular-nums; }
+.th-lbtag { font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-player)); }
+
+/* timeline */
+.th-tl-toggle { display:flex; align-items:center; gap:6px; width:100%; padding:0; border:none; background:transparent; cursor:pointer; font-family:var(--f-mono);
+  font-size:11px; text-transform:uppercase; letter-spacing:.07em; color:var(--text-muted); }
+.th-tl-toggle .car { font-size:9px; transition:transform var(--dur-sm); }
+.th-tl-toggle .gr { flex:1; height:1px; background:var(--border-light); }
+.th-tl { list-style:none; margin:12px 0 0; padding:0 0 0 4px; display:flex; flex-direction:column; }
+.th-tlrow { display:grid; grid-template-columns:54px 28px 1fr; gap:10px; align-items:flex-start; padding:0 0 14px; position:relative; }
+.th-tlrow:not(:last-child)::before { content:''; position:absolute; left:67px; top:24px; bottom:-2px; width:1.5px; background:var(--border); }
+.th-tltime { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); padding-top:5px; font-variant-numeric:tabular-nums; }
+.th-tldot { width:28px; height:28px; border-radius:50%; background:var(--bg-muted); display:inline-flex; align-items:center; justify-content:center; font-size:13px; z-index:1; }
+.th-tle { font-size:13px; color:var(--text-sec); line-height:1.45; padding-top:5px; }
+
+/* notes */
+.th-noteta { width:100%; min-height:64px; resize:none; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg-sunken);
+  padding:11px 13px; font-family:var(--f-body); font-size:13px; color:var(--text); line-height:1.5; }
+.th-noteta[readonly] { cursor:default; }
+.th-noteta:focus { outline:none; border-color:hsl(var(--c-toolkit) / .5); background:var(--bg-card); }
+.th-noteempty { font-size:13px; color:var(--text-muted); font-style:italic; }
+
+/* game stats grid */
+.th-gstats { display:grid; grid-template-columns:repeat(2,1fr); gap:10px; }
+.th-gstat { padding:12px 14px; border-radius:var(--r-md); background:var(--bg-sunken); border:1px solid var(--border-light); }
+.th-gstat .gl { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--text-muted); }
+.th-gstat .gv { font-family:var(--f-display); font-size:22px; font-weight:800; color:var(--text); margin-top:4px; font-variant-numeric:tabular-nums; }
+.th-gstat .gv small { font-size:12px; color:var(--text-muted); font-weight:600; }
+.th-hl { display:flex; flex-wrap:wrap; gap:6px; margin-top:4px; }
+.th-hlchip { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill); background:hsl(var(--c-toolkit) / .12); color:hsl(var(--c-toolkit));
+  font-family:var(--f-display); font-weight:700; font-size:11px; }
+
+/* modal footer */
+.th-mfoot { flex-shrink:0; display:flex; align-items:center; gap:8px; padding:14px 20px; border-top:1px solid var(--border); background:var(--bg-card); flex-wrap:wrap; }
+.th-mbtn { display:inline-flex; align-items:center; gap:6px; padding:9px 14px; border-radius:var(--r-md); border:1px solid var(--border-strong); background:var(--bg-card);
+  color:var(--text); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.th-mbtn:hover { background:var(--bg-muted); }
+.th-mbtn.tk { background:hsl(var(--c-toolkit)); border-color:transparent; color:#fff; }
+.th-mbtn.tk:hover { filter:brightness(1.04); background:hsl(var(--c-toolkit)); }
+.th-mbtn.game { background:hsl(var(--c-game)); border-color:transparent; color:#fff; }
+.th-mbtn.game:hover { filter:brightness(1.04); background:hsl(var(--c-game)); }
+.th-mbtn.danger { border:none; background:transparent; color:hsl(var(--c-danger)); }
+.th-mbtn.danger:hover { background:hsl(var(--c-danger) / .1); }
+.th-mfoot .grow { flex:1; }
+
+/* ─ mobile cards ─ */
+.th-cards { display:flex; flex-direction:column; gap:11px; padding:14px; }
+.th-card { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-lg); padding:13px 14px; cursor:pointer;
+  transition:border-color var(--dur-sm) var(--ease-out); display:flex; flex-direction:column; gap:11px; }
+.th-card:hover, .th-card:focus-visible { border-color:var(--border-strong); }
+.th-card.mine { border-left:3px solid hsl(var(--c-success) / .6); }
+.th-card .chead { display:flex; align-items:center; gap:10px; }
+.th-card .chead .grow { flex:1; }
+.th-card .cdate { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.th-card .cmid { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+.th-card .cfoot { display:flex; align-items:center; gap:10px; padding-top:11px; border-top:1px solid var(--border-light); }
+.th-card .cfoot .grow { flex:1; }
+.th-cscore { display:inline-flex; align-items:center; gap:6px; padding:4px 11px; border-radius:var(--r-md); background:hsl(var(--c-toolkit) / .12); color:hsl(var(--c-toolkit));
+  font-family:var(--f-mono); font-size:13px; font-weight:800; }
+
+/* mobile adaptations */
+.th-app.is-mobile .th-head { padding:12px 14px 0; }
+.th-app.is-mobile .th-h1 { font-size:21px; }
+.th-app.is-mobile .th-htop { flex-direction:column; gap:10px; }
+.th-app.is-mobile .th-hright { flex-direction:row; align-items:center; align-self:stretch; flex-wrap:wrap; }
+.th-app.is-mobile .th-toolbar { flex-wrap:wrap; padding:11px 14px; gap:10px; }
+.th-app.is-mobile .th-search { flex:1 1 100%; max-width:100%; }
+.th-app.is-mobile .th-right { display:none; }
+.th-app.is-mobile .th-fsum { padding:8px 14px; }
+.th-app.is-mobile .th-pag { padding:10px 14px; gap:8px; flex-wrap:nowrap; justify-content:space-between; }
+.th-app.is-mobile .th-pagmeta { flex:1; order:0; text-align:center; }
+.th-app.is-mobile .th-overlay { padding:0; align-items:flex-end; }
+.th-app.is-mobile .th-modal { width:100%; max-height:92%; border-radius:var(--r-2xl) var(--r-2xl) 0 0; animation:th-sheet-in var(--dur-lg) var(--ease-spring); }
+.th-app.is-mobile .th-gstats { grid-template-columns:1fr; }
+`;
+
+window.__TH_CSS = TH_CSS;
+window.__TH = { eHsl, sem, SESSIONS, TOTAL, PAGE_SIZE, GAME_COUNTS, WINNER_COUNTS, N_GAMES,
+  fmtDate, fmtTime, fmtDur, relDate, NOW, MONTHS_FULL, genTimeline, GAME_IDS };

--- a/admin-mockups/design_files/sp4-toolkit-play-dice.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-play-dice.jsx
@@ -1,0 +1,299 @@
+/* sp4-toolkit-play-dice.jsx — Dice Builder full power (presets / builder visivo /
+   formula parser / result + history). Replaces the old fixed dice grid.
+   Loads after sp4-toolkit-play-tools.jsx, before sp4-toolkit-play-ui.jsx. Route: /toolkit/play. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const TPD = window.__TP;
+const {
+  PAD, reducedMotion, mkActor, DICE_TYPES, DICE_PRESETS, DICE_SYNTAX, DICE_HISTORY,
+  parseFormula, specToFormula, describeSpec, rollSpec, resultToHistory,
+} = TPD;
+
+const hhmm = () => { const d = new Date(); return `${PAD(d.getHours())}:${PAD(d.getMinutes())}`; };
+
+// ─── individual die in the result breakdown ─────────────
+const DieResult = ({ r, idx }) => {
+  const cls = 'tp-die-result' + (r.kept ? ' kept' : ' dropped') + (r.crit ? ' crit' : '') + (r.fail ? ' fail' : '');
+  return (
+    <span className={cls} style={{ animationDelay: (idx * 55) + 'ms' }} title={r.rerolledFrom != null ? `re-roll da ${r.rerolledFrom}` : (r.exploded ? 'esploso' : '')}>
+      {r.value}
+      {r.kept && r.crit && <span className="mk" aria-hidden="true">✨</span>}
+      {r.kept && r.fail && <span className="mk" aria-hidden="true">💀</span>}
+    </span>
+  );
+};
+
+// ─── result calc line ───────────────────────────────────
+const CalcLine = ({ res }) => {
+  if (res.mode === 'cs') {
+    return <div className="tp-calc">{res.spec.count} dadi · <b>{res.successes}</b> {res.successes === 1 ? 'tiro' : 'tiri'} <span className="eq">≥ {res.spec.cs}</span></div>;
+  }
+  const kept = res.rolls.filter(r => r.kept).map(r => r.value);
+  return (
+    <div className="tp-calc">
+      {kept.join(' + ')} <span className="eq">=</span> {res.sum}
+      {res.spec.mod ? <React.Fragment> <span className="mod">{res.spec.mod > 0 ? '+' : '−'}{Math.abs(res.spec.mod)}</span> <span className="eq">=</span> {res.total}</React.Fragment> : null}
+    </div>
+  );
+};
+
+// ─── history row ────────────────────────────────────────
+const HistRow = ({ h, onApply, onReroll }) => {
+  const ac = mkActor(h.actorLabel);
+  return (
+    <div className="tp-hist-row" onClick={() => onApply(h.formula)} role="listitem"
+      tabIndex={0} onKeyDown={e => { if (e.key === 'Enter') onReroll(h.formula); }}>
+      <span className="tp-hist-f">{h.formula}</span>
+      <span className="tp-hist-res">→ <b>{h.resultText}</b></span>
+      {h.detail && <span className="tp-hist-detail">({h.detail})</span>}
+      <span className="tp-hist-meta">
+        <span className="tp-hist-time">{h.time}</span>
+        {ac && (
+          <span className="tp-hist-chip" title={ac.name}>
+            <span className="av" style={{ background: `hsl(${ac.color},58%,52%)` }} aria-hidden="true">{ac.initials}</span>
+            <span className="nm">{ac.name}</span>
+          </span>
+        )}
+        <button type="button" className="tp-hist-reroll" aria-label={`Ri-tira ${h.formula}`}
+          onClick={e => { e.stopPropagation(); onReroll(h.formula); }}>🔁</button>
+      </span>
+    </div>
+  );
+};
+
+// ─── advanced toggle ────────────────────────────────────
+const AdvToggle = ({ on, onToggle, label, icon, value, min, max, onValue, hasNum = true }) => (
+  <div className={'tp-adv-toggle' + (on ? ' on' : '')}>
+    <button type="button" className="tp-adv-sw" role="switch" aria-checked={on} aria-label={label} onClick={onToggle} />
+    <span className="tl"><span aria-hidden="true">{icon}</span>{label}</span>
+    {hasNum && (
+      <input className="num" type="number" min={min} max={max} value={on ? value : ''} disabled={!on}
+        aria-label={`${label} valore`} onChange={e => onValue(Math.max(min, Math.min(max, +e.target.value || min)))} />
+    )}
+  </div>
+);
+
+// ─── unified accordion section (single-open) ────────────
+const AccSection = ({ open, onToggle, icon, label, count, badge, children }) => (
+  <div className={'tp-acc' + (open ? ' open' : '')}>
+    <button type="button" className="tp-acc-head" aria-expanded={open} onClick={onToggle}>
+      <span className="ai" aria-hidden="true">{icon}</span>
+      <span className="al">{label}</span>
+      {count != null && <span className="ac">{count}</span>}
+      <span className="grow" />
+      {badge}
+      <span className="chev" aria-hidden="true">▾</span>
+    </button>
+    {open && <div className="tp-acc-body">{children}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── DICE BUILDER ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DiceBuilder = ({ addLog, actor, dice = {} }) => {
+  const init = dice.init || {};
+  const [sides, setSides] = useState(init.sides || 6);
+  const [count, setCount] = useState(init.count || 1);
+  const [mod, setMod] = useState(init.mod || 0);
+  const [kh, setKh] = useState(init.kh ?? null);
+  const [kl, setKl] = useState(init.kl ?? null);
+  const [cs, setCs] = useState(init.cs ?? null);
+  const [reroll, setReroll] = useState(init.reroll ?? null);
+  const [exploding, setExploding] = useState(!!init.exploding);
+  const initPanel = dice.fmOpen ? 'formula' : dice.advOpen ? 'adv' : dice.showHistory ? 'history' : dice.showSyntax ? 'syntax' : null;
+  const [panel, setPanel] = useState(initPanel);
+  const togglePanel = id => setPanel(p => (p === id ? null : id));
+  const [fmText, setFmText] = useState(dice.fmText || '');
+  const [history, setHistory] = useState(dice.history !== undefined ? dice.history : DICE_HISTORY.map(h => ({ ...h })));
+  const [result, setResult] = useState(null);
+  const [phase, setPhase] = useState('idle');     // idle | rolling | result
+  const [pendingN, setPendingN] = useState(0);
+  const [pop, setPop] = useState(false);
+  const [pulseChip, setPulseChip] = useState(dice.pulse || null);
+  const [histAll, setHistAll] = useState(false);
+  const idRef = useRef(0);
+  const rollT = useRef(null), popT = useRef(null), pulseT = useRef(null);
+  const actorRef = useRef(actor);
+  useEffect(() => { actorRef.current = actor; }, [actor]);
+
+  const builderSpec = { count, sides, mod, kh, kl, cs, reroll, exploding };
+  const builderValid = !(kh != null && kl != null) && (kh == null || kh <= count) && (kl == null || kl <= count);
+  const builderFormula = specToFormula(builderSpec);
+  const fmParse = useMemo(() => (fmText ? parseFormula(fmText) : null), [fmText]);
+
+  const applySpec = sp => {
+    setSides(sp.sides); setCount(sp.count); setMod(sp.mod || 0);
+    setKh(sp.kh ?? null); setKl(sp.kl ?? null); setCs(sp.cs ?? null);
+    setReroll(sp.reroll ?? null); setExploding(!!sp.exploding); setPanel(null);
+  };
+
+  const doRoll = useCallback((spec, animate) => {
+    if (!spec) return;
+    const exec = () => {
+      const res = rollSpec(spec);
+      setResult(res); setPhase('result'); setPop(true);
+      clearTimeout(popT.current); popT.current = setTimeout(() => setPop(false), 470);
+      idRef.current += 1;
+      const h = { ...resultToHistory(res, 'dh-r' + idRef.current), time: hhmm(), actorLabel: actorRef.current || null };
+      setHistory(prev => [h, ...prev].slice(0, 12));
+      addLog({ toolType: 'dice', action: 'roll', result: `${h.formula} → ${h.resultText}` });
+    };
+    if (!animate || reducedMotion()) { setPhase('result'); exec(); return; }
+    setPendingN(spec.count); setPhase('rolling');
+    clearTimeout(rollT.current);
+    rollT.current = setTimeout(exec, 620);
+  }, [addLog]);
+
+  // mount: auto-roll / seed / pulse per scenario
+  useEffect(() => {
+    const sp = panel === 'formula' ? (fmParse && fmParse.ok ? fmParse.spec : null) : (builderValid ? builderSpec : null);
+    if (dice.seedResult) doRoll(sp, false);
+    else if (dice.autoRoll) doRoll(sp, true);
+    if (dice.pulse) { pulseT.current = setTimeout(() => setPulseChip(null), 280); }
+    return () => { clearTimeout(rollT.current); clearTimeout(popT.current); clearTimeout(pulseT.current); };
+  }, []); // eslint-disable-line
+
+  const applyFormula = f => { const p = parseFormula(f); if (p.ok) applySpec(p.spec); };
+  const rerollFormula = f => { const p = parseFormula(f); if (p.ok) { applySpec(p.spec); doRoll(p.spec, true); } };
+  const onPreset = p => { const r = parseFormula(p); if (r.ok) { applySpec(r.spec); setPulseChip(p); clearTimeout(pulseT.current); pulseT.current = setTimeout(() => setPulseChip(null), 280); } };
+
+  // advanced toggle handlers
+  const toggleKh = () => { if (kh != null) setKh(null); else { setKh(Math.min(count, 3)); setKl(null); } };
+  const toggleKl = () => { if (kl != null) setKl(null); else { setKl(Math.min(count, 1)); setKh(null); } };
+  const toggleCs = () => setCs(cs != null ? null : Math.min(sides, sides >= 6 ? 6 : sides));
+  const toggleRr = () => setReroll(reroll != null ? null : 1);
+
+  const histShown = histAll ? history : history.slice(0, 5);
+  const total = result ? (result.mode === 'cs' ? result.successes : result.total) : 0;
+
+  return (
+    <div className="tp-db" role="group" aria-label="Dice builder">
+      {/* ── 1.A presets ── */}
+      <div className="tp-db-presets">
+        <span className="lbl">Preset:</span>
+        {DICE_PRESETS.map(p => (
+          <button key={p} type="button" className={'tp-preset' + (pulseChip === p ? ' pulse' : '')} onClick={() => onPreset(p)}>{p}</button>
+        ))}
+        <button type="button" className={'tp-preset custom' + (panel === 'adv' ? ' on' : '')} onClick={() => togglePanel('adv')}>+ Avanzate</button>
+      </div>
+
+      {/* ── 1.B builder visivo ── */}
+      <div className="tp-db-grid">
+        <div className="tp-db-col">
+          <span className="lbl">Tipo dado</span>
+          <div className="tp-db-typechips" role="radiogroup" aria-label="Tipo di dado">
+            {DICE_TYPES.map(s => (
+              <button key={s} type="button" role="radio" aria-checked={sides === s}
+                className={'tp-typechip' + (sides === s ? ' on' : '')} onClick={() => setSides(s)}>D{s}</button>
+            ))}
+          </div>
+        </div>
+        <div className="tp-db-col">
+          <span className="lbl">Quantità</span>
+          <div className="tp-stepper" role="spinbutton" aria-label="Quantità dadi (1-20)" aria-valuenow={count} aria-valuemin={1} aria-valuemax={20}>
+            <button type="button" className="tp-step-btn g" disabled={count <= 1} onClick={() => setCount(c => Math.max(1, c - 1))} aria-label="Diminuisci quantità">−</button>
+            <span className="tp-step-val">{count}</span>
+            <button type="button" className="tp-step-btn g" disabled={count >= 20} onClick={() => setCount(c => Math.min(20, c + 1))} aria-label="Aumenta quantità">+</button>
+          </div>
+          <span className="hint">min 1 · max 20</span>
+        </div>
+        <div className="tp-db-col">
+          <span className="lbl">Modificatore</span>
+          <div className="tp-stepper" role="spinbutton" aria-label="Modificatore (-10 / +20)" aria-valuenow={mod} aria-valuemin={-10} aria-valuemax={20}>
+            <button type="button" className="tp-step-btn t" disabled={mod <= -10} onClick={() => setMod(m => Math.max(-10, m - 1))} aria-label="Diminuisci modificatore">−</button>
+            <span className={'tp-step-val' + (mod === 0 ? ' muted' : '')}>{mod > 0 ? '+' : ''}{mod}</span>
+            <button type="button" className="tp-step-btn t" disabled={mod >= 20} onClick={() => setMod(m => Math.min(20, m + 1))} aria-label="Aumenta modificatore">+</button>
+          </div>
+          <span className="hint">−10 / +20</span>
+        </div>
+      </div>
+
+      {/* builder CTA */}
+      <button type="button" className="tp-db-cta" disabled={!builderValid} onClick={() => doRoll(builderValid ? builderSpec : null, true)}
+        aria-label={builderValid ? `Tira ${describeSpec(builderSpec)}` : 'Formula non valida'}>
+        <span aria-hidden="true">🎲</span>{builderValid ? `Tira ${builderFormula}` : 'Configurazione non valida'}
+      </button>
+
+      {/* ── 1.D result ── */}
+      {phase === 'rolling' ? (
+        <div className="tp-db-result" aria-live="polite" aria-label="Tiro in corso">
+          <div className="tp-result-top"><span className="f">{builderFormula}</span><span className="t">· tirando…</span></div>
+          <div className="tp-dice-row">
+            {Array.from({ length: Math.min(pendingN, 20) }).map((_, i) => <span key={i} className="tp-die-result rolling" style={{ animationDelay: (i * 60) + 'ms' }}>?</span>)}
+          </div>
+        </div>
+      ) : result ? (
+        <div className="tp-db-result" role="status" aria-live="polite" aria-label={`Risultato ultimo tiro: ${total}`}>
+          <div className="tp-result-top"><span className="f">{specToFormula(result.spec)}</span><span className="t">· adesso</span></div>
+          <div className="tp-dice-row">{result.rolls.map((r, i) => <DieResult key={i} r={r} idx={i} />)}</div>
+          <CalcLine res={result} />
+          <div className="tp-total-row">
+            <span className="tl">Totale</span>
+            <span className={'tp-total' + (pop ? ' pop' : '')}>{total}{result.mode === 'cs' && <span className="suf">success{result.successes === 1 ? 'o' : 'i'}</span>}</span>
+          </div>
+        </div>
+      ) : (
+        <div className="tp-db-result empty">Configura e tira — il risultato apparirà qui</div>
+      )}
+
+      {/* ── secondary controls: single-open accordion ── */}
+      <div className="tp-db-acc">
+        <AccSection open={panel === 'adv'} onToggle={() => togglePanel('adv')} icon="⚙" label="Modificatori avanzati">
+          <div className="tp-adv-grid">
+            <AdvToggle on={kh != null} onToggle={toggleKh} label="Keep highest" icon="🔼" value={kh || 1} min={1} max={count} onValue={setKh} />
+            <AdvToggle on={kl != null} onToggle={toggleKl} label="Keep lowest" icon="🔽" value={kl || 1} min={1} max={count} onValue={setKl} />
+            <AdvToggle on={cs != null} onToggle={toggleCs} label="Successi ≥" icon="🎯" value={cs || sides} min={1} max={sides} onValue={setCs} />
+            <AdvToggle on={reroll != null} onToggle={toggleRr} label="Re-roll ≤" icon="🔄" value={reroll || 1} min={1} max={sides - 1} onValue={setReroll} />
+            <AdvToggle on={exploding} onToggle={() => setExploding(v => !v)} label="Esplosivi (max face)" icon="⚠️" hasNum={false} />
+          </div>
+        </AccSection>
+
+        <AccSection open={panel === 'formula'} onToggle={() => togglePanel('formula')} icon="🧙" label="Modalità avanzata (formula)">
+          <div className="tp-db-formula">
+            <div className="tp-formula-row">
+              <span className="fl">Formula</span>
+              <input className={'tp-formula-input' + (fmParse && !fmParse.ok ? ' bad' : '')} value={fmText}
+                role="textbox" aria-label="Formula dadi (sintassi avanzata)" aria-invalid={fmParse ? !fmParse.ok : false} aria-describedby="tp-parse-fb"
+                placeholder="es. 2D6+3, 4D6kh3, 6D6cs6, 3D10!" onChange={e => setFmText(e.target.value)}
+                onKeyDown={e => { if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && fmParse && fmParse.ok) doRoll(fmParse.spec, true); }} />
+            </div>
+            {fmParse && (
+              <div id="tp-parse-fb" className={'tp-parse ' + (fmParse.ok ? 'ok' : 'bad')} aria-live="polite">
+                <span className="ic" aria-hidden="true">{fmParse.ok ? '✓' : '✗'}</span>
+                {fmParse.ok ? <span>Valido: {describeSpec(fmParse.spec)}</span> : <span>Errore: {fmParse.error}</span>}
+              </div>
+            )}
+            <button type="button" className="tp-db-cta" disabled={!fmParse || !fmParse.ok} onClick={() => fmParse && fmParse.ok && doRoll(fmParse.spec, true)}>
+              <span aria-hidden="true">🎲</span>Tira formula
+            </button>
+          </div>
+        </AccSection>
+
+        <AccSection open={panel === 'syntax'} onToggle={() => togglePanel('syntax')} icon="❓" label="Sintassi formula">
+          <div className="tp-syntax" role="note" aria-label="Sintassi formula">
+            {DICE_SYNTAX.map((row, i) => (
+              <div className="tp-syntax-row" key={i}>
+                <code>{row[0]}</code><span className="d">{row[1]}</span><span className="ex">{row[2]}</span>
+              </div>
+            ))}
+          </div>
+        </AccSection>
+
+        <AccSection open={panel === 'history'} onToggle={() => togglePanel('history')} icon="📜" label="Storico recente" count={history.length}
+          badge={history.length > 0 ? <span role="button" tabIndex={0} className="tp-hist-clear" aria-label="Pulisci storico"
+            onClick={e => { e.stopPropagation(); setHistory([]); setHistAll(false); }}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); setHistory([]); setHistAll(false); } }}>🗑</span> : null}>
+          {history.length === 0
+            ? <div className="tp-hist-empty">Nessun tiro ancora — tira per popolare lo storico.</div>
+            : <div role="log" aria-relevant="additions" aria-label="Storico tiri">
+                {histShown.map(h => <HistRow key={h.id} h={h} onApply={applyFormula} onReroll={rerollFormula} />)}
+                {history.length > 5 && !histAll && <button type="button" className="tp-hist-more" onClick={() => setHistAll(true)}>Mostra altri {history.length - 5}</button>}
+              </div>}
+        </AccSection>
+      </div>
+    </div>
+  );
+};
+
+Object.assign(window, { DiceBuilder });

--- a/admin-mockups/design_files/sp4-toolkit-play-tools.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-play-tools.jsx
@@ -1,0 +1,316 @@
+/* sp4-toolkit-play-tools.jsx — i 4 tool widget (dice/counter/timer/randomizer) + log panel.
+   Loads after sp4-toolkit-play.jsx, before sp4-toolkit-play-ui.jsx. Route: /toolkit/play. */
+
+const { useState, useEffect, useRef, useCallback, useMemo } = React;
+const TP = window.__TP;
+const { fmtClock, PAD, reducedMotion, TOOL_ENT, entE, DICE, TIMERS, TIMER_PRESETS, RANDOM_ITEMS, ACTORS, mkActor, LOG_FILTERS } = TP;
+
+const rnd = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+const rollDice = (count, sides) => { let s = 0; for (let i = 0; i < count; i++) s += rnd(1, sides); return s; };
+
+// ═══════════════════════════════════════════════════════
+// ─── COUNTER CARD ───────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const CounterCard = ({ initialValue = 0, initialName = 'Punti', addLog, autoBump }) => {
+  const [value, setValue] = useState(initialValue);
+  const [name, setName] = useState(initialName);
+  const [editing, setEditing] = useState(false);
+  const [pop, setPop] = useState(false);
+  const [hot, setHot] = useState(null);       // '+' | '-' transient highlight
+  const [confirm, setConfirm] = useState(false);
+  const lp = useRef(null);
+  const popT = useRef(null), hotT = useRef(null);
+
+  const flash = dir => {
+    setPop(true); setHot(dir);
+    clearTimeout(popT.current); popT.current = setTimeout(() => setPop(false), 430);
+    clearTimeout(hotT.current); hotT.current = setTimeout(() => setHot(null), 360);
+  };
+  const bump = delta => {
+    setValue(v => {
+      const nv = v + delta;
+      addLog({ toolType: 'counter', action: delta > 0 ? 'increment' : 'decrement', result: `${name} ${delta > 0 ? '+1' : '−1'} = ${nv}` });
+      return nv;
+    });
+    flash(delta > 0 ? '+' : '-');
+  };
+  useEffect(() => {
+    if (autoBump) { const t = setTimeout(() => bump(1), 520); return () => clearTimeout(t); }
+  }, [autoBump]); // eslint-disable-line
+  useEffect(() => () => { clearTimeout(popT.current); clearTimeout(hotT.current); clearTimeout(lp.current); }, []);
+
+  const doReset = () => { setValue(0); setConfirm(false); addLog({ toolType: 'counter', action: 'reset', result: `${name} azzerato` }); };
+
+  return (
+    <div className="tp-counter" role="group" aria-labelledby={`cnt-${initialName}`}>
+      {confirm && (
+        <div className="tp-cconfirm">
+          <div className="q">Azzerare “{name}”?</div>
+          <div className="row">
+            <button type="button" onClick={() => setConfirm(false)}>Annulla</button>
+            <button type="button" className="warn" onClick={doReset}>Azzera</button>
+          </div>
+        </div>
+      )}
+      <div className="tp-ctop">
+        {editing
+          ? <input className="tp-cname-input" autoFocus value={name} aria-label="Nome contatore"
+              onChange={e => setName(e.target.value)} onBlur={() => setEditing(false)}
+              onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') setEditing(false); }} />
+          : <button type="button" className="tp-cname" id={`cnt-${initialName}`} onClick={() => setEditing(true)} title="Clicca per rinominare">{name}</button>}
+        <button type="button" className="tp-creset" onClick={() => setConfirm(true)} aria-label={`Azzera contatore ${name}`}>
+          <span aria-hidden="true">↻</span> reset
+        </button>
+      </div>
+      <div className="tp-cbody">
+        <button type="button" className={'tp-cbtn' + (hot === '-' ? ' hot' : '')} onClick={() => bump(-1)} aria-label={`Decrementa contatore ${name}`}>−</button>
+        <span className={'tp-cval' + (pop ? ' pop' : '') + (hot ? ' up' : '')} aria-live="polite">{value}</span>
+        <button type="button" className={'tp-cbtn' + (hot === '+' ? ' hot' : '')} onClick={() => bump(1)} aria-label={`Incrementa contatore ${name}`}>+</button>
+      </div>
+      <div className="tp-chint">+ / − per modificare · ↻ per azzerare</div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TIMER CARD ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TimerCard = ({ timer, addLog, initStatus = 'idle', initSeconds, actor }) => {
+  const base = initSeconds != null ? initSeconds : timer.defaultSeconds;
+  const [preset, setPreset] = useState(timer.defaultSeconds);
+  const [seconds, setSeconds] = useState(base);
+  const [status, setStatus] = useState(initStatus); // idle | running | paused | expired
+  const tickRef = useRef(null);
+  const startTotal = useRef(initStatus === 'running' || initStatus === 'paused' ? Math.max(base, preset) : preset);
+
+  const total = startTotal.current || preset || 1;
+  const finishing = status === 'running' && seconds <= 10 && seconds > 0;
+  const pct = Math.max(0, Math.min(100, (seconds / total) * 100));
+
+  useEffect(() => {
+    if (status !== 'running') { clearInterval(tickRef.current); return; }
+    tickRef.current = setInterval(() => {
+      setSeconds(s => {
+        if (s <= 1) {
+          clearInterval(tickRef.current);
+          setStatus('expired');
+          addLog({ toolType: 'timer', action: 'stop', result: `${timer.name} scaduto` });
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(tickRef.current);
+  }, [status]); // eslint-disable-line
+
+  const start = () => { startTotal.current = preset; setSeconds(preset); setStatus('running'); addLog({ toolType: 'timer', action: 'start', result: `${timer.name} avviato (${preset}s)` }); };
+  const resume = () => { setStatus('running'); };
+  const pause = () => { setStatus('paused'); addLog({ toolType: 'timer', action: 'stop', result: `${timer.name} in pausa (${fmtClock(seconds)})` }); };
+  const reset = () => { clearInterval(tickRef.current); setStatus('idle'); setSeconds(preset); startTotal.current = preset; };
+
+  const cls = 'tp-timer ' + status + (finishing ? ' finishing' : '');
+  const stateLbl = { idle: 'pronto', running: 'in corso', paused: 'pausa', expired: 'scaduto' }[status];
+  const ac = mkActor(actor);
+
+  return (
+    <div className={cls} role="group" aria-labelledby={`tm-${timer.id}`}>
+      <div className="tlabel" id={`tm-${timer.id}`}>
+        <span className="tg" aria-hidden="true">{timer.icon}</span><span className="tnm">{timer.name}</span>
+        {ac && status !== 'idle' && (
+          <span className="tp-actorchip tp-tactor" title={`Turno di ${ac.name}`}>
+            <span className="av" style={{ background: `hsl(${ac.color},58%,52%)` }} aria-hidden="true">{ac.initials}</span>
+            <span className="nm">{ac.name}</span>
+          </span>
+        )}
+        <span className="tstate">{stateLbl}</span>
+      </div>
+      <div className="tp-timer-display">
+        <span className="tp-clock" role="timer" aria-live={status === 'running' ? 'off' : 'polite'}>{fmtClock(seconds)}</span>
+        <div className="tp-progress"><div className="fill" style={{ width: pct + '%' }} /></div>
+        <span className="tp-progress-lbl">{status === 'expired' ? 'tempo scaduto' : `${Math.round(pct)}% rimanente`}</span>
+      </div>
+      <div className="tp-timer-foot">
+        {status === 'idle' && (
+          <span className="tp-tselect">
+            <select value={preset} aria-label="Durata timer" onChange={e => { const v = +e.target.value; setPreset(v); setSeconds(v); startTotal.current = v; }}>
+              {TIMER_PRESETS.map(p => <option key={p} value={p}>{p}s</option>)}
+            </select>
+          </span>
+        )}
+        {status === 'idle' && <button type="button" className="tp-tbtn primary" onClick={start}><span aria-hidden="true">▶</span> Avvia</button>}
+        {status === 'running' && <button type="button" className="tp-tbtn primary" onClick={pause}><span aria-hidden="true">⏸</span> Pausa</button>}
+        {status === 'paused' && <button type="button" className="tp-tbtn primary" onClick={resume}><span aria-hidden="true">▶</span> Riprendi</button>}
+        {status === 'expired' && <button type="button" className="tp-tbtn primary danger" onClick={reset}><span aria-hidden="true">↻</span> Reset</button>}
+        {(status === 'running' || status === 'paused') && <button type="button" className="tp-tbtn ghost" onClick={reset}><span aria-hidden="true">↻</span> Reset</button>}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── RANDOMIZER CARD ────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const RandomizerCard = ({ addLog, autoPick }) => {
+  const [items, setItems] = useState([...RANDOM_ITEMS]);
+  const [adding, setAdding] = useState('');
+  const [phase, setPhase] = useState('idle'); // idle | picking | picked
+  const [cycleIdx, setCycleIdx] = useState(-1);
+  const [winner, setWinner] = useState(null);
+  const [pop, setPop] = useState(false);
+  const timers = useRef([]);
+  const empty = items.length === 0;
+
+  const clearAll = () => { timers.current.forEach(clearTimeout); timers.current = []; };
+  useEffect(() => () => clearAll(), []);
+
+  const pick = useCallback(() => {
+    if (empty || phase === 'picking') return;
+    const finalIdx = rnd(0, items.length - 1);
+    const finalName = items[finalIdx];
+    if (reducedMotion()) {
+      setWinner(finalName); setPhase('picked'); setPop(true);
+      setTimeout(() => setPop(false), 500);
+      addLog({ toolType: 'random', action: 'pick', result: `Random pick: ${finalName}` });
+      return;
+    }
+    setPhase('picking'); setWinner(null);
+    clearAll();
+    // decaying cycle: fast → slow, settling on finalIdx
+    let t = 0, delay = 80, idx = 0;
+    const steps = 16 + finalIdx;
+    for (let i = 0; i < steps; i++) {
+      const cur = i % items.length;
+      timers.current.push(setTimeout(() => setCycleIdx(cur), t));
+      t += delay;
+      delay += i > steps - 7 ? 55 : 8; // decay near end
+    }
+    timers.current.push(setTimeout(() => {
+      setCycleIdx(finalIdx); setWinner(finalName); setPhase('picked'); setPop(true);
+      addLog({ toolType: 'random', action: 'pick', result: `Random pick: ${finalName}` });
+      timers.current.push(setTimeout(() => setPop(false), 500));
+      timers.current.push(setTimeout(() => setCycleIdx(-1), 900));
+    }, t + 60));
+  }, [empty, phase, items, addLog]);
+
+  useEffect(() => {
+    if (autoPick) { const t = setTimeout(pick, 480); return () => clearTimeout(t); }
+  }, [autoPick]); // eslint-disable-line
+
+  const add = () => { const v = adding.trim(); if (!v) return; setItems(prev => [...prev, v]); setAdding(''); };
+  const remove = i => setItems(prev => prev.filter((_, j) => j !== i));
+
+  return (
+    <div className="tp-rand" role="group" aria-labelledby="rand-title">
+      <div className="tp-rand-list">
+        <div className="lh" id="rand-title">Lista items · {items.length}</div>
+        {items.map((it, i) => (
+          <div key={i} className={'tp-rand-item' + (phase === 'picking' && cycleIdx === i ? ' cycling' : '') + (phase === 'picked' && winner === it && cycleIdx === i ? ' winner' : '')}>
+            <span className="dot" aria-hidden="true" />
+            <span className="txt">{it}</span>
+            <button type="button" className="rm" onClick={() => remove(i)} aria-label={`Rimuovi ${it}`}>✕</button>
+          </div>
+        ))}
+        <div className="tp-rand-add">
+          <span aria-hidden="true" style={{ color: 'var(--text-muted)' }}>＋</span>
+          <input value={adding} placeholder="Aggiungi item…" aria-label="Aggiungi item alla lista"
+            onChange={e => setAdding(e.target.value)} onKeyDown={e => { if (e.key === 'Enter') add(); }} />
+        </div>
+      </div>
+      <div className="tp-rand-right">
+        <div className={'tp-rand-result' + (winner ? ' has' : '')} aria-live="polite">
+          {winner
+            ? <React.Fragment><span className={'big' + (pop ? ' pop' : '')}>{winner} 🎉</span><span className="meta">estratto ora</span></React.Fragment>
+            : <span className="ph">{empty ? 'lista vuota' : 'pronto a estrarre'}</span>}
+        </div>
+        <button type="button" className={'tp-rand-btn' + (empty ? ' disabled' : '')} disabled={empty} onClick={pick} aria-label="Estrai un item a caso">
+          <span aria-hidden="true">🎲</span>{phase === 'picking' ? 'Estraendo…' : 'Estrai!'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── LOG PANEL ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const LogEntry = ({ e }) => {
+  const meta = TOOL_ENT[e.toolType] || TOOL_ENT.dice;
+  const ac = mkActor(e.actorLabel);
+  return (
+    <div className={'tp-logentry' + (e.fresh ? ' fresh' : '')} style={{ '--e': entE(meta.ent) }} role="listitem">
+      <span className="lic" aria-hidden="true">{meta.icon}</span>
+      <div className="lbody">
+        <div className="lres">{e.result}</div>
+        <div className="lmeta">
+          <span className="ltime">{e.time}</span>
+          {ac && (
+            <span className="lchip" title={ac.name}>
+              <span className="av" style={{ background: `hsl(${ac.color},58%,52%)` }} aria-hidden="true">{ac.initials}</span>
+              <span className="nm">{ac.name}</span>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const LogPanel = ({ log, filter, setFilter, sortNewestFirst, setSort, onClear, mobile }) => {
+  const [accOpen, setAccOpen] = useState(true);
+  const [showAll, setShowAll] = useState(false);
+  const filtered = useMemo(() => filter === 'all' ? log : log.filter(e => e.toolType === filter), [log, filter]);
+  const ordered = sortNewestFirst ? filtered : [...filtered].reverse();
+  const COLLAPSE = 20;
+  const visible = showAll ? ordered : ordered.slice(0, COLLAPSE);
+  const hidden = ordered.length - visible.length;
+
+  return (
+    <aside className={'tp-logcol' + (mobile ? (accOpen ? ' open' : '') : '')} aria-label="Log eventi">
+      {mobile && (
+        <button type="button" className={'tp-logacc-btn' + (accOpen ? ' open' : '')} aria-expanded={accOpen} onClick={() => setAccOpen(o => !o)}>
+          <span className="li" aria-hidden="true">📋</span>Log eventi
+          <span className="grow" /><span className="badge">{log.length}</span>
+          <span className="chev" aria-hidden="true">▾</span>
+        </button>
+      )}
+      <div className="tp-loghead">
+        <div className="tp-logtop">
+          <span className="li" aria-hidden="true">📋</span>
+          <div>
+            <div className="lt">Log eventi</div>
+            <div className="lc">Ultime {Math.max(log.length, 0)} azioni</div>
+          </div>
+          <span className="grow" />
+          <button type="button" className="tp-logclear" onClick={onClear} disabled={log.length === 0}>
+            <span aria-hidden="true">🗑</span> Pulisci
+          </button>
+        </div>
+        <div className="tp-logfilters" role="radiogroup" aria-label="Filtra log per tipo">
+          {LOG_FILTERS.map(f => (
+            <button key={f.id} type="button" role="radio" aria-checked={filter === f.id}
+              className={'tp-lfchip' + (filter === f.id ? ' on' : '')} onClick={() => setFilter(f.id)}>
+              <span aria-hidden="true">{f.icon}</span>{f.label}
+            </button>
+          ))}
+        </div>
+        <div className="tp-logsort">
+          <span className="cnt">{filtered.length} {filtered.length === 1 ? 'evento' : 'eventi'}{filter !== 'all' ? ' filtrati' : ''}</span>
+          <button type="button" className="tp-sortbtn" onClick={() => setSort(v => !v)} aria-label="Cambia ordinamento log">
+            <span aria-hidden="true">{sortNewestFirst ? '⬆' : '⬇'}</span>{sortNewestFirst ? 'Recenti in alto' : 'Recenti in basso'}
+          </button>
+        </div>
+      </div>
+      {filtered.length === 0
+        ? <div className="tp-logempty">
+            <span className="em" aria-hidden="true">📋</span>
+            <p>{filter === 'all' ? 'Nessuna azione ancora — interagisci con un tool per popolare il log.' : 'Nessun evento per questo filtro.'}</p>
+          </div>
+        : <div className="tp-logbody" role="log" aria-live="polite" aria-relevant="additions" aria-label="Eventi recenti">
+            {visible.map(e => <LogEntry key={e.id} e={e} />)}
+            {hidden > 0 && <button type="button" className="tp-logmore" onClick={() => setShowAll(true)}>Vedi precedenti ({hidden})</button>}
+          </div>}
+    </aside>
+  );
+};
+
+Object.assign(window, { CounterCard, TimerCard, RandomizerCard, LogPanel, LogEntry });

--- a/admin-mockups/design_files/sp4-toolkit-play-ui.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-play-ui.jsx
@@ -1,0 +1,340 @@
+/* sp4-toolkit-play-ui.jsx — header + tabs, actor input, PlayApp orchestrator, frames, state picker.
+   Loads after sp4-toolkit-play.jsx + sp4-toolkit-play-tools.jsx. Route: /toolkit/play. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const TP = window.__TP;
+const { eHsl, fmtClock, PAD, TOOL_ENT, entE, DICE, TIMERS, COUNTER_INIT, RANDOM_ITEMS, ACTORS, mkActor, LOG_FILTERS, MOCK_LOG } = TP;
+
+const nowClock = () => { const d = new Date(); return `${PAD(d.getHours())}:${PAD(d.getMinutes())}`; };
+
+// ═══════════════════════════════════════════════════════
+// ─── HEADER (sticky + tabs) ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const TABS = [
+  { id: 'stats',     icon: '📊', label: 'Stats',     href: 'sp4-toolkit-stats.html' },
+  { id: 'history',   icon: '📜', label: 'History',   href: 'sp4-toolkit-history.html' },
+  { id: 'templates', icon: '🎨', label: 'Templates', href: 'sp4-toolkit-templates.html' },
+  { id: 'play',      icon: '🎮', label: 'Play',      href: null },
+];
+
+const ActorInput = ({ actor, setActor, mobile }) => {
+  const [draft, setDraft] = useState('');
+  const commit = () => { const v = draft.trim().slice(0, 30); if (v) { setActor(v); setDraft(''); } };
+  const ac = mkActor(actor);
+  return (
+    <div className="tp-actor">
+      {actor
+        ? <span className="tp-actorchip" title={`Giocatore corrente: ${ac.name}`}>
+            <span className="av" style={{ background: `hsl(${ac.color},58%,52%)` }} aria-hidden="true">{ac.initials}</span>
+            <span className="nm">{ac.name}</span>
+            <button type="button" className="x" onClick={() => setActor('')} aria-label="Rimuovi giocatore corrente">✕</button>
+          </span>
+        : <span className="tp-actor-field">
+            <span className="ic" aria-hidden="true">👤</span>
+            <input value={draft} maxLength={30} placeholder={mobile ? 'Chi gioca?' : 'Chi gioca? (opzionale)'}
+              aria-label="Etichetta giocatore corrente (opzionale)"
+              onChange={e => setDraft(e.target.value)} onBlur={commit}
+              onKeyDown={e => { if (e.key === 'Enter') commit(); }} />
+          </span>}
+    </div>
+  );
+};
+
+const Header = ({ mobile, actor, setActor }) => (
+  <header className="tp-head">
+    <div className="tp-htop">
+      <div className="tp-htxt">
+        <div className="tp-bread"><span>Toolkit</span><span className="sep" aria-hidden="true">›</span><span className="cur">Play</span></div>
+        <div className="tp-titlerow">
+          <span className="tp-ico" aria-hidden="true">🎮</span>
+          <h1 className="tp-h1">Toolkit play{!mobile && ' · Strumenti partita'}</h1>
+        </div>
+        {!mobile && <p className="tp-sub">Helper standalone per dadi, contatori, timer e randomizer durante le partite fisiche.</p>}
+      </div>
+      <div className="tp-hright">
+        <ActorInput actor={actor} setActor={setActor} mobile={mobile} />
+        <button type="button" className="tp-cfg"><span aria-hidden="true">🔧</span>{mobile ? 'Configura' : 'Configura toolkit'}</button>
+      </div>
+    </div>
+    <nav className="tp-tabs" role="tablist" aria-label="Sezioni toolkit">
+      {TABS.map(t => {
+        const on = t.id === 'play';
+        const cls = 'tp-tab' + (on ? ' on' : '');
+        const inner = <React.Fragment><span aria-hidden="true">{t.icon}</span>{t.label}</React.Fragment>;
+        return t.href
+          ? <a key={t.id} href={t.href} className={cls} role="tab" aria-selected={false}>{inner}</a>
+          : <button key={t.id} type="button" role="tab" aria-selected={on} className={cls}>{inner}</button>;
+      })}
+    </nav>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TOOL SECTIONS ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const SectionHead = ({ ent, icon, title, sub, children }) => (
+  <div className="tp-shead" style={{ '--e': entE(ent) }}>
+    <div className="tp-shead-main">
+      <span className="tp-sicon" aria-hidden="true">{icon}</span>
+      <div className="tp-stext">
+        <div className="tp-stitle">{title}</div>
+        <div className="tp-ssub">{sub}</div>
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+const DiceSection = ({ addLog, actor, dice, onJumpLog }) => (
+  <section className="tp-section" style={{ '--e': entE('game') }} role="group" aria-label="Dadi — dice builder">
+    <SectionHead ent="game" icon="🎲" title="Dadi" sub="Configura tipo, quantità, modificatori — o usa la formula avanzata" />
+    <DiceBuilder addLog={addLog} actor={actor} dice={dice || {}} />
+  </section>
+);
+
+const CounterSection = ({ addLog, firstValue, autoBump }) => {
+  const [counters, setCounters] = useState([{ key: 'c0', name: COUNTER_INIT.name, value: firstValue }]);
+  const add = () => setCounters(prev => [...prev, { key: 'c' + Date.now(), name: 'Contatore ' + (prev.length + 1), value: 0 }]);
+  return (
+    <section className="tp-section" style={{ '--e': entE('toolkit') }} role="group" aria-labelledby="sec-counter">
+      <SectionHead ent="toolkit" icon="🔢" title="Contatori" sub={`${counters.length} ${counters.length === 1 ? 'contatore' : 'contatori'} · click +/− per modificare`}>
+        <button type="button" className="tp-saction" onClick={add} id="sec-counter"><span aria-hidden="true">＋</span>Nuovo contatore</button>
+      </SectionHead>
+      <div className="tp-counter-grid">
+        {counters.map((c, i) => (
+          <CounterCard key={c.key} initialName={c.name} initialValue={c.value} addLog={addLog} autoBump={i === 0 && autoBump} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+const TimerSection = ({ addLog, timerStates, actor }) => (
+  <section className="tp-section" style={{ '--e': entE('warning') }} role="group" aria-labelledby="sec-timer">
+    <SectionHead ent="warning" icon="⏱" title="Timer" sub="Timer countdown + Timer turno" />
+    <div className="tp-timer-grid">
+      {TIMERS.map(t => {
+        const sc = (timerStates || {})[t.id] || {};
+        return <TimerCard key={t.id} timer={t} addLog={addLog} initStatus={sc.status || 'idle'} initSeconds={sc.seconds} actor={actor} />;
+      })}
+    </div>
+  </section>
+);
+
+const RandomizerSection = ({ addLog, autoPick }) => (
+  <section className="tp-section" style={{ '--e': entE('event') }} role="group" aria-labelledby="sec-rand">
+    <SectionHead ent="event" icon="🎰" title="Randomizer" sub="Estrai un item a caso da una lista" />
+    <RandomizerCard addLog={addLog} autoPick={autoPick} />
+  </section>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── CLEAR-LOG MODAL ────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ClearModal = ({ count, onCancel, onConfirm, mobile }) => {
+  const ref = useRef(null);
+  useEffect(() => { ref.current && ref.current.focus(); }, []);
+  useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onCancel(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+  return (
+    <div className="tp-overlay" onMouseDown={e => { if (e.target === e.currentTarget) onCancel(); }}>
+      <div className="tp-modal" role="alertdialog" aria-modal="true" aria-labelledby="tp-clear-t" aria-describedby="tp-clear-d">
+        <div className="tp-mhead"><span className="mi" aria-hidden="true">🗑</span><div className="mt" id="tp-clear-t">Cancella tutto il log?</div></div>
+        <div className="tp-mbody"><p id="tp-clear-d">Stai per rimuovere <span className="cnt">{count} {count === 1 ? 'evento' : 'eventi'}</span> dal log. L’azione non è reversibile.</p></div>
+        <div className="tp-mfoot">
+          <button type="button" className="tp-mbtn" ref={ref} onClick={onCancel}>Annulla</button>
+          <button type="button" className="tp-mbtn warn" onClick={onConfirm}><span aria-hidden="true">🗑</span>Cancella tutto</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── PLAY APP (interactive, one per state×viewport) ─────
+// ═══════════════════════════════════════════════════════
+const PlayApp = ({ scenario, mobile }) => {
+  const sc = scenario.sc || {};
+  const initLog = useMemo(() => {
+    let base = sc.logMock === false ? [] : MOCK_LOG.map(e => ({ ...e }));
+    if (sc.extraLog) base = [...sc.extraLog, ...base];
+    return base;
+  }, [scenario.id]); // eslint-disable-line
+
+  const [log, setLog] = useState(initLog);
+  const [actor, setActor] = useState(sc.actor || '');
+  const [filter, setFilter] = useState(sc.filter || 'all');
+  const [sortNewestFirst, setSort] = useState(true);
+  const [clearOpen, setClearOpen] = useState(!!sc.clearModal);
+  const idRef = useRef(1000);
+  const actorRef = useRef(actor);
+  useEffect(() => { actorRef.current = actor; }, [actor]);
+
+  const addLog = useCallback(entry => {
+    idRef.current += 1;
+    const e = { id: 'lg-' + idRef.current, time: nowClock(), actorLabel: actorRef.current || null, fresh: true, ...entry };
+    setLog(prev => [e, ...prev].slice(0, 50));
+  }, []);
+
+  const jumpLog = useCallback(() => setFilter('dice'), []);
+
+  // keyboard: "/" focus first log filter chip
+  useEffect(() => {
+    if (mobile) return;
+    const h = e => {
+      const tag = document.activeElement.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.key === '/') { e.preventDefault(); const c = document.querySelector('.tp-logfilters .tp-lfchip'); c && c.focus(); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mobile]);
+
+  return (
+    <div className={'tp-app' + (mobile ? ' is-mobile' : '')}>
+      <Header mobile={mobile} actor={actor} setActor={setActor} />
+      <div className="tp-layout">
+        <div className="tp-toolcol">
+          <DiceSection addLog={addLog} actor={actor} dice={sc.dice} onJumpLog={jumpLog} />
+          <CounterSection addLog={addLog} firstValue={sc.counterValue != null ? sc.counterValue : COUNTER_INIT.value} autoBump={sc.autoBump} />
+          <TimerSection addLog={addLog} timerStates={sc.timers} actor={actor} />
+          <RandomizerSection addLog={addLog} autoPick={sc.autoPick} />
+        </div>
+        <LogPanel log={log} filter={filter} setFilter={setFilter} sortNewestFirst={sortNewestFirst} setSort={setSort}
+          onClear={() => setClearOpen(true)} mobile={mobile} />
+      </div>
+      {clearOpen && <ClearModal count={log.length} mobile={mobile} onCancel={() => setClearOpen(false)} onConfirm={() => { setLog([]); setClearOpen(false); }} />}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ width = '100%', height = 700, children }) => (
+  <div style={{ width, borderRadius: 'var(--r-xl)', border: '1px solid var(--border)', background: 'var(--bg-card)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)' }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 14px', background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)', fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840' }} />
+      <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.04em' }}>meepleai.app/toolkit/play</span>
+    </div>
+    <div style={{ height }}>{children}</div>
+  </div>
+);
+
+const PhoneFrame = ({ children }) => (
+  <div className="phone" style={{ width: 375, height: 760 }}>
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>16:43</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+    <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>{children}</div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE PICKER + ROOT ────────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATES = [
+  { id: 'default',              label: 'Default',            view: 'desktop', sc: { logMock: true }, desc: 'Toolkit completo: 4 sezioni (dadi · contatori · timer · randomizer) + log con 5 eventi mock. Tutti i tool interattivi.' },
+  { id: 'idle-empty-log',       label: 'Log vuoto',          view: 'desktop', sc: { logMock: false }, desc: 'Utente appena entrato: tool pronti ma log vuoto con empty state “interagisci con un tool per popolare”.' },
+  { id: 'dice-idle',            label: 'Dice · idle',        view: 'desktop', sc: { logMock: true, dice: { history: [], showHistory: true } }, desc: 'Dice builder default (1D6), area risultato placeholder “Configura e tira”, storico vuoto.' },
+  { id: 'dice-building',        label: 'Dice · building',    view: 'desktop', sc: { logMock: true, dice: { init: { count: 4, sides: 6, kh: 3, mod: 2 }, advOpen: true } }, desc: 'Builder mid-config: 4×D6, keep highest 3, +2. Modificatori avanzati aperti, label CTA “Tira 4D6kh3+2” aggiornata live.' },
+  { id: 'dice-preset-applied',  label: 'Dice · preset',      view: 'desktop', sc: { logMock: true, dice: { init: { count: 6, sides: 6, cs: 6 }, pulse: '6D6cs6' } }, desc: 'Preset “6D6cs6” cliccato: builder autofill (count successi ≥6) + pulse animation 220ms sulla chip.' },
+  { id: 'dice-formula-input',   label: 'Dice · formula',     view: 'desktop', sc: { logMock: true, dice: { fmOpen: true, fmText: '4D6kh3+2', showSyntax: true } }, desc: 'Modalità formula aperta con “4D6kh3+2”: feedback live ✓ Valido + interpretazione human-readable, pannello sintassi.' },
+  { id: 'dice-rolling',         label: 'Dice · rolling',     view: 'desktop', sc: { logMock: true, dice: { init: { count: 4, sides: 6, kh: 3, mod: 2 }, autoRoll: true } }, desc: 'Animazione roll in corso: dadi che ruotano (cycle 600ms) prima del settle, CTA disabilitato durante il tiro.' },
+  { id: 'dice-result-shown',    label: 'Dice · result',      view: 'desktop', sc: { logMock: true, dice: { init: { count: 4, sides: 6, kh: 3, mod: 2 }, seedResult: true, showHistory: true } }, desc: 'Risultato visibile: dadi individuali kept/dropped (strike), calcolo inline, totale con pop animation, nuova entry in cima allo storico.' },
+  { id: 'dice-formula-invalid', label: 'Dice · invalid',     view: 'desktop', sc: { logMock: true, dice: { fmOpen: true, fmText: '4D6kx' } }, desc: 'Formula parser con errore: feedback ✗ “Sintassi non riconosciuta”, input border --c-danger, CTA “Tira formula” disabilitato.' },
+  { id: 'timer-running',        label: 'Timer running',      view: 'desktop', sc: { logMock: true, actor: 'Marco R.', timers: { 'tm-count': { status: 'running', seconds: 94 } } }, desc: 'Timer countdown live (01:34 → 01:32 → 01:30…), progress bar decrementa, attore corrente “Marco R.” visibile.' },
+  { id: 'timer-expired',        label: 'Timer expired',      view: 'desktop', sc: { logMock: true, timers: { 'tm-count': { status: 'expired', seconds: 0 } }, extraLog: [{ id: 'lg-exp', time: '16:43', toolType: 'timer', action: 'stop', result: 'Timer countdown scaduto', actorLabel: null }] }, desc: 'Timer a 00:00 con flash --c-danger, badge “scaduto”, action [↻ Reset], log entry “Timer scaduto”.' },
+  { id: 'counter-incrementing', label: 'Counter +1',         view: 'desktop', sc: { logMock: true, counterValue: 4, autoBump: true }, desc: 'Contatore “Punti” 4 → 5 con animazione pop, button [+] evidenziato, log entry “Punti +1 = 5”.' },
+  { id: 'randomizer-picking',   label: 'Randomizer pick',    view: 'desktop', sc: { logMock: true, autoPick: true }, desc: 'Randomizer in picking: items che ciclano con highlight, decay lento, result pop “Sushi 🎉” + log entry.' },
+  { id: 'filter-log-dice',      label: 'Log filter · Dadi',  view: 'desktop', sc: { logMock: true, filter: 'dice' }, desc: 'Log panel con filtro “Dadi” attivo (single-select): solo gli eventi dadi visibili, contatore filtrati.' },
+  { id: 'clear-log-confirm',    label: 'Clear log',          view: 'desktop', sc: { logMock: true, clearModal: true }, desc: 'Modal alertdialog “Cancella tutto il log?” --c-warning con conteggio eventi e conferma distruttiva.' },
+  { id: 'mobile-stack',         label: 'Mobile · stack',     view: 'mobile',  sc: { logMock: true }, desc: 'Viewport 375px: tool in stack verticale, dadi 2-col, log panel come accordion in fondo, modal come bottom-sheet.' },
+];
+const SKEY = 'tp-state';
+
+const VpLabel = ({ children }) => (
+  <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>{children}</div>
+);
+
+const App = () => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || document.documentElement.getAttribute('data-theme') || 'light');
+  const [active, setActive] = useState(() => {
+    const s = localStorage.getItem(SKEY);
+    return STATES.some(x => x.id === s) ? s : 'default';
+  });
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem(SKEY, active); }, [active]);
+
+  const cur = STATES.find(s => s.id === active) || STATES[0];
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', padding: '20px 20px 80px' }}>
+      <style dangerouslySetInnerHTML={{ __html: window.__TP_CSS }} />
+
+      {/* state picker bar */}
+      <header style={{
+        position: 'sticky', top: 12, zIndex: 50, maxWidth: 1320, margin: '0 auto 24px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(16px)', border: '1px solid var(--border)',
+        borderRadius: 'var(--r-xl)', boxShadow: 'var(--shadow-md)', padding: '12px 16px',
+        display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <div style={{ width: 30, height: 30, borderRadius: 8, flexShrink: 0, background: `linear-gradient(135deg, ${eHsl('toolkit')}, ${eHsl('game')})`, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontFamily: 'var(--f-display)', fontSize: 14 }}>S</div>
+          <div>
+            <div style={{ fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 14, lineHeight: 1.1 }}>Toolkit Play</div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)' }}>#1490 · 4/4 · /toolkit/play</div>
+          </div>
+        </div>
+
+        <div role="tablist" aria-label="Stati schermata" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
+          {STATES.map(s => {
+            const on = s.id === active;
+            return (
+              <button key={s.id} type="button" role="tab" aria-selected={on} onClick={() => setActive(s.id)} style={{
+                padding: '7px 12px', borderRadius: 'var(--r-pill)', cursor: 'pointer',
+                background: on ? eHsl('toolkit') : 'var(--bg-muted)', border: on ? 'none' : '1px solid var(--border)',
+                color: on ? '#fff' : 'var(--text-sec)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, whiteSpace: 'nowrap',
+                boxShadow: on ? `0 3px 10px ${eHsl('toolkit', 0.35)}` : 'none',
+              }}>{s.label}</button>
+            );
+          })}
+        </div>
+
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{
+          padding: '8px 14px', borderRadius: 'var(--r-md)', flexShrink: 0, background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer',
+        }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* active state description */}
+      <div style={{ maxWidth: 1320, margin: '0 auto 18px', padding: '0 4px', fontFamily: 'var(--f-mono)', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <strong style={{ color: eHsl('toolkit') }}>{cur.label}</strong> — {cur.desc}
+      </div>
+
+      {/* render area */}
+      <div style={{ maxWidth: 1320, margin: '0 auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 36 }}>
+        {cur.view === 'desktop' && (
+          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Desktop · 1440 — hero + 2-col tool/log (65/35)</VpLabel>
+            <DesktopFrame><PlayApp key={'d-' + cur.id} scenario={cur} mobile={false} /></DesktopFrame>
+          </div>
+        )}
+        {cur.view === 'mobile' && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Mobile · 375 — stack 1-col + log accordion</VpLabel>
+            <PhoneFrame><PlayApp key={'m-' + cur.id} scenario={cur} mobile={true} /></PhoneFrame>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-toolkit-play.html
+++ b/admin-mockups/design_files/sp4-toolkit-play.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<!-- route: /toolkit/play — Toolkit standalone live con 4 tool widgets (dice/counter/timer/randomizer) + log streaming + FSM animation -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /toolkit/play — Toolkit play</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ─── Tool FSM keyframes (cluster #1490 S4 — annotati nel brief) ─── */
+  @keyframes tp-dice-roll {
+    0%   { transform: rotateX(0deg) rotateY(0deg) scale(1); }
+    25%  { transform: rotateX(180deg) rotateY(90deg) scale(1.1); }
+    50%  { transform: rotateX(360deg) rotateY(180deg) scale(1.15); }
+    75%  { transform: rotateX(540deg) rotateY(270deg) scale(1.1); }
+    100% { transform: rotateX(720deg) rotateY(360deg) scale(1); }
+  }
+  @keyframes tp-counter-pop { 0%,100% { transform: scale(1); } 50% { transform: scale(1.22); } }
+  @keyframes tp-timer-alert {
+    0%,100% { color: hsl(var(--c-danger)); border-color: hsl(var(--c-danger) / .55); }
+    50%     { color: hsl(var(--c-warning)); border-color: hsl(var(--c-warning) / .55); }
+  }
+  @keyframes tp-timer-flash {
+    0%,100% { background: hsl(var(--c-danger) / 0); }
+    50%     { background: hsl(var(--c-danger) / .3); }
+  }
+  @keyframes tp-log-slide-in { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }
+  @keyframes tp-randomizer-cycle { 0%,100% { background: hsl(var(--c-event) / .05); } 50% { background: hsl(var(--c-event) / .22); } }
+  @keyframes tp-dice-result-pop { 0% { transform: scale(.9); } 55% { transform: scale(1.06); } 100% { transform: scale(1); } }
+  @keyframes tp-preset-pulse { 0%,100% { transform: scale(1); box-shadow: 0 0 0 0 hsl(var(--c-game) / 0); } 50% { transform: scale(1.08); box-shadow: 0 0 0 4px hsl(var(--c-game) / .22); } }
+  @keyframes tp-die-in { from { transform: translateY(6px) scale(.9); } to { transform: none; } }
+  @keyframes tp-pulse-ring { 0% { box-shadow: 0 0 0 0 hsl(var(--e) / .4); } 100% { box-shadow: 0 0 0 10px hsl(var(--e) / 0); } }
+  @keyframes tp-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes tp-modal-in { from { opacity: 0; transform: translateY(14px) scale(.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
+  @keyframes tp-sheet-in { from { transform: translateY(100%); } to { transform: translateY(0); } }
+
+  /* Focus ring — keyboard only, toolkit entity (continuity #1490) */
+  a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid hsl(var(--c-toolkit));
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tp-die.rolling { animation: none !important; }
+    .tp-num.pop, .tp-cval.pop { animation: none !important; }
+    .tp-timer.finishing { animation: none !important; }
+    .tp-rand-item.cycling { animation: none !important; }
+    .tp-logentry.fresh { animation: none !important; }
+    .tp-die-result, .tp-total.pop, .tp-preset.pulse, .tp-die-result.rolling { animation: none !important; }
+    .tp-overlay, .tp-modal { animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-toolkit-play.jsx?v=1"></script>
+<script type="text/babel" src="sp4-toolkit-play-tools.jsx?v=1"></script>
+<script type="text/babel" src="sp4-toolkit-play-dice.jsx?v=1"></script>
+<script type="text/babel" src="sp4-toolkit-play-ui.jsx?v=1"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-toolkit-play.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-play.jsx
@@ -1,0 +1,636 @@
+/* MeepleAI SP4 wave 4 — M · #1490 · 4/4 — sp4-toolkit-play  (ULTIMO del cluster)
+   Route: /toolkit/play — Toolkit standalone live per assistere partite physical.
+          Helper cross-game (NON legato a sessioni): dadi, contatori, timer, randomizer
+          + log streaming delle azioni. Giocatori fisici al tavolo, l'app fa solo da helper.
+   File: admin-mockups/design_files/sp4-toolkit-play.{html,jsx,-tools.jsx,-ui.jsx}
+   Pattern: Hero + body 2-col (desktop 65/35 tool/log) / stack mobile (log accordion bottom).
+            NO sidebar fissa, NO split-view. Riusa header+tabs+state-picker S1+S2+S3.
+
+   Source restyle (NO ridisegnare logica):
+     apps/web/src/app/(authenticated)/toolkit/play/page.tsx
+     components/toolkit/{DiceRoller,CounterTool,Timer,Randomizer}.tsx
+
+   Entity: --c-toolkit (verde, primaria/header/tabs/log) · tool entities:
+           dice→--c-game · counter→--c-toolkit · timer→--c-warning · random→--c-event.
+           Actor → EntityChip --c-player (header + log entries).
+
+   10 stati (state picker continuity, persistito localStorage `tp-state`):
+     default · idle-empty-log · dice-rolling · timer-running · timer-expired ·
+     counter-incrementing · randomizer-picking · filter-log-dice · clear-log-confirm · mobile-stack
+*/
+
+const { useState, useEffect, useMemo, useRef, useCallback, useLayoutEffect } = React;
+const DS = window.DS;
+
+const eHsl = (type, a) => {
+  const c = DS.EC[type] || DS.EC.toolkit;
+  return a !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${a})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+const sem = (name, a) => a !== undefined ? `hsl(var(--c-${name}) / ${a})` : `hsl(var(--c-${name}))`;
+const PAD = n => String(n).padStart(2, '0');
+const fmtClock = secs => `${PAD(Math.floor(Math.max(0, secs) / 60))}:${PAD(Math.max(0, secs) % 60)}`;
+const reducedMotion = () => window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+// tool-type → entity + glyph (cross-reference brief)
+const TOOL_ENT = {
+  dice:    { ent: 'game',    icon: '🎲' },
+  counter: { ent: 'toolkit', icon: '🔢' },
+  timer:   { ent: 'warning', icon: '⏱' },
+  random:  { ent: 'event',   icon: '🎰' },
+};
+const entVar = ent => ent === 'warning' || ent === 'success' || ent === 'danger' ? `var(--c-${ent})` : `var(--c-${ent})`;
+const entE = ent => `hsl(${entVar(ent)})`;
+
+// ═══════════════════════════════════════════════════════
+// ─── DEFAULT TOOLKIT CONFIG (da page.tsx) ────────────
+// ═══════════════════════════════════════════════════════
+const DICE = [
+  { name: 'D6',  sides: 6,  count: 1 },
+  { name: '2D6', sides: 6,  count: 2 },
+  { name: 'D20', sides: 20, count: 1 },
+  { name: 'D4',  sides: 4,  count: 1 },
+  { name: 'D8',  sides: 8,  count: 1 },
+  { name: 'D10', sides: 10, count: 1 },
+  { name: 'D12', sides: 12, count: 1 },
+];
+const TIMERS = [
+  { id: 'tm-count', name: 'Timer countdown', type: 'countdown', defaultSeconds: 60,  icon: '⏱' },
+  { id: 'tm-turn',  name: 'Timer turno',     type: 'turn',      defaultSeconds: 120, icon: '👤' },
+];
+const TIMER_PRESETS = [30, 60, 90, 120, 180, 300];
+const COUNTER_INIT = { id: 'default-counter', name: 'Punti', value: 5 };
+const RANDOM_ITEMS = ['Pizza', 'Sushi', 'Burger', 'Tacos'];
+
+// actors (cross-ref data.js players, brief richiede Marco/Sara/Aaron)
+const ACTORS = {
+  'Marco R.': { name: 'Marco R.', initials: 'MR', color: 262 },
+  'Sara T.':  { name: 'Sara T.',  initials: 'ST', color: 320 },
+  'Aaron R.': { name: 'Aaron R.', initials: 'AR', color: 38  },
+};
+// resolve any actor label (known or free-typed) to chip data
+const mkActor = name => {
+  if (!name) return null;
+  if (ACTORS[name]) return ACTORS[name];
+  const parts = name.trim().split(/\s+/);
+  const initials = (parts[0][0] + (parts[1] ? parts[1][0] : '')).toUpperCase();
+  let h = 0; for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) % 360;
+  return { name: name.trim(), initials, color: h };
+};
+
+// log filter chips (single-select)
+const LOG_FILTERS = [
+  { id: 'all',     label: 'Tutti',      icon: '▦' },
+  { id: 'dice',    label: 'Dadi',       icon: '🎲' },
+  { id: 'counter', label: 'Contatori',  icon: '🔢' },
+  { id: 'timer',   label: 'Timer',      icon: '⏱' },
+  { id: 'random',  label: 'Random',     icon: '🎰' },
+];
+
+// deterministic mock log (default state — orario fittizio serata)
+const MOCK_LOG = [
+  { id: 'lg-1', time: '16:42', toolType: 'dice',    action: 'roll',      result: 'D20 → 17',                actorLabel: 'Marco R.' },
+  { id: 'lg-2', time: '16:41', toolType: 'timer',   action: 'start',     result: 'Timer turno avviato (120s)', actorLabel: 'Sara T.' },
+  { id: 'lg-3', time: '16:40', toolType: 'counter', action: 'increment', result: 'Punti +1 = 5',            actorLabel: 'Marco R.' },
+  { id: 'lg-4', time: '16:38', toolType: 'random',  action: 'pick',      result: 'Random pick: Sushi',      actorLabel: 'Aaron R.' },
+  { id: 'lg-5', time: '16:35', toolType: 'dice',    action: 'roll',      result: '2D6 → 8',                 actorLabel: null },
+];
+
+// ═══════════════════════════════════════════════════════
+// ─── DICE BUILDER — engine (parser / roller / format) ───
+// ═══════════════════════════════════════════════════════
+const DICE_TYPES = [4, 6, 8, 10, 12, 20, 100];
+const DICE_PRESETS = ['2D6', '1D20', '1D100', '3D6+1', '4D6kh3', '6D6cs6'];
+const DICE_SYNTAX = [
+  ['NdM', 'N dadi di tipo dM', '2D6 · 1D20'],
+  ['+N / −N', 'modificatore al totale', '2D6+3'],
+  ['khN / klN', 'tieni gli N più alti / bassi', '4D6kh3'],
+  ['csN', 'conta successi ≥ N', '6D6cs6'],
+  ['rN', 're-roll sui tiri ≤ N', '2D6r1'],
+  ['!', 'dadi esplosivi (max face)', '3D10!'],
+];
+const diceRnd = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+// parse a formula string → { ok, spec } | { ok:false, error }
+function parseFormula(raw) {
+  if (!raw || !raw.trim()) return { ok: false, error: 'Inserisci una formula (es. 2D6)' };
+  let s = raw.trim().toLowerCase().replace(/\s+/g, '').replace(/[−–]/g, '-');
+  const m = s.match(/^(\d*)d(\d+)/);
+  if (!m) return { ok: false, error: 'Manca il dado — usa NdM (es. 2d6)' };
+  const count = m[1] === '' ? 1 : parseInt(m[1], 10);
+  const sides = parseInt(m[2], 10);
+  if (count < 1 || count > 20) return { ok: false, error: 'Quantità fuori range (1–20)' };
+  if (!DICE_TYPES.includes(sides)) return { ok: false, error: `d${sides} non supportato (d4–d100)` };
+  const spec = { count, sides, mod: 0, kh: null, kl: null, cs: null, reroll: null, exploding: false };
+  let rest = s.slice(m[0].length);
+  while (rest.length) {
+    let mm;
+    if ((mm = rest.match(/^kh(\d+)/))) spec.kh = +mm[1];
+    else if ((mm = rest.match(/^kl(\d+)/))) spec.kl = +mm[1];
+    else if ((mm = rest.match(/^cs(\d+)/))) spec.cs = +mm[1];
+    else if ((mm = rest.match(/^r(\d+)/))) spec.reroll = +mm[1];
+    else if ((mm = rest.match(/^!/))) spec.exploding = true;
+    else if ((mm = rest.match(/^([+-]\d+)/))) spec.mod = +mm[1];
+    else return { ok: false, error: `Sintassi non riconosciuta dopo «${s.slice(0, s.length - rest.length)}»` };
+    rest = rest.slice(mm[0].length);
+  }
+  if (spec.kh != null && spec.kl != null) return { ok: false, error: 'kh e kl non sono combinabili' };
+  if (spec.kh != null && spec.kh > count) return { ok: false, error: `kh${spec.kh} richiede ≥ ${spec.kh} dadi` };
+  if (spec.kl != null && spec.kl > count) return { ok: false, error: `kl${spec.kl} richiede ≥ ${spec.kl} dadi` };
+  if (spec.cs != null && (spec.cs < 1 || spec.cs > sides)) return { ok: false, error: `cs${spec.cs} fuori dal range del dado` };
+  return { ok: true, spec };
+}
+
+// canonical formula string from a spec
+function specToFormula(sp) {
+  let f = `${sp.count}D${sp.sides}`;
+  if (sp.kh != null) f += `kh${sp.kh}`;
+  if (sp.kl != null) f += `kl${sp.kl}`;
+  if (sp.cs != null) f += `cs${sp.cs}`;
+  if (sp.reroll != null) f += `r${sp.reroll}`;
+  if (sp.exploding) f += '!';
+  if (sp.mod) f += `${sp.mod > 0 ? '+' : ''}${sp.mod}`;
+  return f;
+}
+
+// human-readable interpretation
+function describeSpec(sp) {
+  const p = [`${sp.count} ${sp.count === 1 ? 'dado' : 'dadi'} d${sp.sides}`];
+  if (sp.kh != null) p.push(`tieni i ${sp.kh} più alti`);
+  if (sp.kl != null) p.push(`tieni i ${sp.kl} più bassi`);
+  if (sp.cs != null) p.push(`conta successi ≥ ${sp.cs}`);
+  if (sp.reroll != null) p.push(`re-roll ≤ ${sp.reroll}`);
+  if (sp.exploding) p.push('esplosivi');
+  if (sp.mod) p.push(`${sp.mod > 0 ? '+' : ''}${sp.mod} modificatore`);
+  return p.join(', ');
+}
+
+// execute a spec → { rolls[], mode, total/successes, spec }
+function rollSpec(sp) {
+  const sides = sp.sides;
+  const rolls = [];
+  for (let i = 0; i < sp.count; i++) {
+    let base = diceRnd(1, sides);
+    let rerolledFrom = null;
+    if (sp.reroll != null && base <= sp.reroll) { rerolledFrom = base; base = diceRnd(1, sides); }
+    let value = base, exploded = false, guard = 0;
+    if (sp.exploding) {
+      let cur = base;
+      while (cur === sides && guard < 20) { exploded = true; cur = diceRnd(1, sides); value += cur; guard++; }
+    }
+    rolls.push({ value, base, kept: true, rerolledFrom, exploded, crit: base === sides, fail: base === 1 });
+  }
+  if (sp.kh != null || sp.kl != null) {
+    const n = sp.kh != null ? sp.kh : sp.kl;
+    const sorted = rolls.map((r, idx) => ({ idx, v: r.value })).sort((a, b) => sp.kh != null ? b.v - a.v : a.v - b.v);
+    const keep = new Set(sorted.slice(0, n).map(o => o.idx));
+    rolls.forEach((r, idx) => { r.kept = keep.has(idx); });
+  }
+  if (sp.cs != null) {
+    const successes = rolls.filter(r => r.kept && r.value >= sp.cs).length;
+    return { rolls, mode: 'cs', successes, total: successes, spec: sp };
+  }
+  const sum = rolls.filter(r => r.kept).reduce((a, r) => a + r.value, 0);
+  return { rolls, mode: 'sum', sum, total: sum + sp.mod, spec: sp };
+}
+
+// roll result → compact history/log shape
+function resultToHistory(res, id) {
+  const sp = res.spec;
+  const formula = specToFormula(sp);
+  const kept = res.rolls.filter(r => r.kept).map(r => r.value);
+  let detail = null;
+  if (sp.kh != null || sp.kl != null) detail = `tieni ${kept.join(',')}`;
+  else if (res.rolls.length > 1) detail = res.rolls.map(r => r.value).join(',');
+  if (sp.mod) detail = (detail ? detail + ' ' : '') + `${sp.mod > 0 ? '+' : ''}${sp.mod}`;
+  const resultText = res.mode === 'cs'
+    ? `${res.successes} ${res.successes === 1 ? 'successo' : 'successi'}`
+    : `${res.total}`;
+  return { id, formula, resultText, detail };
+}
+
+// fixture recent rolls (varietà di formule)
+const DICE_HISTORY = [
+  { id: 'dh1', formula: '4D6kh3+2', resultText: '17', detail: 'tieni 6,5,4 +2', time: '16:42', actorLabel: 'Marco R.' },
+  { id: 'dh2', formula: '1D20',     resultText: '17', detail: null,            time: '16:40', actorLabel: 'Sara T.' },
+  { id: 'dh3', formula: '3D6+1',    resultText: '13', detail: '4,2,6 +1',      time: '16:38', actorLabel: 'Aaron R.' },
+  { id: 'dh4', formula: '6D6cs6',   resultText: '2 successi', detail: null,     time: '16:35', actorLabel: 'Marco R.' },
+  { id: 'dh5', formula: '2D6r1',    resultText: '9',  detail: 're-roll 1→4',   time: '16:32', actorLabel: 'Sara T.' },
+];
+
+window.__TP = {
+  eHsl, sem, PAD, fmtClock, reducedMotion,
+  TOOL_ENT, entE, DICE, TIMERS, TIMER_PRESETS, COUNTER_INIT, RANDOM_ITEMS,
+  ACTORS, mkActor, LOG_FILTERS, MOCK_LOG,
+  DICE_TYPES, DICE_PRESETS, DICE_SYNTAX, DICE_HISTORY,
+  parseFormula, specToFormula, describeSpec, rollSpec, resultToHistory,
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── COMPONENT CSS (inject) — solo token da tokens.css ──
+// ═══════════════════════════════════════════════════════
+const TP_CSS = `
+.tp-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+
+/* ─ header (sticky) ─ */
+.tp-head { flex-shrink:0; position:sticky; top:0; z-index:12; background:var(--glass-bg); backdrop-filter:blur(14px); border-bottom:1px solid var(--border); padding:14px 22px 0; }
+.tp-htop { display:flex; align-items:flex-start; gap:16px; }
+.tp-htxt { min-width:0; flex:1; }
+.tp-bread { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:7px; }
+.tp-bread .sep { opacity:.5; }
+.tp-bread .cur { color:var(--text-sec); font-weight:700; }
+.tp-titlerow { display:flex; align-items:center; gap:10px; }
+.tp-ico { width:34px; height:34px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-toolkit) / .16); color:hsl(var(--c-toolkit));
+  display:inline-flex; align-items:center; justify-content:center; font-size:18px; }
+.tp-h1 { font-family:var(--f-display); font-weight:800; font-size:28px; letter-spacing:-.02em; line-height:1.1; color:var(--text); white-space:nowrap; }
+.tp-sub { font-size:13.5px; color:var(--text-sec); margin-top:5px; max-width:540px; }
+
+/* header right: actor input + config CTA */
+.tp-hright { display:flex; flex-direction:column; align-items:flex-end; gap:10px; flex-shrink:0; }
+.tp-actor { display:flex; align-items:center; gap:8px; }
+.tp-actor-field { position:relative; display:flex; align-items:center; }
+.tp-actor-field .ic { position:absolute; left:11px; font-size:13px; opacity:.6; pointer-events:none; }
+.tp-actor input { width:188px; padding:8px 12px 8px 32px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:13px; color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.tp-actor input::placeholder { color:var(--text-muted); }
+.tp-actor input:focus { border-color:hsl(var(--c-toolkit) / .6); box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .14); }
+.tp-actorchip { display:inline-flex; align-items:center; gap:7px; padding:5px 11px 5px 5px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .12); border:1px solid hsl(var(--c-player) / .26); white-space:nowrap; }
+.tp-actorchip .av { width:22px; height:22px; flex-shrink:0; border-radius:50%; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--f-display); font-size:9px; font-weight:800; color:#fff; }
+.tp-actorchip .nm { font-family:var(--f-display); font-weight:700; font-size:12.5px; color:hsl(var(--c-player)); }
+.tp-actorchip .x { width:18px; height:18px; border-radius:50%; border:none; background:hsl(var(--c-player) / .16); color:hsl(var(--c-player));
+  cursor:pointer; font-size:10px; display:inline-flex; align-items:center; justify-content:center; flex-shrink:0; }
+.tp-cfg { display:inline-flex; align-items:center; gap:7px; padding:8px 14px; border-radius:var(--r-md); background:var(--bg-card);
+  border:1.5px solid var(--border); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:12.5px; cursor:pointer; white-space:nowrap; transition:background var(--dur-sm); }
+.tp-cfg:hover { background:var(--bg-hover); }
+
+/* ─ tabs nav (continuity S1+S2+S3) ─ */
+.tp-tabs { display:flex; gap:4px; margin-top:14px; overflow-x:auto; scrollbar-width:none; }
+.tp-tabs::-webkit-scrollbar { display:none; }
+.tp-tab { display:inline-flex; align-items:center; gap:6px; padding:9px 14px 11px; border:none; background:transparent; cursor:pointer; white-space:nowrap;
+  border-bottom:2px solid transparent; color:var(--text-muted); font-family:var(--f-display); font-weight:700; font-size:13px; transition:color var(--dur-sm); text-decoration:none; }
+.tp-tab:hover { color:var(--text-sec); }
+.tp-tab.on { color:hsl(var(--c-toolkit)); border-bottom-color:hsl(var(--c-toolkit)); }
+
+/* ─ body: 2-col layout (tools 65 / log 35) ─ */
+.tp-layout { flex:1; min-height:0; display:grid; grid-template-columns:1fr 360px; gap:0; overflow:hidden; }
+.tp-toolcol { overflow:auto; min-height:0; padding:18px 22px 30px; display:flex; flex-direction:column; gap:24px; }
+.tp-logcol { border-left:1px solid var(--border); background:var(--bg-sunken); display:flex; flex-direction:column; min-height:0; }
+
+/* ─ tool section ─ */
+.tp-section { display:flex; flex-direction:column; gap:13px; }
+.tp-shead { display:flex; align-items:flex-end; gap:11px; }
+.tp-shead-main { flex:1; min-width:0; display:flex; align-items:flex-end; gap:11px; }
+.tp-stext { flex:1; min-width:0; }
+.tp-sicon { width:30px; height:30px; flex-shrink:0; border-radius:var(--r-sm); display:inline-flex; align-items:center; justify-content:center; font-size:16px;
+  background:hsl(var(--e) / .15); }
+.tp-stitle { font-family:var(--f-display); font-weight:800; font-size:17px; letter-spacing:-.01em; color:var(--text); line-height:1.1; }
+.tp-ssub { font-size:12px; color:var(--text-muted); margin-top:2px; }
+.tp-shead .grow { flex:1; }
+.tp-slink { background:none; border:1px solid transparent; cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:12px; color:var(--text-muted); white-space:nowrap; padding:5px 9px; border-radius:var(--r-pill); transition:all var(--dur-sm); }
+.tp-slink:hover { color:hsl(var(--e)); background:hsl(var(--e) / .08); }
+.tp-slink.on { color:hsl(var(--e)); background:hsl(var(--e) / .12); border-color:hsl(var(--e) / .3); }
+.tp-saction { display:inline-flex; align-items:center; gap:6px; padding:7px 12px; border-radius:var(--r-md); background:var(--bg-card); border:1.5px solid var(--border);
+  color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:12px; cursor:pointer; white-space:nowrap; }
+.tp-saction:hover { background:var(--bg-hover); }
+
+/* ─── DICE BUILDER ─────────────────────────────────── */
+.tp-db { --e:var(--c-game); display:flex; flex-direction:column; gap:14px; padding:16px 18px 18px; background:var(--bg-card); border:1.5px solid var(--border-light); border-radius:var(--r-lg); box-shadow:var(--shadow-xs); }
+
+/* presets */
+.tp-db-presets { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.tp-db-presets .lbl { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); flex-shrink:0; }
+.tp-preset { font-family:var(--f-mono); font-weight:700; font-size:12px; padding:5px 11px; border-radius:var(--r-pill); cursor:pointer; white-space:nowrap;
+  background:hsl(var(--e) / .10); border:1.5px solid hsl(var(--e) / .30); color:hsl(var(--e)); transition:all var(--dur-sm); }
+.tp-preset:hover { background:hsl(var(--e) / .18); border-color:hsl(var(--e) / .5); }
+.tp-preset.pulse { animation:tp-preset-pulse .22s var(--ease-spring); }
+.tp-preset.custom { background:var(--bg-card); border-style:dashed; border-color:var(--border-strong); color:var(--text-muted); }
+.tp-preset.custom.on { color:hsl(var(--e)); border-color:hsl(var(--e) / .5); border-style:solid; }
+
+/* builder grid */
+.tp-db-grid { display:grid; grid-template-columns:repeat(3, 1fr); gap:16px; padding:14px; border-radius:var(--r-md); background:var(--bg-sunken); border:1px solid var(--border-light); }
+.tp-db-col { display:flex; flex-direction:column; gap:9px; }
+.tp-db-col > .lbl { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); }
+.tp-db-typechips { display:flex; flex-wrap:wrap; gap:6px; }
+.tp-typechip { font-family:var(--f-mono); font-weight:700; font-size:12px; padding:6px 11px; border-radius:var(--r-sm); cursor:pointer;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text); transition:all var(--dur-sm); }
+.tp-typechip:hover { border-color:hsl(var(--e) / .4); }
+.tp-typechip.on { background:hsl(var(--e)); border-color:hsl(var(--e)); color:#fff; }
+
+/* stepper */
+.tp-stepper { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.tp-step-btn { width:36px; height:36px; flex-shrink:0; border-radius:50%; border:none; cursor:pointer; font-size:18px; font-weight:700; line-height:1;
+  display:inline-flex; align-items:center; justify-content:center; transition:all var(--dur-sm); }
+.tp-step-btn.g { background:hsl(var(--c-game) / .14); color:hsl(var(--c-game)); }
+.tp-step-btn.t { background:hsl(var(--c-toolkit) / .14); color:hsl(var(--c-toolkit)); }
+.tp-step-btn:hover:not(:disabled) { filter:brightness(1.05); transform:scale(1.06); }
+.tp-step-btn:disabled { opacity:.32; cursor:not-allowed; }
+.tp-step-val { font-family:var(--f-mono); font-weight:800; font-size:26px; color:var(--text); font-variant-numeric:tabular-nums; }
+.tp-step-val.muted { color:var(--text-muted); }
+.tp-db-col .hint { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); text-align:center; }
+
+/* advanced toggles */
+.tp-db-adv { display:flex; flex-direction:column; gap:9px; }
+.tp-adv-head { display:inline-flex; align-items:center; gap:7px; cursor:pointer; background:none; border:none; padding:0; align-self:flex-start;
+  font-family:var(--f-display); font-weight:700; font-size:12.5px; color:var(--text-sec); }
+.tp-adv-head:hover { color:hsl(var(--c-game)); }
+.tp-adv-head .chev { transition:transform var(--dur-sm); font-size:9px; }
+.tp-adv-head.open .chev { transform:rotate(180deg); }
+.tp-adv-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:8px; }
+.tp-adv-toggle { display:flex; align-items:center; gap:9px; padding:9px 11px; border-radius:var(--r-md); border:1.5px solid var(--border-light); background:var(--bg-sunken); }
+.tp-adv-toggle.on { border-color:hsl(var(--e) / .4); background:hsl(var(--e) / .07); }
+.tp-adv-sw { width:34px; height:20px; border-radius:var(--r-pill); flex-shrink:0; background:var(--border-strong); position:relative; cursor:pointer; border:none; padding:0; transition:background var(--dur-sm); }
+.tp-adv-sw::after { content:''; position:absolute; top:2px; left:2px; width:16px; height:16px; border-radius:50%; background:#fff; transition:transform var(--dur-sm); box-shadow:var(--shadow-xs); }
+.tp-adv-toggle.on .tp-adv-sw { background:hsl(var(--e)); }
+.tp-adv-toggle.on .tp-adv-sw::after { transform:translateX(14px); }
+.tp-adv-toggle .tl { flex:1; min-width:0; font-family:var(--f-display); font-weight:700; font-size:11.5px; color:var(--text); display:inline-flex; align-items:center; gap:5px; }
+.tp-adv-toggle input.num { width:40px; flex-shrink:0; font-family:var(--f-mono); font-size:12px; padding:4px 5px; border-radius:var(--r-xs); border:1px solid var(--border); background:var(--bg-card); color:var(--text); outline:none; text-align:center; }
+.tp-adv-toggle input.num:disabled { opacity:.4; }
+
+/* main CTA */
+.tp-db-cta { display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:12px 18px; border-radius:var(--r-md); border:none; cursor:pointer;
+  background:hsl(var(--e)); color:#fff; font-family:var(--f-display); font-weight:800; font-size:15px; box-shadow:0 4px 14px hsl(var(--e) / .35); transition:all var(--dur-sm); }
+.tp-db-cta:hover:not(:disabled) { filter:brightness(1.05); transform:translateY(-1px); }
+.tp-db-cta:disabled { background:var(--bg-muted); color:var(--text-muted); cursor:not-allowed; box-shadow:none; }
+
+/* formula mode */
+.tp-fm-head { display:inline-flex; align-items:center; gap:7px; cursor:pointer; background:none; border:none; padding:0; align-self:flex-start;
+  font-family:var(--f-display); font-weight:700; font-size:12.5px; color:var(--text-sec); }
+.tp-fm-head:hover { color:hsl(var(--c-game)); }
+.tp-fm-head .chev { transition:transform var(--dur-sm); font-size:9px; }
+.tp-fm-head.open .chev { transform:rotate(180deg); }
+.tp-db-formula { display:flex; flex-direction:column; gap:10px; padding:13px; border-radius:var(--r-md); background:var(--bg-sunken); border:1px solid var(--border-light); }
+.tp-formula-row { display:flex; align-items:center; gap:9px; }
+.tp-formula-row .fl { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); flex-shrink:0; }
+.tp-formula-input { flex:1; min-width:0; font-family:var(--f-mono); font-size:14px; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.tp-formula-input:focus { border-color:hsl(var(--e) / .6); box-shadow:0 0 0 3px hsl(var(--e) / .14); }
+.tp-formula-input.bad { border-color:hsl(var(--c-danger) / .55); }
+.tp-formula-input.bad:focus { box-shadow:0 0 0 3px hsl(var(--c-danger) / .14); }
+.tp-parse { display:flex; align-items:flex-start; gap:7px; padding:8px 11px; border-radius:var(--r-sm); font-size:12px; line-height:1.45; }
+.tp-parse.ok { background:hsl(var(--c-success) / .09); color:hsl(var(--c-success)); }
+.tp-parse.bad { background:hsl(var(--c-danger) / .09); color:hsl(var(--c-danger)); }
+.tp-parse .ic { flex-shrink:0; }
+
+/* syntax help */
+.tp-syntax { padding:12px 14px; border-radius:var(--r-md); background:var(--bg-sunken); border:1px solid var(--border-light); display:flex; flex-direction:column; gap:7px; }
+.tp-syntax .sh { font-family:var(--f-display); font-weight:800; font-size:12px; color:var(--text); }
+.tp-syntax-row { display:grid; grid-template-columns:96px 1fr auto; gap:10px; align-items:baseline; font-size:11.5px; }
+.tp-syntax-row code { font-family:var(--f-mono); font-weight:700; color:hsl(var(--e)); }
+.tp-syntax-row .d { color:var(--text-sec); }
+.tp-syntax-row .ex { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); white-space:nowrap; }
+
+/* result */
+.tp-db-result { display:flex; flex-direction:column; gap:11px; padding:15px 16px; border-radius:var(--r-md); border:1.5px solid var(--border-light); background:var(--bg-sunken); }
+.tp-db-result.empty { align-items:center; justify-content:center; min-height:84px; color:var(--text-muted); font-family:var(--f-mono); font-size:12px; }
+.tp-result-top { display:flex; align-items:baseline; gap:9px; flex-wrap:wrap; }
+.tp-result-top .f { font-family:var(--f-mono); font-weight:700; font-size:13px; color:hsl(var(--e)); }
+.tp-result-top .t { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-dice-row { display:flex; flex-wrap:wrap; gap:8px; }
+.tp-die-result { width:40px; height:44px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center; position:relative;
+  font-family:var(--f-mono); font-weight:800; font-size:18px; font-variant-numeric:tabular-nums; animation:tp-die-in .3s var(--ease-out) backwards; }
+.tp-die-result.kept { background:hsl(var(--e) / .18); border:1.5px solid hsl(var(--e) / .42); color:hsl(var(--e)); }
+.tp-die-result.dropped { background:var(--bg-muted); border:1.5px solid var(--border); color:var(--text-muted); text-decoration:line-through; text-decoration-thickness:1.5px; opacity:.65; }
+.tp-die-result.crit.kept { box-shadow:0 0 0 2px hsl(var(--c-warning) / .45); }
+.tp-die-result.fail.kept { background:hsl(var(--c-danger) / .12); border-color:hsl(var(--c-danger) / .42); color:hsl(var(--c-danger)); }
+.tp-die-result .mk { position:absolute; top:-8px; right:-6px; font-size:11px; }
+.tp-die-result.rolling { animation:tp-dice-roll .6s var(--ease-in-out) infinite; background:hsl(var(--e) / .14); border:1.5px solid hsl(var(--e) / .3); color:hsl(var(--e)); }
+.tp-calc { font-family:var(--f-mono); font-size:12px; color:var(--text-sec); line-height:1.5; }
+.tp-calc .mod { color:hsl(var(--c-toolkit)); font-weight:700; }
+.tp-calc .eq { color:var(--text-muted); }
+.tp-total-row { display:flex; align-items:baseline; gap:10px; }
+.tp-total-row .tl { font-family:var(--f-mono); font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); }
+.tp-total { font-family:var(--f-display); font-weight:800; font-size:40px; line-height:1; color:hsl(var(--e)); font-variant-numeric:tabular-nums; letter-spacing:-.02em; }
+.tp-total.pop { animation:tp-dice-result-pop .4s var(--ease-spring); }
+.tp-total .suf { font-family:var(--f-display); font-size:16px; font-weight:700; color:var(--text-sec); margin-left:5px; }
+
+/* history */
+.tp-db-history { display:flex; flex-direction:column; gap:0; border-top:1px solid var(--border-light); padding-top:4px; }
+.tp-hist-head { display:flex; align-items:center; gap:8px; padding:8px 2px; }
+.tp-hist-head .ht { font-family:var(--f-display); font-weight:800; font-size:13px; color:var(--text); }
+.tp-hist-head .hc { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-hist-head .grow { flex:1; }
+.tp-hist-clear { background:none; border:none; cursor:pointer; color:var(--text-muted); font-size:13px; padding:5px; border-radius:var(--r-xs); }
+.tp-hist-clear:hover { color:hsl(var(--c-danger)); background:hsl(var(--c-danger) / .1); }
+.tp-hist-row { display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:var(--r-sm); cursor:pointer; }
+.tp-hist-row:hover { background:var(--bg-muted); }
+.tp-hist-f { font-family:var(--f-mono); font-weight:700; font-size:12px; color:hsl(var(--e)); flex-shrink:0; }
+.tp-hist-res { font-family:var(--f-mono); font-size:12px; color:var(--text); }
+.tp-hist-res b { font-weight:700; }
+.tp-hist-detail { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-hist-meta { margin-left:auto; display:flex; align-items:center; gap:8px; flex-shrink:0; }
+.tp-hist-time { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-hist-chip { display:inline-flex; align-items:center; gap:4px; padding:1px 7px 1px 2px; border-radius:var(--r-pill); background:hsl(var(--c-player) / .12); }
+.tp-hist-chip .av { width:14px; height:14px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:6px; font-weight:800; color:#fff; }
+.tp-hist-chip .nm { font-family:var(--f-display); font-weight:700; font-size:9px; color:hsl(var(--c-player)); }
+.tp-hist-reroll { width:26px; height:26px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:hsl(var(--e)); cursor:pointer; font-size:12px; flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; }
+.tp-hist-reroll:hover { background:hsl(var(--e) / .12); border-color:hsl(var(--e) / .4); }
+.tp-hist-empty { padding:16px; text-align:center; font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.tp-hist-more { width:100%; padding:9px; border:none; background:var(--bg-muted); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:11.5px; cursor:pointer; border-radius:var(--r-sm); margin-top:4px; }
+.tp-hist-more:hover { background:var(--bg-hover); }
+
+/* ─── secondary controls accordion (single-open) ─── */
+.tp-db-acc { display:flex; flex-direction:column; border-top:1px solid var(--border-light); }
+.tp-acc { border-bottom:1px solid var(--border-light); }
+.tp-acc:last-child { border-bottom:none; }
+.tp-acc-head { display:flex; align-items:center; gap:9px; width:100%; padding:12px 4px; background:none; border:none; cursor:pointer;
+  font-family:var(--f-display); font-weight:700; font-size:13px; color:var(--text-sec); text-align:left; transition:color var(--dur-sm); }
+.tp-acc-head:hover { color:hsl(var(--c-game)); }
+.tp-acc.open .tp-acc-head { color:var(--text); }
+.tp-acc-head .ai { font-size:14px; flex-shrink:0; }
+.tp-acc-head .ac { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); padding:1px 7px; border-radius:var(--r-pill); background:var(--bg-muted); flex-shrink:0; }
+.tp-acc-head .grow { flex:1; }
+.tp-acc-head .chev { font-size:9px; color:var(--text-muted); flex-shrink:0; transition:transform var(--dur-sm); }
+.tp-acc.open .tp-acc-head .chev { transform:rotate(180deg); }
+.tp-acc-body { padding:2px 2px 14px; }
+
+/* ─── COUNTER GRID ────────────────────────────────── */
+.tp-counter-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:12px; }
+.tp-counter { --e:var(--c-toolkit); position:relative; display:flex; flex-direction:column; gap:12px; padding:16px 18px 18px; overflow:hidden;
+  background:var(--bg-card); border:1.5px solid var(--border-light); border-radius:var(--r-lg); box-shadow:var(--shadow-xs); transition:border-color var(--dur-sm); }
+.tp-counter:hover { border-color:hsl(var(--e) / .3); }
+.tp-ctop { display:flex; align-items:center; gap:8px; }
+.tp-cname { font-family:var(--f-display); font-weight:800; font-size:15px; color:var(--text); background:none; border:none; padding:2px 4px; margin:-2px -4px; border-radius:var(--r-xs);
+  cursor:text; text-align:left; }
+.tp-cname:hover { background:var(--bg-muted); }
+.tp-cname-input { font-family:var(--f-display); font-weight:800; font-size:15px; color:var(--text); background:var(--bg-card); border:1.5px solid hsl(var(--e) / .5);
+  border-radius:var(--r-sm); padding:2px 6px; outline:none; width:140px; }
+.tp-creset { margin-left:auto; background:none; border:none; cursor:pointer; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); display:inline-flex; align-items:center; gap:4px; }
+.tp-creset:hover { color:hsl(var(--c-warning)); }
+.tp-cbody { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.tp-cbtn { width:48px; height:48px; flex-shrink:0; border-radius:50%; border:none; cursor:pointer; font-size:22px; font-weight:700; line-height:1;
+  background:hsl(var(--e) / .14); color:hsl(var(--e)); display:inline-flex; align-items:center; justify-content:center; transition:all var(--dur-sm) var(--ease-out); }
+.tp-cbtn:hover { background:hsl(var(--e) / .24); transform:scale(1.06); }
+.tp-cbtn:active { transform:scale(.94); }
+.tp-cbtn.hot { background:hsl(var(--e)); color:#fff; box-shadow:0 4px 12px hsl(var(--e) / .4); }
+.tp-cval { font-family:var(--f-display); font-weight:800; font-size:46px; line-height:1; color:var(--text); font-variant-numeric:tabular-nums; letter-spacing:-.02em; }
+.tp-cval.pop { animation:tp-counter-pop .42s var(--ease-spring); }
+.tp-cval.up { color:hsl(var(--e)); }
+.tp-chint { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); text-align:center; }
+/* reset confirm overlay */
+.tp-cconfirm { position:absolute; inset:0; z-index:3; background:hsl(var(--c-warning) / .14); backdrop-filter:blur(2px); display:flex; flex-direction:column;
+  align-items:center; justify-content:center; gap:11px; padding:14px; }
+.tp-cconfirm .q { font-family:var(--f-display); font-weight:800; font-size:14px; color:var(--text); }
+.tp-cconfirm .row { display:flex; gap:9px; }
+.tp-cconfirm button { padding:7px 15px; border-radius:var(--r-md); font-family:var(--f-display); font-weight:800; font-size:12.5px; cursor:pointer; border:1px solid var(--border-strong); background:var(--bg-card); color:var(--text); }
+.tp-cconfirm button.warn { background:hsl(var(--c-warning)); border-color:transparent; color:#fff; }
+
+/* ─── TIMER GRID ──────────────────────────────────── */
+.tp-timer-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:12px; }
+.tp-timer { --e:var(--c-warning); position:relative; display:flex; flex-direction:column; gap:14px; padding:16px 18px 18px; overflow:hidden;
+  background:var(--bg-card); border:1.5px solid var(--border-light); border-radius:var(--r-lg); box-shadow:var(--shadow-xs); transition:border-color var(--dur-sm); }
+.tp-timer .tlabel { display:flex; align-items:center; gap:8px; font-family:var(--f-display); font-weight:800; font-size:14px; color:var(--text); flex-wrap:wrap; }
+.tp-timer .tlabel .tg { font-size:15px; flex-shrink:0; }
+.tp-timer .tlabel .tnm { flex-shrink:1; min-width:0; }
+.tp-tactor { padding:3px 9px 3px 3px !important; flex-shrink:0; }
+.tp-tactor .nm { font-size:11px !important; }
+.tp-timer .tstate { margin-left:auto; font-family:var(--f-mono); font-size:10px; padding:2px 8px; border-radius:var(--r-pill); background:var(--bg-muted); color:var(--text-muted); text-transform:uppercase; letter-spacing:.04em; font-weight:700; flex-shrink:0; }
+.tp-timer.running .tstate { background:hsl(var(--c-success) / .15); color:hsl(var(--c-success)); }
+.tp-timer.paused .tstate { background:hsl(var(--c-info) / .15); color:hsl(var(--c-info)); }
+.tp-timer.expired .tstate, .tp-timer.finishing .tstate { background:hsl(var(--c-danger) / .15); color:hsl(var(--c-danger)); }
+.tp-timer-display { display:flex; flex-direction:column; align-items:center; gap:10px; padding:8px 0; border-radius:var(--r-md); border:1.5px solid var(--border-light); }
+.tp-timer.finishing .tp-timer-display { animation:tp-timer-alert 1s var(--ease-in-out) infinite; }
+.tp-timer.expired .tp-timer-display { border-color:hsl(var(--c-danger) / .5); animation:tp-timer-flash .6s var(--ease-in-out) 3; }
+.tp-clock { font-family:var(--f-mono); font-weight:800; font-size:42px; line-height:1; color:var(--text); font-variant-numeric:tabular-nums; letter-spacing:.01em; }
+.tp-timer.finishing .tp-clock { color:hsl(var(--c-danger)); }
+.tp-timer.expired .tp-clock { color:hsl(var(--c-danger)); }
+.tp-progress { width:82%; height:7px; border-radius:var(--r-pill); background:var(--bg-muted); overflow:hidden; }
+.tp-progress .fill { height:100%; border-radius:var(--r-pill); background:hsl(var(--e)); transition:width 1s linear; }
+.tp-timer.finishing .tp-progress .fill, .tp-timer.expired .tp-progress .fill { background:hsl(var(--c-danger)); }
+.tp-progress-lbl { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-timer-foot { display:flex; align-items:center; gap:9px; }
+.tp-tselect { display:inline-flex; align-items:center; gap:5px; }
+.tp-tselect select { font-family:var(--f-mono); font-size:11px; padding:6px 8px; border-radius:var(--r-sm); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text); cursor:pointer; outline:none; }
+.tp-tbtn { display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:9px 14px; border-radius:var(--r-md); border:none; cursor:pointer;
+  font-family:var(--f-display); font-weight:800; font-size:13px; transition:all var(--dur-sm) var(--ease-out); }
+.tp-tbtn.primary { flex:1; background:hsl(var(--e)); color:#fff; box-shadow:0 3px 10px hsl(var(--e) / .35); }
+.tp-tbtn.primary:hover { filter:brightness(1.05); transform:translateY(-1px); }
+.tp-tbtn.primary.danger { background:hsl(var(--c-danger)); box-shadow:0 3px 10px hsl(var(--c-danger) / .35); }
+.tp-tbtn.ghost { background:var(--bg-muted); color:var(--text-sec); border:1px solid var(--border); }
+.tp-tbtn.ghost:hover { background:var(--bg-hover); }
+.tp-timer-actor { position:absolute; top:14px; right:16px; }
+
+/* ─── RANDOMIZER ──────────────────────────────────── */
+.tp-rand { --e:var(--c-event); display:grid; grid-template-columns:1fr auto; gap:18px; align-items:center; padding:18px 20px;
+  background:var(--bg-card); border:1.5px solid var(--border-light); border-radius:var(--r-lg); box-shadow:var(--shadow-xs); }
+.tp-rand-list { display:flex; flex-direction:column; gap:6px; min-width:0; }
+.tp-rand-list .lh { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); margin-bottom:2px; }
+.tp-rand-item { display:flex; align-items:center; gap:9px; padding:8px 11px; border-radius:var(--r-md); background:var(--bg-muted); border:1px solid var(--border-light); }
+.tp-rand-item.cycling { animation:tp-randomizer-cycle .16s steps(2) infinite; border-color:hsl(var(--e) / .4); }
+.tp-rand-item.winner { background:hsl(var(--e) / .16); border-color:hsl(var(--e) / .5); }
+.tp-rand-item .dot { width:7px; height:7px; border-radius:50%; background:hsl(var(--e)); flex-shrink:0; }
+.tp-rand-item .txt { flex:1; font-family:var(--f-display); font-weight:700; font-size:13px; color:var(--text); min-width:0; }
+.tp-rand-item .rm { width:20px; height:20px; border-radius:50%; border:none; background:transparent; color:var(--text-muted); cursor:pointer; font-size:12px; flex-shrink:0; }
+.tp-rand-item .rm:hover { background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); }
+.tp-rand-add { display:inline-flex; align-items:center; gap:7px; padding:8px 11px; border-radius:var(--r-md); border:1.5px dashed var(--border-strong); background:transparent;
+  color:var(--text-muted); font-family:var(--f-display); font-weight:700; font-size:12.5px; cursor:pointer; }
+.tp-rand-add:hover { border-color:hsl(var(--e) / .5); color:hsl(var(--e)); }
+.tp-rand-add input { flex:1; border:none; background:transparent; outline:none; font-family:var(--f-body); font-size:13px; color:var(--text); min-width:0; }
+.tp-rand-right { display:flex; flex-direction:column; align-items:center; gap:12px; width:208px; flex-shrink:0; }
+.tp-rand-result { width:100%; text-align:center; padding:14px 12px; border-radius:var(--r-md); background:var(--bg-sunken); border:1px solid var(--border-light); min-height:62px;
+  display:flex; flex-direction:column; align-items:center; justify-content:center; gap:3px; }
+.tp-rand-result.has { background:hsl(var(--e) / .12); border-color:hsl(var(--e) / .3); }
+.tp-rand-result .big { font-family:var(--f-display); font-weight:800; font-size:22px; color:hsl(var(--e)); line-height:1.1; }
+.tp-rand-result .big.pop { animation:tp-counter-pop .5s var(--ease-spring); }
+.tp-rand-result .meta { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-rand-result .ph { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.tp-rand-btn { width:100%; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:13px; border-radius:var(--r-md); border:none; cursor:pointer;
+  background:hsl(var(--e)); color:#fff; font-family:var(--f-display); font-weight:800; font-size:15px; box-shadow:0 4px 14px hsl(var(--e) / .35); transition:all var(--dur-sm) var(--ease-out); }
+.tp-rand-btn:hover { filter:brightness(1.05); transform:translateY(-1px); }
+.tp-rand-btn.disabled { background:var(--bg-muted); color:var(--text-muted); cursor:not-allowed; box-shadow:none; }
+.tp-rand-btn.disabled:hover { transform:none; filter:none; }
+
+/* ─── LOG PANEL ───────────────────────────────────── */
+.tp-loghead { flex-shrink:0; padding:15px 16px 11px; border-bottom:1px solid var(--border); display:flex; flex-direction:column; gap:11px; }
+.tp-logtop { display:flex; align-items:center; gap:9px; }
+.tp-logtop .li { width:28px; height:28px; flex-shrink:0; border-radius:var(--r-sm); background:hsl(var(--c-toolkit) / .15); color:hsl(var(--c-toolkit)); display:inline-flex; align-items:center; justify-content:center; font-size:14px; }
+.tp-logtop .lt { font-family:var(--f-display); font-weight:800; font-size:15px; color:var(--text); }
+.tp-logtop .lc { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-top:1px; }
+.tp-logtop .grow { flex:1; }
+.tp-logclear { display:inline-flex; align-items:center; gap:5px; padding:6px 10px; border-radius:var(--r-md); border:1px solid var(--border); background:var(--bg-card);
+  color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:11px; cursor:pointer; }
+.tp-logclear:hover { border-color:hsl(var(--c-danger) / .4); color:hsl(var(--c-danger)); }
+.tp-logclear:disabled { opacity:.4; cursor:not-allowed; }
+.tp-logfilters { display:flex; gap:5px; flex-wrap:wrap; row-gap:6px; }
+.tp-lfchip { display:inline-flex; align-items:center; gap:5px; padding:5px 10px; border-radius:var(--r-pill); white-space:nowrap; flex-shrink:0;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:11px; transition:all var(--dur-sm); }
+.tp-lfchip:hover { background:var(--bg-hover); }
+.tp-lfchip.on { background:hsl(var(--c-toolkit) / .14); border-color:hsl(var(--c-toolkit) / .4); color:hsl(var(--c-toolkit)); }
+.tp-logsort { display:flex; align-items:center; justify-content:space-between; }
+.tp-logsort .cnt { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-sortbtn { background:none; border:none; cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:11px; color:var(--text-sec); display:inline-flex; align-items:center; gap:5px; }
+.tp-sortbtn:hover { color:hsl(var(--c-toolkit)); }
+
+.tp-logbody { flex:1; overflow-y:auto; min-height:0; }
+.tp-logentry { display:flex; gap:11px; padding:11px 16px; border-bottom:1px solid var(--border-light); }
+.tp-logentry.fresh { animation:tp-log-slide-in .3s var(--ease-out); }
+.tp-logentry .lic { width:30px; height:30px; flex-shrink:0; border-radius:var(--r-sm); display:inline-flex; align-items:center; justify-content:center; font-size:15px;
+  background:hsl(var(--e) / .15); }
+.tp-logentry .lbody { flex:1; min-width:0; }
+.tp-logentry .lres { font-family:var(--f-body); font-weight:700; font-size:13px; color:var(--text); line-height:1.3; }
+.tp-logentry .lmeta { display:flex; align-items:center; gap:7px; margin-top:4px; }
+.tp-logentry .ltime { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.tp-logentry .lchip { display:inline-flex; align-items:center; gap:5px; padding:1px 7px 1px 2px; border-radius:var(--r-pill); background:hsl(var(--c-player) / .12); }
+.tp-logentry .lchip .av { width:15px; height:15px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:7px; font-weight:800; color:#fff; }
+.tp-logentry .lchip .nm { font-family:var(--f-display); font-weight:700; font-size:10px; color:hsl(var(--c-player)); }
+.tp-logmore { width:100%; padding:11px; border:none; background:var(--bg-muted); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:12px; cursor:pointer; }
+.tp-logmore:hover { background:var(--bg-hover); }
+.tp-logempty { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:13px; padding:36px 26px; text-align:center; }
+.tp-logempty .em { width:58px; height:58px; border-radius:50%; background:var(--bg-muted); display:inline-flex; align-items:center; justify-content:center; font-size:26px; opacity:.7; }
+.tp-logempty p { font-size:13px; color:var(--text-muted); line-height:1.5; max-width:240px; margin:0; }
+
+/* ─── CLEAR-LOG MODAL ─────────────────────────────── */
+.tp-overlay { position:absolute; inset:0; z-index:50; background:rgba(20,12,4,.46); backdrop-filter:blur(3px); display:flex; align-items:center; justify-content:center; padding:28px; animation:tp-overlay-in var(--dur-md) var(--ease-out); }
+[data-theme="dark"] .tp-overlay { background:rgba(0,0,0,.62); }
+.tp-modal { width:min(420px, 100%); background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg);
+  overflow:hidden; animation:tp-modal-in var(--dur-md) var(--ease-spring); }
+.tp-mhead { display:flex; align-items:center; gap:12px; padding:20px 20px 0; }
+.tp-mhead .mi { width:40px; height:40px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-warning) / .16); color:hsl(var(--c-warning)); display:inline-flex; align-items:center; justify-content:center; font-size:19px; }
+.tp-mhead .mt { font-family:var(--f-display); font-weight:800; font-size:18px; color:var(--text); }
+.tp-mbody { padding:12px 20px 0; }
+.tp-mbody p { font-size:13.5px; color:var(--text-sec); line-height:1.55; margin:0; }
+.tp-mbody .cnt { font-family:var(--f-mono); font-weight:700; color:var(--text); }
+.tp-mfoot { display:flex; gap:10px; padding:18px 20px 20px; }
+.tp-mbtn { flex:1; display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:11px; border-radius:var(--r-md); font-family:var(--f-display); font-weight:800; font-size:13px; cursor:pointer; border:1px solid var(--border-strong); background:var(--bg-card); color:var(--text); transition:all var(--dur-sm); }
+.tp-mbtn:hover { background:var(--bg-muted); }
+.tp-mbtn.warn { background:hsl(var(--c-warning)); border-color:transparent; color:#fff; box-shadow:0 4px 14px hsl(var(--c-warning) / .3); }
+.tp-mbtn.warn:hover { filter:brightness(1.05); background:hsl(var(--c-warning)); }
+
+/* ═══ MOBILE ═══ */
+.tp-app.is-mobile .tp-head { padding:12px 14px 0; }
+.tp-app.is-mobile .tp-h1 { font-size:19px; }
+.tp-app.is-mobile .tp-htop { flex-direction:column; gap:11px; }
+.tp-app.is-mobile .tp-hright { flex-direction:row; align-items:center; align-self:stretch; flex-wrap:wrap; gap:8px; }
+.tp-app.is-mobile .tp-actor input { width:140px; }
+.tp-app.is-mobile .tp-layout { display:block; overflow-y:auto; -webkit-overflow-scrolling:touch; }
+.tp-app.is-mobile .tp-toolcol { padding:14px; gap:20px; overflow:visible; height:auto; }
+.tp-app.is-mobile .tp-shead { flex-wrap:wrap; row-gap:10px; align-items:center; }
+.tp-app.is-mobile .tp-shead-main { flex:1 1 100%; }
+.tp-app.is-mobile .tp-db-grid { grid-template-columns:1fr; gap:14px; }
+.tp-app.is-mobile .tp-adv-grid { grid-template-columns:1fr; }
+.tp-app.is-mobile .tp-db-presets { flex-wrap:wrap; row-gap:7px; }
+.tp-app.is-mobile .tp-syntax-row { grid-template-columns:80px 1fr; }
+.tp-app.is-mobile .tp-syntax-row .ex { display:none; }
+.tp-app.is-mobile .tp-counter-grid, .tp-app.is-mobile .tp-timer-grid { grid-template-columns:1fr; }
+.tp-app.is-mobile .tp-rand { grid-template-columns:1fr; }
+.tp-app.is-mobile .tp-rand-right { width:100%; }
+/* log = accordion bottom */
+.tp-app.is-mobile .tp-logcol { border-left:none; border-top:1px solid var(--border); }
+.tp-logacc-btn { display:none; }
+.tp-app.is-mobile .tp-logacc-btn { display:flex; align-items:center; gap:9px; width:100%; padding:13px 16px; border:none; background:var(--bg-sunken); cursor:pointer; white-space:nowrap;
+  font-family:var(--f-display); font-weight:800; font-size:14px; color:var(--text); }
+.tp-app.is-mobile .tp-logacc-btn .li { width:26px; height:26px; border-radius:var(--r-sm); background:hsl(var(--c-toolkit) / .15); color:hsl(var(--c-toolkit)); display:inline-flex; align-items:center; justify-content:center; font-size:13px; }
+.tp-app.is-mobile .tp-logacc-btn .badge { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+.tp-app.is-mobile .tp-logacc-btn .grow { flex:1; }
+.tp-app.is-mobile .tp-logacc-btn .chev { transition:transform var(--dur-sm); }
+.tp-app.is-mobile .tp-logacc-btn.open .chev { transform:rotate(180deg); }
+.tp-app.is-mobile .tp-logcol .tp-loghead, .tp-app.is-mobile .tp-logcol .tp-logbody, .tp-app.is-mobile .tp-logcol .tp-logempty { max-height:0; overflow:hidden; padding-top:0; padding-bottom:0; transition:none; }
+.tp-app.is-mobile .tp-logbody { flex:none; }
+.tp-app.is-mobile .tp-logcol.open .tp-loghead { max-height:none; padding:15px 16px 11px; }
+.tp-app.is-mobile .tp-logcol.open .tp-logbody { max-height:none; overflow:visible; }
+.tp-app.is-mobile .tp-logcol.open .tp-logempty { padding:30px 24px; }
+.tp-app.is-mobile .tp-logtop > .li, .tp-app.is-mobile .tp-logtop > div:not(.grow) { display:none; }
+.tp-app.is-mobile .tp-overlay { padding:0; align-items:flex-end; }
+.tp-app.is-mobile .tp-modal { width:100%; border-radius:var(--r-2xl) var(--r-2xl) 0 0; animation:tp-sheet-in var(--dur-lg) var(--ease-spring); }
+`;
+
+window.__TP_CSS = TP_CSS;

--- a/admin-mockups/design_files/sp4-toolkit-stats.html
+++ b/admin-mockups/design_files/sp4-toolkit-stats.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<!-- route: /toolkit/stats — KPI dashboard analytics sessioni cross-game con monthly activity + top games + score trends -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /toolkit/stats — Analytics sessioni</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ─── Helper classes (continuity con cluster #1489) ─── */
+  @keyframes ts-shimmer { 0% { background-position: -400px 0; } 100% { background-position: 400px 0; } }
+  .ts-shimmer {
+    background: linear-gradient(90deg, var(--bg-muted) 25%, var(--bg-sunken) 37%, var(--bg-muted) 63%);
+    background-size: 800px 100%;
+    animation: ts-shimmer 1.4s linear infinite;
+  }
+  @keyframes ts-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 hsl(var(--c-toolkit) / 0.5); }
+    50%      { box-shadow: 0 0 0 5px hsl(var(--c-toolkit) / 0); }
+  }
+  .ts-pulse { animation: ts-pulse 2s var(--ease-out) infinite; }
+
+  .ts-row {
+    transition: background var(--dur-sm) var(--ease-out),
+                border-color var(--dur-sm) var(--ease-out),
+                transform var(--dur-sm) var(--ease-out);
+  }
+  .ts-row:hover { background: var(--bg-hover); }
+
+  .ts-bar { transition: transform var(--dur-sm) var(--ease-out), filter var(--dur-sm) var(--ease-out); }
+  .ts-bar:hover { transform: scaleY(1.015); transform-origin: bottom; }
+
+  .ts-kpi { transition: box-shadow var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out), transform var(--dur-sm) var(--ease-out); }
+  .ts-kpi:hover { box-shadow: var(--shadow-md); border-color: hsl(var(--c-toolkit) / 0.4); transform: translateY(-2px); }
+
+  .ts-scroll::-webkit-scrollbar { height: 7px; }
+  .ts-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; }
+  .ts-scroll { scrollbar-width: thin; }
+
+  .ts-sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+  }
+
+  /* Focus ring — keyboard only */
+  a:focus-visible, button:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid hsl(var(--c-toolkit));
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ts-shimmer, .ts-pulse { animation: none; }
+    .ts-bar, .ts-kpi, .ts-row { transition: none; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-toolkit-stats.jsx?v=6"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-toolkit-stats.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-stats.jsx
@@ -1,0 +1,859 @@
+/* MeepleAI SP4 wave 4 — S · #1490 · 1/4 — sp4-toolkit-stats
+   Route: /toolkit/stats — KPI dashboard analytics sessioni cross-game con monthly activity + top games + score trends
+   File: admin-mockups/design_files/sp4-toolkit-stats.{html,jsx}
+   Pattern: Hero + body verticale stacked (no split, no sidebar). Palette --c-toolkit (verde, dashboard toolkit cross-game).
+   Sezioni: Header sticky · KPI grid (3) · Most Played Games (top-N) · Monthly Activity (bar chart) · Recent Score Trends (top-N).
+
+   Source restyle (NO ridisegnare logica): apps/web/src/app/(authenticated)/toolkit/stats/client.tsx
+   API: api.sessionStatistics.getStatistics(12) → { totalSessions, totalGamesPlayed, averageSessionDuration,
+        mostPlayedGames[], monthlyActivity[], recentScoreTrends[] }
+
+   8 stati (state picker continuity con cluster #1489, persistito localStorage `ts-state`):
+   default · empty-no-sessions · empty-partial-data · loading · error · range-3m · range-all · mobile-stack
+
+   Deviazioni flaggate: nessuna palette nuova — solo tint di entity esistenti (toolkit/game/success/warning/danger/info).
+*/
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+const eHsl = (type, a) => {
+  const c = DS.EC[type] || DS.EC.toolkit;
+  return a !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${a})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+// semantic via CSS var (theme-aware)
+const sem = (name, a) => a !== undefined ? `hsl(var(--c-${name}) / ${a})` : `hsl(var(--c-${name}))`;
+
+// ═══════════════════════════════════════════════════════
+// ─── FIXTURE (dati realistici, cross-ref data.js) ────
+// ═══════════════════════════════════════════════════════
+const MONTHS_SHORT = ['Gen','Feb','Mar','Apr','Mag','Giu','Lug','Ago','Set','Ott','Nov','Dic'];
+const MONTHS_FULL = ['Gennaio','Febbraio','Marzo','Aprile','Maggio','Giugno','Luglio','Agosto','Settembre','Ottobre','Novembre','Dicembre'];
+
+// 24 mesi reali Lug 2024 → Giu 2026 (recenti 12 = vista default; 24 = "Tutto")
+const COUNTS_24 = [1,0,2,1,3,2,4,2,3,1,2,3,  3,1,4,5,3,6,5,4,7,4,3,2];
+function buildMonthly() {
+  const out = [];
+  // start: Lug 2024 (month index 6, year 2024) → 24 entries ending Giu 2026 (index 5, 2026)
+  let mi = 6, yr = 2024;
+  for (let i = 0; i < 24; i++) {
+    const sessions = COUNTS_24[i];
+    const minutes = sessions ? Math.round(sessions * 82 + (i % 3) * 11) : 0;
+    out.push({
+      key: `${yr}-${String(mi + 1).padStart(2, '0')}`,
+      short: MONTHS_SHORT[mi], full: MONTHS_FULL[mi], year: yr,
+      sessions, minutes,
+    });
+    mi++; if (mi > 11) { mi = 0; yr++; }
+  }
+  return out;
+}
+const MONTHLY_24 = buildMonthly();
+// current month = Giu 2026 (ultimo): in corso
+const CURRENT_KEY = '2026-06';
+
+const MOST_PLAYED_FULL = [
+  { gameId: 'g-catan',    plays: 12 },
+  { gameId: 'g-wingspan', plays: 9 },
+  { gameId: 'g-azul',     plays: 8 },
+  { gameId: 'g-7wonders', plays: 7 },
+  { gameId: 'g-brass',    plays: 5 },
+  { gameId: 'g-arknova',  plays: 3 },
+  { gameId: 'g-spirit',   plays: 2 },
+];
+
+// variance = score − avgScore del gioco (data.js)
+const SCORE_TRENDS_FULL = [
+  { gameId: 'g-wingspan', date: '1 giu 2026',  full: '1 giugno 2026 · 21:14',  score: 92,  variance: 3 },
+  { gameId: 'g-catan',    date: '30 mag 2026', full: '30 maggio 2026 · 20:02', score: 11,  variance: 2 },
+  { gameId: 'g-azul',     date: '28 mag 2026', full: '28 maggio 2026 · 22:40', score: 87,  variance: 15 },
+  { gameId: 'g-7wonders', date: '26 mag 2026', full: '26 maggio 2026 · 19:30', score: 58,  variance: -6 },
+  { gameId: 'g-brass',    date: '24 mag 2026', full: '24 maggio 2026 · 23:05', score: 132, variance: 0 },
+  { gameId: 'g-wingspan', date: '21 mag 2026', full: '21 maggio 2026 · 18:50', score: 76,  variance: -13 },
+  { gameId: 'g-azul',     date: '18 mag 2026', full: '18 maggio 2026 · 21:20', score: 81,  variance: 9 },
+  { gameId: 'g-catan',    date: '15 mag 2026', full: '15 maggio 2026 · 20:45', score: 8,   variance: -1 },
+  { gameId: 'g-arknova',  date: '12 mag 2026', full: '12 maggio 2026 · 22:10', score: 124, variance: 6 },
+  { gameId: 'g-7wonders', date: '9 mag 2026',  full: '9 maggio 2026 · 19:00',  score: 71,  variance: 7 },
+];
+
+const RANGE_LABEL = { '3': 'Ultimi 3 mesi', '6': 'Ultimi 6 mesi', '12': 'Ultimi 12 mesi', 'all': 'Tutto' };
+const RANGE_OPTS = [
+  { id: '3', label: '3 mesi' }, { id: '6', label: '6 mesi' },
+  { id: '12', label: '12 mesi' }, { id: 'all', label: 'Tutto' },
+];
+
+function fmtDuration(min) {
+  const h = Math.floor(min / 60), m = min % 60;
+  if (h && m) return `${h}h ${m}min`;
+  if (h) return `${h}h`;
+  return `${m}min`;
+}
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const EntityChip = ({ gameId, compact, truncate }) => {
+  const g = DS.byId[gameId];
+  if (!g) return null;
+  return (
+    <button type="button" title={`Apri ${g.title} in libreria`}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 5,
+        maxWidth: '100%', overflow: 'hidden',
+        padding: compact ? '2px 8px' : '3px 9px', borderRadius: 'var(--r-pill)',
+        background: eHsl('game', 0.12), color: eHsl('game'),
+        border: `1px solid ${eHsl('game', 0.22)}`,
+        fontFamily: 'var(--f-display)', fontSize: compact ? 11 : 12, fontWeight: 800,
+        cursor: 'pointer', whiteSpace: 'nowrap',
+      }}>
+      <span aria-hidden="true">🎲</span>
+      <span style={truncate ? { overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 } : undefined}>{g.title}</span>
+    </button>
+  );
+};
+
+const TrendChip = ({ dir, children }) => {
+  const cfg = dir === 'up'
+    ? { bg: sem('success', 0.14), fg: sem('success'), icon: '📈' }
+    : dir === 'down'
+      ? { bg: sem('danger', 0.14), fg: sem('danger'), icon: '📉' }
+      : { bg: 'var(--bg-muted)', fg: 'var(--text-muted)', icon: '▶' };
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4,
+      padding: '3px 8px', borderRadius: 'var(--r-pill)',
+      background: cfg.bg, color: cfg.fg,
+      fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700,
+      fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap',
+    }}>
+      <span aria-hidden="true">{cfg.icon}</span>{children}
+    </span>
+  );
+};
+
+const SectionHead = ({ title, link, onLink, accent = 'toolkit', children }) => (
+  <div style={{
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    gap: 12, marginBottom: 14, flexWrap: 'wrap',
+  }}>
+    <h2 style={{
+      fontFamily: 'var(--f-display)', fontSize: 17, fontWeight: 800,
+      color: 'var(--text)', margin: 0,
+    }}>{title}</h2>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      {children}
+      {link && (
+        <button type="button" onClick={onLink} style={{
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          color: eHsl(accent), fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800,
+          padding: '2px 2px',
+        }}>{link} →</button>
+      )}
+    </div>
+  </div>
+);
+
+const Card = ({ children, pad = 20, style }) => (
+  <div style={{
+    background: 'var(--bg-card)', border: '1px solid var(--border-light)',
+    borderRadius: 'var(--r-lg)', padding: pad, boxShadow: 'var(--shadow-sm)',
+    ...style,
+  }}>{children}</div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HEADER ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const Header = ({ compact, range, onRange }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+  useEffect(() => {
+    const onDoc = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    const onEsc = (e) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onEsc);
+    return () => { document.removeEventListener('mousedown', onDoc); document.removeEventListener('keydown', onEsc); };
+  }, []);
+  return (
+    <div style={{
+      position: 'sticky', top: 0, zIndex: 10,
+      background: 'var(--glass-bg)', backdropFilter: 'blur(14px)',
+      borderBottom: '1px solid var(--border)',
+      padding: compact ? '14px 16px' : '22px 28px',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between',
+        gap: 16, flexWrap: 'wrap',
+      }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+            letterSpacing: '.04em', marginBottom: 6,
+          }}>
+            <span>Toolkit</span>
+            <span aria-hidden="true" style={{ margin: '0 6px' }}>›</span>
+            <strong style={{ color: 'var(--text-sec)' }}>Statistiche</strong>
+          </div>
+          <div style={{
+            display: 'flex', alignItems: compact ? 'flex-start' : 'center', gap: 9, marginBottom: 4,
+          }}>
+            <span aria-hidden="true" style={{
+              width: compact ? 30 : 36, height: compact ? 30 : 36, flexShrink: 0,
+              borderRadius: 'var(--r-md)', background: eHsl('toolkit', 0.16), color: eHsl('toolkit'),
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: compact ? 17 : 20,
+            }}>🧰</span>
+            <h1 style={{
+              fontFamily: 'var(--f-display)', fontWeight: 800,
+              fontSize: compact ? 21 : 32, letterSpacing: '-.02em',
+              color: 'var(--text)', margin: 0,
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+            }}>
+              Analytics sessioni
+            </h1>
+          </div>
+          <p style={{
+            color: 'var(--text-sec)', fontSize: compact ? 13 : 15, margin: 0,
+            display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap',
+          }}>
+            Attività di gioco degli ultimi 12 mesi
+            <span aria-hidden="true" style={{ color: 'var(--text-muted)' }}>·</span>
+            <span style={{
+              display: 'inline-flex', alignItems: 'center', gap: 5,
+              fontFamily: 'var(--f-mono)', fontSize: 11, color: eHsl('player'),
+            }}><span aria-hidden="true">👤</span>Marco R.</span>
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+          {/* Time-range pill + dropdown */}
+          <div ref={ref} style={{ position: 'relative' }}>
+            <button type="button" role="combobox" aria-expanded={open} aria-haspopup="listbox"
+              aria-label={`Intervallo temporale: ${RANGE_LABEL[range]}`}
+              onClick={() => setOpen(o => !o)}
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 8,
+                padding: '8px 12px', borderRadius: 'var(--r-pill)',
+                background: eHsl('toolkit', 0.14), border: `1px solid ${eHsl('toolkit', 0.35)}`,
+                color: eHsl('toolkit'), fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800,
+                cursor: 'pointer', whiteSpace: 'nowrap',
+              }}>
+              <span aria-hidden="true">🗓</span>{RANGE_LABEL[range]}
+              <span aria-hidden="true" style={{ fontSize: 9, opacity: .8 }}>▼</span>
+            </button>
+            {open && (
+              <div role="listbox" style={{
+                position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 20,
+                background: 'var(--bg-card)', border: '1px solid var(--border)',
+                borderRadius: 'var(--r-md)', boxShadow: 'var(--shadow-lg)',
+                padding: 5, minWidth: 150,
+              }}>
+                {RANGE_OPTS.map(o => (
+                  <button key={o.id} type="button" role="option" aria-selected={range === o.id}
+                    onClick={() => { onRange(o.id); setOpen(false); }}
+                    style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                      width: '100%', padding: '8px 10px', borderRadius: 'var(--r-sm)',
+                      background: range === o.id ? eHsl('toolkit', 0.12) : 'transparent',
+                      border: 'none', cursor: 'pointer',
+                      color: range === o.id ? eHsl('toolkit') : 'var(--text-sec)',
+                      fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 700, textAlign: 'left',
+                    }}>
+                    {o.label}{range === o.id && <span aria-hidden="true">✓</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {/* Export CSV */}
+          <button type="button" style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            padding: '8px 14px', borderRadius: 'var(--r-md)',
+            background: 'var(--bg-card)', border: '1px solid var(--border-strong)',
+            color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800,
+            cursor: 'pointer', whiteSpace: 'nowrap',
+          }}><span aria-hidden="true">📊</span>{compact ? 'CSV' : 'Esporta CSV'}</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SECTION 1 · KPI CARDS ──────────────────────────
+// ═══════════════════════════════════════════════════════
+const KpiCard = ({ icon, accent, label, value, mono, trend, sub, labelId }) => (
+  <figure role="figure" aria-labelledby={labelId} className="ts-kpi" style={{
+    margin: 0, padding: 20, borderRadius: 'var(--r-lg)',
+    background: 'var(--glass-bg)', backdropFilter: 'blur(8px)',
+    border: '1px solid var(--border-light)', boxShadow: 'var(--shadow-sm)',
+    display: 'flex', flexDirection: 'column', gap: 12,
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <span aria-hidden="true" style={{
+        width: 26, height: 26, borderRadius: 'var(--r-sm)',
+        background: eHsl(accent, 0.16), color: eHsl(accent),
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14,
+      }}>{icon}</span>
+      <figcaption id={labelId} style={{
+        fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+        textTransform: 'uppercase', letterSpacing: '.07em', fontWeight: 700,
+      }}>{label}</figcaption>
+    </div>
+    <div style={{
+      fontFamily: mono ? 'var(--f-mono)' : 'var(--f-display)',
+      fontSize: mono ? 30 : 40, fontWeight: 800, color: 'var(--text)',
+      fontVariantNumeric: 'tabular-nums', lineHeight: 1,
+    }}>{value}</div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', minHeight: 22 }}>
+      {trend && <TrendChip dir={trend.dir}>{trend.text}</TrendChip>}
+      {sub && <span style={{
+        fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', fontWeight: 600,
+      }}>{sub}</span>}
+    </div>
+  </figure>
+);
+
+const KpiGrid = ({ compact, data }) => (
+  <div style={{
+    display: 'grid', gap: 14,
+    gridTemplateColumns: compact ? '1fr' : 'repeat(3, 1fr)',
+  }}>
+    <KpiCard labelId="kpi-sessions" icon="🎮" accent="toolkit" label="Sessioni totali"
+      value={data.totalSessions}
+      trend={{ dir: 'up', text: `+${data.yoy.delta} vs anno scorso · +${data.yoy.pct}%` }} />
+    <KpiCard labelId="kpi-games" icon="🏆" accent="game" label="Giochi giocati"
+      value={data.totalGamesPlayed}
+      sub={`Mediamente ${Math.round(data.totalSessions / Math.max(1, data.totalGamesPlayed))} sessioni / gioco`} />
+    <KpiCard labelId="kpi-duration" icon="⏱" accent="warning" label="Durata media" mono
+      value={data.avgDuration}
+      sub={`Più lunga: ${data.longestSession}`} />
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── SECTION 2 · MOST PLAYED ────────────────────────
+// ═══════════════════════════════════════════════════════
+const RANK_COLOR = ['#d9a441', '#9aa0a6', '#b06a3c']; // amber · silver · bronze
+const MostPlayedRow = ({ row, idx, max }) => {
+  const g = DS.byId[row.gameId];
+  if (!g) return null;
+  const pct = Math.round((row.plays / max) * 100);
+  return (
+    <div tabIndex={0} role="listitem" className="ts-row" title={`Apri ${g.title}`} style={{
+      display: 'flex', flexDirection: 'column', gap: 9,
+      padding: '12px 12px', borderRadius: 'var(--r-md)', cursor: 'pointer',
+    }}>
+      {/* top line: rank · cover · name (full) */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+        <span style={{
+          fontFamily: 'var(--f-mono)', fontSize: 13, fontWeight: 800, width: 24, textAlign: 'center', flexShrink: 0,
+          color: idx < 3 ? RANK_COLOR[idx] : 'var(--text-muted)',
+        }}>#{idx + 1}</span>
+        <span aria-hidden="true" style={{
+          width: 28, height: 34, borderRadius: 'var(--r-sm)', background: g.cover,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 15,
+          color: 'rgba(255,255,255,.92)', flexShrink: 0,
+        }}>{g.coverEmoji}</span>
+        <span style={{ minWidth: 0 }}><EntityChip gameId={row.gameId} /></span>
+      </div>
+      {/* bottom line: progress bar + play count */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingLeft: 34 }}>
+        <div style={{ flex: 1, height: 6, borderRadius: 'var(--r-pill)', background: 'var(--bg-muted)', overflow: 'hidden' }}>
+          <div style={{
+            height: '100%', width: `${pct}%`, borderRadius: 'var(--r-pill)',
+            background: `linear-gradient(90deg, ${eHsl('game', 0.7)}, ${eHsl('game')})`,
+          }} />
+        </div>
+        <span style={{
+          display: 'inline-flex', alignItems: 'center', gap: 5, flexShrink: 0,
+          padding: '4px 9px', borderRadius: 'var(--r-pill)',
+          background: eHsl('game', 0.12), color: eHsl('game'),
+          fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700, whiteSpace: 'nowrap',
+        }}><span aria-hidden="true">📊</span>{row.plays} plays</span>
+      </div>
+    </div>
+  );
+};
+
+const MostPlayed = ({ rows }) => {
+  const max = rows.length ? rows[0].plays : 1;
+  return (
+    <Card pad={16}>
+      <SectionHead title="Giochi più giocati" link="Vedi tutti" accent="game" onLink={() => {}} />
+      <div role="list" style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {rows.map((r, i) => <MostPlayedRow key={r.gameId + i} row={r} idx={i} max={max} />)}
+      </div>
+    </Card>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SECTION 3 · MONTHLY ACTIVITY (bar chart) ───────
+// ═══════════════════════════════════════════════════════
+const MonthlyChart = ({ months, compact }) => {
+  const [metric, setMetric] = useState('sessions');
+  const [hover, setHover] = useState(null);
+  const chartH = compact ? 140 : 200;
+  const valOf = (m) => metric === 'sessions' ? m.sessions : m.minutes;
+  const max = Math.max(1, ...months.map(valOf));
+  const scroll = months.length > 14;
+
+  return (
+    <Card pad={compact ? 16 : 20}>
+      <SectionHead title="Attività mensile">
+        <div role="group" aria-label="Metrica grafico" style={{
+          display: 'flex', gap: 2, padding: 3, borderRadius: 'var(--r-pill)',
+          background: 'var(--bg-muted)',
+        }}>
+          {[{ id: 'sessions', l: 'Sessioni' }, { id: 'duration', l: 'Durata' }].map(o => (
+            <button key={o.id} type="button" aria-pressed={metric === o.id}
+              onClick={() => setMetric(o.id)} style={{
+                padding: '5px 12px', borderRadius: 'var(--r-pill)', border: 'none', cursor: 'pointer',
+                background: metric === o.id ? 'var(--bg-card)' : 'transparent',
+                boxShadow: metric === o.id ? 'var(--shadow-xs)' : 'none',
+                color: metric === o.id ? eHsl('toolkit') : 'var(--text-muted)',
+                fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800,
+              }}>{o.l}</button>
+          ))}
+        </div>
+      </SectionHead>
+
+      <div className={scroll ? 'ts-scroll' : ''} style={{ overflowX: scroll ? 'auto' : 'visible', paddingTop: 22 }}>
+        <div role="img"
+          aria-label={`Grafico a barre attività mensile, ${months.length} mesi. Metrica: ${metric === 'sessions' ? 'numero sessioni' : 'durata totale'}.`}
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${months.length}, ${scroll ? '34px' : 'minmax(0, 1fr)'})`,
+            alignItems: 'end', gap: scroll ? 6 : 8, height: chartH,
+            borderBottom: '1px solid var(--border)',
+          }}>
+          {months.map((m) => {
+            const v = valOf(m);
+            const h = v ? Math.max(4, Math.round((v / max) * (chartH - 26))) : 0;
+            const isCurrent = m.key === CURRENT_KEY;
+            const isHover = hover === m.key;
+            const showTop = h > 30;
+            return (
+              <div key={m.key} style={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'flex-end', height: '100%' }}
+                onMouseEnter={() => setHover(m.key)} onMouseLeave={() => setHover(null)}>
+                {/* tooltip */}
+                {isHover && v > 0 && (
+                  <div role="tooltip" style={{
+                    position: 'absolute', bottom: h + 30, left: '50%', transform: 'translateX(-50%)',
+                    zIndex: 30, background: 'var(--bg-card)', border: '1px solid var(--border)',
+                    borderRadius: 'var(--r-md)', boxShadow: 'var(--shadow-lg)', padding: '8px 11px',
+                    whiteSpace: 'nowrap', pointerEvents: 'none',
+                  }}>
+                    <div style={{ fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, color: 'var(--text)' }}>{m.full} {m.year}</div>
+                    <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>
+                      {m.sessions} sessioni · {fmtDuration(m.minutes)} totali
+                    </div>
+                  </div>
+                )}
+                {showTop && (
+                  <span style={{
+                    fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700, marginBottom: 4,
+                    color: isHover ? eHsl('toolkit') : 'var(--text-sec)', fontVariantNumeric: 'tabular-nums',
+                  }}>{metric === 'sessions' ? v : `${Math.floor(v / 60)}h`}</span>
+                )}
+                <button type="button" tabIndex={0}
+                  aria-label={`${m.full} ${m.year}: ${m.sessions} sessioni, ${fmtDuration(m.minutes)}`}
+                  className={`ts-bar ${isCurrent ? 'ts-pulse' : ''}`}
+                  style={{
+                    width: '100%', maxWidth: scroll ? 34 : 46, height: h || 4, cursor: 'pointer',
+                    border: 'none', padding: 0,
+                    borderRadius: 'var(--r-sm) var(--r-sm) 0 0',
+                    background: v
+                      ? `linear-gradient(to bottom, ${eHsl('toolkit')}, ${eHsl('toolkit', 0.55)})`
+                      : 'transparent',
+                    borderTop: v
+                      ? (isHover ? `2px solid ${eHsl('toolkit')}` : 'none')
+                      : `1.5px dashed ${eHsl('toolkit', 0.4)}`,
+                    boxShadow: isCurrent ? 'none' : (isHover ? `0 2px 10px ${eHsl('toolkit', 0.3)}` : 'none'),
+                  }} />
+                <span style={{
+                  fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: isCurrent ? 800 : 600, marginTop: 7,
+                  color: isCurrent ? eHsl('toolkit') : 'var(--text-muted)',
+                }}>{m.short}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* a11y: raw data table */}
+      <table className="ts-sr-only">
+        <caption>Attività mensile per sessioni e durata</caption>
+        <thead><tr><th>Mese</th><th>Sessioni</th><th>Durata totale</th></tr></thead>
+        <tbody>
+          {months.map(m => (
+            <tr key={m.key}><td>{m.full} {m.year}</td><td>{m.sessions}</td><td>{fmtDuration(m.minutes)}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SECTION 4 · RECENT SCORE TRENDS ────────────────
+// ═══════════════════════════════════════════════════════
+const ScoreRow = ({ row, compact }) => {
+  const g = DS.byId[row.gameId];
+  if (!g) return null;
+  const dir = row.variance > 0 ? 'up' : row.variance < 0 ? 'down' : 'neutral';
+  const varCfg = dir === 'up'
+    ? { icon: '🔺', color: sem('success'), text: `+${row.variance} vs media gioco`, aria: `Positivo, +${row.variance} punti rispetto alla media del gioco` }
+    : dir === 'down'
+      ? { icon: '🔻', color: sem('danger'), text: `${row.variance} vs media gioco`, aria: `Negativo, ${row.variance} punti rispetto alla media del gioco` }
+      : { icon: '▶', color: 'var(--text-muted)', text: 'in media', aria: 'In media rispetto al gioco' };
+  return (
+    <div role="listitem" tabIndex={0} className="ts-row" style={{
+      display: 'flex', alignItems: 'center', gap: 12, padding: '11px 12px',
+      borderRadius: 'var(--r-md)', cursor: 'pointer',
+    }}>
+      <span aria-hidden="true" style={{
+        width: 30, height: 30, borderRadius: 'var(--r-sm)', flexShrink: 0,
+        background: dir === 'up' ? sem('success', 0.14) : dir === 'down' ? sem('danger', 0.14) : 'var(--bg-muted)',
+        color: varCfg.color, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13,
+      }}>{dir === 'up' ? '📈' : dir === 'down' ? '📉' : '▶'}</span>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <EntityChip gameId={row.gameId} compact />
+          <span title={row.full} style={{
+            fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)', fontWeight: 600,
+          }}>{row.date}</span>
+        </div>
+        {!compact && (
+          <span aria-label={varCfg.aria} style={{
+            display: 'inline-flex', alignItems: 'center', gap: 5,
+            fontFamily: 'var(--f-mono)', fontSize: 11, fontWeight: 700, color: varCfg.color,
+          }}><span aria-hidden="true">{varCfg.icon}</span>{varCfg.text}</span>
+        )}
+      </div>
+      <span style={{
+        padding: '6px 12px', borderRadius: 'var(--r-md)',
+        background: eHsl('toolkit', 0.14), color: eHsl('toolkit'),
+        fontFamily: 'var(--f-mono)', fontSize: 15, fontWeight: 800, fontVariantNumeric: 'tabular-nums',
+        whiteSpace: 'nowrap',
+      }}>{row.score}</span>
+    </div>
+  );
+};
+
+const ScoreTrends = ({ rows, compact }) => (
+  <Card pad={16}>
+    <SectionHead title="Punteggi recenti" link="Vedi history" accent="toolkit" onLink={() => {}} />
+    <div role="list" style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {rows.map((r, i) => <ScoreRow key={r.gameId + i} row={r} compact={compact} />)}
+    </div>
+  </Card>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE BLOCKS (empty / partial / loading / error) ─
+// ═══════════════════════════════════════════════════════
+const Banner = ({ tone, icon, children, action }) => {
+  const map = {
+    info: { bg: sem('info', 0.08), bd: sem('info', 0.3), fg: sem('info') },
+    danger: { bg: sem('danger', 0.08), bd: sem('danger', 0.3), fg: sem('danger') },
+  }[tone];
+  return (
+    <div role={tone === 'danger' ? 'alert' : undefined} style={{
+      display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px',
+      borderRadius: 'var(--r-lg)', background: map.bg, border: `1px solid ${map.bd}`,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 18, color: map.fg }}>{icon}</span>
+      <div style={{ flex: 1, fontSize: 13.5, color: 'var(--text)', fontWeight: 600 }}>{children}</div>
+      {action}
+    </div>
+  );
+};
+
+const EmptyNoSessions = () => (
+  <div style={{
+    gridColumn: '1 / -1', padding: '56px 24px', textAlign: 'center',
+    background: 'var(--bg-card)', border: '1px dashed var(--border-strong)',
+    borderRadius: 'var(--r-xl)', display: 'flex', flexDirection: 'column', alignItems: 'center',
+  }}>
+    <div aria-hidden="true" style={{
+      width: 72, height: 72, borderRadius: '50%', marginBottom: 18,
+      background: eHsl('toolkit', 0.12), color: eHsl('toolkit'),
+      display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 32,
+    }}>📊</div>
+    <h2 style={{ fontFamily: 'var(--f-display)', fontSize: 20, fontWeight: 800, color: 'var(--text)', margin: '0 0 8px' }}>
+      Nessuna sessione ancora
+    </h2>
+    <p style={{ fontSize: 14, color: 'var(--text-muted)', maxWidth: 380, margin: '0 0 20px', lineHeight: 1.55 }}>
+      Inizia a giocare per vedere le tue statistiche: KPI, giochi più giocati, attività mensile e andamento punteggi.
+    </p>
+    <button type="button" style={{
+      display: 'inline-flex', alignItems: 'center', gap: 7,
+      padding: '11px 20px', borderRadius: 'var(--r-md)',
+      background: eHsl('toolkit'), color: '#fff', border: 'none',
+      fontFamily: 'var(--f-display)', fontSize: 14, fontWeight: 800, cursor: 'pointer',
+      boxShadow: `0 4px 14px ${eHsl('toolkit', 0.4)}`,
+    }}><span aria-hidden="true">🎮</span>Crea nuova sessione</button>
+  </div>
+);
+
+const Skel = ({ h, w = '100%', r = 'var(--r-md)', style }) => (
+  <div className="ts-shimmer" style={{ height: h, width: w, borderRadius: r, ...style }} />
+);
+
+const LoadingState = ({ compact }) => (
+  <div aria-busy="true" aria-label="Caricamento statistiche…" style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+    <div style={{ display: 'grid', gap: 14, gridTemplateColumns: compact ? '1fr' : 'repeat(3, 1fr)' }}>
+      {[0, 1, 2].map(i => (
+        <Card key={i} pad={20}><div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <Skel h={18} w="55%" /><Skel h={36} w="40%" /><Skel h={14} w="70%" />
+        </div></Card>
+      ))}
+    </div>
+    <Card pad={16}><Skel h={18} w="40%" style={{ marginBottom: 16 }} />
+      {[0, 1, 2, 3, 4].map(i => <Skel key={i} h={20} style={{ marginBottom: 12 }} />)}
+    </Card>
+    <Card pad={20}><Skel h={18} w="35%" style={{ marginBottom: 18 }} />
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(12, 1fr)`, alignItems: 'end', gap: 8, height: compact ? 140 : 200 }}>
+        {Array.from({ length: 12 }).map((_, i) => <Skel key={i} h={`${20 + (i * 13) % 80}%`} r="var(--r-sm) var(--r-sm) 0 0" />)}
+      </div>
+    </Card>
+    <Card pad={16}><Skel h={18} w="40%" style={{ marginBottom: 16 }} />
+      {[0, 1, 2, 3, 4].map(i => <Skel key={i} h={22} style={{ marginBottom: 12 }} />)}
+    </Card>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BODY (compose) ─────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const KPI_DEFAULT = {
+  totalSessions: 47, totalGamesPlayed: 7, avgDuration: '1h 24m', longestSession: '4h 12m',
+  yoy: { delta: 12, pct: 34 },
+};
+const KPI_PARTIAL = {
+  totalSessions: 2, totalGamesPlayed: 1, avgDuration: '46m', longestSession: '52m',
+  yoy: { delta: 2, pct: 100 },
+};
+
+const StatsBody = ({ state, range, onRange, compact }) => {
+  // derive data slices from range
+  const months = useMemo(() => {
+    if (state === 'partial') return MONTHLY_24.slice(-12).map((m, i) => ({ ...m, sessions: i >= 10 ? [1, 1][i - 10] : 0, minutes: i >= 10 ? [42, 50][i - 10] : 0 }));
+    if (range === 'all') return MONTHLY_24;
+    const n = range === '3' ? 3 : range === '6' ? 6 : 12;
+    return MONTHLY_24.slice(-n);
+  }, [range, state]);
+
+  const mostPlayed = useMemo(() => {
+    if (state === 'partial') return MOST_PLAYED_FULL.slice(0, 1).map(r => ({ ...r, plays: 2 }));
+    if (range === 'all') return MOST_PLAYED_FULL.slice(0, 7);
+    if (range === '3') return MOST_PLAYED_FULL.slice(0, 3);
+    return MOST_PLAYED_FULL.slice(0, 5);
+  }, [range, state]);
+
+  const trends = useMemo(() => {
+    if (state === 'partial') return SCORE_TRENDS_FULL.slice(0, 2);
+    if (range === '3') return SCORE_TRENDS_FULL.slice(0, 5);
+    return SCORE_TRENDS_FULL.slice(0, 10);
+  }, [range, state]);
+
+  const kpi = state === 'partial' ? KPI_PARTIAL : KPI_DEFAULT;
+
+  const body = () => {
+    if (state === 'loading') return <LoadingState compact={compact} />;
+    if (state === 'empty') {
+      return <div style={{ display: 'grid' }}><EmptyNoSessions /></div>;
+    }
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? 22 : 28 }}>
+        {state === 'partial' && (
+          <Banner tone="info" icon="📊">
+            Le statistiche diventano più ricche con più dati. Continua a giocare!
+          </Banner>
+        )}
+        {state === 'error' && (
+          <Banner tone="danger" icon="⚠" action={
+            <button type="button" style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              padding: '8px 14px', borderRadius: 'var(--r-md)',
+              background: 'transparent', border: `1px solid ${sem('danger', 0.5)}`,
+              color: sem('danger'), fontFamily: 'var(--f-display)', fontSize: 13, fontWeight: 800, cursor: 'pointer',
+            }}><span aria-hidden="true">🔄</span>Riprova</button>
+          }>
+            Impossibile caricare le statistiche. Riprova tra qualche istante.
+          </Banner>
+        )}
+        <KpiGrid compact={compact} data={kpi} />
+        {state === 'error' ? (
+          <Card pad={20} style={{ opacity: .55 }}>
+            <Skel h={16} w="38%" style={{ marginBottom: 16 }} />
+            {[0, 1, 2].map(i => <Skel key={i} h={20} style={{ marginBottom: 12 }} />)}
+          </Card>
+        ) : (
+          <>
+            <MostPlayed rows={mostPlayed} />
+            <MonthlyChart months={months} compact={compact} />
+            <ScoreTrends rows={trends} compact={compact} />
+          </>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <main role="main" style={{ background: 'var(--bg)', minHeight: compact ? 'auto' : 600 }}>
+      <Header compact={compact} range={range} onRange={onRange} />
+      <div style={{ padding: compact ? '20px 16px 36px' : '28px 28px 56px', maxWidth: 1100, margin: '0 auto' }}>
+        {body()}
+      </div>
+    </main>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES (desktop chrome + phone) ────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ children }) => (
+  <div className="ed-desk" style={{
+    width: '100%', borderRadius: 'var(--r-xl)', border: '1px solid var(--border)',
+    background: 'var(--bg)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)',
+  }}>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: '9px 14px',
+      background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)',
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: sem('danger') }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: sem('warning') }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: sem('toolkit') }} />
+      <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.04em' }}>meepleai.app/toolkit/stats</span>
+    </div>
+    {children}
+  </div>
+);
+
+const PhoneFrame = ({ children }) => (
+  <div className="phone" style={{ width: 375, height: 760 }}>
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>14:32</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+    <div style={{ flex: 1, overflowY: 'auto', position: 'relative', background: 'var(--bg)' }}>
+      {children}
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE PICKER + ROOT ────────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATES = [
+  { id: 'default',  label: 'Default',            state: 'default', range: '12', view: 'both',   desc: 'Tutti i dati popolati: 47 sessioni · top-5 giochi · 12 barre mensili · 10 punteggi recenti.' },
+  { id: 'empty',    label: 'Empty · no sessions', state: 'empty',  range: '12', view: 'desktop', desc: 'Utente nuovo: empty state centrato con CTA "Crea nuova sessione".' },
+  { id: 'partial',  label: 'Empty · partial',     state: 'partial', range: '12', view: 'desktop', desc: 'Utente con 1–2 sessioni: KPI bassi, 1 gioco, poche barre, help banner info.' },
+  { id: 'loading',  label: 'Loading',            state: 'loading', range: '12', view: 'desktop', desc: 'Skeleton shimmer: header + 3 KPI + most played + bar chart + score trends.' },
+  { id: 'error',    label: 'Error',              state: 'error',   range: '12', view: 'desktop', desc: 'Banner danger + Riprova; KPI renderizzati, body con placeholder.' },
+  { id: 'range3',   label: 'Range · 3 mesi',      state: 'default', range: '3',  view: 'desktop', desc: 'Time range 3 mesi: most played top-3, 3 barre mensili, 5 punteggi.' },
+  { id: 'rangeall', label: 'Range · Tutto',       state: 'default', range: 'all', view: 'desktop', desc: 'Time range "Tutto": most played top-7, 24 barre scrollabili orizzontale.' },
+  { id: 'mobile',   label: 'Mobile · 375',        state: 'default', range: '12', view: 'mobile',  desc: 'Vista 375px: KPI 1-col, bar chart 140px, score rows compatte (solo score).' },
+];
+const SKEY = 'ts-state';
+
+const App = () => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || document.documentElement.getAttribute('data-theme') || 'light');
+  const [active, setActive] = useState(() => {
+    const s = localStorage.getItem(SKEY);
+    return STATES.some(x => x.id === s) ? s : 'default';
+  });
+  // per-frame interactive range override (header dropdown)
+  const [rangeOv, setRangeOv] = useState(null);
+
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem(SKEY, active); setRangeOv(null); }, [active]);
+
+  const cur = STATES.find(s => s.id === active) || STATES[0];
+  const range = rangeOv || cur.range;
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', padding: '20px 20px 80px' }}>
+      {/* ─── State picker bar ─── */}
+      <header style={{
+        position: 'sticky', top: 12, zIndex: 50, maxWidth: 1180, margin: '0 auto 28px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(16px)',
+        border: '1px solid var(--border)', borderRadius: 'var(--r-xl)',
+        boxShadow: 'var(--shadow-md)', padding: '12px 16px',
+        display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <div style={{
+            width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+            background: `linear-gradient(135deg, ${eHsl('toolkit')}, ${eHsl('game')})`,
+            color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 800, fontFamily: 'var(--f-display)', fontSize: 14,
+          }}>S</div>
+          <div>
+            <div style={{ fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 14, lineHeight: 1.1 }}>Toolkit Stats</div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)' }}>#1490 · 1/4 · /toolkit/stats</div>
+          </div>
+        </div>
+
+        <div role="tablist" aria-label="Stati schermata" style={{
+          display: 'flex', gap: 6, flexWrap: 'wrap', flex: 1, minWidth: 0,
+        }}>
+          {STATES.map(s => {
+            const on = s.id === active;
+            return (
+              <button key={s.id} type="button" role="tab" aria-selected={on}
+                onClick={() => setActive(s.id)} style={{
+                  padding: '7px 12px', borderRadius: 'var(--r-pill)', cursor: 'pointer',
+                  background: on ? eHsl('toolkit') : 'var(--bg-muted)',
+                  border: on ? 'none' : '1px solid var(--border)',
+                  color: on ? '#fff' : 'var(--text-sec)',
+                  fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, whiteSpace: 'nowrap',
+                  boxShadow: on ? `0 3px 10px ${eHsl('toolkit', 0.35)}` : 'none',
+                }}>{s.label}</button>
+            );
+          })}
+        </div>
+
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{
+          padding: '8px 14px', borderRadius: 'var(--r-md)', flexShrink: 0,
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer',
+        }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* ─── Active state description ─── */}
+      <div style={{
+        maxWidth: 1180, margin: '0 auto 18px', padding: '0 4px',
+        fontFamily: 'var(--f-mono)', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5,
+      }}>
+        <strong style={{ color: eHsl('toolkit') }}>{cur.label}</strong> — {cur.desc}
+      </div>
+
+      {/* ─── Render area ─── */}
+      <div style={{ maxWidth: 1180, margin: '0 auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 36 }}>
+        {(cur.view === 'both' || cur.view === 'desktop') && (
+          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>Desktop · 1440</div>
+            <DesktopFrame>
+              <StatsBody state={cur.state} range={range} onRange={setRangeOv} compact={false} />
+            </DesktopFrame>
+          </div>
+        )}
+        {(cur.view === 'both' || cur.view === 'mobile') && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>Mobile · 375</div>
+            <PhoneFrame>
+              <StatsBody state={cur.state} range={range} onRange={setRangeOv} compact={true} />
+            </PhoneFrame>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-toolkit-templates-ui.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-templates-ui.jsx
@@ -1,0 +1,607 @@
+/* sp4-toolkit-templates-ui.jsx — components + interactive app + harness
+   (loads after sp4-toolkit-templates.jsx). Route: /toolkit/templates — vedi header foundation. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const DS = window.DS;
+const T = window.__TT;
+const {
+  eHsl, sem, fmtDate, relDate, NOW,
+  CATS, CAT_ORDER, CAT_COUNTS, TOOL_META, TOOL_ORDER, CREATORS,
+  TEMPLATES, TOTAL, CLONE_TOTAL, LIB_GAMES,
+} = T;
+
+const pColor = (h, l = 52, s = 58) => `hsl(${h}, ${s}%, ${l}%)`;
+const entVar = ent => ent === 'success' ? 'var(--c-success)' : `var(--c-${ent})`;
+// resolve a category's --e custom prop value
+const catE = cat => `hsl(${entVar(CATS[cat].ent)})`;
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const StarRating = ({ value }) => {
+  const full = Math.floor(value);
+  const half = value - full >= 0.5;
+  return (
+    <span className="tt-rating" role="img" aria-label={`Valutazione ${value} stelle su 5`}>
+      {[0, 1, 2, 3, 4].map(i => {
+        const cls = i < full ? 'full' : (i === full && half ? 'half' : '');
+        return <span key={i} className={'tt-star ' + cls} aria-hidden="true">★</span>;
+      })}
+    </span>
+  );
+};
+
+const ToolComposition = ({ tools }) => {
+  const label = TOOL_ORDER.map(k => `${tools[k]} ${TOOL_META[k].label}`).join(', ');
+  return (
+    <div className="tt-tools" role="img" aria-label={`Composizione: ${label}`}>
+      {TOOL_ORDER.map(k => {
+        const c = tools[k], empty = c === 0;
+        return (
+          <div key={k} className={'tt-tool' + (empty ? ' empty' : '')} aria-hidden="true">
+            <span className="ti">{TOOL_META[k].icon}</span>
+            <span className="tc">{empty ? '—' : c}</span>
+            {!empty && <span className="tip">{TOOL_META[k].tip(c)}</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const CreatorChip = ({ creator }) => (
+  <span className="tt-creator" title={`Creato da ${creator.name}`}>
+    <span className="tt-cav" style={{ background: pColor(creator.color) }} aria-hidden="true">{creator.initials}</span>
+    <span className="tt-cnm">{creator.name}</span>
+  </span>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TEMPLATE CARD ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const TemplateCard = ({ t, onClone }) => {
+  const cat = CATS[t.category];
+  const eStyle = { '--e': catE(t.category) };
+  const cls = 'tt-card' + (t.official ? ' official' : '') + (t.pending ? ' pending' : '');
+  return (
+    <article className={cls} style={eStyle} role="listitem" aria-labelledby={'tplname-' + t.id}>
+      {t.official && <span className="tt-crown" title="Template ufficiale" aria-hidden="true">👑</span>}
+      {t.recent && <span className="tt-corner new" aria-hidden="true">Nuovo</span>}
+
+      {/* header */}
+      <div className="tt-chead">
+        <span className="tt-cicon" aria-hidden="true">{cat.icon}</span>
+        <div className="tt-chtxt">
+          <button type="button" className="tt-cname" id={'tplname-' + t.id} title={t.name}
+            aria-label={`Apri dettaglio template ${t.name}`}>{t.name}</button>
+          <div className="tt-ccat">{cat.label}</div>
+        </div>
+        {t.rating > 0
+          ? <StarRating value={t.rating} />
+          : <span className="tt-ratenew" aria-label="Nessuna valutazione">nuovo</span>}
+      </div>
+
+      {/* description */}
+      <p className="tt-desc">{t.description}</p>
+
+      {/* tool composition */}
+      <ToolComposition tools={t.tools} />
+
+      <span className="tt-spacer" />
+      <div className="tt-cdiv" />
+
+      {/* creator + meta */}
+      <div className="tt-meta">
+        <CreatorChip creator={t.creator} />
+        {t.official && <span className="tt-official"><span aria-hidden="true">⭐</span>Ufficiale</span>}
+        <span className="tt-clones" title={`${t.usageCount} cloni`}>
+          {t.popular && <span className="fire" aria-hidden="true">🔥</span>}
+          <span aria-hidden="true">📋</span>{t.usageCount}
+        </span>
+      </div>
+      {t.popular && <div className="tt-grow" aria-label={`+${t.weekGrowth} cloni questa settimana`}>↗ +{t.weekGrowth} questa settimana</div>}
+
+      {/* footer CTA */}
+      {t.pending
+        ? <button type="button" className="tt-clonebtn disabled" disabled aria-label="Template in approvazione, non clonabile">
+            <span aria-hidden="true">🔒</span>In approvazione</button>
+        : <button type="button" className="tt-clonebtn" onClick={() => onClone(t)} aria-label={`Clona template ${t.name}`}>
+            <span aria-hidden="true">📋</span>Clona template</button>}
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TOOLBAR ────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+function useOutside(onClose) {
+  const ref = useRef(null);
+  useEffect(() => {
+    const onDoc = e => { if (ref.current && !ref.current.contains(e.target)) onClose(); };
+    const onEsc = e => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onEsc);
+    return () => { document.removeEventListener('mousedown', onDoc); document.removeEventListener('keydown', onEsc); };
+  }, [onClose]);
+  return ref;
+}
+
+const SORT_OPTS = [
+  { id: 'popular', label: 'Più popolari' },
+  { id: 'recent', label: 'Più recenti' },
+  { id: 'rating', label: 'Più amati' },
+  { id: 'alpha', label: 'Alfabetico' },
+];
+
+const Toolbar = ({ st, set, typing, searchRef, mobile }) => {
+  const [openSort, setOpenSort] = useState(false);
+  const sortRef = useOutside(() => setOpenSort(false));
+  const chips = [{ key: 'all', label: 'Tutte', count: TOTAL }, ...CAT_ORDER.map(c => ({ key: c, label: CATS[c].label, count: CAT_COUNTS[c], cat: c }))];
+
+  return (
+    <div className="tt-toolbar">
+      {/* search */}
+      <div className={'tt-search' + (st.search ? ' active' : '')}>
+        <span className="ic" aria-hidden="true">🔍</span>
+        <input ref={searchRef} value={st.search} onChange={e => set({ search: e.target.value })} role="searchbox"
+          aria-label="Cerca template per nome o creatore" placeholder="Cerca per nome o creatore…"
+          onKeyDown={e => { if (e.key === 'Escape') set({ search: '' }); }} />
+        {typing && <span className="busy" aria-hidden="true"><i />Cercando…</span>}
+        {st.search && <button className="clear" aria-label="Cancella ricerca" onClick={() => { set({ search: '' }); searchRef.current && searchRef.current.focus(); }}>✕</button>}
+      </div>
+
+      {/* category chips — single-select radiogroup */}
+      <div className={'tt-chips' + (mobile ? ' scroll' : '')} role="radiogroup" aria-label="Filtra per categoria">
+        {chips.map(c => {
+          const on = st.cat === c.key;
+          const isAll = c.key === 'all';
+          const eStyle = isAll ? undefined : { '--e': catE(c.cat) };
+          return (
+            <button key={c.key} type="button" role="radio" aria-checked={on}
+              className={'tt-chip ' + (isAll ? 'all' : 'cat') + (on ? ' on' : '')} style={eStyle}
+              onClick={() => set({ cat: c.key })}>
+              {isAll ? <span className="cdot" aria-hidden="true" /> : <span aria-hidden="true">{CATS[c.cat].icon}</span>}
+              {c.label}<span className="ccount">{c.count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* sort + view */}
+      <div className="tt-right">
+        <div className="tt-fgroup" ref={sortRef}>
+          <button type="button" className="tt-sortbtn" aria-haspopup="listbox" aria-expanded={openSort} onClick={() => setOpenSort(o => !o)}>
+            <span aria-hidden="true">↕</span>{SORT_OPTS.find(s => s.id === st.sort).label}
+            <span aria-hidden="true" style={{ fontSize: 8, opacity: .7 }}>▼</span>
+          </button>
+          {openSort && (
+            <div className="tt-pop" role="listbox" aria-label="Ordina template">
+              <div className="tt-pophead">Ordina per</div>
+              {SORT_OPTS.map(o => (
+                <button key={o.id} type="button" role="option" aria-selected={st.sort === o.id}
+                  className={'tt-popitem' + (st.sort === o.id ? ' sel' : '')} onClick={() => { set({ sort: o.id }); setOpenSort(false); }}>
+                  <span className="check" aria-hidden="true">{st.sort === o.id ? '●' : ''}</span>
+                  <span className="lbl">{o.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {!mobile && (
+          <div className="tt-vtoggle" role="group" aria-label="Densità griglia">
+            <button aria-pressed={st.cols === 4} onClick={() => set({ cols: 4 })} title="Griglia 4 colonne" aria-label="Griglia 4 colonne">▦</button>
+            <button aria-pressed={st.cols === 3} onClick={() => set({ cols: 3 })} title="Griglia 3 colonne" aria-label="Griglia 3 colonne">▥</button>
+            <button aria-pressed={st.cols === 'list'} onClick={() => set({ cols: 'list' })} title="Vista lista" aria-label="Vista lista">☰</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / LOADING / ERROR ────────────────────────
+// ═══════════════════════════════════════════════════════
+const FilterEmpty = ({ onClear }) => (
+  <div className="tt-pad" aria-live="polite">
+    <div className="tt-empty">
+      <div className="em" aria-hidden="true">🔍</div>
+      <h3>Nessun template corrisponde ai filtri</h3>
+      <p>Prova a cambiare categoria o a modificare la ricerca per nome o creatore.</p>
+      <button className="cta" onClick={onClear}>Cancella filtri</button>
+    </div>
+  </div>
+);
+
+const Sk = ({ w, h, r = 'var(--r-sm)', style }) => <div className="tt-sk th-shimmer tt-shimmer" style={{ width: w, height: h, borderRadius: r, ...style }} />;
+const SkeletonGrid = ({ cols }) => (
+  <div className="tt-grid" style={{ '--cols': cols }} aria-busy="true">
+    {Array.from({ length: cols === 3 ? 6 : 8 }).map((_, i) => (
+      <div className="tt-skcard" key={i}>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <Sk w={30} h={30} r="var(--r-sm)" />
+          <div style={{ flex: 1 }}><Sk w="70%" h={15} style={{ marginBottom: 6 }} /><Sk w="40%" h={10} /></div>
+          <Sk w={66} h={12} />
+        </div>
+        <Sk w="100%" h={11} /><Sk w="82%" h={11} />
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 7 }}>
+          {[0, 1, 2, 3].map(j => <Sk key={j} w="100%" h={44} r="var(--r-sm)" />)}
+        </div>
+        <div style={{ flex: 1 }} />
+        <Sk w="100%" h={1} />
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}><Sk w={96} h={24} r="var(--r-pill)" /><Sk w={42} h={12} style={{ marginLeft: 'auto' }} /></div>
+        <Sk w="100%" h={38} r="var(--r-md)" />
+      </div>
+    ))}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── CLONE MODAL ────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const CloneModal = ({ t, mobile, onClose }) => {
+  const cat = CATS[t.category];
+  const closeRef = useRef(null);
+  const modalRef = useRef(null);
+  const [target, setTarget] = useState(LIB_GAMES[0] ? LIB_GAMES[0].id : '');
+  const [name, setName] = useState(`${t.name} (copia)`);
+  const [keepRatings, setKeepRatings] = useState(false);
+  const [editAfter, setEditAfter] = useState(true);
+
+  useEffect(() => { closeRef.current && closeRef.current.focus(); }, []);
+  useEffect(() => {
+    const onKey = e => {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key === 'Tab' && modalRef.current) {
+        const f = modalRef.current.querySelectorAll('button, input, select, [tabindex]:not([tabindex="-1"])');
+        if (!f.length) return;
+        const first = f[0], last = f[f.length - 1];
+        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const toolSummary = TOOL_ORDER.filter(k => t.tools[k] > 0)
+    .map(k => `${TOOL_META[k].icon} ${t.tools[k]} ${t.tools[k] === 1 ? TOOL_META[k].one : TOOL_META[k].label}`);
+
+  return (
+    <div className="tt-overlay" onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="tt-modal" ref={modalRef} role="dialog" aria-modal="true" aria-labelledby="tt-mtitle" style={{ '--e': catE(t.category) }}>
+        <div className="tt-mhead">
+          <span className="tt-mcov" aria-hidden="true">{cat.icon}</span>
+          <div className="tt-mhtxt">
+            <div className="tt-mtitle" id="tt-mtitle">Clona “{t.name}”</div>
+            <div className="tt-msub">{cat.label} · creato da {t.creator.name}{t.official ? ' · ⭐ ufficiale' : ''}</div>
+          </div>
+          <button type="button" className="tt-mclose" ref={closeRef} aria-label="Chiudi" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="tt-mbody">
+          <div className="tt-field">
+            <label htmlFor="tt-target">Gioco di destinazione</label>
+            <select id="tt-target" value={target} onChange={e => setTarget(e.target.value)}>
+              {LIB_GAMES.map(g => <option key={g.id} value={g.id}>{g.coverEmoji} {g.title}</option>)}
+            </select>
+          </div>
+
+          <div className="tt-field">
+            <label htmlFor="tt-name">Nome del nuovo toolkit</label>
+            <input id="tt-name" type="text" value={name} onChange={e => setName(e.target.value)} placeholder="Es. Catan — setup serata" />
+          </div>
+
+          <div className="tt-summary">
+            <div className="sh">Strumenti inclusi</div>
+            <div className="stools">
+              {toolSummary.map((s, i) => <span key={i} className="stool">{s}</span>)}
+            </div>
+          </div>
+
+          <button type="button" className={'tt-toggle' + (editAfter ? ' on' : '')} role="switch" aria-checked={editAfter} onClick={() => setEditAfter(v => !v)}>
+            <span className="tlbl"><div className="tt">Apri l’editor dopo la clonazione</div><div className="td">Personalizza tool e parametri subito dopo</div></span>
+            <span className="tt-sw" aria-hidden="true" />
+          </button>
+
+          <button type="button" className={'tt-toggle' + (keepRatings ? ' on' : '')} role="switch" aria-checked={keepRatings} onClick={() => setKeepRatings(v => !v)}>
+            <span className="tlbl"><div className="tt">Mantieni i valori predefiniti</div><div className="td">Conserva durate timer e soglie contatori originali</div></span>
+            <span className="tt-sw" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="tt-mfoot">
+          <button type="button" className="tt-mbtn" onClick={onClose}>Annulla</button>
+          <button type="button" className="tt-mbtn tk"><span aria-hidden="true">📋</span>Conferma clonazione</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HEADER (sticky + tabs) ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const TABS = [
+  { id: 'stats', icon: '📊', label: 'Stats', href: 'sp4-toolkit-stats.html' },
+  { id: 'history', icon: '📜', label: 'History', href: 'sp4-toolkit-history.html' },
+  { id: 'templates', icon: '🎨', label: 'Templates', href: null },
+  { id: 'play', icon: '🎮', label: 'Play', href: null },
+];
+const Header = ({ mobile, onCreate }) => (
+  <header className="tt-head">
+    <div className="tt-htop">
+      <div className="tt-htxt">
+        <div className="tt-bread"><span>Toolkit</span><span className="sep" aria-hidden="true">›</span><span className="cur">Templates</span></div>
+        <div className="tt-titlerow">
+          <span className="tt-ico" aria-hidden="true">🧰</span>
+          <h1 className="tt-h1">Template toolkit</h1>
+        </div>
+        {!mobile && <p className="tt-sub">Esplora i template approvati e clonali per il tuo gioco.</p>}
+      </div>
+      <div className="tt-hright">
+        <span className="tt-qstat"><b>{TOTAL}</b> template<span aria-hidden="true">·</span><b>{CAT_ORDER.length}</b> categorie<span aria-hidden="true">·</span><b>{CLONE_TOTAL}</b> cloni</span>
+        <button type="button" className="tt-cta" onClick={onCreate}><span aria-hidden="true">+</span>{mobile ? 'Crea' : 'Crea template'}</button>
+      </div>
+    </div>
+    <nav className="tt-tabs" role="tablist" aria-label="Sezioni toolkit">
+      {TABS.map(t => {
+        const on = t.id === 'templates';
+        const cls = 'tt-tab' + (on ? ' on' : '');
+        const inner = <React.Fragment><span aria-hidden="true">{t.icon}</span>{t.label}</React.Fragment>;
+        return t.href
+          ? <a key={t.id} href={t.href} className={cls} role="tab" aria-selected={false}>{inner}</a>
+          : <button key={t.id} type="button" role="tab" aria-selected={on} className={cls}>{inner}</button>;
+      })}
+    </nav>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── TEMPLATES APP (interactive, one per state×viewport) ─
+// ═══════════════════════════════════════════════════════
+const DEFAULT_ST = { search: '', cat: 'all', sort: 'popular', cols: 4 };
+
+const TemplatesApp = ({ scenario, mobile, tablet }) => {
+  const sc = scenario.sc || {};
+  const baseCols = mobile ? 1 : tablet ? 3 : 4;
+  const [st, setSt] = useState({ ...DEFAULT_ST, ...sc, cols: sc.cols || baseCols });
+  const [cloneT, setCloneT] = useState(sc.cloneId ? TEMPLATES.find(t => t.id === sc.cloneId) : null);
+  const [typing, setTyping] = useState(false);
+  const searchRef = useRef(null);
+  const typingTimer = useRef(null);
+  const loading = sc.loading, error = sc.error;
+
+  const set = patch => setSt(prev => ({ ...prev, ...patch }));
+
+  // debounce visual
+  useEffect(() => {
+    if (!st.search) { setTyping(false); return; }
+    setTyping(true);
+    clearTimeout(typingTimer.current);
+    typingTimer.current = setTimeout(() => setTyping(false), 650);
+    return () => clearTimeout(typingTimer.current);
+  }, [st.search]);
+
+  // keyboard: "/" focus search · 1-5 category (desktop)
+  useEffect(() => {
+    if (mobile) return;
+    const h = e => {
+      const tag = document.activeElement.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.key === '/') { e.preventDefault(); searchRef.current && searchRef.current.focus(); }
+      else if (e.key >= '1' && e.key <= '5') {
+        const map = ['all', ...CAT_ORDER];
+        const idx = Number(e.key) - 1;
+        if (map[idx]) set({ cat: map[idx] });
+      }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mobile]);
+
+  // filter + sort
+  const rows = useMemo(() => {
+    const q = st.search.trim().toLowerCase();
+    let out = TEMPLATES.filter(t => {
+      if (st.cat !== 'all' && t.category !== st.cat) return false;
+      if (q && !(t.name.toLowerCase().includes(q) || t.creator.name.toLowerCase().includes(q) || CATS[t.category].label.toLowerCase().includes(q))) return false;
+      return true;
+    });
+    out = [...out].sort((a, b) => {
+      if (st.sort === 'recent') return a.createdAt < b.createdAt ? 1 : -1;
+      if (st.sort === 'rating') return b.rating - a.rating || b.usageCount - a.usageCount;
+      if (st.sort === 'alpha') return a.name.localeCompare(b.name);
+      return b.usageCount - a.usageCount; // popular
+    });
+    return out;
+  }, [st.search, st.cat, st.sort]);
+
+  const nActive = (st.cat !== 'all' ? 1 : 0) + (st.search.trim() ? 1 : 0);
+  const clearAll = () => set({ search: '', cat: 'all' });
+  const gridCols = mobile ? 1 : st.cols;
+  const isList = !mobile && st.cols === 'list';
+  const sumE = st.cat !== 'all' ? catE(st.cat) : 'hsl(var(--c-toolkit))';
+
+  let body;
+  if (loading) body = <SkeletonGrid cols={typeof gridCols === 'number' ? gridCols : 4} />;
+  else if (rows.length === 0) body = <FilterEmpty onClear={clearAll} />;
+  else body = (
+    <div className={'tt-grid' + (isList ? ' list' : '')} style={{ '--cols': typeof gridCols === 'number' ? gridCols : 4 }} role="list" aria-label="Galleria template">
+      {rows.map(t => <TemplateCard key={t.id} t={t} onClone={setCloneT} />)}
+    </div>
+  );
+
+  return (
+    <div className={'tt-app' + (mobile ? ' is-mobile' : '')}>
+      {error && (
+        <div className="tt-errbar" role="alert">
+          <span aria-hidden="true">⚠</span>Impossibile caricare i template — riprova.
+          <span className="grow" />
+          <button className="retry"><span aria-hidden="true">↻</span> Riprova</button>
+        </div>
+      )}
+      <Header mobile={mobile} onCreate={() => {}} />
+      {!error && <Toolbar st={st} set={set} typing={typing} searchRef={searchRef} mobile={mobile} />}
+      {!error && !loading && nActive > 0 && rows.length > 0 && (
+        <div className="tt-fsum" style={{ '--e': sumE }}>
+          <span className="badge"><span aria-hidden="true">⚑</span>{nActive} {nActive === 1 ? 'filtro attivo' : 'filtri attivi'}</span>
+          <span>·</span>
+          <span>{rows.length} {rows.length === 1 ? 'template' : 'template'} su {TOTAL}</span>
+          <span className="grow" />
+          <button className="clear" onClick={clearAll}>Cancella filtri</button>
+        </div>
+      )}
+      <div className="tt-body" aria-busy={loading ? 'true' : undefined}>{!error && body}</div>
+      {cloneT && <CloneModal t={cloneT} mobile={mobile} onClose={() => setCloneT(null)} />}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ width = '100%', height = 686, children }) => (
+  <div style={{
+    width, borderRadius: 'var(--r-xl)', border: '1px solid var(--border)',
+    background: 'var(--bg-card)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)',
+  }}>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: '9px 14px',
+      background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)',
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840' }} />
+      <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.04em' }}>meepleai.app/toolkit/templates</span>
+    </div>
+    <div style={{ height }}>{children}</div>
+  </div>
+);
+
+const PhoneFrame = ({ children }) => (
+  <div className="phone" style={{ width: 375, height: 760 }}>
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>14:32</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+    <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>{children}</div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE PICKER + ROOT ────────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATES = [
+  { id: 'default',          label: 'Default',           view: 'desktop', sc: {}, desc: '24 template, grid 4-col, nessun filtro, ordinamento "più popolari". Mix di card default / ufficiali / popolari / nuove.' },
+  { id: 'filter-strategy',  label: 'Filter · Strategy', view: 'desktop', sc: { cat: 'Strategy' }, desc: 'Chip "Strategy" attivo (single-select radiogroup) → 8 card, badge "1 filtro attivo", accent --c-game.' },
+  { id: 'filter-empty',     label: 'Filter · 0 match',  view: 'desktop', sc: { cat: 'Cooperative', search: 'briscola' }, desc: 'Categoria "Cooperative" + ricerca "briscola" → 0 corrispondenze → empty state con CTA "Cancella filtri".' },
+  { id: 'default-3col-tablet', label: 'Tablet · 3-col', view: 'tablet', sc: { cols: 3 }, desc: 'Viewport 768px: grid 3-col, toolbar wrappa, card invariate. Stesso contenuto del default.' },
+  { id: 'clone-modal-open', label: 'Clone modal',       view: 'desktop', sc: { cloneId: TEMPLATES[0].id }, desc: 'Modal "Clona template" su Strategy Standard: gioco target, nuovo nome, riepilogo strumenti, due opzioni, CTA conferma.' },
+  { id: 'loading',          label: 'Loading',           view: 'desktop', sc: { loading: true }, desc: 'Skeleton shimmer: header + toolbar + 8 card placeholder con composizione tool.' },
+  { id: 'error',            label: 'Error',             view: 'desktop', sc: { error: true }, desc: 'Banner danger in alto + Riprova; toolbar e grid nascosti.' },
+  { id: 'mobile-stack',     label: 'Mobile · stack',    view: 'mobile',  sc: {}, desc: 'Viewport 375px: card full-width in colonna singola, chip categoria con scroll orizzontale, modal come bottom-sheet.' },
+];
+const SKEY = 'tt-state';
+
+const VpLabel = ({ children }) => (
+  <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>{children}</div>
+);
+
+const App = () => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || document.documentElement.getAttribute('data-theme') || 'light');
+  const [active, setActive] = useState(() => {
+    const s = localStorage.getItem(SKEY);
+    return STATES.some(x => x.id === s) ? s : 'default';
+  });
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem(SKEY, active); }, [active]);
+
+  const cur = STATES.find(s => s.id === active) || STATES[0];
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', padding: '20px 20px 80px' }}>
+      <style dangerouslySetInnerHTML={{ __html: window.__TT_CSS }} />
+
+      {/* state picker bar */}
+      <header style={{
+        position: 'sticky', top: 12, zIndex: 50, maxWidth: 1320, margin: '0 auto 24px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(16px)',
+        border: '1px solid var(--border)', borderRadius: 'var(--r-xl)',
+        boxShadow: 'var(--shadow-md)', padding: '12px 16px',
+        display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <div style={{
+            width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+            background: `linear-gradient(135deg, ${eHsl('toolkit')}, ${eHsl('game')})`,
+            color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 800, fontFamily: 'var(--f-display)', fontSize: 14,
+          }}>S</div>
+          <div>
+            <div style={{ fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 14, lineHeight: 1.1 }}>Toolkit Templates</div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)' }}>#1490 · 3/4 · /toolkit/templates</div>
+          </div>
+        </div>
+
+        <div role="tablist" aria-label="Stati schermata" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
+          {STATES.map(s => {
+            const on = s.id === active;
+            return (
+              <button key={s.id} type="button" role="tab" aria-selected={on} onClick={() => setActive(s.id)} style={{
+                padding: '7px 12px', borderRadius: 'var(--r-pill)', cursor: 'pointer',
+                background: on ? eHsl('toolkit') : 'var(--bg-muted)',
+                border: on ? 'none' : '1px solid var(--border)',
+                color: on ? '#fff' : 'var(--text-sec)',
+                fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, whiteSpace: 'nowrap',
+                boxShadow: on ? `0 3px 10px ${eHsl('toolkit', 0.35)}` : 'none',
+              }}>{s.label}</button>
+            );
+          })}
+        </div>
+
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{
+          padding: '8px 14px', borderRadius: 'var(--r-md)', flexShrink: 0,
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer',
+        }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* active state description */}
+      <div style={{ maxWidth: 1320, margin: '0 auto 18px', padding: '0 4px', fontFamily: 'var(--f-mono)', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <strong style={{ color: eHsl('toolkit') }}>{cur.label}</strong> — {cur.desc}
+      </div>
+
+      {/* render area */}
+      <div style={{ maxWidth: 1320, margin: '0 auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 36 }}>
+        {cur.view === 'desktop' && (
+          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Desktop · 1440 — hero + grid gallery 4-col</VpLabel>
+            <DesktopFrame>
+              <TemplatesApp key={'d-' + cur.id} scenario={cur} mobile={false} />
+            </DesktopFrame>
+          </div>
+        )}
+        {cur.view === 'tablet' && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Tablet · 768 — grid gallery 3-col</VpLabel>
+            <DesktopFrame width={768} height={720}>
+              <TemplatesApp key={'t-' + cur.id} scenario={cur} mobile={false} tablet={true} />
+            </DesktopFrame>
+          </div>
+        )}
+        {cur.view === 'mobile' && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Mobile · 375 — stack 1-col + bottom-sheet modal</VpLabel>
+            <PhoneFrame>
+              <TemplatesApp key={'m-' + cur.id} scenario={cur} mobile={true} />
+            </PhoneFrame>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-toolkit-templates.html
+++ b/admin-mockups/design_files/sp4-toolkit-templates.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<!-- route: /toolkit/templates — Gallery template toolkit con filter categoria + Clone CTA + ratings -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /toolkit/templates — Template toolkit</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ─── Helper classes (continuity con cluster #1490 S1+S2) ─── */
+  @keyframes tt-shimmer { 0% { background-position: -400px 0; } 100% { background-position: 400px 0; } }
+  .tt-shimmer, .th-shimmer {
+    background: linear-gradient(90deg, var(--bg-muted) 25%, var(--bg-sunken) 37%, var(--bg-muted) 63%);
+    background-size: 800px 100%;
+    animation: tt-shimmer 1.4s linear infinite;
+  }
+  @keyframes tt-typedot { 0%,100% { opacity: 1; transform: scale(1); } 50% { opacity: .3; transform: scale(.6); } }
+  @keyframes tt-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes tt-modal-in { from { opacity: 0; transform: translateY(14px) scale(.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
+  @keyframes tt-sheet-in { from { transform: translateY(100%); } to { transform: translateY(0); } }
+
+  /* Focus ring — keyboard only, toolkit entity */
+  a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid hsl(var(--c-toolkit));
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tt-shimmer, .th-shimmer { animation: none !important; }
+    .tt-overlay, .tt-modal { animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-toolkit-templates.jsx?v=1"></script>
+<script type="text/babel" src="sp4-toolkit-templates-ui.jsx?v=1"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-toolkit-templates.jsx
+++ b/admin-mockups/design_files/sp4-toolkit-templates.jsx
@@ -1,0 +1,414 @@
+/* MeepleAI SP4 wave 4 — S · #1490 · 3/4 — sp4-toolkit-templates
+   Route: /toolkit/templates — Gallery dei template toolkit approvati clonabili.
+          Un template è un "preset toolkit" pre-configurato con set di tool
+          (dice / cards / timer / counter) bilanciati per un tipo di gioco.
+   File: admin-mockups/design_files/sp4-toolkit-templates.{html,jsx,-ui.jsx}
+   Pattern: Hero + body con grid gallery (riusa grid sp4-library-desktop +
+            filter chips / search debounce da S2 #1490). NO sidebar, NO split-view.
+            Desktop = grid 4-col, tablet 3-col, mobile 2-col / 1-col.
+
+   Source restyle (NO ridisegnare logica):
+     apps/web/src/app/(authenticated)/toolkit/templates/page.tsx
+   API: api.gameToolkit.getApprovedTemplates(category?) →
+        Array<{ id, name, diceTools[], cardTools[], timerTools[], counterTools[],
+                stateTemplate{category,description}, creator{name,userId,isOfficial},
+                usageCount, rating, createdAt }>
+
+   Entity: --c-toolkit (verde, continuity con S1+S2) primaria · category entities:
+           Strategy→--c-game · Party→--c-event · CardGames→--c-kb · Cooperative→--c-success.
+           Creator → EntityChip --c-player. Tool types (dice/cards/timer/counter) = internal.
+
+   8 stati (state picker continuity, persistito localStorage `tt-state`):
+     default · filter-strategy · filter-empty · default-3col-tablet ·
+     clone-modal-open · loading · error · mobile-stack
+
+   Deviazione flaggata: i template "ufficiali" sono attribuiti a creator reali
+   (Marco R. / Sara T. / Aaron R.) con flag isOfficial=true (curati/verificati dal team),
+   per rispettare "dati realistici" del _common.md invece di un autore di sistema anonimo.
+*/
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const DS = window.DS;
+
+const eHsl = (type, a) => {
+  const c = DS.EC[type] || DS.EC.toolkit;
+  return a !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${a})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+const sem = (name, a) => a !== undefined ? `hsl(var(--c-${name}) / ${a})` : `hsl(var(--c-${name}))`;
+
+const MONTHS_SHORT = ['gen','feb','mar','apr','mag','giu','lug','ago','set','ott','nov','dic'];
+const PAD = n => String(n).padStart(2, '0');
+const NOW = new Date(2026, 4, 28, 16, 5); // 28 mag 2026 (allineato a S2)
+const fmtDate = d => `${d.getDate()} ${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()}`;
+function relDate(d, now) {
+  const days = Math.round((now - d) / 86400000);
+  if (days <= 0) return 'oggi';
+  if (days === 1) return 'ieri';
+  if (days < 7) return `${days} giorni fa`;
+  if (days < 30) return `${Math.floor(days / 7)} settimane fa`;
+  if (days < 365) return `${Math.floor(days / 30)} mesi fa`;
+  return `${Math.floor(days / 365)} anni fa`;
+}
+
+// ═══════════════════════════════════════════════════════
+// ─── CATEGORY META (entity-mapped) ──────────────────
+// ═══════════════════════════════════════════════════════
+const CATS = {
+  Strategy:    { key: 'Strategy',    label: 'Strategy',    it: 'Strategia',   icon: '🎯', ent: 'game' },
+  Party:       { key: 'Party',       label: 'Party',       it: 'Party',       icon: '🎉', ent: 'event' },
+  CardGames:   { key: 'CardGames',   label: 'Card Games',  it: 'Carte',       icon: '📄', ent: 'kb' },
+  Cooperative: { key: 'Cooperative', label: 'Cooperative', it: 'Cooperativo', icon: '🤝', ent: 'success' },
+};
+const CAT_ORDER = ['Strategy', 'Party', 'CardGames', 'Cooperative'];
+
+// tool type meta (internal, NON entity)
+const TOOL_META = {
+  dice:    { icon: '🎲', label: 'dadi',      one: 'dado',      tip: c => `${c} ${c === 1 ? 'dado' : 'dadi'} · 6 facce` },
+  cards:   { icon: '🃏', label: 'mazzi',     one: 'mazzo',     tip: c => `${c} ${c === 1 ? 'mazzo' : 'mazzi'} di carte` },
+  timer:   { icon: '⏱️', label: 'timer',     one: 'timer',     tip: c => `${c} timer turno` },
+  counter: { icon: '🔢', label: 'contatori', one: 'contatore', tip: c => `${c} ${c === 1 ? 'contatore' : 'contatori'}` },
+};
+const TOOL_ORDER = ['dice', 'cards', 'timer', 'counter'];
+
+// creators (cross-ref data.js players + 1 extra)
+const CREATORS = {
+  'Marco R.': { name: 'Marco R.', initials: 'MR', color: 262 },
+  'Sara T.':  { name: 'Sara T.',  initials: 'ST', color: 320 },
+  'Aaron R.': { name: 'Aaron R.', initials: 'AR', color: 38  },
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FIXTURE — 24 template deterministici ───────────
+// ═══════════════════════════════════════════════════════
+// [name, cat, desc, dice, cards, timer, counter, creator, official, usage, rating, daysAgo, pending]
+const RAW = [
+  // ── Strategy (8) ──
+  ['Strategy Standard', 'Strategy', 'Setup classico per giochi euro e familiari: dadi, timer e contatori bilanciati per partite fluide.', 2, 0, 1, 4, 'Marco R.', false, 124, 4.5, 210, false],
+  ['Euro Classico', 'Strategy', 'Per gestionali a piazzamento lavoratori: nessun dado, molti contatori risorsa da tracciare.', 0, 0, 1, 6, 'Sara T.', false, 98, 4.0, 150, false],
+  ['Worker Placement Pro', 'Strategy', 'Preset curato per piazzamento lavoratori competitivo, con timer per turno e tracker azioni.', 0, 0, 1, 5, 'Sara T.', true, 156, 5.0, 300, false],
+  ['Engine Builder', 'Strategy', 'Ottimizzato per motori di produzione: un mazzo sviluppo e sei contatori sinergia, niente timer.', 0, 1, 0, 6, 'Marco R.', false, 67, 4.0, 70, false],
+  ['Heavy Eurogame', 'Strategy', 'Configurazione pesante per partite lunghe: due timer di fase e otto contatori per economie complesse.', 1, 0, 2, 8, 'Aaron R.', false, 41, 4.5, 95, false],
+  ['Tableau Builder', 'Strategy', 'Costruzione tableau con due mazzi carte e quattro contatori di combo e ricorrenze.', 0, 2, 0, 4, 'Aaron R.', false, 52, 4.0, 25, false],
+  ['4X Galattico', 'Strategy', 'Esplora, espandi, sfrutta, stermina: dadi combattimento, mazzo tecnologie e tracker territori.', 3, 1, 1, 5, 'Sara T.', false, 33, 3.5, 40, false],
+  ['Economic Sim', 'Strategy', 'Simulazione economica avanzata con mercato dinamico — preset in fase di approvazione dal team.', 2, 0, 2, 7, 'Marco R.', false, 0, 0, 3, true],
+
+  // ── Party (6) ──
+  ['Party Quick', 'Party', 'Veloce e leggero per serate in compagnia: due dadi e due contatori punteggio, zero attese.', 2, 0, 0, 2, 'Sara T.', true, 142, 4.5, 180, false],
+  ['Social Deduction', 'Party', 'Per giochi di ruolo nascosto: timer di discussione e contatori voti e sospetti.', 0, 2, 1, 2, 'Aaron R.', false, 89, 4.5, 110, false],
+  ['Festa Veloce', 'Party', 'Round rapidi a squadre: un dado, un mazzo prove e tre contatori punteggio.', 1, 1, 0, 3, 'Marco R.', false, 76, 4.0, 60, false],
+  ['Family Fun', 'Party', 'Pensato per famiglie e bambini: dado singolo e due contatori, nessuno stress da setup.', 1, 0, 0, 2, 'Marco R.', false, 63, 4.0, 20, false],
+  ['Quiz Night', 'Party', 'Serata quiz a squadre: timer di risposta e quattro contatori, uno per ogni team.', 0, 0, 1, 4, 'Sara T.', false, 54, 3.5, 30, false],
+  ['Goliardia', 'Party', 'Nuovo preset per serate goliardiche: dadi penalità e timer sfida a rotazione.', 2, 1, 1, 0, 'Aaron R.', false, 12, 3.5, 4, false],
+
+  // ── CardGames (5) ──
+  ['Deck Builder', 'CardGames', 'Preset curato per deck-building: mazzo principale, scarti e quattro contatori risorse.', 0, 3, 0, 4, 'Marco R.', true, 134, 4.5, 250, false],
+  ['Card Battle', 'CardGames', 'Scontri a carte uno contro uno: due mazzi e tre contatori per vita ed energia.', 0, 2, 0, 3, 'Marco R.', false, 71, 4.0, 85, false],
+  ['Briscola Digitale', 'CardGames', 'Classici italiani di carte: mazzo da 40 e due contatori per il punteggio delle mani.', 0, 1, 0, 2, 'Aaron R.', false, 58, 4.5, 33, false],
+  ['Trick Taking', 'CardGames', 'Per giochi di prese: mazzo da 52, timer di mano e due contatori prese vinte.', 0, 1, 1, 2, 'Sara T.', false, 47, 4.0, 45, false],
+  ['Solitario Pro', 'CardGames', 'Solitari avanzati con sfida a tempo: due mazzi, un timer e un contatore mosse.', 0, 2, 1, 1, 'Marco R.', false, 22, 3.5, 12, false],
+
+  // ── Cooperative (5) ──
+  ['Pandemic Style', 'Cooperative', 'Preset curato per cooperativi a diffusione: dado eventi, mazzo crisi e contatori focolaio.', 1, 1, 0, 6, 'Aaron R.', true, 119, 5.0, 220, false],
+  ['Co-op Survival', 'Cooperative', 'Sopravvivenza cooperativa: dadi minaccia e cinque contatori per risorse condivise dal gruppo.', 2, 0, 0, 5, 'Sara T.', false, 81, 4.5, 130, false],
+  ['Dungeon Crawler', 'Cooperative', 'Esplorazione dungeon in squadra: dadi combattimento, mazzo eventi e contatori HP per eroe.', 3, 2, 0, 4, 'Aaron R.', false, 64, 4.0, 50, false],
+  ['Spirit Sync', 'Cooperative', 'Sinergia tra spiriti: nessun dado, mazzo poteri e cinque contatori energia e presenza.', 0, 2, 0, 5, 'Marco R.', false, 38, 4.5, 28, false],
+  ['Legacy Campaign', 'Cooperative', 'Campagna legacy persistente: timer di sessione, mazzo storia e sei contatori di progressione.', 1, 1, 1, 6, 'Sara T.', false, 9, 4.0, 5, false],
+];
+
+function buildTemplates() {
+  return RAW.map((r, i) => {
+    const [name, category, description, dice, cards, timer, counter, creatorName, official, usageCount, rating, daysAgo, pending] = r;
+    const createdAt = new Date(NOW.getTime() - daysAgo * 86400000);
+    const tools = { dice, cards, timer, counter };
+    const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+    return {
+      id: `tpl-${PAD(i)}-${slug}`,
+      name, category, description, tools,
+      creator: { ...CREATORS[creatorName], isOfficial: official },
+      usageCount, rating, createdAt, daysAgo,
+      pending: !!pending,
+      popular: usageCount > 100 && !pending,
+      recent: daysAgo < 7 && !pending,
+      official,
+      // deterministic "growth this week" for popular cards
+      weekGrowth: usageCount > 100 ? 6 + (i % 9) : 0,
+    };
+  });
+}
+const TEMPLATES = buildTemplates();
+const TOTAL = TEMPLATES.length;
+const CLONE_TOTAL = TEMPLATES.reduce((a, t) => a + t.usageCount, 0);
+const CAT_COUNTS = Object.fromEntries(CAT_ORDER.map(c => [c, TEMPLATES.filter(t => t.category === c).length]));
+
+// games library for the clone modal target dropdown
+const LIB_GAMES = DS.games.filter(g => g.status === 'owned');
+
+window.__TT_CSS = ''; // filled below
+window.__TT = {
+  eHsl, sem, fmtDate, relDate, NOW,
+  CATS, CAT_ORDER, CAT_COUNTS, TOOL_META, TOOL_ORDER, CREATORS,
+  TEMPLATES, TOTAL, CLONE_TOTAL, LIB_GAMES,
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── COMPONENT CSS (inject) — solo token da tokens.css ──
+// ═══════════════════════════════════════════════════════
+const TT_CSS = `
+.tt-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+
+/* ─ error banner ─ */
+.tt-errbar { flex-shrink:0; display:flex; align-items:center; gap:11px; padding:11px 18px; font-family:var(--f-display); font-weight:700; font-size:13px;
+  background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); border-bottom:1px solid hsl(var(--c-danger) / .3); }
+.tt-errbar .grow { flex:1; }
+.tt-errbar .retry { display:inline-flex; align-items:center; gap:6px; padding:6px 13px; border-radius:var(--r-md); border:1px solid hsl(var(--c-danger) / .4);
+  background:var(--bg-card); color:hsl(var(--c-danger)); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; }
+
+/* ─ header (sticky) ─ */
+.tt-head { flex-shrink:0; position:sticky; top:0; z-index:12; background:var(--glass-bg); backdrop-filter:blur(14px); border-bottom:1px solid var(--border); padding:14px 22px 0; }
+.tt-htop { display:flex; align-items:flex-start; gap:16px; }
+.tt-htxt { min-width:0; flex:1; }
+.tt-bread { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:7px; }
+.tt-bread .sep { opacity:.5; }
+.tt-bread .cur { color:var(--text-sec); font-weight:700; }
+.tt-titlerow { display:flex; align-items:center; gap:10px; }
+.tt-ico { width:34px; height:34px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-toolkit) / .16); color:hsl(var(--c-toolkit));
+  display:inline-flex; align-items:center; justify-content:center; font-size:18px; }
+.tt-h1 { font-family:var(--f-display); font-weight:800; font-size:30px; letter-spacing:-.02em; line-height:1.1; color:var(--text); white-space:nowrap; }
+.tt-sub { font-size:14px; color:var(--text-sec); margin-top:5px; max-width:560px; }
+.tt-hright { display:flex; flex-direction:column; align-items:flex-end; gap:10px; flex-shrink:0; }
+.tt-qstat { display:inline-flex; align-items:center; gap:7px; font-family:var(--f-mono); font-size:11px; color:var(--text-muted); white-space:nowrap; }
+.tt-qstat b { color:var(--text-sec); font-weight:700; }
+.tt-cta { display:inline-flex; align-items:center; gap:7px; padding:9px 16px; border-radius:var(--r-md); background:hsl(var(--c-toolkit));
+  border:none; color:#fff; font-family:var(--f-display); font-weight:800; font-size:13px; cursor:pointer; white-space:nowrap;
+  box-shadow:0 4px 14px hsl(var(--c-toolkit) / .35); transition:all var(--dur-sm) var(--ease-out); }
+.tt-cta:hover { filter:brightness(1.05); transform:translateY(-1px); }
+
+/* ─ tabs nav ─ */
+.tt-tabs { display:flex; gap:4px; margin-top:14px; overflow-x:auto; scrollbar-width:none; }
+.tt-tabs::-webkit-scrollbar { display:none; }
+.tt-tab { display:inline-flex; align-items:center; gap:6px; padding:9px 14px 11px; border:none; background:transparent; cursor:pointer; white-space:nowrap;
+  border-bottom:2px solid transparent; color:var(--text-muted); font-family:var(--f-display); font-weight:700; font-size:13px; transition:color var(--dur-sm); text-decoration:none; }
+.tt-tab:hover { color:var(--text-sec); }
+.tt-tab.on { color:hsl(var(--c-toolkit)); border-bottom-color:hsl(var(--c-toolkit)); }
+
+/* ─ toolbar ─ */
+.tt-toolbar { flex-shrink:0; display:flex; align-items:center; gap:12px; padding:11px 22px; background:var(--bg); border-bottom:1px solid var(--border); flex-wrap:wrap; row-gap:10px; }
+.tt-search { flex:0 1 300px; max-width:340px; min-width:160px; position:relative; }
+.tt-search .ic { position:absolute; left:11px; top:50%; transform:translateY(-50%); font-size:13px; opacity:.6; pointer-events:none; }
+.tt-search input { width:100%; padding:9px 70px 9px 32px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:13px; color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.tt-search input::placeholder { color:var(--text-muted); }
+.tt-search input:focus, .tt-search.active input { border-color:hsl(var(--c-toolkit) / .6); box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .14); }
+.tt-search .clear { position:absolute; right:9px; top:50%; transform:translateY(-50%); width:20px; height:20px; border-radius:var(--r-pill);
+  border:none; background:var(--bg-muted); color:var(--text-sec); cursor:pointer; font-size:11px; display:inline-flex; align-items:center; justify-content:center; }
+.tt-search .clear:hover { background:var(--border-strong); color:var(--text); }
+.tt-search .busy { position:absolute; right:34px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; gap:5px;
+  font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-info)); white-space:nowrap; }
+.tt-search .busy i { width:6px; height:6px; border-radius:50%; background:currentColor; animation:tt-typedot 1s var(--ease-in-out) infinite; }
+
+/* category filter chips (radiogroup, single-select) */
+.tt-chips { flex:1 1 auto; display:flex; align-items:center; gap:8px; flex-wrap:wrap; row-gap:8px; min-width:0; padding:2px; }
+.tt-chips.scroll { flex-wrap:nowrap; overflow-x:auto; scrollbar-width:none; }
+.tt-chips.scroll::-webkit-scrollbar { display:none; }
+.tt-chip { display:inline-flex; align-items:center; gap:7px; padding:7px 13px; border-radius:var(--r-pill); white-space:nowrap; flex-shrink:0;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out);
+  font-family:var(--f-display); font-weight:700; font-size:12.5px; }
+.tt-chip:hover { background:var(--bg-hover); }
+.tt-chip .cdot { width:8px; height:8px; border-radius:50%; flex-shrink:0; background:var(--text-muted); }
+.tt-chip .ccount { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); opacity:.9; }
+/* "Tutte" = neutral toolkit */
+.tt-chip.all.on { color:var(--text); background:var(--bg-muted); border-color:var(--border-strong); }
+.tt-chip.all.on .cdot { background:hsl(var(--c-toolkit)); }
+.tt-chip.all.on .ccount { color:var(--text-sec); }
+/* category-tinted active (via --e) */
+.tt-chip.cat .cdot { background:hsl(var(--e)); }
+.tt-chip.cat.on { background:hsl(var(--e) / .14); border-color:hsl(var(--e) / .4); color:hsl(var(--e)); }
+.tt-chip.cat.on .ccount { color:currentColor; }
+
+/* right cluster: sort + view */
+.tt-right { flex-shrink:0; display:flex; align-items:center; gap:10px; }
+.tt-fgroup { position:relative; display:flex; align-items:center; }
+.tt-sortbtn { display:inline-flex; align-items:center; gap:7px; padding:8px 13px; border-radius:var(--r-md); background:var(--bg-card); border:1.5px solid var(--border);
+  color:var(--text-sec); cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:12.5px; white-space:nowrap; }
+.tt-sortbtn:hover { background:var(--bg-hover); }
+.tt-pop { position:absolute; top:calc(100% + 6px); right:0; z-index:30; background:var(--bg-card); border:1px solid var(--border);
+  border-radius:var(--r-md); box-shadow:var(--shadow-lg); padding:6px; min-width:210px; display:flex; flex-direction:column; gap:2px; }
+.tt-pophead { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); padding:4px 8px 6px; }
+.tt-popitem { display:flex; align-items:center; gap:9px; width:100%; padding:8px 10px; border-radius:var(--r-sm); border:none; background:transparent; cursor:pointer;
+  color:var(--text); font-family:var(--f-display); font-weight:600; font-size:13px; text-align:left; }
+.tt-popitem:hover { background:var(--bg-muted); }
+.tt-popitem .check { width:16px; height:16px; border-radius:50%; border:1.5px solid var(--border-strong); flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; font-size:10px; color:hsl(var(--c-toolkit)); }
+.tt-popitem.sel .check { border-color:hsl(var(--c-toolkit)); }
+.tt-popitem .lbl { flex:1; }
+
+.tt-vtoggle { display:inline-flex; padding:3px; gap:2px; background:var(--bg-muted); border-radius:var(--r-md); border:1px solid var(--border); }
+.tt-vtoggle button { display:inline-flex; align-items:center; gap:5px; padding:6px 10px; border-radius:var(--r-sm); border:none; background:transparent; color:var(--text-muted);
+  font-family:var(--f-display); font-weight:700; font-size:11px; cursor:pointer; }
+.tt-vtoggle button[aria-pressed="true"] { background:var(--bg-card); color:hsl(var(--c-toolkit)); box-shadow:var(--shadow-xs); }
+
+/* active filter summary */
+.tt-fsum { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:8px 22px; background:var(--bg-sunken); border-bottom:1px solid var(--border-light);
+  font-family:var(--f-mono); font-size:11px; color:var(--text-sec); }
+.tt-fsum .badge { display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:var(--r-pill); background:hsl(var(--e, var(--c-toolkit)) / .14); color:hsl(var(--e)); font-weight:700; }
+.tt-fsum .clear { background:transparent; border:none; cursor:pointer; color:hsl(var(--c-warning)); font-family:var(--f-display); font-weight:800; font-size:12px; }
+.tt-fsum .grow { flex:1; }
+
+/* ─ body / grid ─ */
+.tt-body { flex:1; overflow:auto; min-height:0; position:relative; padding:18px 22px 26px; }
+.tt-grid { display:grid; gap:16px; grid-template-columns:repeat(var(--cols, 4), minmax(0, 1fr)); }
+.tt-grid.list { grid-template-columns:1fr; gap:11px; }
+
+/* ─ template card ─ */
+.tt-card { position:relative; display:flex; flex-direction:column; gap:13px; min-height:322px; padding:17px 16px 16px;
+  background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--r-lg); box-shadow:var(--shadow-sm);
+  transition:box-shadow var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out), transform var(--dur-sm) var(--ease-out); }
+.tt-card:hover { box-shadow:var(--shadow-md); border-color:hsl(var(--c-toolkit) / .4); transform:translateY(-2px); }
+.tt-card.official { border-color:hsl(var(--c-toolkit) / .35); box-shadow:0 0 0 1px hsl(var(--c-toolkit) / .12), var(--shadow-sm); }
+.tt-card.pending { opacity:.66; }
+.tt-card.pending:hover { transform:none; box-shadow:var(--shadow-sm); border-color:var(--border-light); }
+
+/* corner badges */
+.tt-corner { position:absolute; top:-9px; right:13px; display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill);
+  font-family:var(--f-display); font-weight:800; font-size:10px; letter-spacing:.04em; text-transform:uppercase; box-shadow:var(--shadow-xs); z-index:2; }
+.tt-corner.new { background:hsl(var(--c-info)); color:#fff; }
+.tt-crown { position:absolute; top:-10px; left:13px; width:24px; height:24px; border-radius:var(--r-pill); display:inline-flex; align-items:center; justify-content:center;
+  background:hsl(var(--c-warning)); color:#fff; font-size:12px; box-shadow:var(--shadow-sm); z-index:2; }
+
+/* card header */
+.tt-chead { display:flex; align-items:flex-start; gap:10px; }
+.tt-cicon { width:30px; height:30px; flex-shrink:0; border-radius:var(--r-sm); display:inline-flex; align-items:center; justify-content:center; font-size:16px;
+  background:hsl(var(--e) / .14); }
+.tt-chtxt { flex:1; min-width:0; }
+.tt-cname { font-family:var(--f-display); font-weight:800; font-size:16px; line-height:1.2; color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  border:none; background:transparent; padding:0; cursor:pointer; text-align:left; width:100%; }
+.tt-cname:hover { color:hsl(var(--c-toolkit)); }
+.tt-ccat { font-family:var(--f-mono); font-size:10px; color:hsl(var(--e)); text-transform:uppercase; letter-spacing:.05em; margin-top:3px; font-weight:600; }
+.tt-rating { display:inline-flex; align-items:center; gap:1px; flex-shrink:0; }
+.tt-star { font-size:12px; line-height:1; position:relative; color:var(--border-strong); }
+.tt-star.full { color:hsl(var(--c-warning)); }
+.tt-star.half { color:var(--border-strong); }
+.tt-star.half::before { content:'★'; position:absolute; left:0; top:0; width:50%; overflow:hidden; color:hsl(var(--c-warning)); }
+.tt-ratenew { font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-info)); font-weight:700; padding:2px 7px; border-radius:var(--r-pill); background:hsl(var(--c-info) / .12); }
+
+/* description */
+.tt-desc { font-size:12.5px; color:var(--text-sec); line-height:var(--lh-snug); margin:0;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; min-height:34px; }
+
+/* tool composition */
+.tt-tools { display:grid; grid-template-columns:repeat(4, 1fr); gap:7px; }
+.tt-tool { display:flex; flex-direction:column; align-items:center; gap:3px; padding:9px 4px; border-radius:var(--r-sm);
+  background:var(--bg-muted); border:1px solid var(--border-light); position:relative; cursor:default; }
+.tt-tool.empty { opacity:.4; }
+.tt-tool .ti { font-size:15px; line-height:1; }
+.tt-tool .tc { font-family:var(--f-mono); font-size:13px; font-weight:700; color:var(--text); font-variant-numeric:tabular-nums; }
+.tt-tool.empty .tc { color:var(--text-muted); font-weight:600; }
+.tt-tool .tip { position:absolute; bottom:calc(100% + 6px); left:50%; transform:translateX(-50%); white-space:nowrap; z-index:5;
+  background:var(--text); color:var(--bg-card); font-family:var(--f-mono); font-size:10px; padding:4px 8px; border-radius:var(--r-xs);
+  opacity:0; pointer-events:none; transition:opacity var(--dur-xs); box-shadow:var(--shadow-md); }
+.tt-tool:hover .tip { opacity:1; }
+
+.tt-spacer { flex:1; }
+
+/* divider */
+.tt-cdiv { height:1px; background:var(--border-light); }
+
+/* creator + meta row */
+.tt-meta { display:flex; align-items:center; gap:8px; }
+.tt-creator { display:inline-flex; align-items:center; gap:7px; min-width:0; padding:3px 9px 3px 3px; border-radius:var(--r-pill);
+  background:hsl(var(--c-player) / .1); border:1px solid hsl(var(--c-player) / .2); }
+.tt-cav { width:18px; height:18px; flex-shrink:0; border-radius:50%; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--f-display); font-size:8px; font-weight:800; color:#fff; }
+.tt-cnm { font-family:var(--f-display); font-weight:700; font-size:11.5px; color:hsl(var(--c-player)); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; }
+.tt-official { display:inline-flex; align-items:center; gap:4px; padding:3px 8px; border-radius:var(--r-pill); flex-shrink:0;
+  background:hsl(var(--c-warning) / .14); color:hsl(var(--c-warning)); font-family:var(--f-display); font-weight:800; font-size:10px; }
+.tt-clones { margin-left:auto; display:inline-flex; align-items:center; gap:5px; font-family:var(--f-mono); font-size:11px; color:var(--text-muted); white-space:nowrap; flex-shrink:0; }
+.tt-clones .fire { color:hsl(var(--c-game)); }
+.tt-grow { font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-success)); font-weight:700; }
+
+/* footer CTA */
+.tt-clonebtn { display:inline-flex; align-items:center; justify-content:center; gap:7px; width:100%; padding:10px; border-radius:var(--r-md); border:none;
+  background:hsl(var(--c-toolkit)); color:#fff; font-family:var(--f-display); font-weight:800; font-size:13px; cursor:pointer;
+  transition:all var(--dur-sm) var(--ease-out); }
+.tt-clonebtn:hover { filter:brightness(1.05); transform:translateY(-1px); box-shadow:0 4px 14px hsl(var(--c-toolkit) / .35); }
+.tt-clonebtn.disabled { background:var(--bg-muted); color:var(--text-muted); cursor:not-allowed; box-shadow:none; }
+.tt-clonebtn.disabled:hover { transform:none; filter:none; }
+
+/* ─ list view row ─ */
+.tt-grid.list .tt-card { flex-direction:row; align-items:center; min-height:0; gap:16px; padding:13px 16px; }
+.tt-grid.list .tt-card .tt-chead { flex:0 0 220px; }
+.tt-grid.list .tt-desc { flex:1; -webkit-line-clamp:2; min-height:0; }
+.tt-grid.list .tt-tools { flex:0 0 200px; grid-template-columns:repeat(4,1fr); }
+.tt-grid.list .tt-cdiv, .tt-grid.list .tt-spacer { display:none; }
+.tt-grid.list .tt-meta { flex:0 0 auto; }
+.tt-grid.list .tt-clonebtn { width:auto; flex:0 0 auto; padding:9px 16px; }
+.tt-grid.list .tt-corner, .tt-grid.list .tt-crown { display:none; }
+
+/* ─ empty / loading ─ */
+.tt-pad { min-height:340px; display:flex; align-items:center; justify-content:center; padding:30px 24px; }
+.tt-empty { text-align:center; max-width:420px; border:1.5px dashed var(--border-strong); border-radius:var(--r-xl); padding:46px 34px;
+  display:flex; flex-direction:column; align-items:center; }
+.tt-empty .em { width:70px; height:70px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:30px; margin-bottom:16px;
+  background:hsl(var(--c-warning) / .12); }
+.tt-empty h3 { font-family:var(--f-display); font-size:20px; font-weight:800; margin:0 0 8px; }
+.tt-empty p { font-size:14px; color:var(--text-sec); line-height:1.55; margin:0 0 22px; }
+.tt-empty .cta { display:inline-flex; align-items:center; gap:8px; padding:10px 19px; border-radius:var(--r-md); border:1px solid hsl(var(--c-warning) / .5);
+  background:transparent; color:hsl(var(--c-warning)); font-family:var(--f-display); font-weight:800; font-size:14px; cursor:pointer; }
+
+.tt-sk { border-radius:var(--r-sm); }
+.tt-skcard { display:flex; flex-direction:column; gap:13px; min-height:322px; padding:17px 16px; background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--r-lg); }
+
+/* ─ clone modal ─ */
+.tt-overlay { position:absolute; inset:0; z-index:50; background:rgba(20,12,4,.46); backdrop-filter:blur(3px); display:flex; align-items:center; justify-content:center; padding:28px; animation:tt-overlay-in var(--dur-md) var(--ease-out); }
+[data-theme="dark"] .tt-overlay { background:rgba(0,0,0,.62); }
+.tt-modal { width:min(540px, 100%); max-height:100%; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg);
+  display:flex; flex-direction:column; overflow:hidden; animation:tt-modal-in var(--dur-md) var(--ease-spring); }
+.tt-mhead { flex-shrink:0; display:flex; align-items:flex-start; gap:13px; padding:18px 20px; border-bottom:1px solid var(--border); }
+.tt-mcov { width:40px; height:40px; flex-shrink:0; border-radius:var(--r-md); display:inline-flex; align-items:center; justify-content:center; font-size:19px; background:hsl(var(--e) / .16); }
+.tt-mhtxt { flex:1; min-width:0; }
+.tt-mtitle { font-family:var(--f-display); font-weight:800; font-size:19px; letter-spacing:-.01em; color:var(--text); }
+.tt-msub { font-family:var(--f-mono); font-size:11px; color:var(--text-sec); margin-top:4px; }
+.tt-mclose { width:32px; height:32px; flex-shrink:0; border-radius:var(--r-sm); border:none; background:var(--bg-muted); color:var(--text-muted); cursor:pointer; font-size:16px; }
+.tt-mclose:hover { background:var(--border-strong); color:var(--text); }
+.tt-mbody { flex:1; overflow-y:auto; padding:18px 20px; display:flex; flex-direction:column; gap:18px; }
+.tt-field { display:flex; flex-direction:column; gap:7px; }
+.tt-field label { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); }
+.tt-field input[type=text], .tt-field select { font-family:var(--f-body); font-size:13px; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.tt-field input:focus, .tt-field select:focus { border-color:hsl(var(--c-toolkit) / .6); box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .14); }
+.tt-toggle { display:flex; align-items:center; gap:11px; padding:11px 13px; border-radius:var(--r-md); border:1px solid var(--border-light); background:var(--bg-sunken); cursor:pointer; }
+.tt-toggle .tlbl { flex:1; min-width:0; }
+.tt-toggle .tlbl .tt { font-family:var(--f-display); font-weight:700; font-size:13px; color:var(--text); }
+.tt-toggle .tlbl .td { font-size:11.5px; color:var(--text-muted); margin-top:2px; }
+.tt-sw { width:40px; height:23px; border-radius:var(--r-pill); flex-shrink:0; background:var(--border-strong); position:relative; transition:background var(--dur-sm); }
+.tt-sw::after { content:''; position:absolute; top:2px; left:2px; width:19px; height:19px; border-radius:50%; background:#fff; box-shadow:var(--shadow-sm); transition:transform var(--dur-sm) var(--ease-out); }
+.tt-toggle.on .tt-sw { background:hsl(var(--c-toolkit)); }
+.tt-toggle.on .tt-sw::after { transform:translateX(17px); }
+.tt-summary { display:flex; flex-direction:column; gap:8px; padding:13px; border-radius:var(--r-md); background:hsl(var(--c-toolkit) / .07); border:1px solid hsl(var(--c-toolkit) / .2); }
+.tt-summary .sh { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:hsl(var(--c-toolkit)); font-weight:700; }
+.tt-summary .stools { display:flex; flex-wrap:wrap; gap:7px; }
+.tt-summary .stool { display:inline-flex; align-items:center; gap:5px; padding:4px 9px; border-radius:var(--r-pill); background:var(--bg-card); border:1px solid var(--border-light);
+  font-family:var(--f-mono); font-size:11px; color:var(--text-sec); font-weight:600; }
+.tt-mfoot { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:14px 20px; border-top:1px solid var(--border); }
+.tt-mbtn { display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:10px 16px; border-radius:var(--r-md); border:1px solid var(--border-strong); background:var(--bg-card);
+  color:var(--text); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.tt-mbtn:hover { background:var(--bg-muted); }
+.tt-mbtn.tk { flex:1; background:hsl(var(--c-toolkit)); border-color:transparent; color:#fff; box-shadow:0 4px 14px hsl(var(--c-toolkit) / .3); }
+.tt-mbtn.tk:hover { filter:brightness(1.05); background:hsl(var(--c-toolkit)); }
+
+/* ─ mobile adaptations ─ */
+.tt-app.is-mobile .tt-head { padding:12px 14px 0; }
+.tt-app.is-mobile .tt-h1 { font-size:20px; }
+.tt-app.is-mobile .tt-htop { flex-direction:column; gap:10px; }
+.tt-app.is-mobile .tt-hright { flex-direction:row; align-items:center; align-self:stretch; flex-wrap:wrap; }
+.tt-app.is-mobile .tt-toolbar { padding:11px 14px; gap:10px; }
+.tt-app.is-mobile .tt-search { flex:1 1 100%; max-width:100%; }
+.tt-app.is-mobile .tt-chips { flex-wrap:nowrap; overflow-x:auto; scrollbar-width:none; }
+.tt-app.is-mobile .tt-chips::-webkit-scrollbar { display:none; }
+.tt-app.is-mobile .tt-right { flex:1 1 100%; justify-content:space-between; }
+.tt-app.is-mobile .tt-body { padding:14px; }
+.tt-app.is-mobile .tt-fsum { padding:8px 14px; }
+.tt-app.is-mobile .tt-overlay { padding:0; align-items:flex-end; }
+.tt-app.is-mobile .tt-modal { width:100%; max-height:92%; border-radius:var(--r-2xl) var(--r-2xl) 0 0; animation:tt-sheet-in var(--dur-lg) var(--ease-spring); }
+`;
+
+window.__TT_CSS = TT_CSS;

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -128,19 +128,17 @@ sub-pages · nodi architetturali N4/N6/N7.
 - **Recommendation**: aprire `[Design v1 · B11] Mockup Play Records (index,
   new, detail, edit, stats)`.
 
-### Gap N3 — `/toolkit/{history,stats,templates,play}`
+### Gap N3 — `/toolkit/{history,stats,templates,play}` ✅ CLOSED 2026-06-02 (PR pending, #1490)
 
-- **Route impattate** (4):
-  - `/toolkit/history` — paginated list
-  - `/toolkit/stats` — KPI dashboard
-  - `/toolkit/templates` — gallery + filter
-  - `/toolkit/play` — live session toolkit panel
-- **Impatto**: `sp4-toolkit-detail.html` mappa generico "+ sub-routes" ma
-  ognuna ha dati e interazioni distinte. Mancano esempi concreti (Adzic).
-- **Existing**: nessuna. `sp4-toolkit-detail` copre `[sessionId]` detail solo.
-- **Tier suggerito**: S (per ognuna).
-- **Recommendation**: aprire `[Design v1 · B15] Mockup Toolkit sub-pages
-  (history, stats, templates, play)`.
+- **Route impattate** (4) — TUTTE coperte:
+  - `/toolkit/stats` → `sp4-toolkit-stats.html` + `.jsx` (S1, KPI dashboard 12-mesi + Most Played + Monthly bar chart + Score Trends, 8 stati)
+  - `/toolkit/history` → `sp4-toolkit-history.html` + `.jsx` + `-ui.jsx` (S2, paginated list + filtri game/date/winner + detail modal con classifica/timeline/note/stats, 9 stati)
+  - `/toolkit/templates` → `sp4-toolkit-templates.html` + `.jsx` + `-ui.jsx` (S3, gallery grid 4-col + filter categoria + 4 card variants + clone modal, 8 stati)
+  - `/toolkit/play` → `sp4-toolkit-play.html` + `.jsx` + `-dice.jsx` + `-tools.jsx` + `-ui.jsx` (S4, Dice Builder full power + Counter + Timer + Randomizer + log streaming, 16 stati incluso 7 dice-* states)
+- **Issue tracker**: [#1490 Design v1 · B15] Mockup Toolkit sub-pages — opened 2026-05-22, mockup shipped 2026-06-02 via Claude Design web canvas (pattern P156 handoff package consolidato post-cluster #1489).
+- **Closing PR**: `feature/issue-1490-mockup-toolkit-sub-pages` → `main-dev`.
+- **Updates correlati**: `00-hub.html` (4 nuove card SP4, **merge corretto 4/4 turni** — P155 NOT triggered per intero cluster, primo Phase D senza bug), `v2-migration-matrix.md` (nuova sezione "Toolkit standalone sub-pages" con 4 row done).
+- **Highlights**: Dice Builder full power (preset chips + builder visivo + formula parser khN/klN/csN/explosive + result kept-dropped highlight + storico re-rollable) come pattern UX dice TTRPG-grade.
 
 ## P2 — Gap secondari / IA conflict
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -786,6 +786,15 @@ instead.
 | `/pipeline-builder` | — | gap |
 | `/n8n` | — | gap (integration UI) |
 
+### Toolkit standalone sub-pages (cross-game helpers)
+
+| Route | Mockup | Note |
+|-------|--------|------|
+| `/toolkit/stats` | `sp4-toolkit-stats.html` [done] | B15 #1490 1/4 · KPI dashboard analytics 12-mesi (sessioni / giochi / durata) + Most Played top-N + Monthly bar chart + Recent Score Trends, 8 stati |
+| `/toolkit/history` | `sp4-toolkit-history.html` [done] | B15 #1490 2/4 · Lista paginata sessioni finalizzate cross-game con filtri (game/date/winner) + detail modal (classifica/timeline/note/stats), 9 stati |
+| `/toolkit/templates` | `sp4-toolkit-templates.html` [done] | B15 #1490 3/4 · Gallery template grid 4-col con filter categoria (Strategy/Party/CardGames/Cooperative) + Clone CTA + 4 card variants (official/popular/recent/pending), 8 stati |
+| `/toolkit/play` | `sp4-toolkit-play.html` [done] | B15 #1490 4/4 · Toolkit standalone live (4 tool widgets: **Dice Builder full power** con presets+formula parser khN/klN/csN/explosive + Counter + Timer countdown/turn FSM + Randomizer) + log streaming cross-tool, 16 stati |
+
 ### Critical gaps summary
 
 > **Updated 2026-05-31** (cross-audit 2026-05-12 + 2026-05-22): 3 dei 5 gap


### PR DESCRIPTION
## Summary

Chiude **gap B15** (issue #1490 "Design v1 — Toolkit sub-pages"). 4 mockup user-facing per `apps/web/src/app/(authenticated)/toolkit/{stats,history,templates,play}`, prodotti via Claude Design web canvas (pattern P156 handoff package consolidato post-cluster #1489).

## Schermate (4/4 done — 14 file totali per split-multi pattern)

| # | Route | File | Stati | Tier | Note |
|---|---|---|---|---|---|
| **S1** | `/toolkit/stats` | `sp4-toolkit-stats.html` + `.jsx` | 8 | S | KPI dashboard 12-mesi + bar chart + top games |
| **S2** | `/toolkit/history` | `sp4-toolkit-history.html` + `.jsx` + `-ui.jsx` | 9 | S | Paginated list + filtri + detail modal |
| **S3** | `/toolkit/templates` | `sp4-toolkit-templates.html` + `.jsx` + `-ui.jsx` | 8 | S | Gallery 4-col + clone modal + 4 card variants |
| **S4** | `/toolkit/play` | `sp4-toolkit-play.html` + `.jsx` + `-dice.jsx` + `-tools.jsx` + `-ui.jsx` | **16** | M | **Dice Builder full power** + Counter + Timer + Randomizer + log streaming |

**Totale**: 14 file (4 HTML + 10 JSX split-multi) · ~5.5 KB HTML + ~525 KB JSX · **41 stati totali** · 4 tool widgets interattivi · CSS keyframes animation cluster-wide consistent (dice-roll 3D rotation, counter-pop scale, timer-alert pulse, randomizer-cycle, log-slide-in).

## Highlights cluster

- **S4 Dice Builder full power** (post-revisione user): preset chips (2D6, 1D20, 1D100, 3D6+1, 4D6kh3, 6D6cs6) + builder visivo (type chips + qty stepper + mod stepper + 4 advanced toggles khN/klN/csN/rN/explosive) + formula parser TTRPG-grade con feedback live ✓/✗ + result display kept-dropped highlight con pop animation + storico re-rollable. 7 dice-* stati espliciti.
- **S2/S3 split-multi files**: pattern stylistico Claude Design per scope grandi — helper file (CSS string + fixture + window globals) + UI file (React component). Scalabile.
- **S4 quad-split**: helper + dice dedicato + tools (counter/timer/randomizer) + UI root. Per i 16 stati FSM-heavy.

## 00-hub.html merge corretto (4/4 turni)

**Primo cluster Phase D senza P155 bug** — Claude Design ha correttamente preservato le 343+ righe esistenti su tutti 4 turni del cluster, aggiungendo solo la nuova card per ogni screen. Diff chirurgico verificato.

(Confronto cluster #1489: P155 triggered 5/5 turni, manual merge richiesto. Cluster #1490: 0/4 turni, file accepted directly.)

## Quality bullets (DoD per ogni mockup, verificato)

- [x] Solo CSS variables da `tokens.css`
- [x] Light + dark mode parity (su tutti 41 stati)
- [x] Mobile 375 + desktop 1440 responsive
- [x] State picker UI consistency cross-screen (`ts-state` / `th-state` / `tt-state` / `tp-state` naming)
- [x] Theme toggle 🌗 persistito localStorage `mai-theme`
- [x] EntityChip / EntityPip per cross-entity reference (--c-toolkit primaria, --c-game / --c-player / --c-event / --c-warning / --c-success / --c-kb / --c-success per tool entities)
- [x] ARIA comprehensive (`role="table/dialog/searchbox/navigation/radiogroup/radio/spinbutton/switch/log/timer/figure/img/list/listitem/region/status/alert"`, `aria-live/busy/expanded/labelledby/modal/sort/pressed/checked/valuenow`, keyboard shortcuts full)
- [x] Reduced motion CSS (`@media (prefers-reduced-motion: reduce)` su tutti 4 screen)
- [x] Testo IT + dati realistici da `data.js` (Catan, Wingspan, Power Grid, Codenames, Marco R., Sara T., Aaron R., italiano consistente)
- [x] Header comment ogni file con route + brief + screen + tier + pattern + states

## Updates correlati

- **`00-hub.html`**: 4 nuove card sezione SP4 con pattern `.arrow/.num/h3/p/.tags` coerente con card adiacenti (343→410 righe, merge corretto 4/4 turni)
- **`v2-migration-matrix.md`**: nuova sezione "Toolkit standalone sub-pages (cross-game helpers)" con 4 row done
- **`2026-05-22-mockup-gaps.md`**: gap **N3 (B15) marked CLOSED** con dettaglio routes + file split-multi + Dice Builder highlight

## Test plan

- [ ] Visual smoke test browser: `cd admin-mockups/design_files && python -m http.server 8765` → verifica ogni `sp4-toolkit-*.html` su `:8765/<file>.html` (default light + toggle dark via 🌗)
- [ ] Verifica responsive 375 / 1440 via devtools per ogni screen
- [ ] Verifica state picker funzionante (16 stati S4, 9 S2, 8 S1/S3)
- [ ] Verifica `00-hub.html` mostra 4 nuove card SP4 (sezione "SP4 · Entity desktop & editor")
- [ ] Verifica gap N3 in `2026-05-22-mockup-gaps.md` marked CLOSED
- [ ] Verifica matrix `/toolkit/*` rows in nuova sezione `Toolkit standalone sub-pages` con `done`

## Closes

Closes #1490 (gap B15 / Design v1 · Toolkit sub-pages)

## Out of scope (deferred a follow-up issues separate)

- Implementation FE delle 4 route `apps/web/src/app/(authenticated)/toolkit/**` (richiede follow-up issue separata per ciascuna o bundle, pattern come post-#1489)
- Backend extension per `/toolkit/templates` clone endpoint (epic separato)

## Next mockup gaps (epic #1475 Phase D residue)

Restano 2 mockup gap user-facing in Phase D, tutti P2 designer-led:

- #1491 B16 Library Wishlist (P2, 1-2 screens)
- #1492 B17 Sessions sub-pages (P2, ADR + 1-8 files)

Epic #1475 user-facing UI passerà da 23/26 (88%) a **24/26 (92%)** dopo merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)