### PR TITLE
feat(admin-infra): #1837 F4-C1 KPISparkline + LiveEventLog

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
@@ -4,12 +4,15 @@
  * ContainerDashboard — Container status grid with SSE-driven refresh + polling fallback.
  * Issue #143  — Admin Infrastructure Panel Phase 4 (original polling implementation).
  * Issue #1853 — Wire `useLiveEvents` for real-time updates; demote polling to 60s+ fallback.
+ * Issue #1837 — Lift `useLiveEvents` subscription to page.tsx so ContainerDashboard +
+ *               LiveEventLog share a single EventSource. Accept `liveEvents` + `sseConnected`
+ *               as props instead of subscribing internally.
  *
  * Refresh strategy:
- *   - SSE primary: `useLiveEvents({ aggregateTypes: ['Container', 'Infrastructure'] })`
- *     triggers `fetchContainers()` whenever a new infra/container event arrives.
- *   - Polling fallback: 60s default (was 30s), settable up to 5m, guarantees state
- *     converges even when SSE is offline or the BE has not yet emitted relevant events.
+ *   - SSE primary: parent owns `useLiveEvents({ aggregateTypes: ['Container', 'Infrastructure'] })`
+ *     and forwards events here. New events trigger `fetchContainers()`.
+ *   - Polling fallback: 60s default, settable up to 5m, guarantees state converges even when
+ *     SSE is offline or the BE has not yet emitted relevant events.
  *
  * BE event-type gap (known, out of scope per #1853):
  *   The backend currently does not emit `Container.*` / `Infrastructure.*` domain
@@ -24,7 +27,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Clock, Loader2, Pause, Play, RadioTower, RefreshCw, ScrollText } from 'lucide-react';
 import Link from 'next/link';
 
-import { useLiveEvents } from '@/components/admin/monitor/use-live-events';
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Button } from '@/components/ui/primitives/button';
 import { useToast } from '@/hooks/useToast';
@@ -202,7 +205,15 @@ export function computePollingBackoff(
   return Math.min(baseSeconds * multiplier, caps.maxDelaySeconds);
 }
 
-export function ContainerDashboard() {
+interface ContainerDashboardProps {
+  liveEvents?: ReadonlyArray<DomainEventDto>;
+  sseConnected?: boolean;
+}
+
+export function ContainerDashboard({
+  liveEvents = [],
+  sseConnected = false,
+}: ContainerDashboardProps = {}) {
   const [containers, setContainers] = useState<ContainerInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -247,16 +258,12 @@ export function ContainerDashboard() {
   );
 
   // -----------------------------------------------------------------
-  // #1853 — SSE-driven refresh (primary path)
+  // #1853 / #1837 — SSE-driven refresh (primary path)
   // -----------------------------------------------------------------
-  // `useLiveEvents` opens an EventSource scoped to Container/Infrastructure
-  // events. When any matching event arrives the latest item id changes and
-  // we trigger a fresh `fetchContainers()`. The hook handles backoff,
-  // pause/resume and unmount cleanup internally — no `EventSource` leak.
-  const { events: liveEvents, isStreaming: sseConnected } = useLiveEvents({
-    aggregateTypes: ['Container', 'Infrastructure'],
-    initialLimit: 10,
-  });
+  // The parent page owns the `useLiveEvents` subscription and forwards
+  // events here. When the most-recent event id changes we trigger a
+  // `fetchContainers()`. This avoids opening a second EventSource for
+  // LiveEventLog and keeps a single source of truth for the SSE stream.
   const lastSeenEventIdRef = useRef<string | null>(null);
 
   useEffect(() => {

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/KPISparklineStrip.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/KPISparklineStrip.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+/**
+ * KPISparklineStrip (#1837 SP5 F4-C1) — 4 KPI con mini-sparkline SVG
+ * sopra il ContainerDashboard.
+ *
+ * KPI rendered (match mockup `sp5-admin-infra.html` riga 275-316):
+ *   1. Container attivi (active/total) — no sparkline (no time-series)
+ *   2. CPU media (last value + sparkline da getMetricsTimeSeries.cpu)
+ *   3. RAM usata (last value/total + sparkline da getMetricsTimeSeries.memory)
+ *   4. Batch job in coda (queued · running) — no sparkline
+ *
+ * Entity color mapping:
+ *   - containers → entity-toolkit (green)
+ *   - cpu → entity-chat (blue)
+ *   - memory → entity-kb (teal)
+ *   - batchJobs → entity-agent (amber)
+ */
+
+import { cn } from '@/lib/utils';
+
+import {
+  useInfrastructureKpis,
+  type TimeSeriesPoint,
+  type Trend,
+} from './hooks/use-infrastructure-kpis';
+
+const SPARKLINE_WIDTH = 70;
+const SPARKLINE_HEIGHT = 28;
+
+function buildSparklinePath(series: TimeSeriesPoint[]): { line: string; fill: string } | null {
+  if (series.length < 2) return null;
+  const values = series.map(p => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const stepX = SPARKLINE_WIDTH / (series.length - 1);
+  const points = series.map((p, i) => {
+    const x = i * stepX;
+    const y = SPARKLINE_HEIGHT - ((p.value - min) / range) * (SPARKLINE_HEIGHT - 4) - 2;
+    return `${x.toFixed(2)},${y.toFixed(2)}`;
+  });
+  const line = `M${points.join(' L')}`;
+  const fill = `${line} L${SPARKLINE_WIDTH},${SPARKLINE_HEIGHT} L0,${SPARKLINE_HEIGHT} Z`;
+  return { line, fill };
+}
+
+function TrendLabel({ trend, pct, suffix }: { trend: Trend; pct: number; suffix?: string }) {
+  if (trend === 'flat') {
+    return <span className="text-muted-foreground">▬ stabile {suffix ?? ''}</span>;
+  }
+  const arrow = trend === 'up' ? '▲' : '▼';
+  const colorClass =
+    trend === 'up' ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400';
+  return (
+    <span className={colorClass}>
+      {arrow} {Math.abs(pct)}% {suffix ?? ''}
+    </span>
+  );
+}
+
+function Sparkline({
+  series,
+  testId,
+  colorClass,
+}: {
+  series: TimeSeriesPoint[];
+  testId: string;
+  colorClass: string;
+}) {
+  const path = buildSparklinePath(series);
+  if (!path) return null;
+  return (
+    <svg
+      data-testid={testId}
+      aria-hidden="true"
+      width={SPARKLINE_WIDTH}
+      height={SPARKLINE_HEIGHT}
+      viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+      className={cn('absolute right-3 top-3 opacity-85', colorClass)}
+    >
+      <path d={path.fill} fill="currentColor" opacity={0.15} />
+      <path
+        d={path.line}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function KpiCardSkeleton({ testId }: { testId: string }) {
+  return (
+    <div
+      data-testid={testId}
+      className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] animate-pulse"
+    >
+      <div className="mb-2 h-3 w-24 rounded bg-muted" />
+      <div className="h-7 w-16 rounded bg-muted" />
+    </div>
+  );
+}
+
+export function KPISparklineStrip() {
+  const { containers, cpu, memory, batchJobs } = useInfrastructureKpis();
+
+  return (
+    <div
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      data-testid="kpi-sparkline-strip"
+    >
+      {containers.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-containers" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`Container attivi ${containers.active} su ${containers.total}, ${containers.stopped} stopped`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-entity-toolkit"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            Container attivi
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {containers.active}
+            <span className="text-sm text-muted-foreground font-semibold">/{containers.total}</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">
+            ▬ {containers.stopped} stopped · 0 crashed
+          </p>
+        </article>
+      )}
+
+      {cpu.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-cpu" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`CPU media ${cpu.value}%, trend ${cpu.trend} ${cpu.trendPct}%`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-entity-chat"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            CPU media
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {cpu.value}
+            <span className="text-sm text-muted-foreground font-semibold">%</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px]">
+            <TrendLabel trend={cpu.trend} pct={cpu.trendPct} suffix="vs 1h fa" />
+          </p>
+          <Sparkline series={cpu.series} testId="kpi-sparkline-cpu" colorClass="text-entity-chat" />
+        </article>
+      )}
+
+      {memory.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-memory" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`RAM usata ${memory.value} di ${memory.total} GB`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-entity-kb"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            RAM usata
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {memory.value}
+            <span className="text-sm text-muted-foreground font-semibold">/{memory.total} GB</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px]">
+            <TrendLabel trend={memory.trend} pct={memory.trendPct} suffix="ultimi 60m" />
+          </p>
+          <Sparkline
+            series={memory.series}
+            testId="kpi-sparkline-memory"
+            colorClass="text-entity-kb"
+          />
+        </article>
+      )}
+
+      {batchJobs.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-batchjobs" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`Batch job: ${batchJobs.queued} in coda, ${batchJobs.running} in esecuzione`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-entity-agent"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            Batch job in coda
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {batchJobs.queued}
+            <span className="text-sm text-muted-foreground font-semibold">
+              {' '}
+              · {batchJobs.running} run
+            </span>
+          </p>
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">▬ live</p>
+        </article>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/LiveEventLog.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/LiveEventLog.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+/**
+ * LiveEventLog (#1837 SP5 F4-C1) — feed visuale dei domain events
+ * Container/Infrastructure consumati dalla subscription useLiveEvents
+ * sollevata a livello di `page.tsx`. NO subscription propria (props-driven).
+ *
+ * Layout mockup `.event-log .row`:
+ *   [ts: 96px mono] [lvl: 60px uppercase color] [msg: 1fr ellipsis]
+ *
+ * Fade-out: eventi loggedAt > staleThresholdMs fa → opacity 50.
+ * Riconciliazione: setInterval ogni 5s aggiorna `now` (re-render rows
+ * con/senza opacità senza richiedere update dello state esterno).
+ */
+
+import { useEffect, useState } from 'react';
+
+import { Radio } from 'lucide-react';
+
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+import { cn } from '@/lib/utils';
+
+import {
+  buildLogMessage,
+  deriveLogLevel,
+  formatLogTimestamp,
+  isStaleEvent,
+  type LogLevel,
+} from './_utils/event-log-mapper';
+
+const LEVEL_CLASSES: Record<LogLevel, string> = {
+  INFO: 'text-sky-600 dark:text-sky-400',
+  OK: 'text-emerald-600 dark:text-emerald-400',
+  WARN: 'text-amber-600 dark:text-amber-400',
+  ERR: 'text-rose-600 dark:text-rose-400',
+};
+
+const DEFAULT_MAX_VISIBLE = 20;
+const DEFAULT_STALE_THRESHOLD_MS = 30_000;
+const STALE_RECONCILE_INTERVAL_MS = 5_000;
+
+interface LiveEventLogProps {
+  events: ReadonlyArray<DomainEventDto>;
+  isStreaming: boolean;
+  isLoading: boolean;
+  maxVisible?: number;
+  staleThresholdMs?: number;
+}
+
+export function LiveEventLog({
+  events,
+  isStreaming,
+  isLoading,
+  maxVisible = DEFAULT_MAX_VISIBLE,
+  staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS,
+}: LiveEventLogProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), STALE_RECONCILE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const visible = events.slice(0, maxVisible);
+
+  if (isLoading && visible.length === 0) {
+    return (
+      <div
+        role="log"
+        aria-live="polite"
+        data-testid="live-event-log"
+        className="rounded-lg border border-border bg-card/60 p-6 text-center text-sm text-muted-foreground"
+      >
+        Caricamento eventi…
+      </div>
+    );
+  }
+
+  if (visible.length === 0) {
+    return (
+      <div
+        role="log"
+        aria-live="polite"
+        data-testid="live-event-log"
+        className="rounded-lg border border-border bg-card/60 p-6 text-center text-sm text-muted-foreground"
+      >
+        {isStreaming
+          ? 'Nessun evento ricevuto. SSE in attesa.'
+          : 'Stream offline. Tentativo di riconnessione in corso…'}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="log"
+      aria-live="polite"
+      data-testid="live-event-log"
+      className="rounded-lg border border-border bg-card/60 font-mono text-xs"
+    >
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        <Radio
+          aria-hidden="true"
+          className={cn('h-3 w-3', isStreaming ? 'text-emerald-500' : 'text-muted-foreground')}
+        />
+        <span>{isStreaming ? 'streaming · SSE' : 'offline · SSE down'}</span>
+        <span className="ml-auto text-muted-foreground/70">
+          {visible.length} / {events.length}
+        </span>
+      </div>
+
+      <ul className="max-h-[340px] overflow-y-auto divide-y divide-border">
+        {visible.map(event => {
+          const stale = isStaleEvent(event.loggedAt, now, staleThresholdMs);
+          const level = deriveLogLevel(event.eventType);
+          return (
+            <li
+              key={event.id}
+              data-testid="live-event-row"
+              className={cn(
+                'grid grid-cols-[96px_60px_1fr] items-center gap-3 px-3 py-1.5 transition-opacity',
+                stale ? 'opacity-50' : 'opacity-100'
+              )}
+            >
+              <span className="text-muted-foreground">{formatLogTimestamp(event.loggedAt)}</span>
+              <span
+                className={cn(
+                  'font-bold uppercase tracking-wider text-[10px]',
+                  LEVEL_CLASSES[level]
+                )}
+              >
+                {level}
+              </span>
+              <span className="truncate text-foreground">{buildLogMessage(event)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
@@ -2,6 +2,7 @@
  * ContainerDashboard Component Tests
  * Issue #144  — Container Management tests (original polling implementation).
  * Issue #1853 — SSE-driven refresh + polling fallback (60s minimum).
+ * Issue #1837 — Lift useLiveEvents subscription to page.tsx; props-driven SSE forwarding.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -9,10 +10,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
-import type { UseLiveEventsResult } from '@/components/admin/monitor/use-live-events';
 
 const mockGetDockerContainers = vi.hoisted(() => vi.fn());
-const mockUseLiveEvents = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -24,10 +23,6 @@ vi.mock('@/lib/api', () => ({
 
 vi.mock('@/hooks/useToast', () => ({
   useToast: () => ({ toast: vi.fn() }),
-}));
-
-vi.mock('@/components/admin/monitor/use-live-events', () => ({
-  useLiveEvents: mockUseLiveEvents,
 }));
 
 import { ContainerDashboard, computePollingBackoff } from '../ContainerDashboard';
@@ -62,20 +57,6 @@ const mockContainers = [
   },
 ];
 
-/** Build a stable UseLiveEventsResult, overridable per test. */
-function liveEventsResult(overrides: Partial<UseLiveEventsResult> = {}): UseLiveEventsResult {
-  return {
-    events: [],
-    isLoading: false,
-    isStreaming: false,
-    error: null,
-    pause: vi.fn(),
-    resume: vi.fn(),
-    refetch: vi.fn(),
-    ...overrides,
-  };
-}
-
 function makeEvent(id: string): DomainEventDto {
   return {
     id,
@@ -94,8 +75,6 @@ function makeEvent(id: string): DomainEventDto {
 describe('ContainerDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: SSE disconnected, no events
-    mockUseLiveEvents.mockReturnValue(liveEventsResult());
   });
 
   it('shows loading state initially', () => {
@@ -243,43 +222,29 @@ describe('ContainerDashboard', () => {
   /*  #1853 — SSE wiring                                                 */
   /* ------------------------------------------------------------------ */
 
-  it('shows SSE status badge "Polling only" when SSE is disconnected', async () => {
+  it('shows SSE status badge "Polling only" when sseConnected prop is false', async () => {
     mockGetDockerContainers.mockResolvedValue(mockContainers);
-    render(<ContainerDashboard />);
+    render(<ContainerDashboard liveEvents={[]} sseConnected={false} />);
 
     const badge = await screen.findByTestId('sse-status-indicator');
     expect(badge).toHaveTextContent(/polling only/i);
   });
 
-  it('shows SSE status badge "Live" when SSE is connected', async () => {
+  it('shows SSE status badge "Live" when sseConnected prop is true', async () => {
     mockGetDockerContainers.mockResolvedValue(mockContainers);
-    mockUseLiveEvents.mockReturnValue(liveEventsResult({ isStreaming: true }));
-    render(<ContainerDashboard />);
+    render(<ContainerDashboard liveEvents={[]} sseConnected={true} />);
 
     const badge = await screen.findByTestId('sse-status-indicator');
     expect(badge).toHaveTextContent(/^live$/i);
   });
 
-  it('subscribes to Container + Infrastructure aggregateTypes', async () => {
+  it('refreshes containers when a new live event arrives via prop change', async () => {
     mockGetDockerContainers.mockResolvedValue(mockContainers);
-    render(<ContainerDashboard />);
-
-    await waitFor(() => {
-      expect(mockUseLiveEvents).toHaveBeenCalled();
-    });
-
-    const firstCallArg = mockUseLiveEvents.mock.calls[0]?.[0] as {
-      aggregateTypes?: string[];
-    };
-    expect(firstCallArg?.aggregateTypes).toEqual(['Container', 'Infrastructure']);
-  });
-
-  it('refreshes containers when a new live event arrives', async () => {
-    mockGetDockerContainers.mockResolvedValue(mockContainers);
-    // First render: events seeded by SSE backfill (counts as "first observation",
+    // First render: events seeded by backfill (counts as "first observation",
     // so we expect NO extra fetch beyond the initial mount fetch).
-    mockUseLiveEvents.mockReturnValue(liveEventsResult({ events: [makeEvent('ev-1')] }));
-    const { rerender } = render(<ContainerDashboard />);
+    const { rerender } = render(
+      <ContainerDashboard liveEvents={[makeEvent('ev-1')]} sseConnected={true} />
+    );
 
     // Wait for the initial mount fetch to settle (StrictMode may invoke it twice;
     // we rely on a delta comparison below rather than an absolute call count).
@@ -289,10 +254,9 @@ describe('ContainerDashboard', () => {
     const callsAfterMount = mockGetDockerContainers.mock.calls.length;
 
     // New event arrives mid-session — the dashboard must refresh containers.
-    mockUseLiveEvents.mockReturnValue(
-      liveEventsResult({ events: [makeEvent('ev-2'), makeEvent('ev-1')] })
+    rerender(
+      <ContainerDashboard liveEvents={[makeEvent('ev-2'), makeEvent('ev-1')]} sseConnected={true} />
     );
-    rerender(<ContainerDashboard />);
 
     await waitFor(() => {
       expect(mockGetDockerContainers.mock.calls.length).toBeGreaterThan(callsAfterMount);

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/KPISparklineStrip.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/KPISparklineStrip.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const useInfrastructureKpisMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../hooks/use-infrastructure-kpis', () => ({
+  useInfrastructureKpis: () => useInfrastructureKpisMock(),
+}));
+
+import { KPISparklineStrip } from '../KPISparklineStrip';
+
+function defaultKpis() {
+  return {
+    containers: { active: 7, total: 8, stopped: 1, loading: false },
+    cpu: {
+      value: 34,
+      series: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 20 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 34 },
+      ],
+      trend: 'up' as const,
+      trendPct: 70,
+      loading: false,
+    },
+    memory: {
+      value: 18.4,
+      total: 32,
+      series: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 17 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 18.4 },
+      ],
+      trend: 'up' as const,
+      trendPct: 8,
+      loading: false,
+    },
+    batchJobs: { queued: 4, running: 2, loading: false },
+  };
+}
+
+function makeKpis(overrides: Partial<ReturnType<typeof defaultKpis>> = {}) {
+  return { ...defaultKpis(), ...overrides };
+}
+
+describe('KPISparklineStrip', () => {
+  beforeEach(() => {
+    useInfrastructureKpisMock.mockReset();
+  });
+
+  it('renders 4 KPI cards', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getAllByTestId('kpi-card')).toHaveLength(4);
+  });
+
+  it('shows container active/total', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('/8')).toBeInTheDocument();
+  });
+
+  it('shows CPU percentage with sparkline svg', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('34')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-sparkline-cpu')).toBeInTheDocument();
+  });
+
+  it('shows memory GB + total', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('18.4')).toBeInTheDocument();
+    expect(screen.getByText('/32 GB')).toBeInTheDocument();
+  });
+
+  it('shows batch jobs queued + running', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText(/2 run/)).toBeInTheDocument();
+  });
+
+  it('shows skeleton when containers loading', () => {
+    useInfrastructureKpisMock.mockReturnValue(
+      makeKpis({
+        containers: { active: 0, total: 0, stopped: 0, loading: true },
+      })
+    );
+    render(<KPISparklineStrip />);
+    expect(screen.getByTestId('kpi-skeleton-containers')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when cpu loading', () => {
+    useInfrastructureKpisMock.mockReturnValue(
+      makeKpis({
+        cpu: {
+          value: 0,
+          series: [],
+          trend: 'flat',
+          trendPct: 0,
+          loading: true,
+        },
+      })
+    );
+    render(<KPISparklineStrip />);
+    expect(screen.getByTestId('kpi-skeleton-cpu')).toBeInTheDocument();
+  });
+
+  it('renders up trend label with arrow', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    // default makeKpis has 2 'up' KPIs (cpu + memory)
+    expect(screen.getAllByText(/▲/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders down trend label with arrow', () => {
+    useInfrastructureKpisMock.mockReturnValue(
+      makeKpis({
+        cpu: {
+          value: 10,
+          series: [],
+          trend: 'down',
+          trendPct: 50,
+          loading: false,
+        },
+      })
+    );
+    render(<KPISparklineStrip />);
+    expect(screen.getByText(/▼/)).toBeInTheDocument();
+  });
+
+  it('renders flat trend label', () => {
+    useInfrastructureKpisMock.mockReturnValue(
+      makeKpis({
+        cpu: {
+          value: 10,
+          series: [],
+          trend: 'flat',
+          trendPct: 0,
+          loading: false,
+        },
+      })
+    );
+    render(<KPISparklineStrip />);
+    expect(screen.getByText(/stabile/i)).toBeInTheDocument();
+  });
+
+  it('omits sparkline for containers and batch jobs (no time-series available)', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.queryByTestId('kpi-sparkline-containers')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('kpi-sparkline-batchjobs')).not.toBeInTheDocument();
+  });
+
+  it('omits sparkline svg when series has < 2 points', () => {
+    useInfrastructureKpisMock.mockReturnValue(
+      makeKpis({
+        cpu: {
+          value: 34,
+          series: [{ timestamp: '2026-06-03T14:00:00Z', value: 34 }],
+          trend: 'flat',
+          trendPct: 0,
+          loading: false,
+        },
+      })
+    );
+    render(<KPISparklineStrip />);
+    expect(screen.queryByTestId('kpi-sparkline-cpu')).not.toBeInTheDocument();
+  });
+
+  it('cards have accessible aria-label', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByLabelText(/Container attivi 7/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/CPU media 34/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/RAM usata 18.4/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Batch job/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/LiveEventLog.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/LiveEventLog.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+import { LiveEventLog } from '../LiveEventLog';
+
+function evt(o: Partial<DomainEventDto> = {}): DomainEventDto {
+  return {
+    id: o.id ?? `evt-${Math.random()}`,
+    eventId: 'evt-id-1',
+    eventType: 'Container.Restarted',
+    aggregateType: 'Container',
+    aggregateId: 'meepleai-api',
+    userId: null,
+    payloadJson: '{}',
+    payloadVersion: 1,
+    occurredAt: '2026-06-03T14:23:08.412Z',
+    loggedAt: '2026-06-03T14:23:08.412Z',
+    ...o,
+  };
+}
+
+describe('LiveEventLog rendering', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T14:23:10.000Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders one row per event with ts + level + message', () => {
+    render(<LiveEventLog events={[evt({ id: '1' })]} isStreaming isLoading={false} />);
+    expect(screen.getByText('14:23:08.412')).toBeInTheDocument();
+    expect(screen.getByText('INFO')).toBeInTheDocument();
+    expect(screen.getByText(/container restarted aggregate=meepleai-api/)).toBeInTheDocument();
+  });
+
+  it('container has role=log and aria-live=polite', () => {
+    render(<LiveEventLog events={[evt()]} isStreaming isLoading={false} />);
+    const log = screen.getByRole('log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('limits visible rows to maxVisible (default 20)', () => {
+    const events = Array.from({ length: 25 }, (_, i) => evt({ id: `e-${i}` }));
+    render(<LiveEventLog events={events} isStreaming isLoading={false} />);
+    expect(screen.getAllByTestId('live-event-row')).toHaveLength(20);
+  });
+
+  it('respects custom maxVisible prop', () => {
+    const events = Array.from({ length: 10 }, (_, i) => evt({ id: `e-${i}` }));
+    render(<LiveEventLog events={events} isStreaming isLoading={false} maxVisible={5} />);
+    expect(screen.getAllByTestId('live-event-row')).toHaveLength(5);
+  });
+
+  it('shows empty placeholder when no events and streaming', () => {
+    render(<LiveEventLog events={[]} isStreaming isLoading={false} />);
+    expect(screen.getByText(/Nessun evento ricevuto/)).toBeInTheDocument();
+  });
+
+  it('shows disconnected placeholder when not streaming and no events', () => {
+    render(<LiveEventLog events={[]} isStreaming={false} isLoading={false} />);
+    expect(screen.getByText(/Stream offline/)).toBeInTheDocument();
+  });
+
+  it('shows loading placeholder when isLoading=true even with no events', () => {
+    render(<LiveEventLog events={[]} isStreaming={false} isLoading />);
+    expect(screen.getByText(/Caricamento eventi/)).toBeInTheDocument();
+  });
+
+  it('shows visible/total count in header', () => {
+    const events = Array.from({ length: 30 }, (_, i) => evt({ id: `e-${i}` }));
+    render(<LiveEventLog events={events} isStreaming isLoading={false} maxVisible={10} />);
+    expect(screen.getByText(/10 \/ 30/)).toBeInTheDocument();
+  });
+});
+
+describe('LiveEventLog level colors', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T14:23:10.000Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it.each([
+    ['Container.Started', 'OK'],
+    ['Container.Failed', 'ERR'],
+    ['Service.Degraded', 'WARN'],
+    ['Container.Restarting', 'INFO'],
+  ] as const)('renders level label "%s" for eventType %s', (eventType, expectedLevel) => {
+    render(<LiveEventLog events={[evt({ eventType })]} isStreaming isLoading={false} />);
+    expect(screen.getByText(expectedLevel)).toBeInTheDocument();
+  });
+});
+
+describe('LiveEventLog fade-out', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T14:23:10.000Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('marks events older than 30s with reduced opacity class', () => {
+    const fresh = evt({ id: 'fresh', loggedAt: '2026-06-03T14:23:00.000Z' }); // 10s old
+    const stale = evt({ id: 'stale', loggedAt: '2026-06-03T14:22:30.000Z' }); // 40s old
+
+    render(<LiveEventLog events={[fresh, stale]} isStreaming isLoading={false} />);
+
+    const rows = screen.getAllByTestId('live-event-row');
+    expect(rows[0]).toHaveClass('opacity-100');
+    expect(rows[1]).toHaveClass('opacity-50');
+  });
+
+  it('respects custom staleThresholdMs prop', () => {
+    const fresh = evt({ id: 'fresh', loggedAt: '2026-06-03T14:23:00.000Z' }); // 10s old
+    render(
+      <LiveEventLog events={[fresh]} isStreaming isLoading={false} staleThresholdMs={5_000} />
+    );
+    // 10s old > 5s threshold → stale
+    expect(screen.getByTestId('live-event-row')).toHaveClass('opacity-50');
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/event-log-mapper.test.ts
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/event-log-mapper.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+import {
+  buildLogMessage,
+  deriveLogLevel,
+  formatLogTimestamp,
+  isStaleEvent,
+} from '../_utils/event-log-mapper';
+
+describe('deriveLogLevel', () => {
+  it.each([
+    ['Container.Created', 'OK'],
+    ['Container.Started', 'OK'],
+    ['Service.Healthy', 'OK'],
+    ['Container.Updated', 'INFO'],
+    ['Container.Restarting', 'INFO'],
+    ['UnknownAggregate.SomethingElse', 'INFO'],
+    ['Service.Degraded', 'WARN'],
+    ['Service.SlowResponse', 'WARN'],
+    ['Container.Failed', 'ERR'],
+    ['Service.Unhealthy', 'ERR'],
+    ['Container.Crashed', 'ERR'],
+  ] as const)('maps %s -> %s', (eventType, expected) => {
+    expect(deriveLogLevel(eventType)).toBe(expected);
+  });
+});
+
+describe('formatLogTimestamp', () => {
+  it('formats ISO timestamp as HH:mm:ss.SSS in UTC', () => {
+    expect(formatLogTimestamp('2026-06-03T14:23:08.412Z')).toBe('14:23:08.412');
+  });
+
+  it('pads single-digit components', () => {
+    expect(formatLogTimestamp('2026-06-03T01:02:03.040Z')).toBe('01:02:03.040');
+  });
+
+  it('returns placeholder for invalid input', () => {
+    expect(formatLogTimestamp('not-a-date')).toBe('--:--:--.---');
+  });
+});
+
+function makeEvent(overrides: Partial<DomainEventDto> = {}): DomainEventDto {
+  return {
+    id: 'evt-1',
+    eventId: 'evt-id-1',
+    eventType: 'Container.Restarted',
+    aggregateType: 'Container',
+    aggregateId: 'meepleai-api',
+    userId: null,
+    payloadJson: '{}',
+    payloadVersion: 1,
+    occurredAt: '2026-06-03T14:23:08.412Z',
+    loggedAt: '2026-06-03T14:23:08.412Z',
+    ...overrides,
+  };
+}
+
+describe('buildLogMessage', () => {
+  it('uses lowercase aggregate type + event suffix + aggregateId', () => {
+    expect(buildLogMessage(makeEvent())).toBe('container restarted aggregate=meepleai-api');
+  });
+
+  it('falls back to full eventType when no dot suffix', () => {
+    expect(buildLogMessage(makeEvent({ eventType: 'OpaqueEvent' }))).toBe(
+      'container OpaqueEvent aggregate=meepleai-api'
+    );
+  });
+
+  it('omits aggregate= when aggregateId is null', () => {
+    expect(buildLogMessage(makeEvent({ aggregateId: null }))).toBe('container restarted');
+  });
+
+  it('omits aggregate= when aggregateId is empty string', () => {
+    expect(buildLogMessage(makeEvent({ aggregateId: '' }))).toBe('container restarted');
+  });
+
+  it('uses "event" as fallback when aggregateType is null', () => {
+    expect(buildLogMessage(makeEvent({ aggregateType: null }))).toBe(
+      'event restarted aggregate=meepleai-api'
+    );
+  });
+});
+
+describe('isStaleEvent', () => {
+  const now = Date.parse('2026-06-03T14:23:38.000Z');
+
+  it('returns false for events within threshold', () => {
+    expect(isStaleEvent('2026-06-03T14:23:08.000Z', now, 30_000)).toBe(false);
+  });
+
+  it('returns true for events older than threshold', () => {
+    expect(isStaleEvent('2026-06-03T14:23:07.999Z', now, 30_000)).toBe(true);
+  });
+
+  it('returns true for invalid timestamps (safe default - fade out)', () => {
+    expect(isStaleEvent('garbage', now, 30_000)).toBe(true);
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
@@ -3,7 +3,7 @@
  * Issue #144 — Container Management tests
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 vi.mock('@/hooks/useSetNavConfig', () => ({
@@ -16,12 +16,16 @@ vi.mock('next/navigation', () => ({
 
 const mockGetDockerContainers = vi.hoisted(() => vi.fn());
 const mockRestartService = vi.hoisted(() => vi.fn());
+const mockGetMetricsTimeSeries = vi.hoisted(() => vi.fn());
+const mockGetAllBatchJobs = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api', () => ({
   api: {
     admin: {
       getDockerContainers: mockGetDockerContainers,
       restartService: mockRestartService,
+      getMetricsTimeSeries: mockGetMetricsTimeSeries,
+      getAllBatchJobs: mockGetAllBatchJobs,
     },
   },
 }));
@@ -47,8 +51,14 @@ vi.mock('@/components/admin/monitor/use-live-events', () => ({
 import ContainerDashboardPage from '../page';
 
 describe('ContainerDashboardPage', () => {
-  it('renders page with title', () => {
+  beforeEach(() => {
+    // Hanging promise for "loading" state; tests only check structure
     mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
+    mockGetMetricsTimeSeries.mockReturnValue(new Promise(() => {}));
+    mockGetAllBatchJobs.mockReturnValue(new Promise(() => {}));
+  });
+
+  it('renders page with title', () => {
     render(<ContainerDashboardPage />);
 
     expect(screen.getByTestId('containers-page')).toBeInTheDocument();
@@ -56,11 +66,19 @@ describe('ContainerDashboardPage', () => {
     expect(screen.getByText('Infrastructure & Containers')).toBeInTheDocument();
   });
 
-  it('renders container dashboard and restart panel', () => {
-    mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
+  it('renders all SP5 #1837 sections', () => {
     render(<ContainerDashboardPage />);
 
+    expect(screen.getByTestId('kpi-sparkline-strip')).toBeInTheDocument();
     expect(screen.getByTestId('container-dashboard')).toBeInTheDocument();
+    expect(screen.getByTestId('live-event-log')).toBeInTheDocument();
     expect(screen.getByTestId('restart-all-panel')).toBeInTheDocument();
+  });
+
+  it('LiveEventLog has role=log + aria-live=polite (a11y)', () => {
+    render(<ContainerDashboardPage />);
+
+    const log = screen.getByRole('log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/use-infrastructure-kpis.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/use-infrastructure-kpis.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockGetDockerContainers = vi.hoisted(() => vi.fn());
+const mockGetMetricsTimeSeries = vi.hoisted(() => vi.fn());
+const mockGetAllBatchJobs = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getDockerContainers: mockGetDockerContainers,
+      getMetricsTimeSeries: mockGetMetricsTimeSeries,
+      getAllBatchJobs: mockGetAllBatchJobs,
+    },
+  },
+}));
+
+import { useInfrastructureKpis } from '../hooks/use-infrastructure-kpis';
+
+describe('useInfrastructureKpis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('combines 3 endpoints into 4 KPI shapes (happy path)', async () => {
+    mockGetDockerContainers.mockResolvedValue([
+      {
+        id: '1',
+        name: 'api',
+        image: 'x',
+        state: 'running',
+        status: '',
+        created: '',
+        labels: {},
+      },
+      {
+        id: '2',
+        name: 'redis',
+        image: 'y',
+        state: 'running',
+        status: '',
+        created: '',
+        labels: {},
+      },
+      {
+        id: '3',
+        name: 'pg',
+        image: 'z',
+        state: 'exited',
+        status: '',
+        created: '',
+        labels: {},
+      },
+    ]);
+
+    mockGetMetricsTimeSeries.mockResolvedValue({
+      cpu: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 20 },
+        { timestamp: '2026-06-03T14:30:00Z', value: 28 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 34 },
+      ],
+      memory: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 12.0 },
+        { timestamp: '2026-06-03T14:30:00Z', value: 15.0 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 18.4 },
+      ],
+      requests: [],
+    });
+
+    mockGetAllBatchJobs.mockImplementation((p: { status?: string }) =>
+      Promise.resolve({
+        jobs: [],
+        total: p.status === 'queued' ? 4 : p.status === 'running' ? 2 : 0,
+        page: 1,
+        pageSize: 20,
+      })
+    );
+
+    const { result } = renderHook(() => useInfrastructureKpis());
+
+    await waitFor(() => expect(result.current.containers.loading).toBe(false));
+    await waitFor(() => expect(result.current.cpu.loading).toBe(false));
+    await waitFor(() => expect(result.current.batchJobs.loading).toBe(false));
+
+    expect(result.current.containers).toMatchObject({ active: 2, total: 3, stopped: 1 });
+    expect(result.current.cpu).toMatchObject({ value: 34, trend: 'up' });
+    expect(result.current.cpu.series).toHaveLength(3);
+    expect(result.current.memory).toMatchObject({ value: 18.4, trend: 'up', total: 32 });
+    expect(result.current.batchJobs).toMatchObject({ queued: 4, running: 2 });
+  });
+
+  it('handles failed fetches with safe fallback values', async () => {
+    mockGetDockerContainers.mockRejectedValue(new Error('boom'));
+    mockGetMetricsTimeSeries.mockRejectedValue(new Error('boom'));
+    mockGetAllBatchJobs.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useInfrastructureKpis());
+
+    await waitFor(() => expect(result.current.containers.loading).toBe(false));
+    await waitFor(() => expect(result.current.cpu.loading).toBe(false));
+    await waitFor(() => expect(result.current.batchJobs.loading).toBe(false));
+
+    expect(result.current.containers).toMatchObject({ active: 0, total: 0, stopped: 0 });
+    expect(result.current.cpu).toMatchObject({ value: 0, trend: 'flat' });
+    expect(result.current.cpu.series).toEqual([]);
+    expect(result.current.batchJobs).toMatchObject({ queued: 0, running: 0 });
+  });
+
+  it('computes trend "down" when last < first', async () => {
+    mockGetDockerContainers.mockResolvedValue([]);
+    mockGetAllBatchJobs.mockResolvedValue({ jobs: [], total: 0, page: 1, pageSize: 20 });
+    mockGetMetricsTimeSeries.mockResolvedValue({
+      cpu: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 50 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 25 },
+      ],
+      memory: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 20 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 18 },
+      ],
+      requests: [],
+    });
+
+    const { result } = renderHook(() => useInfrastructureKpis());
+    await waitFor(() => expect(result.current.cpu.loading).toBe(false));
+
+    expect(result.current.cpu.trend).toBe('down');
+    expect(result.current.memory.trend).toBe('down');
+  });
+
+  it('computes trend "flat" when difference is below threshold', async () => {
+    mockGetDockerContainers.mockResolvedValue([]);
+    mockGetAllBatchJobs.mockResolvedValue({ jobs: [], total: 0, page: 1, pageSize: 20 });
+    mockGetMetricsTimeSeries.mockResolvedValue({
+      cpu: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 50 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 50.1 },
+      ],
+      memory: [],
+      requests: [],
+    });
+
+    const { result } = renderHook(() => useInfrastructureKpis());
+    await waitFor(() => expect(result.current.cpu.loading).toBe(false));
+
+    expect(result.current.cpu.trend).toBe('flat');
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/_utils/event-log-mapper.ts
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/_utils/event-log-mapper.ts
@@ -1,0 +1,40 @@
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+export type LogLevel = 'INFO' | 'WARN' | 'ERR' | 'OK';
+
+const OK_SUFFIXES = ['.Created', '.Started', '.Healthy'] as const;
+const ERR_SUFFIXES = ['.Failed', '.Unhealthy', '.Crashed'] as const;
+const WARN_SUFFIXES = ['.Degraded', '.SlowResponse'] as const;
+
+const INVALID_TIMESTAMP = '--:--:--.---';
+
+export function deriveLogLevel(eventType: string): LogLevel {
+  if (OK_SUFFIXES.some(s => eventType.endsWith(s))) return 'OK';
+  if (ERR_SUFFIXES.some(s => eventType.endsWith(s))) return 'ERR';
+  if (WARN_SUFFIXES.some(s => eventType.endsWith(s))) return 'WARN';
+  return 'INFO';
+}
+
+export function formatLogTimestamp(iso: string): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return INVALID_TIMESTAMP;
+  const d = new Date(ms);
+  const pad2 = (n: number) => String(n).padStart(2, '0');
+  const pad3 = (n: number) => String(n).padStart(3, '0');
+  return `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())}.${pad3(d.getUTCMilliseconds())}`;
+}
+
+export function buildLogMessage(event: DomainEventDto): string {
+  const aggregateLower = event.aggregateType ? event.aggregateType.toLowerCase() : 'event';
+  const dotIdx = event.eventType.lastIndexOf('.');
+  const verb = dotIdx >= 0 ? event.eventType.slice(dotIdx + 1).toLowerCase() : event.eventType;
+  const parts = [aggregateLower, verb];
+  if (event.aggregateId) parts.push(`aggregate=${event.aggregateId}`);
+  return parts.join(' ');
+}
+
+export function isStaleEvent(loggedAt: string, now: number, thresholdMs: number): boolean {
+  const ms = Date.parse(loggedAt);
+  if (Number.isNaN(ms)) return true;
+  return now - ms > thresholdMs;
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/hooks/use-infrastructure-kpis.ts
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/hooks/use-infrastructure-kpis.ts
@@ -1,0 +1,171 @@
+'use client';
+
+/**
+ * useInfrastructureKpis — combina 3 endpoint admin in 4 KPI shapes
+ * per il componente KPISparklineStrip (#1837 SP5 F4-C1).
+ *
+ * Endpoint riusati (zero modifiche BE):
+ *   - GET /api/v1/admin/docker/containers
+ *   - GET /api/v1/admin/infrastructure/metrics/timeseries?range=1h
+ *   - GET /api/v1/admin/operations/batch-jobs?status={queued|running}
+ *
+ * Memory.total è hardcoded a 32 GB perché BE non espone il limite del host;
+ * follow-up: estendere /admin/infrastructure/details con `hostMemoryTotalGb`.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { api } from '@/lib/api';
+
+export type Trend = 'up' | 'down' | 'flat';
+
+export interface TimeSeriesPoint {
+  timestamp: string;
+  value: number;
+}
+
+interface ContainerKpi {
+  active: number;
+  total: number;
+  stopped: number;
+  loading: boolean;
+}
+
+interface MetricKpi {
+  value: number;
+  series: TimeSeriesPoint[];
+  trend: Trend;
+  trendPct: number;
+  loading: boolean;
+}
+
+interface MemoryKpi extends MetricKpi {
+  total: number;
+}
+
+interface BatchJobsKpi {
+  queued: number;
+  running: number;
+  loading: boolean;
+}
+
+export interface InfrastructureKpis {
+  containers: ContainerKpi;
+  cpu: MetricKpi;
+  memory: MemoryKpi;
+  batchJobs: BatchJobsKpi;
+}
+
+const FLAT_THRESHOLD_PCT = 0.5;
+const HOST_MEMORY_TOTAL_GB = 32; // see file-level comment
+
+function computeTrend(series: TimeSeriesPoint[]): { trend: Trend; pct: number } {
+  if (series.length < 2) return { trend: 'flat', pct: 0 };
+  const first = series[0].value;
+  const last = series[series.length - 1].value;
+  if (first === 0) return { trend: last > 0 ? 'up' : 'flat', pct: 0 };
+  const pct = ((last - first) / first) * 100;
+  if (Math.abs(pct) < FLAT_THRESHOLD_PCT) return { trend: 'flat', pct: 0 };
+  return { trend: pct > 0 ? 'up' : 'down', pct: Math.round(pct * 10) / 10 };
+}
+
+const EMPTY_METRIC: MetricKpi = {
+  value: 0,
+  series: [],
+  trend: 'flat',
+  trendPct: 0,
+  loading: true,
+};
+const EMPTY_MEMORY: MemoryKpi = { ...EMPTY_METRIC, total: HOST_MEMORY_TOTAL_GB };
+
+export function useInfrastructureKpis(): InfrastructureKpis {
+  const [containers, setContainers] = useState<ContainerKpi>({
+    active: 0,
+    total: 0,
+    stopped: 0,
+    loading: true,
+  });
+  const [cpu, setCpu] = useState<MetricKpi>(EMPTY_METRIC);
+  const [memory, setMemory] = useState<MemoryKpi>(EMPTY_MEMORY);
+  const [batchJobs, setBatchJobs] = useState<BatchJobsKpi>({
+    queued: 0,
+    running: 0,
+    loading: true,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void api.admin
+      .getDockerContainers()
+      .then(list => {
+        if (cancelled) return;
+        const active = list.filter(c => c.state === 'running').length;
+        setContainers({
+          active,
+          total: list.length,
+          stopped: list.length - active,
+          loading: false,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setContainers({ active: 0, total: 0, stopped: 0, loading: false });
+      });
+
+    void api.admin
+      .getMetricsTimeSeries('1h')
+      .then(resp => {
+        if (cancelled) return;
+        const cpuSeries = resp?.cpu ?? [];
+        const memSeries = resp?.memory ?? [];
+        const cpuValue = cpuSeries.length ? cpuSeries[cpuSeries.length - 1].value : 0;
+        const memValue = memSeries.length ? memSeries[memSeries.length - 1].value : 0;
+        const cpuTrend = computeTrend(cpuSeries);
+        const memTrend = computeTrend(memSeries);
+        setCpu({
+          value: cpuValue,
+          series: cpuSeries,
+          trend: cpuTrend.trend,
+          trendPct: cpuTrend.pct,
+          loading: false,
+        });
+        setMemory({
+          value: memValue,
+          series: memSeries,
+          trend: memTrend.trend,
+          trendPct: memTrend.pct,
+          total: HOST_MEMORY_TOTAL_GB,
+          loading: false,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCpu({ ...EMPTY_METRIC, loading: false });
+        setMemory({ ...EMPTY_MEMORY, loading: false });
+      });
+
+    Promise.all([
+      api.admin.getAllBatchJobs({ status: 'queued', pageSize: 1 }),
+      api.admin.getAllBatchJobs({ status: 'running', pageSize: 1 }),
+    ])
+      .then(([queued, running]) => {
+        if (cancelled) return;
+        setBatchJobs({
+          queued: queued?.total ?? 0,
+          running: running?.total ?? 0,
+          loading: false,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBatchJobs({ queued: 0, running: 0, loading: false });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { containers, cpu, memory, batchJobs };
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx
@@ -1,34 +1,38 @@
 'use client';
 
 /**
- * #1837 SP5 F4-C1 — `/admin/monitor/containers` re-skin
+ * #1837 SP5 F4-C1 — `/admin/monitor/containers` re-skin (composition layer).
  *
  * Layout SP5 (mockup `sp5-admin-infra.html`):
- *   1. Hero header (titolo + descrizione + crumbs)
- *   2. ContainerDashboard — grid container con auto-refresh + StatusSummary KPI
- *   3. RestartAllPanel — restart dependency-ordered (typed-confirm)
+ *   1. Hero header (titolo + crumbs)
+ *   2. KPISparklineStrip — 4 KPI con sparkline (CPU/Memory inline)
+ *   3. ContainerDashboard — grid container + auto-refresh + StatusSummary KPI
+ *   4. LiveEventLog — feed SSE Container/Infrastructure con fade-out 30s
+ *   5. RestartAllPanel — restart dependency-ordered (typed-confirm)
  *
- * Originale (Issue #143): page admin Phase 4. Re-skin SP5 introduce:
- *   - Header SP5-style con breadcrumb-like crumbs
- *   - StatusSummary KPI con token semantici emerald/rose (era green/red hardcoded)
- *   - ContainerStatusBadge dot color token-aligned
+ * SSE subscription è ora "lifted" a questa page: ContainerDashboard +
+ * LiveEventLog ricevono `events` / `isStreaming` come prop e condividono
+ * una singola EventSource (no doppia connessione SSE).
  *
- * BE pending (documentato, follow-up issue da aprire):
- *   - KPISparkline per CPU/Memory/Network — richiede endpoint metrics aggregato
- *
- * Resolved follow-ups:
- *   - #1853 — ContainerDashboard now subscribes to `useLiveEvents({ aggregateTypes:
- *     ['Container', 'Infrastructure'] })`. The hook activates automatically when BE
- *     starts emitting those event types; until then the polling fallback (60s minimum)
- *     keeps the UI accurate.
- *   - #1854 — RestartAllPanel inline confirmation replaced with `AdminConfirmationDialog`
- *     (Radix Dialog → role=dialog + aria-labelledby + focus trap + Escape, axe-clean).
+ * Resolved follow-ups: #1853 (SSE wiring) · #1854 (typed-confirm dialog).
+ * Open gap (out of scope, follow-up issue tracciato in spec):
+ *   - Per-container CPU/Memory metrics (richiede estensione ContainerInfo BE)
+ *   - Resources section (disco + memoria host breakdown)
  */
 
+import { useLiveEvents } from '@/components/admin/monitor/use-live-events';
+
 import { ContainerDashboard } from './ContainerDashboard';
+import { KPISparklineStrip } from './KPISparklineStrip';
+import { LiveEventLog } from './LiveEventLog';
 import { RestartAllPanel } from './RestartAllPanel';
 
 export default function ContainerDashboardPage() {
+  const { events, isStreaming, isLoading } = useLiveEvents({
+    aggregateTypes: ['Container', 'Infrastructure'],
+    initialLimit: 50,
+  });
+
   return (
     <div data-testid="containers-page" className="space-y-6">
       {/* SP5 hero header */}
@@ -47,7 +51,19 @@ export default function ContainerDashboardPage() {
         </p>
       </header>
 
-      <ContainerDashboard />
+      <KPISparklineStrip />
+
+      <ContainerDashboard liveEvents={events} sseConnected={isStreaming} />
+
+      <section aria-labelledby="live-events-heading" className="space-y-2">
+        <h2
+          id="live-events-heading"
+          className="font-quicksand text-sm font-semibold text-foreground"
+        >
+          Eventi live
+        </h2>
+        <LiveEventLog events={events} isStreaming={isStreaming} isLoading={isLoading} />
+      </section>
 
       {/* Issue #145: Restart All with dependency-ordered restart */}
       <RestartAllPanel />

--- a/docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md
+++ b/docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md
@@ -252,5 +252,5 @@ Sparkline path: stroke `currentColor` (eredita dal parent `text-<color>` class),
 - Parent epic: [#1833](https://github.com/meepleAi-app/meepleai-monorepo/issues/1833)
 - Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-infra.html`
 - Spec consolidamento: [`docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md`](../../superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md)
-- Hook riusato: [`apps/web/src/components/admin/monitor/use-live-events.ts`](../../../../apps/web/src/components/admin/monitor/use-live-events.ts)
+- Hook riusato: [`apps/web/src/components/admin/monitor/use-live-events.ts`](../../../apps/web/src/components/admin/monitor/use-live-events.ts)
 - Already merged: #1853 (SSE wiring) · #1854 (typed-confirm)

--- a/docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md
+++ b/docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md
@@ -1,0 +1,256 @@
+# SP5 F4-C1 — `/admin/monitor/containers` re-skin (KPISparkline + LiveEventLog)
+
+**Issue**: [#1837](https://github.com/meepleAi-app/meepleai-monorepo/issues/1837) · **Parent epic**: [#1833](https://github.com/meepleAi-app/meepleai-monorepo/issues/1833) F4 Ondata Ops · **Date**: 2026-06-03
+
+## Goal
+
+Completare il re-skin SP5 di `/admin/monitor/containers` aggiungendo i 2 componenti residui del mockup `sp5-admin-infra.html` non ancora coperti dai merge precedenti (#1853 + #1854):
+
+1. **KPISparkline strip** — 4 KPI con mini-sparkline SVG (Container attivi, CPU media, RAM usata, Batch job in coda)
+2. **LiveEventLog** — feed live visivo dei domain events `Container`/`Infrastructure` con fade-out a 30s
+
+Il terzo componente chiave del mockup, **ConfirmModal typed-confirm** ("RESTART ALL"), è già implementato in `RestartAllPanel.tsx` via `AdminConfirmationDialog` (issue #1854 mergiata 2026-05-31).
+
+## Context — cosa è già fatto
+
+- `page.tsx` ha hero header SP5-style (breadcrumb + titolo + descrizione)
+- `ContainerDashboard.tsx` (#1853):
+  - SSE primary via `useLiveEvents({ aggregateTypes: ['Container', 'Infrastructure'] })`
+  - Polling fallback con exponential backoff (60s → 5min cap)
+  - SSE liveness indicator badge (`RadioTower` icon)
+  - Auto-refresh controls + countdown
+  - `StatusSummary` 3-KPI (Total/Running/Stopped) token-aligned
+  - `ContainerCard` grid 1/2/3 col responsive
+- `RestartAllPanel.tsx` (#1854):
+  - `AdminConfirmationDialog` Level 2 typed-confirm `"RESTART ALL"`
+  - Tier-ordered restart sequenziale (Tier 1 AI services → Tier 2 API)
+  - Per-service `ServiceProgressRow` con status icons
+
+## Scope — cosa aggiungere
+
+### KPISparkline strip
+
+Striscia di 4 KPI sopra il `ContainerDashboard`, riusando endpoint esistenti:
+
+| KPI | Source | Sparkline data |
+|---|---|---|
+| Container attivi `7/8` | `api.admin.getDockerContainers()` (running vs total) | derivato da history (vedi note) |
+| CPU media `34%` | `getMetricsTimeSeries({ range: '1h' }).cpu` (ultimo punto) | `cpu[]` time-series |
+| RAM usata `18.4/32 GB` | `getMetricsTimeSeries({ range: '1h' }).memory` (ultimo punto) | `memory[]` time-series |
+| Batch job in coda `4 · 2 run` | `api.admin.getAllBatchJobs({ status: 'queued' })` + `'running'` | derivato da history (vedi note) |
+
+**Sparkline rendering**: SVG inline 70×28 viewBox, stroke=currentColor stroke-width=1.5, fill semi-trasparente per entity coloring (replicare `.spark` / `.spark-fill` dal mockup).
+
+**Trend label** sotto il valore: `▲ +X% vs 1h fa` (up) / `▼ -X% ultimi 5m` (down) / `▬ flat`. Calcolato da `(latest - first) / first`.
+
+**Note sui sparkline data**:
+- CPU + Memory: sparkline disponibile via `getMetricsTimeSeries({ range: '1h' })`
+- Container attivi + Batch jobs: non c'è time-series storico → due opzioni:
+  - **(a)** non mostrare sparkline (solo valore + trend), KPI render senza `<svg>`
+  - **(b)** accumulare in-memory durante la sessione (12 sample/h via auto-refresh) → flat finché non si raccolgono dati
+  - **Scelta**: **(a)** — semplifica, evita state in-memory + edge case session-reload. Sparkline mostrato solo per CPU/Memory.
+
+### LiveEventLog
+
+Feed visivo dei domain events `Container.*` + `Infrastructure.*` consumati dallo stesso `useLiveEvents` già sottoscritto da `ContainerDashboard`. **Non duplicare la subscription**: il `LiveEventLog` riceve `events: DomainEventDto[]` come prop da `page.tsx`.
+
+**Layout** (mockup `.event-log .row` riga 199):
+```
+[ts: 96px mono] [lvl: 60px uppercase color] [msg: 1fr ellipsis]
+```
+
+**Styling per livello** (mockup riga 203-207):
+- `INFO` → `text-chat` (color blue)
+- `WARN` → `text-amber-500`
+- `ERR` → `text-event` (color rose)
+- `OK` → `text-toolkit` (color emerald)
+
+**Mapping `DomainEventDto` → log row**:
+- `ts` = `loggedAt` formattato `HH:mm:ss.SSS`
+- `lvl` = derivato da `eventType` suffix:
+  - `*.Created` / `*.Started` / `*.Healthy` → `OK`
+  - `*.Updated` / `*.Restarting` / qualsiasi altro → `INFO`
+  - `*.Degraded` / `*.SlowResponse` → `WARN`
+  - `*.Failed` / `*.Unhealthy` / `*.Crashed` → `ERR`
+- `msg` = `aggregateType lowercased + " " + payload key extraction`. Default: `eventType + " " + aggregateId`.
+
+**Fade-out 30s**: row più vecchia di 30s ha `opacity: 0.5` (replicare con `text-muted-foreground/70` o classe `event-row-stale`). Trigger via setInterval 5s che riconcilia.
+
+**`role="log" aria-live="polite"`** sul container (mockup riga 469).
+
+**Empty state**: "Nessun evento ricevuto. SSE in attesa." quando `events.length === 0` e `isStreaming === true`. Se `!isStreaming`: "Stream offline. Tentativo di riconnessione in corso…".
+
+**Max rows visibili**: 20 (più di così è rumore visivo; il buffer `useLiveEvents` è 1000 ma il feed mostra solo le top 20).
+
+### Resources section — OUT OF SCOPE
+
+La sezione 4 del mockup (`Risorse` con disco /var/lib/docker + memoria host) **NON è elencata** tra i 3 componenti chiave dell'issue (`KPISparkline · LiveEventLog · ConfirmModal`). Richiede endpoint BE nuovo (`/admin/infrastructure/disk-usage` con breakdown images/volumes/logs e memoria host con breakdown containers/cache/kernel) che oggi non esiste.
+
+**Tracking follow-up**: aprire issue separata dopo merge di #1837, scope BE-prima (endpoint) + FE-poi (componente Resources).
+
+### Per-container CPU/Memory — DOCUMENTATO GAP
+
+Il page.tsx esistente cita: *"BE pending (documentato, follow-up issue da aprire): KPISparkline per CPU/Memory/Network — richiede endpoint metrics aggregato"*. Lo Scenario A AC richiede "CPU%, Memory%" per card → mantengo il gap noto (mostro "—" come placeholder nelle ContainerCard, non bloccante), e estendo il follow-up esistente all'apertura di un'issue separata.
+
+## Acceptance Criteria — cosa testare
+
+### Scenario A — KPI strip rendering (Given/When/Then)
+
+```
+Given /api/v1/admin/docker/containers returns 7 running + 1 stopped
+And /api/v1/admin/infrastructure/metrics/timeseries?range=1h returns cpu/memory series
+And /api/v1/admin/operations/batch-jobs returns 4 queued + 2 running
+
+When admin opens /admin/monitor/containers
+Then 4 KPI cards visible above ContainerDashboard
+And card "Container attivi" shows "7" with subtle "/8"
+And card "CPU media" shows last data point + sparkline SVG (path with valid d= attribute)
+And card "RAM usata" shows value formatted as "X.X GB" + sparkline
+And card "Batch job in coda" shows "4 · 2 run"
+And each card has trend label (▲/▼/▬) computed from first vs last data point
+```
+
+### Scenario B — Live event feed (Given/When/Then)
+
+```
+Given SSE active on /api/v1/admin/events/stream with aggregateTypes=Container,Infrastructure
+And LiveEventLog mounted with empty initial buffer
+
+When BE emits a `Container.Restarted` event for aggregate "meepleai-api"
+Then LiveEventLog prepends a new row with format "[HH:MM:SS.SSS] [INFO] container restarted aggregate=meepleai-api"
+And the row has level color "INFO" (text-chat-600)
+And rows older than 30 seconds become opacity-50
+
+Given LiveEventLog has 25 buffered events
+Then only the top 20 are rendered (visual limit)
+```
+
+### Scenario C — Empty / disconnected states (additive AC)
+
+```
+Given useLiveEvents returns events=[] and isStreaming=true
+Then LiveEventLog shows "Nessun evento ricevuto. SSE in attesa." (empty placeholder)
+
+Given useLiveEvents returns events=[] and isStreaming=false
+Then LiveEventLog shows "Stream offline. Tentativo di riconnessione in corso…"
+```
+
+### Scenario D — Accessibility (regression guard)
+
+```
+Given LiveEventLog renders
+Then container has role="log" and aria-live="polite"
+And axe-core scan finds 0 violations on KPISparkline + LiveEventLog
+
+Given KPISparklineStrip renders
+Then each KPI card has accessible label "<KPI name> <value> <trend>"
+And sparkline SVG has aria-hidden="true" (decorative)
+```
+
+### Scenario E — Regression coverage (existing tests still pass)
+
+```
+Given existing #1853 tests for ContainerDashboard SSE+polling
+Then they continue to pass (no regression on dual-channel refresh)
+
+Given existing #1854 tests for AdminConfirmationDialog typed-confirm
+Then they continue to pass (no regression on RestartAllPanel flow)
+```
+
+## Tech Approach
+
+### File structure
+
+```
+apps/web/src/app/admin/(dashboard)/monitor/containers/
+├── page.tsx                            (modify: import + mount new components)
+├── ContainerDashboard.tsx              (unchanged)
+├── RestartAllPanel.tsx                 (unchanged)
+├── KPISparklineStrip.tsx               (NEW: 4-KPI strip wrapper)
+├── LiveEventLog.tsx                    (NEW: SSE event feed visual)
+├── hooks/
+│   └── use-infrastructure-kpis.ts      (NEW: hook combines 3 endpoints)
+├── _utils/
+│   └── event-log-mapper.ts             (NEW: DomainEventDto → log row)
+└── __tests__/
+    ├── KPISparklineStrip.test.tsx      (NEW)
+    ├── LiveEventLog.test.tsx           (NEW)
+    ├── use-infrastructure-kpis.test.tsx (NEW)
+    └── event-log-mapper.test.ts        (NEW)
+```
+
+### Component contracts
+
+**`KPISparklineStrip`** — self-contained, fetches its own data:
+```ts
+// Props: none (uses internal hook + react-query/SWR-style fetching)
+export function KPISparklineStrip(): JSX.Element;
+```
+
+**`LiveEventLog`** — receives events as prop (no own SSE subscription):
+```ts
+interface LiveEventLogProps {
+  events: ReadonlyArray<DomainEventDto>;
+  isStreaming: boolean;
+  isLoading: boolean;
+  maxVisible?: number;  // default 20
+  staleThresholdMs?: number;  // default 30_000
+}
+export function LiveEventLog(props: LiveEventLogProps): JSX.Element;
+```
+
+**`use-infrastructure-kpis`** — combines 3 endpoints, returns 4 KPI shapes:
+```ts
+interface InfrastructureKpis {
+  containers: { active: number; total: number; stopped: number; loading: boolean };
+  cpu: { value: number; series: TimeSeriesPoint[]; trend: 'up'|'down'|'flat'; trendPct: number; loading: boolean };
+  memory: { value: number; total: number; series: TimeSeriesPoint[]; trend: 'up'|'down'|'flat'; trendPct: number; loading: boolean };
+  batchJobs: { queued: number; running: number; loading: boolean };
+}
+export function useInfrastructureKpis(): InfrastructureKpis;
+```
+
+**`event-log-mapper`** — pure helpers, 100% testable:
+```ts
+export type LogLevel = 'INFO' | 'WARN' | 'ERR' | 'OK';
+
+export function deriveLogLevel(eventType: string): LogLevel;
+export function formatLogTimestamp(loggedAt: string): string; // "HH:mm:ss.SSS"
+export function buildLogMessage(event: DomainEventDto): string;
+export function isStaleEvent(loggedAt: string, now: number, thresholdMs: number): boolean;
+```
+
+### Decision: subscribe-once
+
+Per evitare doppia subscription SSE, **`ContainerDashboard` continua a subscriverlo** e **`page.tsx` solleva la subscription al livello padre**, passando `events` come prop a entrambi `ContainerDashboard` e `LiveEventLog`. Refactor minimo del ContainerDashboard: rimuovere `useLiveEvents()` interno e accettare `liveEvents: DomainEventDto[]` + `sseConnected: boolean` come prop.
+
+**Trade-off**: il refactor tocca ContainerDashboard, ma minimizza fetch SSE (1 connessione, non 2). Preferito su isolated subscription per evitare doppio carico BE.
+
+### Token semantici / styling
+
+Tutti i nuovi componenti seguono regola ESLint `local/no-hardcoded-color-utility`: usare `bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`, e entity utilities (`bg-entity-event/10`, ecc). Mockup `.lvl.info` → `text-chat-600 dark:text-chat-400`; `.lvl.warn` → `text-amber-500`; `.lvl.err` → `text-rose-600 dark:text-rose-400`; `.lvl.ok` → `text-emerald-600 dark:text-emerald-400`.
+
+Sparkline path: stroke `currentColor` (eredita dal parent `text-<color>` class), fill `currentColor opacity-15`.
+
+## Non-Goals
+
+- ❌ Per-container CPU/Memory metrics (gap noto, follow-up)
+- ❌ Resources section (disco + memoria host, follow-up)
+- ❌ Cambio routing nav (`/admin/monitor/containers` invariato)
+- ❌ Modifiche backend (zero endpoint nuovi)
+- ❌ ConfirmModal refactor (già implementato in #1854)
+- ❌ Mobile fallback (mockup desktop-only)
+
+## Follow-ups da aprire post-merge
+
+1. **`feat(admin-infra-be): per-container resource metrics (CPU/Memory)`** — estende endpoint `/admin/docker/containers` con docker stats integration. AC: ContainerInfo include `cpuPercent`, `memoryUsedBytes`, `memoryLimitBytes`. Blocker per Scenario A AC #1837 (oggi "—" placeholder).
+2. **`feat(admin-infra): Resources section (disk + memory host breakdown)`** — endpoint nuovo `/admin/infrastructure/resources` con disk breakdown (images/volumes/logs/free) + memoria host (containers/cache/kernel/free), componente `ResourcesPanel` con stacked bars come da mockup sezione 4.
+
+## References
+
+- Issue: [#1837](https://github.com/meepleAi-app/meepleai-monorepo/issues/1837)
+- Parent epic: [#1833](https://github.com/meepleAi-app/meepleai-monorepo/issues/1833)
+- Mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-infra.html`
+- Spec consolidamento: [`docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md`](../../superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md)
+- Hook riusato: [`apps/web/src/components/admin/monitor/use-live-events.ts`](../../../../apps/web/src/components/admin/monitor/use-live-events.ts)
+- Already merged: #1853 (SSE wiring) · #1854 (typed-confirm)

--- a/docs/superpowers/plans/2026-06-03-1837-c1-infra-reskin.md
+++ b/docs/superpowers/plans/2026-06-03-1837-c1-infra-reskin.md
@@ -1,0 +1,1451 @@
+# SP5 F4-C1 `/admin/monitor/containers` re-skin — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere `KPISparklineStrip` (4 KPI con sparkline) e `LiveEventLog` (feed SSE visuale con fade-out 30s) alla pagina `/admin/monitor/containers`, completando il re-skin SP5 iniziato in #1853/#1854.
+
+**Architecture:** Solleva la subscription `useLiveEvents` da `ContainerDashboard` al `page.tsx` padre, passa `events` come prop a `LiveEventLog` (nuovo) e `ContainerDashboard` (refactor). `KPISparklineStrip` ha hook proprio `useInfrastructureKpis` che combina 3 endpoint esistenti (`getDockerContainers`, `getMetricsTimeSeries`, `getAllBatchJobs`). Zero modifiche BE.
+
+**Tech Stack:** Next.js 16 App Router · React 19 · TypeScript · Vitest · Testing Library · SWR/native fetch · Tailwind 4 con token semantici
+
+**Spec:** `docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md`
+
+**Branch:** `feature/issue-1837-c1-infra-reskin` (target: `main-dev`)
+
+---
+
+## File Structure
+
+```
+apps/web/src/app/admin/(dashboard)/monitor/containers/
+├── page.tsx                                            [MODIFY: lift useLiveEvents, mount new components]
+├── ContainerDashboard.tsx                              [MODIFY: accept liveEvents+sseConnected props, remove internal useLiveEvents]
+├── RestartAllPanel.tsx                                 [UNCHANGED]
+├── KPISparklineStrip.tsx                               [NEW]
+├── LiveEventLog.tsx                                    [NEW]
+├── hooks/
+│   └── use-infrastructure-kpis.ts                      [NEW]
+├── _utils/
+│   └── event-log-mapper.ts                             [NEW]
+└── __tests__/
+    ├── event-log-mapper.test.ts                        [NEW: pure unit, no DOM]
+    ├── use-infrastructure-kpis.test.tsx                [NEW]
+    ├── LiveEventLog.test.tsx                           [NEW]
+    ├── KPISparklineStrip.test.tsx                      [NEW]
+    └── ContainerDashboard.test.tsx                     [MODIFY: pass props instead of mocking useLiveEvents internal]
+```
+
+---
+
+## Phase 0 — Branch verification
+
+### Task 0.1: Confirm branch & clean state
+
+- [ ] **Step 1: Verify branch**
+
+Run: `git branch --show-current`
+Expected: `feature/issue-1837-c1-infra-reskin`
+
+- [ ] **Step 2: Verify clean tree (todo.txt OK)**
+
+Run: `git status --short`
+Expected: only `?? todo.txt` (untracked, OK to ignore — not in scope)
+
+- [ ] **Step 3: Verify parent config**
+
+Run: `git config branch.feature/issue-1837-c1-infra-reskin.parent`
+Expected: `main-dev`
+
+---
+
+## Phase 1 — Pure helpers (TDD foundation)
+
+### Task 1.1: Create event-log-mapper with deriveLogLevel
+
+**Files:**
+- Create: `apps/web/src/app/admin/(dashboard)/monitor/containers/_utils/event-log-mapper.ts`
+- Test: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/event-log-mapper.test.ts`
+
+- [ ] **Step 1: Write the failing tests for `deriveLogLevel`**
+
+```typescript
+// apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/event-log-mapper.test.ts
+import { describe, expect, it } from 'vitest';
+import { deriveLogLevel } from '../_utils/event-log-mapper';
+
+describe('deriveLogLevel', () => {
+  it.each([
+    ['Container.Created', 'OK'],
+    ['Container.Started', 'OK'],
+    ['Service.Healthy', 'OK'],
+    ['Container.Updated', 'INFO'],
+    ['Container.Restarting', 'INFO'],
+    ['UnknownAggregate.SomethingElse', 'INFO'],
+    ['Service.Degraded', 'WARN'],
+    ['Service.SlowResponse', 'WARN'],
+    ['Container.Failed', 'ERR'],
+    ['Service.Unhealthy', 'ERR'],
+    ['Container.Crashed', 'ERR'],
+  ] as const)('maps %s → %s', (eventType, expected) => {
+    expect(deriveLogLevel(eventType)).toBe(expected);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/event-log-mapper.test.ts`
+Expected: FAIL — `Cannot find module '../_utils/event-log-mapper'`
+
+- [ ] **Step 3: Implement minimal `deriveLogLevel`**
+
+```typescript
+// apps/web/src/app/admin/(dashboard)/monitor/containers/_utils/event-log-mapper.ts
+
+export type LogLevel = 'INFO' | 'WARN' | 'ERR' | 'OK';
+
+const OK_SUFFIXES = ['.Created', '.Started', '.Healthy'] as const;
+const ERR_SUFFIXES = ['.Failed', '.Unhealthy', '.Crashed'] as const;
+const WARN_SUFFIXES = ['.Degraded', '.SlowResponse'] as const;
+
+export function deriveLogLevel(eventType: string): LogLevel {
+  if (OK_SUFFIXES.some(s => eventType.endsWith(s))) return 'OK';
+  if (ERR_SUFFIXES.some(s => eventType.endsWith(s))) return 'ERR';
+  if (WARN_SUFFIXES.some(s => eventType.endsWith(s))) return 'WARN';
+  return 'INFO';
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: same command as Step 2
+Expected: 11/11 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/_utils/event-log-mapper.ts apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/event-log-mapper.test.ts
+git commit -m "feat(admin-infra): #1837 deriveLogLevel mapper"
+```
+
+---
+
+### Task 1.2: Add formatLogTimestamp + buildLogMessage + isStaleEvent
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/containers/_utils/event-log-mapper.ts`
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/event-log-mapper.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// add to existing __tests__/event-log-mapper.test.ts
+import { buildLogMessage, formatLogTimestamp, isStaleEvent } from '../_utils/event-log-mapper';
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+describe('formatLogTimestamp', () => {
+  it('formats ISO timestamp as HH:mm:ss.SSS in UTC', () => {
+    expect(formatLogTimestamp('2026-06-03T14:23:08.412Z')).toBe('14:23:08.412');
+  });
+
+  it('pads single-digit components', () => {
+    expect(formatLogTimestamp('2026-06-03T01:02:03.040Z')).toBe('01:02:03.040');
+  });
+
+  it('returns "--:--:--.---" for invalid input', () => {
+    expect(formatLogTimestamp('not-a-date')).toBe('--:--:--.---');
+  });
+});
+
+describe('buildLogMessage', () => {
+  function makeEvent(overrides: Partial<DomainEventDto> = {}): DomainEventDto {
+    return {
+      id: 'evt-1',
+      eventType: 'Container.Restarted',
+      aggregateType: 'Container',
+      aggregateId: 'meepleai-api',
+      loggedAt: '2026-06-03T14:23:08.412Z',
+      payload: null,
+      ...overrides,
+    } as DomainEventDto;
+  }
+
+  it('uses lowercase aggregate type + event suffix + aggregateId', () => {
+    expect(buildLogMessage(makeEvent())).toBe('container restarted aggregate=meepleai-api');
+  });
+
+  it('falls back to full eventType when no dot suffix', () => {
+    expect(buildLogMessage(makeEvent({ eventType: 'OpaqueEvent' })))
+      .toBe('container OpaqueEvent aggregate=meepleai-api');
+  });
+
+  it('handles empty aggregateId gracefully', () => {
+    expect(buildLogMessage(makeEvent({ aggregateId: '' })))
+      .toBe('container restarted');
+  });
+});
+
+describe('isStaleEvent', () => {
+  const now = Date.parse('2026-06-03T14:23:38.000Z');
+
+  it('returns false for events within threshold', () => {
+    expect(isStaleEvent('2026-06-03T14:23:08.000Z', now, 30_000)).toBe(false);
+  });
+
+  it('returns true for events older than threshold', () => {
+    expect(isStaleEvent('2026-06-03T14:23:07.999Z', now, 30_000)).toBe(true);
+  });
+
+  it('returns true for invalid timestamps (safe default — fade out)', () => {
+    expect(isStaleEvent('garbage', now, 30_000)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/event-log-mapper.test.ts`
+Expected: FAIL — missing exports `formatLogTimestamp`, `buildLogMessage`, `isStaleEvent`
+
+- [ ] **Step 3: Implement helpers**
+
+Append to `_utils/event-log-mapper.ts`:
+
+```typescript
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+const INVALID_TIMESTAMP = '--:--:--.---';
+
+export function formatLogTimestamp(iso: string): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return INVALID_TIMESTAMP;
+  const d = new Date(ms);
+  const pad2 = (n: number) => String(n).padStart(2, '0');
+  const pad3 = (n: number) => String(n).padStart(3, '0');
+  return `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())}.${pad3(d.getUTCMilliseconds())}`;
+}
+
+export function buildLogMessage(event: DomainEventDto): string {
+  const aggregateLower = event.aggregateType.toLowerCase();
+  const dotIdx = event.eventType.lastIndexOf('.');
+  const verb = dotIdx >= 0 ? event.eventType.slice(dotIdx + 1).toLowerCase() : event.eventType;
+  const parts = [aggregateLower, verb];
+  if (event.aggregateId) parts.push(`aggregate=${event.aggregateId}`);
+  return parts.join(' ');
+}
+
+export function isStaleEvent(loggedAt: string, now: number, thresholdMs: number): boolean {
+  const ms = Date.parse(loggedAt);
+  if (Number.isNaN(ms)) return true;
+  return now - ms > thresholdMs;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: same as Step 2
+Expected: all describe blocks PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/_utils/event-log-mapper.ts apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/event-log-mapper.test.ts
+git commit -m "feat(admin-infra): #1837 timestamp/message/stale helpers"
+```
+
+---
+
+## Phase 2 — `useInfrastructureKpis` hook
+
+### Task 2.1: Hook with happy-path tests
+
+**Files:**
+- Create: `apps/web/src/app/admin/(dashboard)/monitor/containers/hooks/use-infrastructure-kpis.ts`
+- Test: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/use-infrastructure-kpis.test.tsx`
+
+- [ ] **Step 1: Inspect existing api mock pattern**
+
+Run: `grep -rn "vi.mock.*lib/api" apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/ 2>&1 | head -5`
+Expected: existing tests already mock `@/lib/api` — reuse same pattern
+
+- [ ] **Step 2: Write failing test for hook initialization + data flow**
+
+```typescript
+// __tests__/use-infrastructure-kpis.test.tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useInfrastructureKpis } from '../hooks/use-infrastructure-kpis';
+
+const getDockerContainers = vi.fn();
+const getMetricsTimeSeries = vi.fn();
+const getAllBatchJobs = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      get getDockerContainers() { return getDockerContainers; },
+      get getMetricsTimeSeries() { return getMetricsTimeSeries; },
+      get getAllBatchJobs() { return getAllBatchJobs; },
+    },
+  },
+}));
+
+describe('useInfrastructureKpis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('combines 3 endpoints into 4 KPI shapes', async () => {
+    getDockerContainers.mockResolvedValue([
+      { id: '1', name: 'api', image: 'x', state: 'running', status: '', created: '', labels: {} },
+      { id: '2', name: 'redis', image: 'y', state: 'running', status: '', created: '', labels: {} },
+      { id: '3', name: 'pg', image: 'z', state: 'exited', status: '', created: '', labels: {} },
+    ]);
+
+    getMetricsTimeSeries.mockResolvedValue({
+      cpu: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 20 },
+        { timestamp: '2026-06-03T14:30:00Z', value: 28 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 34 },
+      ],
+      memory: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 12.0 },
+        { timestamp: '2026-06-03T14:30:00Z', value: 15.0 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 18.4 },
+      ],
+      requests: [],
+    });
+
+    getAllBatchJobs.mockImplementation((p: { status?: string }) =>
+      Promise.resolve({
+        jobs: [],
+        total: p.status === 'queued' ? 4 : p.status === 'running' ? 2 : 0,
+        page: 1,
+        pageSize: 20,
+      })
+    );
+
+    const { result } = renderHook(() => useInfrastructureKpis());
+
+    await waitFor(() => expect(result.current.containers.loading).toBe(false));
+    await waitFor(() => expect(result.current.cpu.loading).toBe(false));
+    await waitFor(() => expect(result.current.batchJobs.loading).toBe(false));
+
+    expect(result.current.containers).toMatchObject({ active: 2, total: 3, stopped: 1 });
+    expect(result.current.cpu).toMatchObject({ value: 34, trend: 'up' });
+    expect(result.current.cpu.series).toHaveLength(3);
+    expect(result.current.memory).toMatchObject({ value: 18.4, trend: 'up' });
+    expect(result.current.batchJobs).toMatchObject({ queued: 4, running: 2 });
+  });
+
+  it('marks failed fetches as loading=false with safe fallback values', async () => {
+    getDockerContainers.mockRejectedValue(new Error('boom'));
+    getMetricsTimeSeries.mockRejectedValue(new Error('boom'));
+    getAllBatchJobs.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useInfrastructureKpis());
+
+    await waitFor(() => expect(result.current.containers.loading).toBe(false));
+    await waitFor(() => expect(result.current.cpu.loading).toBe(false));
+
+    expect(result.current.containers).toMatchObject({ active: 0, total: 0, stopped: 0 });
+    expect(result.current.cpu).toMatchObject({ value: 0, trend: 'flat' });
+    expect(result.current.cpu.series).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify failure**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/use-infrastructure-kpis.test.tsx`
+Expected: FAIL — module missing
+
+- [ ] **Step 4: Implement hook**
+
+```typescript
+// hooks/use-infrastructure-kpis.ts
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+
+export type Trend = 'up' | 'down' | 'flat';
+
+export interface TimeSeriesPoint {
+  timestamp: string;
+  value: number;
+}
+
+interface ContainerKpi { active: number; total: number; stopped: number; loading: boolean }
+interface MetricKpi { value: number; series: TimeSeriesPoint[]; trend: Trend; trendPct: number; loading: boolean }
+interface MemoryKpi extends MetricKpi { total: number }
+interface BatchJobsKpi { queued: number; running: number; loading: boolean }
+
+export interface InfrastructureKpis {
+  containers: ContainerKpi;
+  cpu: MetricKpi;
+  memory: MemoryKpi;
+  batchJobs: BatchJobsKpi;
+}
+
+const FLAT_THRESHOLD = 0.5; // %
+
+function computeTrend(series: TimeSeriesPoint[]): { trend: Trend; pct: number } {
+  if (series.length < 2) return { trend: 'flat', pct: 0 };
+  const first = series[0].value;
+  const last = series[series.length - 1].value;
+  if (first === 0) return { trend: last > 0 ? 'up' : 'flat', pct: 0 };
+  const pct = ((last - first) / first) * 100;
+  if (Math.abs(pct) < FLAT_THRESHOLD) return { trend: 'flat', pct: 0 };
+  return { trend: pct > 0 ? 'up' : 'down', pct: Math.round(pct * 10) / 10 };
+}
+
+const EMPTY_METRIC: MetricKpi = { value: 0, series: [], trend: 'flat', trendPct: 0, loading: true };
+const EMPTY_MEMORY: MemoryKpi = { ...EMPTY_METRIC, total: 0 };
+
+export function useInfrastructureKpis(): InfrastructureKpis {
+  const [containers, setContainers] = useState<ContainerKpi>({
+    active: 0, total: 0, stopped: 0, loading: true,
+  });
+  const [cpu, setCpu] = useState<MetricKpi>(EMPTY_METRIC);
+  const [memory, setMemory] = useState<MemoryKpi>(EMPTY_MEMORY);
+  const [batchJobs, setBatchJobs] = useState<BatchJobsKpi>({
+    queued: 0, running: 0, loading: true,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void api.admin.getDockerContainers()
+      .then(list => {
+        if (cancelled) return;
+        const active = list.filter(c => c.state === 'running').length;
+        setContainers({ active, total: list.length, stopped: list.length - active, loading: false });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setContainers({ active: 0, total: 0, stopped: 0, loading: false });
+      });
+
+    void api.admin.getMetricsTimeSeries('1h')
+      .then(resp => {
+        if (cancelled) return;
+        const cpuSeries = resp?.cpu ?? [];
+        const memSeries = resp?.memory ?? [];
+        const cpuValue = cpuSeries.length ? cpuSeries[cpuSeries.length - 1].value : 0;
+        const memValue = memSeries.length ? memSeries[memSeries.length - 1].value : 0;
+        const cpuTrend = computeTrend(cpuSeries);
+        const memTrend = computeTrend(memSeries);
+        setCpu({ value: cpuValue, series: cpuSeries, trend: cpuTrend.trend, trendPct: cpuTrend.pct, loading: false });
+        setMemory({ value: memValue, series: memSeries, trend: memTrend.trend, trendPct: memTrend.pct, total: 32, loading: false });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCpu({ ...EMPTY_METRIC, loading: false });
+        setMemory({ ...EMPTY_MEMORY, loading: false });
+      });
+
+    Promise.all([
+      api.admin.getAllBatchJobs({ status: 'queued', pageSize: 1 }),
+      api.admin.getAllBatchJobs({ status: 'running', pageSize: 1 }),
+    ])
+      .then(([queued, running]) => {
+        if (cancelled) return;
+        setBatchJobs({ queued: queued?.total ?? 0, running: running?.total ?? 0, loading: false });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBatchJobs({ queued: 0, running: 0, loading: false });
+      });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  return { containers, cpu, memory, batchJobs };
+}
+```
+
+> Note on `memory.total`: hardcoded `32` GB matches mockup display. Until BE exposes host memory limit via `/admin/infrastructure/details`, this is a known display constant. Surface in follow-up if user complains.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: same as Step 3
+Expected: 2/2 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/hooks/use-infrastructure-kpis.ts apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/use-infrastructure-kpis.test.tsx
+git commit -m "feat(admin-infra): #1837 useInfrastructureKpis hook"
+```
+
+---
+
+## Phase 3 — `LiveEventLog` component
+
+### Task 3.1: Render rows from events prop
+
+**Files:**
+- Create: `apps/web/src/app/admin/(dashboard)/monitor/containers/LiveEventLog.tsx`
+- Test: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/LiveEventLog.test.tsx`
+
+- [ ] **Step 1: Write failing test for basic rendering**
+
+```typescript
+// __tests__/LiveEventLog.test.tsx
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LiveEventLog } from '../LiveEventLog';
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+function evt(o: Partial<DomainEventDto> = {}): DomainEventDto {
+  return {
+    id: o.id ?? 'evt-' + Math.random(),
+    eventType: 'Container.Restarted',
+    aggregateType: 'Container',
+    aggregateId: 'meepleai-api',
+    loggedAt: '2026-06-03T14:23:08.412Z',
+    payload: null,
+    ...o,
+  } as DomainEventDto;
+}
+
+describe('LiveEventLog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T14:23:10.000Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('renders one row per event with ts, level, message', () => {
+    render(<LiveEventLog events={[evt({ id: '1' })]} isStreaming isLoading={false} />);
+    expect(screen.getByText('14:23:08.412')).toBeInTheDocument();
+    expect(screen.getByText(/INFO/i)).toBeInTheDocument();
+    expect(screen.getByText(/container restarted aggregate=meepleai-api/)).toBeInTheDocument();
+  });
+
+  it('container has role=log and aria-live=polite', () => {
+    render(<LiveEventLog events={[evt()]} isStreaming isLoading={false} />);
+    const log = screen.getByRole('log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('limits visible rows to maxVisible (default 20)', () => {
+    const events = Array.from({ length: 25 }, (_, i) => evt({ id: `e-${i}` }));
+    render(<LiveEventLog events={events} isStreaming isLoading={false} />);
+    expect(screen.getAllByTestId('live-event-row')).toHaveLength(20);
+  });
+
+  it('shows empty placeholder when no events and streaming', () => {
+    render(<LiveEventLog events={[]} isStreaming isLoading={false} />);
+    expect(screen.getByText(/Nessun evento ricevuto/)).toBeInTheDocument();
+  });
+
+  it('shows disconnected placeholder when not streaming and no events', () => {
+    render(<LiveEventLog events={[]} isStreaming={false} isLoading={false} />);
+    expect(screen.getByText(/Stream offline/)).toBeInTheDocument();
+  });
+
+  it('shows loading placeholder when isLoading=true even with no events', () => {
+    render(<LiveEventLog events={[]} isStreaming={false} isLoading />);
+    expect(screen.getByText(/Caricamento eventi/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/LiveEventLog.test.tsx`
+Expected: FAIL — module missing
+
+- [ ] **Step 3: Implement minimal LiveEventLog**
+
+```typescript
+// LiveEventLog.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Radio } from 'lucide-react';
+
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+import { cn } from '@/lib/utils';
+
+import {
+  buildLogMessage,
+  deriveLogLevel,
+  formatLogTimestamp,
+  isStaleEvent,
+  type LogLevel,
+} from './_utils/event-log-mapper';
+
+const LEVEL_CLASSES: Record<LogLevel, string> = {
+  INFO: 'text-chat-600 dark:text-chat-400',
+  OK: 'text-emerald-600 dark:text-emerald-400',
+  WARN: 'text-amber-600 dark:text-amber-400',
+  ERR: 'text-rose-600 dark:text-rose-400',
+};
+
+const DEFAULT_MAX_VISIBLE = 20;
+const DEFAULT_STALE_THRESHOLD_MS = 30_000;
+const STALE_RECONCILE_INTERVAL_MS = 5_000;
+
+interface LiveEventLogProps {
+  events: ReadonlyArray<DomainEventDto>;
+  isStreaming: boolean;
+  isLoading: boolean;
+  maxVisible?: number;
+  staleThresholdMs?: number;
+}
+
+export function LiveEventLog({
+  events,
+  isStreaming,
+  isLoading,
+  maxVisible = DEFAULT_MAX_VISIBLE,
+  staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS,
+}: LiveEventLogProps): JSX.Element {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), STALE_RECONCILE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const visible = events.slice(0, maxVisible);
+
+  if (isLoading && visible.length === 0) {
+    return (
+      <div
+        role="log"
+        aria-live="polite"
+        data-testid="live-event-log"
+        className="rounded-lg border border-border bg-card/60 p-6 text-center text-sm text-muted-foreground"
+      >
+        Caricamento eventi…
+      </div>
+    );
+  }
+
+  if (visible.length === 0) {
+    return (
+      <div
+        role="log"
+        aria-live="polite"
+        data-testid="live-event-log"
+        className="rounded-lg border border-border bg-card/60 p-6 text-center text-sm text-muted-foreground"
+      >
+        {isStreaming
+          ? 'Nessun evento ricevuto. SSE in attesa.'
+          : 'Stream offline. Tentativo di riconnessione in corso…'}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="log"
+      aria-live="polite"
+      data-testid="live-event-log"
+      className="rounded-lg border border-border bg-card/60 font-mono text-xs"
+    >
+      <div className="flex items-center gap-2 border-b border-border-light px-3 py-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        <Radio
+          aria-hidden="true"
+          className={cn(
+            'h-3 w-3',
+            isStreaming ? 'text-emerald-500' : 'text-muted-foreground'
+          )}
+        />
+        <span>{isStreaming ? 'streaming · SSE' : 'offline · SSE down'}</span>
+        <span className="ml-auto text-muted-foreground/70">
+          {visible.length} / {events.length}
+        </span>
+      </div>
+
+      <ul className="max-h-[340px] overflow-y-auto divide-y divide-border-light">
+        {visible.map(event => {
+          const stale = isStaleEvent(event.loggedAt, now, staleThresholdMs);
+          const level = deriveLogLevel(event.eventType);
+          return (
+            <li
+              key={event.id}
+              data-testid="live-event-row"
+              className={cn(
+                'grid grid-cols-[96px_60px_1fr] items-center gap-3 px-3 py-1.5 transition-opacity',
+                stale ? 'opacity-50' : 'opacity-100'
+              )}
+            >
+              <span className="text-muted-foreground">{formatLogTimestamp(event.loggedAt)}</span>
+              <span className={cn('font-bold uppercase tracking-wider text-[10px]', LEVEL_CLASSES[level])}>
+                {level}
+              </span>
+              <span className="truncate text-foreground">{buildLogMessage(event)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: same as Step 2
+Expected: 6/6 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/LiveEventLog.tsx apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/LiveEventLog.test.tsx
+git commit -m "feat(admin-infra): #1837 LiveEventLog component"
+```
+
+---
+
+### Task 3.2: Fade-out 30s reconciliation
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/LiveEventLog.test.tsx`
+
+- [ ] **Step 1: Write failing test for fade-out**
+
+Append to existing `LiveEventLog.test.tsx`:
+
+```typescript
+describe('LiveEventLog fade-out', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T14:23:10.000Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('marks events older than 30s with reduced opacity', () => {
+    const fresh = evt({ id: 'fresh', loggedAt: '2026-06-03T14:23:00.000Z' }); // 10s old
+    const stale = evt({ id: 'stale', loggedAt: '2026-06-03T14:22:30.000Z' }); // 40s old
+
+    render(<LiveEventLog events={[fresh, stale]} isStreaming isLoading={false} />);
+
+    const rows = screen.getAllByTestId('live-event-row');
+    expect(rows[0]).toHaveClass('opacity-100');
+    expect(rows[1]).toHaveClass('opacity-50');
+  });
+
+  it('reconciles fade-out on interval tick', async () => {
+    const evt1 = evt({ id: 'e1', loggedAt: '2026-06-03T14:23:05.000Z' }); // 5s old
+    const { rerender } = render(
+      <LiveEventLog events={[evt1]} isStreaming isLoading={false} />
+    );
+
+    expect(screen.getByTestId('live-event-row')).toHaveClass('opacity-100');
+
+    // Advance time past 30s threshold + interval tick (5s)
+    vi.advanceTimersByTime(31_000);
+    rerender(<LiveEventLog events={[evt1]} isStreaming isLoading={false} />);
+
+    expect(screen.getByTestId('live-event-row')).toHaveClass('opacity-50');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify pass (fade-out logic already in implementation)**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/LiveEventLog.test.tsx`
+Expected: 8/8 PASS (6 from Task 3.1 + 2 new)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/LiveEventLog.test.tsx
+git commit -m "test(admin-infra): #1837 LiveEventLog fade-out coverage"
+```
+
+---
+
+## Phase 4 — `KPISparklineStrip` component
+
+### Task 4.1: KPI strip with mocked hook
+
+**Files:**
+- Create: `apps/web/src/app/admin/(dashboard)/monitor/containers/KPISparklineStrip.tsx`
+- Test: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/KPISparklineStrip.test.tsx`
+
+- [ ] **Step 1: Write failing test mocking the hook**
+
+```typescript
+// __tests__/KPISparklineStrip.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { KPISparklineStrip } from '../KPISparklineStrip';
+
+const useInfrastructureKpisMock = vi.fn();
+
+vi.mock('../hooks/use-infrastructure-kpis', () => ({
+  useInfrastructureKpis: () => useInfrastructureKpisMock(),
+}));
+
+function makeKpis(overrides: Partial<ReturnType<typeof defaultKpis>> = {}) {
+  return { ...defaultKpis(), ...overrides };
+}
+
+function defaultKpis() {
+  return {
+    containers: { active: 7, total: 8, stopped: 1, loading: false },
+    cpu: {
+      value: 34,
+      series: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 20 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 34 },
+      ],
+      trend: 'up' as const,
+      trendPct: 70,
+      loading: false,
+    },
+    memory: {
+      value: 18.4,
+      total: 32,
+      series: [
+        { timestamp: '2026-06-03T14:00:00Z', value: 17 },
+        { timestamp: '2026-06-03T15:00:00Z', value: 18.4 },
+      ],
+      trend: 'up' as const,
+      trendPct: 8,
+      loading: false,
+    },
+    batchJobs: { queued: 4, running: 2, loading: false },
+  };
+}
+
+describe('KPISparklineStrip', () => {
+  it('renders 4 KPI cards', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getAllByTestId('kpi-card')).toHaveLength(4);
+  });
+
+  it('shows container active/total', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('/8')).toBeInTheDocument();
+  });
+
+  it('shows CPU percentage with sparkline svg', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('34')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-sparkline-cpu')).toBeInTheDocument();
+  });
+
+  it('shows memory GB + total', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('18.4')).toBeInTheDocument();
+    expect(screen.getByText('/32 GB')).toBeInTheDocument();
+  });
+
+  it('shows batch jobs queued + running', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText(/2 run/)).toBeInTheDocument();
+  });
+
+  it('shows skeleton when loading', () => {
+    useInfrastructureKpisMock.mockReturnValue(
+      makeKpis({
+        containers: { active: 0, total: 0, stopped: 0, loading: true },
+      })
+    );
+    render(<KPISparklineStrip />);
+    expect(screen.getByTestId('kpi-skeleton-containers')).toBeInTheDocument();
+  });
+
+  it('renders trend label with arrow', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.getByText(/▲/)).toBeInTheDocument();
+  });
+
+  it('omits sparkline for containers and batch jobs (no time-series available)', () => {
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    expect(screen.queryByTestId('kpi-sparkline-containers')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('kpi-sparkline-batchjobs')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/KPISparklineStrip.test.tsx`
+Expected: FAIL — module missing
+
+- [ ] **Step 3: Implement KPISparklineStrip**
+
+```typescript
+// KPISparklineStrip.tsx
+'use client';
+
+import { useInfrastructureKpis, type TimeSeriesPoint, type Trend } from './hooks/use-infrastructure-kpis';
+import { cn } from '@/lib/utils';
+
+const SPARKLINE_WIDTH = 70;
+const SPARKLINE_HEIGHT = 28;
+
+function buildSparklinePath(series: TimeSeriesPoint[]): { line: string; fill: string } | null {
+  if (series.length < 2) return null;
+  const values = series.map(p => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const stepX = SPARKLINE_WIDTH / (series.length - 1);
+  const points = series.map((p, i) => {
+    const x = i * stepX;
+    const y = SPARKLINE_HEIGHT - ((p.value - min) / range) * (SPARKLINE_HEIGHT - 4) - 2;
+    return `${x.toFixed(2)},${y.toFixed(2)}`;
+  });
+  const line = `M${points.join(' L')}`;
+  const fill = `${line} L${SPARKLINE_WIDTH},${SPARKLINE_HEIGHT} L0,${SPARKLINE_HEIGHT} Z`;
+  return { line, fill };
+}
+
+function TrendLabel({ trend, pct, suffix }: { trend: Trend; pct: number; suffix?: string }) {
+  if (trend === 'flat') return <span className="text-muted-foreground">▬ stabile {suffix ?? ''}</span>;
+  const arrow = trend === 'up' ? '▲' : '▼';
+  const color = trend === 'up' ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400';
+  return (
+    <span className={color}>
+      {arrow} {Math.abs(pct)}% {suffix ?? ''}
+    </span>
+  );
+}
+
+function Sparkline({ series, testId, colorClass }: { series: TimeSeriesPoint[]; testId: string; colorClass: string }) {
+  const path = buildSparklinePath(series);
+  if (!path) return null;
+  return (
+    <svg
+      data-testid={testId}
+      aria-hidden="true"
+      width={SPARKLINE_WIDTH}
+      height={SPARKLINE_HEIGHT}
+      viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+      className={cn('absolute right-3 top-3 opacity-85', colorClass)}
+    >
+      <path d={path.fill} fill="currentColor" opacity={0.15} />
+      <path d={path.line} fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function KpiCardSkeleton({ testId }: { testId: string }) {
+  return (
+    <div
+      data-testid={testId}
+      className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] animate-pulse"
+    >
+      <div className="mb-2 h-3 w-24 rounded bg-muted" />
+      <div className="h-7 w-16 rounded bg-muted" />
+    </div>
+  );
+}
+
+export function KPISparklineStrip(): JSX.Element {
+  const { containers, cpu, memory, batchJobs } = useInfrastructureKpis();
+
+  return (
+    <div
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      data-testid="kpi-sparkline-strip"
+    >
+      {containers.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-containers" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`Container attivi ${containers.active} su ${containers.total}, ${containers.stopped} stopped`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-emerald-500"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            Container attivi
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {containers.active}
+            <span className="text-sm text-muted-foreground font-semibold">/{containers.total}</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">
+            ▬ {containers.stopped} stopped · 0 crashed
+          </p>
+        </article>
+      )}
+
+      {cpu.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-cpu" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`CPU media ${cpu.value}%, trend ${cpu.trend} ${cpu.trendPct}%`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-chat-500"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            CPU media
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {cpu.value}
+            <span className="text-sm text-muted-foreground font-semibold">%</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px]">
+            <TrendLabel trend={cpu.trend} pct={cpu.trendPct} suffix="vs 1h fa" />
+          </p>
+          <Sparkline series={cpu.series} testId="kpi-sparkline-cpu" colorClass="text-chat-500" />
+        </article>
+      )}
+
+      {memory.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-memory" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`RAM usata ${memory.value} di ${memory.total} GB`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-kb-500"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            RAM usata
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {memory.value}
+            <span className="text-sm text-muted-foreground font-semibold">/{memory.total} GB</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px]">
+            <TrendLabel trend={memory.trend} pct={memory.trendPct} suffix="ultimi 60m" />
+          </p>
+          <Sparkline series={memory.series} testId="kpi-sparkline-memory" colorClass="text-kb-500" />
+        </article>
+      )}
+
+      {batchJobs.loading ? (
+        <KpiCardSkeleton testId="kpi-skeleton-batchjobs" />
+      ) : (
+        <article
+          data-testid="kpi-card"
+          aria-label={`Batch job: ${batchJobs.queued} in coda, ${batchJobs.running} in esecuzione`}
+          className="relative rounded-xl border border-border bg-card/60 p-4 min-h-[88px] border-l-4 border-l-agent-500"
+        >
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            Batch job in coda
+          </p>
+          <p className="mt-1 font-quicksand text-2xl font-bold text-foreground tabular-nums">
+            {batchJobs.queued}
+            <span className="text-sm text-muted-foreground font-semibold"> · {batchJobs.running} run</span>
+          </p>
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">▬ live</p>
+        </article>
+      )}
+    </div>
+  );
+}
+```
+
+> **Note**: classes `border-l-chat-500`, `text-chat-500`, `border-l-kb-500`, `text-kb-500`, `border-l-agent-500` may not exist as Tailwind utilities yet. Step 4 verifies — if they don't, swap to entity utilities `bg-entity-chat`/`text-entity-chat` per CLAUDE.md token rules. The mockup uses HSL var `--c-chat/kb/agent` which entity utilities expose.
+
+- [ ] **Step 4: Run tests + verify Tailwind classes exist**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/KPISparklineStrip.test.tsx`
+Expected: 8/8 PASS
+
+Then verify entity color classes:
+
+Run: `grep -rn "border-l-chat\|text-chat-500\|border-l-kb-500\|border-l-agent-500" apps/web/src/ | head -10`
+
+If empty, replace in `KPISparklineStrip.tsx`:
+- `border-l-chat-500` → `border-l-[hsl(var(--c-chat))]`
+- `text-chat-500` → `text-[hsl(var(--c-chat))]`
+- etc. (line-level eslint-disable not needed because these are `var(--)` indirection, not literal hex)
+
+Re-run tests to confirm green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/KPISparklineStrip.tsx apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/KPISparklineStrip.test.tsx
+git commit -m "feat(admin-infra): #1837 KPISparklineStrip component"
+```
+
+---
+
+## Phase 5 — Lift SSE subscription + wire components
+
+### Task 5.1: Refactor ContainerDashboard to accept liveEvents as prop
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx:205-272`
+- Modify: any existing test file under `__tests__/` that constructs `<ContainerDashboard />`
+
+- [ ] **Step 1: Inventory existing ContainerDashboard tests**
+
+Run: `ls apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/ContainerDashboard*.test.* 2>&1`
+Expected: list of existing tests (capture file names)
+
+- [ ] **Step 2: Read one existing test to understand mock pattern**
+
+Read: `apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx`
+
+Identify how `useLiveEvents` is currently mocked (likely `vi.mock('@/components/admin/monitor/use-live-events')`).
+
+- [ ] **Step 3: Update ContainerDashboard signature**
+
+Modify `ContainerDashboard.tsx`:
+
+```typescript
+// At top of file, change import (still need types but not the hook)
+import type { DomainEventDto } from '@/components/admin/monitor/live-event-types';
+
+// Replace existing useLiveEvents call (around line 256) with props
+interface ContainerDashboardProps {
+  liveEvents: ReadonlyArray<DomainEventDto>;
+  sseConnected: boolean;
+}
+
+export function ContainerDashboard({ liveEvents, sseConnected }: ContainerDashboardProps) {
+  // ...existing code...
+
+  // DELETE the `useLiveEvents({ aggregateTypes: ['Container', 'Infrastructure'], initialLimit: 10 })` block
+  // and the destructured `events: liveEvents, isStreaming: sseConnected` lines.
+}
+```
+
+Remove the `import { useLiveEvents } from '@/components/admin/monitor/use-live-events';` line.
+
+- [ ] **Step 4: Update existing tests to pass props**
+
+For each test file using `<ContainerDashboard />`, replace with `<ContainerDashboard liveEvents={[]} sseConnected={true} />` (or appropriate mock values). Remove the `vi.mock('@/components/admin/monitor/use-live-events')` block.
+
+- [ ] **Step 5: Run all ContainerDashboard tests**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/ContainerDashboard`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/ContainerDashboard.tsx apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/ContainerDashboard*.test.*
+git commit -m "refactor(admin-infra): #1837 lift useLiveEvents to page parent"
+```
+
+---
+
+### Task 5.2: Wire page.tsx with KPISparklineStrip + LiveEventLog + lifted SSE
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx`
+
+- [ ] **Step 1: Replace page.tsx body**
+
+```typescript
+// page.tsx
+'use client';
+
+/**
+ * #1837 SP5 F4-C1 — `/admin/monitor/containers` re-skin (composition layer).
+ *
+ * Layout SP5 (mockup `sp5-admin-infra.html`):
+ *   1. Hero header (titolo + crumbs)
+ *   2. KPISparklineStrip — 4 KPI con sparkline (CPU/Memory inline)
+ *   3. ContainerDashboard — grid container + auto-refresh + StatusSummary KPI
+ *   4. LiveEventLog — feed SSE Container/Infrastructure con fade-out 30s
+ *   5. RestartAllPanel — restart dependency-ordered (typed-confirm)
+ *
+ * SSE subscription is lifted to this page so ContainerDashboard +
+ * LiveEventLog share a single EventSource (no double-connect).
+ *
+ * Resolved follow-ups: #1853 (SSE wiring) · #1854 (typed-confirm dialog).
+ * Open gap (out of scope here, follow-up issue): per-container CPU/Memory
+ * + Resources section (disk /var/lib/docker + memory host breakdown).
+ */
+
+import { useLiveEvents } from '@/components/admin/monitor/use-live-events';
+
+import { ContainerDashboard } from './ContainerDashboard';
+import { KPISparklineStrip } from './KPISparklineStrip';
+import { LiveEventLog } from './LiveEventLog';
+import { RestartAllPanel } from './RestartAllPanel';
+
+export default function ContainerDashboardPage() {
+  const { events, isStreaming, isLoading } = useLiveEvents({
+    aggregateTypes: ['Container', 'Infrastructure'],
+    initialLimit: 50,
+  });
+
+  return (
+    <div data-testid="containers-page" className="space-y-6">
+      <header>
+        <nav
+          aria-label="breadcrumb"
+          className="font-mono text-[10.5px] uppercase tracking-wider text-muted-foreground mb-1"
+        >
+          Monitor &middot; Containers
+        </nav>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          Infrastructure &amp; Containers
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Docker container status, metrics, e azioni di restart dependency-ordered.
+        </p>
+      </header>
+
+      <KPISparklineStrip />
+
+      <ContainerDashboard liveEvents={events} sseConnected={isStreaming} />
+
+      <section aria-labelledby="live-events-heading" className="space-y-2">
+        <h2
+          id="live-events-heading"
+          className="font-quicksand text-sm font-semibold text-foreground"
+        >
+          Eventi live
+        </h2>
+        <LiveEventLog events={events} isStreaming={isStreaming} isLoading={isLoading} />
+      </section>
+
+      <RestartAllPanel />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm --filter web typecheck`
+Expected: 0 errors
+
+- [ ] **Step 3: Run lint**
+
+Run: `pnpm --filter web lint apps/web/src/app/admin/\(dashboard\)/monitor/containers/`
+Expected: 0 errors
+
+- [ ] **Step 4: Run full test suite for containers folder**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/__tests__/`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/containers/page.tsx
+git commit -m "feat(admin-infra): #1837 wire KPISparkline + LiveEventLog into page"
+```
+
+---
+
+## Phase 6 — E2E smoke test (optional but recommended)
+
+### Task 6.1: Playwright smoke for new components
+
+**Files:**
+- Check: `apps/web/e2e/admin/monitor/containers/` for existing E2E specs
+- Create or modify accordingly
+
+- [ ] **Step 1: Find existing E2E for this page**
+
+Run: `find apps/web/e2e -path "*monitor/containers*" -name "*.spec.ts" 2>&1`
+
+If exists, modify; if not, create `apps/web/e2e/admin/monitor/containers/c1-infra-reskin.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../../_utils/auth-helpers'; // adjust path if helper exists
+
+test.describe('SP5 F4-C1 Infrastructure & Containers', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/admin/monitor/containers');
+  });
+
+  test('renders KPI strip + container dashboard + live event log', async ({ page }) => {
+    await expect(page.getByTestId('kpi-sparkline-strip')).toBeVisible();
+    await expect(page.getByTestId('container-dashboard')).toBeVisible();
+    await expect(page.getByTestId('live-event-log')).toBeVisible();
+    await expect(page.getByTestId('restart-all-panel')).toBeVisible();
+  });
+
+  test('KPI strip shows 4 cards or skeletons', async ({ page }) => {
+    // Wait for either real cards or skeletons (max 4 total slots)
+    const cards = page.getByTestId(/kpi-(card|skeleton-)/);
+    await expect(cards.first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('live event log is role=log with aria-live=polite', async ({ page }) => {
+    const log = page.getByRole('log');
+    await expect(log).toHaveAttribute('aria-live', 'polite');
+  });
+});
+```
+
+- [ ] **Step 2: Verify existing auth helper signature**
+
+If helper path/name differs, adjust import or write minimal inline login.
+
+- [ ] **Step 3: Run E2E**
+
+Run: `pnpm --filter web e2e --grep "SP5 F4-C1"`
+Expected: 3/3 PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/admin/monitor/containers/c1-infra-reskin.spec.ts
+git commit -m "test(admin-infra): #1837 E2E smoke for new components"
+```
+
+---
+
+## Phase 7 — Final verification + push + PR
+
+### Task 7.1: Repo-wide checks
+
+- [ ] **Step 1: Full FE typecheck**
+
+Run: `pnpm --filter web typecheck`
+Expected: 0 errors
+
+- [ ] **Step 2: Full FE lint**
+
+Run: `pnpm --filter web lint`
+Expected: 0 errors, 0 hardcoded-color violations on new files
+
+- [ ] **Step 3: Containers folder test coverage**
+
+Run: `pnpm --filter web vitest run apps/web/src/app/admin/\(dashboard\)/monitor/containers/ --coverage`
+Expected: ≥80% line coverage on new files (`KPISparklineStrip.tsx`, `LiveEventLog.tsx`, `use-infrastructure-kpis.ts`, `event-log-mapper.ts`)
+
+- [ ] **Step 4: Push branch**
+
+Run: `git push -u origin feature/issue-1837-c1-infra-reskin`
+
+- [ ] **Step 5: Open PR to main-dev**
+
+Use HEREDOC body:
+
+```bash
+gh pr create --base main-dev --title "feat(admin-infra): #1837 F4-C1 KPISparkline + LiveEventLog" --body "$(cat <<'EOF'
+## Summary
+- Completa il re-skin SP5 di `/admin/monitor/containers` (epic #1833 F4 Ondata Ops)
+- Aggiunge **KPISparklineStrip** (4 KPI: Container attivi, CPU media, RAM usata, Batch job in coda) con sparkline SVG inline su CPU/Memory
+- Aggiunge **LiveEventLog** (feed SSE Container/Infrastructure con fade-out 30s, max 20 rows, `role="log" aria-live="polite"`)
+- Solleva la subscription `useLiveEvents` a `page.tsx` per condividerla tra `ContainerDashboard` + `LiveEventLog` (zero doppia connessione SSE)
+- Zero modifiche backend, riusa endpoint esistenti (`/admin/docker/containers`, `/admin/infrastructure/metrics/timeseries`, `/admin/operations/batch-jobs`)
+
+## Out of scope (follow-up tracciato in spec)
+- Per-container CPU/Memory metrics (richiede estensione `ContainerInfo` BE)
+- Resources section (disk /var/lib/docker + host memory breakdown, richiede endpoint nuovo)
+
+## Already merged (no changes here)
+- #1853 SSE wiring in ContainerDashboard
+- #1854 AdminConfirmationDialog typed-confirm in RestartAllPanel
+
+## Test plan
+- [x] Unit: `event-log-mapper.test.ts` (level/timestamp/message/stale logic)
+- [x] Unit: `use-infrastructure-kpis.test.tsx` (combined 3-endpoint hook)
+- [x] Unit: `LiveEventLog.test.tsx` (rendering + fade-out + empty states + a11y)
+- [x] Unit: `KPISparklineStrip.test.tsx` (4 cards + sparkline + skeleton)
+- [x] Regression: existing `ContainerDashboard.test.tsx` adjusted for new props
+- [x] E2E: smoke spec verifies 4 components visible + role=log + aria-live=polite
+- [x] pnpm typecheck + pnpm lint clean
+
+Closes #1837. Refs epic #1833.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Capture PR URL**
+
+Save the URL output by `gh pr create` for the code-review subagent in next phase.
+
+---
+
+## Phase 8 — Code review subagent + merge
+
+### Task 8.1: Subagent review
+
+- [ ] **Step 1: Dispatch code-review subagent**
+
+Use `superpowers:code-reviewer` subagent or `/code-review:code-review <PR-URL>` with the PR URL from Phase 7.
+
+- [ ] **Step 2: Triage findings**
+
+Score ≥75 issues: fix in this branch.
+Score <75 issues: triage to follow-up issues if non-blocking, otherwise close as out-of-scope.
+
+- [ ] **Step 3: Commit fixes (if any)**
+
+```bash
+git add <fixed files>
+git commit -m "fix(admin-infra): #1837 code review: <one-line summary>"
+git push
+```
+
+- [ ] **Step 4: Re-run typecheck + lint + tests**
+
+Same commands as Phase 7 Task 7.1 Step 1-3.
+
+### Task 8.2: Merge + close issue
+
+- [ ] **Step 1: Merge PR (squash)**
+
+After CI green:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 2: Verify #1837 closed automatically**
+
+Run: `gh issue view 1837 --json state`
+Expected: `"state": "CLOSED"`
+
+- [ ] **Step 3: Add comment to epic #1833 with sub-task progress**
+
+```bash
+gh issue comment 1833 --body "F4-C1 #1837 merged. Sequenza residua: C7 #1840 → C5 #1838."
+```
+
+- [ ] **Step 4: Switch back to main-dev and cleanup**
+
+```bash
+git checkout main-dev
+git pull --ff-only
+git branch -D feature/issue-1837-c1-infra-reskin
+git remote prune origin
+```
+
+---
+
+## Self-Review Checklist
+
+After writing this plan I verified:
+
+**1. Spec coverage**: each scope item in the spec maps to one or more tasks:
+- KPISparklineStrip → Phase 4
+- LiveEventLog → Phase 3 + Task 5.2 (wire)
+- Subscribe-once lifted to page → Phase 5
+- Empty / disconnected / loading states → Task 3.1 tests
+- Accessibility (role=log, aria-live, axe) → Task 3.1 + Phase 6
+- Regression on #1853/#1854 → Task 5.1 + Phase 6 smoke
+
+**2. Placeholders**: scanned for "TBD/TODO/implement later/handle edge cases" — none present. Every code block is complete.
+
+**3. Type consistency**: `LiveEventLogProps`, `InfrastructureKpis`, `Trend`, `LogLevel`, `TimeSeriesPoint` referenced consistently across phases.
+
+---
+
+## Execution Handoff
+
+Two execution options:
+
+**1. Subagent-Driven** — dispatch fresh subagent per task with two-stage review
+**2. Inline Execution** — execute tasks in current session with checkpoints
+
+For this PR (12h estimated, single-developer flow), **inline execution** is likely faster: tasks are linearly dependent (Phase 1 → 2 → 3 → 4 → 5), context handoff overhead between subagents would dominate.


### PR DESCRIPTION
## Summary

Completa il re-skin SP5 di `/admin/monitor/containers` (epic #1833 F4 Ondata Ops):

- **`KPISparklineStrip`** — 4 KPI sopra `ContainerDashboard` (Container attivi · CPU media · RAM usata · Batch job in coda) con sparkline SVG inline su CPU/Memory
- **`LiveEventLog`** — feed SSE `Container`/`Infrastructure` con fade-out 30s, max 20 rows, `role="log" aria-live="polite"`
- **Lift `useLiveEvents`** a `page.tsx` per condividerla tra `ContainerDashboard` + `LiveEventLog` (zero doppia connessione SSE)
- **Zero modifiche backend**: riusa endpoint esistenti `/admin/docker/containers`, `/admin/infrastructure/metrics/timeseries`, `/admin/operations/batch-jobs`

## Out of scope (follow-up tracciato in spec)

- Per-container CPU/Memory metrics (richiede estensione `ContainerInfo` BE)
- Resources section (disco `/var/lib/docker` + host memory breakdown, richiede endpoint nuovo)

## Already merged (no changes here)

- #1853 SSE wiring in ContainerDashboard
- #1854 AdminConfirmationDialog typed-confirm in RestartAllPanel

## Commits (5 phase)

1. `4b48328` — Phase 1: event-log-mapper helpers + spec/plan docs
2. `80dff99` — Phase 2: useInfrastructureKpis hook
3. `f074384` — Phase 3: LiveEventLog component
4. `112f281` — Phase 4: KPISparklineStrip component
5. `4329331` — Phase 5: lift useLiveEvents + wire page

## Test plan

- [x] **Unit**: `event-log-mapper.test.ts` (22/22) — level/timestamp/message/stale logic
- [x] **Unit**: `use-infrastructure-kpis.test.tsx` (4/4) — combined 3-endpoint hook
- [x] **Unit**: `LiveEventLog.test.tsx` (14/14) — rendering + fade-out + empty/loading states + a11y
- [x] **Unit**: `KPISparklineStrip.test.tsx` (13/13) — 4 cards + sparkline + skeleton + trend labels
- [x] **Regression**: `ContainerDashboard.test.tsx` (25/25) adjusted for new props
- [x] **Page**: `page.test.tsx` (3/3) — composizione + a11y `role=log`
- [x] **Totale**: **92/92 verdi** nella cartella containers
- [x] `pnpm typecheck` clean
- [x] `pnpm eslint` clean su tutti i file PR (warning residui sono pre-esistenti in `useLibrary.ts`)

## Spec & Plan

- Spec: [`docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md`](docs/for-developers/specs/2026-06-03-1837-c1-infra-reskin.md)
- Plan: [`docs/superpowers/plans/2026-06-03-1837-c1-infra-reskin.md`](docs/superpowers/plans/2026-06-03-1837-c1-infra-reskin.md)

Closes #1837. Refs epic #1833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)