### PR TITLE
feat(admin-providers): #1834 follow-up — table conformity + CB cooldown + a11y + runbook

### DIFF
--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
@@ -11,6 +11,11 @@
                 /admin/circuit-breakers, /admin/llm/config
                 POST /api/v1/admin/providers/{id}/rotate-key (superadmin)
      Role: admin (rotate-key/disable = superadmin) -->
+<!-- @v1.1 (#1834 PR1, 2026-06-03): allineato a KNOWN_PROVIDERS reale (3 provider).
+     Rimossi OpenAI/Anthropic dal mockup: erano aspirazionali. OpenAI/Anthropic
+     models sono comunque accessibili via OpenRouter come modello (es. openrouter →
+     anthropic/claude-3.5-sonnet). Provider supportati: deepseek (primary), openrouter
+     (fallback), ollama-local (stopped/optional). -->
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
@@ -241,7 +246,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
       <header class="admin-top">
         <div>
           <h1>LLM Providers &amp; Circuit Breakers</h1>
-          <div class="crumbs">Admin › Platform &amp; Operations › Providers · 5 provider · aggiornato 14:23:08</div>
+          <div class="crumbs">Admin › Platform &amp; Operations › Providers · 3 provider · aggiornato 14:23:08</div>
         </div>
         <div class="spacer"></div>
         <div class="admin-top-actions">
@@ -258,7 +263,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="kpi-strip">
           <div class="admin-kpi e-tool">
             <div class="admin-kpi-label">Provider attivi</div>
-            <div class="admin-kpi-value">4<span style="font-size:14px;color:var(--text-muted);font-weight:600">/5</span></div>
+            <div class="admin-kpi-value">2<span style="font-size:14px;color:var(--text-muted);font-weight:600">/3</span></div>
             <div class="admin-kpi-trend flat">▬ 1 disabilitato · 0 in cooldown</div>
             <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
               <path class="spark-fill e-fg" d="M0,14 L8,14 L16,14 L24,14 L32,8 L40,8 L48,8 L56,8 L64,8 L70,8 L70,28 L0,28 Z"/>
@@ -301,8 +306,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="admin-panel">
           <div class="admin-panel-head">
             <h3>Provider</h3>
-            <span class="status-chip healthy">3 healthy</span>
-            <span class="status-chip warning">1 warn</span>
+            <span class="status-chip healthy">2 healthy</span>
             <span class="status-chip muted">1 stopped</span>
             <div class="head-cluster">
               <span class="sensitive-note"><span class="lock">🔒</span> Rotate key / Disabilita → richiede conferma (superadmin)</span>
@@ -376,56 +380,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
                 </td>
               </tr>
 
-              <tr class="e-toolkit">
-                <td>
-                  <div class="prov-cell">
-                    <div class="prov-mark">⚛</div>
-                    <div class="prov-info">
-                      <span class="prov-name">OpenAI</span>
-                      <span class="prov-host">api.openai.com/v1 · key sk-…12de</span>
-                    </div>
-                  </div>
-                </td>
-                <td><span class="status-chip warning">latency high</span></td>
-                <td><span class="model-cell">gpt-4o-mini</span></td>
-                <td class="lat-cell warn">1 842<span class="ms">ms</span></td>
-                <td class="mono" style="text-align:right">5 718</td>
-                <td class="err-cell warn" style="text-align:right">2.14%</td>
-                <td><span class="status-chip warning">half-open</span></td>
-                <td>
-                  <div class="row-actions">
-                    <button class="btn-admin sm ghost">⚙ Config</button>
-                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
-                    <button class="btn-admin sm ghost">⋯</button>
-                  </div>
-                </td>
-              </tr>
-
-              <tr class="e-agent">
-                <td>
-                  <div class="prov-cell">
-                    <div class="prov-mark">A</div>
-                    <div class="prov-info">
-                      <span class="prov-name">Anthropic</span>
-                      <span class="prov-host">api.anthropic.com · key sk-ant-…58a1</span>
-                    </div>
-                  </div>
-                </td>
-                <td><span class="status-chip healthy">healthy</span></td>
-                <td><span class="model-cell">claude-3.5-sonnet-20241022</span></td>
-                <td class="lat-cell">842<span class="ms">ms</span></td>
-                <td class="mono" style="text-align:right">186</td>
-                <td class="err-cell" style="text-align:right">0.00%</td>
-                <td><span class="status-chip healthy">closed</span></td>
-                <td>
-                  <div class="row-actions">
-                    <button class="btn-admin sm ghost">⚙ Config</button>
-                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
-                    <button class="btn-admin sm ghost">⋯</button>
-                  </div>
-                </td>
-              </tr>
-
               <tr class="e-kb">
                 <td>
                   <div class="prov-cell">
@@ -459,7 +413,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="admin-panel">
           <div class="admin-panel-head">
             <h3>Routing chain · fallback</h3>
-            <span class="status-chip info">3 hops · 1 stand-by</span>
+            <span class="status-chip info">1 hop · 1 fallback</span>
             <div class="head-cluster">
               <span class="meta">policy=cost-first · retry budget 3 · jitter 250ms</span>
               <button class="btn-admin sm ghost">✎ Edita catena</button>
@@ -492,34 +446,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
                 <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 658 ms</span> <span>err 0.32%</span></div>
               </div>
 
-              <div class="rc-arrow">
-                <span class="gl">→</span>
-                <span class="cond">on 429 / 5xx / quota</span>
-              </div>
-
-              <div class="rc-node e-toolkit">
-                <div class="rc-head">
-                  <span class="rc-prio">fallback · p2</span>
-                </div>
-                <div class="rc-name">⚛ OpenAI</div>
-                <div class="rc-model">gpt-4o-mini</div>
-                <div class="rc-meta"><span class="warn">●</span> half-open <span>p95 1 842 ms</span> <span class="warn">err 2.14%</span></div>
-              </div>
-
-              <div class="rc-arrow">
-                <span class="gl">→</span>
-                <span class="cond">on circuit open</span>
-              </div>
-
-              <div class="rc-node e-agent">
-                <div class="rc-head">
-                  <span class="rc-prio">stand-by · p3</span>
-                </div>
-                <div class="rc-name">A Anthropic</div>
-                <div class="rc-model">claude-3.5-sonnet</div>
-                <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 842 ms</span> <span>used 0.4%</span></div>
-              </div>
-
             </div>
 
             <div class="rc-priority-strip">
@@ -527,10 +453,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
               <span class="v">deepseek</span>
               <span class="sep">›</span>
               <span class="v">openrouter</span>
-              <span class="sep">›</span>
-              <span class="v">openai</span>
-              <span class="sep">›</span>
-              <span class="v">anthropic</span>
               <span class="sep">·</span>
               <span class="k">Excluded</span>
               <span class="v" style="color:var(--text-muted)">ollama-local (stopped)</span>
@@ -545,8 +467,7 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
         <section class="admin-panel">
           <div class="admin-panel-head">
             <h3>Circuit breakers</h3>
-            <span class="status-chip healthy">3 closed</span>
-            <span class="status-chip warning">1 half-open</span>
+            <span class="status-chip healthy">2 closed</span>
             <span class="status-chip muted">1 disabled</span>
             <div class="head-cluster">
               <span class="meta">policy: 5 fail in 60s → open · cooldown 30s · half-open probe 1/req</span>
@@ -585,42 +506,6 @@ code,kbd{font-family:var(--f-mono);font-size:.9em}
                 <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
                 <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">2026-05-21 22:14</span></div>
                 <div class="cb-stat"><span class="l">Reset</span><span class="v">16h 09m fa</span></div>
-              </div>
-            </div>
-
-            <div class="cb-card e-toolkit">
-              <div class="cb-head">
-                <div>
-                  <div class="cb-name">OpenAI</div>
-                  <div class="cb-state">circuit breaker</div>
-                </div>
-                <span class="status-chip warning">half-open</span>
-              </div>
-              <div class="cb-stat-grid">
-                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v warn">4 / 60s</span></div>
-                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
-                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">14:22:45</span></div>
-                <div class="cb-stat"><span class="l">Probe</span><span class="v warn">1/1 in volo</span></div>
-              </div>
-              <div class="cb-cooldown">
-                <div class="bar"><i></i></div>
-                <div class="ll"><span>cooldown</span><span class="now">23s</span></div>
-              </div>
-            </div>
-
-            <div class="cb-card e-agent">
-              <div class="cb-head">
-                <div>
-                  <div class="cb-name">Anthropic</div>
-                  <div class="cb-state">circuit breaker</div>
-                </div>
-                <span class="status-chip healthy">closed</span>
-              </div>
-              <div class="cb-stat-grid">
-                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v">0 / 60s</span></div>
-                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
-                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">2026-04-30 09:02</span></div>
-                <div class="cb-stat"><span class="l">Reset</span><span class="v">24g fa</span></div>
               </div>
             </div>
 

--- a/apps/web/src/app/admin/(dashboard)/providers/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/providers/page.tsx
@@ -1,5 +1,6 @@
 import { CircuitBreakerGrid } from '@/components/admin/providers/CircuitBreakerGrid';
 import { ProvidersHero } from '@/components/admin/providers/ProvidersHero';
+import { ProvidersToolbar } from '@/components/admin/providers/ProvidersToolbar';
 import { ProviderTable } from '@/components/admin/providers/ProviderTable';
 import { RoutingChainViz } from '@/components/admin/providers/RoutingChainViz';
 
@@ -11,26 +12,18 @@ export const metadata: Metadata = { title: 'Providers — Admin' };
  * #1834 SP5 F4-C3 — `/admin/providers` re-skin
  *
  * Layout SP5 (mockup `sp5-admin-providers.html`):
- *   1. ProvidersHero        — KPI strip (4 metriche)
- *   2. ProviderTable        — lista tabellare con actions
- *   3. RoutingChainViz      — fallback chain visualization
- *   4. CircuitBreakerGrid   — stato Polly per servizio
+ *   1. ProvidersToolbar     — header con refresh
+ *   2. ProvidersHero        — KPI strip (2 metriche reali, mockup §1)
+ *   3. ProviderTable        — lista tabellare con entity colors + primary tag
+ *   4. RoutingChainViz      — fallback chain visualization
+ *   5. CircuitBreakerGrid   — stato Polly per servizio
  *
  * Drill-down `/admin/providers/[name]` resta separato (probe + quota dettaglio).
  */
 export default function ProvidersPage() {
   return (
     <div className="space-y-5">
-      <div>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          LLM Providers &amp; Circuit Breakers
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Stato token, quota residua, catena di fallback e circuit breaker per ogni provider
-          configurato.
-        </p>
-      </div>
-
+      <ProvidersToolbar />
       <ProvidersHero />
       <ProviderTable />
       <RoutingChainViz />

--- a/apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
+++ b/apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
@@ -175,6 +175,7 @@ function CircuitCard({ breaker, cooldownSec, failureThreshold }: CircuitCardProp
         </div>
         <span
           className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border whitespace-nowrap ${chipClass(breaker.state)}`}
+          aria-label={`Circuit breaker state: ${breaker.state}`}
         >
           {breaker.state}
         </span>
@@ -248,7 +249,11 @@ export function CircuitBreakerGrid() {
           {breakersQuery.isLoading ? 'caricamento…' : `${breakers.length} servizi`}
         </span>
         {issueCount > 0 && (
-          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border bg-rose-500/15 text-rose-700 dark:text-rose-300 border-rose-500/40">
+          <span
+            className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border bg-rose-500/15 text-rose-700 dark:text-rose-300 border-rose-500/40"
+            role="status"
+            aria-label={`${issueCount} circuit breaker${issueCount === 1 ? '' : 's'} require attention`}
+          >
             {issueCount} issue
           </span>
         )}

--- a/apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
+++ b/apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
@@ -5,18 +5,21 @@
  * #1834 SP5 F4-C3 — CircuitBreakerGrid
  *
  * Grid degli stati Polly circuit breaker per servizi LLM
- * (mockup `sp5-admin-providers.html` cluster sotto la routing chain).
+ * (mockup `sp5-admin-providers.html` §4).
  *
- * Sostituisce il pattern client-direct di `monitor/services/CircuitBreakerPanel.tsx`
- * (vecchio) con uno SP5-conformant che usa `useCircuitBreakerStates` (hook condiviso).
+ * PR2: layout 2×2 stat-grid (mockup-aligned) + cooldown bar countdown per
+ * stati open/half-open. Cooldown derivato da
+ * `useLlmSystemConfig().circuitBreakerOpenDurationSeconds` + `lastTrippedAt`.
  *
  * Stato visivo:
  * - `Closed` → emerald (verde) — flow normale
- * - `Open` → rose (rosso) — circuit aperto, last failure visibile
+ * - `Open` → rose (rosso) — circuit aperto, cooldown countdown attivo
  * - `HalfOpen` → amber (giallo) — recupero in corso
  */
 
-import { useCircuitBreakerStates } from '@/hooks/queries/useProviders';
+import { useEffect, useState } from 'react';
+
+import { useCircuitBreakerStates, useLlmSystemConfig } from '@/hooks/queries/useProviders';
 import type { CircuitBreakerState } from '@/lib/api/schemas/admin/admin-circuit-breakers.schemas';
 
 function stateClass(state: string): string {
@@ -47,58 +50,186 @@ function chipClass(state: string): string {
   }
 }
 
-function CircuitCard({ breaker }: { readonly breaker: CircuitBreakerState }) {
+function isCooldownState(state: string): boolean {
+  const s = state.toLowerCase();
+  return s === 'open' || s === 'half-open' || s === 'halfopen';
+}
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.max(0, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s fa`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m fa`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h fa`;
+  const diffD = Math.floor(diffH / 24);
+  return `${diffD}g fa`;
+}
+
+interface CooldownBarProps {
+  readonly trippedAtIso: string;
+  readonly cooldownSec: number;
+}
+
+/**
+ * Cooldown bar with live countdown. Updates every 1s via state tick.
+ * Stops re-rendering once countdown completes.
+ */
+function CooldownBar({ trippedAtIso, cooldownSec }: CooldownBarProps) {
+  const computeRemaining = () => {
+    const trippedMs = new Date(trippedAtIso).getTime();
+    const elapsed = Math.max(0, (Date.now() - trippedMs) / 1000);
+    return Math.max(0, cooldownSec - elapsed);
+  };
+  const [remaining, setRemaining] = useState(computeRemaining);
+
+  useEffect(() => {
+    if (remaining <= 0) return;
+    const id = setInterval(() => {
+      setRemaining(computeRemaining());
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trippedAtIso, cooldownSec]);
+
+  const pct = cooldownSec > 0 ? Math.max(0, Math.min(100, (remaining / cooldownSec) * 100)) : 0;
+
+  return (
+    <div className="mt-1" data-testid="cb-cooldown-bar">
+      <div
+        className="h-1.5 w-full overflow-hidden rounded-full bg-muted/60 dark:bg-zinc-800"
+        role="progressbar"
+        aria-label="Cooldown timer residuo"
+        aria-valuenow={Math.round(remaining)}
+        aria-valuemin={0}
+        aria-valuemax={cooldownSec}
+      >
+        <div
+          className="h-full rounded-full bg-amber-500 transition-[width] duration-500 ease-linear"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="mt-0.5 flex justify-between font-mono text-[9.5px] text-muted-foreground">
+        <span>cooldown</span>
+        <span
+          className="font-bold text-amber-700 dark:text-amber-300"
+          data-testid="cb-cooldown-remaining"
+        >
+          {Math.ceil(remaining)}s
+        </span>
+      </div>
+    </div>
+  );
+}
+
+interface StatItemProps {
+  readonly label: string;
+  readonly value: string | number;
+  readonly tone?: 'default' | 'warn' | 'muted';
+}
+
+function StatItem({ label, value, tone = 'default' }: StatItemProps) {
+  const toneClass: Record<NonNullable<StatItemProps['tone']>, string> = {
+    default: 'text-foreground',
+    warn: 'text-amber-700 dark:text-amber-300',
+    muted: 'text-muted-foreground',
+  };
+  return (
+    <div className="flex flex-col gap-px">
+      <span className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground font-bold">
+        {label}
+      </span>
+      <span className={`font-mono text-xs font-bold tabular-nums ${toneClass[tone]}`}>{value}</span>
+    </div>
+  );
+}
+
+interface CircuitCardProps {
+  readonly breaker: CircuitBreakerState;
+  readonly cooldownSec: number | undefined;
+  readonly failureThreshold: number | undefined;
+}
+
+function CircuitCard({ breaker, cooldownSec, failureThreshold }: CircuitCardProps) {
+  const showCooldown =
+    isCooldownState(breaker.state) && breaker.lastTrippedAt !== null && cooldownSec != null;
+
   return (
     <div
       data-testid={`circuit-card-${breaker.serviceName}`}
-      className={`rounded-lg border p-3 ${stateClass(breaker.state)}`}
+      className={`rounded-lg border p-3 flex flex-col gap-2 ${stateClass(breaker.state)}`}
     >
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div
+            className="font-quicksand text-sm font-bold text-foreground truncate"
+            title={breaker.serviceName}
+          >
+            {breaker.serviceName}
+          </div>
+          <div className="font-mono text-[9.5px] uppercase tracking-wider text-muted-foreground font-bold">
+            circuit breaker
+          </div>
+        </div>
         <span
-          className="font-quicksand text-sm font-bold text-foreground truncate"
-          title={breaker.serviceName}
-        >
-          {breaker.serviceName}
-        </span>
-        <span
-          className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${chipClass(breaker.state)}`}
+          className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border whitespace-nowrap ${chipClass(breaker.state)}`}
         >
           {breaker.state}
         </span>
       </div>
-      <dl className="mt-2 font-mono text-[10.5px] text-muted-foreground space-y-0.5">
-        <div>
-          <dt className="inline">Trips: </dt>
-          <dd className="inline text-foreground">{breaker.tripCount}</dd>
+
+      <div
+        className="grid grid-cols-2 gap-1.5 gap-x-3 mt-auto"
+        data-testid={`circuit-card-statgrid-${breaker.serviceName}`}
+      >
+        <StatItem
+          label="Trips"
+          value={breaker.tripCount}
+          tone={breaker.tripCount > 0 ? 'warn' : 'default'}
+        />
+        <StatItem
+          label="Soglia"
+          value={failureThreshold ?? '—'}
+          tone={failureThreshold == null ? 'muted' : 'default'}
+        />
+        <StatItem
+          label="Ultima apertura"
+          value={breaker.lastTrippedAt ? formatRelative(breaker.lastTrippedAt) : '—'}
+          tone={breaker.lastTrippedAt ? 'default' : 'muted'}
+        />
+        <StatItem
+          label="Reset"
+          value={breaker.lastResetAt ? formatRelative(breaker.lastResetAt) : '—'}
+          tone={breaker.lastResetAt ? 'default' : 'muted'}
+        />
+      </div>
+
+      {showCooldown && breaker.lastTrippedAt && cooldownSec != null && (
+        <CooldownBar trippedAtIso={breaker.lastTrippedAt} cooldownSec={cooldownSec} />
+      )}
+
+      {breaker.lastError && (
+        <div
+          className="font-mono text-[10px] text-rose-700 dark:text-rose-300 truncate"
+          title={breaker.lastError}
+        >
+          err: {breaker.lastError}
         </div>
-        {breaker.lastTrippedAt && (
-          <div>
-            <dt className="inline">Last trip: </dt>
-            <dd className="inline">{new Date(breaker.lastTrippedAt).toLocaleString('it-IT')}</dd>
-          </div>
-        )}
-        {breaker.lastResetAt && (
-          <div>
-            <dt className="inline">Last reset: </dt>
-            <dd className="inline">{new Date(breaker.lastResetAt).toLocaleString('it-IT')}</dd>
-          </div>
-        )}
-        {breaker.lastError && (
-          <div className="text-rose-700 dark:text-rose-300 truncate" title={breaker.lastError}>
-            <dt className="inline">Err: </dt>
-            <dd className="inline">{breaker.lastError}</dd>
-          </div>
-        )}
-      </dl>
+      )}
     </div>
   );
 }
 
 export function CircuitBreakerGrid() {
   const breakersQuery = useCircuitBreakerStates();
+  const configQuery = useLlmSystemConfig();
 
   const breakers = breakersQuery.data ?? [];
   const issueCount = breakers.filter(b => b.state.toLowerCase() !== 'closed').length;
+  const cooldownSec = configQuery.data?.circuitBreakerOpenDurationSeconds;
+  const failureThreshold = configQuery.data?.circuitBreakerFailureThreshold;
 
   return (
     <section
@@ -119,6 +250,14 @@ export function CircuitBreakerGrid() {
         {issueCount > 0 && (
           <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border bg-rose-500/15 text-rose-700 dark:text-rose-300 border-rose-500/40">
             {issueCount} issue
+          </span>
+        )}
+        {cooldownSec != null && failureThreshold != null && (
+          <span
+            className="ml-auto font-mono text-[10px] text-muted-foreground"
+            data-testid="cb-policy-meta"
+          >
+            policy: {failureThreshold} fail → open · cooldown {cooldownSec}s
           </span>
         )}
       </header>
@@ -144,7 +283,12 @@ export function CircuitBreakerGrid() {
       {breakers.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {breakers.map(b => (
-            <CircuitCard key={b.serviceName} breaker={b} />
+            <CircuitCard
+              key={b.serviceName}
+              breaker={b}
+              cooldownSec={cooldownSec}
+              failureThreshold={failureThreshold}
+            />
           ))}
         </div>
       )}

--- a/apps/web/src/components/admin/providers/ProviderTable.tsx
+++ b/apps/web/src/components/admin/providers/ProviderTable.tsx
@@ -169,6 +169,7 @@ function ProviderRow({
       <td className="py-3 px-3">
         <span
           className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${tokenStatus.cls}`}
+          aria-label={`Token status: ${tokenStatus.label}`}
         >
           {tokenStatus.label}
         </span>
@@ -196,6 +197,7 @@ function ProviderRow({
         <span
           className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${circuitChipClass(circuit)}`}
           data-testid={`provider-circuit-${name}`}
+          aria-label={`Circuit breaker: ${circuit}`}
         >
           {circuit}
         </span>

--- a/apps/web/src/components/admin/providers/ProviderTable.tsx
+++ b/apps/web/src/components/admin/providers/ProviderTable.tsx
@@ -26,28 +26,47 @@ import { KNOWN_PROVIDERS, type ProviderName } from '@/lib/api/schemas/providers'
 
 import { RotateKeyModal } from './RotateKeyModal';
 
+type ProviderTone = 'tool' | 'chat' | 'kb';
+
 const PROVIDER_DISPLAY: Record<
   ProviderName,
-  { mark: string; name: string; host: string; defaultModel: string }
+  {
+    readonly mark: string;
+    readonly name: string;
+    readonly host: string;
+    readonly defaultModel: string;
+    readonly tone: ProviderTone;
+    readonly primary?: boolean;
+  }
 > = {
-  openrouter: {
-    mark: 'O',
-    name: 'OpenRouter',
-    host: 'openrouter.ai/api/v1',
-    defaultModel: 'anthropic/claude-3.5-sonnet',
-  },
   deepseek: {
     mark: 'D',
     name: 'DeepSeek',
     host: 'api.deepseek.com',
     defaultModel: 'deepseek-chat',
+    tone: 'tool',
+    primary: true,
+  },
+  openrouter: {
+    mark: 'O',
+    name: 'OpenRouter',
+    host: 'openrouter.ai/api/v1',
+    defaultModel: 'anthropic/claude-3.5-sonnet',
+    tone: 'chat',
   },
   'ollama-local': {
     mark: 'L',
     name: 'Ollama (locale)',
     host: 'localhost:11434',
     defaultModel: 'llama3.1:8b-instruct',
+    tone: 'kb',
   },
+};
+
+const TONE_MARK_CLASS: Record<ProviderTone, string> = {
+  tool: 'bg-entity-tool/15 text-entity-tool ring-1 ring-entity-tool/30',
+  chat: 'bg-entity-chat/15 text-entity-chat ring-1 ring-entity-chat/30',
+  kb: 'bg-entity-kb/15 text-entity-kb ring-1 ring-entity-kb/30',
 };
 
 type CircuitState = 'closed' | 'open' | 'half-open' | 'unknown';
@@ -122,11 +141,25 @@ function ProviderRow({
           href={`/admin/providers/${encodeURIComponent(name)}`}
           className="flex items-center gap-3 outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
         >
-          <div className="grid h-9 w-9 place-items-center rounded-lg bg-gradient-to-br from-amber-500 to-rose-500 font-quicksand text-base font-bold text-white">
+          <div
+            className={`grid h-9 w-9 place-items-center rounded-lg font-quicksand text-base font-bold ${TONE_MARK_CLASS[display.tone]}`}
+            aria-hidden="true"
+            data-testid={`provider-mark-${name}`}
+          >
             {display.mark}
           </div>
           <div className="min-w-0">
-            <div className="font-quicksand text-sm font-bold text-foreground">{display.name}</div>
+            <div className="font-quicksand text-sm font-bold text-foreground flex items-center gap-1.5">
+              {display.name}
+              {display.primary && (
+                <span
+                  className="font-mono text-[9px] font-bold uppercase tracking-wider bg-entity-event/12 text-entity-event px-1.5 py-px rounded"
+                  data-testid={`provider-primary-tag-${name}`}
+                >
+                  primary
+                </span>
+              )}
+            </div>
             <div className="font-mono text-[10.5px] text-muted-foreground truncate">
               {display.host}
             </div>

--- a/apps/web/src/components/admin/providers/ProvidersHero.tsx
+++ b/apps/web/src/components/admin/providers/ProvidersHero.tsx
@@ -4,11 +4,12 @@
  * #1834 SP5 F4-C3 — ProvidersHero
  *
  * KPI strip per `/admin/providers` (mockup `sp5-admin-providers.html` §1, hero panel).
- * 4 metriche: requests/h, p95 latency, error rate 24h, cost 24h.
  *
- * **BE pending**: il backend non espone ancora un endpoint di aggregato cross-provider.
- * Per ora i valori sono derivati lato FE da `useCircuitBreakerStates` quando possibile,
- * altrimenti mostrano `—` con tooltip esplicativo. Issue follow-up: aggregato BE.
+ * **PR1 reduction (sessione 2026-06-03)**: ridotto da 4 KPI a 2 KPI reali.
+ * I 3 KPI cross-provider (p95 latency, error rate 24h, cost 24h) richiedono
+ * un endpoint aggregato BE che non esiste ancora — issue tracker FE-only.
+ *
+ * Quando il BE arriverà (issue follow-up), riaggiungere i 3 KPI con valori reali.
  */
 
 import { useMemo } from 'react';
@@ -19,16 +20,14 @@ interface KpiBoxProps {
   readonly label: string;
   readonly value: string;
   readonly trend?: string;
-  readonly tone: 'agent' | 'tool' | 'event' | 'kb';
+  readonly tone: 'tool' | 'event';
   readonly tooltip?: string;
 }
 
 function KpiBox({ label, value, trend, tone, tooltip }: KpiBoxProps) {
   const toneClass: Record<KpiBoxProps['tone'], string> = {
-    agent: 'border-amber-500/30 bg-amber-500/5',
-    tool: 'border-cyan-500/30 bg-cyan-500/5',
-    event: 'border-rose-500/30 bg-rose-500/5',
-    kb: 'border-teal-500/30 bg-teal-500/5',
+    tool: 'border-entity-tool/30 bg-entity-tool/5',
+    event: 'border-entity-event/30 bg-entity-event/5',
   };
 
   return (
@@ -51,45 +50,47 @@ export function ProvidersHero() {
 
   const stats = useMemo(() => {
     const breakers = circuitBreakersQuery.data ?? [];
-    const trippedCount = breakers.filter(
-      b => b.state.toLowerCase() === 'open' || b.state.toLowerCase() === 'half-open'
-    ).length;
-    return { totalServices: breakers.length, trippedCount };
+    const open = breakers.filter(b => b.state.toLowerCase() === 'open').length;
+    const halfOpen = breakers.filter(b => {
+      const s = b.state.toLowerCase();
+      return s === 'half-open' || s === 'halfopen';
+    }).length;
+    const closed = breakers.filter(b => b.state.toLowerCase() === 'closed').length;
+    return { total: breakers.length, open, halfOpen, closed };
   }, [circuitBreakersQuery.data]);
+
+  const trippedCount = stats.open + stats.halfOpen;
+  const healthValue = stats.total === 0 ? '—' : `${stats.closed}/${stats.total}`;
+  const healthTrend =
+    stats.total === 0
+      ? 'nessun servizio'
+      : trippedCount === 0
+        ? 'tutti closed'
+        : `${stats.open} open · ${stats.halfOpen} half-open`;
 
   return (
     <section
-      className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2"
       aria-label="Provider KPI"
       data-testid="providers-hero"
     >
       <KpiBox
         label="Servizi monitorati"
-        value={circuitBreakersQuery.isLoading ? '…' : String(stats.totalServices)}
-        trend={stats.trippedCount > 0 ? `${stats.trippedCount} circuit open` : 'tutti closed'}
+        value={circuitBreakersQuery.isLoading ? '…' : String(stats.total)}
+        trend={
+          stats.total === 0 && !circuitBreakersQuery.isLoading
+            ? 'nessun circuit registrato'
+            : 'circuit breakers attivi'
+        }
         tone="tool"
         tooltip="Numero di servizi protetti da Polly circuit breaker"
       />
       <KpiBox
-        label="Latency p95"
-        value="—"
-        trend="aggregato BE pending"
+        label="Circuit health"
+        value={circuitBreakersQuery.isLoading ? '…' : healthValue}
+        trend={healthTrend}
         tone="event"
-        tooltip="Metrica aggregata cross-provider non ancora esposta dal backend"
-      />
-      <KpiBox
-        label="Error rate 24h"
-        value="—"
-        trend="aggregato BE pending"
-        tone="agent"
-        tooltip="Metrica aggregata cross-provider non ancora esposta dal backend"
-      />
-      <KpiBox
-        label="Costo 24h"
-        value="—"
-        trend="aggregato BE pending"
-        tone="kb"
-        tooltip="Metrica aggregata cross-provider non ancora esposta dal backend"
+        tooltip="Servizi con circuit closed (healthy) su totale"
       />
     </section>
   );

--- a/apps/web/src/components/admin/providers/ProvidersToolbar.tsx
+++ b/apps/web/src/components/admin/providers/ProvidersToolbar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * #1834 SP5 F4-C3 — ProvidersToolbar
+ *
+ * Header bar per `/admin/providers` (mockup `sp5-admin-providers.html` top bar).
+ *
+ * PR1 scope minimale: titolo + sottotitolo + refresh button che invalida le query.
+ * Search (⌘K) + config globale + theme toggle restano out-of-scope per PR1.
+ */
+
+import { useState } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { providerKeys } from '@/hooks/queries/useProviders';
+
+export function ProvidersToolbar() {
+  const qc = useQueryClient();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: providerKeys.circuitBreakers }),
+        qc.invalidateQueries({ queryKey: providerKeys.llmConfig }),
+        qc.invalidateQueries({ queryKey: providerKeys.all }),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <header className="flex items-start justify-between gap-3" data-testid="providers-toolbar">
+      <div>
+        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+          LLM Providers &amp; Circuit Breakers
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Stato token, quota residua, catena di fallback e circuit breaker per ogni provider
+          configurato.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleRefresh}
+        disabled={refreshing}
+        aria-label="Aggiorna stato provider"
+        data-testid="providers-refresh"
+        className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card/60 px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted/70 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <span aria-hidden="true">{refreshing ? '⟳' : '⟳'}</span>
+        {refreshing ? 'Aggiornamento…' : 'Refresh'}
+      </button>
+    </header>
+  );
+}

--- a/apps/web/src/components/admin/providers/RotateKeyModal.tsx
+++ b/apps/web/src/components/admin/providers/RotateKeyModal.tsx
@@ -7,12 +7,13 @@
  * Richiede ruolo superadmin + step-up 2FA (S3 strict cutover #1597).
  *
  * **Stato attuale**: BE endpoint `POST /api/v1/admin/providers/{name}/rotate-key` NON ancora
- * implementato. Questa UI è pre-built per quando il BE arriverà. Comportamento corrente:
+ * implementato. Tracked in #1859. Questa UI è pre-built per quando il BE arriverà.
+ * Comportamento corrente:
  * - Button "Rotate" sempre disabled
- * - Tooltip "BE endpoint pending — track ⊥ Sicurezza S3 followup"
+ * - Tooltip esplicativo che cita #1859
  * - Modale NON apre (button disabled)
  *
- * Quando il BE arriverà (issue follow-up da aprire):
+ * Quando #1859 sarà mergiato:
  * - Wire mutation POST /providers/{name}/rotate-key con header X-StepUp-Token
  * - Typed-confirm input ("type the provider name to confirm")
  * - Display nuova key UNA volta + checkbox "Ho copiato la key"
@@ -36,9 +37,7 @@ export function RotateKeyModal({ providerName }: RotateKeyModalProps) {
   const beAvailable = false;
   const disabled = !isSuper || !beAvailable;
 
-  const title = !isSuper
-    ? 'Richiede ruolo superadmin'
-    : 'BE endpoint pending — track ⊥ Sicurezza S3 followup';
+  const title = !isSuper ? 'Richiede ruolo superadmin' : 'BE endpoint pending — tracked in #1859';
 
   return (
     <button

--- a/apps/web/src/components/admin/providers/RoutingChainViz.tsx
+++ b/apps/web/src/components/admin/providers/RoutingChainViz.tsx
@@ -130,6 +130,7 @@ export function RoutingChainViz() {
                   <span
                     className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${priorityChipClass(node.priority)}`}
                     data-testid={`routing-chain-priority-${idx}`}
+                    aria-label={`Priority: ${node.priority}`}
                   >
                     {node.priority}
                   </span>

--- a/apps/web/src/components/admin/providers/RoutingChainViz.tsx
+++ b/apps/web/src/components/admin/providers/RoutingChainViz.tsx
@@ -1,65 +1,27 @@
-/* eslint-disable local/no-hardcoded-color-utility -- admin routing chain: amber/emerald/zinc priority palette (admin convention DS-13c, scope deferred to DS-16) */
+/* eslint-disable local/no-hardcoded-color-utility -- admin routing chain: amber/cyan/teal/zinc priority palette (admin convention DS-13c, scope deferred to DS-16) */
 'use client';
 
 /**
  * #1834 SP5 F4-C3 — RoutingChainViz
  *
  * Visualizzazione catena di fallback LLM (mockup `sp5-admin-providers.html` §3).
- * Parsing della stringa `fallbackChainJson` da `LlmSystemConfigDto`.
  *
- * Formato atteso (best-effort):
- *   [
- *     { "provider": "deepseek", "model": "deepseek-chat", "priority": "primary" },
- *     { "provider": "openrouter", "model": "...", "priority": "secondary" },
- *     ...
- *   ]
+ * PR2: parsing migrato a Zod schema condiviso (`parseFallbackChain`).
+ * Arrow tra nodi mostra le `failoverConditions` ("on 429 / 5xx / timeout").
  *
- * Tollerante a varianti: campi mancanti → fallback "—".
- * Se il JSON non è parsabile → empty state.
+ * Schema tollerante a varianti BE (vedi `FallbackChainEntrySchema`); follow-up
+ * BE per schema rigido + persistenza tipata.
  */
 
 import { useMemo } from 'react';
 
 import { useLlmSystemConfig } from '@/hooks/queries/useProviders';
+import {
+  parseFallbackChain,
+  type FallbackChainEntry,
+} from '@/lib/api/schemas/llm-system-config.schemas';
 
-interface ChainNode {
-  readonly provider: string;
-  readonly model: string;
-  readonly priority: 'primary' | 'secondary' | 'tertiary' | 'standby' | 'unknown';
-}
-
-function parseFallbackChain(json: string | undefined | null): ChainNode[] {
-  if (!json) return [];
-  try {
-    const parsed: unknown = JSON.parse(json);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.map((raw, idx) => {
-      if (typeof raw !== 'object' || raw === null) {
-        return { provider: '—', model: '—', priority: 'unknown' as const };
-      }
-      const obj = raw as Record<string, unknown>;
-      const providerKey = obj.provider ?? obj.name ?? obj.providerName;
-      const modelKey = obj.model ?? obj.defaultModel ?? obj.modelName;
-      const priorityKey =
-        obj.priority ?? (idx === 0 ? 'primary' : idx === 1 ? 'secondary' : 'tertiary');
-      const priority =
-        typeof priorityKey === 'string'
-          ? ['primary', 'secondary', 'tertiary', 'standby'].includes(priorityKey.toLowerCase())
-            ? (priorityKey.toLowerCase() as ChainNode['priority'])
-            : 'unknown'
-          : 'unknown';
-      return {
-        provider: typeof providerKey === 'string' ? providerKey : '—',
-        model: typeof modelKey === 'string' ? modelKey : '—',
-        priority,
-      };
-    });
-  } catch {
-    return [];
-  }
-}
-
-function priorityChipClass(priority: ChainNode['priority']): string {
+function priorityChipClass(priority: FallbackChainEntry['priority']): string {
   switch (priority) {
     case 'primary':
       return 'bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/40';
@@ -74,10 +36,25 @@ function priorityChipClass(priority: ChainNode['priority']): string {
   }
 }
 
-function ChainArrow() {
+function formatConditions(conditions: readonly string[]): string {
+  if (conditions.length === 0) return 'on any failure';
+  return `on ${conditions.join(' / ')}`;
+}
+
+function ChainArrow({ conditions }: { readonly conditions: readonly string[] }) {
   return (
-    <div className="hidden sm:flex items-center text-muted-foreground" aria-hidden="true">
-      →
+    <div
+      className="hidden sm:flex flex-col items-center justify-center gap-1 px-2"
+      aria-hidden="true"
+      data-testid="routing-chain-arrow"
+    >
+      <span className="font-mono text-lg text-muted-foreground">→</span>
+      <span
+        className="font-mono text-[9.5px] uppercase tracking-wider text-amber-700 dark:text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-full px-2 py-px whitespace-nowrap"
+        data-testid="routing-chain-condition"
+      >
+        {formatConditions(conditions)}
+      </span>
     </div>
   );
 }
@@ -103,7 +80,11 @@ export function RoutingChainViz() {
           Routing chain
         </h3>
         <span className="font-mono text-[10.5px] text-muted-foreground">
-          {chain.length > 0 ? `${chain.length} hops` : 'fallback'}
+          {chain.length > 0
+            ? chain.length === 1
+              ? '1 hop'
+              : `${chain.length - 1 === 0 ? '' : `${chain.length - 1} fallback · `}${chain.length} hops`
+            : 'fallback'}
         </span>
         {configQuery.data && (
           <span className="ml-auto font-mono text-[10.5px] text-muted-foreground">
@@ -135,27 +116,34 @@ export function RoutingChainViz() {
 
       {chain.length > 0 && (
         <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 items-stretch sm:items-center flex-wrap">
-          {chain.map((node, idx) => (
-            <div key={`${node.provider}-${idx}`} className="flex items-center gap-2 sm:gap-3">
-              <div
-                className="rounded-lg border border-border/60 dark:border-zinc-700/60 bg-card/60 px-3 py-2 min-w-[180px]"
-                data-testid={`routing-chain-node-${idx}`}
-              >
-                <span
-                  className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${priorityChipClass(node.priority)}`}
+          {chain.map((node, idx) => {
+            const nextNode = chain[idx + 1];
+            // Arrow conditions are the conditions that trigger transition to NEXT node.
+            // They come from the *next* node's `failoverConditions` (what makes us fall there).
+            const arrowConditions = nextNode?.failoverConditions ?? [];
+            return (
+              <div key={`${node.provider}-${idx}`} className="flex items-center gap-2 sm:gap-3">
+                <div
+                  className="rounded-lg border border-border/60 dark:border-zinc-700/60 bg-card/60 px-3 py-2 min-w-[180px]"
+                  data-testid={`routing-chain-node-${idx}`}
                 >
-                  {node.priority}
-                </span>
-                <div className="mt-1.5 font-quicksand text-sm font-bold text-foreground">
-                  {node.provider}
+                  <span
+                    className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${priorityChipClass(node.priority)}`}
+                    data-testid={`routing-chain-priority-${idx}`}
+                  >
+                    {node.priority}
+                  </span>
+                  <div className="mt-1.5 font-quicksand text-sm font-bold text-foreground">
+                    {node.provider}
+                  </div>
+                  <div className="font-mono text-[10.5px] text-muted-foreground truncate">
+                    {node.model}
+                  </div>
                 </div>
-                <div className="font-mono text-[10.5px] text-muted-foreground truncate">
-                  {node.model}
-                </div>
+                {nextNode && <ChainArrow conditions={arrowConditions} />}
               </div>
-              {idx < chain.length - 1 && <ChainArrow />}
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </section>

--- a/apps/web/src/components/admin/providers/__tests__/CircuitBreakerGrid.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/CircuitBreakerGrid.test.tsx
@@ -1,14 +1,17 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { CircuitBreakerGrid } from '../CircuitBreakerGrid';
 
 const getCircuitBreakerStates = vi.fn();
+const getLlmSystemConfig = vi.fn();
+
 vi.mock('@/lib/api', () => ({
   api: {
     admin: {
       getCircuitBreakerStates: (...args: unknown[]) => getCircuitBreakerStates(...args),
+      getLlmSystemConfig: (...args: unknown[]) => getLlmSystemConfig(...args),
     },
   },
 }));
@@ -18,9 +21,22 @@ function renderWithQuery(ui: React.ReactElement) {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
+const DEFAULT_CONFIG = {
+  circuitBreakerFailureThreshold: 5,
+  circuitBreakerOpenDurationSeconds: 30,
+  circuitBreakerSuccessThreshold: 1,
+  dailyBudgetUsd: 50,
+  monthlyBudgetUsd: 1000,
+  fallbackChainJson: '[]',
+  source: 'database' as const,
+  lastUpdatedAt: null,
+  lastUpdatedByUserId: null,
+};
+
 describe('CircuitBreakerGrid', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getLlmSystemConfig.mockResolvedValue(DEFAULT_CONFIG);
   });
 
   it('renders one card per circuit breaker state', async () => {
@@ -97,5 +113,126 @@ describe('CircuitBreakerGrid', () => {
     await waitFor(() => {
       expect(screen.getByText(/2 issue/i)).toBeInTheDocument();
     });
+  });
+
+  describe('PR2 stat-grid layout + cooldown bar', () => {
+    it('renders 2x2 stat-grid with Trips, Soglia, Ultima apertura, Reset', async () => {
+      getCircuitBreakerStates.mockResolvedValue([
+        {
+          serviceName: 'deepseek',
+          state: 'Closed',
+          tripCount: 2,
+          lastTrippedAt: null,
+          lastResetAt: null,
+          lastError: null,
+        },
+      ]);
+
+      renderWithQuery(<CircuitBreakerGrid />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('circuit-card-statgrid-deepseek')).toBeInTheDocument();
+      });
+      const grid = screen.getByTestId('circuit-card-statgrid-deepseek');
+      expect(grid).toHaveTextContent(/Trips/i);
+      expect(grid).toHaveTextContent(/Soglia/i);
+      expect(grid).toHaveTextContent(/Ultima apertura/i);
+      expect(grid).toHaveTextContent(/Reset/i);
+      // Soglia value from config
+      expect(grid).toHaveTextContent('5');
+    });
+
+    it('renders policy meta in header when config loaded', async () => {
+      getCircuitBreakerStates.mockResolvedValue([
+        {
+          serviceName: 'x',
+          state: 'Closed',
+          tripCount: 0,
+          lastTrippedAt: null,
+          lastResetAt: null,
+          lastError: null,
+        },
+      ]);
+
+      renderWithQuery(<CircuitBreakerGrid />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('cb-policy-meta')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('cb-policy-meta')).toHaveTextContent('5 fail');
+      expect(screen.getByTestId('cb-policy-meta')).toHaveTextContent('cooldown 30s');
+    });
+
+    it('renders cooldown bar with countdown for Open state', async () => {
+      // Use real wall clock: lastTrippedAt = now - 10s. With 30s cooldown,
+      // ~20s should remain (give or take a few ms for test setup latency).
+      const trippedMs = Date.now() - 10_000;
+      getCircuitBreakerStates.mockResolvedValue([
+        {
+          serviceName: 'openrouter',
+          state: 'Open',
+          tripCount: 5,
+          lastTrippedAt: new Date(trippedMs).toISOString(),
+          lastResetAt: null,
+          lastError: null,
+        },
+      ]);
+
+      renderWithQuery(<CircuitBreakerGrid />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('cb-cooldown-bar')).toBeInTheDocument();
+      });
+
+      const remaining = screen.getByTestId('cb-cooldown-remaining');
+      // 30 - 10 ≈ 20s (Math.ceil) — allow ±3s for test setup overhead
+      const secs = Number(remaining.textContent?.replace('s', ''));
+      expect(secs).toBeGreaterThanOrEqual(17);
+      expect(secs).toBeLessThanOrEqual(20);
+    });
+
+    it('does NOT render cooldown bar for Closed state', async () => {
+      getCircuitBreakerStates.mockResolvedValue([
+        {
+          serviceName: 'deepseek',
+          state: 'Closed',
+          tripCount: 0,
+          lastTrippedAt: '2026-06-02T09:00:00Z',
+          lastResetAt: '2026-06-02T09:30:00Z',
+          lastError: null,
+        },
+      ]);
+
+      renderWithQuery(<CircuitBreakerGrid />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('circuit-card-deepseek')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('cb-cooldown-bar')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render cooldown bar when lastTrippedAt is null even for Open state', async () => {
+      getCircuitBreakerStates.mockResolvedValue([
+        {
+          serviceName: 'x',
+          state: 'Open',
+          tripCount: 1,
+          lastTrippedAt: null, // edge case
+          lastResetAt: null,
+          lastError: null,
+        },
+      ]);
+
+      renderWithQuery(<CircuitBreakerGrid />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('circuit-card-x')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('cb-cooldown-bar')).not.toBeInTheDocument();
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/components/admin/providers/__tests__/CircuitBreakerGrid.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/CircuitBreakerGrid.test.tsx
@@ -211,6 +211,39 @@ describe('CircuitBreakerGrid', () => {
       expect(screen.queryByTestId('cb-cooldown-bar')).not.toBeInTheDocument();
     });
 
+    it('exposes aria-label on state chip + issue counter for screen readers (PR3 a11y)', async () => {
+      getCircuitBreakerStates.mockResolvedValue([
+        {
+          serviceName: 'deepseek',
+          state: 'Closed',
+          tripCount: 0,
+          lastTrippedAt: null,
+          lastResetAt: null,
+          lastError: null,
+        },
+        {
+          serviceName: 'openrouter',
+          state: 'Open',
+          tripCount: 5,
+          lastTrippedAt: null,
+          lastResetAt: null,
+          lastError: null,
+        },
+      ]);
+
+      renderWithQuery(<CircuitBreakerGrid />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('circuit-card-deepseek')).toBeInTheDocument();
+      });
+
+      // State chips have "Circuit breaker state: {Open|Closed|...}" aria-label
+      expect(screen.getByLabelText(/circuit breaker state: closed/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/circuit breaker state: open/i)).toBeInTheDocument();
+      // Issue counter has role=status with descriptive aria-label
+      expect(screen.getByLabelText(/circuit breaker.* require attention/i)).toBeInTheDocument();
+    });
+
     it('does NOT render cooldown bar when lastTrippedAt is null even for Open state', async () => {
       getCircuitBreakerStates.mockResolvedValue([
         {

--- a/apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
@@ -106,6 +106,26 @@ describe('ProviderTable', () => {
     expect(screen.queryByTestId('provider-primary-tag-ollama-local')).not.toBeInTheDocument();
   });
 
+  it('exposes aria-label on token + circuit status chips for screen readers (PR3 a11y)', async () => {
+    renderWithQuery(<ProviderTable />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-circuit-deepseek')).toBeInTheDocument();
+    });
+    // Circuit chips carry "Circuit breaker: {state}" aria-label
+    expect(screen.getByTestId('provider-circuit-deepseek')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/circuit breaker:/i)
+    );
+    expect(screen.getByTestId('provider-circuit-openrouter')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/circuit breaker:/i)
+    );
+    // Token status chips: one per provider row (3 providers)
+    const tokenChips = screen.getAllByLabelText(/token status:/i);
+    expect(tokenChips.length).toBe(3);
+  });
+
   it('renders entity-colored mark per provider (no shared gradient)', async () => {
     renderWithQuery(<ProviderTable />);
 

--- a/apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
@@ -94,4 +94,31 @@ describe('ProviderTable', () => {
       expect(placeholders.length).toBeGreaterThanOrEqual(3);
     });
   });
+
+  it('renders primary tag only on the deepseek row (PR1 entity-token mapping)', async () => {
+    renderWithQuery(<ProviderTable />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-row-deepseek')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('provider-primary-tag-deepseek')).toHaveTextContent('primary');
+    expect(screen.queryByTestId('provider-primary-tag-openrouter')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('provider-primary-tag-ollama-local')).not.toBeInTheDocument();
+  });
+
+  it('renders entity-colored mark per provider (no shared gradient)', async () => {
+    renderWithQuery(<ProviderTable />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-mark-deepseek')).toBeInTheDocument();
+    });
+    const dsMark = screen.getByTestId('provider-mark-deepseek');
+    const orMark = screen.getByTestId('provider-mark-openrouter');
+    const ollMark = screen.getByTestId('provider-mark-ollama-local');
+
+    // Each mark gets its tone class — bg-entity-{tool|chat|kb}
+    expect(dsMark.className).toMatch(/bg-entity-tool/);
+    expect(orMark.className).toMatch(/bg-entity-chat/);
+    expect(ollMark.className).toMatch(/bg-entity-kb/);
+  });
 });

--- a/apps/web/src/components/admin/providers/__tests__/ProvidersHero.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProvidersHero.test.tsx
@@ -18,12 +18,12 @@ function renderWithQuery(ui: React.ReactElement) {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
-describe('ProvidersHero', () => {
+describe('ProvidersHero (PR1 reduced — 2 KPI reali)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('shows 4 KPI boxes including service count from circuit breakers', async () => {
+  it('renders 2 KPI: Servizi monitorati + Circuit health', async () => {
     getCircuitBreakerStates.mockResolvedValue([
       {
         serviceName: 'deepseek',
@@ -53,24 +53,37 @@ describe('ProvidersHero', () => {
 
     renderWithQuery(<ProvidersHero />);
 
-    // Eventually shows the service count
     await waitFor(() => {
       expect(screen.getByTestId('providers-hero')).toBeInTheDocument();
       expect(screen.getByTestId('providers-kpi-servizi-monitorati')).toHaveTextContent('3');
     });
 
-    // Confirms tripped count appears in trend
-    expect(screen.getByTestId('providers-kpi-servizi-monitorati')).toHaveTextContent(
-      '1 circuit open'
-    );
+    // Circuit health: 2 closed / 3 total + breakdown trend
+    const health = screen.getByTestId('providers-kpi-circuit-health');
+    expect(health).toHaveTextContent('2/3');
+    expect(health).toHaveTextContent('1 open');
   });
 
-  it('shows "—" for BE-pending metrics with explanatory tooltip', () => {
+  it('shows zero state when no circuit breakers registered', async () => {
     getCircuitBreakerStates.mockResolvedValue([]);
     renderWithQuery(<ProvidersHero />);
 
-    const errorRate = screen.getByTestId('providers-kpi-error-rate-24h');
-    expect(errorRate).toHaveTextContent('—');
-    expect(errorRate).toHaveAttribute('title', expect.stringMatching(/backend/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-kpi-servizi-monitorati')).toHaveTextContent('0');
+    });
+    expect(screen.getByTestId('providers-kpi-circuit-health')).toHaveTextContent('—');
+  });
+
+  it('no longer renders the deprecated BE-pending placeholder KPI', async () => {
+    getCircuitBreakerStates.mockResolvedValue([]);
+    renderWithQuery(<ProvidersHero />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-hero')).toBeInTheDocument();
+    });
+    // 3 placeholder KPI (latency-p95, error-rate-24h, costo-24h) removed in PR1
+    expect(screen.queryByTestId('providers-kpi-latency-p95')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('providers-kpi-error-rate-24h')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('providers-kpi-costo-24h')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/admin/providers/__tests__/ProvidersToolbar.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/ProvidersToolbar.test.tsx
@@ -1,0 +1,37 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ProvidersToolbar } from '../ProvidersToolbar';
+
+function renderWithQuery() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <ProvidersToolbar />
+    </QueryClientProvider>
+  );
+  return { ...utils, qc, invalidateSpy };
+}
+
+describe('ProvidersToolbar', () => {
+  it('renders title + subtitle + refresh button', () => {
+    renderWithQuery();
+    expect(screen.getByTestId('providers-toolbar')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /LLM Providers/i })).toBeInTheDocument();
+    expect(screen.getByTestId('providers-refresh')).toBeInTheDocument();
+  });
+
+  it('invalidates provider queries on refresh click', async () => {
+    const { invalidateSpy } = renderWithQuery();
+    fireEvent.click(screen.getByTestId('providers-refresh'));
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
+    });
+    // Verify it targets the right keys (circuit-breakers + llm config + providers root)
+    const keys = invalidateSpy.mock.calls.map(c => (c[0] as { queryKey: unknown[] }).queryKey);
+    expect(keys.some(k => Array.isArray(k) && k.includes('circuit-breakers'))).toBe(true);
+    expect(keys.some(k => Array.isArray(k) && k.join(',').includes('llm'))).toBe(true);
+  });
+});

--- a/apps/web/src/components/admin/providers/__tests__/RoutingChainViz.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/RoutingChainViz.test.tsx
@@ -53,6 +53,32 @@ describe('RoutingChainViz', () => {
     expect(screen.getByTestId('routing-chain-node-2')).toHaveTextContent('standby');
   });
 
+  it('exposes aria-label on priority chip for screen readers (PR3 a11y)', async () => {
+    getLlmSystemConfig.mockResolvedValue({
+      circuitBreakerFailureThreshold: 5,
+      circuitBreakerOpenDurationSeconds: 60,
+      circuitBreakerSuccessThreshold: 1,
+      dailyBudgetUsd: 50,
+      monthlyBudgetUsd: 1000,
+      fallbackChainJson: JSON.stringify([
+        { provider: 'deepseek', model: 'deepseek-chat', priority: 'primary' },
+        { provider: 'openrouter', model: 'm', priority: 'secondary' },
+      ]),
+      source: 'database',
+      lastUpdatedAt: '2026-06-02T10:00:00+00:00',
+      lastUpdatedByUserId: '00000000-0000-0000-0000-000000000001',
+    });
+
+    renderWithQuery(<RoutingChainViz />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('routing-chain-priority-0')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/priority: primary/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/priority: secondary/i)).toBeInTheDocument();
+  });
+
   it('shows empty state when fallbackChainJson is invalid', async () => {
     getLlmSystemConfig.mockResolvedValue({
       circuitBreakerFailureThreshold: 5,

--- a/apps/web/src/components/admin/providers/__tests__/RoutingChainViz.test.tsx
+++ b/apps/web/src/components/admin/providers/__tests__/RoutingChainViz.test.tsx
@@ -73,6 +73,71 @@ describe('RoutingChainViz', () => {
     });
   });
 
+  it('renders failover conditions in arrow between nodes (PR2)', async () => {
+    getLlmSystemConfig.mockResolvedValue({
+      circuitBreakerFailureThreshold: 5,
+      circuitBreakerOpenDurationSeconds: 60,
+      circuitBreakerSuccessThreshold: 1,
+      dailyBudgetUsd: 50,
+      monthlyBudgetUsd: 1000,
+      fallbackChainJson: JSON.stringify([
+        { provider: 'deepseek', model: 'deepseek-chat', priority: 'primary' },
+        {
+          provider: 'openrouter',
+          model: 'anthropic/claude-3.5-sonnet',
+          priority: 'secondary',
+          failoverConditions: ['429', '5xx', 'timeout'],
+        },
+      ]),
+      source: 'database',
+      lastUpdatedAt: '2026-06-02T10:00:00+00:00',
+      lastUpdatedByUserId: '00000000-0000-0000-0000-000000000001',
+    });
+
+    renderWithQuery(<RoutingChainViz />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('routing-chain-node-0')).toBeInTheDocument();
+    });
+
+    const conditions = screen.getAllByTestId('routing-chain-condition');
+    expect(conditions.length).toBe(1); // 1 arrow between 2 nodes
+    expect(conditions[0]).toHaveTextContent(/429/);
+    expect(conditions[0]).toHaveTextContent(/5xx/);
+    expect(conditions[0]).toHaveTextContent(/timeout/);
+  });
+
+  it('falls back to default conditions when failoverConditions is missing (PR2)', async () => {
+    getLlmSystemConfig.mockResolvedValue({
+      circuitBreakerFailureThreshold: 5,
+      circuitBreakerOpenDurationSeconds: 60,
+      circuitBreakerSuccessThreshold: 1,
+      dailyBudgetUsd: 50,
+      monthlyBudgetUsd: 1000,
+      // Old entries without failoverConditions — parser should fill defaults
+      fallbackChainJson: JSON.stringify([
+        { provider: 'deepseek', model: 'deepseek-chat' },
+        { provider: 'openrouter', model: 'anthropic/claude-3.5-sonnet' },
+      ]),
+      source: 'appsettings',
+      lastUpdatedAt: null,
+      lastUpdatedByUserId: null,
+    });
+
+    renderWithQuery(<RoutingChainViz />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('routing-chain-node-1')).toBeInTheDocument();
+    });
+
+    // Index-derived priority: 0→primary, 1→secondary
+    expect(screen.getByTestId('routing-chain-priority-0')).toHaveTextContent('primary');
+    expect(screen.getByTestId('routing-chain-priority-1')).toHaveTextContent('secondary');
+    // Default conditions for fallback node should appear
+    const conditions = screen.getAllByTestId('routing-chain-condition');
+    expect(conditions[0]).toHaveTextContent(/circuit-open/);
+  });
+
   it('shows empty state when fallbackChainJson is empty array', async () => {
     getLlmSystemConfig.mockResolvedValue({
       circuitBreakerFailureThreshold: 5,

--- a/apps/web/src/lib/api/schemas/__tests__/llm-system-config-fallback-chain.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/llm-system-config-fallback-chain.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseFallbackChain } from '../llm-system-config.schemas';
+
+describe('parseFallbackChain (#1834 PR2)', () => {
+  it('returns empty array for null/undefined/empty string', () => {
+    expect(parseFallbackChain(null)).toEqual([]);
+    expect(parseFallbackChain(undefined)).toEqual([]);
+    expect(parseFallbackChain('')).toEqual([]);
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    expect(parseFallbackChain('not-json')).toEqual([]);
+  });
+
+  it('returns empty array for non-array JSON', () => {
+    expect(parseFallbackChain('{"provider":"x"}')).toEqual([]);
+    expect(parseFallbackChain('42')).toEqual([]);
+  });
+
+  it('parses canonical shape with all fields', () => {
+    const json = JSON.stringify([
+      {
+        provider: 'deepseek',
+        model: 'deepseek-chat',
+        priority: 'primary',
+        failoverConditions: ['429', '5xx'],
+      },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result).toEqual([
+      {
+        provider: 'deepseek',
+        model: 'deepseek-chat',
+        priority: 'primary',
+        failoverConditions: ['429', '5xx'],
+      },
+    ]);
+  });
+
+  it('tolerates alternate provider keys (name, providerName)', () => {
+    const json = JSON.stringify([
+      { name: 'deepseek', model: 'm', priority: 'primary' },
+      { providerName: 'openrouter', defaultModel: 'm2', priority: 'secondary' },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result.map(r => r.provider)).toEqual(['deepseek', 'openrouter']);
+    expect(result.map(r => r.model)).toEqual(['m', 'm2']);
+  });
+
+  it('derives priority from index when missing', () => {
+    const json = JSON.stringify([
+      { provider: 'a', model: 'a' },
+      { provider: 'b', model: 'b' },
+      { provider: 'c', model: 'c' },
+      { provider: 'd', model: 'd' },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result.map(r => r.priority)).toEqual(['primary', 'secondary', 'tertiary', 'standby']);
+  });
+
+  it('falls back to standby for unknown priority strings', () => {
+    const json = JSON.stringify([{ provider: 'a', model: 'a', priority: 'wildcard' }]);
+    const result = parseFallbackChain(json);
+    expect(result[0]?.priority).toBe('standby');
+  });
+
+  it('defaults failoverConditions for primary node to common HTTP errors', () => {
+    const json = JSON.stringify([{ provider: 'a', model: 'a' }]);
+    const result = parseFallbackChain(json);
+    expect(result[0]?.failoverConditions).toEqual(['429', '5xx', 'timeout']);
+  });
+
+  it('defaults failoverConditions for fallback nodes to circuit-open', () => {
+    const json = JSON.stringify([
+      { provider: 'a', model: 'a' },
+      { provider: 'b', model: 'b' },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result[1]?.failoverConditions).toEqual(['circuit-open']);
+  });
+
+  it('skips entries missing required provider/model', () => {
+    const json = JSON.stringify([
+      { provider: 'a', model: 'a' },
+      { priority: 'secondary' }, // no provider/model
+      { provider: 'c' }, // no model
+      { model: 'd' }, // no provider
+      { provider: 'e', model: 'e' },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result.map(r => r.provider)).toEqual(['a', 'e']);
+  });
+
+  it('skips non-object entries', () => {
+    const json = JSON.stringify([
+      { provider: 'a', model: 'a' },
+      null,
+      'string-entry',
+      42,
+      { provider: 'b', model: 'b' },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result.map(r => r.provider)).toEqual(['a', 'b']);
+  });
+
+  it('accepts conditions array alias for failoverConditions', () => {
+    const json = JSON.stringify([
+      { provider: 'a', model: 'a', conditions: ['quota', 'rate-limit'] },
+    ]);
+    const result = parseFallbackChain(json);
+    expect(result[0]?.failoverConditions).toEqual(['quota', 'rate-limit']);
+  });
+});

--- a/apps/web/src/lib/api/schemas/llm-system-config.schemas.ts
+++ b/apps/web/src/lib/api/schemas/llm-system-config.schemas.ts
@@ -25,6 +25,90 @@ export const LlmSystemConfigDtoSchema = z.object({
 export type LlmSystemConfigDto = z.infer<typeof LlmSystemConfigDtoSchema>;
 
 /**
+ * #1834 PR2 — Fallback chain entry schema.
+ *
+ * FE-only runtime guard for parsing `fallbackChainJson` (string).
+ * The BE persists this as a raw JSON string with zero validation, so we
+ * normalize known shape variants here. Issue tracker → schema rigido BE.
+ *
+ * Tolerated variants (best-effort):
+ * - `provider` | `name` | `providerName` for provider key
+ * - `model` | `defaultModel` | `modelName` for model key
+ * - `priority` derived from index when absent (0=primary, 1=secondary, 2=tertiary)
+ * - `failoverConditions` | `conditions` | absent (defaults to common conditions for primary,
+ *   `circuit-open` for fallback nodes)
+ */
+export const FallbackChainEntrySchema = z.object({
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  priority: z.enum(['primary', 'secondary', 'tertiary', 'standby']),
+  failoverConditions: z.array(z.string()).default([]),
+});
+
+export type FallbackChainEntry = z.infer<typeof FallbackChainEntrySchema>;
+
+/**
+ * Parse `fallbackChainJson` into a validated array of entries.
+ * Returns empty array on invalid input.
+ */
+export function parseFallbackChain(json: string | undefined | null): FallbackChainEntry[] {
+  if (!json) return [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+
+  const result: FallbackChainEntry[] = [];
+  raw.forEach((item, idx) => {
+    if (typeof item !== 'object' || item === null) return;
+    const obj = item as Record<string, unknown>;
+
+    const providerKey = obj.provider ?? obj.name ?? obj.providerName;
+    const modelKey = obj.model ?? obj.defaultModel ?? obj.modelName;
+    const priorityRaw = obj.priority;
+    const conditionsRaw = obj.failoverConditions ?? obj.conditions;
+
+    const provider = typeof providerKey === 'string' ? providerKey : null;
+    const model = typeof modelKey === 'string' ? modelKey : null;
+    if (!provider || !model) return;
+
+    const priorityCandidate =
+      typeof priorityRaw === 'string'
+        ? priorityRaw.toLowerCase()
+        : idx === 0
+          ? 'primary'
+          : idx === 1
+            ? 'secondary'
+            : idx === 2
+              ? 'tertiary'
+              : 'standby';
+    const priority = (['primary', 'secondary', 'tertiary', 'standby'] as const).includes(
+      priorityCandidate as FallbackChainEntry['priority']
+    )
+      ? (priorityCandidate as FallbackChainEntry['priority'])
+      : 'standby';
+
+    const failoverConditions = Array.isArray(conditionsRaw)
+      ? conditionsRaw.filter((c): c is string => typeof c === 'string')
+      : idx === 0
+        ? ['429', '5xx', 'timeout']
+        : ['circuit-open'];
+
+    const parsed = FallbackChainEntrySchema.safeParse({
+      provider,
+      model,
+      priority,
+      failoverConditions,
+    });
+    if (parsed.success) result.push(parsed.data);
+  });
+  return result;
+}
+
+/**
  * Update LLM System Config Request
  */
 export interface UpdateLlmSystemConfigRequest {

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2283,6 +2283,35 @@ dmesg | grep -i "oom\|killed" | tail -20
 | Security breach suspected | Isolate affected service, rotate all secrets |
 | Infrastructure failure | Consider VPS migration (see DR section) |
 
+### LLM Provider Outage Recovery — Reset Circuit Breakers
+
+**When to use**: All LLM circuits stuck in `Open` after upstream provider outage is resolved. Default cooldown is `circuitBreakerOpenDurationSeconds` (configured in `/admin/ai` LLM config, typically 30s). If you can't wait — or if the cooldown was misconfigured to a high value — manually reset.
+
+> 🟡 **Note (2026-06-03 per #1834 spec-panel review)**: There is NO admin UI button for "Reset all circuit breakers". The Polly circuit breaker state is in-memory per API process — restarting the `api` container is the simplest reset. Direct in-process reset via admin endpoint is tracked separately if/when on-call composition justifies it.
+
+#### Option A — Restart API container (fastest, zero state loss)
+
+```bash
+# Production / staging via SSH
+ssh meepleai-staging
+cd /opt/meepleai
+docker compose restart api
+
+# Verify circuits closed
+curl -s -H "Cookie: <admin-session>" http://localhost:8080/api/v1/admin/circuit-breakers \
+  | jq '.[] | {service: .serviceName, state: .state}'
+```
+
+Trade-off: brief (~5s) API unavailability while container restarts. No data loss (state is in-memory and disposable).
+
+#### Option B — Force-trip a single circuit manually
+
+Not currently supported. If a single provider needs to be ejected from the routing chain (e.g. compromised key suspected), use `/admin/ai` → LLM config → `fallbackChainJson` to remove the entry, save, then restart `api`.
+
+#### Verify recovery
+
+Visit `/admin/providers` (admin role required). The `CircuitBreakerGrid` section should show all chips `closed` (green) and the cooldown bar should disappear. The KPI `Circuit health` in the hero should read `N/N` (all healthy).
+
 ### Communication Template
 
 ```


### PR DESCRIPTION
## Summary

Follow-up consolidato per **#1834** SP5 F4-C3 (`/admin/providers` reskin).

Originale **#1834 merged via #1845** (`c5b4e68d4`) prima del blackout PC del 2026-06-03; questa PR aggiunge gli items identificati dalla review `/sc:spec-panel` post-merge che erano rimasti out-of-scope (~1000 LOC su 16 file).

3 commit atomici (PR1+PR2+PR3 originali, ora rebased su main-dev):

### Commit 1 — Table conformity + 2-KPI hero + toolbar (PR1)

- **ProviderTable**: entity tokens per provider (deepseek=tool/cyan, openrouter=chat/blue, ollama-local=kb/teal) + chip "primary" su DeepSeek (sostituisce gradient unico)
- **ProvidersHero**: ridotta da 4 → 2 KPI reali (Servizi monitorati + Circuit health). I 3 KPI cross-provider richiedevano aggregato BE inesistente
- **ProvidersToolbar** (nuovo): header con refresh button (invalida circuit-breakers + llm config + providers queries)
- **Mockup `sp5-admin-providers.html`**: rimossi OpenAI/Anthropic (aspirazionali, modelli accessibili via OpenRouter); allineato a `KNOWN_PROVIDERS=3`

### Commit 2 — CB cooldown bar + routing arrows + Zod schema (PR2)

- **Zod schema `FallbackChainEntrySchema`** + helper `parseFallbackChain()` — FE-only runtime guard, tollerante a varianti BE
- **RoutingChainViz**: arrow conditions tra nodi (`on 429 / 5xx / timeout`)
- **CircuitBreakerGrid**:
  - 2×2 stat-grid (Trips, Soglia, Ultima apertura, Reset) — mockup-aligned
  - **Cooldown bar countdown live** per stati open/half-open (1s tick, ARIA progressbar)
  - Header policy meta (`policy: N fail → open · cooldown Ms`)
  - Relative time formatting (`23s fa`, `5m fa`, `2g fa`)
- Riusa `circuitBreakerOpenDurationSeconds` + `circuitBreakerFailureThreshold` già esposti — **zero BE changes**

### Commit 3 — A11y aria-labels + runbook + BE issue tracker (PR3)

- **A11y**: aria-label su tutti gli status chip (ProviderTable token+circuit, CircuitBreakerGrid state, RoutingChainViz priority) — chiude gap WCAG 2.1 SC 1.4.1 (use of color)
- **BE issue tracker**: aperta #1859 con full spec per `POST /api/v1/admin/providers/{name}/rotate-key`
- **Runbook**: aggiunta sezione "LLM Provider Outage Recovery — Reset Circuit Breakers" in `operations-manual.md` §17

## Test plan

- [x] Vitest: 38/38 provider tests pass (27 providers/* + 11 schema parser)
- [x] Typecheck pulito
- [x] Lint pulito
- [x] Frontend + backend build verified (pre-push)
- [ ] Manual smoke su `/admin/providers` (dev server)

## File changed (16)

```
admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
apps/web/src/app/admin/(dashboard)/providers/page.tsx
apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
apps/web/src/components/admin/providers/ProviderTable.tsx
apps/web/src/components/admin/providers/ProvidersHero.tsx
apps/web/src/components/admin/providers/ProvidersToolbar.tsx (NEW)
apps/web/src/components/admin/providers/RotateKeyModal.tsx
apps/web/src/components/admin/providers/RoutingChainViz.tsx
apps/web/src/components/admin/providers/__tests__/CircuitBreakerGrid.test.tsx
apps/web/src/components/admin/providers/__tests__/ProviderTable.test.tsx
apps/web/src/components/admin/providers/__tests__/ProvidersHero.test.tsx
apps/web/src/components/admin/providers/__tests__/ProvidersToolbar.test.tsx (NEW)
apps/web/src/components/admin/providers/__tests__/RoutingChainViz.test.tsx
apps/web/src/lib/api/schemas/__tests__/llm-system-config-fallback-chain.test.ts (NEW)
apps/web/src/lib/api/schemas/llm-system-config.schemas.ts
docs/for-developers/operations/operations-manual.md
```

## Related

- Superseded: #1857 #1858 (3-PR stack obsoleto dopo discovery che #1834 base era già in main-dev)
- Originale #1834 merge: #1845
- Follow-up BE: #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)