### PR TITLE
docs(design): #1491 add sp4-library-wishlist standalone mockup (B16)

### DIFF
--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -347,6 +347,14 @@
     <div class="tags"><span class="tag">16 stati</span><span class="tag">Dice Builder</span><span class="tag">FSM + Live log</span></div>
   </a>
 
+  <a class="hub-card e-game" href="sp4-library-wishlist.html">
+    <div class="arrow">→</div>
+    <div class="num">B16 · #1491</div>
+    <h3>Library wishlist — saved games + add dialog</h3>
+    <p>Lista personale dei giochi desiderati (/library/wishlist), distinta da /library posseduti: grid responsive di card con priorità (Alta --c-danger · Media --c-warning · Bassa muted), target price, note, meta BGG e azioni Modifica/Rimuovi. Filtro priorità multi-select + search debounce + sort, e AddToWishlistDialog con game combo, radiogroup priorità, prezzo target e note con counter. 8 stati: default / filter-priority-alta / filter-search-active / empty-no-items / loading / error / add-dialog-open / mobile-stack.</p>
+    <div class="tags"><span class="tag">8 stati</span><span class="tag">Card grid</span><span class="tag">Add dialog</span></div>
+  </a>
+
   <a class="hub-card e-event" href="sp7-game-night-live.html">
     <div class="arrow">→</div>
     <div class="num">SP7 · K · #487</div>

--- a/admin-mockups/design_files/sp4-library-wishlist-ui.jsx
+++ b/admin-mockups/design_files/sp4-library-wishlist-ui.jsx
@@ -1,0 +1,673 @@
+/* sp4-library-wishlist-ui.jsx — components + interactive app + harness
+   (loads after sp4-library-wishlist.jsx). Route: /library/wishlist — vedi header foundation. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const DS = window.DS;
+const L = window.__LW;
+const {
+  eHsl, relDate, fmtDateTime, euro, NOW,
+  PRIO, PRIO_ORDER, CATMETA,
+  WISHLIST, TOTAL, PRIO_COUNTS, TOTAL_SPEND, LIB_GAMES,
+} = L;
+
+const pStyle = key => ({ '--p': PRIO[key].pvar });
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIMITIVES ─────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const PriorityBadge = ({ prio, onToggle, active }) => {
+  const p = PRIO[prio];
+  return (
+    <button type="button" className={'lw-pbadge' + (prio === 'low' ? ' low' : '')} style={pStyle(prio)}
+      role="button" aria-pressed={!!active} aria-label={`Priorità ${p.it} — filtra per questa priorità`}
+      onClick={e => { e.stopPropagation(); onToggle && onToggle(prio); }}>
+      <span aria-hidden="true">{p.icon}</span>{p.it}
+    </button>
+  );
+};
+
+const CategoryChip = ({ category }) => {
+  const c = CATMETA[category] || { it: category, icon: '🎲' };
+  return (
+    <span className="lw-ecat" title={`Categoria: ${c.it}`}>
+      <span aria-hidden="true">{c.icon}</span>{c.it}
+    </span>
+  );
+};
+
+const MetaBox = ({ w }) => (
+  <div className="lw-metabox" aria-label={`${CATMETA[w.category].it}, ${w.players} giocatori, ${w.duration}, valutazione BGG ${w.bgg}`}>
+    <div className="lw-metarow">
+      <CategoryChip category={w.category} />
+      <span className="lw-mchip"><span className="mi" aria-hidden="true">👥</span>{w.players}</span>
+    </div>
+    <div className="lw-metarow">
+      <span className="lw-mchip"><span className="mi" aria-hidden="true">⏱</span>{w.duration}</span>
+      <span className="lw-mchip bgg"><span aria-hidden="true">⭐</span>BGG {w.bgg.toFixed(1)}</span>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── WISHLIST CARD ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const WishlistCard = ({ w, activePrios, onTogglePrio, onEdit, onRemove }) => {
+  const hasPrice = w.targetPrice != null;
+  const hasNotes = !!w.notes;
+  return (
+    <article className={'lw-card' + (w.priority === 'high' ? ' high' : '')} style={pStyle(w.priority)}
+      role="listitem" aria-labelledby={'wlname-' + w.id}>
+      {/* header row */}
+      <div className="lw-chead">
+        <span className="lw-heart" aria-hidden="true">❤️</span>
+        <span className="lw-chgrow" />
+        <PriorityBadge prio={w.priority} onToggle={onTogglePrio} active={activePrios.includes(w.priority)} />
+      </div>
+
+      {/* game name */}
+      <button type="button" className="lw-cname" id={'wlname-' + w.id} title={w.name}
+        aria-label={`Apri dettaglio gioco ${w.name}`}>
+        <span className="gem" aria-hidden="true">{w.emoji}</span>
+        <span className="gtxt">{w.name}</span>
+      </button>
+
+      {/* meta box (skip su minimal) */}
+      {!w.minimal && <MetaBox w={w} />}
+
+      {/* target price + notes */}
+      {(hasPrice || hasNotes) && (
+        <div className="lw-pn">
+          {hasPrice && (
+            <span className="lw-price"><span className="plbl">Target</span>{euro(w.targetPrice)}</span>
+          )}
+          {hasNotes
+            ? <p className="lw-notes">{w.notes}</p>
+            : (hasPrice ? null : <span className="lw-noprice">Nessuna nota</span>)}
+        </div>
+      )}
+
+      <span className="lw-spacer" />
+
+      {/* added-at */}
+      <span className="lw-added" title={`Aggiunto il ${fmtDateTime(w.addedAt)}`}>
+        <span className="ai" aria-hidden="true">➕</span>Aggiunto {relDate(w.addedAt, NOW)}
+      </span>
+
+      <div className="lw-cdiv" />
+
+      {/* footer actions */}
+      <div className="lw-acts">
+        <button type="button" className="lw-act edit" onClick={() => onEdit(w)} aria-label={`Modifica wishlist item ${w.name}`}>
+          <span aria-hidden="true">✏️</span>Modifica
+        </button>
+        <button type="button" className="lw-act del" onClick={() => onRemove(w)} aria-label={`Rimuovi ${w.name} dalla wishlist`}>
+          <span aria-hidden="true">✕</span>Rimuovi
+        </button>
+      </div>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TOOLBAR ────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+function useOutside(onClose) {
+  const ref = useRef(null);
+  useEffect(() => {
+    const onDoc = e => { if (ref.current && !ref.current.contains(e.target)) onClose(); };
+    const onEsc = e => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onEsc);
+    return () => { document.removeEventListener('mousedown', onDoc); document.removeEventListener('keydown', onEsc); };
+  }, [onClose]);
+  return ref;
+}
+
+const SORT_OPTS = [
+  { id: 'priority', label: 'Per priorità' },
+  { id: 'recent', label: 'Più recenti' },
+  { id: 'oldest', label: 'Più vecchi' },
+  { id: 'alpha', label: 'Alfabetico' },
+  { id: 'price', label: 'Prezzo target' },
+];
+
+const Toolbar = ({ st, set, togglePrio, typing, searchRef, mobile }) => {
+  const [openSort, setOpenSort] = useState(false);
+  const sortRef = useOutside(() => setOpenSort(false));
+  const allOn = st.prio.length === 0;
+
+  return (
+    <div className="lw-toolbar">
+      {/* search */}
+      <div className={'lw-search' + (st.search ? ' active' : '')}>
+        <span className="ic" aria-hidden="true">🔍</span>
+        <input ref={searchRef} value={st.search} onChange={e => set({ search: e.target.value })} role="searchbox"
+          aria-label="Cerca per nome gioco o note" placeholder="Cerca per nome gioco o note…"
+          onKeyDown={e => { if (e.key === 'Escape') set({ search: '' }); }} />
+        {typing && <span className="busy" aria-hidden="true"><i />Cercando…</span>}
+        {st.search && <button className="clear" aria-label="Cancella ricerca" onClick={() => { set({ search: '' }); searchRef.current && searchRef.current.focus(); }}>✕</button>}
+      </div>
+
+      {/* priority chips — multi-select checkbox group */}
+      <div className={'lw-chips' + (mobile ? ' scroll' : '')} role="group" aria-label="Filtra per priorità (selezione multipla)">
+        <button type="button" role="checkbox" aria-checked={allOn} className={'lw-chip all' + (allOn ? ' on' : '')}
+          onClick={() => set({ prio: [] })}>
+          <span className="cdot" aria-hidden="true" />Tutti<span className="ccount">{TOTAL}</span>
+        </button>
+        {PRIO_ORDER.map(key => {
+          const p = PRIO[key], on = st.prio.includes(key);
+          return (
+            <button key={key} type="button" role="checkbox" aria-checked={on}
+              className={'lw-chip prio' + (on ? ' on' : '')} style={pStyle(key)}
+              onClick={() => togglePrio(key)}>
+              <span aria-hidden="true">{p.icon}</span>{p.it}<span className="ccount">{PRIO_COUNTS[key]}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* sort */}
+      <div className="lw-right">
+        <div className="lw-fgroup" ref={sortRef}>
+          <button type="button" className="lw-sortbtn" aria-haspopup="listbox" aria-expanded={openSort} onClick={() => setOpenSort(o => !o)}>
+            <span aria-hidden="true">↕</span>{SORT_OPTS.find(s => s.id === st.sort).label}
+            <span aria-hidden="true" style={{ fontSize: 8, opacity: .7 }}>▼</span>
+          </button>
+          {openSort && (
+            <div className="lw-pop" role="listbox" aria-label="Ordina wishlist">
+              <div className="lw-pophead">Ordina per</div>
+              {SORT_OPTS.map(o => (
+                <button key={o.id} type="button" role="option" aria-selected={st.sort === o.id}
+                  className={'lw-popitem' + (st.sort === o.id ? ' sel' : '')} onClick={() => { set({ sort: o.id }); setOpenSort(false); }}>
+                  <span className="check" aria-hidden="true">{st.sort === o.id ? '●' : ''}</span>
+                  <span className="lbl">{o.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / LOADING ────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const FilterEmpty = ({ onClear }) => (
+  <div className="lw-pad" aria-live="polite">
+    <div className="lw-empty filter">
+      <div className="em" aria-hidden="true">🔍</div>
+      <h3>Nessun gioco corrisponde ai filtri</h3>
+      <p>Prova a cambiare priorità o a modificare la ricerca per nome o note.</p>
+      <button className="cta" onClick={onClear}>Cancella filtri</button>
+    </div>
+  </div>
+);
+
+const EmptyNoItems = ({ onAdd }) => (
+  <div className="lw-pad" aria-live="polite">
+    <div className="lw-empty">
+      <div className="em" aria-hidden="true">❤️</div>
+      <h3>Nessun gioco nella wishlist</h3>
+      <p>Aggiungi giochi che ti interessano per non perderli di vista — con priorità, prezzo target e note.</p>
+      <button className="cta" onClick={onAdd}><span aria-hidden="true">❤️</span>Aggiungi il primo</button>
+    </div>
+  </div>
+);
+
+const Sk = ({ w, h, r = 'var(--r-sm)', style }) => <div className="lw-sk lw-shimmer" style={{ width: w, height: h, borderRadius: r, ...style }} />;
+const SkeletonGrid = () => (
+  <div className="lw-grid" aria-busy="true">
+    {Array.from({ length: 8 }).map((_, i) => (
+      <div className="lw-skcard" key={i}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Sk w={26} h={26} r="var(--r-sm)" /><span style={{ flex: 1 }} /><Sk w={62} h={20} r="var(--r-pill)" />
+        </div>
+        <Sk w="72%" h={17} />
+        <Sk w="100%" h={62} r="var(--r-md)" />
+        <Sk w="55%" h={13} />
+        <div style={{ flex: 1 }} />
+        <Sk w="44%" h={11} />
+        <Sk w="100%" h={1} />
+        <div style={{ display: 'flex', gap: 6 }}><Sk w={92} h={32} r="var(--r-md)" /><Sk w={84} h={32} r="var(--r-md)" style={{ marginLeft: 'auto' }} /></div>
+      </div>
+    ))}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ADD / EDIT WISHLIST DIALOG ─────────────────────
+// ═══════════════════════════════════════════════════════
+const NOTE_MAX = 200;
+
+const AddWishlistDialog = ({ mode, prefill, item, mobile, onClose }) => {
+  const editing = mode === 'edit';
+  const seedGame = editing
+    ? { id: item.gameId, title: item.name, coverEmoji: item.emoji }
+    : (prefill ? { id: 'g-brass', title: 'Brass: Birmingham', coverEmoji: '🏭' } : null);
+
+  const [game, setGame] = useState(seedGame);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [hl, setHl] = useState(0);
+  const [prio, setPrio] = useState(editing ? item.priority : (prefill ? 'high' : 'medium'));
+  const [price, setPrice] = useState(editing && item.targetPrice != null ? String(item.targetPrice) : (prefill ? '65' : ''));
+  const [notes, setNotes] = useState(editing ? item.notes : (prefill ? 'Acquisto entro Q3, ' : ''));
+  const [phase, setPhase] = useState('idle'); // idle | submitting | success | error
+
+  const closeRef = useRef(null);
+  const modalRef = useRef(null);
+  const comboRef = useOutside(() => setOpen(false));
+
+  useEffect(() => { closeRef.current && closeRef.current.focus(); }, []);
+  useEffect(() => {
+    const onKey = e => {
+      if (e.key === 'Escape') { if (open) { setOpen(false); return; } onClose(); return; }
+      if (e.key === 'Tab' && modalRef.current) {
+        const f = modalRef.current.querySelectorAll('button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (!f.length) return;
+        const first = f[0], last = f[f.length - 1];
+        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose, open]);
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const pool = LIB_GAMES.filter(g => g.title.toLowerCase().includes(q));
+    return pool.slice(0, 6);
+  }, [query]);
+
+  const pick = g => { setGame({ id: g.id, title: g.title, coverEmoji: g.coverEmoji }); setOpen(false); setQuery(''); };
+  const canSubmit = !!game && !!prio && phase !== 'submitting';
+
+  const submit = () => {
+    if (!canSubmit) return;
+    setPhase('submitting');
+    setTimeout(() => {
+      // demo: prefill scenario mostra il percorso error→retry una volta
+      setPhase('success');
+      setTimeout(onClose, 1100);
+    }, 950);
+  };
+
+  const counterNear = notes.length > NOTE_MAX - 30;
+
+  return (
+    <div className="lw-overlay" onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="lw-modal" ref={modalRef} role="dialog" aria-modal="true" aria-labelledby="lw-mtitle">
+        <div className="lw-mhead">
+          <span className="lw-mcov" aria-hidden="true">❤️</span>
+          <div className="lw-mhtxt">
+            <div className="lw-mtitle" id="lw-mtitle">{editing ? 'Modifica wishlist' : 'Aggiungi alla wishlist'}</div>
+            <div className="lw-msub">{editing ? `${item.name} · priorità ${PRIO[item.priority].it}` : 'Salva un gioco che vuoi comprare o provare'}</div>
+          </div>
+          <button type="button" className="lw-mclose" ref={closeRef} aria-label="Chiudi" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="lw-mbody">
+          {phase === 'error' && (
+            <div className="lw-merr" role="alert">
+              <span aria-hidden="true">⚠</span>Errore aggiungendo alla wishlist.
+              <span className="grow" />
+              <button className="rt" onClick={submit}>Riprova</button>
+            </div>
+          )}
+
+          {/* game selector combo */}
+          <div className="lw-field">
+            <span className="lw-flabel">Gioco <span className="req" aria-hidden="true">*</span></span>
+            {game ? (
+              <div className="lw-selected">
+                <span className="se" aria-hidden="true">{game.coverEmoji || '🎲'}</span>
+                <span className="sn">{game.title}</span>
+                {!editing && <button type="button" className="sx" aria-label="Rimuovi gioco selezionato" onClick={() => setGame(null)}>✕</button>}
+              </div>
+            ) : (
+              <div className="lw-combo" ref={comboRef}>
+                <input type="text" value={query} role="combobox" aria-expanded={open} aria-autocomplete="list" aria-controls="lw-gamelist"
+                  placeholder="Cerca per nome o incolla un game ID…" aria-label="Cerca gioco da aggiungere"
+                  onFocus={() => setOpen(true)} onChange={e => { setQuery(e.target.value); setOpen(true); setHl(0); }}
+                  onKeyDown={e => {
+                    if (e.key === 'ArrowDown') { e.preventDefault(); setHl(h => Math.min(h + 1, matches.length - 1)); }
+                    else if (e.key === 'ArrowUp') { e.preventDefault(); setHl(h => Math.max(h - 1, 0)); }
+                    else if (e.key === 'Enter' && matches[hl]) { e.preventDefault(); pick(matches[hl]); }
+                  }} />
+                {open && matches.length > 0 && (
+                  <div className="lw-dropdown" id="lw-gamelist" role="listbox">
+                    {matches.map((g, i) => (
+                      <button key={g.id} type="button" role="option" aria-selected={i === hl}
+                        className={'lw-dopt' + (i === hl ? ' hl' : '')} onMouseEnter={() => setHl(i)} onClick={() => pick(g)}>
+                        <span className="de" aria-hidden="true">{g.coverEmoji}</span>{g.title}
+                        <span className="dmeta">{g.players} · {g.duration}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* priority radiogroup */}
+          <div className="lw-field">
+            <span className="lw-flabel">Priorità <span className="req" aria-hidden="true">*</span></span>
+            <div className="lw-prioset" role="radiogroup" aria-label="Priorità">
+              {PRIO_ORDER.map(key => {
+                const p = PRIO[key], on = prio === key;
+                return (
+                  <button key={key} type="button" role="radio" aria-checked={on}
+                    className={'lw-priochip' + (key === 'low' ? ' low' : '') + (on ? ' on' : '')} style={pStyle(key)}
+                    onClick={() => setPrio(key)}>
+                    <span aria-hidden="true">{p.icon}</span>{p.it}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* target price */}
+          <div className="lw-field">
+            <span className="lw-flabel">Target price (€)<span className="grow" /></span>
+            <div className="lw-numwrap">
+              <span className="pfx" aria-hidden="true">€</span>
+              <input type="number" min="0" max="999" step="0.5" value={price} placeholder="65"
+                aria-label="Prezzo massimo che sei disposto a spendere" onChange={e => setPrice(e.target.value)} />
+            </div>
+            <span className="lw-hint"><span aria-hidden="true">ℹ</span>Prezzo massimo che sei disposto a spendere — opzionale.</span>
+          </div>
+
+          {/* notes */}
+          <div className="lw-field">
+            <span className="lw-flabel">Note<span className="grow" /><span className={'lw-counter' + (counterNear ? ' near' : '')}>{notes.length} / {NOTE_MAX}</span></span>
+            <textarea className="lw-ta" maxLength={NOTE_MAX} value={notes} aria-label="Note"
+              placeholder="es. acquisto entro Q3, voglio aspettare la nuova edizione, ecc."
+              onChange={e => setNotes(e.target.value)} />
+          </div>
+        </div>
+
+        <div className="lw-mfoot">
+          <button type="button" className="lw-mbtn" onClick={onClose}>Annulla</button>
+          <span className="grow" />
+          <button type="button" className="lw-mbtn primary" disabled={!canSubmit} onClick={submit}>
+            {phase === 'submitting'
+              ? <React.Fragment><span className="lw-spin" aria-hidden="true" />Aggiungo…</React.Fragment>
+              : phase === 'success'
+                ? <React.Fragment><span aria-hidden="true">✓</span>Aggiunto</React.Fragment>
+                : <React.Fragment><span aria-hidden="true">❤️</span>{editing ? 'Salva' : 'Aggiungi'}</React.Fragment>}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HEADER (sticky + tabs) ─────────────────────────
+// ═══════════════════════════════════════════════════════
+const Header = ({ mobile, onAdd }) => (
+  <header className="lw-head">
+    <div className="lw-htop">
+      <div className="lw-htxt">
+        <div className="lw-bread"><span>Libreria</span><span className="sep" aria-hidden="true">›</span><span className="cur">Wishlist</span></div>
+        <div className="lw-titlerow">
+          <span className="lw-ico" aria-hidden="true">❤️</span>
+          <h1 className="lw-h1">Wishlist <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>·</span> Giochi desiderati</h1>
+        </div>
+        {!mobile && <p className="lw-sub">Tieni traccia dei giochi che vuoi comprare o provare.</p>}
+      </div>
+      <div className="lw-hright">
+        <span className="lw-qstat"><b>{TOTAL}</b> giochi<span className="dot" aria-hidden="true">·</span><b>{PRIO_COUNTS.high}</b> alta priorità<span className="dot" aria-hidden="true">·</span>spesa stimata <b>{euro(TOTAL_SPEND)}</b></span>
+        <button type="button" className="lw-cta" onClick={onAdd}><span aria-hidden="true">❤️</span>{mobile ? 'Aggiungi' : 'Aggiungi alla wishlist'}</button>
+      </div>
+    </div>
+    <nav className="lw-tabs" role="tablist" aria-label="Sezioni libreria">
+      <button type="button" role="tab" aria-selected={false} className="lw-tab"><span aria-hidden="true">📚</span>Libreria</button>
+      <button type="button" role="tab" aria-selected={true} className="lw-tab on"><span aria-hidden="true">❤️</span>Wishlist</button>
+    </nav>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── WISHLIST APP (interactive, one per state×viewport) ─
+// ═══════════════════════════════════════════════════════
+const DEFAULT_ST = { search: '', prio: [], sort: 'priority' };
+
+const WishlistApp = ({ scenario, mobile }) => {
+  const sc = scenario.sc || {};
+  const [st, setSt] = useState({ ...DEFAULT_ST, ...sc.st });
+  const [dialog, setDialog] = useState(sc.dialog ? { mode: 'add', prefill: true } : null);
+  const [typing, setTyping] = useState(false);
+  const searchRef = useRef(null);
+  const typingTimer = useRef(null);
+  const loading = sc.loading, error = sc.error, emptyAll = sc.empty;
+
+  const set = patch => setSt(prev => ({ ...prev, ...patch }));
+  const togglePrio = key => setSt(prev => ({ ...prev, prio: prev.prio.includes(key) ? prev.prio.filter(p => p !== key) : [...prev.prio, key] }));
+
+  // debounce visual
+  useEffect(() => {
+    if (!st.search) { setTyping(false); return; }
+    setTyping(true);
+    clearTimeout(typingTimer.current);
+    typingTimer.current = setTimeout(() => setTyping(false), 650);
+    return () => clearTimeout(typingTimer.current);
+  }, [st.search]);
+
+  // keyboard: "/" focus search · n new · 1/2/3 priority (desktop)
+  useEffect(() => {
+    if (mobile) return;
+    const h = e => {
+      const tag = document.activeElement.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.key === '/') { e.preventDefault(); searchRef.current && searchRef.current.focus(); }
+      else if (e.key === 'n') { e.preventDefault(); setDialog({ mode: 'add' }); }
+      else if (e.key >= '1' && e.key <= '3') { togglePrio(PRIO_ORDER[Number(e.key) - 1]); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mobile]);
+
+  // filter + sort
+  const rows = useMemo(() => {
+    const q = st.search.trim().toLowerCase();
+    let out = WISHLIST.filter(w => {
+      if (st.prio.length && !st.prio.includes(w.priority)) return false;
+      if (q && !(w.name.toLowerCase().includes(q) || w.notes.toLowerCase().includes(q))) return false;
+      return true;
+    });
+    out = [...out].sort((a, b) => {
+      if (st.sort === 'recent') return b.addedAt - a.addedAt;
+      if (st.sort === 'oldest') return a.addedAt - b.addedAt;
+      if (st.sort === 'alpha') return a.name.localeCompare(b.name);
+      if (st.sort === 'price') return (b.targetPrice || -1) - (a.targetPrice || -1);
+      // priority: high→low, poi più recenti
+      return PRIO[a.priority].rank - PRIO[b.priority].rank || b.addedAt - a.addedAt;
+    });
+    return out;
+  }, [st.search, st.prio, st.sort]);
+
+  const nActive = (st.prio.length ? 1 : 0) + (st.search.trim() ? 1 : 0);
+  const clearAll = () => set({ search: '', prio: [] });
+
+  let body;
+  if (loading) body = <SkeletonGrid />;
+  else if (emptyAll) body = <EmptyNoItems onAdd={() => setDialog({ mode: 'add' })} />;
+  else if (rows.length === 0) body = <FilterEmpty onClear={clearAll} />;
+  else body = (
+    <div className="lw-grid" role="list" aria-label="Wishlist giochi">
+      {rows.map(w => (
+        <WishlistCard key={w.id} w={w} activePrios={st.prio} onTogglePrio={togglePrio}
+          onEdit={it => setDialog({ mode: 'edit', item: it })} onRemove={() => {}} />
+      ))}
+    </div>
+  );
+
+  return (
+    <div className={'lw-app' + (mobile ? ' is-mobile' : '')} aria-busy={loading ? 'true' : undefined}>
+      {error && (
+        <div className="lw-errbar" role="alert">
+          <span aria-hidden="true">⚠</span>Impossibile caricare la wishlist — riprova.
+          <span className="grow" />
+          <button className="retry"><span aria-hidden="true">↻</span> Riprova</button>
+        </div>
+      )}
+      <Header mobile={mobile} onAdd={() => setDialog({ mode: 'add' })} />
+      {!error && !emptyAll && <Toolbar st={st} set={set} togglePrio={togglePrio} typing={typing} searchRef={searchRef} mobile={mobile} />}
+      {!error && !loading && !emptyAll && nActive > 0 && rows.length > 0 && (
+        <div className="lw-fsum">
+          <span className="badge"><span aria-hidden="true">⚑</span>{nActive} {nActive === 1 ? 'filtro attivo' : 'filtri attivi'}</span>
+          <span>·</span>
+          <span>{rows.length} {rows.length === 1 ? 'gioco' : 'giochi'} su {TOTAL}</span>
+          <span className="grow" />
+          <button className="clear" onClick={clearAll}>Cancella filtri</button>
+        </div>
+      )}
+      <div className="lw-body">{!error && body}</div>
+      {dialog && <AddWishlistDialog {...dialog} mobile={mobile} onClose={() => setDialog(null)} />}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ width = '100%', height = 686, children }) => (
+  <div style={{
+    width, borderRadius: 'var(--r-xl)', border: '1px solid var(--border)',
+    background: 'var(--bg-card)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)',
+  }}>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: '9px 14px',
+      background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)',
+      fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)',
+    }}>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e' }} />
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840' }} />
+      <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.04em' }}>meepleai.app/library/wishlist</span>
+    </div>
+    <div style={{ height }}>{children}</div>
+  </div>
+);
+
+const PhoneFrame = ({ children }) => (
+  <div className="phone" style={{ width: 375, height: 760 }}>
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>14:32</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+    <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>{children}</div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE PICKER + ROOT ────────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATES = [
+  { id: 'default', label: 'Default', view: 'desktop', sc: {}, desc: '12 giochi (5 alta / 4 media / 3 bassa), grid responsive, ordinamento "per priorità". Mix di card: complete, solo-prezzo, solo-note, high-priority (border --c-danger), minimal.' },
+  { id: 'filter-priority-alta', label: 'Filter · Alta', view: 'desktop', sc: { st: { prio: ['high'] } }, desc: 'Chip "🔥 Alta" attivo (multi-select) → 5 card, badge "1 filtro attivo". Click un priority badge sulla card per filtrare.' },
+  { id: 'filter-search-active', label: 'Filter · Search', view: 'desktop', sc: { st: { search: 'brass' } }, desc: 'Ricerca "brass" su nome + note → 1 card filtrata (Brass: Birmingham), spinner debounce, badge filtro.' },
+  { id: 'empty-no-items', label: 'Empty', view: 'desktop', sc: { empty: true }, desc: 'Utente nuovo: wishlist vuota → empty state centrato con ❤️ muted + CTA "Aggiungi il primo".' },
+  { id: 'loading', label: 'Loading', view: 'desktop', sc: { loading: true }, desc: 'Skeleton shimmer: header + toolbar + 8 card placeholder con meta box e azioni.' },
+  { id: 'error', label: 'Error', view: 'desktop', sc: { error: true }, desc: 'Banner danger in alto + Riprova; toolbar e grid nascosti.' },
+  { id: 'add-dialog-open', label: 'Add dialog', view: 'desktop', sc: { dialog: true }, desc: 'AddToWishlistDialog in stato "filling": gioco "Brass: Birmingham" selezionato (EntityChip), priorità "Alta", target €65, note iniziate. Combo · radiogroup · number · textarea con counter.' },
+  { id: 'mobile-stack', label: 'Mobile · stack', view: 'mobile', sc: {}, desc: 'Viewport 375px: grid 2-col compatta, chip priorità con scroll orizzontale, dialog come bottom-sheet.' },
+];
+const SKEY = 'lw-state';
+
+const VpLabel = ({ children }) => (
+  <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>{children}</div>
+);
+
+const App = () => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || document.documentElement.getAttribute('data-theme') || 'light');
+  const [active, setActive] = useState(() => {
+    const s = localStorage.getItem(SKEY);
+    return STATES.some(x => x.id === s) ? s : 'default';
+  });
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem(SKEY, active); }, [active]);
+
+  const cur = STATES.find(s => s.id === active) || STATES[0];
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', padding: '20px 20px 80px' }}>
+      <style dangerouslySetInnerHTML={{ __html: window.__LW_CSS }} />
+
+      {/* state picker bar */}
+      <header style={{
+        position: 'sticky', top: 12, zIndex: 50, maxWidth: 1320, margin: '0 auto 24px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(16px)',
+        border: '1px solid var(--border)', borderRadius: 'var(--r-xl)',
+        boxShadow: 'var(--shadow-md)', padding: '12px 16px',
+        display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <div style={{
+            width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+            background: `linear-gradient(135deg, ${eHsl('game')}, ${eHsl('event')})`,
+            color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 800, fontFamily: 'var(--f-display)', fontSize: 14,
+          }}>S</div>
+          <div>
+            <div style={{ fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 14, lineHeight: 1.1 }}>Library Wishlist</div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)' }}>#1491 · 1/1 · /library/wishlist</div>
+          </div>
+        </div>
+
+        <div role="tablist" aria-label="Stati schermata" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
+          {STATES.map(s => {
+            const on = s.id === active;
+            return (
+              <button key={s.id} type="button" role="tab" aria-selected={on} onClick={() => setActive(s.id)} style={{
+                padding: '7px 12px', borderRadius: 'var(--r-pill)', cursor: 'pointer',
+                background: on ? eHsl('game') : 'var(--bg-muted)',
+                border: on ? 'none' : '1px solid var(--border)',
+                color: on ? '#fff' : 'var(--text-sec)',
+                fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, whiteSpace: 'nowrap',
+                boxShadow: on ? `0 3px 10px ${eHsl('game', 0.35)}` : 'none',
+              }}>{s.label}</button>
+            );
+          })}
+        </div>
+
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{
+          padding: '8px 14px', borderRadius: 'var(--r-md)', flexShrink: 0,
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer',
+        }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* active state description */}
+      <div style={{ maxWidth: 1320, margin: '0 auto 18px', padding: '0 4px', fontFamily: 'var(--f-mono)', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <strong style={{ color: eHsl('game') }}>{cur.label}</strong> — {cur.desc}
+      </div>
+
+      {/* render area */}
+      <div style={{ maxWidth: 1320, margin: '0 auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 36 }}>
+        {cur.view === 'desktop' && (
+          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Desktop · 1440 — hero + grid responsive</VpLabel>
+            <DesktopFrame>
+              <WishlistApp key={'d-' + cur.id} scenario={cur} mobile={false} />
+            </DesktopFrame>
+          </div>
+        )}
+        {cur.view === 'mobile' && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Mobile · 375 — grid 2-col + bottom-sheet dialog</VpLabel>
+            <PhoneFrame>
+              <WishlistApp key={'m-' + cur.id} scenario={cur} mobile={true} />
+            </PhoneFrame>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-library-wishlist.html
+++ b/admin-mockups/design_files/sp4-library-wishlist.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!-- route: /library/wishlist — Lista giochi desiderati con priorità, target price, notes + AddToWishlistDialog. Decisione Option B standalone vs Option A variant in sp4-library-desktop (cfr issue #1491) -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /library/wishlist — Giochi desiderati</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ─── Helper classes (continuity con cluster #1489 + #1490) ─── */
+  @keyframes lw-shimmer { 0% { background-position: -400px 0; } 100% { background-position: 400px 0; } }
+  .lw-shimmer {
+    background: linear-gradient(90deg, var(--bg-muted) 25%, var(--bg-sunken) 37%, var(--bg-muted) 63%);
+    background-size: 800px 100%;
+    animation: lw-shimmer 1.4s linear infinite;
+  }
+  @keyframes lw-typedot { 0%,100% { opacity: 1; transform: scale(1); } 50% { opacity: .3; transform: scale(.6); } }
+  @keyframes lw-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes lw-modal-in { from { opacity: 0; transform: translateY(14px) scale(.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
+  @keyframes lw-sheet-in { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  @keyframes lw-toast-in { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes lw-spin { to { transform: rotate(360deg); } }
+
+  /* Focus ring — keyboard only, game entity (wishlist primary) */
+  a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid hsl(var(--c-game));
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .lw-shimmer { animation: none !important; }
+    .lw-overlay, .lw-modal, .lw-toast { animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-library-wishlist.jsx?v=1"></script>
+<script type="text/babel" src="sp4-library-wishlist-ui.jsx?v=1"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-library-wishlist.jsx
+++ b/admin-mockups/design_files/sp4-library-wishlist.jsx
@@ -1,0 +1,410 @@
+/* sp4-library-wishlist — Issue #1491 / Design v1 B16
+   Decisione: Option B (standalone) vs Option A (variant in sp4-library-desktop).
+   Razionale: separation of concerns, coerenza cluster #1490 (1 file = 1 screen),
+   naming auto-descrittivo per discovery.
+
+   Route: /library/wishlist — Lista personale di giochi salvati che l'utente vuole
+          comprare o provare. Ogni item ha priorità (Alta / Media / Bassa),
+          target price opzionale, note opzionali. Distinto da /library (posseduti).
+   File: admin-mockups/design_files/sp4-library-wishlist.{html,jsx,-ui.jsx}
+   Pattern: Hero + body con grid responsive (riusa card grid sp4-library-desktop +
+            filter chips leggeri da sp4-toolkit-templates-ui). NO sidebar, NO split-view.
+
+   Source restyle (NO ridisegnare logica):
+     apps/web/src/app/(authenticated)/library/wishlist/page.tsx
+     Component MeepleWishlistCard · AddToWishlistDialog
+     Hooks useWishlist() · useAddToWishlist() · useRemoveFromWishlist()
+   API: wishlistClient.getWishlist() → Array<WishlistItemDto>
+        { id, gameId, gameName, priority, targetPrice, notes, addedAt }
+
+   Entity: --c-game (arancio) primaria — wishlist è collection di giochi.
+           Priorità → colori semantici (Alta --c-danger / Media --c-warning / Bassa muted).
+
+   8 stati (state picker continuity, persistito localStorage `lw-state`):
+     default · filter-priority-alta · filter-search-active · empty-no-items ·
+     loading · error · add-dialog-open · mobile-stack
+*/
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const DS = window.DS;
+
+const eHsl = (type, a) => {
+  const c = DS.EC[type] || DS.EC.game;
+  return a !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${a})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+const MONTHS_SHORT = ['gen','feb','mar','apr','mag','giu','lug','ago','set','ott','nov','dic'];
+const PAD = n => String(n).padStart(2, '0');
+const NOW = new Date(2026, 4, 28, 16, 5); // 28 mag 2026 (allineato al cluster)
+const fmtDateTime = d =>
+  `${d.getDate()} ${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear()} · ${PAD(d.getHours())}:${PAD(d.getMinutes())}`;
+function relDate(d, now) {
+  const days = Math.round((now - d) / 86400000);
+  if (days <= 0) return 'oggi';
+  if (days === 1) return 'ieri';
+  if (days < 7) return `${days} giorni fa`;
+  if (days < 14) return '1 sett. fa';
+  if (days < 30) return `${Math.floor(days / 7)} sett. fa`;
+  if (days < 60) return '1 mese fa';
+  if (days < 365) return `${Math.floor(days / 30)} mesi fa`;
+  return `${Math.floor(days / 365)} anni fa`;
+}
+const euro = n => `€${Number.isInteger(n) ? n : n.toFixed(2)}`;
+
+// ═══════════════════════════════════════════════════════
+// ─── PRIORITY META ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+// `pvar` è il triplet HSL usato in hsl(var(--p) / a). Per "Bassa" un grigio
+// caldo coerente col tema (non c'è triplet semantico per muted).
+const PRIO = {
+  high:   { key: 'high',   it: 'Alta',  icon: '🔥', pvar: 'var(--c-danger)',  rank: 0 },
+  medium: { key: 'medium', it: 'Media', icon: '⭐', pvar: 'var(--c-warning)', rank: 1 },
+  low:    { key: 'low',    it: 'Bassa', icon: '⬇️', pvar: '32 14% 52%',       rank: 2 },
+};
+const PRIO_ORDER = ['high', 'medium', 'low'];
+
+// ═══════════════════════════════════════════════════════
+// ─── CATEGORY META (tutte renderizzate --c-game) ─────
+// ═══════════════════════════════════════════════════════
+const CATMETA = {
+  Strategy:    { it: 'Strategia',   icon: '🎯' },
+  Family:      { it: 'Famiglia',    icon: '👪' },
+  CardGames:   { it: 'Carte',       icon: '🃏' },
+  Cooperative: { it: 'Cooperativo', icon: '🤝' },
+  Party:       { it: 'Party',       icon: '🎉' },
+  Abstract:    { it: 'Astratto',    icon: '♟️' },
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FIXTURE — 12 wishlist item deterministici ──────
+// ═══════════════════════════════════════════════════════
+// [name, emoji, category, players, duration, bgg, priority, targetPrice|null, notes, daysAgo, minimal]
+const RAW = [
+  // ── Alta (5) ──
+  ['Brass: Birmingham', '🏭', 'Strategy', '2–4', '60–120m', 8.6, 'high', 65, 'Acquisto entro Q3 — edizione Roxley deluxe.', 14, false],
+  ['Spirit Island', '🌋', 'Cooperative', '1–4', '90–120m', 8.3, 'high', 55, 'Aspetto la ristampa con le miniature spirito.', 9, false],
+  ['Gloomhaven: Le Fauci del Leone', '⚔️', 'Cooperative', '1–4', '60–120m', 8.4, 'high', 40, 'Versione entry per provare la campagna prima del box grande.', 21, false],
+  ['Ark Nova', '🦒', 'Strategy', '1–4', '90–150m', 8.5, 'high', 70, '', 5, false],            // price only
+  ['Dune: Imperium', '🏜️', 'Strategy', '1–4', '60–120m', 8.4, 'high', null, 'Luca ce l\'ha — valutare se prenderlo o giocarlo da lui.', 3, false], // notes only
+  // ── Media (4) ──
+  ['Wingspan', '🦜', 'Family', '1–5', '40–70m', 8.1, 'medium', 45, 'Regalo per Sara, con espansione europea inclusa.', 30, false],
+  ['Cascadia', '🏞️', 'Family', '1–4', '30–45m', 7.9, 'medium', 30, '', 18, false],           // price only
+  ['Everdell', '🌳', 'Strategy', '1–4', '40–80m', 8.0, 'medium', null, 'Componentistica stupenda — soprattutto l\'albero 3D.', 45, false], // notes only
+  ['The Crew: Missione Nove', '🚀', 'CardGames', '2–5', '20m', 7.9, 'medium', 15, 'Cooperativo a prese, perfetto da viaggio.', 12, false],
+  // ── Bassa (3) ──
+  ['Power Grid', '⚡', 'Strategy', '2–6', '120m', 7.9, 'low', 38, '', 60, false],             // price only
+  ['Patchwork', '🧵', 'Abstract', '2', '15–30m', 7.7, 'low', null, 'Filler veloce per due — buono per la coda di serata.', 50, false], // notes only
+  ['Sky Team', '✈️', 'CardGames', '2', '15m', 7.8, 'low', null, '', 1, true],               // minimal quick-add
+];
+
+function buildWishlist() {
+  return RAW.map((r, i) => {
+    const [name, emoji, category, players, duration, bgg, priority, targetPrice, notes, daysAgo, minimal] = r;
+    const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+    return {
+      id: `wl-${PAD(i)}-${slug}`,
+      gameId: `g-${slug}`,
+      name, emoji, category, players, duration, bgg, priority,
+      targetPrice: targetPrice, notes: notes || '',
+      addedAt: new Date(NOW.getTime() - daysAgo * 86400000),
+      daysAgo, minimal: !!minimal,
+    };
+  });
+}
+const WISHLIST = buildWishlist();
+const TOTAL = WISHLIST.length;
+const PRIO_COUNTS = Object.fromEntries(PRIO_ORDER.map(p => [p, WISHLIST.filter(w => w.priority === p).length]));
+const TOTAL_SPEND = WISHLIST.reduce((a, w) => a + (w.targetPrice || 0), 0);
+
+// catalog per il game selector del dialog (giochi non già in wishlist + alcuni owned)
+const LIB_GAMES = DS.games.filter(g => g.status !== 'wishlist');
+
+window.__LW_CSS = '';
+window.__LW = {
+  eHsl, relDate, fmtDateTime, euro, NOW,
+  PRIO, PRIO_ORDER, CATMETA,
+  WISHLIST, TOTAL, PRIO_COUNTS, TOTAL_SPEND, LIB_GAMES,
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── COMPONENT CSS (inject) — solo token da tokens.css ──
+// ═══════════════════════════════════════════════════════
+const LW_CSS = `
+.lw-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; --e:var(--c-game); }
+
+/* ─ error banner ─ */
+.lw-errbar { flex-shrink:0; display:flex; align-items:center; gap:11px; padding:11px 18px; font-family:var(--f-display); font-weight:700; font-size:13px;
+  background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); border-bottom:1px solid hsl(var(--c-danger) / .3); }
+.lw-errbar .grow { flex:1; }
+.lw-errbar .retry { display:inline-flex; align-items:center; gap:6px; padding:6px 13px; border-radius:var(--r-md); border:1px solid hsl(var(--c-danger) / .4);
+  background:var(--bg-card); color:hsl(var(--c-danger)); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; }
+
+/* ─ header (sticky) ─ */
+.lw-head { flex-shrink:0; position:sticky; top:0; z-index:12; background:var(--glass-bg); backdrop-filter:blur(14px); border-bottom:1px solid var(--border); padding:14px 22px 0; }
+.lw-htop { display:flex; align-items:flex-start; gap:16px; }
+.lw-htxt { min-width:0; flex:1; }
+.lw-bread { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); letter-spacing:.04em; display:flex; align-items:center; gap:6px; margin-bottom:7px; }
+.lw-bread .sep { opacity:.5; }
+.lw-bread .cur { color:var(--text-sec); font-weight:700; }
+.lw-titlerow { display:flex; align-items:center; gap:11px; }
+.lw-ico { width:34px; height:34px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-game) / .16); color:hsl(var(--c-game));
+  display:inline-flex; align-items:center; justify-content:center; font-size:18px; }
+.lw-h1 { font-family:var(--f-display); font-weight:800; font-size:29px; letter-spacing:-.02em; line-height:1.1; color:var(--text); white-space:nowrap; }
+.lw-h1 .heart { color:hsl(var(--c-game)); }
+.lw-sub { font-size:14px; color:var(--text-sec); margin-top:5px; max-width:560px; }
+.lw-hright { display:flex; flex-direction:column; align-items:flex-end; gap:10px; flex-shrink:0; }
+.lw-qstat { display:inline-flex; align-items:center; gap:7px; font-family:var(--f-mono); font-size:11px; color:var(--text-muted); white-space:nowrap; }
+.lw-qstat b { color:var(--text-sec); font-weight:700; }
+.lw-qstat .dot { opacity:.5; }
+.lw-cta { display:inline-flex; align-items:center; gap:7px; padding:9px 16px; border-radius:var(--r-md); background:hsl(var(--c-game));
+  border:none; color:#fff; font-family:var(--f-display); font-weight:800; font-size:13px; cursor:pointer; white-space:nowrap;
+  box-shadow:0 4px 14px hsl(var(--c-game) / .35); transition:all var(--dur-sm) var(--ease-out); }
+.lw-cta:hover { filter:brightness(1.05); transform:translateY(-1px); }
+
+/* ─ tabs nav (tie-in /library) ─ */
+.lw-tabs { display:flex; gap:4px; margin-top:14px; overflow-x:auto; scrollbar-width:none; }
+.lw-tabs::-webkit-scrollbar { display:none; }
+.lw-tab { display:inline-flex; align-items:center; gap:6px; padding:9px 14px 11px; border:none; background:transparent; cursor:pointer; white-space:nowrap;
+  border-bottom:2px solid transparent; color:var(--text-muted); font-family:var(--f-display); font-weight:700; font-size:13px; transition:color var(--dur-sm); text-decoration:none; }
+.lw-tab:hover { color:var(--text-sec); }
+.lw-tab.on { color:hsl(var(--c-game)); border-bottom-color:hsl(var(--c-game)); }
+
+/* ─ toolbar ─ */
+.lw-toolbar { flex-shrink:0; display:flex; align-items:center; gap:12px; padding:11px 22px; background:var(--bg); border-bottom:1px solid var(--border); flex-wrap:wrap; row-gap:10px; }
+.lw-search { flex:0 1 300px; max-width:340px; min-width:160px; position:relative; }
+.lw-search .ic { position:absolute; left:11px; top:50%; transform:translateY(-50%); font-size:13px; opacity:.6; pointer-events:none; }
+.lw-search input { width:100%; padding:9px 70px 9px 32px; border-radius:var(--r-md); border:1.5px solid var(--border);
+  background:var(--bg-card); font-family:var(--f-body); font-size:13px; color:var(--text); outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.lw-search input::placeholder { color:var(--text-muted); }
+.lw-search input:focus, .lw-search.active input { border-color:hsl(var(--c-game) / .6); box-shadow:0 0 0 3px hsl(var(--c-game) / .14); }
+.lw-search .clear { position:absolute; right:9px; top:50%; transform:translateY(-50%); width:20px; height:20px; border-radius:var(--r-pill);
+  border:none; background:var(--bg-muted); color:var(--text-sec); cursor:pointer; font-size:11px; display:inline-flex; align-items:center; justify-content:center; }
+.lw-search .clear:hover { background:var(--border-strong); color:var(--text); }
+.lw-search .busy { position:absolute; right:34px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; gap:5px;
+  font-family:var(--f-mono); font-size:10px; color:hsl(var(--c-info)); white-space:nowrap; }
+.lw-search .busy i { width:6px; height:6px; border-radius:50%; background:currentColor; animation:lw-typedot 1s var(--ease-in-out) infinite; }
+
+/* priority filter chips (multi-select checkbox group) */
+.lw-chips { flex:1 1 auto; display:flex; align-items:center; gap:8px; flex-wrap:wrap; row-gap:8px; min-width:0; padding:2px; }
+.lw-chips.scroll { flex-wrap:nowrap; overflow-x:auto; scrollbar-width:none; }
+.lw-chips.scroll::-webkit-scrollbar { display:none; }
+.lw-chip { display:inline-flex; align-items:center; gap:7px; padding:7px 13px; border-radius:var(--r-pill); white-space:nowrap; flex-shrink:0;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); cursor:pointer; transition:all var(--dur-sm) var(--ease-out);
+  font-family:var(--f-display); font-weight:700; font-size:12.5px; }
+.lw-chip:hover { background:var(--bg-hover); }
+.lw-chip .cdot { width:8px; height:8px; border-radius:50%; flex-shrink:0; background:var(--text-muted); }
+.lw-chip .ccount { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); opacity:.9; }
+/* "Tutti" = neutral game */
+.lw-chip.all.on { color:var(--text); background:var(--bg-muted); border-color:var(--border-strong); }
+.lw-chip.all.on .cdot { background:hsl(var(--c-game)); }
+.lw-chip.all.on .ccount { color:var(--text-sec); }
+/* priority-tinted active (via --p) */
+.lw-chip.prio .cdot { background:hsl(var(--p)); }
+.lw-chip.prio.on { background:hsl(var(--p) / .14); border-color:hsl(var(--p) / .42); color:hsl(var(--p)); }
+.lw-chip.prio.on .ccount { color:currentColor; }
+
+/* right cluster: sort */
+.lw-right { flex-shrink:0; display:flex; align-items:center; gap:10px; }
+.lw-fgroup { position:relative; display:flex; align-items:center; }
+.lw-sortbtn { display:inline-flex; align-items:center; gap:7px; padding:8px 13px; border-radius:var(--r-md); background:var(--bg-card); border:1.5px solid var(--border);
+  color:var(--text-sec); cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:12.5px; white-space:nowrap; }
+.lw-sortbtn:hover { background:var(--bg-hover); }
+.lw-pop { position:absolute; top:calc(100% + 6px); right:0; z-index:30; background:var(--bg-card); border:1px solid var(--border);
+  border-radius:var(--r-md); box-shadow:var(--shadow-lg); padding:6px; min-width:210px; display:flex; flex-direction:column; gap:2px; }
+.lw-pophead { font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); padding:4px 8px 6px; }
+.lw-popitem { display:flex; align-items:center; gap:9px; width:100%; padding:8px 10px; border-radius:var(--r-sm); border:none; background:transparent; cursor:pointer;
+  color:var(--text); font-family:var(--f-display); font-weight:600; font-size:13px; text-align:left; }
+.lw-popitem:hover { background:var(--bg-muted); }
+.lw-popitem .check { width:16px; height:16px; border-radius:50%; border:1.5px solid var(--border-strong); flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; font-size:10px; color:hsl(var(--c-game)); }
+.lw-popitem.sel .check { border-color:hsl(var(--c-game)); }
+.lw-popitem .lbl { flex:1; }
+
+/* active filter summary */
+.lw-fsum { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:8px 22px; background:var(--bg-sunken); border-bottom:1px solid var(--border-light);
+  font-family:var(--f-mono); font-size:11px; color:var(--text-sec); }
+.lw-fsum .badge { display:inline-flex; align-items:center; gap:6px; padding:3px 9px; border-radius:var(--r-pill); background:hsl(var(--c-game) / .14); color:hsl(var(--c-game)); font-weight:700; }
+.lw-fsum .clear { background:transparent; border:none; cursor:pointer; color:hsl(var(--c-warning)); font-family:var(--f-display); font-weight:800; font-size:12px; }
+.lw-fsum .grow { flex:1; }
+
+/* ─ body / grid ─ */
+.lw-body { flex:1; overflow:auto; min-height:0; position:relative; padding:18px 22px 26px; }
+.lw-grid { display:grid; gap:16px; grid-template-columns:repeat(auto-fill, minmax(260px, 1fr)); }
+
+/* ─ wishlist card ─ */
+.lw-card { position:relative; display:flex; flex-direction:column; gap:12px; min-height:280px; padding:16px;
+  background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--r-lg); box-shadow:var(--shadow-sm);
+  transition:box-shadow var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out), transform var(--dur-sm) var(--ease-out); }
+.lw-card:hover { box-shadow:var(--shadow-md); border-color:hsl(var(--c-game) / .4); transform:translateY(-2px); }
+.lw-card.high { border-left:3px solid hsl(var(--c-danger)); }
+
+/* header row */
+.lw-chead { display:flex; align-items:center; gap:8px; }
+.lw-heart { width:26px; height:26px; flex-shrink:0; border-radius:var(--r-sm); display:inline-flex; align-items:center; justify-content:center; font-size:14px;
+  background:hsl(var(--c-game) / .14); }
+.lw-chgrow { flex:1; }
+.lw-pbadge { display:inline-flex; align-items:center; gap:5px; padding:3px 9px 3px 8px; border-radius:var(--r-pill); cursor:pointer; flex-shrink:0;
+  border:1px solid hsl(var(--p) / .4); background:hsl(var(--p) / .14); color:hsl(var(--p));
+  font-family:var(--f-display); font-weight:800; font-size:10.5px; transition:filter var(--dur-xs); }
+.lw-pbadge:hover { filter:brightness(.95); }
+.lw-pbadge.low { color:var(--text-sec); border-color:var(--border-strong); background:var(--bg-muted); }
+
+/* game name */
+.lw-cname { font-family:var(--f-display); font-weight:800; font-size:16.5px; line-height:1.2; color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  border:none; background:transparent; padding:0; cursor:pointer; text-align:left; width:100%; display:flex; align-items:center; gap:7px; }
+.lw-cname .gem { font-size:15px; flex-shrink:0; }
+.lw-cname .gtxt { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lw-cname:hover .gtxt { color:hsl(var(--c-game)); }
+
+/* meta box (mini-card) */
+.lw-metabox { display:flex; flex-direction:column; gap:6px; padding:9px 11px; border-radius:var(--r-md); background:var(--bg-muted); border:1px solid var(--border-light); }
+.lw-metarow { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.lw-ecat { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill); flex-shrink:0;
+  background:hsl(var(--c-game) / .14); color:hsl(var(--c-game)); border:1px solid hsl(var(--c-game) / .22);
+  font-family:var(--f-display); font-weight:700; font-size:10.5px; }
+.lw-mchip { display:inline-flex; align-items:center; gap:4px; font-family:var(--f-mono); font-size:11px; color:var(--text-sec); white-space:nowrap; }
+.lw-mchip .mi { opacity:.7; }
+.lw-mchip.bgg { color:hsl(var(--c-warning)); font-weight:700; }
+
+/* target price + notes */
+.lw-pn { display:flex; flex-direction:column; gap:4px; }
+.lw-price { font-family:var(--f-mono); font-size:13px; font-weight:700; color:var(--text); display:inline-flex; align-items:baseline; gap:6px; }
+.lw-price .plbl { font-family:var(--f-display); font-size:11px; font-weight:700; color:var(--text-muted); text-transform:uppercase; letter-spacing:.05em; }
+.lw-notes { font-size:12px; color:var(--text-sec); line-height:var(--lh-snug); margin:0;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.lw-noprice { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); }
+
+.lw-spacer { flex:1; }
+
+/* added-at */
+.lw-added { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); display:inline-flex; align-items:center; gap:6px; }
+.lw-added .ai { opacity:.7; }
+
+.lw-cdiv { height:1px; background:var(--border-light); }
+
+/* footer actions */
+.lw-acts { display:flex; align-items:center; gap:6px; }
+.lw-act { display:inline-flex; align-items:center; gap:6px; padding:7px 11px; border-radius:var(--r-md); border:1px solid var(--border-light); background:transparent;
+  color:var(--text-sec); cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:12px; transition:all var(--dur-sm) var(--ease-out); }
+.lw-act.edit:hover { color:hsl(var(--c-game)); border-color:hsl(var(--c-game) / .4); background:hsl(var(--c-game) / .08); }
+.lw-act.del { margin-left:auto; }
+.lw-act.del:hover { color:hsl(var(--c-danger)); border-color:hsl(var(--c-danger) / .4); background:hsl(var(--c-danger) / .08); }
+
+/* ─ empty / loading ─ */
+.lw-pad { min-height:340px; display:flex; align-items:center; justify-content:center; padding:30px 24px; }
+.lw-empty { text-align:center; max-width:440px; border:1.5px dashed var(--border-strong); border-radius:var(--r-xl); padding:46px 34px;
+  display:flex; flex-direction:column; align-items:center; }
+.lw-empty .em { width:74px; height:74px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:32px; margin-bottom:16px;
+  background:hsl(var(--c-game) / .12); }
+.lw-empty h3 { font-family:var(--f-display); font-size:21px; font-weight:800; margin:0 0 8px; }
+.lw-empty p { font-size:14px; color:var(--text-sec); line-height:1.55; margin:0 0 22px; max-width:340px; }
+.lw-empty .cta { display:inline-flex; align-items:center; gap:8px; padding:11px 20px; border-radius:var(--r-md); border:none;
+  background:hsl(var(--c-game)); color:#fff; font-family:var(--f-display); font-weight:800; font-size:14px; cursor:pointer; box-shadow:0 4px 14px hsl(var(--c-game) / .32); }
+.lw-empty.filter { border-style:dashed; }
+.lw-empty.filter .em { background:hsl(var(--c-warning) / .12); }
+.lw-empty.filter .cta { background:transparent; color:hsl(var(--c-warning)); border:1px solid hsl(var(--c-warning) / .5); box-shadow:none; }
+
+.lw-sk { border-radius:var(--r-sm); }
+.lw-skcard { display:flex; flex-direction:column; gap:12px; min-height:280px; padding:16px; background:var(--bg-card); border:1px solid var(--border-light); border-radius:var(--r-lg); }
+
+/* ─ add/edit dialog ─ */
+.lw-overlay { position:absolute; inset:0; z-index:50; background:rgba(20,12,4,.46); backdrop-filter:blur(3px); display:flex; align-items:center; justify-content:center; padding:28px; animation:lw-overlay-in var(--dur-md) var(--ease-out); }
+[data-theme="dark"] .lw-overlay { background:rgba(0,0,0,.62); }
+.lw-modal { width:min(520px, 100%); max-height:100%; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg);
+  display:flex; flex-direction:column; overflow:hidden; animation:lw-modal-in var(--dur-md) var(--ease-spring); }
+.lw-mhead { flex-shrink:0; display:flex; align-items:flex-start; gap:13px; padding:18px 20px; border-bottom:1px solid var(--border); }
+.lw-mcov { width:40px; height:40px; flex-shrink:0; border-radius:var(--r-md); display:inline-flex; align-items:center; justify-content:center; font-size:19px; background:hsl(var(--c-game) / .16); color:hsl(var(--c-game)); }
+.lw-mhtxt { flex:1; min-width:0; }
+.lw-mtitle { font-family:var(--f-display); font-weight:800; font-size:19px; letter-spacing:-.01em; color:var(--text); }
+.lw-msub { font-family:var(--f-mono); font-size:11px; color:var(--text-sec); margin-top:4px; }
+.lw-mclose { width:32px; height:32px; flex-shrink:0; border-radius:var(--r-sm); border:none; background:var(--bg-muted); color:var(--text-muted); cursor:pointer; font-size:16px; }
+.lw-mclose:hover { background:var(--border-strong); color:var(--text); }
+.lw-mbody { flex:1; overflow-y:auto; padding:18px 20px; display:flex; flex-direction:column; gap:17px; }
+
+/* error banner in dialog */
+.lw-merr { display:flex; align-items:center; gap:9px; padding:10px 12px; border-radius:var(--r-md); background:hsl(var(--c-danger) / .08); border:1px solid hsl(var(--c-danger) / .3);
+  color:hsl(var(--c-danger)); font-family:var(--f-display); font-weight:700; font-size:12.5px; }
+.lw-merr .grow { flex:1; }
+.lw-merr .rt { border:none; background:transparent; color:hsl(var(--c-danger)); font-family:var(--f-display); font-weight:800; font-size:12px; cursor:pointer; text-decoration:underline; }
+
+.lw-field { display:flex; flex-direction:column; gap:7px; }
+.lw-flabel { display:flex; align-items:center; gap:6px; font-family:var(--f-mono); font-size:10px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); }
+.lw-flabel .req { color:hsl(var(--c-danger)); }
+.lw-flabel .grow { flex:1; }
+.lw-counter { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.lw-counter.near { color:hsl(var(--c-warning)); }
+
+/* game combo */
+.lw-combo { position:relative; }
+.lw-combo input { width:100%; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text);
+  font-family:var(--f-body); font-size:13px; outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.lw-combo input:focus { border-color:hsl(var(--c-game) / .6); box-shadow:0 0 0 3px hsl(var(--c-game) / .14); }
+.lw-selected { display:flex; align-items:center; gap:8px; padding:8px 8px 8px 11px; border-radius:var(--r-md); background:hsl(var(--c-game) / .1); border:1.5px solid hsl(var(--c-game) / .3); }
+.lw-selected .se { font-size:16px; }
+.lw-selected .sn { flex:1; font-family:var(--f-display); font-weight:700; font-size:13.5px; color:hsl(var(--c-game)); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lw-selected .sx { width:24px; height:24px; flex-shrink:0; border-radius:var(--r-sm); border:none; background:hsl(var(--c-game) / .14); color:hsl(var(--c-game)); cursor:pointer; font-size:12px; }
+.lw-selected .sx:hover { background:hsl(var(--c-game) / .24); }
+.lw-dropdown { position:absolute; top:calc(100% + 5px); left:0; right:0; z-index:20; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-md);
+  box-shadow:var(--shadow-lg); padding:5px; display:flex; flex-direction:column; gap:1px; max-height:184px; overflow-y:auto; }
+.lw-dopt { display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:var(--r-sm); border:none; background:transparent; cursor:pointer; text-align:left;
+  font-family:var(--f-display); font-weight:600; font-size:13px; color:var(--text); }
+.lw-dopt:hover, .lw-dopt.hl { background:var(--bg-muted); }
+.lw-dopt .de { font-size:15px; }
+.lw-dopt .dmeta { margin-left:auto; font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+
+/* priority radio chips */
+.lw-prioset { display:flex; gap:8px; }
+.lw-priochip { flex:1; display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:10px 8px; border-radius:var(--r-md); cursor:pointer;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:12.5px; transition:all var(--dur-sm) var(--ease-out); }
+.lw-priochip:hover { background:var(--bg-hover); }
+.lw-priochip.on { background:hsl(var(--p) / .14); border-color:hsl(var(--p) / .5); color:hsl(var(--p)); }
+.lw-priochip.low.on { color:var(--text); border-color:var(--border-strong); background:var(--bg-muted); }
+
+/* number + textarea */
+.lw-numwrap { position:relative; display:flex; align-items:center; }
+.lw-numwrap .pfx { position:absolute; left:12px; font-family:var(--f-mono); font-size:13px; color:var(--text-muted); pointer-events:none; }
+.lw-numwrap input { width:100%; padding:10px 12px 10px 28px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text);
+  font-family:var(--f-mono); font-size:13px; outline:none; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.lw-numwrap input:focus { border-color:hsl(var(--c-game) / .6); box-shadow:0 0 0 3px hsl(var(--c-game) / .14); }
+.lw-ta { width:100%; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text);
+  font-family:var(--f-body); font-size:13px; line-height:1.5; outline:none; resize:vertical; min-height:64px; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.lw-ta:focus { border-color:hsl(var(--c-game) / .6); box-shadow:0 0 0 3px hsl(var(--c-game) / .14); }
+.lw-ta::placeholder { color:var(--text-muted); }
+.lw-hint { font-size:11px; color:var(--text-muted); display:inline-flex; align-items:center; gap:5px; }
+
+.lw-mfoot { flex-shrink:0; display:flex; align-items:center; gap:10px; padding:14px 20px; border-top:1px solid var(--border); }
+.lw-mfoot .grow { flex:1; }
+.lw-mbtn { display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:10px 16px; border-radius:var(--r-md); border:1px solid var(--border-strong); background:var(--bg-card);
+  color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:13px; cursor:pointer; transition:all var(--dur-sm) var(--ease-out); }
+.lw-mbtn:hover { background:var(--bg-muted); color:var(--text); }
+.lw-mbtn.primary { background:hsl(var(--c-game)); border-color:transparent; color:#fff; box-shadow:0 4px 14px hsl(var(--c-game) / .3); }
+.lw-mbtn.primary:hover { filter:brightness(1.05); background:hsl(var(--c-game)); color:#fff; }
+.lw-mbtn.primary:disabled { background:var(--bg-muted); color:var(--text-muted); box-shadow:none; cursor:not-allowed; border-color:var(--border); }
+.lw-spin { width:14px; height:14px; border-radius:50%; border:2px solid rgba(255,255,255,.4); border-top-color:#fff; animation:lw-spin .7s linear infinite; }
+
+/* toast */
+.lw-toast { position:absolute; right:20px; bottom:20px; z-index:70; display:flex; align-items:center; gap:10px; padding:12px 16px; border-radius:var(--r-md);
+  background:var(--bg-card); border:1px solid hsl(var(--c-game) / .35); box-shadow:var(--shadow-lg); animation:lw-toast-in var(--dur-md) var(--ease-spring); }
+.lw-toast .tk { width:26px; height:26px; border-radius:50%; flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; background:hsl(var(--c-game) / .16); color:hsl(var(--c-game)); font-size:14px; }
+.lw-toast .tt { font-family:var(--f-display); font-weight:700; font-size:13px; color:var(--text); }
+
+/* ─ mobile adaptations ─ */
+.lw-app.is-mobile .lw-head { padding:12px 14px 0; }
+.lw-app.is-mobile .lw-h1 { font-size:20px; white-space:normal; }
+.lw-app.is-mobile .lw-htop { flex-direction:column; gap:10px; }
+.lw-app.is-mobile .lw-hright { flex-direction:row; align-items:center; align-self:stretch; flex-wrap:wrap; justify-content:space-between; }
+.lw-app.is-mobile .lw-toolbar { padding:11px 14px; gap:10px; }
+.lw-app.is-mobile .lw-search { flex:1 1 100%; max-width:100%; }
+.lw-app.is-mobile .lw-chips { flex:1 1 100%; flex-wrap:wrap; overflow:visible; row-gap:8px; }
+.lw-app.is-mobile .lw-chip { flex:1 1 auto; justify-content:center; }
+.lw-app.is-mobile .lw-right { flex:1 1 100%; }
+.lw-app.is-mobile .lw-sortbtn { flex:1; justify-content:center; }
+.lw-app.is-mobile .lw-body { padding:14px; }
+.lw-app.is-mobile .lw-grid { grid-template-columns:repeat(auto-fill, minmax(150px, 1fr)); gap:12px; }
+.lw-app.is-mobile .lw-card { min-height:0; }
+.lw-app.is-mobile .lw-fsum { padding:8px 14px; }
+.lw-app.is-mobile .lw-overlay { padding:0; align-items:flex-end; }
+.lw-app.is-mobile .lw-modal { width:100%; max-height:94%; border-radius:var(--r-2xl) var(--r-2xl) 0 0; animation:lw-sheet-in var(--dur-lg) var(--ease-spring); }
+.lw-app.is-mobile .lw-toast { left:14px; right:14px; bottom:14px; }
+`;
+
+window.__LW_CSS = LW_CSS;

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -158,15 +158,14 @@ sub-pages · nodi architetturali N4/N6/N7.
   l'altra con `redirect()` Next.js. Aggiornare il mapping
   in `MOCKUPS_INDEX.md` e in `v2-migration-matrix.md`.
 
-### Gap N5 — `/library/wishlist`
+### Gap N5 — `/library/wishlist` ✅ CLOSED 2026-06-02 (PR pending, #1491)
 
-- **Stato**: route esistente, codice impl attivo (`MeepleWishlistCard`,
-  `AddToWishlistDialog`, `useWishlist`).
-- **Mockup attuale**: nessuno dedicato. Riusa `MeepleCard` + Dialog primitives.
-- **Impatto**: layout/empty state/add-dialog UX non specificati centralmente.
-- **Tier**: S.
-- **Recommendation**: estendere `sp4-library-desktop.html` con variant
-  wishlist OR aprire `[Design v1 · B16] Mockup Library Wishlist standalone`.
+- **Stato**: route coperta da mockup dedicato (Option B standalone vinto).
+- **Mockup shipped**: `sp4-library-wishlist.html` + `.jsx` + `-ui.jsx` (split-multi pattern come cluster #1490). Coverage: card grid responsive con priority badge (Alta --c-danger / Media --c-warning / Bassa --text-muted), target price, notes, BGG meta, Modifica/Rimuovi actions; toolbar con search debounce + priority filter multi-select + sort; AddToWishlistDialog form (game combobox autocomplete + priority radiogroup + target price number + notes textarea con char counter); 8 stati (default / filter-priority-alta / filter-search-active / empty-no-items / loading / error / add-dialog-open / mobile-stack).
+- **Issue tracker**: [#1491 Design v1 · B16] Mockup Library Wishlist — opened 2026-05-22, mockup shipped 2026-06-02 via Claude Design web canvas (pattern P156 + cluster iterative project knowledge P159).
+- **Closing PR**: `feature/issue-1491-mockup-library-wishlist` → `main-dev`.
+- **Decisione architecturale**: Option B (standalone) vs Option A (variant in sp4-library-desktop) — spec-panel discussion 3 esperti (Fowler architecture + Adzic concrete examples + Doumont visual clarity) convergent su B per separation of concerns + coerenza cluster #1490 (1 file = 1 screen) + naming auto-descrittivo. Documentata in header comment file.
+- **Updates correlati**: `00-hub.html` (1 nuova card SP4 entity --c-game, **merge corretto 3 cluster consecutivo** — P155 NOT triggered), `v2-migration-matrix.md` (riga `/library/wishlist` aggiunta).
 
 ### Gap N6 — `/games/[id]/{reviews,rules,strategies}`
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -709,7 +709,7 @@ instead.
 | Route | Mockup | Note |
 |-------|--------|------|
 | `/library` | `sp4-library-desktop.html` + `sp4-library-mobile.html` | Tier S done (PR #574/635/638); mobile variant SP8 brief 2026-05-30 (IA semplificata 3 tab + overflow Più=Agents/KB) |
-| `/library/wishlist` | — | gap — issue B16 #1491 aperta (audit 2026-05-22 gap N5) |
+| `/library/wishlist` | `sp4-library-wishlist.html` [done] | B16 #1491 · Standalone (Option B vs A variant) · Card grid responsive + priority filter multi-select (Alta/Media/Bassa) + AddToWishlistDialog (game combo + radiogroup + target price + notes), 8 stati |
 | `/library/playlists` · `/[id]` · `/shared/[token]` | n/a | route INESISTENTI nel codebase (false-positive audit 2026-05-12, confermato 2026-05-22) — rimosso dal scope |
 | `/library/private` · `/add` · `/[id]` | `sp4-add-game-pdf-dedup.html` + `sp4-upload-wizard-extended.html` [partial] | — |
 | `/library/private/[id]/toolkit/configure` | `sp4-toolkit-detail.html` ↻ | — |


### PR DESCRIPTION
## Summary

Chiude **gap B16** (issue #1491 "Design v1 — Library Wishlist standalone"). 1 mockup screen Tier S split-multi (3 file: HTML scaffold + helper JSX + UI JSX) per `/library/wishlist`, prodotto via Claude Design web canvas.

## Decisione architecturale (documentata in header)

**Option B (standalone)** vs Option A (variant in sp4-library-desktop). Spec-panel 3 esperti (Fowler / Adzic / Doumont) convergent su B per:
- **Separation of concerns** — 1 file = 1 route, no coupling cross-screen
- **Coerenza cluster #1490** — single-file pattern già consolidato (sp4-toolkit-*)
- **Naming auto-descrittivo** — discovery rapido nel design system

## Files (3 in admin-mockups/design_files/)

- `sp4-library-wishlist.html` (50 LOC scaffold + keyframes inline)
- `sp4-library-wishlist.jsx` (410 LOC helper: CSS string + fixture + window globals; mobile CSS fix `wrap+row-gap` per touch UX invece di horizontal scroll)
- `sp4-library-wishlist-ui.jsx` (673 LOC componente React + STATES matrix 8 stati + state picker)

## Coverage

| Componente | Dettaglio |
|------------|-----------|
| **Card grid** | Responsive 4-col desktop / 2-col mobile, 6 variants (default/high-priority/with-price-only/with-notes-only/complete/minimal) |
| **Priority badges** | Alta `--c-danger` / Media `--c-warning` / Bassa `--text-muted` con click-to-filter pattern power-user |
| **Card body** | Game name + meta box (category EntityChip + players + duration + BGG rating) + target price + notes preview + addedAt relative + Modifica/Rimuovi quick actions |
| **Toolbar** | Search debounce + priority multi-select chips + sort dropdown |
| **AddToWishlistDialog** | Game combobox autocomplete + priority radiogroup + target price number + notes textarea char counter |
| **8 stati** | default / filter-priority-alta / filter-search-active / empty-no-items / loading / error / add-dialog-open / mobile-stack |

## Quality bullets (DoD verificato)

- [x] Solo CSS variables da `tokens.css`
- [x] Light + dark mode parity
- [x] Mobile 375 + desktop 1440 responsive (mobile chips `wrap+row-gap` user fix)
- [x] State picker UI continuity (`lw-state` localStorage)
- [x] Theme toggle 🌗 persistito `mai-theme`
- [x] EntityChip cluster-wide consistent (--c-game primaria)
- [x] ARIA comprehensive (`role="list/dialog/searchbox/combobox/radiogroup/radio/checkbox/button"`, `aria-modal/expanded/autocomplete/checked/pressed/label`, focus management)
- [x] Keyboard shortcuts (`/` focus search, `n` new wishlist item, `1/2/3` quick filter priority)
- [x] Reduced motion CSS (`@media (prefers-reduced-motion: reduce)`)
- [x] Testo IT + dati realistici da `data.js` (Brass: Birmingham, Wingspan, Ark Nova, Spirit Island, Gloomhaven, Catan, Power Grid — giochi BGG-popular)
- [x] Header comment con decisione architecturale Option B + reasoning

## Updates correlati

- **`00-hub.html`**: 1 nuova card SP4 (entity --c-game) — merge **CORRETTO 3 cluster consecutivo** (#1489 5/5 P155 triggered, #1490 4/4 NOT triggered, #1491 1/1 NOT triggered)
- **`v2-migration-matrix.md`**: row `/library/wishlist` flipped da `gap` a `done`
- **`2026-05-22-mockup-gaps.md`**: gap **N5 (B16) marked CLOSED** con dettaglio decisione + coverage

## User mid-session fix

Mobile chips: changed from `flex-wrap:nowrap + overflow-x:auto` (horizontal scroll hidden) to `flex-wrap:wrap + row-gap:8px + flex:1 1 auto + justify-content:center` (chip wrap su new line, touch-friendly). Applicato in `sp4-library-wishlist.jsx` linee 397-398.

## Test plan

- [ ] Visual smoke: `cd admin-mockups/design_files && python -m http.server 8765` → verifica `sp4-library-wishlist.html` su `:8765/<file>.html` (default light + toggle dark via 🌗)
- [ ] Verifica responsive 375 / 1440 via devtools (mobile chips wrap visibile)
- [ ] Verifica state picker funzionante (8 stati)
- [ ] Verifica `00-hub.html` mostra 1 nuova card SP4
- [ ] Verifica gap N5 in `2026-05-22-mockup-gaps.md` marked CLOSED
- [ ] Verifica matrix row `/library/wishlist` done

## Closes

Closes #1491 (gap B16 / Design v1 · Library Wishlist standalone)

## Out of scope (deferred a follow-up issues)

- Implementation FE delle modifiche post-mockup a `apps/web/src/components/wishlist/**` (esistente già funzionale; possibili refactor minor identificabili in code review separato)

## Next mockup gaps (epic #1475 Phase D residue)

Resta **1 mockup gap user-facing** in Phase D:

- **#1492 B17 Sessions sub-pages** (P2, ADR Opt A 8 file vs Opt B tabs consolidation + 1-8 files)

Epic #1475 user-facing UI passerà da 24/26 (92%) a **25/26 (96%)** dopo merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)