### PR TITLE
feat(admin-alerts): #1840 F4-C7 — AlertRuleList TestAlert button stub

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/AlertsTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/AlertsTab.tsx
@@ -118,6 +118,7 @@ export function AlertsTab() {
           Nuova Regola
         </Button>
       </div>
+      {/* TODO #1840 C7: wire onTestAlert once POST /alert-rules/{id}/test is implemented */}
       <AlertRuleList rules={rules} onDelete={handleDelete} onToggle={handleToggle} />
       <CreateAlertRuleDialog
         open={createDialogOpen}

--- a/apps/web/src/components/admin/alert-rules/AlertRuleList.tsx
+++ b/apps/web/src/components/admin/alert-rules/AlertRuleList.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from 'lucide-react';
+import { Trash2, Zap } from 'lucide-react';
 
 import { Badge } from '@/components/ui/data-display/badge';
 import {
@@ -18,9 +18,22 @@ interface AlertRuleListProps {
   onEdit?: (rule: AlertRule) => void;
   onDelete: (id: string) => void;
   onToggle: (id: string) => void;
+  /**
+   * #1840 SP5 F4-C7: TestAlert handler. Optional perché il BE
+   * endpoint `/alert-rules/{id}/test` non è ancora implementato.
+   * Quando il BE arriverà, AlertsTab passerà questa prop e il bottone
+   * sarà cliccabile invece di disabled.
+   */
+  onTestAlert?: (id: string) => void;
 }
 
-export function AlertRuleList({ rules, onEdit: _onEdit, onDelete, onToggle }: AlertRuleListProps) {
+export function AlertRuleList({
+  rules,
+  onEdit: _onEdit,
+  onDelete,
+  onToggle,
+  onTestAlert,
+}: AlertRuleListProps) {
   const getSeverityColor = (severity: string) => {
     switch (severity) {
       case 'Critical':
@@ -74,6 +87,21 @@ export function AlertRuleList({ rules, onEdit: _onEdit, onDelete, onToggle }: Al
                 </TableCell>
                 <TableCell>
                   <div className="flex gap-2">
+                    {/* #1840 SP5 F4-C7: TestAlert button (BE endpoint pending) */}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={!onTestAlert}
+                      title={
+                        onTestAlert
+                          ? 'Invia notifica di test al canale configurato'
+                          : 'BE endpoint /alert-rules/{id}/test non ancora implementato'
+                      }
+                      onClick={() => onTestAlert?.(rule.id)}
+                      data-testid={`test-alert-${rule.id}`}
+                    >
+                      <Zap className="h-4 w-4" />
+                    </Button>
                     <Button variant="ghost" size="sm" onClick={() => onDelete(rule.id)}>
                       <Trash2 className="h-4 w-4" />
                     </Button>

--- a/apps/web/src/components/admin/alert-rules/AlertRuleList.tsx
+++ b/apps/web/src/components/admin/alert-rules/AlertRuleList.tsx
@@ -92,6 +92,7 @@ export function AlertRuleList({
                       variant="ghost"
                       size="sm"
                       disabled={!onTestAlert}
+                      aria-label={`Test alert rule ${rule.name}`}
                       title={
                         onTestAlert
                           ? 'Invia notifica di test al canale configurato'

--- a/apps/web/src/components/admin/alert-rules/__tests__/AlertRuleList.test.tsx
+++ b/apps/web/src/components/admin/alert-rules/__tests__/AlertRuleList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { AlertRuleList } from '../AlertRuleList';
+
+import type { AlertRule } from '@/lib/api/schemas/alert-rules.schemas';
+
+const sampleRule: AlertRule = {
+  id: 'rule-1',
+  name: 'Error rate high',
+  alertType: 'ErrorRate',
+  severity: 'Critical',
+  thresholdValue: 5,
+  thresholdUnit: '%',
+  durationMinutes: 5,
+  isEnabled: true,
+  description: 'Trigger when error rate > 5%',
+  createdAt: '2026-06-02T10:00:00Z',
+  updatedAt: null,
+};
+
+describe('AlertRuleList — #1840 SP5 F4-C7 TestAlert button', () => {
+  it('renders test alert button disabled when onTestAlert is not provided', () => {
+    render(<AlertRuleList rules={[sampleRule]} onDelete={vi.fn()} onToggle={vi.fn()} />);
+    const btn = screen.getByTestId('test-alert-rule-1');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', expect.stringMatching(/BE endpoint/i));
+  });
+
+  it('renders test alert button enabled when onTestAlert is provided', () => {
+    const onTestAlert = vi.fn();
+    render(
+      <AlertRuleList
+        rules={[sampleRule]}
+        onDelete={vi.fn()}
+        onToggle={vi.fn()}
+        onTestAlert={onTestAlert}
+      />
+    );
+    const btn = screen.getByTestId('test-alert-rule-1');
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+    expect(onTestAlert).toHaveBeenCalledWith('rule-1');
+  });
+});


### PR DESCRIPTION
## Summary

Issue #1840, sub-task dell'epic #1833 (F4 Ondata Ops).

**Scoperta pre-implementation**: `AlertsTab` + endpoint BE `/admin/alert-rules` sono **già implementati e mergiati** in main-dev. La maggior parte dello scope C7 (AlertsTab + AlertsBanner + AlertRuleList + CreateAlertRuleDialog) è quindi già coperta. Questo PR ship un piccolo delta:

## Changes

- **AlertRuleList.tsx**: nuova prop opzionale `onTestAlert` con rendering bottone `Zap` (lucide) per ogni row alert. Disabled finché il BE endpoint `POST /alert-rules/{id}/test` non sarà implementato (tooltip esplicativo).
- **AlertRuleList.test.tsx** (NEW): 2 unit test per disabled state + click handler.

## C7 — Stato componenti mockup (audit completo)

| Componente mockup | Stato attuale |
|---|---|
| `AlertRulesTable` | ✅ già implementato (`AlertRuleList`) |
| `MetricSelector` | ✅ già in `CreateAlertRuleDialog` form |
| `ChannelChip` | ⚠️ `AlertRule` schema BE non ha campo `channel` (Slack/email/PagerDuty destinatario) |
| `AlertActivityFeed` | ⚠️ richiede SSE filter `type=alert` su `/admin/events/stream` (oggi `LiveEventLog` supporta solo domain events agent/kb/chat/session) |
| `TestAlert` | ✅ button stub aggiunto in questo PR (BE endpoint pending) |

## Follow-up issue da aprire

- **BE**: aggiungere campo `channel` ad `AlertRule` entity + estendere `AlertConfigEndpoints` per supportare destinazione notifica
- **BE**: implementare `POST /alert-rules/{id}/test` per inviare notifica di test al canale configurato
- **BE+FE**: estendere event registry con `type=alert` events (alert.fired, alert.resolved) + filter su `LiveEventLog` per AlertActivityFeed live feed

## Test plan

- [x] 2 nuovi unit Vitest (`AlertRuleList.test.tsx`)
- [x] `AlertsTab.test.tsx` esistente intatto (6/6)
- [x] `AlertRuleForm.test.tsx` esistente intatto (6/6)
- [x] `pnpm typecheck` ✅ 0 errori
- [x] Pre-commit hook ✅ lint-staged + prettier

## References

- Spec consolidamento §5 Gruppo C (C7 P1)
- Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-alerts.html`
- Parent epic: #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)