### PR TITLE
fix(lint): #1849 baseline text-white in GameCoverPlaceholder gate

### DIFF
--- a/apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx
@@ -38,7 +38,9 @@ export function GameCoverPlaceholder({ gameId, title, className }: GameCoverPlac
       data-game-id={gameId}
       aria-hidden="true"
       className={cn(
-        'relative flex h-full w-full items-center justify-center overflow-hidden text-white',
+        'relative flex h-full w-full items-center justify-center overflow-hidden',
+        // eslint-disable-next-line local/no-hardcoded-color-utility -- gradient applied via inline style below (mockup .e-bg pattern); see #1849
+        'text-white',
         className
       )}
       style={{


### PR DESCRIPTION
## Summary

- Unblocks `Frontend Static (lint + typecheck)` gate on every open PR against `main-dev`
- Adds a line-level `eslint-disable-next-line local/no-hardcoded-color-utility` on the `text-white` token in `GameCoverPlaceholder.tsx`, with a comment pointing to #1849
- The colored gradient IS applied (justifying CLAUDE.md mockup `.e-bg` exemption) but via inline `style={{ background: ... }}` rather than a Tailwind `bg-*` class, so the lint pattern matcher cannot detect the exemption automatically

## Context

PR #1825 introduced `apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx` for issue #1822 (L1 deterministic placeholder cover). The new component shipped with `text-white` hardcoded, immediately turning `Frontend Static` red on every PR opened against `main-dev` from 2026-06-02 onward.

**Confirmed baseline (not regression):**

- F4 Ondata Ops cluster #1845 #1846 #1847 #1848 — none of these touch `meeple-card/`, all inherit the failure
- Dependabot #1778 #1779 #1780 #1781 — same fail, same line
- Memory `feedback_frontend_static_gate_baseline.md` already documents that the gate is PR-only and inherits prior shipped-red commits

## Out of scope

- `Frontend Tests` shard 1/3 and shard 2/3 baseline failures (`AdvancedFilterPanel > Apply Filters` etc.) — separate tracking issue forthcoming
- Migrating the gradient itself to a Tailwind arbitrary `bg-[linear-gradient(...)]` class — defers to DS-16 (CSS variable migration codemod)

## Test plan

- [x] `pnpm exec eslint apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx` clean locally (0 errors, 0 warnings)
- [ ] CI: `Frontend Static (lint + typecheck)` green on this PR
- [ ] After merge: rebase #1845 and confirm `Frontend Static` flips to green

Closes #1849