### PR TITLE
fix(library): #1822 follow-up — forward HybridHubItem.id to MeepleCard

### DIFF
--- a/apps/web/src/components/features/library/LibraryHybridGrid.tsx
+++ b/apps/web/src/components/features/library/LibraryHybridGrid.tsx
@@ -119,6 +119,7 @@ export function LibraryHybridGrid({
             <MeepleCard
               entity={item.entity}
               variant={variant}
+              id={item.id}
               title={item.title}
               subtitle={item.subtitle}
               imageUrl={itemImageUrl(item)}


### PR DESCRIPTION
## Summary

One-line follow-up to #1822 (L1 placeholder).

The L1 fix added a rich \`<GameCoverPlaceholder>\` to \`Cover.tsx\` gated on \`entity === 'game' && gameId\`. The variant cards forward \`MeepleCard.id\` → Cover.gameId, but \`LibraryHybridGrid\` was not passing \`item.id\` to MeepleCard, so /library cards fell through to the legacy entity-icon (🎲) placeholder instead of the per-game hue+initials variant.

## Verification

- Live smoke on staging post-#1825 deploy (\`055edc5\`): \`/library\` shows \`🎲\` for Catan rather than \`CA\` on a hue background.
- Network panel: zero requests to \`cf.geekdo-images.com\` (the BGG-elimination part of L1 works fine — only the rich-placeholder selection is broken).

## Fix

```diff
 <MeepleCard
   entity={item.entity}
   variant={variant}
+  id={item.id}
   title={item.title}
   ...
 />
```

\`HybridHubItemBase.id\` is already a required \`string\` (see \`hybrid-hub.types.ts:33\`), so this is a pure additive call-site fix.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Post-deploy: \`/library\` Catan card renders "CA" on hue-tinted background (data-testid \`game-cover-placeholder\` present)

Follow-up of #1822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)