### PR TITLE
feat(admin-business): #1838 F4-C5 — /admin/business NEW page scaffold

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/business/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/business/page.tsx
@@ -1,0 +1,81 @@
+import { BudgetKpiStrip } from '@/components/admin/business/BudgetKpiStrip';
+import { BudgetPlaceholderPanel } from '@/components/admin/business/BudgetPlaceholderPanel';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'Budget & Cost — Admin' };
+
+/**
+ * #1838 SP5 F4-C5 — `/admin/business` (NEW page)
+ *
+ * Layout SP5 (mockup `sp5-admin-budget.html`):
+ *   1. Hero header (titolo + crumbs + descrizione)
+ *   2. BudgetKpiStrip — 4 KPI (spesa oggi/mese, budget residuo, proiezione)
+ *   3. CostStackedArea placeholder — stacked area cost per provider 30gg
+ *   4. FeatureCostTable placeholder — costi per feature con drill provider
+ *   5. CostSimulator placeholder — what-if calculator
+ *   6. BudgetGauge placeholder — gauge spent vs budget mensile
+ *
+ * **Stato attuale**: page nuova creata + nav config aggiornata. Tutti i 4
+ * pannelli sono placeholder "BE pending" perché gli endpoint cost aggregation
+ * non sono ancora implementati nel backend.
+ *
+ * Endpoint BE attesi (follow-up issue da aprire):
+ *   GET /api/v1/admin/business               → KPI aggregati
+ *   GET /api/v1/admin/budget                 → budget mensile + spent
+ *   GET /api/v1/admin/cost-calculator        → simulator input/output
+ *   POST /api/v1/admin/budget/limit          → update budget limit
+ *   GET /api/v1/admin/business/breakdown?range=30d → CostStackedArea data
+ *   GET /api/v1/admin/business/per-feature   → FeatureCostTable
+ */
+export default function BudgetPage() {
+  return (
+    <div className="space-y-5" data-testid="business-page">
+      {/* SP5 hero header */}
+      <header>
+        <nav
+          aria-label="breadcrumb"
+          className="font-mono text-[10.5px] uppercase tracking-wider text-muted-foreground mb-1"
+        >
+          Admin &middot; Platform &amp; Operations &middot; Budget
+        </nav>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          Budget &amp; Cost
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          KPI di spesa per provider/feature, simulator di costo, e configurazione budget mensile.
+        </p>
+      </header>
+
+      <BudgetKpiStrip />
+
+      <BudgetPlaceholderPanel
+        id="cost-stacked-area"
+        title="Costi per provider · 30 giorni"
+        description="Stacked area chart con breakdown costo giornaliero per provider (DeepSeek, OpenRouter, OpenAI, Anthropic, ...) — last 30 days con linea budget cap."
+        endpoint="GET /api/v1/admin/business/breakdown?range=30d"
+      />
+
+      <BudgetPlaceholderPanel
+        id="feature-cost-table"
+        title="Costi per feature"
+        description="Tabella per-feature (rag-query, embedding, image-gen, ...) con cost totale + breakdown per provider drillabile."
+        endpoint="GET /api/v1/admin/business/per-feature"
+      />
+
+      <BudgetPlaceholderPanel
+        id="cost-simulator"
+        title="What-if calculator"
+        description="Simulator: 'se aumento RPM del X% e cambio modello a Y, costo previsto = Z'. Output con warning quando supera budget."
+        endpoint="GET /api/v1/admin/cost-calculator"
+      />
+
+      <BudgetPlaceholderPanel
+        id="budget-gauge"
+        title="Budget mensile"
+        description="Gauge spent vs budget mensile + ETA exhaust + threshold alert (80% / 95% / 100%). Configurazione via POST /admin/budget/limit."
+        endpoint="GET /api/v1/admin/budget"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/business/BudgetKpiStrip.tsx
+++ b/apps/web/src/components/admin/business/BudgetKpiStrip.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+/**
+ * #1838 SP5 F4-C5 — BudgetKpiStrip
+ *
+ * KPI strip per `/admin/business` (mockup `sp5-admin-budget.html` §1, kpi-strip).
+ * 4 metriche: spesa oggi, spesa mese, budget residuo, proiezione fine mese.
+ *
+ * **BE pending**: il backend non espone ancora un endpoint cost aggregation
+ * (`/admin/business/breakdown`, `/admin/budget`). UI mostra valori placeholder
+ * "—" con tooltip esplicativo finché i BE endpoint non saranno disponibili.
+ */
+
+interface KpiBoxProps {
+  readonly label: string;
+  readonly value: string;
+  readonly trend?: string;
+  readonly tone: 'agent' | 'event' | 'toolkit' | 'chat';
+  readonly tooltip?: string;
+}
+
+function KpiBox({ label, value, trend, tone, tooltip }: KpiBoxProps) {
+  const toneClass: Record<KpiBoxProps['tone'], string> = {
+    agent: 'border-amber-500/30 bg-amber-500/5',
+    event: 'border-rose-500/30 bg-rose-500/5',
+    toolkit: 'border-teal-500/30 bg-teal-500/5',
+    chat: 'border-cyan-500/30 bg-cyan-500/5',
+  };
+
+  return (
+    <div
+      className={`rounded-lg border ${toneClass[tone]} p-4`}
+      title={tooltip}
+      data-testid={`budget-kpi-${label.toLowerCase().replace(/\s+/g, '-')}`}
+    >
+      <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 font-quicksand text-2xl font-bold text-foreground">{value}</div>
+      {trend && <div className="mt-1 font-mono text-[10px] text-muted-foreground">{trend}</div>}
+    </div>
+  );
+}
+
+export function BudgetKpiStrip() {
+  return (
+    <section
+      className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+      aria-label="Budget KPI"
+      data-testid="budget-kpi-strip"
+    >
+      <KpiBox
+        label="Spesa oggi"
+        value="—"
+        trend="aggregato BE pending"
+        tone="agent"
+        tooltip="Endpoint /admin/business/breakdown?range=24h non ancora implementato"
+      />
+      <KpiBox
+        label="Spesa mese"
+        value="—"
+        trend="aggregato BE pending"
+        tone="event"
+        tooltip="Endpoint /admin/business/breakdown?range=30d non ancora implementato"
+      />
+      <KpiBox
+        label="Budget residuo"
+        value="—"
+        trend="config /admin/budget pending"
+        tone="toolkit"
+        tooltip="Endpoint /admin/budget non ancora implementato"
+      />
+      <KpiBox
+        label="Proiezione fine mese"
+        value="—"
+        trend="ETA exhaust pending"
+        tone="chat"
+        tooltip="Calcolo proiezione richiede serie storica + budget config"
+      />
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/business/BudgetPlaceholderPanel.tsx
+++ b/apps/web/src/components/admin/business/BudgetPlaceholderPanel.tsx
@@ -28,7 +28,7 @@ export function BudgetPlaceholderPanel({
 }: BudgetPlaceholderPanelProps) {
   return (
     <section
-      className="rounded-lg border border-border/60 dark:border-zinc-700/60 bg-card/80 dark:bg-zinc-900/80 p-6"
+      className="rounded-lg border border-border/60 bg-card/80 p-6"
       aria-labelledby={`${id}-heading`}
       data-testid={`budget-placeholder-${id}`}
     >
@@ -36,7 +36,7 @@ export function BudgetPlaceholderPanel({
         <h3 id={`${id}-heading`} className="font-quicksand text-base font-bold text-foreground">
           {title}
         </h3>
-        <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border bg-zinc-500/10 text-zinc-700 dark:text-zinc-300 border-zinc-500/30">
+        <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border bg-muted/40 text-muted-foreground border-border/40">
           BE pending
         </span>
       </header>

--- a/apps/web/src/components/admin/business/BudgetPlaceholderPanel.tsx
+++ b/apps/web/src/components/admin/business/BudgetPlaceholderPanel.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+/**
+ * #1838 SP5 F4-C5 — BudgetPlaceholderPanel
+ *
+ * Componente generico per i 4 pannelli SP5 mockup non ancora wired al BE:
+ *   - CostStackedArea (mockup §2)
+ *   - FeatureCostTable (mockup §3)
+ *   - CostSimulator (mockup §4)
+ *   - BudgetGauge (mockup §5)
+ *
+ * Mostra un placeholder con titolo, descrizione "Coming soon", e una nota
+ * tecnica sull'endpoint BE da implementare.
+ */
+
+export interface BudgetPlaceholderPanelProps {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly endpoint: string;
+}
+
+export function BudgetPlaceholderPanel({
+  id,
+  title,
+  description,
+  endpoint,
+}: BudgetPlaceholderPanelProps) {
+  return (
+    <section
+      className="rounded-lg border border-border/60 dark:border-zinc-700/60 bg-card/80 dark:bg-zinc-900/80 p-6"
+      aria-labelledby={`${id}-heading`}
+      data-testid={`budget-placeholder-${id}`}
+    >
+      <header className="mb-3 flex items-center gap-2">
+        <h3 id={`${id}-heading`} className="font-quicksand text-base font-bold text-foreground">
+          {title}
+        </h3>
+        <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border bg-zinc-500/10 text-zinc-700 dark:text-zinc-300 border-zinc-500/30">
+          BE pending
+        </span>
+      </header>
+
+      <p className="text-sm text-muted-foreground">{description}</p>
+
+      <p className="mt-3 font-mono text-[10.5px] text-muted-foreground">
+        Endpoint richiesto: <code className="bg-muted/40 px-1.5 py-0.5 rounded">{endpoint}</code>
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/business/__tests__/BudgetKpiStrip.test.tsx
+++ b/apps/web/src/components/admin/business/__tests__/BudgetKpiStrip.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { BudgetKpiStrip } from '../BudgetKpiStrip';
+
+describe('BudgetKpiStrip', () => {
+  it('renders 4 KPI boxes with BE-pending placeholders', () => {
+    render(<BudgetKpiStrip />);
+
+    expect(screen.getByTestId('budget-kpi-strip')).toBeInTheDocument();
+    expect(screen.getByTestId('budget-kpi-spesa-oggi')).toHaveTextContent('—');
+    expect(screen.getByTestId('budget-kpi-spesa-mese')).toHaveTextContent('—');
+    expect(screen.getByTestId('budget-kpi-budget-residuo')).toHaveTextContent('—');
+    expect(screen.getByTestId('budget-kpi-proiezione-fine-mese')).toHaveTextContent('—');
+  });
+
+  it('shows endpoint hint in tooltip', () => {
+    render(<BudgetKpiStrip />);
+
+    const oggi = screen.getByTestId('budget-kpi-spesa-oggi');
+    expect(oggi).toHaveAttribute('title', expect.stringMatching(/breakdown/i));
+  });
+});

--- a/apps/web/src/components/admin/business/__tests__/BudgetPlaceholderPanel.test.tsx
+++ b/apps/web/src/components/admin/business/__tests__/BudgetPlaceholderPanel.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { BudgetPlaceholderPanel } from '../BudgetPlaceholderPanel';
+
+describe('BudgetPlaceholderPanel', () => {
+  it('renders title, description, endpoint, BE pending chip', () => {
+    render(
+      <BudgetPlaceholderPanel
+        id="test-panel"
+        title="Test Title"
+        description="Test description text"
+        endpoint="GET /api/v1/admin/test"
+      />
+    );
+
+    expect(screen.getByTestId('budget-placeholder-test-panel')).toBeInTheDocument();
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test description text')).toBeInTheDocument();
+    expect(screen.getByText(/BE pending/i)).toBeInTheDocument();
+    expect(screen.getByText('GET /api/v1/admin/test')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+++ b/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
@@ -6,6 +6,7 @@ import {
   Bot,
   BookOpen,
   Database,
+  DollarSign,
   FileSearch,
   Gamepad2,
   Globe,
@@ -83,6 +84,7 @@ export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
     icon: Globe,
     items: [
       { label: 'Providers', href: '/admin/providers', icon: Globe },
+      { label: 'Budget & Cost', href: '/admin/business', icon: DollarSign },
       { label: 'Analytics', href: '/admin/analytics', icon: BarChart2 },
       {
         label: 'Staging Access',


### PR DESCRIPTION
## Summary

Page **NUOVA** `/admin/business` (Budget & Cost) per il mockup SP5 (`sp5-admin-budget.html`). Issue #1838, sub-task dell'epic #1833 (F4 Ondata Ops).

## Scope (a) — scaffold ship-ready

Lo scope C5 era largo (BudgetGauge + CostStackedArea + FeatureCostTable + CostSimulator) ma **nessuno dei 6 endpoint BE del mockup è implementato**. Questo PR ship:

1. **page.tsx NEW** in `app/admin/(dashboard)/business/page.tsx` — header SP5 (titolo + crumbs + descrizione)
2. **BudgetKpiStrip** — 4 KPI box mockup-conformant (spesa oggi/mese, budget residuo, proiezione fine mese) con placeholder `—` + tooltip endpoint
3. **BudgetPlaceholderPanel** — componente generico riutilizzato per i 4 pannelli SP5 (CostStackedArea, FeatureCostTable, CostSimulator, BudgetGauge) con chip "BE pending" + endpoint richiesto
4. **admin-nav-config**: aggiunta voce "Budget & Cost" gruppo C (Platform & Operations), icona `DollarSign`, min role admin

## Scope (b) deferred a follow-up

Tutti i 6 endpoint BE da implementare:
- `GET /admin/business` — KPI aggregati
- `GET /admin/budget` — budget mensile + spent
- `GET /admin/cost-calculator` — simulator I/O
- `POST /admin/budget/limit` — update budget config
- `GET /admin/business/breakdown?range=30d` — CostStackedArea data
- `GET /admin/business/per-feature` — FeatureCostTable

Quando i BE landeranno, scope (b) wired: data binding + Recharts wrappers per BudgetGauge/CostStackedArea + form CostSimulator.

## Test plan

- [x] 3 nuovi unit Vitest (BudgetKpiStrip + BudgetPlaceholderPanel)
- [x] admin-nav-config tests intatti (5/5)
- [x] `pnpm typecheck` ✅ 0 errori
- [x] Pre-commit hook ✅ lint-staged + prettier
- [ ] Visual designer review manuale vs mockup

## References

- Spec consolidamento §5 Gruppo C (C5 P1)
- Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-budget.html`
- Parent epic: #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)