### PR TITLE
fix(admin-monitor): #1853 #1854 recover lost follow-up commits from PR #1867

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
@@ -168,6 +168,40 @@ function StatusSummary({ containers }: { containers: ContainerInfo[] }) {
 /*  Main Component                                                     */
 /* ------------------------------------------------------------------ */
 
+/**
+ * Cap the polling backoff multiplier at 5× the base interval so the worst case
+ * stays at 5 minutes (60s base × 5 = 300s). Beyond that admins should reach for
+ * the manual refresh button or investigate why the BE is down.
+ */
+const MAX_BACKOFF_MULTIPLIER = 5;
+const MAX_BACKOFF_DELAY_SECONDS = 300;
+
+/**
+ * Compute the next polling delay applying exponential backoff.
+ *
+ * Schedule (with baseSeconds=60):
+ *   failures=0 → 60s  (1×, no backoff)
+ *   failures=1 → 60s  (2^0=1×, first failure tolerated)
+ *   failures=2 → 120s (2×)
+ *   failures=3 → 240s (4×)
+ *   failures≥4 → 300s (capped at MAX_BACKOFF_DELAY_SECONDS)
+ *
+ * Exported for unit testing — keeps the React component free of fake-timer
+ * tests that are fragile against StrictMode + nested setTimeout chains.
+ */
+export function computePollingBackoff(
+  baseSeconds: number,
+  failures: number,
+  caps: { maxMultiplier: number; maxDelaySeconds: number } = {
+    maxMultiplier: MAX_BACKOFF_MULTIPLIER,
+    maxDelaySeconds: MAX_BACKOFF_DELAY_SECONDS,
+  }
+): number {
+  if (failures <= 0) return baseSeconds;
+  const multiplier = Math.min(Math.pow(2, failures - 1), caps.maxMultiplier);
+  return Math.min(baseSeconds * multiplier, caps.maxDelaySeconds);
+}
+
 export function ContainerDashboard() {
   const [containers, setContainers] = useState<ContainerInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -175,9 +209,15 @@ export function ContainerDashboard() {
   const [refreshInterval, setRefreshInterval] = useState<number>(DEFAULT_REFRESH_INTERVAL);
   const [countdown, setCountdown] = useState<number>(DEFAULT_REFRESH_INTERVAL);
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const hasLoadedRef = useRef(false);
+  /**
+   * Tracks consecutive `fetchContainers` failures so the polling fallback can
+   * apply exponential backoff (1×, 2×, 4×, 5× cap). Reset to 0 on the first
+   * successful fetch. Capped at 4 to bound the multiplier exponent.
+   */
+  const consecutiveFailuresRef = useRef(0);
   const { toast } = useToast();
 
   const fetchContainers = useCallback(async () => {
@@ -185,7 +225,9 @@ export function ContainerDashboard() {
       const data = await api.admin.getDockerContainers();
       setContainers(data);
       hasLoadedRef.current = true;
+      consecutiveFailuresRef.current = 0;
     } catch {
+      consecutiveFailuresRef.current = Math.min(consecutiveFailuresRef.current + 1, 4);
       if (!hasLoadedRef.current) {
         toast({ title: 'Failed to load container data', variant: 'destructive' });
       }
@@ -193,6 +235,16 @@ export function ContainerDashboard() {
       setLoading(false);
     }
   }, [toast]);
+
+  /**
+   * Bound the polling delay against the current `consecutiveFailuresRef`.
+   * Uses the exported `computePollingBackoff` helper so the schedule stays
+   * unit-testable in isolation.
+   */
+  const computeNextPollingDelay = useCallback(
+    () => computePollingBackoff(refreshInterval, consecutiveFailuresRef.current),
+    [refreshInterval]
+  );
 
   // -----------------------------------------------------------------
   // #1853 — SSE-driven refresh (primary path)
@@ -227,33 +279,41 @@ export function ContainerDashboard() {
   }, [fetchContainers]);
 
   // -----------------------------------------------------------------
-  // Polling fallback (low-frequency: 60s minimum)
+  // Polling fallback (low-frequency: 60s minimum) with exponential backoff
   // -----------------------------------------------------------------
+  // Two coordinated timers:
+  //   1. `pollTimerRef` (setTimeout, recursive) — backoff-aware fetch scheduler.
+  //      The next delay is computed by `computeNextPollingDelay()` so the
+  //      `consecutiveFailuresRef` count drives the wait between polls.
+  //   2. `countdownRef` (setInterval, 1s) — drives the visible "Xs" countdown.
+  //      The updater is pure (no side effects), so StrictMode's double-invoke
+  //      validation can't trigger extra fetches.
   useEffect(() => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     if (countdownRef.current) clearInterval(countdownRef.current);
+    if (!autoRefresh) return;
 
-    if (autoRefresh) {
-      setCountdown(refreshInterval);
+    setCountdown(refreshInterval);
 
-      countdownRef.current = setInterval(() => {
-        setCountdown(prev => {
-          if (prev <= 1) return refreshInterval;
-          return prev - 1;
-        });
-      }, 1000);
+    countdownRef.current = setInterval(() => {
+      // Pure updater — no fetch side effects (would double-fire under StrictMode).
+      setCountdown(prev => (prev > 1 ? prev - 1 : computeNextPollingDelay()));
+    }, 1000);
 
-      intervalRef.current = setInterval(() => {
-        fetchContainers();
-        setCountdown(refreshInterval);
-      }, refreshInterval * 1000);
-    }
+    const scheduleNextPoll = () => {
+      const delaySeconds = computeNextPollingDelay();
+      pollTimerRef.current = setTimeout(async () => {
+        await fetchContainers();
+        scheduleNextPoll(); // chain — next delay reflects updated failure count
+      }, delaySeconds * 1000);
+    };
+    scheduleNextPoll();
 
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
       if (countdownRef.current) clearInterval(countdownRef.current);
     };
-  }, [autoRefresh, refreshInterval, fetchContainers]);
+  }, [autoRefresh, refreshInterval, fetchContainers, computeNextPollingDelay]);
 
   return (
     <div className="space-y-6" data-testid="container-dashboard">
@@ -281,6 +341,8 @@ export function ContainerDashboard() {
             onClick={() => setAutoRefresh(!autoRefresh)}
             className="gap-1.5"
             data-testid="auto-refresh-toggle"
+            aria-pressed={autoRefresh}
+            aria-label={autoRefresh ? 'Pause auto-refresh' : 'Resume auto-refresh'}
           >
             {autoRefresh ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
             {autoRefresh ? 'Pause' : 'Resume'}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
@@ -111,6 +111,12 @@ export function RestartAllPanel() {
   }, []);
 
   const executeRestartAll = useCallback(async () => {
+    // Close the confirmation dialog immediately so the admin can watch the
+    // ServiceProgressRow stream live. `AdminConfirmationDialog.handleConfirm`
+    // awaits `onConfirm` *before* calling `onClose`, so without this the
+    // dialog would stay open (in "Elaborazione…" state) for the full 5+ s
+    // restart loop, hiding the per-service progress underneath.
+    setShowConfirm(false);
     setIsRestarting(true);
 
     // Initialize progress

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/components/admin/monitor/use-live-events', () => ({
   useLiveEvents: mockUseLiveEvents,
 }));
 
-import { ContainerDashboard } from '../ContainerDashboard';
+import { ContainerDashboard, computePollingBackoff } from '../ContainerDashboard';
 
 const mockContainers = [
   {
@@ -299,6 +299,27 @@ describe('ContainerDashboard', () => {
     });
   });
 
+  it('exposes aria-pressed on the Pause/Resume toggle (a11y)', async () => {
+    const user = userEvent.setup();
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    const toggle = await screen.findByTestId('auto-refresh-toggle');
+    // Initially auto-refresh is ON → aria-pressed="true"
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(toggle).toHaveAttribute('aria-label', 'Pause auto-refresh');
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(toggle).toHaveAttribute('aria-label', 'Resume auto-refresh');
+  });
+
+  // Backoff is unit-tested in isolation below (`computePollingBackoff` table)
+  // because exercising it through the real component would require fake
+  // timers + a nested `setTimeout` chain + StrictMode double-invoke handling,
+  // which together are very flaky.
+
   it('polling fallback offers 60s/2m/5m intervals only', async () => {
     mockGetDockerContainers.mockResolvedValue(mockContainers);
     render(<ContainerDashboard />);
@@ -307,5 +328,28 @@ describe('ContainerDashboard', () => {
     const optionValues = Array.from(select.options).map(o => Number(o.value));
     expect(optionValues).toEqual([60, 120, 300]);
     expect(select.value).toBe('60'); // default
+  });
+});
+
+describe('computePollingBackoff (unit)', () => {
+  // Schedule table, baseSeconds=60, default caps (5× / 300s):
+  it.each([
+    [0, 60], // no failures → base interval
+    [1, 60], // 2^0 = 1× — first failure tolerated, no backoff yet
+    [2, 120], // 2^1 = 2×
+    [3, 240], // 2^2 = 4×
+    [4, 300], // 2^3 = 8× would be 480, but multiplier capped at 5 → 300
+    [5, 300], // multiplier still 5 → 300
+    [10, 300], // worst case stays at the 300s ceiling
+  ])('failures=%d → %ds (base 60)', (failures, expected) => {
+    expect(computePollingBackoff(60, failures)).toBe(expected);
+  });
+
+  it('honours custom caps', () => {
+    expect(computePollingBackoff(30, 5, { maxMultiplier: 3, maxDelaySeconds: 60 })).toBe(60); // 30 * min(2^4, 3) = 30 * 3 = 90, clamped at 60
+  });
+
+  it('treats negative failures as 0', () => {
+    expect(computePollingBackoff(60, -1)).toBe(60);
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/RestartAllPanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/RestartAllPanel.test.tsx
@@ -185,6 +185,34 @@ describe('RestartAllPanel', () => {
     );
   });
 
+  it('closes dialog immediately when restart starts so ServiceProgress is visible', async () => {
+    // Regression guard: AdminConfirmationDialog.handleConfirm awaits onConfirm
+    // BEFORE calling onClose. The 5+ second restart loop must NOT keep the
+    // modal open on top of the per-service progress rows — admins need to see
+    // the live status of each tier during the restart.
+    const user = userEvent.setup();
+    // Slow restart so we can observe the dialog state mid-flight.
+    mockRestartService.mockImplementation(
+      () =>
+        new Promise(resolve =>
+          setTimeout(() => resolve({ message: 'OK', estimatedDowntime: '5s' }), 200)
+        )
+    );
+
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+    await user.type(await screen.findByRole('textbox'), 'RESTART ALL');
+    await user.click(screen.getByRole('button', { name: /confirm restart all/i }));
+
+    // Dialog must be gone almost immediately (well before the first restart
+    // finishes); the in-flight progress panel must already be visible.
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('restart-progress')).toBeInTheDocument();
+  });
+
   it('passes axe a11y scan with dialog open', async () => {
     const user = userEvent.setup();
     const { container } = render(<RestartAllPanel />);

--- a/apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx
+++ b/apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx
@@ -145,13 +145,22 @@ export function AdminConfirmationDialog({
               {title}
             </DialogTitle>
           </div>
-          <DialogDescription className="pt-3 space-y-2">
-            <p className="text-base">{message}</p>
-            {warningMessage && (
-              <p className="text-sm text-yellow-600 dark:text-yellow-500 font-medium">
-                ⚠️ {warningMessage}
-              </p>
-            )}
+          {/*
+            #1854-review — `DialogDescription` is rendered as `<p>` by Radix.
+            Wrapping the message + warning paragraphs in another `<p>` triggers
+            "<p> cannot contain a nested <p>" hydration warnings. `asChild`
+            re-roots the description as the `<div>` below so the two children
+            stay valid `<p>` elements without nesting.
+          */}
+          <DialogDescription className="pt-3 space-y-2" asChild>
+            <div>
+              <p className="text-base">{message}</p>
+              {warningMessage && (
+                <p className="text-sm text-yellow-600 dark:text-yellow-500 font-medium">
+                  ⚠️ {warningMessage}
+                </p>
+              )}
+            </div>
           </DialogDescription>
         </DialogHeader>
 


### PR DESCRIPTION
## Context

PR #1867 was merged with \`headRefOid=f1c25451\` (core implementation commit only) — the **critical UX fix** and the **3 polish findings** that landed on the same feature branch as later commits never made it to \`main-dev\`.

Reason: probable residue of an earlier \`gh pr merge --auto\` invocation done on the original SHA, fired when checks went green before the polish commit was registered as the PR HEAD. The remote feature branch \`origin/feature/issue-1853-1854-c1-followup\` is still alive at HEAD \`95efb3c44\`, which is where the recovered commits come from.

## What this PR restores

| Cherry-picked from | New SHA | Title |
|---|---|---|
| \`0703cab44\` | \`1cc6c63dd\` | fix(admin-monitor): #1854 close confirm dialog immediately on Confirm |
| \`95efb3c44\` | \`f1846dbdc\` | chore(admin-monitor): #1853 #1854 apply remaining review findings |

### Restored fixes

**🔴 #1854 — Dialog immediate-close regression** (from \`0703cab44\`)
\`AdminConfirmationDialog.handleConfirm\` awaits \`onConfirm\` before \`onClose\`, so the dialog stayed open under \`Elaborazione…\` for the full ~5s restart loop, hiding \`ServiceProgressRow\`. \`setShowConfirm(false)\` is now the first line of \`executeRestartAll\`. Regression test \`closes dialog immediately when restart starts so ServiceProgress is visible\` covers it.

**🟢 #1854 — AdminConfirmationDialog nested \`<p>\`** (from \`95efb3c44\`)
\`DialogDescription\` is rendered as \`<p>\` by Radix; the message + warning children were nested \`<p>\` (invalid HTML). Reworked with Radix \`asChild\` + \`<div>\` wrapper.

**🟢 #1853 — Pause/Resume \`aria-pressed\`** (from \`95efb3c44\`)
Added \`aria-pressed={autoRefresh}\` + dynamic \`aria-label\` to the polling fallback toggle button.

**🟢 #1853 — Exponential backoff on polling failures** (from \`95efb3c44\`)
Tracks \`consecutiveFailuresRef\`, exported pure helper \`computePollingBackoff(baseSeconds, failures, caps?)\`. Schedule: 0/1 → base, 2 → 2×, 3 → 4×, ≥4 → 5× capped at 300s. Refactored polling timer into a \`setTimeout\` chain (\`pollTimerRef\`) + pure 1s \`setInterval\` countdown ticker, so React StrictMode's double-invoke validation can't fire duplicate fetches.

## Test plan

- [x] \`pnpm test apps/web/src/app/admin/(dashboard)/monitor/containers src/components/ui/admin/__tests__/admin-confirmation-dialog.test.tsx --run\` — **52/52 pass**
- [x] Cherry-pick had no conflicts (base \`f1c25451\` already in \`main-dev\` via PR #1867 merge commit \`953f9c969\`)

## Cleanup follow-up

After this PR merges, manually delete the dangling \`feature/issue-1853-1854-c1-followup\` remote branch — it still holds the original-SHA commits and was never reaped by \`--delete-branch\` because the actual merge SHA was the older f1c254518.

## Related
- PR #1867 — partial merge that triggered this recovery
- Closes follow-up for #1853 (DoD reopened from review)
- Closes follow-up for #1854 (DoD reopened from review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)