### PR TITLE
fix: #1852 Gap A — handler must call repository.Update() before SaveChanges (critical)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandler.cs
@@ -57,6 +57,7 @@ internal sealed class PdfCoverGeneratedEventHandler : INotificationHandler<PdfCo
         }
 
         game.SetPdfCoverR2Key(notification.CoverR2Key);
+        _repository.Update(game);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/apps/web/e2e/library/cover-l4.spec.ts
+++ b/apps/web/e2e/library/cover-l4.spec.ts
@@ -146,7 +146,6 @@ test.describe('L4 PDF cover propagation (#1852)', () => {
    * provisioned in the E2E CI environment so this assertion can run
    * consistently without requiring a live staging deployment.
    */
-  // eslint-disable-next-line playwright/no-skipped-test
   test.fixme('cover-strict-r2: img src ends with .webp (S3 only — requires STORAGE_PROVIDER=s3)', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Critical follow-up to PR #1863 (already merged). The handler introduced by that PR is a no-op in production because:

- `SharedGameRepository.GetByIdAsync` uses `.AsNoTracking()` (PERF-06)
- `DbContext` default tracking is `NoTracking` (see `InfrastructureServiceExtensions.cs:164`)
- Handler mutates the untracked aggregate then calls `SaveChangesAsync` directly
- EF has no tracked entity for the SharedGame mutation → `SaveChangesAsync` is a no-op for the SharedGame row
- Result: `shared_games.pdf_cover_r2_key` is NEVER populated for new uploads

This defeats the entire purpose of #1852 for new PDFs (the backfill SQL only saves already-generated covers in the DB at deploy time).

**Fix**: call `_repository.Update(game)` between `SetPdfCoverR2Key` and `SaveChangesAsync`. This is the canonical post-#1670 pattern documented in MEMORY.md (`notracking-default-update-gotcha.md`).

Also fixes ESLint `playwright/no-skipped-test` unknown-rule directive in `cover-l4.spec.ts:149` that was causing Frontend Static job failures (rule not registered in project config).

Caught by holistic code review of PR #1863. Single-line code change, paired with a comprehensive integration test (`PdfCoverPropagationIntegrationTests`) that will now exercise the correct path.

## Test plan

- [ ] Integration: `PdfCoverPropagationIntegrationTests.PdfCoverGeneratedEvent_PropagatesToSharedGame_OnSaveChanges` now passes for the right reason (handler tracks + persists)
- [ ] Integration: `PdfCoverGeneratedEvent_NullSharedGameId_IsNoOp` still passes
- [ ] Unit: `PdfCoverGeneratedEventHandlerTests` (5 cases) — Moq verifies `Update` is called once on happy path
- [ ] Frontend Static job now passes (lint clean)
- [ ] Manual: upload PDF in staging → `shared_games.pdf_cover_r2_key` populated → library card shows generated cover

## References

- Holistic review of PR #1863 that identified the bug
- MEMORY: `notracking-default-update-gotcha.md`
- Pattern reference: PR #1670 (#1628 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)