### PR TITLE
feat(admin-infra): #1837 F4-C1 — /admin/monitor/containers SP5 re-skin

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
@@ -35,8 +35,9 @@ function ContainerStatusBadge({ state }: { state: string }) {
   const variant =
     state === 'running' ? 'secondary' : state === 'exited' ? 'destructive' : 'outline';
 
+  // SP5 #1837: token-aligned dot colors (was hardcoded bg-green/red/yellow-500).
   const dotColor =
-    state === 'running' ? 'bg-green-500' : state === 'exited' ? 'bg-red-500' : 'bg-yellow-500';
+    state === 'running' ? 'bg-emerald-500' : state === 'exited' ? 'bg-rose-500' : 'bg-amber-500';
 
   return (
     <Badge variant={variant} className="gap-1.5 text-xs" data-testid="container-status-badge">
@@ -113,19 +114,30 @@ function StatusSummary({ containers }: { containers: ContainerInfo[] }) {
   const stopped = containers.filter(c => c.state !== 'running').length;
   const total = containers.length;
 
+  // SP5 #1837: token-aligned KPI strip (was green-600/red-600 hardcoded).
   return (
     <div className="grid grid-cols-3 gap-3" data-testid="status-summary">
-      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md">
-        <p className="text-xs text-muted-foreground">Total</p>
-        <p className="text-lg font-semibold font-mono">{total}</p>
+      <div className="rounded-xl border border-border/60 bg-card/70 p-3 backdrop-blur-md">
+        <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          Total
+        </p>
+        <p className="font-quicksand text-lg font-bold text-foreground">{total}</p>
       </div>
-      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md">
-        <p className="text-xs text-green-600">Running</p>
-        <p className="text-lg font-semibold font-mono text-green-600">{running}</p>
+      <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3 backdrop-blur-md">
+        <p className="font-mono text-[10px] uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+          Running
+        </p>
+        <p className="font-quicksand text-lg font-bold text-emerald-700 dark:text-emerald-300">
+          {running}
+        </p>
       </div>
-      <div className="rounded-xl border bg-card/70 p-3 backdrop-blur-md">
-        <p className="text-xs text-red-600">Stopped</p>
-        <p className="text-lg font-semibold font-mono text-red-600">{stopped}</p>
+      <div className="rounded-xl border border-rose-500/30 bg-rose-500/5 p-3 backdrop-blur-md">
+        <p className="font-mono text-[10px] uppercase tracking-wider text-rose-700 dark:text-rose-300">
+          Stopped
+        </p>
+        <p className="font-quicksand text-lg font-bold text-rose-700 dark:text-rose-300">
+          {stopped}
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
@@ -38,7 +38,8 @@ describe('ContainerDashboardPage', () => {
     render(<ContainerDashboardPage />);
 
     expect(screen.getByTestId('containers-page')).toBeInTheDocument();
-    expect(screen.getByText('Container Dashboard')).toBeInTheDocument();
+    // SP5 #1837: titolo aggiornato da "Container Dashboard" a "Infrastructure & Containers"
+    expect(screen.getByText('Infrastructure & Containers')).toBeInTheDocument();
   });
 
   it('renders container dashboard and restart panel', () => {

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx
@@ -1,8 +1,23 @@
 'use client';
 
 /**
- * Container Dashboard Page — Admin Infrastructure Panel Phase 4
- * Issue #143
+ * #1837 SP5 F4-C1 — `/admin/monitor/containers` re-skin
+ *
+ * Layout SP5 (mockup `sp5-admin-infra.html`):
+ *   1. Hero header (titolo + descrizione + crumbs)
+ *   2. ContainerDashboard — grid container con auto-refresh + StatusSummary KPI
+ *   3. RestartAllPanel — restart dependency-ordered (typed-confirm)
+ *
+ * Originale (Issue #143): page admin Phase 4. Re-skin SP5 introduce:
+ *   - Header SP5-style con breadcrumb-like crumbs
+ *   - StatusSummary KPI con token semantici emerald/rose (era green/red hardcoded)
+ *   - ContainerStatusBadge dot color token-aligned
+ *
+ * BE pending (documentato, follow-up issue da aprire):
+ *   - KPISparkline per CPU/Memory/Network — richiede endpoint metrics aggregato
+ *   - LiveEventLog filtrato `type=infra` — richiede event types specifici per
+ *     container start/stop/restart (oggi LiveEventLog supporta solo eventi domain
+ *     come `agent.created`, `kb.doc.indexed`, etc.)
  */
 
 import { ContainerDashboard } from './ContainerDashboard';
@@ -11,14 +26,21 @@ import { RestartAllPanel } from './RestartAllPanel';
 export default function ContainerDashboardPage() {
   return (
     <div data-testid="containers-page" className="space-y-6">
-      <div>
+      {/* SP5 hero header */}
+      <header>
+        <nav
+          aria-label="breadcrumb"
+          className="font-mono text-[10.5px] uppercase tracking-wider text-muted-foreground mb-1"
+        >
+          Monitor &middot; Containers
+        </nav>
         <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
-          Container Dashboard
+          Infrastructure &amp; Containers
         </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Docker container status, metrics, and management controls.
+        <p className="mt-1 text-sm text-muted-foreground">
+          Docker container status, metrics, e azioni di restart dependency-ordered.
         </p>
-      </div>
+      </header>
 
       <ContainerDashboard />
 


### PR DESCRIPTION
## Summary

Re-skin di `/admin/monitor/containers` per il mockup SP5 (`sp5-admin-infra.html`). Issue #1837, sub-task dell'epic #1833 (F4 Ondata Ops).

## Scope (onesto)

Lo scope C1 era largo (KPISparkline + LiveEventLog + ConfirmModal typed-confirm) ma il FE ha già `ContainerDashboard` (auto-refresh + grid + StatusSummary KPI) e `RestartAllPanel` (dependency-ordered sequential restart) **production-ready**. Questo PR si focalizza su:

1. **Header SP5** (page.tsx): breadcrumb-like crumbs "Monitor · Containers" + titolo "Infrastructure & Containers" + descrizione
2. **Token alignment** (ContainerDashboard.tsx):
   - `ContainerStatusBadge` dot color: `bg-green-500/red-500/yellow-500` → `bg-emerald-500/rose-500/amber-500`
   - `StatusSummary` KPI cards: rimosso `text-green-600/red-600` hardcoded, sostituito con palette emerald/rose con border+bg tints (mockup-conformant)

ContainerDashboard logic + RestartAllPanel sono **invariati**.

## BE gaps documentati (follow-up issue da aprire)

UI mostra il pannello attuale senza i seguenti SP5-mockup components:
- **KPISparkline** per CPU/Memory/Network — richiede endpoint metrics aggregato cross-container (oggi `getDockerContainers` ritorna info statiche per container, non time-series)
- **LiveEventLog** filtrato `type=infra` — richiede event types specifici (container.started/stopped/restarted) nel domain event registry (oggi `LiveEventLog` supporta solo agent/kb/chat/session domain events, non lo stream container Docker)

Entrambi richiedono BE work follow-up.

## Test plan

- [x] 21/21 test Vitest passing (ContainerDashboard + RestartAllPanel + page)
- [x] `page.test.tsx` aggiornato per nuovo titolo "Infrastructure & Containers"
- [x] `pnpm typecheck` ✅ 0 errori
- [x] Pre-commit hook ✅ lint-staged ok
- [ ] Visual designer review manuale vs mockup

## References

- Spec consolidamento §5 Gruppo C (C1 P1)
- Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-infra.html`
- Parent epic: #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)