### PR TITLE
docs(design): #1492 add sp4-session-play residual mockup (B17 closure + epic #1475 100%)

### DIFF
--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -355,6 +355,14 @@
     <div class="tags"><span class="tag">8 stati</span><span class="tag">Card grid</span><span class="tag">Add dialog</span></div>
   </a>
 
+  <a class="hub-card e-session" href="sp4-session-play.html">
+    <div class="arrow">→</div>
+    <div class="num">B17 · #1492 · 1/1</div>
+    <h3>Session play — live game session view</h3>
+    <p>Vista live durante la partita (/sessions/[id]/play, active play mode — distinta da /live spectator): header sticky con status FSM (Attiva/In pausa/Conclusa) + turno corrente + durata live, layout 3-col desktop (Scoreboard PV con inline +/− e breakdown / Activity feed SSE con filtri multi-select / Chat agent rules con streaming) e stack mobile con chat bottom-sheet. Score &amp; Dispute modal, Rules sheet slide-over, dispute handling, finalize prompt. 10 stati: active-default / paused / dispute / score-modal / dispute-modal / rules-sheet / agent-streaming / sse-disconnected / finalize / mobile-stack. Chiude epic #1475 (gap N7).</p>
+    <div class="tags"><span class="tag">10 stati</span><span class="tag">3-col + Live FSM</span><span class="tag">SSE · Chat · Dispute</span></div>
+  </a>
+
   <a class="hub-card e-event" href="sp7-game-night-live.html">
     <div class="arrow">→</div>
     <div class="num">SP7 · K · #487</div>

--- a/admin-mockups/design_files/sp4-session-play-parts.jsx
+++ b/admin-mockups/design_files/sp4-session-play-parts.jsx
@@ -1,0 +1,474 @@
+/* sp4-session-play-parts.jsx — panels (Scoreboard, QuickActions, ActivityFeed, Chat),
+   modals (Score, Dispute), Rules sheet, Toast. Loads after sp4-session-play.jsx.
+   Route: /sessions/[id]/play. Exports components to window for -ui.jsx. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const SP = window.__SP;
+const {
+  eHsl, sem, PAD, fmtDur, entE, GAME, SESSION, PLAYERS, SCORE_CATEGORIES, QUICK_ACTIONS,
+  EVENT_TYPE, FEED_FILTERS, findPlayer, QUICK_PROMPTS, RULES_TOC,
+} = SP;
+
+const Avatar = ({ p, size = 16, font = 7, cls = 'av' }) => (
+  <span className={cls} style={{ width: size, height: size, fontSize: font, background: `hsl(${p.color},58%,52%)` }} aria-hidden="true">{p.initials}</span>
+);
+const PlayerChip = ({ p }) => (
+  <span className="sp-chip"><Avatar p={p} size={20} font={8} /><span className="nm">{p.name}</span></span>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HEADER (sticky, span 3-col) ────────────────────────
+// ═══════════════════════════════════════════════════════
+const SessionHeader = ({ status, durationSecs, turnPlayer, round, onPause, onResume, onFinish, onRules, mobile }) => {
+  const statusMap = {
+    live:   { cls: 'live',   dot: 'live', label: 'Attiva' },
+    paused: { cls: 'paused', dot: '',     label: 'In pausa' },
+    done:   { cls: 'done',   dot: '',     label: 'Conclusa' },
+  };
+  const s = statusMap[status] || statusMap.live;
+  return (
+    <header className="sp-head">
+      <div className="sp-bread">
+        <span>Sessioni</span><span className="sep" aria-hidden="true">›</span>
+        <span className="gchip"><span aria-hidden="true">{GAME.emoji}</span>{GAME.title}</span>
+        <span className="sep" aria-hidden="true">›</span><span className="cur">Live play</span>
+      </div>
+      <div className="sp-htop">
+        <div className="sp-htxt">
+          <div className="sp-titlerow">
+            <h1 className="sp-h1">{GAME.title}</h1>
+            <span className={'sp-statusbadge ' + s.cls}>
+              <span className={'sp-statusdot ' + s.dot} aria-hidden="true"></span>{s.label}
+            </span>
+          </div>
+          {status !== 'done' && turnPlayer && (
+            <div className="sp-turn">
+              <span className="lbl">Turno di</span><PlayerChip p={turnPlayer} />
+            </div>
+          )}
+          <div className="sp-meta">
+            <span className="mi"><span className="g" aria-hidden="true">⏱</span><b>{fmtDur(durationSecs)}</b> live</span>
+            <span className="mi"><span className="g" aria-hidden="true">👤</span><b>{PLAYERS.length}</b> giocatori</span>
+            <span className="mi"><span className="g" aria-hidden="true">🎯</span>Turno <b>{round}</b> di ~15</span>
+            <span className="mi"><span className="g" aria-hidden="true">#</span>{SESSION.code}</span>
+          </div>
+        </div>
+        <div className="sp-hcta">
+          {status === 'paused'
+            ? <button type="button" className="sp-btn warn" onClick={onResume}><span aria-hidden="true">▶</span>Riprendi</button>
+            : <button type="button" className="sp-btn warn" onClick={onPause}><span aria-hidden="true">⏸</span>{!mobile && 'Pausa'}</button>}
+          <button type="button" className="sp-btn primary" onClick={onFinish}><span aria-hidden="true">🏁</span>{mobile ? 'Concludi' : 'Conclude partita'}</button>
+          {!mobile && <button type="button" className="sp-iconbtn" onClick={onRules} aria-label="Apri menu (regole, impostazioni, salva ed esci)" title="Regole · impostazioni · salva ed esci">⋯</button>}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SESSION BANNER (paused / dispute / finalize) ───────
+// ═══════════════════════════════════════════════════════
+const SessionBanner = ({ kind, onPrimary, onSecondary }) => {
+  const map = {
+    paused:   { icon: '⏸', role: 'status', title: 'Partita in pausa da Marco R. (15:42)', desc: 'I timer sono fermi. Riprendi quando il tavolo è pronto.', primary: ['▶ Riprendi', 'warn'], secondary: null },
+    dispute:  { icon: '⚖️', role: 'alert', title: 'Dispute aperta — Aaron R.', desc: '«La strada conta come 2 segmenti?» · in attesa di risoluzione', primary: ['Risolvi ora', 'warn'], secondary: ['Vedi nel feed', 'ghost'] },
+    finalize: { icon: '🏁', role: 'status', title: 'Tutti i giocatori hanno completato il turno', desc: 'Vuoi concludere la partita e calcolare il punteggio finale?', primary: ['Conclude partita', 'success'], secondary: ['Continua', 'ghost'] },
+  };
+  const b = map[kind];
+  if (!b) return null;
+  return (
+    <div className={'sp-banner ' + kind} role={b.role} aria-live={b.role === 'alert' ? 'assertive' : 'polite'}>
+      <span className="bi" aria-hidden="true">{b.icon}</span>
+      <div className="btxt">
+        <div className="bt">{b.title}</div>
+        <div className="bd">{b.desc}</div>
+      </div>
+      <div className="bcta">
+        {b.secondary && <button type="button" className={'sp-bbtn ' + b.secondary[1]} onClick={onSecondary}>{b.secondary[0]}</button>}
+        <button type="button" className={'sp-bbtn ' + b.primary[1]} onClick={onPrimary}>{b.primary[0]}</button>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SCOREBOARD ─────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ScoreRow = ({ p, rank, expanded, onToggle, onInc, popping }) => {
+  const dCls = p.delta > 0 ? 'up' : p.delta < 0 ? 'down' : 'flat';
+  const dArrow = p.delta > 0 ? '▲' : p.delta < 0 ? '▼' : '─';
+  const dTxt = p.delta === 0 ? '0' : `${p.delta > 0 ? '+' : ''}${p.delta}`;
+  return (
+    <React.Fragment>
+      <li className={'sp-prow' + (p.active ? ' active' : '')} aria-current={p.active ? 'true' : undefined}
+        onClick={onToggle} tabIndex={0}
+        onKeyDown={e => { if (e.key === 'Enter') onToggle(); }}>
+        <span className="rank">#{rank}</span>
+        <Avatar p={p} size={34} font={12} cls="sp-pav" />
+        <div className="sp-pmain">
+          <div className="sp-pname">{p.name}{p.active && <span className="sp-pturn">🎯 Sta giocando</span>}</div>
+          <div className={'sp-pdelta ' + dCls}><span aria-hidden="true">{dArrow}</span>{dTxt} dall'ultimo aggiornamento</div>
+        </div>
+        <div className="sp-pscore">
+          <div className={'sp-score' + (popping ? ' pop' : '')}>{p.score}<span className="vp">PV</span></div>
+          <div className="sp-pinc" onClick={e => e.stopPropagation()}>
+            <button type="button" className="sp-incbtn" onClick={() => onInc(-1)} aria-label={'Decrementa punteggio ' + p.name}>−</button>
+            <button type="button" className="sp-incbtn" onClick={() => onInc(1)} aria-label={'Incrementa punteggio ' + p.name}>+</button>
+          </div>
+        </div>
+      </li>
+      {expanded && (
+        <div className="sp-breakdown">
+          {p.breakdown.map(([label, val]) => (
+            <div className="sp-brow" key={label}><span className="bl">{label}</span><span className="bv">{val} PV</span></div>
+          ))}
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+const Scoreboard = ({ players, onInc, popId }) => {
+  const [expanded, setExpanded] = useState(null);
+  const ranked = [...players].sort((a, b) => b.score - a.score);
+  return (
+    <section className="sp-board" role="region" aria-label="Classifica live">
+      <div className="sp-phead" style={{ '--e': entE('session') }}>
+        <span className="pi" aria-hidden="true">🏆</span>
+        <div>
+          <div className="pt">Classifica live</div>
+          <div className="pc">{players.length} giocatori · Punti Vittoria</div>
+        </div>
+      </div>
+      <ul className="sp-board" role="list" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {ranked.map((p, i) => (
+          <ScoreRow key={p.id} p={p} rank={i + 1} expanded={expanded === p.id}
+            onToggle={() => setExpanded(e => e === p.id ? null : p.id)}
+            onInc={d => onInc(p.id, d)} popping={popId === p.id} />
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── QUICK ACTIONS ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const QuickActions = ({ onAction }) => (
+  <section className="sp-qa" role="region" aria-label="Azioni rapide">
+    <div className="sp-qa-head">
+      <span className="qi" aria-hidden="true">⚡</span>
+      <span className="qt">Azioni rapide</span>
+    </div>
+    <div className="sp-qa-grid">
+      {QUICK_ACTIONS.map(a => (
+        <button key={a.id} type="button" className="sp-qabtn" style={{ '--e': entE(a.ent) }} onClick={() => onAction(a.id)}>
+          <span className="qg" aria-hidden="true">{a.icon}</span>
+          <span className="ql">{a.label}</span>
+        </button>
+      ))}
+    </div>
+  </section>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ACTIVITY FEED ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ActivityEvent = ({ ev, onResolve }) => {
+  const t = EVENT_TYPE[ev.type] || EVENT_TYPE.milestone;
+  const actor = ev.actor ? findPlayer(ev.actor) : null;
+  return (
+    <div className={'sp-event' + (ev.fresh ? ' fresh' : '') + (ev.type === 'dispute' ? ' flag' : '')} style={{ '--e': entE(t.ent) }}>
+      <span className="eic" aria-hidden="true">{t.icon}</span>
+      <div className="ebody">
+        <div className="etop">
+          <span className="etime">{ev.time}</span>
+          <span className="etext">{ev.text}</span>
+        </div>
+        {ev.detail && <div className="edetail">{ev.detail}</div>}
+        <div className="sp-emeta">
+          {actor && <span className="sp-echip"><Avatar p={actor} /><span className="nm">{actor.name}</span></span>}
+          {ev.resolvable
+            ? <span className="sp-eactions"><button type="button" className="sp-elink">Vedi</button><button type="button" className="sp-elink danger" onClick={onResolve}>Risolvi</button></span>
+            : <span className="sp-eactions"><button type="button" className="sp-elink">Rispondi</button><button type="button" className="sp-elink">Nota</button></span>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ActivityFeed = ({ feed, sseOff, mobile, collapsed, onToggleCollapse, onResolveDispute }) => {
+  const [filters, setFilters] = useState(['all']);
+  const toggle = id => {
+    setFilters(prev => {
+      if (id === 'all') return ['all'];
+      const next = prev.includes('all') ? [id] : prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id];
+      return next.length === 0 ? ['all'] : next;
+    });
+  };
+  const shown = filters.includes('all') ? feed : feed.filter(e => filters.includes(e.type));
+  return (
+    <section className={'sp-feed' + (sseOff ? ' disc' : '') + (collapsed ? ' collapsed' : '')} role="region" aria-label="Activity feed">
+      <div className="sp-phead sp-feedhead" style={{ '--e': entE('session') }}>
+        <span className="pi" aria-hidden="true">📡</span>
+        <div className="grow">
+          <div className="pt">Attività live</div>
+          <div className="pc">{shown.length} eventi · feed cronologico</div>
+        </div>
+        <span className={'sp-ssetag' + (sseOff ? ' off' : '')} aria-label={sseOff ? 'Connessione persa, riconnessione in corso' : 'Connesso live'}>
+          <span className={'sp-ssedot' + (sseOff ? ' off' : ' live')} aria-hidden="true"></span>{sseOff ? 'Riconnessione…' : 'Connesso live'}
+        </span>
+        {mobile && <button type="button" className="sp-collapse-btn" onClick={onToggleCollapse} aria-label={collapsed ? 'Espandi feed' : 'Comprimi feed'} aria-expanded={!collapsed}>▾</button>}
+      </div>
+      <div className="sp-feedfilters" role="group" aria-label="Filtra eventi">
+        {FEED_FILTERS.map(f => (
+          <button key={f.id} type="button" className={'sp-fchip' + (filters.includes(f.id) ? ' on' : '')}
+            aria-pressed={filters.includes(f.id)} onClick={() => toggle(f.id)}>
+            <span aria-hidden="true">{f.icon}</span>{f.label}
+          </button>
+        ))}
+      </div>
+      <div className="sp-feedbody" role="log" aria-live="polite" aria-relevant="additions" aria-busy={sseOff}>
+        {shown.map(ev => <ActivityEvent key={ev.id} ev={ev} onResolve={onResolveDispute} />)}
+        <button type="button" className="sp-feedmore">↑ Carica eventi precedenti</button>
+      </div>
+    </section>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── CHAT WIDGET ────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const ChatMessage = ({ m, onCite }) => {
+  if (m.role === 'user') {
+    const p = findPlayer(m.actor);
+    return (
+      <div className={'sp-msg user' + (m.fresh ? ' fresh' : '')}>
+        <span className="sp-msgwho">{p && <Avatar p={p} size={15} font={6} />}{p ? p.name : 'Tu'}</span>
+        <div className="sp-bubble">{m.text}</div>
+      </div>
+    );
+  }
+  return (
+    <div className={'sp-msg agent' + (m.fresh ? ' fresh' : '')}>
+      <span className="sp-msgwho"><span aria-hidden="true">🤖</span>Catan Coach</span>
+      <div className="sp-bubble">
+        {m.text}{m.streaming && <span className="sp-cursor" aria-hidden="true"></span>}
+        {m.cite && !m.streaming && <div><button type="button" className="sp-cite" onClick={() => onCite(m.cite)}><span aria-hidden="true">📜</span>Vedi {m.cite}</button></div>}
+      </div>
+    </div>
+  );
+};
+
+const ChatWidget = ({ chat, streaming, onCite, onExpand, expanded, mobile, onCloseSheet }) => {
+  const bodyRef = useRef(null);
+  useEffect(() => { if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight; }, [chat, streaming]);
+  const [draft, setDraft] = useState('');
+  return (
+    <section className="sp-chat" role="region" aria-label="Chat con agent">
+      <div className="sp-chathead">
+        <span className="ca" aria-hidden="true">🤖</span>
+        <div className="cmeta">
+          <div className="cname">Catan Coach</div>
+          <div className="crole">Agent · esperto regole</div>
+        </div>
+        {mobile
+          ? <button type="button" className="sp-iconbtn" onClick={onCloseSheet} aria-label="Chiudi chat">✕</button>
+          : expanded
+            ? <button type="button" className="sp-iconbtn" onClick={onExpand} aria-label="Riduci chat" title="Riduci chat">⤡</button>
+            : <button type="button" className="sp-iconbtn" onClick={onExpand} aria-label="Espandi chat a schermo intero" title="Espandi chat">⛶</button>}
+      </div>
+      <div className="sp-chatbody" ref={bodyRef} role="log" aria-live="polite" aria-busy={streaming}>
+        {chat.map(m => <ChatMessage key={m.id} m={m} onCite={onCite} />)}
+        {streaming && (
+          <div className="sp-msg agent fresh">
+            <span className="sp-msgwho"><span aria-hidden="true">🤖</span>Catan Coach</span>
+            <div className="sp-bubble" style={{ padding: 0 }}><div className="sp-typing" aria-label="L'agent sta scrivendo"><span></span><span></span><span></span></div></div>
+          </div>
+        )}
+      </div>
+      <div className="sp-chatfoot">
+        <div className="sp-prompts">
+          {QUICK_PROMPTS.map(q => <button key={q} type="button" className="sp-prompt" onClick={() => setDraft(q)}>{q}</button>)}
+        </div>
+        <div className="sp-inputrow">
+          <textarea className="sp-chatinput" rows={1} placeholder="Scrivi un messaggio per l'agent…"
+            aria-label="Messaggio per agent" value={draft} onChange={e => setDraft(e.target.value)} />
+          <button type="button" className="sp-sendbtn" disabled={!draft.trim()} aria-label="Invia messaggio">➤</button>
+        </div>
+        {!mobile && <div className="sp-kbdhint"><kbd>Ctrl</kbd>+<kbd>Enter</kbd> per inviare</div>}
+      </div>
+    </section>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── SCORE INPUT MODAL ──────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const useModalDismiss = (onClose, mobile) => {
+  const ref = useRef(null);
+  useEffect(() => { ref.current && ref.current.focus(); }, []);
+  useEffect(() => {
+    if (mobile) return; // mobile: no Esc key — usa ✕ / tap backdrop
+    const onKey = e => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose, mobile]);
+  return ref;
+};
+
+const ScoreModal = ({ onClose, mobile }) => {
+  const [player, setPlayer] = useState('p-sara');
+  const [cat, setCat] = useState('longest-road');
+  const [pts, setPts] = useState(2);
+  const closeRef = useModalDismiss(onClose, mobile);
+  return (
+    <div className="sp-overlay" onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="sp-modal" role="dialog" aria-modal="true" aria-labelledby="sp-score-t" style={{ '--e': entE('toolkit') }}>
+        <div className="sp-mhead">
+          <span className="mi" aria-hidden="true">📋</span>
+          <div className="mt" id="sp-score-t">Aggiungi punteggio</div>
+          <button type="button" className="mx" ref={closeRef} onClick={onClose} aria-label="Chiudi">✕</button>
+        </div>
+        <div className="sp-mbody">
+          <div className="sp-field">
+            <span className="fl">Giocatore</span>
+            <div className="sp-pselect">
+              {PLAYERS.map(p => (
+                <button key={p.id} type="button" className={'sp-popt' + (player === p.id ? ' on' : '')} onClick={() => setPlayer(p.id)}>
+                  <Avatar p={p} size={22} font={9} /><span className="nm">{p.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="sp-field">
+            <span className="fl">Categoria di punteggio</span>
+            <div className="sp-catgrid">
+              {SCORE_CATEGORIES.map(c => (
+                <button key={c.id} type="button" className={'sp-catopt' + (cat === c.id ? ' on' : '')} onClick={() => setCat(c.id)}>
+                  <span className="cl">{c.label}</span><span className="cp">+{c.pts} PV</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="sp-field">
+            <span className="fl">Punti</span>
+            <div className="sp-stepperrow">
+              <button type="button" className="sp-stepbtn" onClick={() => setPts(v => Math.max(0, v - 1))} aria-label="Diminuisci punti">−</button>
+              <span className="sp-stepval">{pts}<span className="pl"> PV</span></span>
+              <button type="button" className="sp-stepbtn" onClick={() => setPts(v => v + 1)} aria-label="Aumenta punti">+</button>
+            </div>
+          </div>
+          <div className="sp-field">
+            <span className="fl">Nota (opzionale)</span>
+            <textarea className="sp-ta" rows={2} placeholder="Es. strada completata con il porto…" aria-label="Nota opzionale"></textarea>
+          </div>
+        </div>
+        <div className="sp-mfoot">
+          <button type="button" className="sp-mbtn" onClick={onClose}>Annulla</button>
+          <button type="button" className="sp-mbtn primary" onClick={onClose}><span aria-hidden="true">＋</span>Aggiungi punto</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DISPUTE MODAL ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DisputeModal = ({ onClose, mobile }) => {
+  const closeRef = useModalDismiss(onClose, mobile);
+  return (
+    <div className="sp-overlay" onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="sp-modal" role="dialog" aria-modal="true" aria-labelledby="sp-disp-t" style={{ '--e': entE('danger') }}>
+        <div className="sp-mhead">
+          <span className="mi" aria-hidden="true">⚖️</span>
+          <div className="mt" id="sp-disp-t">Dispute — Aaron R.</div>
+          <button type="button" className="mx" ref={closeRef} onClick={onClose} aria-label="Chiudi">✕</button>
+        </div>
+        <div className="sp-mbody">
+          <div className="sp-field">
+            <span className="fl">Descrizione</span>
+            <p style={{ margin: 0, fontSize: 13.5, color: 'var(--text-sec)', lineHeight: 1.55 }}>
+              «La strada che ho costruito attraversa un incrocio con un insediamento avversario — conta comunque come 2 segmenti per la strada più lunga?»
+            </p>
+          </div>
+          <div className="sp-suggest">
+            <span className="si" aria-hidden="true">🤖</span>
+            <div className="sb">
+              <div className="sl">Suggerimento agent · Catan Coach</div>
+              <div className="st">Per regola §3.4, una strada interrotta da un insediamento o città avversari <b>spezza</b> il percorso: i segmenti dopo l'interruzione non contano per la strada più lunga. Vedi p.8 §3.4.</div>
+            </div>
+          </div>
+        </div>
+        <div className="sp-mfoot">
+          <button type="button" className="sp-mbtn" onClick={onClose}>Annulla dispute</button>
+          <button type="button" className="sp-mbtn" onClick={onClose}>Risolvi manualmente</button>
+          <button type="button" className="sp-mbtn agent" onClick={onClose}><span aria-hidden="true">🤖</span>Conferma con agent</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── RULES SHEET (slide-over right) ─────────────────────
+// ═══════════════════════════════════════════════════════
+const RulesSheet = ({ onClose, mobile }) => {
+  const [section, setSection] = useState('s3');
+  useEffect(() => {
+    if (mobile) return;
+    const onKey = e => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose, mobile]);
+  return (
+    <React.Fragment>
+      <div className="sp-sheet-overlay" onClick={onClose}></div>
+      <aside className="sp-sheet" role="dialog" aria-modal="false" aria-labelledby="sp-rules-t">
+        <div className="sp-sheethead">
+          <span className="shi" aria-hidden="true">📜</span>
+          <div className="sht">
+            <div className="shtitle" id="sp-rules-t">Regolamento Catan</div>
+            <div className="shsub">catan-regole.pdf · 18 pagine</div>
+          </div>
+          <button type="button" className="sp-iconbtn" onClick={onClose} aria-label="Chiudi regole">✕</button>
+        </div>
+        <div className="sp-sheetbody">
+          <nav className="sp-toc" aria-label="Indice regolamento">
+            {RULES_TOC.map(t => (
+              <button key={t.id} type="button" className={'sp-tocitem' + (section === t.id ? ' on' : '')} onClick={() => setSection(t.id)} aria-current={section === t.id ? 'true' : undefined}>
+                <span className="tn">{t.n}</span><span className="tl">{t.label}</span><span className="tp">{t.page}</span>
+              </button>
+            ))}
+          </nav>
+          <div className="sp-rulescontent">
+            <div className="sp-pdfpage">
+              <div className="pn">catan-regole.pdf · p.8</div>
+              <h4>§3 — Carte sviluppo</h4>
+              <p>Le carte sviluppo si acquistano spendendo 1 grano, 1 lana e 1 minerale. Vengono tenute coperte fino al momento del gioco.</p>
+              <h5>§3.4 — Limiti di gioco per turno</h5>
+              <p>Puoi giocare <span className="hl">una sola carta sviluppo per turno</span>, in qualsiasi momento durante il tuo turno, eccetto le carte Punto Vittoria che restano coperte fino alla fine della partita. Una carta acquistata nello stesso turno non può essere giocata.</p>
+              <p>Per la <span className="hl">strada più lunga</span>: un percorso continuo di almeno 5 segmenti. Una strada interrotta da un insediamento o città avversari spezza il percorso e i segmenti successivi non contano.</p>
+              <h5>§3.5 — Cavaliere</h5>
+              <p>La carta Cavaliere sposta il ladro e ruba una risorsa a un avversario adiacente. 3 carte Cavaliere giocate assegnano la carta Esercito più grande (2 PV).</p>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </React.Fragment>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── TOAST ──────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const Toast = ({ text }) => (
+  <div className="sp-toast" role="status"><span className="td" aria-hidden="true"></span>{text}</div>
+);
+
+Object.assign(window, {
+  SP_Avatar: Avatar, SP_PlayerChip: PlayerChip,
+  SessionHeader, SessionBanner, Scoreboard, QuickActions, ActivityFeed, ChatWidget,
+  ScoreModal, DisputeModal, RulesSheet, SP_Toast: Toast,
+});

--- a/admin-mockups/design_files/sp4-session-play-ui.jsx
+++ b/admin-mockups/design_files/sp4-session-play-ui.jsx
@@ -1,0 +1,271 @@
+/* sp4-session-play-ui.jsx — SessionApp orchestrator, frames, 10-state picker, App root.
+   Loads after sp4-session-play.jsx + sp4-session-play-parts.jsx. Route: /sessions/[id]/play. */
+
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+const SP = window.__SP;
+const { eHsl, PAD, fmtDur, BASE_FEED, BASE_CHAT, EVENT_TYPE, findPlayer, PLAYERS } = SP;
+
+// ═══════════════════════════════════════════════════════
+// ─── SESSION APP (interactive, one per state × viewport) ─
+// ═══════════════════════════════════════════════════════
+const SessionApp = ({ scenario, mobile }) => {
+  const sc = scenario.sc || {};
+
+  const [players, setPlayers] = useState(() => PLAYERS.map(p => ({ ...p })));
+  const [popId, setPopId] = useState(null);
+  const [feed, setFeed] = useState(() => BASE_FEED.map(e => ({ ...e })));
+  const [status, setStatus] = useState(sc.status || 'live');
+  const [banner, setBanner] = useState(sc.banner || null);
+  const [modal, setModal] = useState(sc.modal || null);
+  const [rules, setRules] = useState(!!sc.rules);
+  const [sseOff, setSseOff] = useState(!!sc.sseOff);
+  const [toast, setToast] = useState(sc.toast || null);
+  const [chatSheet, setChatSheet] = useState(false);
+  const [chatFull, setChatFull] = useState(false);
+  const [feedCollapsed, setFeedCollapsed] = useState(false);
+  const idRef = useRef(2000);
+
+  const nowClock = () => { const d = new Date(); return `${PAD(d.getHours())}:${PAD(d.getMinutes())}`; };
+
+  // chat thread (+ optional streaming tail for agent-streaming state)
+  const chat = useMemo(() => {
+    let base = BASE_CHAT.map(m => ({ ...m }));
+    if (sc.streamingChat) {
+      base.push({ id: 'm-stream-q', role: 'user', actor: 'p-marco', text: 'Se gioco un Cavaliere posso anche costruire una strada nello stesso turno?' });
+      base.push({ id: 'm-stream-a', role: 'agent', text: 'Sì: giocare una carta Cavaliere non consuma la tua azione di costruzione. Puoi spostare il ladro, rubare una risorsa e poi', streaming: true });
+    }
+    return base;
+  }, [scenario.id]); // eslint-disable-line
+
+  const addEvent = useCallback((type, text, detail, actor) => {
+    idRef.current += 1;
+    setFeed(prev => [{ id: 'ev-' + idRef.current, type, time: nowClock(), actor: actor || null, text, detail, fresh: true }, ...prev]);
+  }, []);
+
+  const handleInc = useCallback((id, d) => {
+    setPlayers(prev => prev.map(p => p.id === id ? { ...p, score: Math.max(0, p.score + d), delta: d } : p));
+    setPopId(id); setTimeout(() => setPopId(null), 440);
+    const p = findPlayer(id);
+    addEvent('score', `${p.name} ha aggiornato il punteggio`, `${d > 0 ? '+' : ''}${d} PV manuale`, id);
+  }, [addEvent]);
+
+  const handleAction = useCallback(actionId => {
+    if (actionId === 'score') setModal('score');
+    else if (actionId === 'dispute') setModal('dispute');
+    else if (actionId === 'rules') setRules(true);
+    else if (actionId === 'dice') addEvent('dice', 'Tiro dadi 2D6 → 7', 'il ladro si attiva', null);
+    else if (actionId === 'photo') addEvent('photo', 'Foto della board caricata', 'turno corrente', null);
+    else if (actionId === 'save') setToast('Sessione salvata');
+  }, [addEvent]);
+
+  useEffect(() => { if (toast) { const t = setTimeout(() => setToast(null), 3200); return () => clearTimeout(t); } }, [toast]);
+
+  // desktop keyboard shortcuts (gated to !mobile — mobile non ha Ctrl/Esc)
+  useEffect(() => {
+    if (mobile) return;
+    const h = e => {
+      const tag = document.activeElement.tagName;
+      const typing = tag === 'INPUT' || tag === 'TEXTAREA';
+      if (e.key === 'Escape') { setModal(null); setRules(false); setChatFull(false); }
+      if (typing) return;
+      if (e.key === '/') { e.preventDefault(); const i = document.querySelector('.sp-chatinput'); i && i.focus(); }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); setStatus(s => s === 'paused' ? 'live' : 'paused'); setBanner(b => b === 'paused' ? null : 'paused'); }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 's' || e.key === 'S')) { e.preventDefault(); setToast('Sessione salvata'); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [mobile]);
+
+  const turnPlayer = players.find(p => p.active);
+  const dimmed = status === 'paused';
+
+  return (
+    <div className={'sp-app' + (mobile ? ' is-mobile' : '') + (dimmed ? ' dimmed' : '')}>
+      <SessionHeader
+        status={status} durationSecs={sc.durationSecs || 5040} turnPlayer={turnPlayer} round={sc.round || 8}
+        onPause={() => { setStatus('paused'); setBanner('paused'); }}
+        onResume={() => { setStatus('live'); setBanner(null); }}
+        onFinish={() => setBanner('finalize')}
+        onRules={() => setRules(true)} mobile={mobile} />
+
+      {banner && (
+        <SessionBanner kind={banner}
+          onPrimary={() => {
+            if (banner === 'paused') { setStatus('live'); setBanner(null); }
+            else if (banner === 'dispute') { setModal('dispute'); }
+            else if (banner === 'finalize') { setStatus('done'); setBanner(null); setToast('Partita conclusa · punteggio salvato'); }
+          }}
+          onSecondary={() => setBanner(null)} />
+      )}
+
+      <div className="sp-layout">
+        <div className="sp-col left">
+          <div className="sp-colscroll">
+            <Scoreboard players={players} onInc={handleInc} popId={popId} />
+            <QuickActions onAction={handleAction} />
+          </div>
+        </div>
+
+        <div className="sp-col center">
+          <ActivityFeed feed={feed} sseOff={sseOff} mobile={mobile}
+            collapsed={mobile && feedCollapsed} onToggleCollapse={() => setFeedCollapsed(c => !c)}
+            onResolveDispute={() => setModal('dispute')} />
+        </div>
+
+        <div className="sp-col right">
+          <ChatWidget chat={chat} streaming={false} onCite={() => setRules(true)} onExpand={() => setChatFull(true)} mobile={false} />
+        </div>
+      </div>
+
+      {/* desktop: fullscreen chat overlay (Espandi chat) */}
+      {!mobile && chatFull && (
+        <div className="sp-overlay" onMouseDown={e => { if (e.target === e.currentTarget) setChatFull(false); }}>
+          <div className="sp-chatfull" role="dialog" aria-modal="true" aria-label="Chat agent a schermo intero">
+            <ChatWidget chat={chat} streaming={false} onCite={() => { setChatFull(false); setRules(true); }} onExpand={() => setChatFull(false)} expanded={true} mobile={false} />
+          </div>
+        </div>
+      )}
+
+      {/* mobile: sticky chat FAB + bottom-sheet chat */}
+      {mobile && !chatSheet && (
+        <button type="button" className="sp-chatfab" onClick={() => setChatSheet(true)}>
+          <span className="cg" aria-hidden="true">🤖</span>Apri chat agent
+          <span className="cbadge">{chat.length} msg</span>
+        </button>
+      )}
+      {mobile && chatSheet && (
+        <div className="sp-chatsheet">
+          <div className="sp-chatsheet-grab" aria-hidden="true"></div>
+          <ChatWidget chat={chat} streaming={false} onCite={() => { setChatSheet(false); setRules(true); }} mobile={true} onCloseSheet={() => setChatSheet(false)} />
+        </div>
+      )}
+
+      {modal === 'score' && <ScoreModal onClose={() => setModal(null)} mobile={mobile} />}
+      {modal === 'dispute' && <DisputeModal onClose={() => setModal(null)} mobile={mobile} />}
+      {rules && <RulesSheet onClose={() => setRules(false)} mobile={mobile} />}
+      {toast && <SP_Toast text={toast} />}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── FRAMES ─────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopFrame = ({ height = 720, children }) => (
+  <div style={{ width: '100%', borderRadius: 'var(--r-xl)', border: '1px solid var(--border)', background: 'var(--bg-card)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)' }}>
+    <div className="sp-desk" style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 14px', background: 'var(--bg-muted)', borderBottom: '1px solid var(--border)', fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57' }}></span>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e' }}></span>
+      <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840' }}></span>
+      <span style={{ flex: 1, textAlign: 'center', letterSpacing: '.04em' }}>meepleai.app/sessions/sess-abc-123/play</span>
+    </div>
+    <div style={{ height }}>{children}</div>
+  </div>
+);
+
+const PhoneFrame = ({ children }) => (
+  <div className="phone" style={{ width: 375, height: 780 }}>
+    <div className="phone-sbar" style={{ color: 'var(--text)' }}>
+      <span style={{ fontFamily: 'var(--f-mono)' }}>16:43</span>
+      <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+    </div>
+    <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>{children}</div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATE PICKER + ROOT ────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATES = [
+  { id: 'active-default',        label: 'Active default',     view: 'desktop', sc: { status: 'live' }, desc: 'Sessione live: scoreboard 4 player con Marco R. attivo, activity feed 8 eventi (SSE connesso), chat agent 2 round. Tutti i tool interattivi (score +/−, quick actions, filtri feed).' },
+  { id: 'paused',                label: 'Paused',             view: 'desktop', sc: { status: 'paused', banner: 'paused' }, desc: 'Banner --c-warning “Partita in pausa da Marco R. (15:42)”, body dimmed (saturazione ridotta), CTA “▶ Riprendi” in header e banner.' },
+  { id: 'active-with-dispute',   label: 'Dispute attiva',     view: 'desktop', sc: { status: 'live', banner: 'dispute' }, desc: 'Banner --c-danger role=alert “Dispute aperta — Aaron R.”, evento dispute evidenziato nel feed (border-left rosso) con azione “Risolvi”.' },
+  { id: 'score-input-modal-open',label: 'Score modal',        view: 'desktop', sc: { status: 'live', modal: 'score' }, desc: 'Modal Score Input aperto mid-form: Sara T. selezionata, categoria “Strada più lunga”, 2 PV. Stepper punti + nota. role=dialog aria-modal, ✕ + Esc + tap-backdrop per chiudere.' },
+  { id: 'dispute-modal-open',    label: 'Dispute modal',      view: 'desktop', sc: { status: 'live', modal: 'dispute' }, desc: 'Modal Dispute aperto: descrizione + suggerimento agent (regola §3.4) + 3 CTA (Annulla / Risolvi manualmente / Conferma con agent).' },
+  { id: 'rules-sheet-open',      label: 'Rules sheet',        view: 'desktop', sc: { status: 'live', rules: true }, desc: 'Rules Sheet slide-over destra (aria-modal=false, non bloccante): TOC sinistra + contenuto PDF Catan p.8 §3.4 con highlight, scrollabile.' },
+  { id: 'agent-streaming',       label: 'Agent streaming',    view: 'desktop', sc: { status: 'live', streamingChat: true }, desc: 'Chat widget con risposta agent in streaming: testo parziale + cursore lampeggiante, aria-busy. Auto-scroll al messaggio nuovo.' },
+  { id: 'sse-disconnected',      label: 'SSE disconnesso',    view: 'desktop', sc: { status: 'live', sseOff: true, toast: 'Riconnesso · feed aggiornato' }, desc: 'Indicator activity feed in rosso “Riconnessione…” con flash --c-danger, aria-busy. Toast “Riconnesso” quando la connessione torna.' },
+  { id: 'finalize-prompt',       label: 'Finalize prompt',    view: 'desktop', sc: { status: 'live', banner: 'finalize' }, desc: 'Banner --c-success “Tutti i giocatori hanno completato il turno”: CTA “Conclude partita” / “Continua”. Conclude → status “Conclusa” + toast.' },
+  { id: 'mobile-stack',          label: 'Mobile · stack',     view: 'mobile',  sc: { status: 'live' }, desc: 'Viewport 375px: header → scoreboard fullwidth → quick actions 2-col → activity feed collassabile → chat come bottom-sheet via CTA sticky “Apri chat agent”. Nessuna shortcut Ctrl/Esc: tutto touch (✕ / tap-backdrop / Invia).' },
+];
+const SKEY = 'sp-state';
+
+const VpLabel = ({ children }) => (
+  <div style={{ fontFamily: 'var(--f-mono)', fontSize: 11, color: 'var(--text-sec)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 700 }}>{children}</div>
+);
+
+const App = () => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || document.documentElement.getAttribute('data-theme') || 'light');
+  const [active, setActive] = useState(() => {
+    const s = localStorage.getItem(SKEY);
+    return STATES.some(x => x.id === s) ? s : 'active-default';
+  });
+  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); localStorage.setItem('mai-theme', theme); }, [theme]);
+  useEffect(() => { localStorage.setItem(SKEY, active); }, [active]);
+
+  const cur = STATES.find(s => s.id === active) || STATES[0];
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)', padding: '20px 20px 80px' }}>
+      <style dangerouslySetInnerHTML={{ __html: window.__SP_CSS }} />
+
+      {/* state picker bar (continuity #1489 + #1490 + #1491) */}
+      <header style={{
+        position: 'sticky', top: 12, zIndex: 50, maxWidth: 1340, margin: '0 auto 24px',
+        background: 'var(--glass-bg)', backdropFilter: 'blur(16px)', border: '1px solid var(--border)',
+        borderRadius: 'var(--r-xl)', boxShadow: 'var(--shadow-md)', padding: '12px 16px',
+        display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+          <div style={{ width: 30, height: 30, borderRadius: 8, flexShrink: 0, background: `linear-gradient(135deg, ${eHsl('session')}, ${eHsl('player')})`, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontFamily: 'var(--f-display)', fontSize: 14 }}>S</div>
+          <div>
+            <div style={{ fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 14, lineHeight: 1.1 }}>Session play</div>
+            <div style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)' }}>#1492 · 1/1 · /sessions/[id]/play</div>
+          </div>
+        </div>
+
+        <div role="tablist" aria-label="Stati schermata" style={{ display: 'flex', gap: 6, flexWrap: 'wrap', flex: 1, minWidth: 0 }}>
+          {STATES.map(s => {
+            const on = s.id === active;
+            return (
+              <button key={s.id} type="button" role="tab" aria-selected={on} onClick={() => setActive(s.id)} style={{
+                padding: '7px 12px', borderRadius: 'var(--r-pill)', cursor: 'pointer',
+                background: on ? eHsl('session') : 'var(--bg-muted)', border: on ? 'none' : '1px solid var(--border)',
+                color: on ? '#fff' : 'var(--text-sec)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, whiteSpace: 'nowrap',
+                boxShadow: on ? `0 3px 10px ${eHsl('session', 0.35)}` : 'none',
+              }}>{s.label}</button>
+            );
+          })}
+        </div>
+
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{
+          padding: '8px 14px', borderRadius: 'var(--r-md)', flexShrink: 0, background: 'var(--bg-card)', border: '1px solid var(--border)',
+          color: 'var(--text)', fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 800, cursor: 'pointer',
+        }}>🌗 {theme === 'light' ? 'Light' : 'Dark'}</button>
+      </header>
+
+      {/* active state description */}
+      <div style={{ maxWidth: 1340, margin: '0 auto 18px', padding: '0 4px', fontFamily: 'var(--f-mono)', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <strong style={{ color: eHsl('session') }}>{cur.label}</strong> — {cur.desc}
+      </div>
+
+      {/* render area */}
+      <div style={{ maxWidth: 1340, margin: '0 auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 36 }}>
+        {cur.view === 'desktop' && (
+          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Desktop · 1440 — header + 3-col (Scoreboard 30 / Activity 40 / Chat 30)</VpLabel>
+            <DesktopFrame><SessionApp key={'d-' + cur.id} scenario={cur} mobile={false} /></DesktopFrame>
+          </div>
+        )}
+        {cur.view === 'mobile' && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+            <VpLabel>Mobile · 375 — stack 1-col + chat bottom-sheet</VpLabel>
+            <PhoneFrame><SessionApp key={'m-' + cur.id} scenario={cur} mobile={true} /></PhoneFrame>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-mockups/design_files/sp4-session-play.html
+++ b/admin-mockups/design_files/sp4-session-play.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<!-- route: /sessions/[id]/play — Live game session 3-col view (Scoreboard + Activity feed + Chat) con SSE updates, dispute handling, agent integration. Chiude gap N7 residuo issue #1492 (8a sub-route NOT in scope ADR 2026-05-31). -->
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI · /sessions/[id]/play — Session play (live)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ─── Session play keyframes (cluster #1492 — chiude epic #1475) ─── */
+  @keyframes sp-pulse-dot { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.55); opacity: .45; } }
+  @keyframes sp-pulse-ring { 0% { box-shadow: 0 0 0 0 hsl(var(--c-success) / .5); } 100% { box-shadow: 0 0 0 8px hsl(var(--c-success) / 0); } }
+  @keyframes sp-event-in { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes sp-msg-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes sp-score-pop { 0% { transform: scale(1); } 45% { transform: scale(1.22); } 100% { transform: scale(1); } }
+  @keyframes sp-cursor-blink { 0%,49% { opacity: 1; } 50%,100% { opacity: 0; } }
+  @keyframes sp-typing-bounce { 0%,80%,100% { transform: translateY(0); opacity: .4; } 40% { transform: translateY(-4px); opacity: 1; } }
+  @keyframes sp-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes sp-modal-in { from { opacity: 0; transform: translateY(14px) scale(.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
+  @keyframes sp-sheet-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+  @keyframes sp-sheet-up { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  @keyframes sp-toast-in { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes sp-disc-flash { 0%,100% { background: hsl(var(--c-danger) / 0); } 50% { background: hsl(var(--c-danger) / .16); } }
+  @keyframes sp-active-glow { 0%,100% { box-shadow: inset 3px 0 0 hsl(var(--c-session)); } 50% { box-shadow: inset 3px 0 0 hsl(var(--c-session) / .55); } }
+
+  /* Focus ring — keyboard only, session entity (continuity #1490) */
+  a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, [tabindex]:focus-visible {
+    outline: 2px solid hsl(var(--c-session));
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sp-ssedot.live, .sp-statusdot.live { animation: none !important; }
+    .sp-event.fresh, .sp-msg.fresh { animation: none !important; }
+    .sp-cursor, .sp-typing span { animation: none !important; }
+    .sp-overlay, .sp-modal, .sp-sheet, .sp-toast, .sp-feed.disc { animation: none !important; }
+    .sp-prow.active { animation: none !important; }
+    .sp-score.pop { animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-session-play.jsx?v=1"></script>
+<script type="text/babel" src="sp4-session-play-parts.jsx?v=1"></script>
+<script type="text/babel" src="sp4-session-play-ui.jsx?v=1"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-session-play.jsx
+++ b/admin-mockups/design_files/sp4-session-play.jsx
@@ -1,0 +1,453 @@
+/* MeepleAI SP4 — B17 · #1492 · 1/1 — sp4-session-play  (chiude epic #1475, gap N7 residuo)
+   Route: /sessions/[id]/play — Live game session view (active play mode).
+          Distinta da /sessions/[id]/live (spectator con tabs ?tab=). Qui l'host gioca:
+          scoreboard live, quick actions, activity feed SSE, chat agent rules.
+   File: sp4-session-play.{html,jsx,-parts.jsx,-ui.jsx}
+   Pattern: Hero header (span 3-col) + 3-col desktop (Scoreboard+Actions / Activity feed / Chat)
+            + stack mobile (chat = bottom sheet) + Rules sheet slide-over + Score/Dispute modals.
+   Riusa: chat bubble (#1489 S5), activity log streaming (#1490 S4), modal/sheet (#1490, #1489).
+
+   Source restyle (NO ridisegnare logica):
+     apps/web/src/app/(authenticated)/sessions/[id]/play/page.tsx → LiveSessionView
+     components/game-night/{SessionHeader,LiveScoreboard,QuickActions,ActivityFeed,
+       SessionChatWidget,ScoreInput,ScoreAssistant,SaveCompleteDialog}.tsx
+
+   Entity: --c-session (primaria/header/active player) · --c-player (scoreboard/chat user)
+           --c-agent (chat header) · --c-chat (agent bubbles) · --c-toolkit (CTA primary)
+           event types: --c-toolkit score · --c-game dice · --c-danger dispute · --c-kb photo · --c-agent agent.
+
+   10 stati (state picker, persistito localStorage `sp-state`):
+     active-default · paused · active-with-dispute · score-input-modal-open · dispute-modal-open ·
+     rules-sheet-open · agent-streaming · sse-disconnected · finalize-prompt · mobile-stack
+*/
+
+const { useState, useEffect, useMemo, useRef, useCallback, useLayoutEffect } = React;
+const DS = window.DS;
+
+const eHsl = (type, a) => {
+  const c = DS.EC[type] || DS.EC.session;
+  return a !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${a})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+const sem = (name, a) => a !== undefined ? `hsl(var(--c-${name}) / ${a})` : `hsl(var(--c-${name}))`;
+const PAD = n => String(n).padStart(2, '0');
+const fmtDur = secs => { const h = Math.floor(secs / 3600); const m = Math.floor((secs % 3600) / 60); return h > 0 ? `${h}h ${PAD(m)}m` : `${m}m ${PAD(secs % 60)}s`; };
+const reducedMotion = () => window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const entE = ent => `hsl(var(--c-${ent}))`;
+
+// ═══════════════════════════════════════════════════════
+// ─── GAME + SESSION FIXTURE (Catan — da data.js) ────────
+// ═══════════════════════════════════════════════════════
+const GAME = { id: 'g-catan', title: 'I Coloni di Catan', emoji: '🌾' };
+const SESSION = { id: 'sess-abc-123', code: 'CTN-9K3', date: 'Mar 2 · 16:00' };
+
+// players (brief: Marco R./Sara T./Aaron R./Lara F., VP Catan realistici 8–15)
+const PLAYERS = [
+  { id: 'p-marco', name: 'Marco R.', initials: 'MR', color: 262, score: 9, delta: 2, active: true,
+    breakdown: [['Insediamenti', 3], ['Città', 2], ['Strada più lunga', 2], ['Carte sviluppo (PV)', 2]] },
+  { id: 'p-sara', name: 'Sara T.', initials: 'ST', color: 320, score: 7, delta: -1, active: false,
+    breakdown: [['Insediamenti', 4], ['Città', 1], ['Esercito più grande', 2], ['Carte sviluppo (PV)', 0]] },
+  { id: 'p-aaron', name: 'Aaron R.', initials: 'AR', color: 38, score: 6, delta: 0, active: false,
+    breakdown: [['Insediamenti', 4], ['Città', 1], ['Strada più lunga', 0], ['Carte sviluppo (PV)', 1]] },
+  { id: 'p-lara', name: 'Lara F.', initials: 'LF', color: 180, score: 5, delta: 1, active: false,
+    breakdown: [['Insediamenti', 3], ['Città', 1], ['Strada più lunga', 0], ['Carte sviluppo (PV)', 1]] },
+];
+
+const SCORE_CATEGORIES = [
+  { id: 'settlement', label: 'Insediamento', pts: 1 },
+  { id: 'city', label: 'Città', pts: 2 },
+  { id: 'longest-road', label: 'Strada più lunga', pts: 2 },
+  { id: 'largest-army', label: 'Esercito più grande', pts: 2 },
+  { id: 'dev-card', label: 'Carta sviluppo', pts: 1 },
+  { id: 'vp-card', label: 'Carta Punto Vittoria', pts: 1 },
+];
+
+// quick actions (6, 2-col grid)
+const QUICK_ACTIONS = [
+  { id: 'dice', icon: '🎲', label: 'Tira dadi', ent: 'game' },
+  { id: 'photo', icon: '📸', label: 'Foto board', ent: 'kb' },
+  { id: 'score', icon: '📋', label: 'Score input', ent: 'toolkit' },
+  { id: 'dispute', icon: '⚖️', label: 'Dispute', ent: 'danger' },
+  { id: 'rules', icon: '📜', label: 'Regole', ent: 'kb' },
+  { id: 'save', icon: '💾', label: 'Salva', ent: 'session' },
+];
+
+// activity event types → entity + glyph (cross-reference brief)
+const EVENT_TYPE = {
+  score:    { ent: 'toolkit', icon: '🎯' },
+  dice:     { ent: 'game',    icon: '🎲' },
+  dispute:  { ent: 'danger',  icon: '⚖️' },
+  photo:    { ent: 'kb',      icon: '📸' },
+  agent:    { ent: 'agent',   icon: '🤖' },
+  milestone:{ ent: 'session', icon: '🏁' },
+};
+
+// activity feed filter chips (multi-select)
+const FEED_FILTERS = [
+  { id: 'all',     label: 'Tutti',    icon: '▦' },
+  { id: 'score',   label: 'Punteggi', icon: '🎯' },
+  { id: 'dispute', label: 'Dispute',  icon: '⚖️' },
+  { id: 'photo',   label: 'Foto',     icon: '📸' },
+  { id: 'agent',   label: 'Agent',    icon: '🤖' },
+];
+
+const findPlayer = id => PLAYERS.find(p => p.id === id);
+
+// base activity feed (cronologico, newest first) — 8+ event
+const BASE_FEED = [
+  { id: 'ev-1', type: 'score',   time: '16:42', actor: 'p-marco', text: 'ha aggiornato il punteggio', detail: '+2 strada più lunga → 9 PV' },
+  { id: 'ev-2', type: 'dice',    time: '16:38', actor: 'p-sara',  text: 'tira 2D6 → 8', detail: 'commercio porto · +2 grano' },
+  { id: 'ev-3', type: 'dispute', time: '16:32', actor: 'p-aaron', text: 'ha aperto una dispute', detail: '«La strada conta come 2 segmenti?»', resolvable: true },
+  { id: 'ev-4', type: 'photo',   time: '16:25', actor: 'p-lara',  text: 'ha caricato una foto della board', detail: 'Turno 5 · setup centrale' },
+  { id: 'ev-5', type: 'agent',   time: '16:18', actor: null,      text: 'Agent: Marco può costruire 2 strade questo turno', detail: 'risposta a domanda regole' },
+  { id: 'ev-6', type: 'score',   time: '16:12', actor: 'p-sara',  text: 'ha aggiornato il punteggio', detail: '+2 esercito più grande → 7 PV' },
+  { id: 'ev-7', type: 'dice',    time: '16:06', actor: 'p-aaron', text: 'tira 2D6 → 6', detail: 'nessuna produzione · ladro su 7 evitato' },
+  { id: 'ev-8', type: 'milestone', time: '16:00', actor: null,    text: 'Partita iniziata', detail: '4 giocatori · Catan base' },
+];
+
+// chat agent thread (Catan Coach) — 3 round (#1489 S5 bubble pattern)
+const BASE_CHAT = [
+  { id: 'm-1', role: 'user', actor: 'p-marco', text: 'Posso usare 2 carte sviluppo nello stesso turno?' },
+  { id: 'm-2', role: 'agent', text: 'No: puoi giocare solo 1 carta sviluppo per turno (eccetto le carte Punto Vittoria, che si rivelano a fine partita). Vedi regolamento p.8 §3.4.', cite: 'p.8 §3.4' },
+  { id: 'm-3', role: 'user', actor: 'p-sara', text: 'E per la strada più lunga? Quanti segmenti servono?' },
+  { id: 'm-4', role: 'agent', text: 'Servono almeno 5 segmenti di strada continui. Chi la ottiene prende 2 PV, finché un altro giocatore non costruisce una strada più lunga. Vedi p.6 §2.7.', cite: 'p.6 §2.7' },
+];
+
+const QUICK_PROMPTS = ['Spiega le regole base', 'Come si calcola il punteggio finale?', 'Risolvi la dispute aperta'];
+
+// rules sheet — TOC + Catan content (p.8 highlighted)
+const RULES_TOC = [
+  { id: 's1', n: '§1', label: 'Setup e materiali', page: 'p.2' },
+  { id: 's2', n: '§2', label: 'Il turno di gioco', page: 'p.5' },
+  { id: 's3', n: '§3', label: 'Carte sviluppo', page: 'p.8', highlight: true },
+  { id: 's4', n: '§4', label: 'Commercio', page: 'p.10' },
+  { id: 's5', n: '§5', label: 'Punti vittoria', page: 'p.12' },
+];
+
+window.__SP = {
+  eHsl, sem, PAD, fmtDur, reducedMotion, entE,
+  GAME, SESSION, PLAYERS, SCORE_CATEGORIES, QUICK_ACTIONS, EVENT_TYPE, FEED_FILTERS,
+  findPlayer, BASE_FEED, BASE_CHAT, QUICK_PROMPTS, RULES_TOC,
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── COMPONENT CSS (inject) — solo token da tokens.css ──
+// ═══════════════════════════════════════════════════════
+window.__SP_CSS = `
+.sp-app { display:flex; flex-direction:column; height:100%; min-height:0; background:var(--bg); color:var(--text); position:relative; overflow:hidden; }
+.sp-app.dimmed .sp-layout { filter:saturate(.5) brightness(.97); opacity:.82; transition:filter var(--dur-md), opacity var(--dur-md); }
+
+/* ─ header (sticky, span 3-col) ─ */
+.sp-head { flex-shrink:0; position:sticky; top:0; z-index:14; background:var(--glass-bg); backdrop-filter:blur(14px); border-bottom:1px solid var(--border); padding:13px 22px 14px; }
+.sp-bread { font-family:var(--f-mono); font-size:11px; color:var(--text-muted); letter-spacing:.03em; display:flex; align-items:center; gap:7px; margin-bottom:9px; flex-wrap:wrap; }
+.sp-bread .sep { opacity:.5; }
+.sp-bread .cur { color:var(--text-sec); font-weight:700; }
+.sp-bread .gchip { display:inline-flex; align-items:center; gap:5px; padding:1px 8px 1px 5px; border-radius:var(--r-pill); background:hsl(var(--c-game) / .12); color:hsl(var(--c-game)); font-weight:700; }
+
+.sp-htop { display:flex; align-items:flex-start; gap:16px; }
+.sp-htxt { min-width:0; flex:1; }
+.sp-titlerow { display:flex; align-items:center; gap:11px; flex-wrap:wrap; }
+.sp-h1 { font-family:var(--f-display); font-weight:800; font-size:25px; letter-spacing:-.02em; line-height:1.1; color:var(--text); }
+.sp-statusbadge { display:inline-flex; align-items:center; gap:7px; padding:4px 11px 4px 9px; border-radius:var(--r-pill); font-family:var(--f-display); font-weight:800; font-size:12px; white-space:nowrap; }
+.sp-statusbadge.live { background:hsl(var(--c-success) / .14); color:hsl(var(--c-success)); }
+.sp-statusbadge.paused { background:hsl(var(--c-warning) / .15); color:hsl(var(--c-warning)); }
+.sp-statusbadge.done { background:hsl(var(--c-success)); color:#fff; }
+.sp-statusdot { width:8px; height:8px; border-radius:50%; flex-shrink:0; background:currentColor; }
+.sp-statusdot.live { animation:sp-pulse-dot 1.6s var(--ease-in-out) infinite; }
+
+/* turn indicator */
+.sp-turn { display:inline-flex; align-items:center; gap:8px; margin-top:9px; font-size:13px; color:var(--text-sec); flex-wrap:wrap; }
+.sp-turn .lbl { font-family:var(--f-display); font-weight:700; }
+.sp-chip { display:inline-flex; align-items:center; gap:6px; padding:2px 10px 2px 3px; border-radius:var(--r-pill); background:hsl(var(--c-player) / .12); border:1px solid hsl(var(--c-player) / .26); white-space:nowrap; }
+.sp-chip .av { width:20px; height:20px; flex-shrink:0; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:8px; font-weight:800; color:#fff; }
+.sp-chip .nm { font-family:var(--f-display); font-weight:700; font-size:12px; color:hsl(var(--c-player)); }
+
+/* meta sub-row */
+.sp-meta { display:flex; align-items:center; gap:16px; margin-top:11px; flex-wrap:wrap; }
+.sp-meta .mi { display:inline-flex; align-items:center; gap:6px; font-family:var(--f-mono); font-size:11.5px; color:var(--text-sec); }
+.sp-meta .mi .g { font-size:13px; }
+.sp-meta .mi b { color:var(--text); font-weight:700; }
+
+/* header CTA right */
+.sp-hcta { display:flex; align-items:center; gap:9px; flex-shrink:0; }
+.sp-btn { display:inline-flex; align-items:center; justify-content:center; gap:7px; padding:9px 15px; border-radius:var(--r-md); cursor:pointer; white-space:nowrap;
+  font-family:var(--f-display); font-weight:800; font-size:13px; border:1.5px solid var(--border); background:var(--bg-card); color:var(--text-sec); transition:all var(--dur-sm); }
+.sp-btn:hover { background:var(--bg-hover); }
+.sp-btn.warn { border-color:hsl(var(--c-warning) / .5); color:hsl(var(--c-warning)); }
+.sp-btn.warn:hover { background:hsl(var(--c-warning) / .1); }
+.sp-btn.primary { background:hsl(var(--c-toolkit)); border-color:transparent; color:#fff; box-shadow:0 3px 12px hsl(var(--c-toolkit) / .32); }
+.sp-btn.primary:hover { filter:brightness(1.05); transform:translateY(-1px); }
+.sp-btn.sm { padding:7px 11px; font-size:12px; }
+.sp-iconbtn { width:38px; height:38px; flex-shrink:0; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text-sec); cursor:pointer; font-size:16px; display:inline-flex; align-items:center; justify-content:center; transition:all var(--dur-sm); }
+.sp-iconbtn:hover { background:var(--bg-hover); }
+
+/* ─ session banner (paused / dispute / finalize) ─ */
+.sp-banner { display:flex; align-items:center; gap:12px; padding:12px 22px; flex-shrink:0; animation:sp-event-in var(--dur-md) var(--ease-out); }
+.sp-banner .bi { width:30px; height:30px; flex-shrink:0; border-radius:var(--r-md); display:inline-flex; align-items:center; justify-content:center; font-size:16px; }
+.sp-banner .btxt { flex:1; min-width:0; }
+.sp-banner .bt { font-family:var(--f-display); font-weight:800; font-size:14px; line-height:1.25; }
+.sp-banner .bd { font-size:12px; margin-top:2px; opacity:.85; }
+.sp-banner .bcta { display:flex; gap:8px; flex-shrink:0; }
+.sp-banner.paused { background:hsl(var(--c-warning) / .12); border-bottom:1px solid hsl(var(--c-warning) / .3); }
+.sp-banner.paused .bi { background:hsl(var(--c-warning) / .18); color:hsl(var(--c-warning)); }
+.sp-banner.paused .bt { color:hsl(var(--c-warning)); }
+.sp-banner.dispute { background:hsl(var(--c-danger) / .1); border-bottom:1px solid hsl(var(--c-danger) / .3); }
+.sp-banner.dispute .bi { background:hsl(var(--c-danger) / .16); color:hsl(var(--c-danger)); }
+.sp-banner.dispute .bt { color:hsl(var(--c-danger)); }
+.sp-banner.finalize { background:hsl(var(--c-success) / .12); border-bottom:1px solid hsl(var(--c-success) / .3); }
+.sp-banner.finalize .bi { background:hsl(var(--c-success) / .18); color:hsl(var(--c-success)); }
+.sp-banner.finalize .bt { color:hsl(var(--c-success)); }
+.sp-bbtn { display:inline-flex; align-items:center; gap:6px; padding:8px 14px; border-radius:var(--r-md); cursor:pointer; white-space:nowrap; font-family:var(--f-display); font-weight:800; font-size:12.5px; border:none; color:#fff; }
+.sp-bbtn.warn { background:hsl(var(--c-warning)); }
+.sp-bbtn.success { background:hsl(var(--c-success)); }
+.sp-bbtn.ghost { background:transparent; border:1.5px solid var(--border-strong); color:var(--text-sec); }
+
+/* ─ 3-col layout (30/40/30) ─ */
+.sp-layout { flex:1; min-height:0; display:grid; grid-template-columns:320px 1fr 340px; gap:0; overflow:hidden; }
+.sp-col { min-height:0; display:flex; flex-direction:column; overflow:hidden; }
+.sp-col.left { border-right:1px solid var(--border); background:var(--bg-sunken); }
+.sp-col.center { background:var(--bg); }
+.sp-col.right { border-left:1px solid var(--border); background:var(--bg-sunken); }
+.sp-colscroll { flex:1; min-height:0; overflow-y:auto; display:flex; flex-direction:column; }
+
+/* panel header (shared) */
+.sp-phead { display:flex; align-items:center; gap:9px; padding:14px 16px 11px; flex-shrink:0; border-bottom:1px solid var(--border-light); }
+.sp-phead .pi { width:28px; height:28px; flex-shrink:0; border-radius:var(--r-sm); display:inline-flex; align-items:center; justify-content:center; font-size:14px; background:hsl(var(--e) / .15); color:hsl(var(--e)); }
+.sp-phead .pt { font-family:var(--f-display); font-weight:800; font-size:14px; color:var(--text); letter-spacing:-.01em; }
+.sp-phead .pc { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-top:1px; }
+.sp-phead .grow { flex:1; }
+
+/* ─── SCOREBOARD ─────────────────────────────────────── */
+.sp-board { display:flex; flex-direction:column; }
+.sp-prow { position:relative; display:flex; align-items:center; gap:11px; padding:12px 14px; border-bottom:1px solid var(--border-light); cursor:pointer; transition:background var(--dur-sm); }
+.sp-prow:hover { background:var(--bg-hover); }
+.sp-prow.active { background:hsl(var(--c-session) / .08); box-shadow:inset 3px 0 0 hsl(var(--c-session)); }
+.sp-prow .rank { font-family:var(--f-mono); font-weight:700; font-size:12px; color:var(--text-muted); width:22px; flex-shrink:0; text-align:center; }
+.sp-prow.active .rank { color:hsl(var(--c-session)); }
+.sp-pav { width:34px; height:34px; flex-shrink:0; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:12px; font-weight:800; color:#fff; }
+.sp-pmain { flex:1; min-width:0; }
+.sp-pname { font-family:var(--f-display); font-weight:700; font-size:13.5px; color:var(--text); display:flex; align-items:center; gap:6px; }
+.sp-pturn { font-family:var(--f-mono); font-size:9px; padding:1px 6px; border-radius:var(--r-pill); background:hsl(var(--c-session) / .16); color:hsl(var(--c-session)); white-space:nowrap; }
+.sp-pdelta { font-family:var(--f-mono); font-size:10.5px; margin-top:2px; display:flex; align-items:center; gap:4px; }
+.sp-pdelta.up { color:hsl(var(--c-success)); }
+.sp-pdelta.down { color:hsl(var(--c-danger)); }
+.sp-pdelta.flat { color:var(--text-muted); }
+.sp-pscore { display:flex; flex-direction:column; align-items:flex-end; flex-shrink:0; }
+.sp-score { font-family:var(--f-display); font-weight:800; font-size:24px; line-height:1; color:var(--text); font-variant-numeric:tabular-nums; }
+.sp-prow.active .sp-score { color:hsl(var(--c-session)); }
+.sp-score.pop { animation:sp-score-pop .42s var(--ease-spring); }
+.sp-score .vp { font-size:10px; font-weight:700; color:var(--text-muted); margin-left:2px; }
+.sp-pinc { display:flex; gap:5px; margin-top:6px; }
+.sp-incbtn { width:30px; height:30px; flex-shrink:0; border-radius:var(--r-sm); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text-sec); cursor:pointer; font-size:15px; font-weight:700; line-height:1; display:inline-flex; align-items:center; justify-content:center; transition:all var(--dur-xs); }
+.sp-incbtn:hover { border-color:hsl(var(--c-session) / .5); color:hsl(var(--c-session)); background:hsl(var(--c-session) / .08); }
+.sp-incbtn:active { transform:scale(.92); }
+/* expanded breakdown */
+.sp-breakdown { padding:4px 14px 13px 47px; background:hsl(var(--c-session) / .03); border-bottom:1px solid var(--border-light); display:flex; flex-direction:column; gap:5px; animation:sp-event-in var(--dur-sm) var(--ease-out); }
+.sp-brow { display:flex; align-items:center; justify-content:space-between; gap:10px; font-size:11.5px; }
+.sp-brow .bl { color:var(--text-sec); }
+.sp-brow .bv { font-family:var(--f-mono); font-weight:700; color:var(--text); }
+
+/* ─── QUICK ACTIONS ──────────────────────────────────── */
+.sp-qa { padding:13px 14px 16px; border-top:1px solid var(--border); }
+.sp-qa-head { display:flex; align-items:center; gap:8px; margin-bottom:11px; }
+.sp-qa-head .qi { width:26px; height:26px; flex-shrink:0; border-radius:var(--r-sm); background:hsl(var(--c-toolkit) / .15); color:hsl(var(--c-toolkit)); display:inline-flex; align-items:center; justify-content:center; font-size:13px; }
+.sp-qa-head .qt { font-family:var(--f-display); font-weight:800; font-size:13px; color:var(--text); }
+.sp-qa-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+.sp-qabtn { display:flex; align-items:center; gap:9px; padding:11px 12px; border-radius:var(--r-md); cursor:pointer; text-align:left;
+  background:hsl(var(--e) / .08); border:1.5px solid hsl(var(--e) / .2); color:var(--text); transition:all var(--dur-sm); min-height:44px; }
+.sp-qabtn:hover { background:hsl(var(--e) / .15); border-color:hsl(var(--e) / .4); transform:translateY(-1px); }
+.sp-qabtn .qg { font-size:17px; flex-shrink:0; }
+.sp-qabtn .ql { font-family:var(--f-display); font-weight:700; font-size:12.5px; line-height:1.15; }
+
+/* ─── ACTIVITY FEED ──────────────────────────────────── */
+.sp-feed { display:flex; flex-direction:column; min-height:0; }
+.sp-feed.disc .sp-feedhead { animation:sp-disc-flash 1.1s var(--ease-in-out) 3; }
+.sp-ssedot { width:8px; height:8px; border-radius:50%; flex-shrink:0; background:hsl(var(--c-success)); }
+.sp-ssedot.live { animation:sp-pulse-dot 1.6s var(--ease-in-out) infinite; }
+.sp-ssedot.off { background:hsl(var(--c-danger)); }
+.sp-ssetag { display:inline-flex; align-items:center; gap:6px; padding:2px 9px; border-radius:var(--r-pill); font-family:var(--f-mono); font-size:10px; font-weight:700; background:hsl(var(--c-success) / .12); color:hsl(var(--c-success)); white-space:nowrap; }
+.sp-ssetag.off { background:hsl(var(--c-danger) / .12); color:hsl(var(--c-danger)); }
+/* filters */
+.sp-feedfilters { display:flex; gap:6px; padding:10px 16px; flex-wrap:wrap; border-bottom:1px solid var(--border-light); flex-shrink:0; }
+.sp-fchip { display:inline-flex; align-items:center; gap:5px; padding:5px 11px; border-radius:var(--r-pill); white-space:nowrap; cursor:pointer;
+  background:var(--bg-card); border:1.5px solid var(--border); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:11px; transition:all var(--dur-sm); }
+.sp-fchip:hover { background:var(--bg-hover); }
+.sp-fchip.on { background:hsl(var(--c-session) / .14); border-color:hsl(var(--c-session) / .4); color:hsl(var(--c-session)); }
+/* feed body */
+.sp-feedbody { flex:1; min-height:0; overflow-y:auto; display:flex; flex-direction:column; }
+.sp-feedmore { margin:10px auto; padding:7px 16px; border-radius:var(--r-pill); border:1px solid var(--border); background:var(--bg-card); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:11.5px; cursor:pointer; flex-shrink:0; }
+.sp-feedmore:hover { background:var(--bg-hover); }
+.sp-event { display:flex; gap:12px; padding:13px 16px; border-bottom:1px solid var(--border-light); position:relative; }
+.sp-event:hover { background:var(--bg-hover); }
+.sp-event.fresh { animation:sp-event-in .35s var(--ease-out); }
+.sp-event.flag { background:hsl(var(--c-danger) / .06); box-shadow:inset 3px 0 0 hsl(var(--c-danger)); }
+.sp-event .eic { width:32px; height:32px; flex-shrink:0; border-radius:var(--r-md); display:inline-flex; align-items:center; justify-content:center; font-size:15px; background:hsl(var(--e) / .14); }
+.sp-event .ebody { flex:1; min-width:0; }
+.sp-event .etop { display:flex; align-items:baseline; gap:8px; flex-wrap:wrap; }
+.sp-event .etime { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); flex-shrink:0; }
+.sp-event .etext { font-family:var(--f-body); font-weight:700; font-size:13px; color:var(--text); line-height:1.35; }
+.sp-event .edetail { font-size:12px; color:var(--text-sec); margin-top:3px; line-height:1.4; }
+.sp-emeta { display:flex; align-items:center; gap:8px; margin-top:7px; flex-wrap:wrap; }
+.sp-echip { display:inline-flex; align-items:center; gap:5px; padding:1px 8px 1px 2px; border-radius:var(--r-pill); background:hsl(var(--c-player) / .12); }
+.sp-echip .av { width:16px; height:16px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:7px; font-weight:800; color:#fff; }
+.sp-echip .nm { font-family:var(--f-display); font-weight:700; font-size:10px; color:hsl(var(--c-player)); }
+.sp-eactions { display:flex; gap:7px; }
+.sp-elink { background:none; border:none; cursor:pointer; font-family:var(--f-display); font-weight:700; font-size:11px; color:var(--text-muted); padding:2px 4px; border-radius:var(--r-xs); }
+.sp-elink:hover { color:hsl(var(--c-session)); }
+.sp-elink.danger:hover { color:hsl(var(--c-danger)); }
+
+/* ─── CHAT WIDGET ────────────────────────────────────── */
+.sp-chat { display:flex; flex-direction:column; min-height:0; height:100%; }
+.sp-chathead { display:flex; align-items:center; gap:10px; padding:13px 14px; border-bottom:1px solid var(--border-light); flex-shrink:0; }
+.sp-chathead .ca { width:32px; height:32px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-agent) / .15); color:hsl(var(--c-agent)); display:inline-flex; align-items:center; justify-content:center; font-size:16px; }
+.sp-chathead .cmeta { flex:1; min-width:0; }
+.sp-chathead .cname { font-family:var(--f-display); font-weight:800; font-size:13.5px; color:var(--text); }
+.sp-chathead .crole { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-top:1px; }
+.sp-chatbody { flex:1; min-height:0; overflow-y:auto; padding:14px; display:flex; flex-direction:column; gap:12px; }
+.sp-msg { display:flex; flex-direction:column; gap:4px; max-width:88%; }
+.sp-msg.fresh { animation:sp-msg-in .3s var(--ease-out); }
+.sp-msg.user { align-self:flex-end; align-items:flex-end; }
+.sp-msg.agent { align-self:flex-start; align-items:flex-start; }
+.sp-msgwho { display:inline-flex; align-items:center; gap:6px; font-family:var(--f-mono); font-size:9px; color:var(--text-muted); }
+.sp-msgwho .av { width:15px; height:15px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:6px; font-weight:800; color:#fff; }
+.sp-bubble { padding:9px 12px; border-radius:var(--r-lg); font-size:13px; line-height:1.45; }
+.sp-msg.user .sp-bubble { background:hsl(var(--c-player) / .14); color:var(--text); border-bottom-right-radius:var(--r-xs); }
+.sp-msg.agent .sp-bubble { background:hsl(var(--c-chat) / .12); color:var(--text); border-bottom-left-radius:var(--r-xs); }
+.sp-cite { display:inline-flex; align-items:center; gap:4px; margin-top:6px; padding:2px 8px; border-radius:var(--r-pill); background:hsl(var(--c-kb) / .14); color:hsl(var(--c-kb)); font-family:var(--f-mono); font-size:10px; font-weight:700; cursor:pointer; border:none; }
+.sp-cite:hover { background:hsl(var(--c-kb) / .22); }
+.sp-cursor { display:inline-block; width:7px; height:14px; background:hsl(var(--c-chat)); margin-left:2px; vertical-align:text-bottom; animation:sp-cursor-blink .9s steps(1) infinite; border-radius:1px; }
+.sp-typing { display:inline-flex; gap:4px; align-items:center; padding:11px 13px; }
+.sp-typing span { width:7px; height:7px; border-radius:50%; background:hsl(var(--c-chat)); animation:sp-typing-bounce 1.2s var(--ease-in-out) infinite; }
+.sp-typing span:nth-child(2) { animation-delay:.18s; }
+.sp-typing span:nth-child(3) { animation-delay:.36s; }
+/* chat input */
+.sp-chatfoot { flex-shrink:0; border-top:1px solid var(--border-light); padding:10px 12px 12px; display:flex; flex-direction:column; gap:9px; }
+.sp-prompts { display:flex; gap:6px; flex-wrap:wrap; }
+.sp-prompt { padding:5px 10px; border-radius:var(--r-pill); background:var(--bg-card); border:1px solid var(--border); color:var(--text-sec); font-family:var(--f-display); font-weight:700; font-size:10.5px; cursor:pointer; white-space:nowrap; }
+.sp-prompt:hover { border-color:hsl(var(--c-agent) / .4); color:hsl(var(--c-agent)); }
+.sp-inputrow { display:flex; align-items:flex-end; gap:8px; }
+.sp-chatinput { flex:1; min-width:0; resize:none; font-family:var(--f-body); font-size:13px; padding:10px 12px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text); outline:none; line-height:1.4; max-height:96px; transition:border-color var(--dur-sm), box-shadow var(--dur-sm); }
+.sp-chatinput:focus { border-color:hsl(var(--c-agent) / .55); box-shadow:0 0 0 3px hsl(var(--c-agent) / .12); }
+.sp-sendbtn { width:42px; height:42px; flex-shrink:0; border-radius:var(--r-md); border:none; cursor:pointer; background:hsl(var(--c-agent)); color:#fff; font-size:17px; display:inline-flex; align-items:center; justify-content:center; transition:all var(--dur-sm); }
+.sp-sendbtn:hover { filter:brightness(1.06); transform:translateY(-1px); }
+.sp-sendbtn:disabled { background:var(--bg-muted); color:var(--text-muted); cursor:not-allowed; transform:none; }
+.sp-kbdhint { font-family:var(--f-mono); font-size:9.5px; color:var(--text-muted); text-align:right; }
+.sp-kbdhint kbd { font-family:var(--f-mono); padding:1px 5px; border-radius:var(--r-xs); background:var(--bg-muted); border:1px solid var(--border); font-size:9px; }
+
+/* ─── MODAL (Score / Dispute) ────────────────────────── */
+.sp-overlay { position:absolute; inset:0; z-index:50; background:rgba(20,12,4,.46); backdrop-filter:blur(3px); display:flex; align-items:center; justify-content:center; padding:26px; animation:sp-overlay-in var(--dur-md) var(--ease-out); }
+[data-theme="dark"] .sp-overlay { background:rgba(0,0,0,.62); }
+.sp-modal { width:min(440px, 100%); max-height:100%; overflow-y:auto; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg); animation:sp-modal-in var(--dur-md) var(--ease-spring); }
+.sp-mhead { display:flex; align-items:center; gap:12px; padding:18px 18px 0; }
+.sp-mhead .mi { width:38px; height:38px; flex-shrink:0; border-radius:var(--r-md); display:inline-flex; align-items:center; justify-content:center; font-size:18px; background:hsl(var(--e) / .15); color:hsl(var(--e)); }
+.sp-mhead .mt { flex:1; min-width:0; font-family:var(--f-display); font-weight:800; font-size:17px; color:var(--text); line-height:1.2; }
+.sp-mhead .mx { width:32px; height:32px; flex-shrink:0; border-radius:var(--r-md); border:none; background:var(--bg-muted); color:var(--text-sec); cursor:pointer; font-size:14px; display:inline-flex; align-items:center; justify-content:center; }
+.sp-mhead .mx:hover { background:var(--bg-hover); color:var(--text); }
+.sp-mbody { padding:14px 18px 4px; display:flex; flex-direction:column; gap:13px; }
+.sp-field { display:flex; flex-direction:column; gap:7px; }
+.sp-field > .fl { font-family:var(--f-display); font-weight:700; font-size:12px; color:var(--text-sec); }
+.sp-pselect { display:flex; gap:7px; flex-wrap:wrap; }
+.sp-popt { display:inline-flex; align-items:center; gap:7px; padding:6px 11px 6px 5px; border-radius:var(--r-pill); cursor:pointer; background:var(--bg-card); border:1.5px solid var(--border); transition:all var(--dur-sm); }
+.sp-popt:hover { border-color:hsl(var(--c-player) / .4); }
+.sp-popt.on { background:hsl(var(--c-player) / .12); border-color:hsl(var(--c-player) / .5); }
+.sp-popt .av { width:22px; height:22px; flex-shrink:0; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--f-display); font-size:9px; font-weight:800; color:#fff; }
+.sp-popt .nm { font-family:var(--f-display); font-weight:700; font-size:12px; color:var(--text); }
+.sp-catgrid { display:grid; grid-template-columns:1fr 1fr; gap:7px; }
+.sp-catopt { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:9px 11px; border-radius:var(--r-md); cursor:pointer; background:var(--bg-card); border:1.5px solid var(--border); transition:all var(--dur-sm); }
+.sp-catopt:hover { border-color:hsl(var(--c-toolkit) / .4); }
+.sp-catopt.on { background:hsl(var(--c-toolkit) / .1); border-color:hsl(var(--c-toolkit) / .5); }
+.sp-catopt .cl { font-family:var(--f-display); font-weight:700; font-size:12px; color:var(--text); }
+.sp-catopt .cp { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); }
+.sp-catopt.on .cp { color:hsl(var(--c-toolkit)); }
+.sp-stepperrow { display:flex; align-items:center; gap:12px; }
+.sp-stepbtn { width:40px; height:40px; flex-shrink:0; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text); cursor:pointer; font-size:19px; font-weight:700; display:inline-flex; align-items:center; justify-content:center; }
+.sp-stepbtn:hover { border-color:hsl(var(--c-toolkit) / .5); color:hsl(var(--c-toolkit)); }
+.sp-stepval { font-family:var(--f-display); font-weight:800; font-size:30px; color:var(--text); font-variant-numeric:tabular-nums; min-width:48px; text-align:center; }
+.sp-stepval .pl { font-size:14px; color:var(--text-muted); }
+.sp-ta { width:100%; resize:none; font-family:var(--f-body); font-size:13px; padding:9px 11px; border-radius:var(--r-md); border:1.5px solid var(--border); background:var(--bg-card); color:var(--text); outline:none; line-height:1.45; }
+.sp-ta:focus { border-color:hsl(var(--c-toolkit) / .5); box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .12); }
+/* dispute agent suggestion */
+.sp-suggest { display:flex; gap:10px; padding:12px; border-radius:var(--r-md); background:hsl(var(--c-agent) / .08); border:1px solid hsl(var(--c-agent) / .22); }
+.sp-suggest .si { width:28px; height:28px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-agent) / .16); color:hsl(var(--c-agent)); display:inline-flex; align-items:center; justify-content:center; font-size:14px; }
+.sp-suggest .sb { flex:1; min-width:0; }
+.sp-suggest .sl { font-family:var(--f-display); font-weight:800; font-size:11px; color:hsl(var(--c-agent)); margin-bottom:3px; }
+.sp-suggest .st { font-size:12.5px; color:var(--text-sec); line-height:1.5; }
+.sp-mfoot { display:flex; gap:9px; padding:14px 18px 18px; flex-wrap:wrap; }
+.sp-mbtn { flex:1; min-width:120px; display:inline-flex; align-items:center; justify-content:center; gap:6px; padding:11px; border-radius:var(--r-md); font-family:var(--f-display); font-weight:800; font-size:13px; cursor:pointer; border:1.5px solid var(--border-strong); background:var(--bg-card); color:var(--text); transition:all var(--dur-sm); }
+.sp-mbtn:hover { background:var(--bg-muted); }
+.sp-mbtn.primary { background:hsl(var(--c-toolkit)); border-color:transparent; color:#fff; box-shadow:0 4px 14px hsl(var(--c-toolkit) / .3); }
+.sp-mbtn.primary:hover { filter:brightness(1.05); background:hsl(var(--c-toolkit)); }
+.sp-mbtn.agent { background:hsl(var(--c-agent)); border-color:transparent; color:#fff; }
+.sp-mbtn.agent:hover { filter:brightness(1.05); background:hsl(var(--c-agent)); }
+
+/* ─── RULES SHEET (slide-over right) ─────────────────── */
+.sp-sheet-overlay { position:absolute; inset:0; z-index:48; background:rgba(20,12,4,.3); backdrop-filter:blur(1px); animation:sp-overlay-in var(--dur-md) var(--ease-out); }
+[data-theme="dark"] .sp-sheet-overlay { background:rgba(0,0,0,.5); }
+.sp-sheet { position:absolute; top:0; right:0; bottom:0; z-index:49; width:min(560px, 92%); background:var(--bg-card); border-left:1px solid var(--border); box-shadow:var(--shadow-lg); display:flex; flex-direction:column; animation:sp-sheet-in var(--dur-md) var(--ease-out); }
+.sp-sheethead { display:flex; align-items:center; gap:11px; padding:16px 18px; border-bottom:1px solid var(--border); flex-shrink:0; }
+.sp-sheethead .shi { width:34px; height:34px; flex-shrink:0; border-radius:var(--r-md); background:hsl(var(--c-kb) / .15); color:hsl(var(--c-kb)); display:inline-flex; align-items:center; justify-content:center; font-size:16px; }
+.sp-sheethead .sht { flex:1; min-width:0; }
+.sp-sheethead .shtitle { font-family:var(--f-display); font-weight:800; font-size:15px; color:var(--text); }
+.sp-sheethead .shsub { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); margin-top:1px; }
+.sp-sheetbody { flex:1; min-height:0; display:grid; grid-template-columns:170px 1fr; overflow:hidden; }
+.sp-toc { border-right:1px solid var(--border); background:var(--bg-sunken); overflow-y:auto; padding:10px 8px; display:flex; flex-direction:column; gap:2px; }
+.sp-tocitem { display:flex; align-items:baseline; gap:8px; padding:9px 10px; border-radius:var(--r-md); cursor:pointer; text-align:left; background:none; border:none; transition:background var(--dur-sm); }
+.sp-tocitem:hover { background:var(--bg-hover); }
+.sp-tocitem.on { background:hsl(var(--c-kb) / .12); }
+.sp-tocitem .tn { font-family:var(--f-mono); font-size:10px; font-weight:700; color:var(--text-muted); flex-shrink:0; }
+.sp-tocitem.on .tn { color:hsl(var(--c-kb)); }
+.sp-tocitem .tl { font-family:var(--f-display); font-weight:700; font-size:12px; color:var(--text-sec); line-height:1.3; }
+.sp-tocitem.on .tl { color:var(--text); }
+.sp-tocitem .tp { font-family:var(--f-mono); font-size:9px; color:var(--text-muted); margin-left:auto; flex-shrink:0; }
+.sp-rulescontent { overflow-y:auto; padding:20px 22px; }
+.sp-pdfpage { background:var(--bg); border:1px solid var(--border); border-radius:var(--r-md); padding:22px 24px; box-shadow:var(--shadow-xs); }
+.sp-pdfpage .pn { font-family:var(--f-mono); font-size:10px; color:var(--text-muted); text-align:right; margin-bottom:14px; }
+.sp-pdfpage h4 { font-family:var(--f-display); font-weight:800; font-size:18px; color:var(--text); margin-bottom:12px; }
+.sp-pdfpage h5 { font-family:var(--f-display); font-weight:800; font-size:13px; color:var(--text); margin:16px 0 7px; }
+.sp-pdfpage p { font-size:13px; color:var(--text-sec); line-height:1.65; margin:0 0 11px; }
+.sp-pdfpage .hl { background:hsl(var(--c-kb) / .18); border-radius:var(--r-xs); padding:1px 3px; color:var(--text); box-shadow:0 0 0 1px hsl(var(--c-kb) / .3); }
+
+/* ─── FULLSCREEN CHAT (desktop expand) ───────────────── */
+.sp-chatfull { width:min(680px, 100%); height:min(86%, 760px); background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r-xl); box-shadow:var(--shadow-lg); overflow:hidden; display:flex; flex-direction:column; animation:sp-modal-in var(--dur-md) var(--ease-spring); }
+.sp-chatfull .sp-chat { height:100%; }
+.sp-chatfull .sp-bubble { font-size:14px; }
+
+/* ─── TOAST ──────────────────────────────────────────── */
+.sp-toast { position:absolute; bottom:20px; left:50%; transform:translateX(-50%); z-index:70; display:inline-flex; align-items:center; gap:9px;
+  padding:11px 16px; border-radius:var(--r-pill); background:var(--text); color:var(--bg); box-shadow:var(--shadow-lg); font-family:var(--f-display); font-weight:700; font-size:13px; animation:sp-toast-in var(--dur-md) var(--ease-spring); white-space:nowrap; }
+.sp-toast .td { width:8px; height:8px; border-radius:50%; background:hsl(var(--c-success)); flex-shrink:0; }
+
+/* ═══ MOBILE ═══ */
+.sp-app.is-mobile .sp-head { padding:11px 14px 12px; }
+.sp-app.is-mobile .sp-h1 { font-size:19px; }
+.sp-app.is-mobile .sp-htop { flex-direction:column; gap:11px; }
+.sp-app.is-mobile .sp-hcta { align-self:stretch; flex-wrap:wrap; }
+.sp-app.is-mobile .sp-hcta .sp-btn.primary { flex:1; }
+.sp-app.is-mobile .sp-banner { padding:11px 14px; flex-wrap:wrap; }
+.sp-app.is-mobile .sp-banner .bcta { width:100%; }
+.sp-app.is-mobile .sp-banner .sp-bbtn { flex:1; justify-content:center; }
+.sp-app.is-mobile .sp-layout { display:block; overflow-y:auto; -webkit-overflow-scrolling:touch; }
+.sp-app.is-mobile .sp-col { overflow:visible; height:auto; }
+.sp-app.is-mobile .sp-col.left { border-right:none; border-bottom:1px solid var(--border); }
+.sp-app.is-mobile .sp-col.center { border-bottom:1px solid var(--border); }
+.sp-app.is-mobile .sp-col.right { display:none; } /* chat → bottom sheet */
+.sp-app.is-mobile .sp-colscroll { overflow:visible; }
+.sp-app.is-mobile .sp-feedbody { overflow:visible; }
+/* collapsible activity feed on mobile */
+.sp-app.is-mobile .sp-feed.collapsed .sp-feedfilters,
+.sp-app.is-mobile .sp-feed.collapsed .sp-feedbody { display:none; }
+.sp-collapse-btn { display:none; }
+.sp-app.is-mobile .sp-collapse-btn { display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border-radius:var(--r-sm); border:1px solid var(--border); background:var(--bg-card); color:var(--text-sec); cursor:pointer; font-size:11px; flex-shrink:0; transition:transform var(--dur-sm); }
+.sp-app.is-mobile .sp-feed:not(.collapsed) .sp-collapse-btn { transform:rotate(180deg); }
+/* mobile chat sheet trigger */
+.sp-chatfab { display:none; }
+.sp-app.is-mobile .sp-chatfab { display:flex; position:sticky; bottom:0; z-index:30; align-items:center; gap:10px; width:100%; padding:13px 16px; border:none; border-top:1px solid var(--border);
+  background:hsl(var(--c-agent)); color:#fff; cursor:pointer; font-family:var(--f-display); font-weight:800; font-size:14px; box-shadow:0 -6px 20px hsl(var(--c-agent) / .25); }
+.sp-chatfab .cg { font-size:18px; }
+.sp-chatfab .cbadge { margin-left:auto; font-family:var(--f-mono); font-size:11px; background:rgba(255,255,255,.25); padding:2px 9px; border-radius:var(--r-pill); }
+/* mobile chat as bottom sheet */
+.sp-chatsheet { position:absolute; left:0; right:0; bottom:0; top:38px; z-index:55; background:var(--bg-card); border-top-left-radius:var(--r-2xl); border-top-right-radius:var(--r-2xl); box-shadow:var(--shadow-drawer); display:flex; flex-direction:column; overflow:hidden; animation:sp-sheet-up var(--dur-md) var(--ease-out); }
+.sp-chatsheet-grab { display:flex; align-items:center; justify-content:center; padding:9px 0 4px; flex-shrink:0; }
+.sp-chatsheet-grab::before { content:''; width:38px; height:4px; border-radius:var(--r-pill); background:var(--border-strong); }
+.sp-app.is-mobile .sp-qa-grid { grid-template-columns:1fr 1fr; }
+.sp-app.is-mobile .sp-catgrid { grid-template-columns:1fr; }
+`;

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -200,11 +200,13 @@ sub-pages · nodi architetturali N4/N6/N7.
   - ✅ `/sessions/live/[sessionId]/photos` → `sp4-session-live?tab=photos`
   - ✅ `/sessions/live/[sessionId]/agent` → `sp4-session-live?tab=agent`
   - ✅ `/sessions/live/[sessionId]/players` → `sp4-session-live?tab=players`
-  - ⚠️ `/sessions/[id]/play` — gap residuo, fuori scope ADR 2026-05-31
+  - ✅ `/sessions/[id]/play` → `sp4-session-play.html` + `.jsx` + `-parts.jsx` + `-ui.jsx` (residuo chiuso 2026-06-02, 10 stati, 3-col live view distinta da /live spectator) — PR pending #1492
 - **Mockup canonical**: tutti i 10 file (6 modificati + 4 nuovi) shipped in
-  `admin-mockups/design_files/`. Sync companion: `MOCKUPS_INDEX.md`
-  (+4 component-mock, total 83→87) e `v2-migration-matrix.md`
-  (Route Index aggiornato con tab mapping).
+  `admin-mockups/design_files/` 2026-05-31, **+ 4 file sp4-session-play** shipped 2026-06-02
+  (residuo closure). Sync companion: `MOCKUPS_INDEX.md`
+  (+4 component-mock, total 83→87, +4 sp4-session-play files 87→91) e `v2-migration-matrix.md`
+  (Route Index aggiornato con tab mapping + /play row done).
+- **Issue #1492 CLOSED 2026-06-02** — **epic #1475 user-facing UI a 26/26 (100%)** (gap N7 fully resolved including residual).
 
 ## P3 — Coverage stati (cross-cutting, Adzic)
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -83,9 +83,11 @@ ambiguity. Each route is also classified by **Tier** (S/M/L) to gate dispatch st
 > (shared runtime), `sp4-session-live-tabs.jsx` (`window.LiveTabs`),
 > `sp4-session-summary-sections.jsx`, `sp4-session-summary-tabs.jsx`
 > (`window.SummaryReviewTabs`). `/sessions/[id]/join` reuse `sp3-join.html`
-> (no design). 8th sub-route `/sessions/[id]/play` non in scope ADR (rimane
-> route fisica). ADR: `claudedocs/2026-05-31-sessions-consolidation-adr.md`.
-> Issue #1492.
+> (no design). 8th sub-route `/sessions/[id]/play` chiusa 2026-06-02 via
+> `sp4-session-play.html` (residuo gap N7, 10 stati, 3-col live view —
+> distinta da `/sessions/[id]/live` spectator). ADR:
+> `claudedocs/2026-05-31-sessions-consolidation-adr.md`.
+> Issue #1492 CLOSED 2026-06-02 — **epic #1475 user-facing UI a 26/26 (100%)**.
 
 > **Updated 2026-05-31** (Documentation reconciliation cross-audit
 > 2026-05-12 + 2026-05-22): the Route → Mockup index now reflects 3 mockup
@@ -749,7 +751,7 @@ instead.
 | `/sessions/[id]/{scoreboard,notes,players}` | `sp4-session-wingspan-summary.html` ↻ tabs | Consolidated 2026-05-31 — route da deletare, redirect 301/308 a `?tab=` equivalente |
 | `/sessions/[id]/{scores,photos,agent,players}` | `sp4-session-wingspan-live.html` ↻ tabs | Consolidated 2026-05-31 — route da deletare, redirect 301/308 a `?tab=` equivalente. NOTA: `/sessions/[id]/players` esiste sia post-game (summary tab) sia live (live tab) — context-dependent |
 | `/sessions/[id]/join` | `sp3-join.html` ↻ | Reuse — non consolidato (flow distinto) |
-| `/sessions/[id]/play` | — | Route esistente, NON in scope ADR 2026-05-31 — gap residuo |
+| `/sessions/[id]/play` | `sp4-session-play.html` [done] | B17 #1492 · Live play view 3-col (Scoreboard PV inline +/- / Activity feed SSE / Chat agent streaming) + Rules sheet + Score/Dispute modals, 10 stati. **Chiude residuo gap N7 + epic #1475 a 26/26 (100%).** |
 | `/sessions/live/[id]` (+ `/agent`, `/photos`, `/players`, `/scores`) | `sp4-session-live.html` + `librogame-runthrough-session-end.html` | Consolidation 2026-05-31 applicabile (stesso pattern `?tab=`); coexistenza route fisiche da pianificare |
 | `/game-nights` | `sp4-game-nights-index.html` | Tier L pending |
 | `/game-nights/new` | `sp7-game-night-create.html` | Tier L+ DONE (PR #1297 components, PR #1302 orchestrator, PR #1305 W4 E2E + a11y + conformity entry); baseline PNGs auto-generated post-merge via bootstrap workflows |


### PR DESCRIPTION
## Summary

**🎉 CHIUSURA EPIC #1475 USER-FACING UI A 26/26 (100%)**

Chiude **residuo gap N7** (issue #1492 B17 "Mockup Sessions sub-pages"). 1 mockup standalone Tier S split-multi (4 file) per `/sessions/[id]/play` — 8a sub-route NOT in scope ADR 2026-05-31 (consolidation Opt B+ hybrid). Issue #1492 fully closed.

## Decisione architecturale (locked via spec-panel 4 esperti)

**Opt B: coprire residuo + chiusura unica** (vs A close admin + defer / C close indef). Rationale:
- Chiusura unica gap N7 vs frammentazione issue
- Single-screen fast-path Tier S ~1.5h totale (P163 cluster pattern validato 3 volte)
- Epic #1475 chiude pulito a 26/26 (100%) — milestone simbolico 14-week journey

## Files (4 in admin-mockups/design_files/)

- `sp4-session-play.html` (57 LOC scaffold + keyframes inline)
- `sp4-session-play.jsx` (453 LOC helper: CSS string + fixture + window globals)
- `sp4-session-play-parts.jsx` (474 LOC sub-components: Scoreboard, QuickActions, ActivityFeed, SessionChatWidget, Score/Dispute modals, Rules Sheet, dynamic banner)
- `sp4-session-play-ui.jsx` (271 LOC orchestrator + STATES matrix 10 stati + state picker)

## Coverage

| Componente | Dettaglio |
|------------|-----------|
| **Header sticky** | Status FSM badge (Attiva/In pausa/Conclusa) + turn indicator + meta info (durata live timer, players count, round counter) + CTAs (Pausa / Conclude partita) |
| **Layout 3-col desktop** | Scoreboard 30% + Activity feed SSE 40% + Chat agent 30% |
| **LiveScoreboard** | 4 player con avatar + total score + delta vs last update (▲▼─) + inline score input +/- touch-friendly + active player highlight (`aria-current="true"`) + click row → breakdown punteggio categorie |
| **QuickActions** | 6 button grid 2-col (Tira dadi, Foto, Score input, Dispute, Regole, Save) |
| **ActivityFeed** | Eventi cronologici SSE-driven con icon entity colored per tipo (🎯/🎲/⚖️/📸/🤖/🏁) + filter multi-select chip, `role="log" aria-live="polite" aria-relevant="additions"` |
| **SessionChatWidget** | Chat embedded agent rules con streaming cursor blink, auto-scroll, quick prompts, espandi fullscreen via `role="dialog" aria-modal` |
| **Modali** | Score Input (player selector + category + points stepper + note), Dispute (description + agent suggestion + 3 CTA), Rules Sheet slide-over (aria-modal=false non-blocking) |
| **Mobile stack** | Chat bottom-sheet via CTA sticky "Apri chat agent", activity feed collapsable, scoreboard fullwidth |

## 10 stati implementati

active-default · paused · active-with-dispute · score-input-modal-open · dispute-modal-open · rules-sheet-open · agent-streaming · sse-disconnected · finalize-prompt · mobile-stack

## Quality bullets (DoD verificato)

- [x] Solo CSS variables da `tokens.css`
- [x] Light + dark mode parity (SSE indicator visibile in entrambi)
- [x] Mobile 375 + desktop 1440 responsive (3-col → stack mobile, chat bottom-sheet)
- [x] State picker UI continuity (`localStorage 'sp-state'`, naming cluster `lw-state → sp-state`)
- [x] Theme toggle 🌗 persistito `mai-theme`
- [x] EntityChip cluster-wide consistent (--c-session primaria, --c-player/--c-game/--c-agent secondarie)
- [x] ARIA comprehensive (`role="main/region/log/dialog/list/textbox/alert/status"`, `aria-live/busy/modal/current/relevant/labelledby/label/expanded`, focus management cross-pane)
- [x] Keyboard shortcuts (`+/-` score active player, `Enter` expand event, `Ctrl+S` save, `Ctrl+P` pause, `/` focus chat, `Esc` close modal)
- [x] Reduced motion CSS
- [x] Testo IT + dati realistici (Catan, Marco R./Sara T./Aaron R./Lara F., punteggi VP realistici 8-15)
- [x] Header comment con scope + decisione residuo gap N7 closure

## Updates correlati

- **`00-hub.html`**: 1 nuova card SP4 (entity --c-session) — merge **CORRETTO 4 cluster consecutivo** (#1489 5/5 P155 triggered, #1490+#1491+#1492 0/6 NOT triggered, Claude Design ha imparato pattern dal Project Knowledge cumulativo)
- **`v2-migration-matrix.md`**: row `/sessions/[id]/play` flipped da `gap` a `done` + nota header consolidation aggiornata con closure 2026-06-02
- **`2026-05-22-mockup-gaps.md`**: gap **N7 residuo marked CLOSED** + nota epic #1475 a 26/26 100%

## Test plan

- [ ] Visual smoke: `cd admin-mockups/design_files && python -m http.server 8765` → verifica `sp4-session-play.html` su `:8765/<file>.html` (default light + toggle dark)
- [ ] Verifica responsive 375 / 1440 via devtools (3-col → stack, chat bottom-sheet)
- [ ] Verifica state picker funzionante (10 stati)
- [ ] Verifica `00-hub.html` mostra 1 nuova card SP4 + sezione tutto preservato
- [ ] Verifica gap N7 in `2026-05-22-mockup-gaps.md` marked CLOSED con residual
- [ ] Verifica matrix row `/sessions/[id]/play` done

## 🎉 Epic #1475 chiusura

| Phase | Stato pre | Stato post |
|-------|-----------|-----------|
| **A** Pilot game-detail | 9/9 ✅ | 9/9 ✅ |
| **B** Route implementation | 9/9 ✅ | 9/9 ✅ |
| **C** Conformity audit | 3/3 ✅ | 3/3 ✅ |
| **D** Mockup gaps | 4/5 ✅ (#1488 #1489 #1490 #1491) | **5/5 ✅** (+#1492) |
| **Totale** | 25/26 (96%) | **26/26 (100%)** ✅ |

**Epic #1475 user-facing UI completion — STRUTTURALMENTE CHIUSO** dopo cluster Phase D Claude Design workflow (#1489 → #1490 → #1491 → #1492 = 4 cluster, 11 mockup screens, 30 file totali, ~12h sessione design).

## Closes

Closes #1492 (gap B17 residuo / Design v1 · Sessions sub-pages)

## Out of scope (deferred a follow-up issues)

- Implementation FE per `apps/web/src/app/(authenticated)/sessions/[id]/play/page.tsx` re-skin secondo nuovo mockup (esistente già funzionale; follow-up issue separata)
- Implementation FE per route consolidation (delete + redirect 301/308) — separate issues per cluster

## Pattern shipped questo cluster

- **P163** `single-screen-cluster-fast-path` riconfermato 3× (cluster #1491 + cluster #1492)
- **P145** `admin-merge-on-user-request` validato **10 volte consecutive**
- **P162** `P155-NOT-triggered-after-trust-grown` riconfermato 4 cluster consecutivo (Claude Design pattern hub-aware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)