### PR TITLE
feat(admin-providers): #1834 PR1 — table conformity + 2-KPI hero + toolbar

### DIFF
--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
@@ -11,6 +11,11 @@
                 /admin/circuit-breakers, /admin/llm/config
                 POST /api/v1/admin/providers/{id}/rotate-key (superadmin)
      Role: admin (rotate-key/disable = superadmin) -->
+<!-- @v1.1 (#1834 PR1, 2026-06-03): allineato a KNOWN_PROVIDERS reale (3 provider).
+     Rimossi OpenAI/Anthropic dal mockup: erano aspirazionali. OpenAI/Anthropic
+     models sono comunque accessibili via OpenRouter come modello (es. openrouter →
+     anthropic/claude-3.5-sonnet). Provider supportati: deepseek (primary), openrouter
+     (fallback), ollama-local (stopped/optional). -->
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
@@ -241,7 +246,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
       <header class="admin-top">
         <div>
           <h1>LLM Providers &amp; Circuit Breakers</h1>
-          <div class="crumbs">Admin › Platform &amp; Operations › Providers · 5 provider · aggiornato 14:23:08</div>
+          <div class="crumbs">Admin › Platform &amp; Operations › Providers · 3 provider · aggiornato 14:23:08</div>
         </div>
         <div class="spacer"></div>
         <div class="admin-top-actions">
@@ -258,7 +263,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="kpi-strip">
           <div class="admin-kpi e-tool">
             <div class="admin-kpi-label">Provider attivi</div>
-            <div class="admin-kpi-value">4<span style="font-size:14px;color:var(--text-muted);font-weight:600">/5</span></div>
+            <div class="admin-kpi-value">2<span style="font-size:14px;color:var(--text-muted);font-weight:600">/3</span></div>
             <div class="admin-kpi-trend flat">▬ 1 disabilitato · 0 in cooldown</div>
             <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
               <path class="spark-fill e-fg" d="M0,14 L8,14 L16,14 L24,14 L32,8 L40,8 L48,8 L56,8 L64,8 L70,8 L70,28 L0,28 Z"/>
@@ -301,8 +306,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="admin-panel">
           <div class="admin-panel-head">
             <h3>Provider</h3>
-            <span class="status-chip healthy">3 healthy</span>
-            <span class="status-chip warning">1 warn</span>
+            <span class="status-chip healthy">2 healthy</span>
             <span class="status-chip muted">1 stopped</span>
             <div class="head-cluster">
               <span class="sensitive-note"><span class="lock">🔒</span> Rotate key / Disabilita → richiede conferma (superadmin)</span>
@@ -376,56 +380,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
                 </td>
               </tr>
 
-              <tr class="e-toolkit">
-                <td>
-                  <div class="prov-cell">
-                    <div class="prov-mark">⚛</div>
-                    <div class="prov-info">
-                      <span class="prov-name">OpenAI</span>
-                      <span class="prov-host">api.openai.com/v1 · key sk-…12de</span>
-                    </div>
-                  </div>
-                </td>
-                <td><span class="status-chip warning">latency high</span></td>
-                <td><span class="model-cell">gpt-4o-mini</span></td>
-                <td class="lat-cell warn">1 842<span class="ms">ms</span></td>
-                <td class="mono" style="text-align:right">5 718</td>
-                <td class="err-cell warn" style="text-align:right">2.14%</td>
-                <td><span class="status-chip warning">half-open</span></td>
-                <td>
-                  <div class="row-actions">
-                    <button class="btn-admin sm ghost">⚙ Config</button>
-                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
-                    <button class="btn-admin sm ghost">⋯</button>
-                  </div>
-                </td>
-              </tr>
-
-              <tr class="e-agent">
-                <td>
-                  <div class="prov-cell">
-                    <div class="prov-mark">A</div>
-                    <div class="prov-info">
-                      <span class="prov-name">Anthropic</span>
-                      <span class="prov-host">api.anthropic.com · key sk-ant-…58a1</span>
-                    </div>
-                  </div>
-                </td>
-                <td><span class="status-chip healthy">healthy</span></td>
-                <td><span class="model-cell">claude-3.5-sonnet-20241022</span></td>
-                <td class="lat-cell">842<span class="ms">ms</span></td>
-                <td class="mono" style="text-align:right">186</td>
-                <td class="err-cell" style="text-align:right">0.00%</td>
-                <td><span class="status-chip healthy">closed</span></td>
-                <td>
-                  <div class="row-actions">
-                    <button class="btn-admin sm ghost">⚙ Config</button>
-                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
-                    <button class="btn-admin sm ghost">⋯</button>
-                  </div>
-                </td>
-              </tr>
-
               <tr class="e-kb">
                 <td>
                   <div class="prov-cell">
@@ -459,7 +413,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="admin-panel">
           <div class="admin-panel-head">
             <h3>Routing chain · fallback</h3>
-            <span class="status-chip info">3 hops · 1 stand-by</span>
+            <span class="status-chip info">1 hop · 1 fallback</span>
             <div class="head-cluster">
               <span class="meta">policy=cost-first · retry budget 3 · jitter 250ms</span>
               <button class="btn-admin sm ghost">✎ Edita catena</button>
@@ -492,34 +446,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
                 <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 658 ms</span> <span>err 0.32%</span></div>
               </div>
 
-              <div class="rc-arrow">
-                <span class="gl">→</span>
-                <span class="cond">on 429 / 5xx / quota</span>
-              </div>
-
-              <div class="rc-node e-toolkit">
-                <div class="rc-head">
-                  <span class="rc-prio">fallback · p2</span>
-                </div>
-                <div class="rc-name">⚛ OpenAI</div>
-                <div class="rc-model">gpt-4o-mini</div>
-                <div class="rc-meta"><span class="warn">●</span> half-open <span>p95 1 842 ms</span> <span class="warn">err 2.14%</span></div>
-              </div>
-
-              <div class="rc-arrow">
-                <span class="gl">→</span>
-                <span class="cond">on circuit open</span>
-              </div>
-
-              <div class="rc-node e-agent">
-                <div class="rc-head">
-                  <span class="rc-prio">stand-by · p3</span>
-                </div>
-                <div class="rc-name">A Anthropic</div>
-                <div class="rc-model">claude-3.5-sonnet</div>
-                <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 842 ms</span> <span>used 0.4%</span></div>
-              </div>
-
             </div>
 
             <div class="rc-priority-strip">
@@ -527,10 +453,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
               <span class="v">deepseek</span>
               <span class="sep">›</span>
               <span class="v">openrouter</span>
-              <span class="sep">›</span>
-              <span class="v">openai</span>
-              <span class="sep">›</span>
-              <span class="v">anthropic</span>
               <span class="sep">·</span>
               <span class="k">Excluded</span>
               <span class="v" style="color:var(--text-muted)">ollama-local (stopped)</span>
@@ -545,8 +467,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="admin-panel">
           <div class="admin-panel-head">
             <h3>Circuit breakers</h3>
-            <span class="status-chip healthy">3 closed</span>
-            <span class="status-chip warning">1 half-open</span>
+            <span class="status-chip healthy">2 closed</span>
             <span class="status-chip muted">1 disabled</span>
             <div class="head-cluster">
               <span class="meta">policy: 5 fail in 60s → open · cooldown 30s · half-open probe 1/req</span>
@@ -585,42 +506,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
                 <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
                 <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">2026-05-21 22:14</span></div>
                 <div class="cb-stat"><span class="l">Reset</span><span class="v">16h 09m fa</span></div>
-              </div>
-            </div>
-
-            <div class="cb-card e-toolkit">
-              <div class="cb-head">
-                <div>
-                  <div class="cb-name">OpenAI</div>
-                  <div class="cb-state">circuit breaker</div>
-                </div>
-                <span class="status-chip warning">half-open</span>
-              </div>
-              <div class="cb-stat-grid">
-                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v warn">4 / 60s</span></div>
-                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
-                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">14:22:45</span></div>
-                <div class="cb-stat"><span class="l">Probe</span><span class="v warn">1/1 in volo</span></div>
-              </div>
-              <div class="cb-cooldown">
-                <div class="bar"><i></i></div>
-                <div class="ll"><span>cooldown</span><span class="now">23s</span></div>
-              </div>
-            </div>
-
-            <div class="cb-card e-agent">
-              <div class="cb-head">
-                <div>
-                  <div class="cb-name">Anthropic</div>
-                  <div class="cb-state">circuit breaker</div>
-                </div>
-                <span class="status-chip healthy">closed</span>
-              </div>
-              <div class="cb-stat-grid">
-                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v">0 / 60s</span></div>
-                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
-                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">2026-04-30 09:02</span></div>
-                <div class="cb-stat"><span class="l">Reset</span><span class="v">24g fa</span></div>
               </div>
             </div>
 

--- a/apps/web/src/app/admin/(dashboard)/providers/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/providers/page.tsx
@@ -1,5 +1,6 @@
 import { CircuitBreakerGrid } from '@/components/admin/providers/CircuitBreakerGrid';
 import { ProvidersHero } from '@/components/admin/providers/ProvidersHero';
+import { ProvidersToolbar } from '@/components/admin/providers/ProvidersToolbar';
 import { ProviderTable } from '@/components/admin/providers/ProviderTable';
 import { RoutingChainViz } from '@/components/admin/providers/RoutingChainViz';
 
@@ -11,26 +12,18 @@ export const metadata: Metadata = { title: 'Providers — Admin' };
  * #1834 SP5 F4-C3 — `/admin/providers` re-skin
  *
  * Layout SP5 (mockup `sp5-admin-providers.html`):
- *   1. ProvidersHero        — KPI strip (4 metriche)
- *   2. ProviderTable        — lista tabellare con actions
- *   3. RoutingChainViz      — fallback chain visualization
- *   4. CircuitBreakerGrid   — stato Polly per servizio
+ *   1. ProvidersToolbar     — header con refresh
+ *   2. ProvidersHero        — KPI strip (2 metriche reali, mockup §1)
+ *   3. ProviderTable        — lista tabellare con entity colors + primary tag
+ *   4. RoutingChainViz      — fallback chain visualization
+ *   5. CircuitBreakerGrid   — stato Polly per servizio
  *
  * Drill-down `/admin/providers/[name]` resta separato (probe + quota dettaglio).
  */
 export default function ProvidersPage() {
   return (
     <div className="space-y-5">
-      <div>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          LLM Providers &amp; Circuit Breakers
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Stato token, quota residua, catena di fallback e circuit breaker per ogni provider
-          configurato.
-        </p>
-      </div>
-
+      <ProvidersToolbar />
       <ProvidersHero />
       <ProviderTable />
       <RoutingChainViz />

--- a/apps/web/src/components/admin/providers/ProviderTable.tsx
+++ b/apps/web/src/components/admin/providers/ProviderTable.tsx
@@ -26,28 +26,47 @@ import { KNOWN_PROVIDERS, type ProviderName } from '@/lib/api/schemas/providers'
 
 import { RotateKeyModal } from './RotateKeyModal';
 
+type ProviderTone = 'tool' | 'chat' | 'kb';
+
 const PROVIDER_DISPLAY: Record<
   ProviderName,
-  { mark: string; name: string; host: string; defaultModel: string }
+  {
+    readonly mark: string;
+    readonly name: string;
+    readonly host: string;
+    readonly defaultModel: string;
+    readonly tone: ProviderTone;
+    readonly primary?: boolean;
+  }
 > = {
-  openrouter: {
-    mark: 'O',
-    name: 'OpenRouter',
-    host: 'openrouter.ai/api/v1',
-    defaultModel: 'anthropic/claude-3.5-sonnet',
-  },
   deepseek: {
     mark: 'D',
     name: 'DeepSeek',
     host: 'api.deepseek.com',
     defaultModel: 'deepseek-chat',
+    tone: 'tool',
+    primary: true,
+  },
+  openrouter: {
+    mark: 'O',
+    name: 'OpenRouter',
+    host: 'openrouter.ai/api/v1',
+    defaultModel: 'anthropic/claude-3.5-sonnet',
+    tone: 'chat',
   },
   'ollama-local': {
     mark: 'L',
     name: 'Ollama (locale)',
     host: 'localhost:11434',
     defaultModel: 'llama3.1:8b-instruct',
+    tone: 'kb',
   },
+};
+
+const TONE_MARK_CLASS: Record<ProviderTone, string> = {
+  tool: 'bg-entity-tool/15 text-entity-tool ring-1 ring-entity-tool/30',
+  chat: 'bg-entity-chat/15 text-entity-chat ring-1 ring-entity-chat/30',
+  kb: 'bg-entity-kb/15 text-entity-kb ring-1 ring-entity-kb/30',
 };
 
 type CircuitState = 'closed' | 'open' | 'half-open' | 'unknown';
@@ -122,11 +141,25 @@ function ProviderRow({
           href={`/admin/providers/${encodeURIComponent(name)}`}
           className="flex items-center gap-3 outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
         >
-          <div className="grid h-9 w-9 place-items-center rounded-lg bg-gradient-to-br from-amber-500 to-rose-500 font-quicksand text-base font-bold text-white">
+          <div
+            className={`grid h-9 w-9 place-items-center rounded-lg font-quicksand text-base font-bold ${TONE_MARK_CLASS[display.tone]}`}
+            aria-hidden="true"
+            data-testid={`provider-mark-${name}`}
+          >
             {display.mark}
           </div>
           <div className="min-w-0">
-            <div className="font-quicksand text-sm font-bold text-foreground">{display.name}</div>
+            <div className="font-quicksand text-sm font-bold text-foreground flex items-center gap-1.5">
+              {display.name}
+              {display.primary && (
+                <span
+                  className="font-mono text-[9px] font-bold uppercase tracking-wider bg-entity-event/12 text-entity-event px-1.5 py-px rounded"
+                  data-testid={`provider-primary-tag-${name}`}
+                >
+                  primary
+                </span>
+              )}
+            </div>
             <div className="font-mono text-[10.5px] text-muted-foreground truncate">
               {display.host}
             </div>

--- a/apps/web/src/components/admin/providers/ProvidersHero.tsx
+++ b/apps/web/src/components/admin/providers/ProvidersHero.tsx
@@ -4,11 +4,12 @@
  * #1834 SP5 F4-C3 — ProvidersHero
  *
  * KPI strip per `/admin/providers` (mockup `sp5-admin-providers.html` §1, hero panel).
- * 4 metriche: requests/h, p95 latency, error rate 24h, cost 24h.
  *
- * **BE pending**: il backend non espone ancora un endpoint di aggregato cross-provider.
- * Per ora i valori sono derivati lato FE da `useCircuitBreakerStates` quando possibile,
- * altrimenti mostrano `—` con tooltip esplicativo. Issue follow-up: aggregato BE.
+ * **PR1 reduction (sessione 2026-06-03)**: ridotto da 4 KPI a 2 KPI reali.
+ * I 3 KPI cross-provider (p95 latency, error rate 24h, cost 24h) richiedono
+ * un endpoint aggregato BE che non esiste ancora — issue tracker FE-only.
+ *
+ * Quando il BE arriverà (issue follow-up), riaggiungere i 3 KPI con valori reali.
  */
 
 import { useMemo } from 'react';
@@ -19,16 +20,14 @@ interface KpiBoxProps {
   readonly label: string;
   readonly value: string;
   readonly trend?: string;
-  readonly tone: 'agent' | 'tool' | 'event' | 'kb';
+  readonly tone: 'tool' | 'event';
   readonly tooltip?: string;
 }
 
 function KpiBox({ label, value, trend, tone, tooltip }: KpiBoxProps) {
   const toneClass: Record<KpiBoxProps['tone'], string> = {
-    agent: 'border-amber-500/30 bg-amber-500/5',
-    tool: 'border-cyan-500/30 bg-cyan-500/5',
-    event: 'border-rose-500/30 bg-rose-500/5',
-    kb: 'border-teal-500/30 bg-teal-500/5',
+    tool: 'border-entity-tool/30 bg-entity-tool/5',
+    event: 'border-entity-event/30 bg-entity-event/5',
   };
 
   return (
@@ -51,45 +50,47 @@ export function ProvidersHero() {
 
   const stats = useMemo(() => {
     const breakers = circuitBreakersQuery.data ?? [];
-    const trippedCount = breakers.filter(
-      b => b.state.toLowerCase() === 'open' || b.state.toLowerCase() === 'half-open'
-    ).length;
-    return { totalServices: breakers.length, trippedCount };
+    const open = breakers.filter(b => b.state.toLowerCase() === 'open').length;
+    const halfOpen = breakers.filter(b => {
+      const s = b.state.toLowerCase();
+      return s === 'half-open' || s === 'halfopen';
+    }).length;
+    const closed = breakers.filter(b => b.state.toLowerCase() === 'closed').length;
+    return { total: breakers.length, open, halfOpen, closed };
   }, [circuitBreakersQuery.data]);
+
+  const trippedCount = stats.open + stats.halfOpen;
+  const healthValue = stats.total === 0 ? '—' : `${stats.closed}/${stats.total}`;
+  const healthTrend =
+    stats.total === 0
+      ? 'nessun servizio'
+      : trippedCount === 0
+        ? 'tutti closed'
+        : `${stats.open} open · ${stats.halfOpen} half-open`;
 
   return (
     <section
-      className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2"
       aria-label="Provider KPI"
       data-testid="providers-hero"
     >
       <KpiBox
         label="Servizi monitorati"
-        value={circuitBreakersQuery.isLoading ? '…' : String(stats.totalServices)}
-        trend={stats.trippedCount > 0 ? `${stats.trippedCount} circuit open` : 'tutti closed'}
+        value={circuitBreakersQuery.isLoading ? '…' : String(stats.total)}
+        trend={
+          stats.total === 0 && !circuitBreakersQuery.isLoading
+            ? 'nessun circuit registrato'
+            : 'circuit breakers attivi'
+        }
         tone="tool"
         tooltip="Numero di servizi protetti da Polly circuit breaker"
       />
       <KpiBox
-        label="Latency p95"
-        value="—"
-        trend="aggregato BE pending"
+        label="Circuit health"
+        value={circuitBreakersQuery.isLoading ? '…' : healthValue}
+        trend={healthTrend}
         tone="event"
-        tooltip="Metrica aggregata cross-provider non ancora esposta dal backend"
-      />
-      <KpiBox
-        label="Error rate 24h"
-        value="—"
-        trend="aggregato BE pending"
-        tone="agent"
-        tooltip="Metrica aggregata cross-provider non ancora esposta dal backend"
-      />
-      <KpiBox
-        label="Costo 24h"
-        value="—"
-        trend="aggregato BE pending"
-        tone="kb"
-        tooltip="Metrica aggregata cross-provider non ancora esposta dal backend"
+        tooltip="Servizi con circuit closed (healthy) su totale"
       />
     </section>
   );

--- a/apps/web/src/components/admin/providers/ProvidersToolbar.tsx
+++ b/apps/web/src/components/admin/providers/ProvidersToolbar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * #1834 SP5 F4-C3 — ProvidersToolbar
+ *
+ * Header bar per `/admin/providers` (mockup `sp5-admin-providers.html` top bar).
+ *
+ * PR1 scope minimale: titolo + sottotitolo + refresh button che invalida le query.
+ * Search (⌘K) + config globale + theme toggle restano out-of-scope per PR1.
+ */
+
+import { useState } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { providerKeys } from '@/hooks/queries/useProviders';
+
+export function ProvidersToolbar() {
+  const qc = useQueryClient();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: providerKeys.circuitBreakers }),
+        qc.invalidateQueries({ queryKey: providerKeys.llmConfig }),
+        qc.invalidateQueries({ queryKey: providerKeys.all }),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <header className="flex items-start justify-between gap-3" data-testid="providers-toolbar">
+      <div>
+        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+          LLM Providers &amp; Circuit Breakers
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Stato token, quota residua, catena di fallback e circuit breaker per ogni provider
+          configurato.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleRefresh}
+        disabled={refreshing}
+        aria-label="Aggiorna stato provider"
+        data-testid="providers-refresh"
+        className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card/60 px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted/70 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <span aria-hidden="true">{refreshing ? '⟳' : '⟳'}</span>
+        {refreshing ? 'Aggiornamento…' : 'Refresh'}
+      </button>
+    </header>
+  );
+}

--- a/apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
@@ -94,4 +94,31 @@ describe('ProviderTable', () => {
       expect(placeholders.length).toBeGreaterThanOrEqual(3);
     });
   });
+
+  it('renders primary tag only on the deepseek row (PR1 entity-token mapping)', async () => {
+    renderWithQuery(<ProviderTable />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-row-deepseek')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('provider-primary-tag-deepseek')).toHaveTextContent('primary');
+    expect(screen.queryByTestId('provider-primary-tag-openrouter')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('provider-primary-tag-ollama-local')).not.toBeInTheDocument();
+  });
+
+  it('renders entity-colored mark per provider (no shared gradient)', async () => {
+    renderWithQuery(<ProviderTable />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-mark-deepseek')).toBeInTheDocument();
+    });
+    const dsMark = screen.getByTestId('provider-mark-deepseek');
+    const orMark = screen.getByTestId('provider-mark-openrouter');
+    const ollMark = screen.getByTestId('provider-mark-ollama-local');
+
+    // Each mark gets its tone class — bg-entity-{tool|chat|kb}
+    expect(dsMark.className).toMatch(/bg-entity-tool/);
+    expect(orMark.className).toMatch(/bg-entity-chat/);
+    expect(ollMark.className).toMatch(/bg-entity-kb/);
+  });
 });

--- a/apps/web/src/components/admin/providers/__tests__/ProvidersHero.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProvidersHero.test.tsx
@@ -18,12 +18,12 @@ function renderWithQuery(ui: React.ReactElement) {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
-describe('ProvidersHero', () => {
+describe('ProvidersHero (PR1 reduced — 2 KPI reali)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('shows 4 KPI boxes including service count from circuit breakers', async () => {
+  it('renders 2 KPI: Servizi monitorati + Circuit health', async () => {
     getCircuitBreakerStates.mockResolvedValue([
       {
         serviceName: 'deepseek',
@@ -53,24 +53,37 @@ describe('ProvidersHero', () => {
 
     renderWithQuery(<ProvidersHero />);
 
-    // Eventually shows the service count
     await waitFor(() => {
       expect(screen.getByTestId('providers-hero')).toBeInTheDocument();
       expect(screen.getByTestId('providers-kpi-servizi-monitorati')).toHaveTextContent('3');
     });
 
-    // Confirms tripped count appears in trend
-    expect(screen.getByTestId('providers-kpi-servizi-monitorati')).toHaveTextContent(
-      '1 circuit open'
-    );
+    // Circuit health: 2 closed / 3 total + breakdown trend
+    const health = screen.getByTestId('providers-kpi-circuit-health');
+    expect(health).toHaveTextContent('2/3');
+    expect(health).toHaveTextContent('1 open');
   });
 
-  it('shows "—" for BE-pending metrics with explanatory tooltip', () => {
+  it('shows zero state when no circuit breakers registered', async () => {
     getCircuitBreakerStates.mockResolvedValue([]);
     renderWithQuery(<ProvidersHero />);
 
-    const errorRate = screen.getByTestId('providers-kpi-error-rate-24h');
-    expect(errorRate).toHaveTextContent('—');
-    expect(errorRate).toHaveAttribute('title', expect.stringMatching(/backend/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-kpi-servizi-monitorati')).toHaveTextContent('0');
+    });
+    expect(screen.getByTestId('providers-kpi-circuit-health')).toHaveTextContent('—');
+  });
+
+  it('no longer renders the deprecated BE-pending placeholder KPI', async () => {
+    getCircuitBreakerStates.mockResolvedValue([]);
+    renderWithQuery(<ProvidersHero />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-hero')).toBeInTheDocument();
+    });
+    // 3 placeholder KPI (latency-p95, error-rate-24h, costo-24h) removed in PR1
+    expect(screen.queryByTestId('providers-kpi-latency-p95')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('providers-kpi-error-rate-24h')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('providers-kpi-costo-24h')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/admin/providers/__tests__/ProvidersToolbar.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProvidersToolbar.test.tsx
@@ -1,0 +1,37 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ProvidersToolbar } from '../ProvidersToolbar';
+
+function renderWithQuery() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <ProvidersToolbar />
+    </QueryClientProvider>
+  );
+  return { ...utils, qc, invalidateSpy };
+}
+
+describe('ProvidersToolbar', () => {
+  it('renders title + subtitle + refresh button', () => {
+    renderWithQuery();
+    expect(screen.getByTestId('providers-toolbar')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /LLM Providers/i })).toBeInTheDocument();
+    expect(screen.getByTestId('providers-refresh')).toBeInTheDocument();
+  });
+
+  it('invalidates provider queries on refresh click', async () => {
+    const { invalidateSpy } = renderWithQuery();
+    fireEvent.click(screen.getByTestId('providers-refresh'));
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+    // Verify it targets the right keys (circuit-breakers + llm config + providers root)
+    const keys = invalidateSpy.mock.calls.map(c => (c[0] as { queryKey: unknown[] }).queryKey);
+    expect(keys.some(k => Array.isArray(k) && k.includes('circuit-breakers'))).toBe(true);
+    expect(keys.some(k => Array.isArray(k) && k.join(',').includes('llm'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

PR 1/3 from `/sc:spec-panel` review (sessione 2026-06-03). Riallinea la pagina `/admin/providers` al mockup `sp5-admin-providers.html` solo per la parte UI **senza dipendenze BE**.

- **Provider table**: entity tokens per provider (deepseek=tool/cyan, openrouter=chat/blue, ollama-local=kb/teal) + chip "primary" su DeepSeek
- **Hero**: ridotta da 4 → 2 KPI reali (Servizi monitorati, Circuit health). I 3 KPI cross-provider richiedevano aggregato BE inesistente → issue tracker
- **Toolbar** (nuova): header con refresh button (invalida circuit-breakers + llm config + providers queries)
- **Mockup sync**: rimossi OpenAI/Anthropic (aspirazionali, gli stessi modelli sono accessibili via OpenRouter routing); allineato a `KNOWN_PROVIDERS=3`

## Out of scope (in PR2/PR3)

- PR2: cooldown bar CB cards, routing chain arrow conditions, Zod schema fallback chain
- PR3: a11y status-chip aria-labels, Reset all runbook entry, RotateKey BE issue tracker

## Test plan

- [x] Unit tests (Vitest): 17/17 pass — `ProvidersHero` 3 new, `ProviderTable` 2 new, `ProvidersToolbar` 2 new
- [x] Typecheck pulito
- [x] Lint pulito (no nuove warning/error)
- [x] Frontend build verified (pre-push)
- [ ] Manual smoke su `/admin/providers` (dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)