### PR TITLE
feat(library): #1585-followup PR3 overlays reskin to sp4 mockup

### DIFF
--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -341,9 +341,12 @@ export function LibraryHub(): ReactElement {
     const count = selected.size;
     return {
       regionLabel: t('pages.library.selectionMode.selectedCount', { count }),
-      counter: t('pages.library.selectionMode.selectedCount', { count }),
-      cancel: t('pages.library.selectionMode.exit'),
-      archive: t('pages.library.bulk.actions.delete'),
+      counter: t('pages.library.bulk.counter', { count }),
+      counterCompact: t('pages.library.bulk.counterCompact'),
+      closeAriaLabel: t('pages.library.bulk.closeAriaLabel'),
+      archive: t('pages.library.bulk.actions.archive'),
+      tag: t('pages.library.bulk.actions.tag'),
+      exportLabel: t('pages.library.bulk.actions.export'),
       confirmTitle: t('pages.library.bulk.confirm.deleteTitle', { count }),
       confirmDescription: t('pages.library.bulk.confirm.deleteMessage'),
       confirmCta: t('pages.library.bulk.confirm.confirmCta'),

--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -39,6 +39,7 @@ import {
   LibraryHybridGrid,
   LibraryTabs,
   RecentActivityRail,
+  countActiveFilters,
   type ActivityItem,
   type BulkSelectionBarLabels,
   type EmptyLibraryLabels,
@@ -62,7 +63,7 @@ import {
   type HybridHubSources,
   type HybridHubTab,
 } from '@/lib/library/hybrid-hub.derive';
-import type { HybridHubEntity, HybridHubItem } from '@/lib/library/hybrid-hub.types';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
 import type { LibrarySortKey } from '@/lib/library/library-filters';
 import { useLibraryView } from '@/lib/library/use-library-view';
 import { IS_VISUAL_TEST_BUILD } from '@/lib/library/visual-test-fixture';
@@ -135,45 +136,14 @@ export function LibraryHub(): ReactElement {
   const [gamesQuery, setGamesQuery] = useState('');
   const [gamesView, setGamesView] = useState<GamesViewKey>('grid');
 
-  // Phase 3b #1593: AdvancedFiltersDrawer state
+  // AdvancedFiltersDrawer cross-entity hub-level state (#1585-followup Task 3.3).
+  // Refactored from scope-conditional (one filter shape per tab) to a single
+  // cross-entity `LibraryFilters` that survives tab switches — matches the
+  // mockup hub-level filter surface.
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [activeFilters, setActiveFilters] = useState<LibraryFilters>({ scope: 'game' });
+  const [activeFilters, setActiveFilters] = useState<LibraryFilters>({});
 
-  const drawerEntityScope = useMemo<HybridHubEntity>(() => {
-    switch (tab) {
-      case 'games':
-        return 'game';
-      case 'agents':
-        return 'agent';
-      case 'kb':
-        return 'kb';
-      case 'sessions':
-        return 'session';
-      case 'chat':
-        return 'chat';
-      case 'all':
-      default:
-        return 'game';
-    }
-  }, [tab]);
-
-  // Reset filters to the new scope's empty variant when the tab changes.
-  useEffect(() => {
-    setActiveFilters({ scope: drawerEntityScope } as LibraryFilters);
-  }, [drawerEntityScope]);
-
-  // Count non-empty filter fields (excluding the `scope` discriminant) for the chip badge.
-  const activeFiltersCount = useMemo(() => {
-    let count = 0;
-    for (const [key, value] of Object.entries(activeFilters)) {
-      if (key === 'scope') continue;
-      if (value === undefined || value === null) continue;
-      if (Array.isArray(value) && value.length === 0) continue;
-      if (value === false) continue;
-      count++;
-    }
-    return count;
-  }, [activeFilters]);
+  const activeFiltersCount = useMemo(() => countActiveFilters(activeFilters), [activeFilters]);
 
   const stateOverride = parseStateOverride(searchParams.get('state'));
 
@@ -604,10 +574,9 @@ export function LibraryHub(): ReactElement {
       <AdvancedFiltersDrawer
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
-        entityScope={drawerEntityScope}
         activeFilters={activeFilters}
         onApply={setActiveFilters}
-        onClear={() => setActiveFilters({ scope: drawerEntityScope } as LibraryFilters)}
+        onClear={() => setActiveFilters({})}
       />
     </div>
   );

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -184,6 +184,12 @@ const MESSAGES: Record<string, string> = {
   'pages.library.selectionMode.exitAriaLabel': 'Esci dalla modalità selezione',
   'pages.library.selectionMode.selectedCount':
     '{count, plural, =0 {Nessuno selezionato} =1 {1 selezionato} other {# selezionati}}',
+  'pages.library.bulk.counter': '{count, plural, =1 {selezionato} other {selezionati}}',
+  'pages.library.bulk.counterCompact': 'sel.',
+  'pages.library.bulk.closeAriaLabel': 'Annulla selezione',
+  'pages.library.bulk.actions.archive': 'Archivia',
+  'pages.library.bulk.actions.tag': 'Tag',
+  'pages.library.bulk.actions.export': 'Esporta',
   'pages.library.bulk.actions.delete': 'Elimina',
   'pages.library.bulk.confirm.deleteTitle':
     '{count, plural, =1 {Confermi rimozione di 1 gioco?} other {Confermi rimozione di # giochi?}}',

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -219,36 +219,61 @@ const MESSAGES: Record<string, string> = {
   'pages.library.activityRail.shortcuts.focusSearch': 'focus search',
   'pages.library.activityRail.shortcuts.advancedFilters': 'filtri avanzati',
   'pages.library.activityRail.shortcuts.allShortcuts': 'tutte le scorciatoie',
-  // ─── AdvancedFiltersDrawer header/footer keys (Phase 3a #1606) ───
-  'pages.library.filters.title': 'Più filtri',
-  'pages.library.filters.description': "Filtra la libreria per dimensioni specifiche dell'entità.",
-  'pages.library.filters.clear': 'Reimposta',
+  // ─── AdvancedFiltersDrawer cross-entity (#1585-followup Task 3.3) ───
+  'pages.library.filters.title': 'Filtri avanzati',
+  'pages.library.filters.description': 'Filtra la libreria per dimensioni cross-entity.',
+  'pages.library.filters.closeAriaLabel': 'Chiudi pannello filtri',
+  'pages.library.filters.header.subtitle':
+    '{count, plural, =0 {Nessun filtro · scope: library} =1 {1 attivo · scope: library} other {# attivi · scope: library}}',
   'pages.library.filters.apply': 'Applica',
+  'pages.library.filters.applyWithCount': 'Applica ({count})',
+  'pages.library.filters.reset': 'Reset',
+  'pages.library.filters.clear': 'Reimposta',
   'common.cancel': 'Annulla',
-  // ─── Drawer section labels — game scope ───
-  'pages.library.filters.section.state': 'Stato',
-  'pages.library.filters.section.withKb': 'Solo con Knowledge Base',
-  'pages.library.filters.section.rating': 'Rating minimo',
-  'pages.library.filters.section.players': 'Numero di giocatori',
-  'pages.library.filters.section.year': 'Anno di pubblicazione',
-  // ─── Drawer section labels — agent scope ───
-  'pages.library.filters.section.agentType': 'Tipo di agente',
-  'pages.library.filters.section.activeOnly': 'Solo attivi',
-  // ─── Drawer section labels — session scope ───
-  'pages.library.filters.section.sessionStatus': 'Stato sessione',
-  'pages.library.filters.section.sessionType': 'Tipo sessione',
-  'pages.library.filters.section.playerCount': 'Giocatori (min)',
-  // ─── Drawer section labels — kb scope ───
-  'pages.library.filters.section.processingState': 'Stato di elaborazione',
-  'pages.library.filters.kbState.ready': 'Pronto',
-  'pages.library.filters.kbState.pending': 'In elaborazione',
-  'pages.library.filters.kbState.failed': 'Errore',
-  // ─── Drawer section labels — chat scope ───
-  'pages.library.filters.section.messageCountMin': 'Messaggi (min)',
-  // ─── Drawer checkbox option labels ───
-  'pages.library.filters.state.owned': 'Posseduto',
-  'pages.library.filters.state.wishlist': 'Wishlist',
-  'pages.library.filters.state.loaned': 'In prestito',
+  // section: status
+  'pages.library.filters.section.status.title': 'Stato',
+  'pages.library.filters.section.status.options.owned': 'Posseduto',
+  'pages.library.filters.section.status.options.wishlist': 'Wishlist',
+  'pages.library.filters.section.status.options.setup': 'In setup',
+  'pages.library.filters.section.status.options.archived': 'Archiviato',
+  // section: entity
+  'pages.library.filters.section.entity.title': 'Tipo entità',
+  'pages.library.filters.section.entity.options.game': 'Giochi',
+  'pages.library.filters.section.entity.options.agent': 'Agenti',
+  'pages.library.filters.section.entity.options.kb': 'Documenti KB',
+  'pages.library.filters.section.entity.options.session': 'Sessioni',
+  'pages.library.filters.section.entity.options.chat': 'Chat',
+  // section: game (select-multi)
+  'pages.library.filters.section.game.title': 'Gioco',
+  'pages.library.filters.section.game.placeholder': 'Filtra per gioco specifico...',
+  'pages.library.filters.section.game.empty': 'Nessun gioco disponibile.',
+  // section: period
+  'pages.library.filters.section.period.title': 'Periodo',
+  'pages.library.filters.section.period.options.7d': 'Ultimi 7 giorni',
+  'pages.library.filters.section.period.options.30d': 'Ultimi 30 giorni',
+  'pages.library.filters.section.period.options.1y': 'Ultimo anno',
+  'pages.library.filters.section.period.options.all': 'Sempre',
+  'pages.library.filters.section.period.options.range': 'Range personalizzato',
+  // section: tags
+  'pages.library.filters.section.tags.title': 'Tag',
+  'pages.library.filters.section.tags.options.family': 'Family',
+  'pages.library.filters.section.tags.options.strategy': 'Strategy',
+  'pages.library.filters.section.tags.options.coop': 'Coop',
+  'pages.library.filters.section.tags.options.engine': 'Engine builder',
+  'pages.library.filters.section.tags.options.auction': 'Auction',
+  'pages.library.filters.section.tags.options.rollAndWrite': 'Roll & Write',
+  'pages.library.filters.section.tags.options.cardDriven': 'Card driven',
+  'pages.library.filters.section.tags.options.tableau': 'Tableau',
+  // section: rating
+  'pages.library.filters.section.rating.title': 'Rating',
+  'pages.library.filters.section.rating.minAriaLabel': 'Rating minimo',
+  'pages.library.filters.section.rating.maxAriaLabel': 'Rating massimo',
+  // section: weight
+  'pages.library.filters.section.weight.title': 'Complessità',
+  'pages.library.filters.section.weight.options.light': 'Light',
+  'pages.library.filters.section.weight.options.medium': 'Medium',
+  'pages.library.filters.section.weight.options.heavy': 'Heavy',
+  'pages.library.filters.section.weight.options.extra': 'Extra heavy',
   // ─── gamesTab i18n keys (#1566) ───
   'pages.library.gamesTab.filters.search.placeholder': 'Cerca per titolo…',
   'pages.library.gamesTab.filters.search.ariaLabel': 'Cerca giochi nella tua libreria',

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/AdvancedFiltersDrawer.tsx
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/AdvancedFiltersDrawer.tsx
@@ -1,363 +1,709 @@
 /**
- * AdvancedFiltersDrawer (Phase 3a #1606).
+ * AdvancedFiltersDrawer.
  *
- * Standalone reusable component that composes the existing `Drawer` primitive
- * with entity-conditional filter sections derived from `entityScope`. Owns its
- * own draft state internally; parent only observes via `onApply` / `onClear`
- * callbacks.
+ * SP4 mockup conformance (Issue #1585-followup, plan
+ * docs/superpowers/plans/2026-06-03-library-sp4-mockup-conformance.md Task 3.3).
+ * Mapped from `admin-mockups/design_files/sp4-library-desktop.jsx`
+ * (AdvancedFiltersDrawer + DrawerSection, lines 312–637).
+ *
+ * REFACTORED from scope-conditional (5 entity variants × per-scope sections)
+ * to **cross-entity hub-level** drawer with the static 7-section descriptor
+ * from `DRAWER_SECTIONS`. The drawer no longer requires `entityScope`; one
+ * unified `LibraryFilters` shape powers the draft state.
+ *
+ * Structure:
+ *  - Custom header (icon box + title + active-count subtitle + close ✕)
+ *  - Scrollable body with 7 `DrawerSection` accordion panels
+ *    (chips-multi / select-multi / period-quick / range kinds)
+ *  - Footer with Reset (transparent) + Applica (entity-agent primary, count)
+ *
+ * Built atop the shared `Drawer` primitive so Radix/Vaul mobile-bottom vs
+ * desktop-right is handled for a11y + focus trap + Esc + backdrop, but the
+ * inner markup is fully bespoke to match the mockup verbatim.
  */
 
 'use client';
 
-import { useEffect, useState, type ReactElement } from 'react';
-
 import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from '@/components/ui/drawer';
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactElement,
+  type SetStateAction,
+} from 'react';
+
+import clsx from 'clsx';
+
+import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/components/ui/drawer';
 import { useTranslation } from '@/hooks/useTranslation';
 
 import {
-  getSectionsForScope,
-  type CheckboxGroupSection,
+  DRAWER_SECTIONS,
+  isDefaultOpen,
+  type ChipOption,
+  type ChipsMultiSection,
+  type EntityColorSlug,
+  type PeriodQuickSection,
   type RangeSection,
   type SectionConfig,
-  type SliderSection,
-  type ToggleSection,
+  type SelectMultiSection,
 } from './sections';
+import { countActiveFilters, type AdvancedFiltersDrawerProps, type LibraryFilters } from './types';
 
-import type { AdvancedFiltersDrawerProps, LibraryFilters } from './types';
+type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
 export function AdvancedFiltersDrawer({
   open,
   onOpenChange,
-  entityScope,
   activeFilters,
+  availableGames,
   onApply,
   onClear,
 }: AdvancedFiltersDrawerProps): ReactElement {
   const { t } = useTranslation();
   const [draft, setDraft] = useState<LibraryFilters>(activeFilters);
+
   useEffect(() => {
     if (open) setDraft(activeFilters);
   }, [open, activeFilters]);
-
-  const handleCancel = () => {
-    setDraft(activeFilters);
-    onOpenChange(false);
-  };
 
   const handleApply = () => {
     onApply(draft);
     onOpenChange(false);
   };
 
-  const handleClear = () => {
-    // All filter fields are optional; an object carrying only the `scope`
-    // discriminant is a valid member of every LibraryFilters variant, so the
-    // cast is safe (it just selects the variant by the runtime scope value).
-    const empty = { scope: entityScope } as LibraryFilters;
-    setDraft(empty);
+  const handleReset = () => {
+    setDraft({});
     onClear();
   };
 
-  const sections = getSectionsForScope(entityScope);
+  const handleClose = () => {
+    setDraft(activeFilters);
+    onOpenChange(false);
+  };
+
+  const activeCount = useMemo(() => countActiveFilters(draft), [draft]);
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange} entity={entityScope}>
-      <DrawerContent data-slot="advanced-filters-drawer">
-        <DrawerHeader>
-          <DrawerTitle>{t('pages.library.filters.title')}</DrawerTitle>
-          <DrawerDescription>{t('pages.library.filters.description')}</DrawerDescription>
-        </DrawerHeader>
+    <Drawer open={open} onOpenChange={onOpenChange} entity="agent" direction="right">
+      <DrawerContent
+        data-slot="advanced-filters-drawer"
+        className="flex h-full max-h-screen w-full max-w-[400px] flex-col gap-0 bg-background p-0 shadow-[-12px_0_40px_rgba(0,0,0,0.18)]"
+      >
+        <DrawerTitle className="sr-only">{t('pages.library.filters.title')}</DrawerTitle>
+        <DrawerDescription className="sr-only">
+          {t('pages.library.filters.description')}
+        </DrawerDescription>
 
-        <div className="flex flex-col gap-4 px-4 pb-4" data-slot="advanced-filters-sections">
-          {sections.map(section => (
-            <SectionRenderer
+        <DrawerHeader t={t} activeCount={activeCount} onClose={handleClose} />
+
+        <div className="flex-1 overflow-y-auto" data-slot="advanced-filters-sections">
+          {DRAWER_SECTIONS.map((section, index) => (
+            <DrawerSectionRenderer
               key={section.key}
               section={section}
               draft={draft}
-              onChange={setDraft}
+              setDraft={setDraft}
+              availableGames={availableGames}
+              defaultOpen={isDefaultOpen(index)}
               t={t}
             />
           ))}
         </div>
 
-        <DrawerFooter>
-          <button
-            type="button"
-            data-slot="advanced-filters-cancel"
-            onClick={handleCancel}
-            className="rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted/40"
-          >
-            {t('common.cancel')}
-          </button>
-          <button
-            type="button"
-            data-slot="advanced-filters-clear"
-            onClick={handleClear}
-            className="rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted/40"
-          >
-            {t('pages.library.filters.clear')}
-          </button>
-          <button
-            type="button"
-            data-slot="advanced-filters-apply"
-            onClick={handleApply}
-            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            {t('pages.library.filters.apply')}
-          </button>
-        </DrawerFooter>
+        <DrawerFooterBar
+          t={t}
+          activeCount={activeCount}
+          onReset={handleReset}
+          onApply={handleApply}
+        />
       </DrawerContent>
     </Drawer>
   );
 }
 
-// ─── Section renderer ────────────────────────────────────────────────────────
+// ─── Header ───────────────────────────────────────────────────────────────────
 
-type TranslateFn = ReturnType<typeof useTranslation>['t'];
+function DrawerHeader({
+  t,
+  activeCount,
+  onClose,
+}: {
+  t: TranslateFn;
+  activeCount: number;
+  onClose: () => void;
+}): ReactElement {
+  return (
+    <header
+      data-slot="advanced-filters-header"
+      className="flex items-center gap-2.5 border-b border-border px-4 py-3.5"
+    >
+      <span
+        aria-hidden="true"
+        className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-entity-agent/[0.12] text-sm text-entity-agent"
+      >
+        ⚙
+      </span>
+      <div className="flex flex-1 flex-col gap-px">
+        <span className="font-display text-sm font-extrabold text-foreground">
+          {t('pages.library.filters.title')}
+        </span>
+        <span
+          data-slot="advanced-filters-active-count"
+          className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-muted-foreground"
+        >
+          {t('pages.library.filters.header.subtitle', { count: activeCount })}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        data-slot="advanced-filters-close"
+        aria-label={t('pages.library.filters.closeAriaLabel')}
+        className="inline-flex h-[30px] w-[30px] flex-shrink-0 items-center justify-center rounded-md border-0 bg-muted text-sm text-foreground hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+    </header>
+  );
+}
 
-interface SectionRendererProps {
+// ─── Footer ───────────────────────────────────────────────────────────────────
+
+function DrawerFooterBar({
+  t,
+  activeCount,
+  onReset,
+  onApply,
+}: {
+  t: TranslateFn;
+  activeCount: number;
+  onReset: () => void;
+  onApply: () => void;
+}): ReactElement {
+  return (
+    <footer
+      data-slot="advanced-filters-footer"
+      className="flex flex-shrink-0 items-center gap-2 border-t border-border bg-card px-4 py-3"
+    >
+      <button
+        type="button"
+        onClick={onReset}
+        data-slot="advanced-filters-reset"
+        className="inline-flex items-center justify-center rounded-md border border-border-strong bg-transparent px-3.5 py-2 font-display text-[12.5px] font-bold text-muted-foreground hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        {t('pages.library.filters.reset')}
+      </button>
+      <button
+        type="button"
+        onClick={onApply}
+        data-slot="advanced-filters-apply"
+        className="inline-flex flex-1 items-center justify-center rounded-md border-0 bg-entity-agent px-3.5 py-2 font-display text-[12.5px] font-extrabold text-white shadow-[0_3px_10px_hsl(var(--c-agent)/0.35)] hover:bg-entity-agent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        {activeCount > 0
+          ? t('pages.library.filters.applyWithCount', { count: activeCount })
+          : t('pages.library.filters.apply')}
+      </button>
+    </footer>
+  );
+}
+
+// ─── Section renderer (accordion wrapper) ─────────────────────────────────────
+
+interface DrawerSectionRendererProps {
   readonly section: SectionConfig;
   readonly draft: LibraryFilters;
-  readonly onChange: (next: LibraryFilters) => void;
+  readonly setDraft: Dispatch<SetStateAction<LibraryFilters>>;
+  readonly availableGames: AdvancedFiltersDrawerProps['availableGames'];
+  readonly defaultOpen: boolean;
   readonly t: TranslateFn;
 }
 
-function SectionRenderer({ section, draft, onChange, t }: SectionRendererProps): ReactElement {
+function DrawerSectionRenderer({
+  section,
+  draft,
+  setDraft,
+  availableGames,
+  defaultOpen,
+  t,
+}: DrawerSectionRendererProps): ReactElement {
+  const [open, setOpen] = useState(defaultOpen);
+  const fillCount = countSectionFill(section, draft);
+
+  return (
+    <div
+      data-slot={`advanced-filters-section-${section.key}`}
+      data-testid={`advanced-filters-section-${section.key}`}
+      className="border-b border-border/60"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        aria-expanded={open}
+        aria-controls={`advanced-filters-section-body-${section.key}`}
+        data-slot={`advanced-filters-section-toggle-${section.key}`}
+        className="flex w-full items-center gap-2.5 border-0 bg-transparent px-[18px] py-3.5 text-left text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/60"
+      >
+        <span aria-hidden="true" className="text-[13px] text-muted-foreground">
+          {section.icon}
+        </span>
+        <span className="flex-1 font-display text-[13.5px] font-extrabold">
+          {t(section.i18nLabel)}
+        </span>
+        {fillCount > 0 ? (
+          <span
+            data-slot={`advanced-filters-section-count-${section.key}`}
+            className="rounded-full bg-entity-agent px-1.5 py-px font-mono text-[9px] font-extrabold text-white"
+          >
+            {fillCount}
+          </span>
+        ) : null}
+        <span
+          aria-hidden="true"
+          className={clsx(
+            'inline-block text-sm text-muted-foreground transition-transform duration-150',
+            open ? 'rotate-90' : 'rotate-0'
+          )}
+        >
+          ›
+        </span>
+      </button>
+      {open ? (
+        <div id={`advanced-filters-section-body-${section.key}`} className="px-[18px] pb-4">
+          <SectionBody
+            section={section}
+            draft={draft}
+            setDraft={setDraft}
+            availableGames={availableGames}
+            t={t}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ─── Kind-specific bodies ─────────────────────────────────────────────────────
+
+interface SectionBodyProps {
+  readonly section: SectionConfig;
+  readonly draft: LibraryFilters;
+  readonly setDraft: Dispatch<SetStateAction<LibraryFilters>>;
+  readonly availableGames: AdvancedFiltersDrawerProps['availableGames'];
+  readonly t: TranslateFn;
+}
+
+function SectionBody({
+  section,
+  draft,
+  setDraft,
+  availableGames,
+  t,
+}: SectionBodyProps): ReactElement {
   switch (section.kind) {
-    case 'checkbox-group':
-      return <CheckboxGroupRenderer section={section} draft={draft} onChange={onChange} t={t} />;
-    case 'toggle':
-      return <ToggleRenderer section={section} draft={draft} onChange={onChange} t={t} />;
-    case 'slider':
-      return <SliderRenderer section={section} draft={draft} onChange={onChange} t={t} />;
+    case 'chips-multi':
+      return <ChipsMultiBody section={section} draft={draft} setDraft={setDraft} t={t} />;
+    case 'select-multi':
+      return (
+        <SelectMultiBody
+          section={section}
+          draft={draft}
+          setDraft={setDraft}
+          availableGames={availableGames}
+          t={t}
+        />
+      );
+    case 'period-quick':
+      return <PeriodQuickBody section={section} draft={draft} setDraft={setDraft} t={t} />;
     case 'range':
-      return <RangeRenderer section={section} draft={draft} onChange={onChange} t={t} />;
+      return <RangeBody section={section} draft={draft} setDraft={setDraft} t={t} />;
   }
 }
 
-function CheckboxGroupRenderer({
+// ─── chips-multi ───
+function ChipsMultiBody({
   section,
   draft,
-  onChange,
+  setDraft,
   t,
 }: {
-  section: CheckboxGroupSection;
+  section: ChipsMultiSection;
   draft: LibraryFilters;
-  onChange: (next: LibraryFilters) => void;
+  setDraft: Dispatch<SetStateAction<LibraryFilters>>;
   t: TranslateFn;
 }): ReactElement {
-  const draftValues = readArrayField(draft, section.key);
+  const values = readStringArray(draft, section.key);
+
   const toggle = (val: string) => {
-    const next = draftValues.includes(val)
-      ? draftValues.filter(v => v !== val)
-      : [...draftValues, val];
-    onChange(writeArrayField(draft, section.key, next));
+    setDraft(current => {
+      const currentValues = readStringArray(current, section.key);
+      const next = currentValues.includes(val)
+        ? currentValues.filter(v => v !== val)
+        : [...currentValues, val];
+      return writeField(current, section.key, next.length > 0 ? next : undefined);
+    });
   };
-  return (
-    <div
-      data-slot={`advanced-filters-section-${section.key}`}
-      data-testid={`advanced-filters-section-${section.key}`}
-      className="flex flex-col gap-2"
-    >
-      <span className="text-sm font-medium text-foreground">{t(section.i18nLabel)}</span>
-      <div className="flex flex-wrap gap-2">
-        {section.options.map(opt => (
-          <label key={opt.value} className="inline-flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={draftValues.includes(opt.value)}
-              onChange={() => toggle(opt.value)}
-              aria-label={t(opt.i18nKey)}
-              className="h-4 w-4 rounded border-border"
-            />
-            <span>{t(opt.i18nKey)}</span>
-          </label>
-        ))}
-      </div>
-    </div>
-  );
-}
 
-function ToggleRenderer({
-  section,
-  draft,
-  onChange,
-  t,
-}: {
-  section: ToggleSection;
-  draft: LibraryFilters;
-  onChange: (next: LibraryFilters) => void;
-  t: TranslateFn;
-}): ReactElement {
-  const checked = Boolean(readScalarField(draft, section.key));
   return (
-    <div
-      data-slot={`advanced-filters-section-${section.key}`}
-      data-testid={`advanced-filters-section-${section.key}`}
-      className="flex items-center justify-between"
-    >
-      <span className="text-sm font-medium text-foreground">{t(section.i18nLabel)}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        aria-label={t(section.i18nLabel)}
-        onClick={() => onChange(writeScalarField(draft, section.key, !checked))}
-        className={`relative h-6 w-11 rounded-full transition-colors ${checked ? 'bg-primary' : 'bg-muted'}`}
-      >
-        <span
-          aria-hidden="true"
-          className={`absolute top-0.5 h-5 w-5 rounded-full bg-card transition-transform ${checked ? 'translate-x-5' : 'translate-x-0.5'}`}
+    <div data-slot={`advanced-filters-chips-${section.key}`} className="flex flex-wrap gap-1.5">
+      {section.options.map(option => (
+        <ChipsMultiOption
+          key={option.value}
+          option={option}
+          active={values.includes(option.value)}
+          onToggle={() => toggle(option.value)}
+          label={t(option.i18nKey)}
         />
-      </button>
+      ))}
     </div>
   );
 }
 
-function SliderRenderer({
+function ChipsMultiOption({
+  option,
+  active,
+  onToggle,
+  label,
+}: {
+  option: ChipOption;
+  active: boolean;
+  onToggle: () => void;
+  label: string;
+}): ReactElement {
+  const color: EntityColorSlug = option.color ?? 'game';
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      data-slot={`advanced-filters-chip-${option.value}`}
+      className={clsx(
+        'inline-flex flex-shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1.5 font-display text-[11.5px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+        active
+          ? `${entityBgActiveClass(color)} ${entityBorderActiveClass(color)} ${entityTextClass(color)}`
+          : 'border-border bg-card text-muted-foreground hover:bg-muted/30'
+      )}
+    >
+      {option.icon ? <span aria-hidden="true">{option.icon}</span> : null}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+// ─── select-multi ───
+function SelectMultiBody({
   section,
   draft,
-  onChange,
+  setDraft,
+  availableGames,
   t,
 }: {
-  section: SliderSection;
+  section: SelectMultiSection;
   draft: LibraryFilters;
-  onChange: (next: LibraryFilters) => void;
+  setDraft: Dispatch<SetStateAction<LibraryFilters>>;
+  availableGames: AdvancedFiltersDrawerProps['availableGames'];
   t: TranslateFn;
 }): ReactElement {
-  const fieldKey = sliderFieldKey(section.key);
-  const value = readNumberField(draft, fieldKey) ?? section.min;
+  const values = readStringArray(draft, section.key);
+
+  const toggle = (id: string) => {
+    setDraft(current => {
+      const currentValues = readStringArray(current, section.key);
+      const next = currentValues.includes(id)
+        ? currentValues.filter(v => v !== id)
+        : [...currentValues, id];
+      return writeField(current, section.key, next.length > 0 ? next : undefined);
+    });
+  };
+
+  const visibleOptions = (availableGames ?? []).slice(0, 5);
+
   return (
-    <div
-      data-slot={`advanced-filters-section-${section.key}`}
-      data-testid={`advanced-filters-section-${section.key}`}
-      className="flex flex-col gap-2"
-    >
-      <span className="text-sm font-medium text-foreground">
-        {t(section.i18nLabel)} <span className="text-muted-foreground">({value})</span>
-      </span>
-      <input
-        type="range"
-        role="slider"
-        aria-label={t(section.i18nLabel)}
-        aria-valuemin={section.min}
-        aria-valuemax={section.max}
-        aria-valuenow={value}
-        min={section.min}
-        max={section.max}
-        step={section.step}
-        value={value}
-        onChange={e => onChange(writeNumberField(draft, fieldKey, Number(e.target.value)))}
-        className="w-full"
-      />
+    <div data-slot={`advanced-filters-select-multi-${section.key}`} className="flex flex-col gap-2">
+      <div
+        data-slot={`advanced-filters-select-multi-placeholder-${section.key}`}
+        className="rounded-md border border-border bg-card px-2.5 py-2 font-body text-xs text-muted-foreground"
+      >
+        {t(section.i18nPlaceholder)}
+      </div>
+      {visibleOptions.length === 0 ? (
+        <div
+          data-slot={`advanced-filters-select-multi-empty-${section.key}`}
+          className="rounded-md bg-muted/30 px-2.5 py-2 font-body text-xs italic text-muted-foreground"
+        >
+          {t('pages.library.filters.section.game.empty')}
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {visibleOptions.map(option => {
+            const active = values.includes(option.id);
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => toggle(option.id)}
+                aria-pressed={active}
+                data-slot={`advanced-filters-select-multi-option-${section.key}-${option.id}`}
+                className={clsx(
+                  'inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2 py-1 font-mono text-[10.5px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+                  active
+                    ? 'border-entity-game/40 bg-entity-game/[0.12] text-entity-game'
+                    : 'border-transparent bg-muted text-muted-foreground hover:bg-muted/80'
+                )}
+              >
+                {active ? <span aria-hidden="true">✓</span> : null}
+                <span>{option.title}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
 
-function RangeRenderer({
+// ─── period-quick ───
+function PeriodQuickBody({
   section,
   draft,
-  onChange,
+  setDraft,
+  t,
+}: {
+  section: PeriodQuickSection;
+  draft: LibraryFilters;
+  setDraft: Dispatch<SetStateAction<LibraryFilters>>;
+  t: TranslateFn;
+}): ReactElement {
+  const value = readScalar(draft, section.key);
+
+  const select = (val: string) => {
+    setDraft(current => writeField(current, section.key, val));
+  };
+
+  return (
+    <div
+      data-slot={`advanced-filters-period-${section.key}`}
+      role="radiogroup"
+      aria-label={t(section.i18nLabel)}
+      className="flex flex-col gap-1"
+    >
+      {section.options.map(option => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => select(option.value)}
+            data-slot={`advanced-filters-period-option-${option.value}`}
+            className={clsx(
+              'flex items-center gap-2 rounded-md border-0 px-2.5 py-1.5 text-left font-display text-[12.5px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+              active
+                ? 'bg-entity-event/[0.12] font-extrabold text-entity-event'
+                : 'bg-transparent font-semibold text-muted-foreground hover:bg-muted/30'
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className={clsx(
+                'inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full',
+                active ? 'border-[3px] border-entity-event' : 'border-[1.5px] border-border-strong'
+              )}
+            />
+            <span>{t(option.i18nKey)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── range ───
+function RangeBody({
+  section,
+  draft,
+  setDraft,
   t,
 }: {
   section: RangeSection;
   draft: LibraryFilters;
-  onChange: (next: LibraryFilters) => void;
+  setDraft: Dispatch<SetStateAction<LibraryFilters>>;
   t: TranslateFn;
 }): ReactElement {
-  const [minField, maxField] = rangeFieldKeys(section.key);
-  const minVal = readNumberField(draft, minField) ?? section.min;
-  const maxVal = readNumberField(draft, maxField) ?? section.max;
+  const lo = readNumber(draft, section.minField) ?? section.defaultLo;
+  const hi = readNumber(draft, section.maxField) ?? section.defaultHi;
+  const total = section.max - section.min;
+  const loPct = ((lo - section.min) / total) * 100;
+  const hiPct = ((hi - section.min) / total) * 100;
+
+  const setLo = (v: number) => {
+    setDraft(current => writeField(current, section.minField, Math.min(v, hi)));
+  };
+  const setHi = (v: number) => {
+    setDraft(current => writeField(current, section.maxField, Math.max(v, lo)));
+  };
+
   return (
-    <div
-      data-slot={`advanced-filters-section-${section.key}`}
-      data-testid={`advanced-filters-section-${section.key}`}
-      className="flex flex-col gap-2"
-    >
-      <span className="text-sm font-medium text-foreground">
-        {t(section.i18nLabel)}{' '}
-        <span className="text-muted-foreground">
-          ({minVal}–{maxVal})
+    <div data-slot={`advanced-filters-range-${section.key}`} className="flex flex-col gap-2">
+      <div
+        className="flex justify-between font-mono text-[11px] font-bold"
+        data-slot={`advanced-filters-range-readout-${section.key}`}
+      >
+        <span className="text-entity-event">{formatRangeValue(lo, section.step)}</span>
+        <span className="text-muted-foreground" aria-hidden="true">
+          —
         </span>
-      </span>
-      <div className="grid grid-cols-2 gap-2">
-        <input
-          type="number"
-          aria-label={`${t(section.i18nLabel)} min`}
-          min={section.min}
-          max={section.max}
-          step={section.step}
-          value={minVal}
-          onChange={e => onChange(writeNumberField(draft, minField, Number(e.target.value)))}
-          className="rounded border border-border bg-background px-2 py-1 text-sm"
+        <span className="text-entity-event">{formatRangeValue(hi, section.step)}</span>
+      </div>
+      <div className="relative h-6">
+        <div
+          aria-hidden="true"
+          className="absolute left-0 right-0 top-[11px] h-1 rounded-sm bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute top-[11px] h-1 rounded-sm bg-entity-event"
+          style={{ left: `${loPct}%`, right: `${100 - hiPct}%` }}
         />
         <input
-          type="number"
-          aria-label={`${t(section.i18nLabel)} max`}
+          type="range"
           min={section.min}
           max={section.max}
           step={section.step}
-          value={maxVal}
-          onChange={e => onChange(writeNumberField(draft, maxField, Number(e.target.value)))}
-          className="rounded border border-border bg-background px-2 py-1 text-sm"
+          value={lo}
+          onChange={e => setLo(Number(e.target.value))}
+          aria-label={t('pages.library.filters.section.rating.minAriaLabel')}
+          className="absolute inset-x-0 top-0 h-6 w-full appearance-none bg-transparent [&::-webkit-slider-thumb]:pointer-events-auto"
+          data-slot={`advanced-filters-range-min-${section.key}`}
+        />
+        <input
+          type="range"
+          min={section.min}
+          max={section.max}
+          step={section.step}
+          value={hi}
+          onChange={e => setHi(Number(e.target.value))}
+          aria-label={t('pages.library.filters.section.rating.maxAriaLabel')}
+          className="absolute inset-x-0 top-0 h-6 w-full appearance-none bg-transparent [&::-webkit-slider-thumb]:pointer-events-auto"
+          data-slot={`advanced-filters-range-max-${section.key}`}
         />
       </div>
     </div>
   );
 }
 
-// ─── Field helpers (scope-aware read/write into LibraryFilters union) ───────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function readArrayField(draft: LibraryFilters, key: string): ReadonlyArray<string> {
+function readStringArray(draft: LibraryFilters, key: string): ReadonlyArray<string> {
   const rec = draft as unknown as Record<string, unknown>;
   const v = rec[key];
   return Array.isArray(v) ? (v as ReadonlyArray<string>) : [];
 }
 
-function writeArrayField(
-  draft: LibraryFilters,
-  key: string,
-  value: ReadonlyArray<string>
-): LibraryFilters {
-  const merged = { ...(draft as unknown as Record<string, unknown>), [key]: value };
-  return merged as unknown as LibraryFilters;
-}
-
-function readScalarField(draft: LibraryFilters, key: string): unknown {
+function readScalar(draft: LibraryFilters, key: string): unknown {
   return (draft as unknown as Record<string, unknown>)[key];
 }
 
-function writeScalarField(draft: LibraryFilters, key: string, value: unknown): LibraryFilters {
-  const merged = { ...(draft as unknown as Record<string, unknown>), [key]: value };
-  return merged as unknown as LibraryFilters;
-}
-
-function readNumberField(draft: LibraryFilters, key: string): number | undefined {
+function readNumber(draft: LibraryFilters, key: string): number | undefined {
   const v = (draft as unknown as Record<string, unknown>)[key];
   return typeof v === 'number' ? v : undefined;
 }
 
-function writeNumberField(draft: LibraryFilters, key: string, value: number): LibraryFilters {
-  const merged = { ...(draft as unknown as Record<string, unknown>), [key]: value };
-  return merged as unknown as LibraryFilters;
+function writeField(draft: LibraryFilters, key: string, value: unknown): LibraryFilters {
+  const next = { ...(draft as unknown as Record<string, unknown>) };
+  if (value === undefined) {
+    delete next[key];
+  } else {
+    next[key] = value;
+  }
+  return next as unknown as LibraryFilters;
 }
 
-function sliderFieldKey(sectionKey: string): string {
-  if (sectionKey === 'rating') return 'ratingMin';
-  if (sectionKey === 'playerCount') return 'playerCountMin';
-  if (sectionKey === 'messageCountMin') return 'messageCountMin';
-  return sectionKey;
+function countSectionFill(section: SectionConfig, draft: LibraryFilters): number {
+  switch (section.kind) {
+    case 'chips-multi':
+    case 'select-multi':
+      return readStringArray(draft, section.key).length;
+    case 'period-quick': {
+      const v = readScalar(draft, section.key);
+      return typeof v === 'string' && v.length > 0 ? 1 : 0;
+    }
+    case 'range': {
+      const lo = readNumber(draft, section.minField);
+      const hi = readNumber(draft, section.maxField);
+      return (lo !== undefined ? 1 : 0) + (hi !== undefined ? 1 : 0);
+    }
+  }
 }
 
-function rangeFieldKeys(sectionKey: string): readonly [string, string] {
-  if (sectionKey === 'players') return ['playersMin', 'playersMax'];
-  if (sectionKey === 'year') return ['yearMin', 'yearMax'];
-  return [`${sectionKey}Min`, `${sectionKey}Max`];
+function formatRangeValue(value: number, step: number): string {
+  return step >= 1 ? String(Math.round(value)) : value.toFixed(1);
+}
+
+// Entity color → Tailwind utility classes. Compile-time exhaustive map so the
+// Tailwind compiler can statically extract the variants (no dynamic-string
+// class generation, which would not be tree-shaken).
+function entityBgActiveClass(color: EntityColorSlug): string {
+  switch (color) {
+    case 'game':
+      return 'bg-entity-game/[0.14]';
+    case 'agent':
+      return 'bg-entity-agent/[0.14]';
+    case 'kb':
+      return 'bg-entity-kb/[0.14]';
+    case 'session':
+      return 'bg-entity-session/[0.14]';
+    case 'chat':
+      return 'bg-entity-chat/[0.14]';
+    case 'event':
+      return 'bg-entity-event/[0.14]';
+    case 'toolkit':
+      return 'bg-entity-toolkit/[0.14]';
+    case 'player':
+      return 'bg-entity-player/[0.14]';
+  }
+}
+
+function entityBorderActiveClass(color: EntityColorSlug): string {
+  switch (color) {
+    case 'game':
+      return 'border-entity-game/40';
+    case 'agent':
+      return 'border-entity-agent/40';
+    case 'kb':
+      return 'border-entity-kb/40';
+    case 'session':
+      return 'border-entity-session/40';
+    case 'chat':
+      return 'border-entity-chat/40';
+    case 'event':
+      return 'border-entity-event/40';
+    case 'toolkit':
+      return 'border-entity-toolkit/40';
+    case 'player':
+      return 'border-entity-player/40';
+  }
+}
+
+function entityTextClass(color: EntityColorSlug): string {
+  switch (color) {
+    case 'game':
+      return 'text-entity-game';
+    case 'agent':
+      return 'text-entity-agent';
+    case 'kb':
+      return 'text-entity-kb';
+    case 'session':
+      return 'text-entity-session';
+    case 'chat':
+      return 'text-entity-chat';
+    case 'event':
+      return 'text-entity-event';
+    case 'toolkit':
+      return 'text-entity-toolkit';
+    case 'player':
+      return 'text-entity-player';
+  }
 }

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/AdvancedFiltersDrawer.test.tsx
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/AdvancedFiltersDrawer.test.tsx
@@ -1,60 +1,83 @@
 /**
- * AdvancedFiltersDrawer — skeleton tests (Phase 3a #1606).
+ * AdvancedFiltersDrawer — cross-entity hub-level tests.
  *
- * Tests: open/close behaviour + Cancel button.
- * No filter section assertions here — those are Tasks 4-6.
+ * SP4 mockup conformance (Issue #1585-followup, plan Task 3.3). Drawer is
+ * no longer scope-conditional; one static 7-section descriptor drives every
+ * tab. Tests assert open/close lifecycle, section rendering, kind-specific
+ * interaction patterns, count subtitle / footer wiring, and a11y basics.
  *
  * Setup notes:
  * - IntlProvider wraps every render so useTranslation (react-intl) works.
  * - installMatchMedia(true) forces desktop (Radix Dialog) mode so
  *   getByRole('dialog') resolves synchronously; otherwise vaul renders
  *   a bottom sheet which exposes no dialog role in jsdom.
- * - The Cancel button is a plain <button> inside DrawerFooter (NOT
- *   DrawerClose) so it can call handleCancel (reset draft + close) in
- *   Task 7 without relying on Radix close semantics.
  */
 
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from 'jest-axe';
 import { IntlProvider } from 'react-intl';
 
 import { AdvancedFiltersDrawer } from '../AdvancedFiltersDrawer';
-import type { LibraryFilters } from '../types';
+import { countActiveFilters, type LibraryFilters } from '../types';
 
-// ── i18n messages needed by the skeleton + game scope tests ──────────────────
+// ── i18n messages used by the drawer (cross-entity) ─────────────────────────
 const messages: Record<string, string> = {
-  'pages.library.filters.title': 'Più filtri',
-  'pages.library.filters.description': "Filtra la libreria per dimensioni specifiche dell'entità.",
-  'common.cancel': 'Annulla',
+  // header
+  'pages.library.filters.title': 'Filtri avanzati',
+  'pages.library.filters.description': 'Filtra la libreria per dimensioni cross-entity.',
+  'pages.library.filters.closeAriaLabel': 'Chiudi pannello filtri',
+  'pages.library.filters.header.subtitle':
+    '{count, plural, =0 {Nessun filtro · scope: library} =1 {1 attivo · scope: library} other {# attivi · scope: library}}',
+  // footer
   'pages.library.filters.apply': 'Applica',
-  'pages.library.filters.clear': 'Reimposta',
-  // section labels (game scope)
-  'pages.library.filters.section.state': 'Stato',
-  'pages.library.filters.section.withKb': 'Solo con Knowledge Base',
-  'pages.library.filters.section.rating': 'Rating minimo',
-  'pages.library.filters.section.players': 'Numero di giocatori',
-  'pages.library.filters.section.year': 'Anno di pubblicazione',
-  // section labels (agent scope)
-  'pages.library.filters.section.agentType': 'Tipo di agente',
-  'pages.library.filters.section.activeOnly': 'Solo attivi',
-  // section labels (session scope)
-  'pages.library.filters.section.sessionStatus': 'Stato sessione',
-  'pages.library.filters.section.sessionType': 'Tipo sessione',
-  'pages.library.filters.section.playerCount': 'Giocatori (min)',
-  // section labels (kb scope)
-  'pages.library.filters.section.processingState': 'Stato di elaborazione',
-  'pages.library.filters.kbState.ready': 'Pronto',
-  'pages.library.filters.kbState.pending': 'In elaborazione',
-  'pages.library.filters.kbState.failed': 'Errore',
-  // section labels (chat scope)
-  'pages.library.filters.section.messageCountMin': 'Messaggi (min)',
-  // checkbox option labels
-  'pages.library.filters.state.owned': 'Posseduto',
-  'pages.library.filters.state.wishlist': 'Wishlist',
-  'pages.library.filters.state.loaned': 'In prestito',
+  'pages.library.filters.applyWithCount': 'Applica ({count})',
+  'pages.library.filters.reset': 'Reset',
+  // section: status
+  'pages.library.filters.section.status.title': 'Stato',
+  'pages.library.filters.section.status.options.owned': 'Posseduto',
+  'pages.library.filters.section.status.options.wishlist': 'Wishlist',
+  'pages.library.filters.section.status.options.setup': 'In setup',
+  'pages.library.filters.section.status.options.archived': 'Archiviato',
+  // section: entity
+  'pages.library.filters.section.entity.title': 'Tipo entità',
+  'pages.library.filters.section.entity.options.game': 'Giochi',
+  'pages.library.filters.section.entity.options.agent': 'Agenti',
+  'pages.library.filters.section.entity.options.kb': 'Documenti KB',
+  'pages.library.filters.section.entity.options.session': 'Sessioni',
+  'pages.library.filters.section.entity.options.chat': 'Chat',
+  // section: game (select-multi)
+  'pages.library.filters.section.game.title': 'Gioco',
+  'pages.library.filters.section.game.placeholder': 'Filtra per gioco specifico...',
+  'pages.library.filters.section.game.empty': 'Nessun gioco disponibile.',
+  // section: period
+  'pages.library.filters.section.period.title': 'Periodo',
+  'pages.library.filters.section.period.options.7d': 'Ultimi 7 giorni',
+  'pages.library.filters.section.period.options.30d': 'Ultimi 30 giorni',
+  'pages.library.filters.section.period.options.1y': 'Ultimo anno',
+  'pages.library.filters.section.period.options.all': 'Sempre',
+  'pages.library.filters.section.period.options.range': 'Range personalizzato',
+  // section: tags
+  'pages.library.filters.section.tags.title': 'Tag',
+  'pages.library.filters.section.tags.options.family': 'Family',
+  'pages.library.filters.section.tags.options.strategy': 'Strategy',
+  'pages.library.filters.section.tags.options.coop': 'Coop',
+  'pages.library.filters.section.tags.options.engine': 'Engine builder',
+  'pages.library.filters.section.tags.options.auction': 'Auction',
+  'pages.library.filters.section.tags.options.rollAndWrite': 'Roll & Write',
+  'pages.library.filters.section.tags.options.cardDriven': 'Card driven',
+  'pages.library.filters.section.tags.options.tableau': 'Tableau',
+  // section: rating
+  'pages.library.filters.section.rating.title': 'Rating',
+  'pages.library.filters.section.rating.minAriaLabel': 'Rating minimo',
+  'pages.library.filters.section.rating.maxAriaLabel': 'Rating massimo',
+  // section: weight
+  'pages.library.filters.section.weight.title': 'Complessità',
+  'pages.library.filters.section.weight.options.light': 'Light',
+  'pages.library.filters.section.weight.options.medium': 'Medium',
+  'pages.library.filters.section.weight.options.heavy': 'Heavy',
+  'pages.library.filters.section.weight.options.extra': 'Extra heavy',
 };
 
 function renderWithIntl(ui: React.ReactElement) {
@@ -65,7 +88,7 @@ function renderWithIntl(ui: React.ReactElement) {
   );
 }
 
-// ── matchMedia mock — force desktop (Radix Dialog) mode ──────────────────────
+// ── matchMedia mock — force desktop (Radix Dialog) mode ─────────────────────
 function installMatchMedia(matches: boolean) {
   const listeners = new Set<(e: MediaQueryListEvent) => void>();
   const mql = {
@@ -82,28 +105,20 @@ function installMatchMedia(matches: boolean) {
   });
 }
 
-// ── fixture ───────────────────────────────────────────────────────────────────
 const noop = () => {};
-const emptyGameFilters: LibraryFilters = { scope: 'game' };
+const emptyFilters: LibraryFilters = {};
 
-// ── tests ─────────────────────────────────────────────────────────────────────
-describe('AdvancedFiltersDrawer — skeleton (open/close + Cancel)', () => {
-  // Force Radix Dialog (desktop) mode so role="dialog" is available synchronously.
-  beforeEach(() => {
-    installMatchMedia(true);
-  });
+// ── tests ──────────────────────────────────────────────────────────────────
+describe('AdvancedFiltersDrawer — open/close lifecycle', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('does not render content when open=false', () => {
+  it('does not render dialog when open=false', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={false}
         onOpenChange={noop}
-        entityScope="game"
-        activeFilters={emptyGameFilters}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
@@ -111,302 +126,369 @@ describe('AdvancedFiltersDrawer — skeleton (open/close + Cancel)', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('renders dialog with title when open=true', () => {
+  it('renders dialog with custom header when open=true', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={noop}
-        entityScope="game"
-        activeFilters={emptyGameFilters}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
     );
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByText(/più filtri/i)).toBeInTheDocument();
+    // The drawer renders the title twice: once in the visible header (font-display)
+    // and once in the Radix sr-only DrawerTitle (a11y). Pin to the visible
+    // occurrence by scoping to the header slot. Radix renders the dialog
+    // content in a portal, so query `document.body` not the render container.
+    const header = document.body.querySelector('[data-slot="advanced-filters-header"]');
+    expect(header).not.toBeNull();
+    expect(within(header as HTMLElement).getByText(/Filtri avanzati/)).toBeInTheDocument();
   });
 
-  it('Cancel button calls onOpenChange(false)', async () => {
+  it('header subtitle shows zero-state message when no filters active', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    expect(screen.getByText(/Nessun filtro · scope: library/)).toBeInTheDocument();
+  });
+
+  it('header subtitle uses ICU plural for activeFilters count', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={{ statuses: ['owned', 'wishlist'] }}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    expect(screen.getByText(/2 attivi · scope: library/)).toBeInTheDocument();
+  });
+
+  it('Close (✕) button calls onOpenChange(false)', async () => {
     const onOpenChange = vi.fn();
     const user = userEvent.setup();
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={onOpenChange}
-        entityScope="game"
-        activeFilters={emptyGameFilters}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
     );
-    await user.click(screen.getByRole('button', { name: /annulla/i }));
+    await user.click(screen.getByRole('button', { name: 'Chiudi pannello filtri' }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });
 
-describe('AdvancedFiltersDrawer — game scope rendering', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
-  });
+describe('AdvancedFiltersDrawer — 7-section rendering', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('renders 5 sections for game scope (state, withKb, rating, players, year)', () => {
+  it('renders all 7 sections in mockup order', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game' }}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
     );
     const slots = screen.getAllByTestId(/^advanced-filters-section-/);
-    expect(slots).toHaveLength(5);
-    expect(slots.map(el => el.getAttribute('data-slot'))).toEqual([
-      'advanced-filters-section-states',
-      'advanced-filters-section-withKb',
-      'advanced-filters-section-rating',
-      'advanced-filters-section-players',
-      'advanced-filters-section-year',
-    ]);
-  });
-
-  it('game.states checkbox group renders 3 options with checked state from activeFilters', () => {
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game', states: ['Owned', 'Wishlist'] }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const owned = screen.getByRole('checkbox', { name: /posseduto/i });
-    const wishlist = screen.getByRole('checkbox', { name: /wishlist/i });
-    const loaned = screen.getByRole('checkbox', { name: /in prestito/i });
-    expect(owned).toBeChecked();
-    expect(wishlist).toBeChecked();
-    expect(loaned).not.toBeChecked();
-  });
-
-  it('toggling a state checkbox updates internal draft (not yet applied — Apply test in Task 7)', async () => {
-    const user = userEvent.setup();
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game' }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const owned = screen.getByRole('checkbox', { name: /posseduto/i });
-    await user.click(owned);
-    expect(owned).toBeChecked();
-  });
-
-  it('game.withKb renders a toggle with checked state from activeFilters', () => {
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game', withKb: true }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const toggle = screen.getByRole('switch', { name: /knowledge base/i });
-    expect(toggle).toBeChecked();
-  });
-
-  it('game.rating slider has correct min/max and reflects activeFilters.ratingMin', () => {
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game', ratingMin: 7 }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const slider = screen.getByRole('slider', { name: /rating/i });
-    expect(slider).toHaveAttribute('aria-valuenow', '7');
-    expect(slider).toHaveAttribute('aria-valuemin', '0');
-    expect(slider).toHaveAttribute('aria-valuemax', '10');
-  });
-});
-
-describe('AdvancedFiltersDrawer — agent scope rendering', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('renders 2 sections for agent scope (types, activeOnly)', () => {
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="agent"
-        activeFilters={{ scope: 'agent' }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const slots = screen.getAllByTestId(/^advanced-filters-section-/);
-    expect(slots).toHaveLength(2);
-    expect(slots.map(el => el.getAttribute('data-slot'))).toEqual([
-      'advanced-filters-section-types',
-      'advanced-filters-section-activeOnly',
-    ]);
-  });
-
-  it('agent.activeOnly toggle reflects activeFilters and updates draft on click', async () => {
-    const user = userEvent.setup();
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="agent"
-        activeFilters={{ scope: 'agent', activeOnly: false }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const toggle = screen.getByRole('switch', { name: /solo attivi/i });
-    expect(toggle).toHaveAttribute('aria-checked', 'false');
-    await user.click(toggle);
-    expect(toggle).toHaveAttribute('aria-checked', 'true');
-  });
-});
-
-describe('AdvancedFiltersDrawer — session scope rendering', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('renders 3 sections for session scope (statuses, sessionTypes, playerCount)', () => {
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="session"
-        activeFilters={{ scope: 'session' }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    const slots = screen.getAllByTestId(/^advanced-filters-section-/);
-    expect(slots).toHaveLength(3);
     expect(slots.map(el => el.getAttribute('data-slot'))).toEqual([
       'advanced-filters-section-statuses',
-      'advanced-filters-section-sessionTypes',
-      'advanced-filters-section-playerCount',
+      'advanced-filters-section-entities',
+      'advanced-filters-section-games',
+      'advanced-filters-section-period',
+      'advanced-filters-section-tags',
+      'advanced-filters-section-rating',
+      'advanced-filters-section-weights',
     ]);
   });
 
-  it('session.playerCount slider has min=1 max=12 and reflects activeFilters.playerCountMin', () => {
+  it('opens the first 3 sections by default (mockup parity)', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={noop}
-        entityScope="session"
-        activeFilters={{ scope: 'session', playerCountMin: 4 }}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
     );
-    const slider = screen.getByRole('slider', { name: /giocatori/i });
-    expect(slider).toHaveAttribute('aria-valuemin', '1');
-    expect(slider).toHaveAttribute('aria-valuemax', '12');
-    expect(slider).toHaveAttribute('aria-valuenow', '4');
-  });
-});
-
-describe('AdvancedFiltersDrawer — kb scope rendering', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
+    expect(screen.getByRole('button', { name: /Stato/, expanded: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Tipo entità/, expanded: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Gioco/, expanded: true })).toBeInTheDocument();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('renders 1 section (processingStates) with 3 checkboxes (Ready/Pending/Failed)', () => {
+  it('keeps sections at index >= 3 collapsed by default', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={noop}
-        entityScope="kb"
-        activeFilters={{ scope: 'kb', processingStates: ['Ready'] }}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
     );
-    const slots = screen.getAllByTestId(/^advanced-filters-section-/);
-    expect(slots).toHaveLength(1);
-    expect(slots[0]?.getAttribute('data-slot')).toBe('advanced-filters-section-processingStates');
-
-    expect(screen.getByRole('checkbox', { name: /pronto/i })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /in elaborazione/i })).not.toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /errore/i })).not.toBeChecked();
-  });
-});
-
-describe('AdvancedFiltersDrawer — chat scope rendering', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
+    expect(screen.getByRole('button', { name: /Periodo/, expanded: false })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Complessità/, expanded: false })
+    ).toBeInTheDocument();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('renders 1 section (messageCountMin slider) with min=0 max=100', () => {
+  it('expands a collapsed section when the toggle is clicked', async () => {
+    const user = userEvent.setup();
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={noop}
-        entityScope="chat"
-        activeFilters={{ scope: 'chat', messageCountMin: 10 }}
+        activeFilters={emptyFilters}
         onApply={noop}
         onClear={noop}
       />
     );
-    const slots = screen.getAllByTestId(/^advanced-filters-section-/);
-    expect(slots).toHaveLength(1);
-    const slider = screen.getByRole('slider', { name: /messaggi/i });
-    expect(slider).toHaveAttribute('aria-valuemin', '0');
-    expect(slider).toHaveAttribute('aria-valuemax', '100');
-    expect(slider).toHaveAttribute('aria-valuenow', '10');
+    const periodToggle = screen.getByRole('button', { name: /Periodo/, expanded: false });
+    await user.click(periodToggle);
+    expect(screen.getByRole('button', { name: /Periodo/, expanded: true })).toBeInTheDocument();
   });
 });
 
-describe('AdvancedFiltersDrawer — Apply / Clear callbacks', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
+describe('AdvancedFiltersDrawer — chips-multi (status section)', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders 4 status chips (owned/wishlist/setup/archived)', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    const statusSection = screen.getByTestId('advanced-filters-section-statuses');
+    expect(within(statusSection).getByRole('button', { name: /Posseduto/ })).toBeInTheDocument();
+    expect(within(statusSection).getByRole('button', { name: /Wishlist/ })).toBeInTheDocument();
+    expect(within(statusSection).getByRole('button', { name: /In setup/ })).toBeInTheDocument();
+    expect(within(statusSection).getByRole('button', { name: /Archiviato/ })).toBeInTheDocument();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it('reflects activeFilters.statuses via aria-pressed', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={{ statuses: ['owned'] }}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    const statusSection = screen.getByTestId('advanced-filters-section-statuses');
+    const ownedChip = within(statusSection).getByRole('button', { name: /Posseduto/ });
+    const wishlistChip = within(statusSection).getByRole('button', { name: /Wishlist/ });
+    expect(ownedChip).toHaveAttribute('aria-pressed', 'true');
+    expect(wishlistChip).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('Apply button calls onApply with current draft and closes the drawer', async () => {
+  it('toggling a chip then clicking Applica emits the updated draft', async () => {
+    const onApply = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={onApply}
+        onClear={noop}
+      />
+    );
+    const statusSection = screen.getByTestId('advanced-filters-section-statuses');
+    await user.click(within(statusSection).getByRole('button', { name: /Posseduto/ }));
+    await user.click(screen.getByRole('button', { name: /^Applica/ }));
+    expect(onApply).toHaveBeenCalledWith({ statuses: ['owned'] });
+  });
+});
+
+describe('AdvancedFiltersDrawer — select-multi (games section)', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('shows the placeholder and an empty-state when availableGames omitted', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    const gamesSection = screen.getByTestId('advanced-filters-section-games');
+    expect(within(gamesSection).getByText('Filtra per gioco specifico...')).toBeInTheDocument();
+    expect(within(gamesSection).getByText('Nessun gioco disponibile.')).toBeInTheDocument();
+  });
+
+  it('renders up to 5 available games as togglable pills', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        availableGames={[
+          { id: 'g1', title: 'Catan' },
+          { id: 'g2', title: 'Wingspan' },
+        ]}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    const gamesSection = screen.getByTestId('advanced-filters-section-games');
+    expect(within(gamesSection).getByRole('button', { name: /Catan/ })).toBeInTheDocument();
+    expect(within(gamesSection).getByRole('button', { name: /Wingspan/ })).toBeInTheDocument();
+  });
+});
+
+describe('AdvancedFiltersDrawer — period-quick (period section)', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders period section as a radiogroup with 5 options', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    // Period collapses by default → expand first
+    await user.click(screen.getByRole('button', { name: /Periodo/ }));
+    const radiogroup = screen.getByRole('radiogroup', { name: /Periodo/ });
+    const options = within(radiogroup).getAllByRole('radio');
+    expect(options).toHaveLength(5);
+  });
+
+  it('selects a period option (aria-checked) and emits on Applica', async () => {
+    const onApply = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={onApply}
+        onClear={noop}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Periodo/ }));
+    await user.click(screen.getByRole('radio', { name: /Ultimi 30 giorni/ }));
+    await user.click(screen.getByRole('button', { name: /^Applica/ }));
+    expect(onApply).toHaveBeenCalledWith({ period: '30d' });
+  });
+});
+
+describe('AdvancedFiltersDrawer — range (rating section)', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders rating section with default readout 6.0 — 10.0', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Rating/ }));
+    const readout = screen.getByTestId('advanced-filters-section-rating');
+    expect(within(readout).getByText('6.0')).toBeInTheDocument();
+    expect(within(readout).getByText('10.0')).toBeInTheDocument();
+  });
+
+  it('renders min and max range inputs with aria-labels', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Rating/ }));
+    expect(screen.getByLabelText('Rating minimo')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rating massimo')).toBeInTheDocument();
+  });
+});
+
+describe('AdvancedFiltersDrawer — footer actions', () => {
+  beforeEach(() => installMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('Reset button calls onClear and clears local draft', async () => {
+    const onClear = vi.fn();
+    const onApply = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={{ statuses: ['owned', 'wishlist'] }}
+        onApply={onApply}
+        onClear={onClear}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+    // After Reset, click Applica should emit an empty draft.
+    await user.click(screen.getByRole('button', { name: /^Applica/ }));
+    expect(onApply).toHaveBeenCalledWith({});
+  });
+
+  it('Applica button shows count suffix when filters are present', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={{ statuses: ['owned', 'wishlist'] }}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Applica (2)' })).toBeInTheDocument();
+  });
+
+  it('Applica button shows no count when no filters are active', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Applica' })).toBeInTheDocument();
+  });
+
+  it('Applica button calls onApply with draft and onOpenChange(false)', async () => {
     const onApply = vi.fn();
     const onOpenChange = vi.fn();
     const user = userEvent.setup();
@@ -414,108 +496,35 @@ describe('AdvancedFiltersDrawer — Apply / Clear callbacks', () => {
       <AdvancedFiltersDrawer
         open={true}
         onOpenChange={onOpenChange}
-        entityScope="game"
-        activeFilters={{ scope: 'game' }}
+        activeFilters={{ statuses: ['owned'] }}
         onApply={onApply}
         onClear={noop}
       />
     );
-
-    const owned = screen.getByRole('checkbox', { name: /posseduto/i });
-    await user.click(owned);
-    await user.click(screen.getByRole('button', { name: /applica/i }));
-
-    expect(onApply).toHaveBeenCalledTimes(1);
-    expect(onApply).toHaveBeenCalledWith({ scope: 'game', states: ['Owned'] });
+    await user.click(screen.getByRole('button', { name: /^Applica/ }));
+    expect(onApply).toHaveBeenCalledWith({ statuses: ['owned'] });
     expect(onOpenChange).toHaveBeenCalledWith(false);
-  });
-
-  it('Clear button calls onClear and resets draft to empty scope, drawer stays open', async () => {
-    const onClear = vi.fn();
-    const onOpenChange = vi.fn();
-    const user = userEvent.setup();
-    renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={onOpenChange}
-        entityScope="game"
-        activeFilters={{ scope: 'game', states: ['Owned'], ratingMin: 7 }}
-        onApply={noop}
-        onClear={onClear}
-      />
-    );
-
-    const owned = screen.getByRole('checkbox', { name: /posseduto/i });
-    expect(owned).toBeChecked();
-
-    await user.click(screen.getByRole('button', { name: /reimposta/i }));
-
-    expect(onClear).toHaveBeenCalledTimes(1);
-    expect(onOpenChange).not.toHaveBeenCalledWith(false); // drawer stays open
-    expect(screen.getByRole('checkbox', { name: /posseduto/i })).not.toBeChecked();
-  });
-
-  it('when reopened with new activeFilters, draft resets to the new activeFilters', async () => {
-    const { rerender } = renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={false}
-        onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game' }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    rerender(
-      <IntlProvider locale="it" messages={messages}>
-        <AdvancedFiltersDrawer
-          open={true}
-          onOpenChange={noop}
-          entityScope="game"
-          activeFilters={{ scope: 'game', states: ['Wishlist'] }}
-          onApply={noop}
-          onClear={noop}
-        />
-      </IntlProvider>
-    );
-    expect(screen.getByRole('checkbox', { name: /wishlist/i })).toBeChecked();
   });
 });
 
-describe('AdvancedFiltersDrawer — a11y', () => {
-  beforeEach(() => {
-    installMatchMedia(true);
+describe('countActiveFilters', () => {
+  it('returns 0 for empty filters', () => {
+    expect(countActiveFilters({})).toBe(0);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it('counts array values by length (not by field count)', () => {
+    expect(countActiveFilters({ statuses: ['owned', 'wishlist'] })).toBe(2);
   });
 
-  it('renders no axe violations for game scope when open', async () => {
-    const { container } = renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="game"
-        activeFilters={{ scope: 'game' }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
+  it('counts scalar truthy values as 1', () => {
+    expect(countActiveFilters({ period: '7d' })).toBe(1);
   });
 
-  it('renders no axe violations for kb scope when open', async () => {
-    const { container } = renderWithIntl(
-      <AdvancedFiltersDrawer
-        open={true}
-        onOpenChange={noop}
-        entityScope="kb"
-        activeFilters={{ scope: 'kb' }}
-        onApply={noop}
-        onClear={noop}
-      />
-    );
-    expect(await axe(container)).toHaveNoViolations();
+  it('counts range fields ratingMin/ratingMax independently', () => {
+    expect(countActiveFilters({ ratingMin: 6, ratingMax: 10 })).toBe(2);
+  });
+
+  it('ignores undefined fields', () => {
+    expect(countActiveFilters({ statuses: undefined, period: undefined })).toBe(0);
   });
 });

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/sections.test.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/sections.test.ts
@@ -1,78 +1,149 @@
+/**
+ * AdvancedFiltersDrawer — DRAWER_SECTIONS configuration tests.
+ *
+ * SP4 mockup conformance (Issue #1585-followup, plan Task 3.3). The drawer
+ * uses a static 7-section descriptor (no scope dispatch). Tests assert the
+ * shape, ordering, kind variety, and default-open behaviour matches the
+ * mockup (admin-mockups/design_files/sp4-library-desktop.jsx:319-388).
+ */
+
 import { describe, expect, it } from 'vitest';
 
-import { getSectionsForScope } from '../sections';
+import { DRAWER_SECTIONS, isDefaultOpen } from '../sections';
 
-describe('getSectionsForScope', () => {
-  it('returns 5 sections for game scope (states, withKb, rating, players, year)', () => {
-    const sections = getSectionsForScope('game');
-    expect(sections.map(s => s.key)).toEqual(['states', 'withKb', 'rating', 'players', 'year']);
-  });
-
-  it('game.states is a checkbox group with the 3 user-facing states (Owned/Wishlist/InPrestito)', () => {
-    const sections = getSectionsForScope('game');
-    const states = sections.find(s => s.key === 'states');
-    expect(states?.kind).toBe('checkbox-group');
-    expect(states && 'options' in states ? states.options.map(o => o.value) : []).toEqual([
-      'Owned',
-      'Wishlist',
-      'InPrestito',
+describe('DRAWER_SECTIONS', () => {
+  it('exposes 7 sections matching the mockup order', () => {
+    expect(DRAWER_SECTIONS.map(s => s.key)).toEqual([
+      'statuses',
+      'entities',
+      'games',
+      'period',
+      'tags',
+      'rating',
+      'weights',
     ]);
   });
 
-  it('game.rating is a single-slider 0-10', () => {
-    const sections = getSectionsForScope('game');
-    const rating = sections.find(s => s.key === 'rating');
-    expect(rating?.kind).toBe('slider');
-    if (rating && rating.kind === 'slider') {
-      expect(rating.min).toBe(0);
-      expect(rating.max).toBe(10);
+  it('uses chips-multi for status / entity / tags / weights sections', () => {
+    const chipsMultiKeys = DRAWER_SECTIONS.filter(s => s.kind === 'chips-multi').map(s => s.key);
+    expect(chipsMultiKeys).toEqual(['statuses', 'entities', 'tags', 'weights']);
+  });
+
+  it('uses select-multi for games section', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'games');
+    expect(section?.kind).toBe('select-multi');
+  });
+
+  it('uses period-quick for period section', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'period');
+    expect(section?.kind).toBe('period-quick');
+  });
+
+  it('uses range for rating section with [1..10] step 0.5 default [6, 10]', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'rating');
+    expect(section?.kind).toBe('range');
+    if (section && section.kind === 'range') {
+      expect(section.min).toBe(1);
+      expect(section.max).toBe(10);
+      expect(section.step).toBe(0.5);
+      expect(section.defaultLo).toBe(6);
+      expect(section.defaultHi).toBe(10);
+      expect(section.minField).toBe('ratingMin');
+      expect(section.maxField).toBe('ratingMax');
     }
   });
 
-  it('game.players is a range with min=1 max=10', () => {
-    const sections = getSectionsForScope('game');
-    const players = sections.find(s => s.key === 'players');
-    expect(players?.kind).toBe('range');
-    if (players && players.kind === 'range') {
-      expect(players.min).toBe(1);
-      expect(players.max).toBe(10);
+  it('exposes 4 status options (owned/wishlist/setup/archived)', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'statuses');
+    expect(section?.kind).toBe('chips-multi');
+    if (section && section.kind === 'chips-multi') {
+      expect(section.options.map(o => o.value)).toEqual(['owned', 'wishlist', 'setup', 'archived']);
     }
   });
 
-  it('returns 2 sections for agent scope (types, activeOnly)', () => {
-    const sections = getSectionsForScope('agent');
-    expect(sections.map(s => s.key)).toEqual(['types', 'activeOnly']);
-    expect(sections[0]?.kind).toBe('checkbox-group');
-    expect(sections[1]?.kind).toBe('toggle');
+  it('exposes 5 entity options (game/agent/kb/session/chat)', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'entities');
+    expect(section?.kind).toBe('chips-multi');
+    if (section && section.kind === 'chips-multi') {
+      expect(section.options.map(o => o.value)).toEqual(['game', 'agent', 'kb', 'session', 'chat']);
+    }
   });
 
-  it('returns 3 sections for session scope (statuses, sessionTypes, playerCount)', () => {
-    const sections = getSectionsForScope('session');
-    expect(sections.map(s => s.key)).toEqual(['statuses', 'sessionTypes', 'playerCount']);
+  it('exposes 5 period options (7d/30d/1y/all/range)', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'period');
+    expect(section?.kind).toBe('period-quick');
+    if (section && section.kind === 'period-quick') {
+      expect(section.options.map(o => o.value)).toEqual(['7d', '30d', '1y', 'all', 'range']);
+    }
   });
 
-  it('returns 1 section for kb scope (processingStates) with 3 fixed options Ready/Pending/Failed', () => {
-    const sections = getSectionsForScope('kb');
-    expect(sections.map(s => s.key)).toEqual(['processingStates']);
-    const ps = sections[0];
-    expect(ps && ps.kind === 'checkbox-group' ? ps.options.map(o => o.value) : []).toEqual([
-      'Ready',
-      'Pending',
-      'Failed',
-    ]);
+  it('exposes 8 tag options (mockup taxonomy)', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'tags');
+    expect(section?.kind).toBe('chips-multi');
+    if (section && section.kind === 'chips-multi') {
+      expect(section.options.map(o => o.value)).toEqual([
+        'family',
+        'strategy',
+        'coop',
+        'engine',
+        'auction',
+        'roll-and-write',
+        'card-driven',
+        'tableau',
+      ]);
+    }
   });
 
-  it('returns 1 section for chat scope (messageCountMin slider min=0)', () => {
-    const sections = getSectionsForScope('chat');
-    expect(sections.map(s => s.key)).toEqual(['messageCountMin']);
-    const mc = sections[0];
-    expect(mc?.kind).toBe('slider');
+  it('exposes 4 weight options (light/medium/heavy/extra)', () => {
+    const section = DRAWER_SECTIONS.find(s => s.key === 'weights');
+    expect(section?.kind).toBe('chips-multi');
+    if (section && section.kind === 'chips-multi') {
+      expect(section.options.map(o => o.value)).toEqual(['light', 'medium', 'heavy', 'extra']);
+    }
   });
 
-  it('returns a new array reference each call (pure, no shared state)', () => {
-    const a = getSectionsForScope('game');
-    const b = getSectionsForScope('game');
-    expect(a).not.toBe(b);
-    expect(a).toEqual(b);
+  it('assigns entity colors to chip options (mockup palette)', () => {
+    const statusSection = DRAWER_SECTIONS.find(s => s.key === 'statuses');
+    if (statusSection && statusSection.kind === 'chips-multi') {
+      const ownedColor = statusSection.options.find(o => o.value === 'owned')?.color;
+      expect(ownedColor).toBe('game');
+      const wishlistColor = statusSection.options.find(o => o.value === 'wishlist')?.color;
+      expect(wishlistColor).toBe('event');
+    }
+  });
+
+  it('assigns icons to status / entity chip options (mockup affordance)', () => {
+    const statusSection = DRAWER_SECTIONS.find(s => s.key === 'statuses');
+    if (statusSection && statusSection.kind === 'chips-multi') {
+      expect(statusSection.options.find(o => o.value === 'owned')?.icon).toBe('✓');
+      expect(statusSection.options.find(o => o.value === 'wishlist')?.icon).toBe('★');
+    }
+    const entitySection = DRAWER_SECTIONS.find(s => s.key === 'entities');
+    if (entitySection && entitySection.kind === 'chips-multi') {
+      expect(entitySection.options.find(o => o.value === 'game')?.icon).toBe('🎲');
+      expect(entitySection.options.find(o => o.value === 'agent')?.icon).toBe('🤖');
+    }
+  });
+
+  it('omits icons on tag chip options (mockup parity)', () => {
+    const tagSection = DRAWER_SECTIONS.find(s => s.key === 'tags');
+    if (tagSection && tagSection.kind === 'chips-multi') {
+      expect(tagSection.options.every(o => o.icon === undefined)).toBe(true);
+    }
+  });
+});
+
+describe('isDefaultOpen', () => {
+  it('returns true for the first 3 sections (mockup defaultOpen=true)', () => {
+    expect(isDefaultOpen(0)).toBe(true);
+    expect(isDefaultOpen(1)).toBe(true);
+    expect(isDefaultOpen(2)).toBe(true);
+  });
+
+  it('returns false for sections at index >= 3 (mockup collapsed by default)', () => {
+    expect(isDefaultOpen(3)).toBe(false);
+    expect(isDefaultOpen(4)).toBe(false);
+    expect(isDefaultOpen(5)).toBe(false);
+    expect(isDefaultOpen(6)).toBe(false);
   });
 });

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/index.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/index.ts
@@ -1,11 +1,23 @@
 export { AdvancedFiltersDrawer } from './AdvancedFiltersDrawer';
 export type {
+  AdvancedFiltersDrawerGameOption,
   AdvancedFiltersDrawerProps,
   LibraryFilters,
-  GameLibraryFilters,
-  AgentLibraryFilters,
-  SessionLibraryFilters,
-  KbLibraryFilters,
-  ChatLibraryFilters,
-  FiltersForScope,
+  LibraryFilterEntity,
+  LibraryFilterPeriod,
+  LibraryFilterStatus,
+  LibraryFilterTag,
+  LibraryFilterWeight,
 } from './types';
+export { countActiveFilters } from './types';
+export { DRAWER_SECTIONS, isDefaultOpen } from './sections';
+export type {
+  ChipOption,
+  ChipsMultiSection,
+  EntityColorSlug,
+  PeriodQuickOption,
+  PeriodQuickSection,
+  RangeSection,
+  SectionConfig,
+  SelectMultiSection,
+} from './sections';

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/sections.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/sections.ts
@@ -1,165 +1,298 @@
 /**
- * AdvancedFiltersDrawer — pure section configuration (Phase 3a #1606).
+ * AdvancedFiltersDrawer — section configuration.
  *
- * Declarative section descriptors keyed by `HybridHubEntity` scope. The
- * renderer iterates over the returned array — no scope-switching at render
- * time. Each section is one of three kinds (`checkbox-group`, `toggle`,
- * `slider`, `range`); adding a new kind only requires a new case in the
- * renderer + a new branch here.
+ * SP4 mockup conformance (Issue #1585-followup, plan
+ * docs/superpowers/plans/2026-06-03-library-sp4-mockup-conformance.md Task 3.3).
+ * Mapped from `admin-mockups/design_files/sp4-library-desktop.jsx`
+ * (DRAWER_SECTIONS, lines 319–388).
  *
- * Each call returns a NEW array (caller can safely mutate state derived from
- * it without leaking back into the config).
+ * REFACTORED from scope-conditional `getSectionsForScope` to **static 7-section
+ * declarative config**. The drawer now exposes the same sections regardless
+ * of the active hub tab — matches mockup hub-level filter surface.
+ *
+ * Four section kinds match mockup:
+ *  - `chips-multi`: multi-select toggle chips with optional icon + entity color
+ *  - `select-multi`: searchable multi-select (placeholder + scrolling options)
+ *  - `period-quick`: single-select radio list (7d/30d/1y/all/range) with
+ *    custom-range option that just stores the value 'range' (date pickers
+ *    deferred)
+ *  - `range`: numeric range (lo, hi) backed by two `<input type="range">`
+ *    rendered visually like the mockup dual-thumb slider.
+ *
+ * Adding a new kind requires (1) new branch here, (2) new renderer case in
+ * AdvancedFiltersDrawer.tsx, (3) new test in sections.test.ts.
  */
 
-import type { HybridHubEntity } from '@/lib/library/hybrid-hub.types';
+import type {
+  LibraryFilterEntity,
+  LibraryFilterPeriod,
+  LibraryFilterStatus,
+  LibraryFilterTag,
+  LibraryFilterWeight,
+} from './types';
 
-export interface CheckboxOption<V extends string = string> {
+/** All chips-multi option literals are entity-color slugs from tokens.css. */
+export type EntityColorSlug =
+  | 'game'
+  | 'agent'
+  | 'kb'
+  | 'session'
+  | 'chat'
+  | 'event'
+  | 'toolkit'
+  | 'player';
+
+export interface ChipOption<V extends string = string> {
+  readonly value: V;
+  readonly i18nKey: string;
+  readonly icon?: string;
+  readonly color?: EntityColorSlug;
+}
+
+export interface ChipsMultiSection<V extends string = string> {
+  readonly kind: 'chips-multi';
+  readonly key: string;
+  readonly i18nLabel: string;
+  readonly icon: string;
+  readonly options: ReadonlyArray<ChipOption<V>>;
+}
+
+export interface SelectMultiSection {
+  readonly kind: 'select-multi';
+  readonly key: string;
+  readonly i18nLabel: string;
+  readonly icon: string;
+  readonly i18nPlaceholder: string;
+}
+
+export interface PeriodQuickOption<V extends string = string> {
   readonly value: V;
   readonly i18nKey: string;
 }
 
-export interface CheckboxGroupSection {
-  readonly kind: 'checkbox-group';
+export interface PeriodQuickSection<V extends string = string> {
+  readonly kind: 'period-quick';
   readonly key: string;
   readonly i18nLabel: string;
-  readonly options: ReadonlyArray<CheckboxOption>;
-}
-
-export interface ToggleSection {
-  readonly kind: 'toggle';
-  readonly key: string;
-  readonly i18nLabel: string;
-}
-
-export interface SliderSection {
-  readonly kind: 'slider';
-  readonly key: string;
-  readonly i18nLabel: string;
-  readonly min: number;
-  readonly max: number;
-  readonly step: number;
+  readonly icon: string;
+  readonly options: ReadonlyArray<PeriodQuickOption<V>>;
 }
 
 export interface RangeSection {
   readonly kind: 'range';
   readonly key: string;
+  /** Field name used to read/write the lower bound on `LibraryFilters`. */
+  readonly minField: string;
+  /** Field name used to read/write the upper bound on `LibraryFilters`. */
+  readonly maxField: string;
   readonly i18nLabel: string;
+  readonly icon: string;
   readonly min: number;
   readonly max: number;
   readonly step: number;
+  readonly defaultLo: number;
+  readonly defaultHi: number;
 }
 
-export type SectionConfig = CheckboxGroupSection | ToggleSection | SliderSection | RangeSection;
+export type SectionConfig =
+  | ChipsMultiSection<LibraryFilterStatus>
+  | ChipsMultiSection<LibraryFilterEntity>
+  | ChipsMultiSection<LibraryFilterTag>
+  | ChipsMultiSection<LibraryFilterWeight>
+  | SelectMultiSection
+  | PeriodQuickSection<LibraryFilterPeriod>
+  | RangeSection;
 
-const GAME_STATE_OPTIONS: ReadonlyArray<CheckboxOption> = [
-  { value: 'Owned', i18nKey: 'pages.library.filters.state.owned' },
-  { value: 'Wishlist', i18nKey: 'pages.library.filters.state.wishlist' },
-  { value: 'InPrestito', i18nKey: 'pages.library.filters.state.loaned' },
+const STATUS_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterStatus>> = [
+  {
+    value: 'owned',
+    i18nKey: 'pages.library.filters.section.status.options.owned',
+    icon: '✓',
+    color: 'game',
+  },
+  {
+    value: 'wishlist',
+    i18nKey: 'pages.library.filters.section.status.options.wishlist',
+    icon: '★',
+    color: 'event',
+  },
+  {
+    value: 'setup',
+    i18nKey: 'pages.library.filters.section.status.options.setup',
+    icon: '⚙',
+    color: 'agent',
+  },
+  {
+    value: 'archived',
+    i18nKey: 'pages.library.filters.section.status.options.archived',
+    icon: '⊘',
+    color: 'kb',
+  },
 ];
 
-const KB_STATE_OPTIONS: ReadonlyArray<CheckboxOption> = [
-  { value: 'Ready', i18nKey: 'pages.library.filters.kbState.ready' },
-  { value: 'Pending', i18nKey: 'pages.library.filters.kbState.pending' },
-  { value: 'Failed', i18nKey: 'pages.library.filters.kbState.failed' },
+const ENTITY_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterEntity>> = [
+  {
+    value: 'game',
+    i18nKey: 'pages.library.filters.section.entity.options.game',
+    icon: '🎲',
+    color: 'game',
+  },
+  {
+    value: 'agent',
+    i18nKey: 'pages.library.filters.section.entity.options.agent',
+    icon: '🤖',
+    color: 'agent',
+  },
+  {
+    value: 'kb',
+    i18nKey: 'pages.library.filters.section.entity.options.kb',
+    icon: '📚',
+    color: 'kb',
+  },
+  {
+    value: 'session',
+    i18nKey: 'pages.library.filters.section.entity.options.session',
+    icon: '🎯',
+    color: 'session',
+  },
+  {
+    value: 'chat',
+    i18nKey: 'pages.library.filters.section.entity.options.chat',
+    icon: '💬',
+    color: 'chat',
+  },
 ];
 
-// Evaluated once at module load. Acceptable for a publication-year filter range:
-// the upper bound only goes stale across a year boundary within a long-running
-// process, which has negligible impact on a board-game year selector.
-const CURRENT_YEAR = new Date().getFullYear();
+const PERIOD_OPTIONS: ReadonlyArray<PeriodQuickOption<LibraryFilterPeriod>> = [
+  { value: '7d', i18nKey: 'pages.library.filters.section.period.options.7d' },
+  { value: '30d', i18nKey: 'pages.library.filters.section.period.options.30d' },
+  { value: '1y', i18nKey: 'pages.library.filters.section.period.options.1y' },
+  { value: 'all', i18nKey: 'pages.library.filters.section.period.options.all' },
+  { value: 'range', i18nKey: 'pages.library.filters.section.period.options.range' },
+];
 
-export function getSectionsForScope(scope: HybridHubEntity): ReadonlyArray<SectionConfig> {
-  switch (scope) {
-    case 'game':
-      return [
-        {
-          kind: 'checkbox-group',
-          key: 'states',
-          i18nLabel: 'pages.library.filters.section.state',
-          options: GAME_STATE_OPTIONS,
-        },
-        { kind: 'toggle', key: 'withKb', i18nLabel: 'pages.library.filters.section.withKb' },
-        {
-          kind: 'slider',
-          key: 'rating',
-          i18nLabel: 'pages.library.filters.section.rating',
-          min: 0,
-          max: 10,
-          step: 0.5,
-        },
-        {
-          kind: 'range',
-          key: 'players',
-          i18nLabel: 'pages.library.filters.section.players',
-          min: 1,
-          max: 10,
-          step: 1,
-        },
-        {
-          kind: 'range',
-          key: 'year',
-          i18nLabel: 'pages.library.filters.section.year',
-          min: 1900,
-          max: CURRENT_YEAR,
-          step: 1,
-        },
-      ];
-    case 'agent':
-      return [
-        {
-          kind: 'checkbox-group',
-          key: 'types',
-          i18nLabel: 'pages.library.filters.section.agentType',
-          options: [],
-        },
-        {
-          kind: 'toggle',
-          key: 'activeOnly',
-          i18nLabel: 'pages.library.filters.section.activeOnly',
-        },
-      ];
-    case 'session':
-      return [
-        {
-          kind: 'checkbox-group',
-          key: 'statuses',
-          i18nLabel: 'pages.library.filters.section.sessionStatus',
-          options: [],
-        },
-        {
-          kind: 'checkbox-group',
-          key: 'sessionTypes',
-          i18nLabel: 'pages.library.filters.section.sessionType',
-          options: [],
-        },
-        {
-          kind: 'slider',
-          key: 'playerCount',
-          i18nLabel: 'pages.library.filters.section.playerCount',
-          min: 1,
-          max: 12,
-          step: 1,
-        },
-      ];
-    case 'kb':
-      return [
-        {
-          kind: 'checkbox-group',
-          key: 'processingStates',
-          i18nLabel: 'pages.library.filters.section.processingState',
-          options: KB_STATE_OPTIONS,
-        },
-      ];
-    case 'chat':
-      return [
-        {
-          kind: 'slider',
-          key: 'messageCountMin',
-          i18nLabel: 'pages.library.filters.section.messageCountMin',
-          min: 0,
-          max: 100,
-          step: 5,
-        },
-      ];
-  }
+const TAG_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterTag>> = [
+  {
+    value: 'family',
+    i18nKey: 'pages.library.filters.section.tags.options.family',
+    color: 'event',
+  },
+  {
+    value: 'strategy',
+    i18nKey: 'pages.library.filters.section.tags.options.strategy',
+    color: 'session',
+  },
+  { value: 'coop', i18nKey: 'pages.library.filters.section.tags.options.coop', color: 'kb' },
+  {
+    value: 'engine',
+    i18nKey: 'pages.library.filters.section.tags.options.engine',
+    color: 'agent',
+  },
+  {
+    value: 'auction',
+    i18nKey: 'pages.library.filters.section.tags.options.auction',
+    color: 'toolkit',
+  },
+  {
+    value: 'roll-and-write',
+    i18nKey: 'pages.library.filters.section.tags.options.rollAndWrite',
+    color: 'player',
+  },
+  {
+    value: 'card-driven',
+    i18nKey: 'pages.library.filters.section.tags.options.cardDriven',
+    color: 'chat',
+  },
+  {
+    value: 'tableau',
+    i18nKey: 'pages.library.filters.section.tags.options.tableau',
+    color: 'game',
+  },
+];
+
+const WEIGHT_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterWeight>> = [
+  { value: 'light', i18nKey: 'pages.library.filters.section.weight.options.light', color: 'kb' },
+  {
+    value: 'medium',
+    i18nKey: 'pages.library.filters.section.weight.options.medium',
+    color: 'agent',
+  },
+  {
+    value: 'heavy',
+    i18nKey: 'pages.library.filters.section.weight.options.heavy',
+    color: 'game',
+  },
+  {
+    value: 'extra',
+    i18nKey: 'pages.library.filters.section.weight.options.extra',
+    color: 'event',
+  },
+];
+
+/**
+ * Static 7-section descriptor matching the mockup `DRAWER_SECTIONS` array.
+ * Order is significant: first 3 sections are open by default (see drawer
+ * `defaultOpen` logic), remaining 4 collapse on initial render.
+ */
+export const DRAWER_SECTIONS: ReadonlyArray<SectionConfig> = [
+  {
+    kind: 'chips-multi',
+    key: 'statuses',
+    i18nLabel: 'pages.library.filters.section.status.title',
+    icon: '●',
+    options: STATUS_OPTIONS,
+  },
+  {
+    kind: 'chips-multi',
+    key: 'entities',
+    i18nLabel: 'pages.library.filters.section.entity.title',
+    icon: '⌗',
+    options: ENTITY_OPTIONS,
+  },
+  {
+    kind: 'select-multi',
+    key: 'games',
+    i18nLabel: 'pages.library.filters.section.game.title',
+    icon: '🎲',
+    i18nPlaceholder: 'pages.library.filters.section.game.placeholder',
+  },
+  {
+    kind: 'period-quick',
+    key: 'period',
+    i18nLabel: 'pages.library.filters.section.period.title',
+    icon: '📅',
+    options: PERIOD_OPTIONS,
+  },
+  {
+    kind: 'chips-multi',
+    key: 'tags',
+    i18nLabel: 'pages.library.filters.section.tags.title',
+    icon: '🏷',
+    options: TAG_OPTIONS,
+  },
+  {
+    kind: 'range',
+    key: 'rating',
+    minField: 'ratingMin',
+    maxField: 'ratingMax',
+    i18nLabel: 'pages.library.filters.section.rating.title',
+    icon: '★',
+    min: 1,
+    max: 10,
+    step: 0.5,
+    defaultLo: 6,
+    defaultHi: 10,
+  },
+  {
+    kind: 'chips-multi',
+    key: 'weights',
+    i18nLabel: 'pages.library.filters.section.weight.title',
+    icon: '⚖',
+    options: WEIGHT_OPTIONS,
+  },
+];
+
+/** Whether a section index should default to expanded (mockup: first 3). */
+export function isDefaultOpen(sectionIndex: number): boolean {
+  return sectionIndex < 3;
 }

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/types.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/types.ts
@@ -1,74 +1,92 @@
 /**
- * AdvancedFiltersDrawer — type definitions (Phase 3a #1606).
+ * AdvancedFiltersDrawer — type definitions.
  *
- * `LibraryFilters` is a discriminated union keyed by `scope` so the public API
- * doesn't leak `Record<string, unknown>`. Each variant only carries the fields
- * relevant to its entity type — Phase 1's `HybridHubEntity` literal drives the
- * scope discriminant.
+ * SP4 mockup conformance (Issue #1585-followup, plan
+ * docs/superpowers/plans/2026-06-03-library-sp4-mockup-conformance.md Task 3.3).
+ * Mapped from `admin-mockups/design_files/sp4-library-desktop.jsx`
+ * (AdvancedFiltersDrawer + DRAWER_SECTIONS, lines 312–637).
  *
- * Section config types (in `./sections.ts`) describe each section declaratively
- * so the renderer doesn't switch on scope at every level — `getSectionsForScope`
- * returns the array, the renderer iterates.
+ * REFACTORED from scope-conditional (game/agent/session/kb/chat discriminated
+ * union with per-scope filter shapes) to **cross-entity hub-level** filter
+ * model. The drawer now exposes the same 7 sections regardless of which tab
+ * the user is viewing; filter outcomes apply across all hub entities. This
+ * matches the mockup which has no `scope` discriminator and presents a
+ * unified library-wide filter surface.
+ *
+ * Each field is independently optional — absence means "no filter on that
+ * dimension". `period === 'range'` enables the optional `periodFrom`/`periodTo`
+ * ISO-date bounds for custom date pickers (UI for the custom range itself
+ * is intentionally out of scope for this PR — the radio option is rendered
+ * but the bound fields stay undefined until a future enhancement).
  */
 
-import type { GameStateType } from '@/lib/api/schemas/library.schemas';
-import type { HybridHubEntity } from '@/lib/library/hybrid-hub.types';
+export type LibraryFilterStatus = 'owned' | 'wishlist' | 'setup' | 'archived';
 
-export interface GameLibraryFilters {
-  readonly scope: 'game';
-  readonly states?: ReadonlyArray<GameStateType>;
-  readonly withKb?: boolean;
+export type LibraryFilterEntity = 'game' | 'agent' | 'kb' | 'session' | 'chat';
+
+export type LibraryFilterPeriod = '7d' | '30d' | '1y' | 'all' | 'range';
+
+export type LibraryFilterTag =
+  | 'family'
+  | 'strategy'
+  | 'coop'
+  | 'engine'
+  | 'auction'
+  | 'roll-and-write'
+  | 'card-driven'
+  | 'tableau';
+
+export type LibraryFilterWeight = 'light' | 'medium' | 'heavy' | 'extra';
+
+export interface LibraryFilters {
+  readonly statuses?: ReadonlyArray<LibraryFilterStatus>;
+  readonly entities?: ReadonlyArray<LibraryFilterEntity>;
+  readonly games?: ReadonlyArray<string>;
+  readonly period?: LibraryFilterPeriod;
+  readonly periodFrom?: string;
+  readonly periodTo?: string;
+  readonly tags?: ReadonlyArray<LibraryFilterTag>;
   readonly ratingMin?: number;
-  readonly playersMin?: number;
-  readonly playersMax?: number;
-  readonly yearMin?: number;
-  readonly yearMax?: number;
+  readonly ratingMax?: number;
+  readonly weights?: ReadonlyArray<LibraryFilterWeight>;
 }
 
-export interface AgentLibraryFilters {
-  readonly scope: 'agent';
-  readonly types?: ReadonlyArray<string>;
-  readonly activeOnly?: boolean;
+export interface AdvancedFiltersDrawerGameOption {
+  readonly id: string;
+  readonly title: string;
 }
-
-export interface SessionLibraryFilters {
-  readonly scope: 'session';
-  readonly statuses?: ReadonlyArray<string>;
-  readonly sessionTypes?: ReadonlyArray<string>;
-  readonly playerCountMin?: number;
-}
-
-export interface KbLibraryFilters {
-  readonly scope: 'kb';
-  readonly processingStates?: ReadonlyArray<'Ready' | 'Pending' | 'Failed'>;
-}
-
-export interface ChatLibraryFilters {
-  readonly scope: 'chat';
-  readonly messageCountMin?: number;
-}
-
-export type LibraryFilters =
-  | GameLibraryFilters
-  | AgentLibraryFilters
-  | SessionLibraryFilters
-  | KbLibraryFilters
-  | ChatLibraryFilters;
-
-/**
- * Narrow `LibraryFilters` to the variant matching a given `HybridHubEntity` scope.
- */
-export type FiltersForScope<S extends HybridHubEntity> = Extract<LibraryFilters, { scope: S }>;
 
 export interface AdvancedFiltersDrawerProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
-  /** Drives which sections render. Single entity — NOT 'all' from HybridHubTab. */
-  readonly entityScope: HybridHubEntity;
   /** Active filters applied to the surface; shown in the drawer when it opens. */
   readonly activeFilters: LibraryFilters;
-  /** Called with the new draft when the user clicks Apply. Drawer closes after. */
+  /**
+   * Optional list of games surfaced in the "Gioco" select-multi section.
+   * When omitted, the section renders an empty-state hint instead of options.
+   */
+  readonly availableGames?: ReadonlyArray<AdvancedFiltersDrawerGameOption>;
+  /** Called with the new draft when the user clicks Applica. Drawer closes after. */
   readonly onApply: (filters: LibraryFilters) => void;
-  /** Called when the user clicks Clear. Drawer resets draft to default empty. */
+  /** Called when the user clicks Reset. Drawer resets draft to {} but stays open. */
   readonly onClear: () => void;
+}
+
+/**
+ * Count of non-empty filter fields, used to drive the header subtitle "N attivi"
+ * and the footer Apply button suffix "(N)".
+ */
+export function countActiveFilters(filters: LibraryFilters): number {
+  let count = 0;
+  for (const value of Object.values(filters)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      if (value.length > 0) count += value.length;
+    } else if (typeof value === 'string' && value.length === 0) {
+      continue;
+    } else {
+      count += 1;
+    }
+  }
+  return count;
 }

--- a/apps/web/src/components/features/library/BulkSelectionBar.tsx
+++ b/apps/web/src/components/features/library/BulkSelectionBar.tsx
@@ -74,8 +74,8 @@ export interface BulkSelectionBarProps {
 
 const ACTION_BUTTON_CLASS = clsx(
   'inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border-0',
-  'bg-white/[0.12] text-inherit font-display text-[11.5px] font-bold',
-  'hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+  'bg-[hsl(0_0%_100%_/_0.12)] text-inherit font-display text-[11.5px] font-bold',
+  'hover:bg-[hsl(0_0%_100%_/_0.20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
   'disabled:cursor-not-allowed disabled:opacity-50',
   'motion-safe:transition-colors motion-safe:duration-150'
 );
@@ -205,8 +205,8 @@ export function BulkSelectionBar({
         aria-label={labels.closeAriaLabel}
         className={clsx(
           'inline-flex flex-shrink-0 items-center justify-center rounded-md',
-          'border border-white/20 bg-transparent px-2.5 py-1.5 text-xs text-inherit',
-          'hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+          'border border-[hsl(0_0%_100%_/_0.20)] bg-transparent px-2.5 py-1.5 text-xs text-inherit',
+          'hover:bg-[hsl(0_0%_100%_/_0.10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'motion-safe:transition-colors motion-safe:duration-150'
         )}

--- a/apps/web/src/components/features/library/BulkSelectionBar.tsx
+++ b/apps/web/src/components/features/library/BulkSelectionBar.tsx
@@ -1,13 +1,18 @@
 /**
  * BulkSelectionBar — Wave B.3 v2 component (Issue #574).
  *
+ * SP4 mockup conformance (Issue #1585-followup, plan
+ * docs/superpowers/plans/2026-06-03-library-sp4-mockup-conformance.md Task 3.2).
  * Mapped from `admin-mockups/design_files/sp4-library-desktop.jsx`
- * (BulkSelectionBar). Spec: docs/superpowers/specs/2026-04-30-v2-migration-wave-b-3-library.md
+ * (BulkSelectionBar, lines 895-944): dark floating bar with entity-game count
+ * chip, 3 action buttons (Archivia / Tag / Esporta), close ✕ affordance.
+ *
+ * Spec: docs/superpowers/specs/2026-04-30-v2-migration-wave-b-3-library.md
  * §3.2 + AC-6.
  *
  * Mounted/unmounted by `LibraryHub` orchestrator based on
  * `selectionMode === 'select'` (mounted even at `selectedCount === 0`
- * to provide explicit Annulla affordance and avoid layout flash).
+ * to provide explicit close affordance and avoid layout flash).
  *
  * Confirm flow uses Radix `<AlertDialog>` primitives (focus trap via
  * `<FocusScope>` automatic, role="alertdialog" automatic, Esc handling
@@ -16,10 +21,10 @@
  *
  * Pure component (mirror Wave B.1 GamesEmptyState + B.2 EmptyAgents):
  *   labels resolved via prop — no `useTranslation` import. Parent
- *   (`LibraryHub`) owns i18n resolution and re-interpolates `counter`
+ *   (`LibraryHub`) owns i18n resolution and re-interpolates `regionLabel`
  *   + `confirmTitle` per `selectedCount` change.
  *
- * Slide-in animation gated by `motion-safe:transition` Tailwind class
+ * Slide-in animation gated by `motion-safe:` Tailwind classes
  * (collapse a 0.01ms sotto `prefers-reduced-motion: reduce`).
  */
 
@@ -44,8 +49,11 @@ import {
 export interface BulkSelectionBarLabels {
   readonly regionLabel: string;
   readonly counter: string;
-  readonly cancel: string;
+  readonly counterCompact?: string;
   readonly archive: string;
+  readonly tag: string;
+  readonly exportLabel: string;
+  readonly closeAriaLabel: string;
   readonly confirmTitle: string;
   readonly confirmDescription?: string;
   readonly confirmCta: string;
@@ -57,15 +65,29 @@ export interface BulkSelectionBarProps {
   readonly labels: BulkSelectionBarLabels;
   readonly onExitSelectMode: () => void;
   readonly onArchive: () => Promise<void>;
+  readonly onTag?: () => void;
+  readonly onExport?: () => void;
+  readonly compact?: boolean;
   readonly disabled?: boolean;
   readonly className?: string;
 }
 
+const ACTION_BUTTON_CLASS = clsx(
+  'inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border-0',
+  'bg-white/[0.12] text-inherit font-display text-[11.5px] font-bold',
+  'hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+  'disabled:cursor-not-allowed disabled:opacity-50',
+  'motion-safe:transition-colors motion-safe:duration-150'
+);
+
 export function BulkSelectionBar({
-  selectedCount: _selectedCount,
+  selectedCount,
   labels,
   onExitSelectMode,
   onArchive,
+  onTag,
+  onExport,
+  compact = false,
   disabled = false,
   className,
 }: BulkSelectionBarProps): ReactElement {
@@ -82,6 +104,10 @@ export function BulkSelectionBar({
     }
   };
 
+  const counterText = compact && labels.counterCompact ? labels.counterCompact : labels.counter;
+
+  const actionPadding = compact ? 'px-2 py-1.5' : 'px-2.5 py-1.5';
+
   return (
     <div
       data-slot="library-bulk-selection-bar"
@@ -91,33 +117,27 @@ export function BulkSelectionBar({
       aria-atomic="true"
       onKeyDown={handleKeyDown}
       className={clsx(
-        'fixed bottom-6 left-1/2 z-40 -translate-x-1/2',
-        'flex items-center gap-3 rounded-full border border-border bg-card px-5 py-3 shadow-lg',
-        'motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-out',
+        'fixed bottom-4 left-1/2 z-40 -translate-x-1/2',
+        'flex items-center gap-2.5',
+        'max-w-[720px] rounded-2xl bg-foreground px-3.5 py-2.5 text-background',
+        'shadow-[0_12px_32px_rgba(0,0,0,0.3)]',
+        'motion-safe:animate-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-200 motion-safe:ease-out',
         className
       )}
     >
       <span
-        data-slot="library-bulk-selection-counter"
-        className="text-sm font-medium text-foreground"
+        data-slot="library-bulk-selection-count-chip"
+        className="flex-shrink-0 rounded-full bg-entity-game px-2 py-0.5 font-mono text-[11px] font-extrabold tabular-nums text-white"
       >
-        {labels.counter}
+        {selectedCount}
       </span>
 
-      <button
-        type="button"
-        onClick={onExitSelectMode}
-        disabled={disabled}
-        data-slot="library-bulk-selection-cancel"
-        className={clsx(
-          'inline-flex h-9 items-center justify-center rounded-full px-4 text-sm font-medium',
-          'border border-border bg-background text-foreground',
-          'hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-          'disabled:cursor-not-allowed disabled:opacity-50'
-        )}
+      <span
+        data-slot="library-bulk-selection-counter"
+        className="flex-1 whitespace-nowrap font-display text-[12.5px] font-bold"
       >
-        {labels.cancel}
-      </button>
+        {counterText}
+      </span>
 
       <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <AlertDialogTrigger asChild>
@@ -125,14 +145,11 @@ export function BulkSelectionBar({
             type="button"
             disabled={disabled}
             data-slot="library-bulk-selection-archive"
-            className={clsx(
-              'inline-flex h-9 items-center justify-center rounded-full px-4 text-sm font-medium',
-              'bg-destructive text-destructive-foreground shadow-sm',
-              'hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
+            aria-label={labels.archive}
+            className={clsx(ACTION_BUTTON_CLASS, actionPadding)}
           >
-            {labels.archive}
+            <span aria-hidden="true">⊘</span>
+            {!compact && <span>{labels.archive}</span>}
           </button>
         </AlertDialogTrigger>
         <AlertDialogContent data-slot="library-bulk-selection-dialog">
@@ -155,6 +172,47 @@ export function BulkSelectionBar({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <button
+        type="button"
+        onClick={onTag}
+        disabled={disabled || !onTag}
+        data-slot="library-bulk-selection-tag"
+        aria-label={labels.tag}
+        className={clsx(ACTION_BUTTON_CLASS, actionPadding)}
+      >
+        <span aria-hidden="true">🏷</span>
+        {!compact && <span>{labels.tag}</span>}
+      </button>
+
+      <button
+        type="button"
+        onClick={onExport}
+        disabled={disabled || !onExport}
+        data-slot="library-bulk-selection-export"
+        aria-label={labels.exportLabel}
+        className={clsx(ACTION_BUTTON_CLASS, actionPadding)}
+      >
+        <span aria-hidden="true">↗</span>
+        {!compact && <span>{labels.exportLabel}</span>}
+      </button>
+
+      <button
+        type="button"
+        onClick={onExitSelectMode}
+        disabled={disabled}
+        data-slot="library-bulk-selection-cancel"
+        aria-label={labels.closeAriaLabel}
+        className={clsx(
+          'inline-flex flex-shrink-0 items-center justify-center rounded-md',
+          'border border-white/20 bg-transparent px-2.5 py-1.5 text-xs text-inherit',
+          'hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          'motion-safe:transition-colors motion-safe:duration-150'
+        )}
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
     </div>
   );
 }

--- a/apps/web/src/components/features/library/__tests__/BulkSelectionBar.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/BulkSelectionBar.test.tsx
@@ -1,13 +1,23 @@
 /**
  * Wave B.3 (Issue #574) — BulkSelectionBar v2 component tests.
  *
- * Spec §3.2 + AC-6:
+ * SP4 mockup conformance (Issue #1585-followup, plan
+ * docs/superpowers/plans/2026-06-03-library-sp4-mockup-conformance.md Task 3.2):
+ *   - Dark floating bar (`bg-foreground` + `text-background`) at `bottom-4` center.
+ *   - Count chip (entity-game) separate from counter label (no number in counter).
+ *   - 3 action buttons (Archivia / Tag / Esporta) — Archive preserves AlertDialog
+ *     confirm flow; Tag + Export are optional callbacks (stub no-op default).
+ *   - Close affordance: ✕ icon button with `closeAriaLabel` (no more "Annulla"
+ *     pill — that role moved to ✕).
+ *   - Compact mode: counterCompact label + icon-only action buttons.
+ *
+ * Wave B.3 invariants preserved:
  *   - Mounted iff parent decides (selectionMode === 'select'). Component itself
  *     is unconditionally rendered when JSX-mounted; mount/unmount lifecycle
  *     ownership lives in `LibraryHub` orchestrator (Commit 3).
  *   - selectedCount=0 still mounts (no count-conditional unmount, avoids
  *     layout flash on Annulla click).
- *   - Annulla button → onExitSelectMode().
+ *   - Close (✕) button → onExitSelectMode().
  *   - Esc keyboard at root (when dialog NOT open) → onExitSelectMode().
  *   - Archivia button → Radix `<AlertDialog>` opens (role="alertdialog").
  *   - Dialog title via `labels.confirmTitle` (pre-interpolated by parent with
@@ -16,35 +26,37 @@
  *   - ARIA: `role="region"` + `aria-label` + `aria-live="polite"` +
  *     `aria-atomic="true"` su root.
  *   - data-slot="library-bulk-selection-bar" + scoped sub-slots.
- *   - Slide-in animation gated by `motion-safe:transition` Tailwind class
+ *   - Slide-in animation gated by `motion-safe:` Tailwind class
  *     (collapse a 0.01ms sotto `prefers-reduced-motion: reduce`).
  *
  * Pure component: labels resolved via prop (mirror Wave B.1 GamesEmptyState +
  * B.2 EmptyAgents). Parent (LibraryHub) owns `useTranslation()`.
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BulkSelectionBar, type BulkSelectionBarLabels } from '../BulkSelectionBar';
 
 const baseLabels: BulkSelectionBarLabels = {
   regionLabel: '3 selezionati',
-  counter: '3 selezionati',
-  cancel: 'Annulla',
+  counter: 'selezionati',
+  counterCompact: 'sel.',
   archive: 'Archivia',
+  tag: 'Tag',
+  exportLabel: 'Esporta',
+  closeAriaLabel: 'Annulla selezione',
   confirmTitle: 'Confermi rimozione di 3 giochi dalla libreria?',
   confirmCta: 'Conferma',
   cancelCta: 'Annulla',
 };
 
-describe('BulkSelectionBar (Wave B.3)', () => {
+describe('BulkSelectionBar (Wave B.3 + SP4 mockup conformance)', () => {
   describe('rendering + ARIA', () => {
     it('renders even when selectedCount=0 (no count-conditional unmount)', () => {
       const labels: BulkSelectionBarLabels = {
         ...baseLabels,
         regionLabel: '0 selezionati',
-        counter: '0 selezionati',
       };
       const { container } = render(
         <BulkSelectionBar
@@ -73,7 +85,7 @@ describe('BulkSelectionBar (Wave B.3)', () => {
       expect(region).toHaveAttribute('aria-label', '3 selezionati');
     });
 
-    it('renders the counter label', () => {
+    it('renders counter label without numeric count (count is in chip)', () => {
       render(
         <BulkSelectionBar
           selectedCount={3}
@@ -82,10 +94,13 @@ describe('BulkSelectionBar (Wave B.3)', () => {
           onArchive={vi.fn().mockResolvedValue(undefined)}
         />
       );
-      expect(screen.getByText('3 selezionati')).toBeInTheDocument();
+      const counter = screen.getByText('selezionati');
+      expect(counter).toBeInTheDocument();
+      // Count "3" is rendered in chip, not in the counter label
+      expect(counter.textContent).not.toMatch(/\d/);
     });
 
-    it('renders cancel + archive buttons with resolved labels', () => {
+    it('renders cancel (✕) + archive buttons with resolved labels', () => {
       render(
         <BulkSelectionBar
           selectedCount={3}
@@ -94,11 +109,11 @@ describe('BulkSelectionBar (Wave B.3)', () => {
           onArchive={vi.fn().mockResolvedValue(undefined)}
         />
       );
-      expect(screen.getByRole('button', { name: 'Annulla' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Annulla selezione' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Archivia' })).toBeInTheDocument();
     });
 
-    it('applies motion-safe transition class for prefers-reduced-motion gating', () => {
+    it('applies motion-safe slide-in animation class for prefers-reduced-motion gating', () => {
       const { container } = render(
         <BulkSelectionBar
           selectedCount={3}
@@ -108,14 +123,87 @@ describe('BulkSelectionBar (Wave B.3)', () => {
         />
       );
       const region = container.querySelector('[data-slot="library-bulk-selection-bar"]');
-      // Motion-safe Tailwind class collapses to 0.01ms under prefers-reduced-motion;
+      // Motion-safe Tailwind classes collapse to no-op under prefers-reduced-motion;
       // E2E asserts computed style. Here only class presence.
-      expect(region?.className).toMatch(/motion-safe:transition/);
+      expect(region?.className).toMatch(/motion-safe:/);
+    });
+  });
+
+  describe('SP4 mockup conformance (sp4-library-desktop.jsx:895-944)', () => {
+    it('renders the dark floating bar (bg-foreground + text-background)', () => {
+      const { container } = render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+      const bar = container.querySelector('[data-slot="library-bulk-selection-bar"]');
+      expect(bar?.className).toMatch(/bg-foreground/);
+      expect(bar?.className).toMatch(/text-background/);
+    });
+
+    it('renders the count chip with entity-game background and tabular-nums', () => {
+      const { container } = render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+      const chip = container.querySelector('[data-slot="library-bulk-selection-count-chip"]');
+      expect(chip).not.toBeNull();
+      expect(chip).toHaveTextContent('3');
+      expect(chip?.className).toMatch(/bg-entity-game/);
+      expect(chip?.className).toMatch(/tabular-nums/);
+    });
+
+    it('renders Archive + Tag + Export action buttons (3 actions)', () => {
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+      expect(screen.getByRole('button', { name: /Archivia/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Tag/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Esporta/ })).toBeInTheDocument();
+    });
+
+    it('renders close (✕) button with closeAriaLabel', () => {
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Annulla selezione' })).toBeInTheDocument();
+    });
+
+    it('positions the bar at fixed bottom-4 center via translate-x', () => {
+      const { container } = render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+      const bar = container.querySelector('[data-slot="library-bulk-selection-bar"]');
+      expect(bar?.className).toMatch(/fixed/);
+      expect(bar?.className).toMatch(/bottom-4/);
+      expect(bar?.className).toMatch(/-translate-x-1\/2/);
     });
   });
 
   describe('exit interactions', () => {
-    it('Annulla click → onExitSelectMode()', () => {
+    it('Close (✕) click → onExitSelectMode()', () => {
       const onExitSelectMode = vi.fn();
       render(
         <BulkSelectionBar
@@ -125,7 +213,7 @@ describe('BulkSelectionBar (Wave B.3)', () => {
           onArchive={vi.fn().mockResolvedValue(undefined)}
         />
       );
-      fireEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Annulla selezione' }));
       expect(onExitSelectMode).toHaveBeenCalledTimes(1);
     });
 
@@ -162,6 +250,85 @@ describe('BulkSelectionBar (Wave B.3)', () => {
     });
   });
 
+  describe('Tag + Export action callbacks', () => {
+    it('Tag click invokes onTag when provided', () => {
+      const onTag = vi.fn();
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+          onTag={onTag}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Tag/ }));
+      expect(onTag).toHaveBeenCalledTimes(1);
+    });
+
+    it('Export click invokes onExport when provided', () => {
+      const onExport = vi.fn();
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+          onExport={onExport}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Esporta/ }));
+      expect(onExport).toHaveBeenCalledTimes(1);
+    });
+
+    it('Tag/Export buttons are no-op (do not crash) when callbacks omitted', () => {
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+      expect(() => fireEvent.click(screen.getByRole('button', { name: /Tag/ }))).not.toThrow();
+      expect(() => fireEvent.click(screen.getByRole('button', { name: /Esporta/ }))).not.toThrow();
+    });
+  });
+
+  describe('compact mode', () => {
+    it('uses counterCompact label instead of counter when compact=true', () => {
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+          compact
+        />
+      );
+      expect(screen.getByText('sel.')).toBeInTheDocument();
+      expect(screen.queryByText('selezionati')).not.toBeInTheDocument();
+    });
+
+    it('hides action labels in compact mode (icons remain via aria-label)', () => {
+      render(
+        <BulkSelectionBar
+          selectedCount={3}
+          labels={baseLabels}
+          onExitSelectMode={vi.fn()}
+          onArchive={vi.fn().mockResolvedValue(undefined)}
+          compact
+        />
+      );
+      // Action labels are no longer in visible text (only icon + aria-label)
+      // The buttons must still be reachable by their accessible name (icon + aria-label fallback).
+      // Archive button still resolves by name='Archivia' (aria-label fallback).
+      expect(screen.getByRole('button', { name: 'Archivia' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Tag' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Esporta' })).toBeInTheDocument();
+    });
+  });
+
   describe('Archivia confirm flow (Radix AlertDialog)', () => {
     it('Archivia click → AlertDialog opens with confirmTitle', async () => {
       render(
@@ -176,7 +343,7 @@ describe('BulkSelectionBar (Wave B.3)', () => {
       // Dialog NOT open initially
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Archivia' }));
+      fireEvent.click(screen.getByRole('button', { name: /Archivia/ }));
 
       // Dialog opens (Radix uses Portal → check globally via screen)
       const dialog = await screen.findByRole('alertdialog');
@@ -202,7 +369,7 @@ describe('BulkSelectionBar (Wave B.3)', () => {
         />
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Archivia' }));
+      fireEvent.click(screen.getByRole('button', { name: /Archivia/ }));
       await screen.findByRole('alertdialog');
 
       // Confirm button (uses confirmCta label "Conferma")
@@ -225,18 +392,15 @@ describe('BulkSelectionBar (Wave B.3)', () => {
         />
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Archivia' }));
+      fireEvent.click(screen.getByRole('button', { name: /Archivia/ }));
       await screen.findByRole('alertdialog');
 
-      // Cancel inside dialog uses cancelCta label. Two buttons share "Annulla":
-      // (1) the bar exit button (already in DOM), (2) dialog cancel.
-      // Dialog cancel is the second one (rendered later). Use within(dialog).
+      // Dialog cancel button (cancelCta label "Annulla" inside dialog). Scope
+      // the search to the dialog to avoid matching the bar's close ✕ aria-label
+      // "Annulla selezione".
       const dialog = screen.getByRole('alertdialog');
-      const cancelInDialog = Array.from(dialog.querySelectorAll('button')).find(
-        b => b.textContent === 'Annulla'
-      );
-      expect(cancelInDialog).toBeDefined();
-      fireEvent.click(cancelInDialog!);
+      const cancelInDialog = within(dialog).getByRole('button', { name: 'Annulla' });
+      fireEvent.click(cancelInDialog);
 
       // Dialog closes
       await waitFor(() => {
@@ -247,7 +411,7 @@ describe('BulkSelectionBar (Wave B.3)', () => {
   });
 
   describe('disabled state', () => {
-    it('disables both cancel + archive buttons when disabled=true', () => {
+    it('disables close + archive + tag + export buttons when disabled=true', () => {
       render(
         <BulkSelectionBar
           selectedCount={3}
@@ -257,11 +421,13 @@ describe('BulkSelectionBar (Wave B.3)', () => {
           disabled
         />
       );
-      expect(screen.getByRole('button', { name: 'Annulla' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Annulla selezione' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Archivia' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Tag' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Esporta' })).toBeDisabled();
     });
 
-    it('disabled cancel does NOT trigger onExitSelectMode on click', () => {
+    it('disabled close ✕ does NOT trigger onExitSelectMode on click', () => {
       const onExitSelectMode = vi.fn();
       render(
         <BulkSelectionBar
@@ -272,7 +438,7 @@ describe('BulkSelectionBar (Wave B.3)', () => {
           disabled
         />
       );
-      fireEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Annulla selezione' }));
       expect(onExitSelectMode).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/src/components/features/library/index.ts
+++ b/apps/web/src/components/features/library/index.ts
@@ -55,12 +55,13 @@ export type {
 
 export { AdvancedFiltersDrawer } from '@/components/features/library/AdvancedFiltersDrawer';
 export type {
+  AdvancedFiltersDrawerGameOption,
   AdvancedFiltersDrawerProps,
+  LibraryFilterEntity,
+  LibraryFilterPeriod,
   LibraryFilters,
-  GameLibraryFilters,
-  AgentLibraryFilters,
-  SessionLibraryFilters,
-  KbLibraryFilters,
-  ChatLibraryFilters,
-  FiltersForScope,
+  LibraryFilterStatus,
+  LibraryFilterTag,
+  LibraryFilterWeight,
 } from '@/components/features/library/AdvancedFiltersDrawer';
+export { countActiveFilters } from '@/components/features/library/AdvancedFiltersDrawer';

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1675,31 +1675,76 @@
           }
         },
         "description": "Filter the library by entity-specific dimensions.",
+        "closeAriaLabel": "Close filters panel",
+        "header": {
+          "subtitle": "{count, plural, =0 {No filters · scope: library} =1 {1 active · scope: library} other {# active · scope: library}}"
+        },
         "apply": "Apply",
+        "applyWithCount": "Apply ({count})",
         "clear": "Reset",
+        "reset": "Reset",
         "section": {
-          "state": "State",
-          "withKb": "With Knowledge Base only",
-          "rating": "Minimum rating",
-          "players": "Player count",
-          "year": "Year published",
-          "agentType": "Agent type",
-          "activeOnly": "Active only",
-          "sessionStatus": "Session status",
-          "sessionType": "Session type",
-          "playerCount": "Players (min)",
-          "processingState": "Processing state",
-          "messageCountMin": "Messages (min)"
-        },
-        "state": {
-          "owned": "Owned",
-          "wishlist": "Wishlist",
-          "loaned": "Loaned"
-        },
-        "kbState": {
-          "ready": "Ready",
-          "pending": "Pending",
-          "failed": "Failed"
+          "status": {
+            "title": "Status",
+            "options": {
+              "owned": "Owned",
+              "wishlist": "Wishlist",
+              "setup": "Setting up",
+              "archived": "Archived"
+            }
+          },
+          "entity": {
+            "title": "Entity type",
+            "options": {
+              "game": "Games",
+              "agent": "Agents",
+              "kb": "KB documents",
+              "session": "Sessions",
+              "chat": "Chat"
+            }
+          },
+          "game": {
+            "title": "Game",
+            "placeholder": "Filter by a specific game...",
+            "empty": "No game available from the current library."
+          },
+          "period": {
+            "title": "Period",
+            "options": {
+              "7d": "Last 7 days",
+              "30d": "Last 30 days",
+              "1y": "Last year",
+              "all": "Always",
+              "range": "Custom range..."
+            }
+          },
+          "tags": {
+            "title": "Tag",
+            "options": {
+              "family": "Family",
+              "strategy": "Strategy",
+              "coop": "Co-op",
+              "engine": "Engine builder",
+              "auction": "Auction",
+              "rollAndWrite": "Roll & Write",
+              "cardDriven": "Card driven",
+              "tableau": "Tableau"
+            }
+          },
+          "rating": {
+            "title": "Rating",
+            "minAriaLabel": "Minimum rating",
+            "maxAriaLabel": "Maximum rating"
+          },
+          "weight": {
+            "title": "Complexity",
+            "options": {
+              "light": "Light · 1.0–2.0",
+              "medium": "Medium · 2.0–3.0",
+              "heavy": "Heavy · 3.0–4.0",
+              "extra": "Extra heavy · 4.0+"
+            }
+          }
         },
         "stato": {
           "label": "State",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1725,7 +1725,14 @@
         "compact": "Compact"
       },
       "bulk": {
+        "counter": "selected",
+        "counterCompact": "sel.",
+        "closeAriaLabel": "Cancel selection",
         "actions": {
+          "archive": "Archive",
+          "archiveAriaLabel": "Archive the selected items",
+          "tag": "Tag",
+          "tagAriaLabel": "Add tags to the selected items",
           "delete": "Delete",
           "deleteAriaLabel": "Delete the selected items",
           "favorite": "Mark favorite",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1775,7 +1775,14 @@
         "compact": "Compatta"
       },
       "bulk": {
+        "counter": "{count, plural, =1 {selezionato} other {selezionati}}",
+        "counterCompact": "sel.",
+        "closeAriaLabel": "Annulla selezione",
         "actions": {
+          "archive": "Archivia",
+          "archiveAriaLabel": "Archivia gli elementi selezionati",
+          "tag": "Tag",
+          "tagAriaLabel": "Aggiungi tag agli elementi selezionati",
           "delete": "Elimina",
           "deleteAriaLabel": "Elimina gli elementi selezionati",
           "favorite": "Aggiungi ai preferiti",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1725,31 +1725,76 @@
           }
         },
         "description": "Filtra la libreria per dimensioni specifiche dell'entità.",
+        "closeAriaLabel": "Chiudi pannello filtri",
+        "header": {
+          "subtitle": "{count, plural, =0 {Nessun filtro · scope: library} =1 {1 attivo · scope: library} other {# attivi · scope: library}}"
+        },
         "apply": "Applica",
+        "applyWithCount": "Applica ({count})",
         "clear": "Reimposta",
+        "reset": "Reset",
         "section": {
-          "state": "Stato",
-          "withKb": "Solo con Knowledge Base",
-          "rating": "Rating minimo",
-          "players": "Numero di giocatori",
-          "year": "Anno di pubblicazione",
-          "agentType": "Tipo di agente",
-          "activeOnly": "Solo attivi",
-          "sessionStatus": "Stato sessione",
-          "sessionType": "Tipo sessione",
-          "playerCount": "Giocatori (min)",
-          "processingState": "Stato di elaborazione",
-          "messageCountMin": "Messaggi (min)"
-        },
-        "state": {
-          "owned": "Posseduto",
-          "wishlist": "Wishlist",
-          "loaned": "In prestito"
-        },
-        "kbState": {
-          "ready": "Pronto",
-          "pending": "In elaborazione",
-          "failed": "Errore"
+          "status": {
+            "title": "Stato",
+            "options": {
+              "owned": "Posseduto",
+              "wishlist": "Wishlist",
+              "setup": "In setup",
+              "archived": "Archiviato"
+            }
+          },
+          "entity": {
+            "title": "Tipo entità",
+            "options": {
+              "game": "Giochi",
+              "agent": "Agenti",
+              "kb": "Documenti KB",
+              "session": "Sessioni",
+              "chat": "Chat"
+            }
+          },
+          "game": {
+            "title": "Gioco",
+            "placeholder": "Filtra per gioco specifico...",
+            "empty": "Nessun gioco disponibile dalla libreria corrente."
+          },
+          "period": {
+            "title": "Periodo",
+            "options": {
+              "7d": "Ultimi 7 giorni",
+              "30d": "Ultimi 30 giorni",
+              "1y": "Ultimo anno",
+              "all": "Sempre",
+              "range": "Range personalizzato..."
+            }
+          },
+          "tags": {
+            "title": "Tag",
+            "options": {
+              "family": "Family",
+              "strategy": "Strategy",
+              "coop": "Coop",
+              "engine": "Engine builder",
+              "auction": "Auction",
+              "rollAndWrite": "Roll & Write",
+              "cardDriven": "Card driven",
+              "tableau": "Tableau"
+            }
+          },
+          "rating": {
+            "title": "Rating",
+            "minAriaLabel": "Rating minimo",
+            "maxAriaLabel": "Rating massimo"
+          },
+          "weight": {
+            "title": "Complessità",
+            "options": {
+              "light": "Light · 1.0–2.0",
+              "medium": "Medium · 2.0–3.0",
+              "heavy": "Heavy · 3.0–4.0",
+              "extra": "Extra heavy · 4.0+"
+            }
+          }
         },
         "stato": {
           "label": "Stato",


### PR DESCRIPTION
## Summary
PR3 finale della consolidation Opt B per `/library` mockup conformance.

Componenti re-skinned:
- `BulkSelectionBar` — floating dark bar (`bg-foreground` + `text-background`) at bottom center, entity-game count chip separato dal counter label, 3 action buttons (Archivia / Tag / Esporta) con icon + label, close ✕ con `closeAriaLabel`, compact mode + motion-safe slide-in.
- `AdvancedFiltersDrawer` — **refactor architetturale** da scope-conditional (5 entity variants × per-scope sections, `LibraryFilters` discriminated union) a **cross-entity hub-level** con 7 sezioni statiche (Stato / Tipo entità / Gioco / Periodo / Tag / Rating / Complessità) e 4 nuovi kind (chips-multi / select-multi / period-quick / range visual stylized). Header custom con entity-agent icon box + count subtitle ICU + close ✕. Footer Reset (transparent) + Applica (entity-agent + count suffix).

Refactor scope:
- `types.ts`: drop `GameLibraryFilters/AgentLibraryFilters/.../FiltersForScope` union, introduce single `LibraryFilters` shape with 7 cross-entity fields + `countActiveFilters()` helper.
- `sections.ts`: drop `getSectionsForScope()` scope dispatcher, add `DRAWER_SECTIONS` static 7-section descriptor + `isDefaultOpen()` (first 3 open by default).
- `AdvancedFiltersDrawer.tsx`: full rewrite for new kinds, accordion section wrappers, entity-color chip mapping (compile-time exhaustive for Tailwind extraction).
- `LibraryHub.tsx` consumer: drop `drawerEntityScope` + per-tab filter reset useEffect, `activeFilters` now `{}` cross-entity, use `countActiveFilters` helper for chip badge.
- i18n (it/en): new keys for cross-entity drawer (`closeAriaLabel`, `header.subtitle` ICU plural, `applyWithCount` ICU, `reset`, 7 section groups), drop obsolete scope-only keys.

## Mockup references
- BulkSelectionBar: `admin-mockups/design_files/sp4-library-desktop.jsx:895-944`
- AdvancedFiltersDrawer: `admin-mockups/design_files/sp4-library-desktop.jsx:312-637`

## Tests
- BulkSelectionBar: 23/23 (Wave B.3 invariants preserved + SP4 mockup conformance suite)
- AdvancedFiltersDrawer: 27/27 (open/close lifecycle, 7-section rendering, chips-multi / select-multi / period-quick / range interactions, footer actions, `countActiveFilters`)
- sections: 15/15 (descriptor shape + isDefaultOpen)
- LibraryHub integration: 36/36 (cross-entity drawer wiring + mock i18n updates)
- Total: 101/101 PR3-touched tests pass.
- TypeScript: `pnpm typecheck` clean.
- ESLint: `pnpm lint` clean via pre-commit hook.

## Out of scope (deferred)
- Visual screenshot (post-screenshot pending manual capture; visual gate retired 2026-05-20 per CLAUDE.md).
- BulkSelectionBar `Tag` + `Esporta` callback wiring (UI shipped as stub, callbacks `onTag` + `onExport` optional in props; wire to real handlers in follow-up).
- AdvancedFiltersDrawer `period === 'range'` custom date-picker (placeholder option rendered; bounds `periodFrom`/`periodTo` plumbing deferred).
- Active filter application against hub data sources (this PR only changes the drawer UI + state shape; consumers of `activeFilters` continue treating it opaquely — wire actual filtering against `useHybridHubItems` derive layer in follow-up).

## Epic closure
Con il merge di PR3, l'allineamento mockup-vs-implementation per `/library` SP4 è completo. La 3-PR sequence (PR1 #1862 header chrome + PR2 #1864 content surface + this PR3 overlays) chiude il gap visivo identificato nello screenshot baseline.

## Test plan
- [x] Unit tests aggiornati per BulkSelectionBar (+SP4 mockup conformance suite) + AdvancedFiltersDrawer (cross-entity rewrite)
- [x] sections.test.ts riscritto per DRAWER_SECTIONS static descriptor
- [x] LibraryHub integration mock i18n aggiornato per nuove keys cross-entity
- [x] TypeScript + ESLint via pre-commit
- [ ] Manual smoke `/library`: select 3 card → BulkSelectionBar dark bar appare con count chip + 4 buttons
- [ ] Manual smoke: click ⚙ Filtri avanzati → drawer 400px da destra con 7 sezioni accordion (3 open by default)
- [ ] Manual smoke: toggle chip in sezione "Stato" → count badge in section header + active count in drawer subtitle update
- [ ] Manual smoke: Applica → drawer chiude, activeFilters applicato (no-op functional sink in current impl, by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)