### PR TITLE
fix(a11y): #1842 MeepleCard headingLevel prop — close heading-order WCAG suppressions

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/_components/__tests__/AgentsLibraryView.test.tsx
+++ b/apps/web/src/app/(authenticated)/agents/_components/__tests__/AgentsLibraryView.test.tsx
@@ -347,17 +347,10 @@ describe('AgentsLibraryView (Wave B.2)', () => {
 
   // ─── jest-axe a11y coverage (#1569) ────────────────────────────────────
 
-  // Default-state scan disables the `heading-order` rule: AgentsHero renders an
-  // <h1> ("Studio agenti") and each MeepleCard renders an <h3>, skipping <h2>.
-  // The <h3> mapping is shared across every v2 entity surface that consumes
-  // MeepleCard (games, players, toolkits, etc.) — a global fix requires a
-  // coordinated change to MeepleCard's heading prop or to every Hero. Tracked
-  // separately so #1569 stays test-only (no component edits).
-  it('passes axe a11y scan in default state with 6 agents (heading-order excluded; follow-up tracked)', async () => {
+  // T12: heading-order rule re-enabled — all 20 consumers now pass headingLevel prop
+  it('passes axe a11y scan in default state with 6 agents', async () => {
     const { container } = renderWithIntl(<AgentsLibraryView />);
-    expect(
-      await axe(container, { rules: { 'heading-order': { enabled: false } } })
-    ).toHaveNoViolations();
+    expect(await axe(container)).toHaveNoViolations();
   });
 
   it('passes axe a11y scan in empty state (no agents)', async () => {

--- a/apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadClient.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadClient.tsx
@@ -113,6 +113,7 @@ function GamePicker({ onSelect }: GamePickerProps): JSX.Element {
                 title={game.title}
                 subtitle={game.yearPublished ? String(game.yearPublished) : undefined}
                 imageUrl={game.imageUrl || undefined}
+                headingLevel={2}
               />
             </button>
           ))}

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -37,6 +37,7 @@
 
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
 import { IntlProvider } from 'react-intl';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactElement } from 'react';
@@ -1058,5 +1059,53 @@ describe('LibraryHub — Phase 3b drawer + rail integration (#1593)', () => {
     expect(rail).toHaveAttribute('data-state', 'populated');
     expect(screen.getByText('Catan Tutor')).toBeInTheDocument();
     expect(screen.getByText('rules.pdf')).toBeInTheDocument();
+  });
+});
+
+// ─── a11y axe (#1842) ─────────────────────────────────────────────────────
+
+describe('LibraryHub — a11y axe (#1842)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsState.value = '';
+    hubMock.mockReturnValue(makeHub());
+    libraryMock.mockReset();
+    libraryMock.mockReturnValue({ data: undefined, isLoading: false, isError: false, error: null });
+    useRemoveGameFromLibraryMock.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue(undefined),
+      isPending: false,
+    });
+    useActivityFeedMock.mockReturnValue({
+      data: { items: [], count: 0 },
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+    });
+    // LibraryHub renders a Drawer (AdvancedFiltersDrawer) which calls
+    // window.matchMedia synchronously via useSyncExternalStore. Without this
+    // stub the hook throws "Cannot read properties of undefined (reading
+    // 'matches')". installMatchMedia(false) → mobile breakpoint path is taken,
+    // which avoids the Radix Dialog render path that would need a portal.
+    installMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // P164 axe-rule-suppression-with-tracked-followup pattern:
+  // nested-interactive is suppressed here because the hybrid grid cards use a
+  // <button data-slot="library-grid-card"> wrapper around MeepleCard, which
+  // itself renders an interactive element. This is a pre-existing structural
+  // issue unrelated to #1842 (heading-order). heading-order IS enabled (default).
+  // Follow-up: replace button wrapper with <div role="button"> or restructure
+  // the card click handler to avoid nesting interactives.
+  it('passes heading-order axe rule (#1842)', async () => {
+    const { container } = renderWithIntl(<LibraryHub />);
+    const results = await axe(container, {
+      rules: { 'nested-interactive': { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/app/(public)/library/shared/[token]/page.tsx
+++ b/apps/web/src/app/(public)/library/shared/[token]/page.tsx
@@ -156,6 +156,7 @@ export default function SharedLibraryPage() {
                   imageUrl={game.imageUrl || undefined}
                   badge={game.isFavorite ? 'Preferito' : undefined}
                   metadata={metadata.length > 0 ? metadata : undefined}
+                  headingLevel={2}
                 />
               );
             })}

--- a/apps/web/src/components/catalog/MeepleGameCatalogCard.tsx
+++ b/apps/web/src/components/catalog/MeepleGameCatalogCard.tsx
@@ -256,6 +256,7 @@ export function MeepleGameCatalogCard({
         status={inLibrary ? 'owned' : undefined}
         actions={actions}
         connections={connections}
+        headingLevel={2}
         onClick={onClick ? () => onClick(game.id) : undefined}
         className={className}
         data-testid={`catalog-game-card-${game.id}`}

--- a/apps/web/src/components/chat-unified/AgentCreationWizard.tsx
+++ b/apps/web/src/components/chat-unified/AgentCreationWizard.tsx
@@ -230,6 +230,7 @@ function GameCollectionPicker({
                 variant="compact"
                 title={entry.gameTitle}
                 imageUrl={entry.gameImageUrl ?? undefined}
+                headingLevel={2}
               />
             </button>
           ))}

--- a/apps/web/src/components/chat/entry/AgentSelector.tsx
+++ b/apps/web/src/components/chat/entry/AgentSelector.tsx
@@ -54,6 +54,7 @@ function SystemAgentGrid({
             subtitle={agent.description}
             badge={agent.icon}
             className={cn(selectedAgentType === agent.type && 'border-amber-500')}
+            headingLevel={2}
           />
         </button>
       ))}
@@ -125,6 +126,7 @@ function CustomAgentGridSection({
                 'border-amber-300/50',
                 selectedCustomAgentId === agent.id && 'border-amber-500'
               )}
+              headingLevel={2}
             />
           </button>
         ))}

--- a/apps/web/src/components/chat/entry/GameSelector.tsx
+++ b/apps/web/src/components/chat/entry/GameSelector.tsx
@@ -99,6 +99,7 @@ function GameGrid({
                 variant="compact"
                 title={game.title}
                 className={cn(selectedGameId === game.id && 'border-amber-500')}
+                headingLevel={2}
               />
             </button>
           ))

--- a/apps/web/src/components/features/agents/AgentsResultsGrid.tsx
+++ b/apps/web/src/components/features/agents/AgentsResultsGrid.tsx
@@ -83,6 +83,7 @@ export function AgentsResultsGrid({
               subtitle={agent.gameName ?? undefined}
               status={cardStatus}
               tags={tags}
+              headingLevel={2}
             />
           </Link>
         );

--- a/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
+++ b/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
@@ -260,9 +260,9 @@ function InfoPanel({ detail }: { detail: LibraryGameDetail }): ReactElement {
   return (
     <div className="grid gap-4">
       <div>
-        <h3 className="mb-2 font-quicksand text-[15px] font-bold uppercase tracking-wide text-[#9a8870]">
+        <h2 className="mb-2 font-quicksand text-[15px] font-bold uppercase tracking-wide text-[#9a8870]">
           Descrizione
-        </h3>
+        </h2>
         <p className="text-[15px] leading-relaxed text-[#5a4a38]">
           {detail.description ??
             `${detail.gameTitle} — campagna libro game. Avvia la modalità per setup tutorial, Q&A regole e traduzione storybook.`}
@@ -271,9 +271,9 @@ function InfoPanel({ detail }: { detail: LibraryGameDetail }): ReactElement {
 
       {/* KB status row */}
       <div>
-        <h3 className="mb-2 font-quicksand text-[15px] font-bold uppercase tracking-wide text-[#9a8870]">
+        <h2 className="mb-2 font-quicksand text-[15px] font-bold uppercase tracking-wide text-[#9a8870]">
           Knowledge base
-        </h3>
+        </h2>
         <div className="flex items-center gap-3 rounded-[10px] border border-[hsl(var(--c-kb)/0.2)] bg-[hsl(var(--c-kb)/0.08)] p-3">
           <span
             aria-hidden="true"

--- a/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
@@ -154,12 +154,8 @@ describe('LibroGameDetailView', () => {
     const gameDetail = makeLibraryGameDetail();
     const { container } = render(<LibroGameDetailView gameDetail={gameDetail} />);
 
-    const results = await axe(container, {
-      rules: {
-        // InfoPanel starts with h3 inside tabpanel; heading hierarchy isolated per panel OK
-        'heading-order': { enabled: false },
-      },
-    });
+    // T12: heading-order rule re-enabled — all consumers now pass headingLevel prop
+    const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/games/GamesResultsGrid.tsx
+++ b/apps/web/src/components/features/games/GamesResultsGrid.tsx
@@ -69,6 +69,7 @@ export function GamesResultsGrid({
             imageUrl={entry.gameImageUrl ?? undefined}
             rating={entry.averageRating ?? undefined}
             ratingMax={10}
+            headingLevel={2}
           />
         </Link>
       ))}

--- a/apps/web/src/components/features/games/__tests__/GamesResultsGrid.test.tsx
+++ b/apps/web/src/components/features/games/__tests__/GamesResultsGrid.test.tsx
@@ -18,6 +18,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, expect, it } from 'vitest';
 
 import { GamesResultsGrid } from '../GamesResultsGrid';
@@ -157,5 +158,11 @@ describe('GamesResultsGrid (Wave B.1)', () => {
     const root = container.querySelector('[data-slot="games-results-grid"]');
     expect(root).toBeInTheDocument();
     expect(root!.querySelectorAll('[data-entity="game"]')).toHaveLength(0);
+  });
+
+  it('passes heading-order axe rule (#1842)', async () => {
+    const { container } = render(<GamesResultsGrid entries={ENTRIES} view="grid" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/home/HomeFeed.tsx
+++ b/apps/web/src/components/features/home/HomeFeed.tsx
@@ -68,6 +68,7 @@ export function HomeFeed() {
                 subtitle={`${session.playerCount} giocatori`}
                 badge={session.status}
                 metadata={[{ label: `${session.durationMinutes} min` }]}
+                headingLevel={2}
                 onClick={() => {
                   if (session.status === 'Setup' || session.status === 'Paused') {
                     router.push(`/sessions/live/${session.id}`);

--- a/apps/web/src/components/features/library/LibraryHybridGrid.tsx
+++ b/apps/web/src/components/features/library/LibraryHybridGrid.tsx
@@ -135,6 +135,7 @@ export function LibraryHybridGrid({
               imageUrl={itemImageUrl(item)}
               rating={itemRating(item)}
               ratingMax={10}
+              headingLevel={2}
             />
             {isSelectMode && isSelected ? (
               <span

--- a/apps/web/src/components/features/players/PlayersResultsGrid.tsx
+++ b/apps/web/src/components/features/players/PlayersResultsGrid.tsx
@@ -83,6 +83,7 @@ export function PlayersResultsGrid({
               id={item.id}
               title={item.gameName}
               subtitle={subtitle}
+              headingLevel={2}
             />
           </button>
         );

--- a/apps/web/src/components/features/players/__tests__/PlayersResultsGrid.test.tsx
+++ b/apps/web/src/components/features/players/__tests__/PlayersResultsGrid.test.tsx
@@ -13,6 +13,7 @@
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { PlayerListItem } from '@/lib/players/players-filters';
@@ -83,5 +84,20 @@ describe('PlayersResultsGrid', () => {
     expect(announce).not.toBeNull();
     expect(announce!.textContent).toContain(`${ITEMS.length} risultati`);
     expect(announce!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  // P164 axe-rule-suppression-with-tracked-followup pattern:
+  // nested-interactive is suppressed here because PlayersResultsGrid wraps
+  // MeepleCard (which contains a <button>) inside another <button> wrapper.
+  // This is a pre-existing structural bug unrelated to #1842.
+  // Follow-up: replace <button> wrapper with <div role="button"> or lift the
+  // click handler into MeepleCard's own interactive surface.
+  // heading-order IS enabled (default) — this test confirms no heading skip.
+  it('passes heading-order axe rule (#1842)', async () => {
+    const { container } = render(<PlayersResultsGrid {...DEFAULT_PROPS} />);
+    const results = await axe(container, {
+      rules: { 'nested-interactive': { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx
@@ -209,4 +209,11 @@ describe('HubToolkitsBody (Issue #1480)', () => {
     const { container } = renderBody({ state: 'default', toolkits: sampleToolkits });
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  // T10 (#1842)
+  it('passes heading-order axe rule (#1842)', async () => {
+    const { container } = renderBody({ state: 'default', toolkits: sampleToolkits });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/apps/web/src/components/game-night/MeepleEventCard.tsx
+++ b/apps/web/src/components/game-night/MeepleEventCard.tsx
@@ -92,6 +92,7 @@ export function MeepleEventCard({
       connections={connections}
       onClick={onClick ? () => onClick(event.id) : undefined}
       className={className}
+      headingLevel={2}
       data-testid={`event-card-${event.id}`}
     />
   );

--- a/apps/web/src/components/game-night/planning/MeepleAISuggestionCard.tsx
+++ b/apps/web/src/components/game-night/planning/MeepleAISuggestionCard.tsx
@@ -22,6 +22,7 @@ export function MeepleAISuggestionCard({ suggestions }: MeepleAISuggestionCardPr
         title="Suggerimenti AI"
         subtitle="Aggiungi giocatori per suggerimenti"
         badge="AI"
+        headingLevel={2}
         data-testid="ai-suggestion-card"
       />
     );
@@ -29,7 +30,13 @@ export function MeepleAISuggestionCard({ suggestions }: MeepleAISuggestionCardPr
 
   return (
     <div data-testid="ai-suggestion-card">
-      <MeepleCard entity="agent" variant="featured" title="Suggerimenti AI" badge="AI" />
+      <MeepleCard
+        entity="agent"
+        variant="featured"
+        title="Suggerimenti AI"
+        badge="AI"
+        headingLevel={2}
+      />
       <div className="space-y-2 px-4 pb-4 -mt-2 rounded-b-2xl border border-t-0 border-border/50 bg-card">
         {suggestions.map(s => (
           <div key={s.gameTitle} className="flex items-start gap-2">

--- a/apps/web/src/components/game-night/planning/MeepleDealtGameCard.tsx
+++ b/apps/web/src/components/game-night/planning/MeepleDealtGameCard.tsx
@@ -25,6 +25,7 @@ export function MeepleDealtGameCard({ game, onRemove, rotation }: MeepleDealtGam
         variant="compact"
         title={game.title}
         imageUrl={game.thumbnailUrl}
+        headingLevel={2}
         actions={[
           {
             icon: XIcon,

--- a/apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx
+++ b/apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx
@@ -65,6 +65,7 @@ export function MeepleGameNightCard({ night }: MeepleGameNightCardProps) {
         badge={STATUS_BADGE[night.status] ?? 'Sconosciuto'}
         connections={connections}
         className="h-full"
+        headingLevel={2}
         data-testid="game-night-card"
       />
     </Link>

--- a/apps/web/src/components/game-night/planning/__tests__/GameNightPlanningLayout.test.tsx
+++ b/apps/web/src/components/game-night/planning/__tests__/GameNightPlanningLayout.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { useGameNightStore } from '@/stores/game-night';
@@ -50,5 +51,11 @@ describe('GameNightPlanningLayout', () => {
   it('renders AI suggestion card in left column', () => {
     render(<GameNightPlanningLayout title="Test" />);
     expect(screen.getByText(/suggerimenti ai/i)).toBeInTheDocument();
+  });
+
+  it('passes heading-order axe rule (#1842)', async () => {
+    const { container } = render(<GameNightPlanningLayout title="Friday Night" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/library/MeepleLibraryGameCard.tsx
+++ b/apps/web/src/components/library/MeepleLibraryGameCard.tsx
@@ -266,6 +266,7 @@ export function MeepleLibraryGameCard({
         badge={badge}
         status={mappedStatus}
         connections={connections}
+        headingLevel={2}
         onClick={
           selectionMode
             ? undefined

--- a/apps/web/src/components/library/MeepleUserLibraryCard.tsx
+++ b/apps/web/src/components/library/MeepleUserLibraryCard.tsx
@@ -129,6 +129,7 @@ export function MeepleUserLibraryCard({
         badge={badge}
         status="owned"
         connections={connections}
+        headingLevel={2}
         onClick={onClick ? () => onClick(game.id) : undefined}
         className={className}
         data-testid={`library-game-card-${game.id}`}

--- a/apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx
+++ b/apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx
@@ -107,6 +107,7 @@ export function MeeplePausedSessionCard({
         metadata={metadata}
         badge={isOld ? 'Vecchia' : undefined}
         connections={connections}
+        headingLevel={2}
         actions={[
           {
             icon: PlayIcon,

--- a/apps/web/src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * #1842 headingLevel cross-variant smoke test.
+ *
+ * Verifies the MeepleCard API contract: passing `headingLevel` produces
+ * the correct semantic tag for each of the 5 variants that own a title
+ * heading (GridCard, ListCard, FeaturedCard, HeroCard, FocusCard).
+ *
+ * CompactCard is intentionally skipped — it renders <span> for the title
+ * (compact-ticker semantic), not a heading.
+ *
+ * Per DEC-5: no visual regression test. Assertions cover semantic tag
+ * + className stability only.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { MeepleCard } from '../MeepleCard';
+
+import type { MeepleCardVariant } from '../types';
+
+interface VariantSpec {
+  variant: MeepleCardVariant;
+  defaultTag: 'H2' | 'H3';
+}
+
+const variants: VariantSpec[] = [
+  { variant: 'grid', defaultTag: 'H3' },
+  { variant: 'list', defaultTag: 'H3' },
+  { variant: 'featured', defaultTag: 'H3' },
+  { variant: 'hero', defaultTag: 'H3' },
+  { variant: 'focus', defaultTag: 'H2' },
+];
+
+describe('MeepleCard headingLevel smoke (#1842)', () => {
+  for (const { variant, defaultTag } of variants) {
+    it(`${variant} renders ${defaultTag} by default`, () => {
+      render(<MeepleCard entity="game" title={`${variant}-default`} variant={variant} />);
+      expect(screen.getByText(`${variant}-default`).tagName).toBe(defaultTag);
+    });
+
+    it(`${variant} renders H2 when headingLevel={2}`, () => {
+      render(
+        <MeepleCard entity="game" title={`${variant}-h2`} variant={variant} headingLevel={2} />
+      );
+      expect(screen.getByText(`${variant}-h2`).tagName).toBe('H2');
+    });
+
+    it(`${variant} preserves className when headingLevel changes (visual stability)`, () => {
+      const { rerender } = render(
+        <MeepleCard entity="game" title={`${variant}-stable`} variant={variant} />
+      );
+      const defaultClass = screen.getByText(`${variant}-stable`).className;
+      rerender(
+        <MeepleCard entity="game" title={`${variant}-stable`} variant={variant} headingLevel={4} />
+      );
+      expect(screen.getByText(`${variant}-stable`).className).toBe(defaultClass);
+    });
+  }
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/__tests__/headingLevel-prop.contract.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/__tests__/headingLevel-prop.contract.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expectTypeOf } from 'vitest';
+
+import type { MeepleCardProps } from '../types';
+
+describe('MeepleCardProps headingLevel contract', () => {
+  it('accepts headingLevel as optional 2 | 3 | 4 union', () => {
+    expectTypeOf<MeepleCardProps>()
+      .toHaveProperty('headingLevel')
+      .toEqualTypeOf<2 | 3 | 4 | undefined>();
+  });
+
+  it('allows omitting headingLevel (backwards compat)', () => {
+    const props: MeepleCardProps = { entity: 'game', title: 'Catan' };
+    expectTypeOf(props.headingLevel).toEqualTypeOf<2 | 3 | 4 | undefined>();
+  });
+
+  it('allows passing headingLevel=2', () => {
+    const props: MeepleCardProps = { entity: 'game', title: 'Catan', headingLevel: 2 };
+    expectTypeOf(props.headingLevel).toEqualTypeOf<2 | 3 | 4 | undefined>();
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/types.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/types.ts
@@ -95,6 +95,17 @@ export interface MeepleCardProps {
    * Naming endorses existing FE convention (Toolkit.coverEmoji, play-records StatsHero.tsx:137).
    */
   coverEmoji?: string;
+  /**
+   * Semantic heading level for the card's title element (2, 3, or 4).
+   * Default: 3 for most variants (GridCard/ListCard/FeaturedCard/HeroCard);
+   * 2 for FocusCard (full-focus detail card).
+   *
+   * Pass `headingLevel={2}` when this card is rendered in a grid below an
+   * `<h1>` hero — without this, axe-core flags `heading-order` (h1→h3 jump
+   * skipping h2). See #1842 spec for the audit of 20 grid-below-hero
+   * consumer surfaces that need `headingLevel={2}`.
+   */
+  headingLevel?: 2 | 3 | 4;
   rating?: number;
   ratingMax?: number;
   metadata?: MeepleCardMetadata[];

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx
@@ -29,6 +29,7 @@ export function FeaturedCard(props: MeepleCardProps) {
     showQuickActions,
     onClick,
     className = '',
+    headingLevel,
   } = props;
   const testId = props['data-testid'];
 
@@ -59,9 +60,14 @@ export function FeaturedCard(props: MeepleCardProps) {
       </div>
       <div className="flex flex-1 flex-col gap-1 px-4 py-3">
         <div className="flex items-start justify-between gap-2">
-          <h3 className="font-[var(--font-quicksand)] text-[1.1rem] font-bold leading-tight text-[var(--mc-text-primary)]">
-            {title}
-          </h3>
+          {(() => {
+            const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+            return (
+              <HeadingTag className="font-[var(--font-quicksand)] text-[1.1rem] font-bold leading-tight text-[var(--mc-text-primary)]">
+                {title}
+              </HeadingTag>
+            );
+          })()}
           {badge && (
             <span
               className="shrink-0 rounded-full border border-[var(--mc-border)] bg-foreground/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[var(--mc-text-primary)] dark:bg-card/15"

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx
@@ -20,6 +20,7 @@ export function FocusCard(props: MeepleCardProps) {
     rating,
     ratingMax,
     metadata = [],
+    headingLevel,
     onClick,
     className = '',
   } = props;
@@ -47,9 +48,14 @@ export function FocusCard(props: MeepleCardProps) {
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
-          <h2 className="font-[var(--font-quicksand)] text-xl font-bold leading-tight text-[var(--mc-text-primary)]">
-            {title}
-          </h2>
+          {(() => {
+            const HeadingTag = `h${headingLevel ?? 2}` as 'h2' | 'h3' | 'h4';
+            return (
+              <HeadingTag className="font-[var(--font-quicksand)] text-xl font-bold leading-tight text-[var(--mc-text-primary)]">
+                {title}
+              </HeadingTag>
+            );
+          })()}
           {subtitle && <p className="text-sm text-[var(--mc-text-secondary)]">{subtitle}</p>}
           {rating !== undefined && <Rating value={rating} max={ratingMax} />}
           {metadata.length > 0 && <MetaChips metadata={metadata} />}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx
@@ -24,6 +24,7 @@ export function GridCard(props: MeepleCardProps) {
     subtitle,
     imageUrl,
     coverEmoji,
+    headingLevel,
     rating,
     ratingMax,
     metadata = [],
@@ -75,9 +76,14 @@ export function GridCard(props: MeepleCardProps) {
         {showQuickActions && actions.length > 0 && <QuickActions actions={actions} />}
       </div>
       <div className="flex flex-1 flex-col gap-[3px] px-3.5 py-2.5 pb-2">
-        <h3 className="font-[var(--font-quicksand)] text-[0.95rem] font-bold leading-tight text-[var(--mc-text-primary)]">
-          {title}
-        </h3>
+        {(() => {
+          const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+          return (
+            <HeadingTag className="font-[var(--font-quicksand)] text-[0.95rem] font-bold leading-tight text-[var(--mc-text-primary)]">
+              {title}
+            </HeadingTag>
+          );
+        })()}
         {subtitle && (
           <p className="text-[0.78rem] leading-tight text-[var(--mc-text-secondary)]">{subtitle}</p>
         )}

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx
@@ -22,6 +22,7 @@ export function HeroCard(props: MeepleCardProps) {
     ratingMax,
     badge,
     manaPips,
+    headingLevel,
     onClick,
     className = '',
   } = props;
@@ -78,9 +79,14 @@ export function HeroCard(props: MeepleCardProps) {
             {badge}
           </span>
         )}
-        <h3 className="font-[var(--font-quicksand)] text-2xl font-bold leading-tight text-white drop-shadow-md">
-          {title}
-        </h3>
+        {(() => {
+          const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+          return (
+            <HeadingTag className="font-[var(--font-quicksand)] text-2xl font-bold leading-tight text-white drop-shadow-md">
+              {title}
+            </HeadingTag>
+          );
+        })()}
         {subtitle && <p className="mt-1 text-sm text-white/80">{subtitle}</p>}
         {rating !== undefined && (
           <div className="mt-2 flex items-center gap-1 text-amber-300">

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx
@@ -22,6 +22,7 @@ export function ListCard(props: MeepleCardProps) {
     badge,
     onClick,
     className = '',
+    headingLevel,
   } = props;
   const testId = props['data-testid'];
 
@@ -49,9 +50,14 @@ export function ListCard(props: MeepleCardProps) {
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
-          <h3 className="truncate font-[var(--font-quicksand)] text-[0.88rem] font-bold text-[var(--mc-text-primary)]">
-            {title}
-          </h3>
+          {(() => {
+            const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+            return (
+              <HeadingTag className="truncate font-[var(--font-quicksand)] text-[0.88rem] font-bold text-[var(--mc-text-primary)]">
+                {title}
+              </HeadingTag>
+            );
+          })()}
           {badge && (
             <span
               className="shrink-0 rounded-full border border-[var(--mc-border)] bg-foreground/10 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wide text-[var(--mc-text-primary)] dark:bg-card/15"

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FeaturedCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FeaturedCard.test.tsx
@@ -18,3 +18,22 @@ describe('FeaturedCard connections path', () => {
     expect(screen.getByTestId('connection-chip-strip')).toBeInTheDocument();
   });
 });
+
+describe('FeaturedCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default', () => {
+    render(<FeaturedCard entity="game" title="Default" />);
+    expect(screen.getByText('Default').tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<FeaturedCard entity="game" title="H2" headingLevel={2} />);
+    expect(screen.getByText('H2').tagName).toBe('H2');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<FeaturedCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<FeaturedCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx
@@ -18,3 +18,22 @@ describe('FocusCard connections path', () => {
     expect(screen.getByTestId('connection-chip-strip')).toBeInTheDocument();
   });
 });
+
+describe('FocusCard headingLevel prop (#1842)', () => {
+  it('renders <h2> by default (preserves existing behavior — FocusCard is page-hero-level)', () => {
+    render(<FocusCard entity="game" title="Default" />);
+    expect(screen.getByText('Default').tagName).toBe('H2');
+  });
+
+  it('renders <h3> when headingLevel={3}', () => {
+    render(<FocusCard entity="game" title="H3" headingLevel={3} />);
+    expect(screen.getByText('H3').tagName).toBe('H3');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<FocusCard entity="game" title="X" />);
+    const h2Class = screen.getByText('X').className;
+    rerender(<FocusCard entity="game" title="X" headingLevel={3} />);
+    expect(screen.getByText('X').className).toBe(h2Class);
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
@@ -157,3 +157,33 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
     expect(screen.getByRole('button', { name: 'Azioni' })).toBeInTheDocument();
   });
 });
+
+/**
+ * #1842 headingLevel prop — dynamic title heading tag.
+ */
+describe('GridCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default (backwards compat)', () => {
+    render(<GridCard entity="game" title="Catan default" />);
+    const el = screen.getByText('Catan default');
+    expect(el.tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<GridCard entity="game" title="Catan h2" headingLevel={2} />);
+    const el = screen.getByText('Catan h2');
+    expect(el.tagName).toBe('H2');
+  });
+
+  it('renders <h4> when headingLevel={4}', () => {
+    render(<GridCard entity="game" title="Catan h4" headingLevel={4} />);
+    const el = screen.getByText('Catan h4');
+    expect(el.tagName).toBe('H4');
+  });
+
+  it('preserves title className across all heading levels (visual stability)', () => {
+    const { rerender } = render(<GridCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<GridCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/HeroCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/HeroCard.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { HeroCard } from '../HeroCard';
+
+describe('HeroCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default', () => {
+    render(<HeroCard entity="game" title="Default" />);
+    expect(screen.getByText('Default').tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<HeroCard entity="game" title="H2" headingLevel={2} />);
+    expect(screen.getByText('H2').tagName).toBe('H2');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<HeroCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<HeroCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx
@@ -18,3 +18,22 @@ describe('ListCard connections path', () => {
     expect(screen.getByTestId('connection-chip-strip')).toBeInTheDocument();
   });
 });
+
+describe('ListCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default', () => {
+    render(<ListCard entity="game" title="Default title" />);
+    expect(screen.getByText('Default title').tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<ListCard entity="game" title="H2 title" headingLevel={2} />);
+    expect(screen.getByText('H2 title').tagName).toBe('H2');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<ListCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<ListCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});

--- a/apps/web/src/components/wishlist/MeepleWishlistCard.tsx
+++ b/apps/web/src/components/wishlist/MeepleWishlistCard.tsx
@@ -80,6 +80,7 @@ export function MeepleWishlistCard({
       badge={formatPriorityItalian(item.priority)}
       metadata={metadata}
       actions={actions.length > 0 ? actions : undefined}
+      headingLevel={2}
       data-testid="wishlist-card"
     />
   );

--- a/docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md
+++ b/docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md
@@ -1,0 +1,1087 @@
+# MeepleCard `headingLevel` Prop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `headingLevel?: 2 | 3 | 4` prop to `MeepleCard` and migrate 20 grid-below-h1-hero consumer surfaces to close the `heading-order` WCAG suppression debt from #1841 + #1481.
+
+**Architecture:** Additive prop on `MeepleCardProps` (default `3`, backwards-compatible). 5 variants (`GridCard/ListCard/FeaturedCard/HeroCard/FocusCard`) render dynamic `<HeadingTag>` instead of hardcoded `<h3>/<h2>`. 20 consumer files pass `headingLevel={2}` at the call site. CompactCard skipped (uses `<span>`, no heading element). 2 existing axe suppressions removed + 5 new axe scans added.
+
+**Tech Stack:** TypeScript, React 19, Vitest + React Testing Library (RTL), `jest-axe` for a11y assertions, Tailwind 4.
+
+**Spec:** [`docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md`](../specs/2026-06-04-meeple-card-heading-level-a11y-design.md)
+
+**Branch:** `feature/issue-1842-meeple-card-heading-level` (already created, parent: `main-dev`)
+
+**Cwd assumption:** All commands assume `cwd=apps/web` unless otherwise noted. From repo root prefix paths with `apps/web/`.
+
+---
+
+## File map
+
+| Order | Action | File | Responsibility |
+|---|---|---|---|
+| T1 | Modify | `apps/web/src/components/ui/data-display/meeple-card/types.ts` | Add `headingLevel?: 2 \| 3 \| 4` to `MeepleCardProps` |
+| T2 | Modify | `apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx` | Dynamic HeadingTag (default 3) |
+| T3 | Modify | `apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx` | Dynamic HeadingTag (default 3) |
+| T4 | Modify | `apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx` | Dynamic HeadingTag (default 3) |
+| T5 | Modify | `apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx` | Dynamic HeadingTag (default 3) |
+| T6 | Modify | `apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx` | Dynamic HeadingTag (default 2 — preserve existing h2) |
+| T7 | Create | `apps/web/src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx` | DOM smoke for 5 variants — tag swap + className unchanged |
+| T8 | Modify | 5 consumer files (batch 1: feature grids) | Pass `headingLevel={2}` |
+| T9 | Modify | 5 consumer files (batch 2: library/catalog cards) | Pass `headingLevel={2}` |
+| T10 | Modify | 5 consumer files (batch 3: public/auth pages + chat entry) | Pass `headingLevel={2}` |
+| T11 | Modify | 5 consumer files (batch 4: game-night planning + paused session) | Pass `headingLevel={2}` |
+| T12 | Modify | 2 test files | Remove `heading-order: { enabled: false }` suppression |
+| T13 | Modify | 5 test files | Add jest-axe scan with heading-order rule enabled |
+| T14 | Verify + PR | Full suite + PR | Sanity check, push, PR |
+
+Total: 14 tasks.
+
+---
+
+## Task 1: Add `headingLevel` prop to `MeepleCardProps`
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/types.ts`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create file `apps/web/src/components/ui/data-display/meeple-card/__tests__/headingLevel-prop.contract.test.ts`:
+
+```typescript
+import { describe, it, expectTypeOf } from 'vitest';
+
+import type { MeepleCardProps } from '../types';
+
+describe('MeepleCardProps headingLevel contract', () => {
+  it('accepts headingLevel as optional 2 | 3 | 4 union', () => {
+    expectTypeOf<MeepleCardProps>().toHaveProperty('headingLevel').toEqualTypeOf<2 | 3 | 4 | undefined>();
+  });
+
+  it('allows omitting headingLevel (backwards compat)', () => {
+    const props: MeepleCardProps = { entity: 'game', title: 'Catan' };
+    expectTypeOf(props.headingLevel).toEqualTypeOf<2 | 3 | 4 | undefined>();
+  });
+
+  it('allows passing headingLevel=2', () => {
+    const props: MeepleCardProps = { entity: 'game', title: 'Catan', headingLevel: 2 };
+    expectTypeOf(props.headingLevel).toEqualTypeOf<2 | 3 | 4 | undefined>();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/__tests__/headingLevel-prop.contract.test.ts
+```
+Expected: FAIL with TS error `'headingLevel' does not exist in type 'MeepleCardProps'` on test 3.
+
+- [ ] **Step 1.3: Add `headingLevel` to `MeepleCardProps`**
+
+In `apps/web/src/components/ui/data-display/meeple-card/types.ts`, find the `MeepleCardProps` interface and add `headingLevel` immediately after `coverEmoji?: string`:
+
+Replace:
+```typescript
+  coverEmoji?: string;
+  rating?: number;
+```
+
+With:
+```typescript
+  coverEmoji?: string;
+  /**
+   * Semantic heading level for the card's title element (2, 3, or 4).
+   * Default: 3 for most variants (4: GridCard/ListCard/FeaturedCard/HeroCard);
+   * 2 for FocusCard (full-focus detail card).
+   *
+   * Pass `headingLevel={2}` when this card is rendered in a grid below an
+   * `<h1>` hero — without this, axe-core flags `heading-order` (h1→h3 jump
+   * skipping h2). See #1842 spec for the audit of 20 grid-below-hero
+   * consumer surfaces that need `headingLevel={2}`.
+   */
+  headingLevel?: 2 | 3 | 4;
+  rating?: number;
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/__tests__/headingLevel-prop.contract.test.ts
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 1.5: Typecheck**
+
+Run from `apps/web/`:
+```bash
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/types.ts apps/web/src/components/ui/data-display/meeple-card/__tests__/headingLevel-prop.contract.test.ts
+git commit -m "feat(meeple-card): #1842 T1 add headingLevel?: 2|3|4 prop to MeepleCardProps"
+```
+
+---
+
+## Task 2: GridCard dynamic HeadingTag (default 3)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx`
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx`
+
+- [ ] **Step 2.1: Append failing tests**
+
+Append to `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx` (before the closing `});` of the last `describe`):
+
+```tsx
+/**
+ * #1842 headingLevel prop — dynamic title heading tag.
+ */
+describe('GridCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default (backwards compat)', () => {
+    render(<GridCard entity="game" title="Catan default" />);
+    const el = screen.getByText('Catan default');
+    expect(el.tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<GridCard entity="game" title="Catan h2" headingLevel={2} />);
+    const el = screen.getByText('Catan h2');
+    expect(el.tagName).toBe('H2');
+  });
+
+  it('renders <h4> when headingLevel={4}', () => {
+    render(<GridCard entity="game" title="Catan h4" headingLevel={4} />);
+    const el = screen.getByText('Catan h4');
+    expect(el.tagName).toBe('H4');
+  });
+
+  it('preserves title className across all heading levels (visual stability)', () => {
+    const { rerender } = render(<GridCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<GridCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
+```
+Expected: 3 of 4 new tests FAIL (h2/h4 variants not supported; current GridCard hardcodes `<h3>`).
+
+- [ ] **Step 2.3: Implement dynamic HeadingTag in GridCard**
+
+In `apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx`:
+
+1. Add `headingLevel` to the destructuring (immediately after `coverEmoji`):
+```tsx
+    coverEmoji,
+    headingLevel,
+    rating,
+```
+
+2. Replace the hardcoded `<h3>` block (around line 78-80):
+
+Find:
+```tsx
+        <h3 className="font-[var(--font-quicksand)] text-[0.95rem] font-bold leading-tight text-[var(--mc-text-primary)]">
+          {title}
+        </h3>
+```
+
+Replace with:
+```tsx
+        {(() => {
+          const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+          return (
+            <HeadingTag className="font-[var(--font-quicksand)] text-[0.95rem] font-bold leading-tight text-[var(--mc-text-primary)]">
+              {title}
+            </HeadingTag>
+          );
+        })()}
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
+```
+Expected: ALL PASS (15 existing + 4 new = 19 tests).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
+git commit -m "feat(meeple-card): #1842 T2 GridCard dynamic HeadingTag (default 3)"
+```
+
+---
+
+## Task 3: ListCard dynamic HeadingTag (default 3)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx`
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx`
+
+- [ ] **Step 3.1: Append failing tests**
+
+Append to `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx` (before closing `});` of last describe):
+
+```tsx
+describe('ListCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default', () => {
+    render(<ListCard entity="game" title="Default title" />);
+    expect(screen.getByText('Default title').tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<ListCard entity="game" title="H2 title" headingLevel={2} />);
+    expect(screen.getByText('H2 title').tagName).toBe('H2');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<ListCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<ListCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});
+```
+
+If `ListCard.test.tsx` does not import `screen` from RTL, add it.
+
+- [ ] **Step 3.2: Run tests to verify failures**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx
+```
+Expected: 2 of 3 new tests FAIL (h2 not supported).
+
+- [ ] **Step 3.3: Implement**
+
+In `apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx`:
+
+1. Destructure `headingLevel` from props.
+2. Replace `<h3 ...>` block (around line 52-54):
+
+Find:
+```tsx
+          <h3 className="truncate font-[var(--font-quicksand)] text-[0.88rem] font-bold text-[var(--mc-text-primary)]">
+            {title}
+          </h3>
+```
+
+Replace with:
+```tsx
+          {(() => {
+            const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+            return (
+              <HeadingTag className="truncate font-[var(--font-quicksand)] text-[0.88rem] font-bold text-[var(--mc-text-primary)]">
+                {title}
+              </HeadingTag>
+            );
+          })()}
+```
+
+- [ ] **Step 3.4: Run tests to verify pass**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx
+```
+Expected: ALL PASS.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/ListCard.test.tsx
+git commit -m "feat(meeple-card): #1842 T3 ListCard dynamic HeadingTag (default 3)"
+```
+
+---
+
+## Task 4: FeaturedCard dynamic HeadingTag (default 3)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx`
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FeaturedCard.test.tsx`
+
+- [ ] **Step 4.1: Append failing tests**
+
+Append to `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FeaturedCard.test.tsx`:
+
+```tsx
+describe('FeaturedCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default', () => {
+    render(<FeaturedCard entity="game" title="Default" />);
+    expect(screen.getByText('Default').tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<FeaturedCard entity="game" title="H2" headingLevel={2} />);
+    expect(screen.getByText('H2').tagName).toBe('H2');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<FeaturedCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<FeaturedCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});
+```
+
+If imports missing, add `import { render, screen } from '@testing-library/react'`.
+
+- [ ] **Step 4.2: Run failing**
+
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/FeaturedCard.test.tsx
+```
+
+- [ ] **Step 4.3: Implement**
+
+In `apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx`:
+
+1. Destructure `headingLevel`.
+2. Replace `<h3>` block (around line 62-64):
+
+Find:
+```tsx
+          <h3 className="font-[var(--font-quicksand)] text-[1.1rem] font-bold leading-tight text-[var(--mc-text-primary)]">
+            {title}
+          </h3>
+```
+
+Replace with:
+```tsx
+          {(() => {
+            const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+            return (
+              <HeadingTag className="font-[var(--font-quicksand)] text-[1.1rem] font-bold leading-tight text-[var(--mc-text-primary)]">
+                {title}
+              </HeadingTag>
+            );
+          })()}
+```
+
+- [ ] **Step 4.4: Run pass**
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FeaturedCard.test.tsx
+git commit -m "feat(meeple-card): #1842 T4 FeaturedCard dynamic HeadingTag (default 3)"
+```
+
+---
+
+## Task 5: HeroCard dynamic HeadingTag (default 3)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx`
+- Create OR modify: `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/HeroCard.test.tsx`
+
+Note: HeroCard.test.tsx may not exist. If it doesn't, create it.
+
+- [ ] **Step 5.1: Verify HeroCard.test.tsx exists**
+
+Run from repo root:
+```bash
+ls apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/HeroCard.test.tsx 2>&1 | head -3
+```
+
+If missing, create it with the test below as the only content (along with imports).
+
+- [ ] **Step 5.2: Write failing tests**
+
+Either append (if file exists) or create with:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { HeroCard } from '../HeroCard';
+
+describe('HeroCard headingLevel prop (#1842)', () => {
+  it('renders <h3> by default', () => {
+    render(<HeroCard entity="game" title="Default" />);
+    expect(screen.getByText('Default').tagName).toBe('H3');
+  });
+
+  it('renders <h2> when headingLevel={2}', () => {
+    render(<HeroCard entity="game" title="H2" headingLevel={2} />);
+    expect(screen.getByText('H2').tagName).toBe('H2');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<HeroCard entity="game" title="X" />);
+    const h3Class = screen.getByText('X').className;
+    rerender(<HeroCard entity="game" title="X" headingLevel={2} />);
+    expect(screen.getByText('X').className).toBe(h3Class);
+  });
+});
+```
+
+- [ ] **Step 5.3: Run failing**
+
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/HeroCard.test.tsx
+```
+
+- [ ] **Step 5.4: Implement**
+
+In `apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx`:
+
+1. Destructure `headingLevel`.
+2. Replace `<h3>` block (around line 81-83):
+
+Find:
+```tsx
+        <h3 className="font-[var(--font-quicksand)] text-2xl font-bold leading-tight text-white drop-shadow-md">
+          {title}
+        </h3>
+```
+
+Replace with:
+```tsx
+        {(() => {
+          const HeadingTag = `h${headingLevel ?? 3}` as 'h2' | 'h3' | 'h4';
+          return (
+            <HeadingTag className="font-[var(--font-quicksand)] text-2xl font-bold leading-tight text-white drop-shadow-md">
+              {title}
+            </HeadingTag>
+          );
+        })()}
+```
+
+- [ ] **Step 5.5: Run pass**
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/HeroCard.test.tsx
+git commit -m "feat(meeple-card): #1842 T5 HeroCard dynamic HeadingTag (default 3)"
+```
+
+---
+
+## Task 6: FocusCard dynamic HeadingTag (default 2)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx`
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx`
+
+FocusCard differs: it currently renders `<h2>` hardcoded (not `<h3>`). Default for this variant is `2`.
+
+- [ ] **Step 6.1: Append failing tests**
+
+Append to `apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx`:
+
+```tsx
+describe('FocusCard headingLevel prop (#1842)', () => {
+  it('renders <h2> by default (preserves existing behavior — FocusCard is page-hero-level)', () => {
+    render(<FocusCard entity="game" title="Default" />);
+    expect(screen.getByText('Default').tagName).toBe('H2');
+  });
+
+  it('renders <h3> when headingLevel={3}', () => {
+    render(<FocusCard entity="game" title="H3" headingLevel={3} />);
+    expect(screen.getByText('H3').tagName).toBe('H3');
+  });
+
+  it('preserves className across heading levels', () => {
+    const { rerender } = render(<FocusCard entity="game" title="X" />);
+    const h2Class = screen.getByText('X').className;
+    rerender(<FocusCard entity="game" title="X" headingLevel={3} />);
+    expect(screen.getByText('X').className).toBe(h2Class);
+  });
+});
+```
+
+- [ ] **Step 6.2: Run failing**
+
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx
+```
+Expected: 1 of 3 new tests FAIL (h3 variant not supported; current renders only h2).
+
+- [ ] **Step 6.3: Implement**
+
+In `apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx`:
+
+1. Destructure `headingLevel`.
+2. Replace `<h2>` block (around line 50):
+
+Find:
+```tsx
+          <h2 className="font-[var(--font-quicksand)] text-xl font-bold leading-tight text-[var(--mc-text-primary)]">
+```
+
+Replace with:
+```tsx
+          {(() => {
+            const HeadingTag = `h${headingLevel ?? 2}` as 'h2' | 'h3' | 'h4';
+            return (
+              <HeadingTag className="font-[var(--font-quicksand)] text-xl font-bold leading-tight text-[var(--mc-text-primary)]">
+```
+
+And close the IIFE block after the closing `</h2>` (around 4 lines later):
+
+Find the closing:
+```tsx
+          </h2>
+```
+
+Replace with:
+```tsx
+              </HeadingTag>
+            );
+          })()}
+```
+
+- [ ] **Step 6.4: Run pass**
+
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx
+```
+Expected: ALL PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/FocusCard.test.tsx
+git commit -m "feat(meeple-card): #1842 T6 FocusCard dynamic HeadingTag (default 2)"
+```
+
+---
+
+## Task 7: DOM smoke test for 5 variants
+
+**Files:**
+- Create: `apps/web/src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx`
+
+This is a meta-test that verifies the API contract works through the top-level `MeepleCard` component for all 5 variants.
+
+- [ ] **Step 7.1: Create smoke test**
+
+Create the file with:
+
+```tsx
+/**
+ * #1842 headingLevel cross-variant smoke test.
+ *
+ * Verifies the MeepleCard API contract: passing `headingLevel` produces
+ * the correct semantic tag for each of the 5 variants that own a title
+ * heading (GridCard, ListCard, FeaturedCard, HeroCard, FocusCard).
+ *
+ * CompactCard is intentionally skipped — it renders <span> for the title
+ * (compact-ticker semantic), not a heading.
+ *
+ * Per DEC-5: no visual regression test. Assertions cover semantic tag
+ * + className stability only.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { MeepleCard } from '../MeepleCard';
+
+import type { MeepleCardVariant } from '../types';
+
+interface VariantSpec {
+  variant: MeepleCardVariant;
+  defaultTag: 'H2' | 'H3';
+}
+
+const variants: VariantSpec[] = [
+  { variant: 'grid', defaultTag: 'H3' },
+  { variant: 'list', defaultTag: 'H3' },
+  { variant: 'featured', defaultTag: 'H3' },
+  { variant: 'hero', defaultTag: 'H3' },
+  { variant: 'focus', defaultTag: 'H2' },
+];
+
+describe('MeepleCard headingLevel smoke (#1842)', () => {
+  for (const { variant, defaultTag } of variants) {
+    it(`${variant} renders ${defaultTag} by default`, () => {
+      render(<MeepleCard entity="game" title={`${variant}-default`} variant={variant} />);
+      expect(screen.getByText(`${variant}-default`).tagName).toBe(defaultTag);
+    });
+
+    it(`${variant} renders H2 when headingLevel={2}`, () => {
+      render(
+        <MeepleCard entity="game" title={`${variant}-h2`} variant={variant} headingLevel={2} />
+      );
+      expect(screen.getByText(`${variant}-h2`).tagName).toBe('H2');
+    });
+
+    it(`${variant} preserves className when headingLevel changes (visual stability)`, () => {
+      const { rerender } = render(
+        <MeepleCard entity="game" title={`${variant}-stable`} variant={variant} />
+      );
+      const defaultClass = screen.getByText(`${variant}-stable`).className;
+      rerender(
+        <MeepleCard entity="game" title={`${variant}-stable`} variant={variant} headingLevel={4} />
+      );
+      expect(screen.getByText(`${variant}-stable`).className).toBe(defaultClass);
+    });
+  }
+});
+```
+
+- [ ] **Step 7.2: Run smoke test**
+
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx
+```
+Expected: ALL PASS (15 tests = 5 variants × 3 assertions).
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx
+git commit -m "test(meeple-card): #1842 T7 cross-variant headingLevel smoke (5 variants × 3 assertions)"
+```
+
+---
+
+## Task 8: Consumer migration batch 1 — feature grids (5 files)
+
+**Files (5):**
+- `apps/web/src/components/features/agents/AgentsResultsGrid.tsx`
+- `apps/web/src/components/features/games/GamesResultsGrid.tsx`
+- `apps/web/src/components/features/players/PlayersResultsGrid.tsx`
+- `apps/web/src/components/features/library/LibraryHybridGrid.tsx`
+- `apps/web/src/components/features/home/HomeFeed.tsx`
+
+Each file passes `headingLevel={2}` to `<MeepleCard>` at the call site. The change is 1-line additive — no failing-first test required (the prop is type-checked and the migration is mechanical pass-through).
+
+- [ ] **Step 8.1: Migrate `AgentsResultsGrid.tsx`**
+
+In `apps/web/src/components/features/agents/AgentsResultsGrid.tsx`, find the `<MeepleCard` JSX block and add `headingLevel={2}` as a prop. Example:
+
+Find:
+```tsx
+<MeepleCard
+  entity="agent"
+  ...
+/>
+```
+
+Add `headingLevel={2}`:
+```tsx
+<MeepleCard
+  entity="agent"
+  headingLevel={2}
+  ...
+/>
+```
+
+(The exact line varies — search for `<MeepleCard` in the file. If multiple usages exist, update all.)
+
+- [ ] **Step 8.2: Migrate `GamesResultsGrid.tsx`**
+
+Same pattern: add `headingLevel={2}` to `<MeepleCard>` invocations.
+
+- [ ] **Step 8.3: Migrate `PlayersResultsGrid.tsx`**
+
+Same pattern.
+
+- [ ] **Step 8.4: Migrate `LibraryHybridGrid.tsx`**
+
+Same pattern.
+
+- [ ] **Step 8.5: Migrate `HomeFeed.tsx`**
+
+Same pattern. Note HomeFeed may use MeepleCard for multiple sections; update ALL MeepleCard invocations.
+
+- [ ] **Step 8.6: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 8.7: Run feature tests for these surfaces**
+
+```bash
+pnpm vitest run src/components/features/agents src/components/features/games src/components/features/players src/components/features/library src/components/features/home
+```
+Expected: ALL PASS (no regressions — additive prop change).
+
+- [ ] **Step 8.8: Commit**
+
+```bash
+git add apps/web/src/components/features/agents/AgentsResultsGrid.tsx apps/web/src/components/features/games/GamesResultsGrid.tsx apps/web/src/components/features/players/PlayersResultsGrid.tsx apps/web/src/components/features/library/LibraryHybridGrid.tsx apps/web/src/components/features/home/HomeFeed.tsx
+git commit -m "feat(meeple-card): #1842 T8 batch 1 — feature grids pass headingLevel={2} (agents/games/players/library/home)"
+```
+
+---
+
+## Task 9: Consumer migration batch 2 — library/catalog cards (5 files)
+
+**Files (5):**
+- `apps/web/src/components/library/MeepleLibraryGameCard.tsx`
+- `apps/web/src/components/library/MeepleUserLibraryCard.tsx`
+- `apps/web/src/components/catalog/MeepleGameCatalogCard.tsx`
+- `apps/web/src/components/wishlist/MeepleWishlistCard.tsx`
+- `apps/web/src/app/(authenticated)/library/wishlist/page.tsx`
+
+- [ ] **Step 9.1: Migrate `MeepleLibraryGameCard.tsx`**
+
+Find `<MeepleCard` invocations and add `headingLevel={2}`.
+
+- [ ] **Step 9.2: Migrate `MeepleUserLibraryCard.tsx`**
+
+Same pattern.
+
+- [ ] **Step 9.3: Migrate `MeepleGameCatalogCard.tsx`**
+
+Same pattern.
+
+- [ ] **Step 9.4: Migrate `MeepleWishlistCard.tsx`**
+
+Same pattern. Note: this is the card component. The page `library/wishlist/page.tsx` consumes it.
+
+- [ ] **Step 9.5: Migrate `app/(authenticated)/library/wishlist/page.tsx`**
+
+The page already renders `<h1>My Wishlist</h1>` and uses `<MeepleWishlistCard>` below. The card already gets `headingLevel={2}` from Step 9.4 (if MeepleWishlistCard is configured correctly). If MeepleWishlistCard is a thin wrapper, the page itself does not pass MeepleCard prop directly — verify and either skip page OR pass through MeepleWishlistCard prop.
+
+- [ ] **Step 9.6: Typecheck + tests**
+
+```bash
+pnpm typecheck && pnpm vitest run src/components/library src/components/catalog src/components/wishlist
+```
+
+- [ ] **Step 9.7: Commit**
+
+```bash
+git add apps/web/src/components/library/MeepleLibraryGameCard.tsx apps/web/src/components/library/MeepleUserLibraryCard.tsx apps/web/src/components/catalog/MeepleGameCatalogCard.tsx apps/web/src/components/wishlist/MeepleWishlistCard.tsx apps/web/src/app/\(authenticated\)/library/wishlist/page.tsx
+git commit -m "feat(meeple-card): #1842 T9 batch 2 — library/catalog/wishlist cards pass headingLevel={2}"
+```
+
+---
+
+## Task 10: Consumer migration batch 3 — public/auth pages + chat entry (5 files)
+
+**Files (5):**
+- `apps/web/src/app/(public)/library/shared/[token]/page.tsx`
+- `apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadClient.tsx`
+- `apps/web/src/components/chat/entry/AgentSelector.tsx`
+- `apps/web/src/components/chat/entry/GameSelector.tsx`
+- `apps/web/src/components/chat-unified/AgentCreationWizard.tsx`
+
+- [ ] **Step 10.1–10.5: Migrate each file** with `headingLevel={2}` on `<MeepleCard>` invocations.
+
+- [ ] **Step 10.6: Typecheck + tests**
+
+```bash
+pnpm typecheck && pnpm vitest run src/components/chat src/components/chat-unified src/app/\(authenticated\)/gamebook src/app/\(public\)/library
+```
+
+- [ ] **Step 10.7: Commit**
+
+```bash
+git add apps/web/src/app/\(public\)/library/shared/\[token\]/page.tsx apps/web/src/app/\(authenticated\)/gamebook/upload/_components/GamebookUploadClient.tsx apps/web/src/components/chat/entry/AgentSelector.tsx apps/web/src/components/chat/entry/GameSelector.tsx apps/web/src/components/chat-unified/AgentCreationWizard.tsx
+git commit -m "feat(meeple-card): #1842 T10 batch 3 — public/auth pages + chat entry pass headingLevel={2}"
+```
+
+---
+
+## Task 11: Consumer migration batch 4 — game-night planning + paused session (5 files)
+
+**Files (5):**
+- `apps/web/src/components/game-night/MeepleEventCard.tsx`
+- `apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx`
+- `apps/web/src/components/game-night/planning/MeepleDealtGameCard.tsx`
+- `apps/web/src/components/game-night/planning/MeepleAISuggestionCard.tsx`
+- `apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx`
+
+- [ ] **Step 11.1–11.5: Migrate each file** with `headingLevel={2}` on `<MeepleCard>` invocations.
+
+- [ ] **Step 11.6: Typecheck + tests**
+
+```bash
+pnpm typecheck && pnpm vitest run src/components/game-night src/components/library/private-game-detail
+```
+
+- [ ] **Step 11.7: Commit**
+
+```bash
+git add apps/web/src/components/game-night/MeepleEventCard.tsx apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx apps/web/src/components/game-night/planning/MeepleDealtGameCard.tsx apps/web/src/components/game-night/planning/MeepleAISuggestionCard.tsx apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx
+git commit -m "feat(meeple-card): #1842 T11 batch 4 — game-night planning + paused session pass headingLevel={2}"
+```
+
+---
+
+## Task 12: Re-enable `heading-order` axe rule on 2 existing suppressions
+
+**Files (2):**
+- `apps/web/src/app/(authenticated)/agents/_components/__tests__/AgentsLibraryView.test.tsx`
+- `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx`
+
+These two files contain `rules: { 'heading-order': { enabled: false } }` overrides added in #1841 (P164 pattern) and earlier #1481 cluster. Now that consumers pass `headingLevel={2}`, the rule should pass without suppression.
+
+- [ ] **Step 12.1: Remove suppression in `AgentsLibraryView.test.tsx`**
+
+In `apps/web/src/app/(authenticated)/agents/_components/__tests__/AgentsLibraryView.test.tsx`, find the axe scan at line ~359 with `{ rules: { 'heading-order': { enabled: false } } }`. Remove the `rules` option, leaving just the call:
+
+Find:
+```tsx
+      await axe(container, { rules: { 'heading-order': { enabled: false } } })
+```
+
+Replace with:
+```tsx
+      await axe(container)
+```
+
+Also remove the associated JSDoc/comment block explaining the suppression (if present, look at lines 350-358).
+
+- [ ] **Step 12.2: Remove suppression in `LibroGameDetailView.test.tsx`**
+
+In `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx`, find the axe scan around line 157-163:
+
+Find:
+```tsx
+    const results = await axe(container, {
+      rules: {
+        'heading-order': { enabled: false },
+      },
+    });
+```
+
+Replace with:
+```tsx
+    const results = await axe(container);
+```
+
+Also remove the associated comment block explaining the suppression.
+
+- [ ] **Step 12.3: Run both tests**
+
+```bash
+pnpm vitest run src/app/\(authenticated\)/agents/_components/__tests__/AgentsLibraryView.test.tsx src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+```
+
+Expected: BOTH PASS without violations (assuming earlier consumer migrations have wired `headingLevel={2}` correctly).
+
+If FAIL with `heading-order` violation: investigate which surface didn't get the prop and add it. The error message will identify the violating element via CSS selector.
+
+- [ ] **Step 12.4: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/agents/_components/__tests__/AgentsLibraryView.test.tsx apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+git commit -m "test(a11y): #1842 T12 re-enable heading-order axe rule on AgentsLibraryView + LibroGameDetailView"
+```
+
+---
+
+## Task 13: Add `heading-order` axe scans to 5 key surfaces
+
+**Files (5):**
+- `apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx`
+- `apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx`
+- `apps/web/src/components/features/players/__tests__/PlayersResultsGrid.test.tsx`
+- `apps/web/src/components/features/games/__tests__/GamesResultsGrid.test.tsx`
+- `apps/web/src/components/game-night/planning/__tests__/GameNightPlanningLayout.test.tsx`
+
+For each file, add a new `it('passes heading-order axe rule', ...)` test that renders the component and runs jest-axe with default (heading-order ENABLED) rule.
+
+- [ ] **Step 13.1: Add axe scan to `LibraryHub.test.tsx`**
+
+In the file, check if `import { axe } from 'jest-axe';` exists at the top. If not, add it.
+
+At the end of the existing `describe(...)` block (or in a new `describe('a11y axe (#1842)', ...)` block), add:
+
+```tsx
+  it('passes heading-order axe rule (#1842)', async () => {
+    const { container } = render(<LibraryHub /* required props */ />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+```
+
+(Replace `<LibraryHub />` with the actual signature including required props. Use existing tests in the same file as a reference for how to set up the render.)
+
+- [ ] **Step 13.2: Add axe scan to `HubToolkitsBody.test.tsx`**
+
+Same pattern.
+
+- [ ] **Step 13.3: Add axe scan to `PlayersResultsGrid.test.tsx`**
+
+Same pattern.
+
+- [ ] **Step 13.4: Add axe scan to `GamesResultsGrid.test.tsx`**
+
+Same pattern.
+
+- [ ] **Step 13.5: Add axe scan to `GameNightPlanningLayout.test.tsx`**
+
+Same pattern.
+
+- [ ] **Step 13.6: Run all 5 new axe scans**
+
+```bash
+pnpm vitest run src/app/\(authenticated\)/library/_components/__tests__/LibraryHub.test.tsx src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx src/components/features/players/__tests__/PlayersResultsGrid.test.tsx src/components/features/games/__tests__/GamesResultsGrid.test.tsx src/components/game-night/planning/__tests__/GameNightPlanningLayout.test.tsx
+```
+
+Expected: ALL PASS (0 axe violations on each surface).
+
+If any FAIL, the violation will point to a card whose consumer didn't get `headingLevel={2}` — go back to T8-T11 and add the prop.
+
+- [ ] **Step 13.7: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/library/_components/__tests__/LibraryHub.test.tsx apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx apps/web/src/components/features/players/__tests__/PlayersResultsGrid.test.tsx apps/web/src/components/features/games/__tests__/GamesResultsGrid.test.tsx apps/web/src/components/game-night/planning/__tests__/GameNightPlanningLayout.test.tsx
+git commit -m "test(a11y): #1842 T13 add heading-order axe scans to 5 key surfaces (LibraryHub/HubToolkitsBody/PlayersResultsGrid/GamesResultsGrid/GameNightPlanningLayout)"
+```
+
+---
+
+## Task 14: Final verify + push + PR
+
+- [ ] **Step 14.1: Run full meeple-card suite**
+
+```bash
+pnpm vitest run src/components/ui/data-display/meeple-card/
+```
+Expected: ALL PASS (>270 tests — includes the new heading-level tests).
+
+- [ ] **Step 14.2: Run full typecheck**
+
+```bash
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 14.3: Run lint**
+
+```bash
+pnpm lint
+```
+Expected: 0 errors. Pre-existing warnings are acceptable.
+
+- [ ] **Step 14.4: Push branch**
+
+From repo root:
+```bash
+git push -u origin feature/issue-1842-meeple-card-heading-level
+```
+
+- [ ] **Step 14.5: Create PR base main-dev**
+
+```bash
+gh pr create --base main-dev --title "fix(a11y): #1842 MeepleCard headingLevel prop — close heading-order WCAG suppressions" --body "$(cat <<'EOF'
+## Summary
+
+Implements #1842 — adds `headingLevel?: 2 | 3 | 4` prop to `MeepleCard` (default `3`) and migrates 20 grid-below-h1-hero consumer surfaces. Closes the `heading-order` axe suppression debt from #1841 (P164 pattern) and #1481.
+
+Surgical primitive prop addition per spec [`docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md`](docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md) and plan [`docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md`](docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md).
+
+## Changes
+
+- **types.ts** — Add `headingLevel?: 2 | 3 | 4` to `MeepleCardProps` (additive, backwards compat).
+- **5 variants** — Dynamic `<HeadingTag>` rendering instead of hardcoded `<h3>` (or `<h2>` for FocusCard). CompactCard unchanged (uses `<span>`, no heading element).
+- **20 consumers migrated** — Pass `headingLevel={2}` at call sites (4 batches × 5 files each).
+- **2 axe suppressions removed** — Re-enable `heading-order` rule on `AgentsLibraryView.test.tsx` + `LibroGameDetailView.test.tsx`.
+- **5 new axe scans added** — `LibraryHub`, `HubToolkitsBody`, `PlayersResultsGrid`, `GamesResultsGrid`, `GameNightPlanningLayout`.
+
+## Decisions (locked in brainstorming 2026-06-04)
+
+| ID | Decision |
+|---|---|
+| DEC-1 | Systematic audit of 59 consumers (issue body underestimated scope 2x) |
+| DEC-2 | Approach A — additive `headingLevel` prop, default 3 |
+| DEC-3 | Per-consumer migration (NOT default change to 2) |
+| DEC-4 | 5 new axe scans + 2 existing suppression re-enable |
+| DEC-5 | DOM structure assertions only (no visual regression infra) |
+| DEC-6 | Defer 7 NEEDS_INSPECTION files to follow-up |
+| DEC-7 | 4 variants migrate (`<h3>` → dynamic); FocusCard already h2 (prop-accept with default 2); CompactCard skip |
+
+## Tests
+
+- 5 new variant tests + 1 cross-variant smoke (15 tests) + 1 contract test = 27+ new assertions
+- 2 existing axe suppressions removed → rule re-enabled in production CI
+- 5 new axe scans cover key grid surfaces
+- Full meeple-card suite: 270+ tests pass, typecheck 0 errors
+
+## Out of scope (deferred follow-up)
+
+- 7 NEEDS_INSPECTION files (`entity-list-view` polymorphic primitive, `shared-games-grid` passthrough, `MeepleChatCard` adapter, `MeepleContributorCard` deep-section, `MeepleParticipantCard` Scoreboard label, `PrivateGamesClient` unused-h1, `LibraryPanel` unused) — tracked here for follow-up issue.
+
+## Related
+
+- Closes #1842
+- Source debt: #1841 (P164 pattern), #1481 (earlier cluster)
+- Origin coverage: #1569 (jest-axe agents-index)
+- Spec: `docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md`
+- Plan: `docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md`
+EOF
+)"
+```
+
+- [ ] **Step 14.6: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+Expected: All checks green. If `Frontend Tests` shard fails per #1851 baseline (`AdvancedFilterPanel` flake), document in PR comment.
+
+- [ ] **Step 14.7: Admin merge (P145 pattern: user direttiva richiede merge + cleanup)**
+
+```bash
+gh pr merge --squash --admin --delete-branch
+```
+
+- [ ] **Step 14.8: Sync main-dev + cleanup**
+
+```bash
+git checkout main-dev && git pull --ff-only origin main-dev
+```
+
+Local branch should already be deleted by `--delete-branch`. If not:
+```bash
+git branch -D feature/issue-1842-meeple-card-heading-level
+```
+
+---
+
+## Self-review checklist
+
+**1. Spec coverage**:
+- §2 DEC-1..DEC-7 → T1-T13 implement all 7 decisions
+- §3 Architecture (dynamic HeadingTag, default 3, per-consumer) → T2-T6 + T8-T11
+- §4 File map (5 primitive + 20 consumer + 2 test re-enable + 5 axe scans + 1 smoke) → T1-T7 + T8-T11 + T12 + T13
+- §5 Data flow (HeadingTag dispatch) → T2-T6 implementation
+- §6 Error handling (TS literal union + fallback) → T1 type definition
+- §7 Testing strategy → T7 smoke + T12 re-enable + T13 new scans
+- §8 Out of scope (NEEDS_INSPECTION 7 files) → documented in PR body, not tasked
+- §9 Rollout & risk → T14 verify + designer-review-deferred via PR description
+
+✅ All sections covered.
+
+**2. Placeholder scan**: no "TBD", "TODO", or "implement later" directives in any step. Every step has concrete code or commands.
+
+**3. Type consistency**:
+- `MeepleCardProps.headingLevel?: 2 | 3 | 4` defined in T1, used consistently in T2-T7 + T9 contract test
+- `HeadingTag = \`h${headingLevel ?? N}\` as 'h2' | 'h3' | 'h4'` — identical pattern across T2-T6 (variants), only default level varies (3 for most, 2 for FocusCard)
+- `MeepleCardVariant` type used in T7 smoke loop
+- Consumer migration commands consistent across T8-T11 (always `headingLevel={2}`)
+
+✅ Type consistency verified.
+
+If any spec requirement is missing from the task list, add a task. Otherwise, plan is complete.

--- a/docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md
+++ b/docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md
@@ -1,0 +1,249 @@
+# #1842 — MeepleCard `headingLevel` prop for heading-order WCAG compliance
+
+**Issue**: [#1842](https://github.com/meepleAi-app/meepleai-monorepo/issues/1842)
+**Author**: brainstorming session 2026-06-04
+**Branch**: `feature/issue-1842-meeple-card-heading-level` → PR target `main-dev`
+**Status**: Design (pre-implementation)
+
+---
+
+## 1. Context & Problem
+
+PR #1841 (#1569 jest-axe agents-index coverage) discovered a **real WCAG `heading-order` violation** on `AgentsLibraryView`: `AgentsHero` renders `<h1>` "Studio agenti", and each `MeepleCard` below renders `<h3>` for the card title. No `<h2>` between them → axe-core flags rule violation.
+
+The suppression `rules: { 'heading-order': { enabled: false } }` was added inline as a temporary workaround. This issue closes the debt by adding `headingLevel?: 2 | 3 | 4` prop to `MeepleCard` and migrating offending consumer surfaces.
+
+### Cross-cutting impact
+
+Audit of all 59 `MeepleCard` consumers (non-test) reveals:
+- **20 NEEDS_MIGRATION** (high confidence): grid-below-h1-hero pattern, axe violation expected
+- **25 SKIP**: single-card detail / admin-only / unused / internal / modal contexts (no h1 above)
+- **7 NEEDS_INSPECTION**: ambiguous (polymorphic primitive, currently unused, adapter prop-passthrough)
+
+Stima iniziale issue body ("~10 surfaces") era **sottostima 2x**. Audit produces precise migration list (§4).
+
+### Existing suppressions (2 known)
+
+1. `apps/web/src/app/(authenticated)/agents/_components/__tests__/AgentsLibraryView.test.tsx:359` — added 2026-06-02 sessione 29 #1841 (P164 pattern: rule suppression + follow-up issue tracking)
+2. `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx:160` — added precedentemente per cluster #1481
+
+Entrambe vanno rimosse post-fix.
+
+---
+
+## 2. Decisions
+
+Locked in brainstorming session 2026-06-04 + AskUserQuestion responses:
+
+| ID | Decision | Rationale |
+|---|---|---|
+| **DEC-1** | Audit sistematico 59 consumers + categorize | Issue body sottostima scope ("10 surfaces"). Audit produces precise NEEDS_MIGRATION/SKIP/INSPECTION table. Zero false-negatives. |
+| **DEC-2** | Approach A — `headingLevel?: 2 \| 3 \| 4` prop additivo, default `3` | Issue body raccomandazione + Fowler clean code (backwards compat). Alternative Option B (demote hero h1 → h2 + sr-only page h1) era rejected come più invasiva. |
+| **DEC-3** | Per-consumer migration (NON default change to `2`) | Default change a `2` rompe consumer detail/single-card legittimi. Esplicito su 20 surfaces > implicit blanket change. Boilerplate noise accettabile. |
+| **DEC-4** | 5-8 nuovi axe scan key surfaces | Re-enable 2 esistenti (AgentsLibraryView + LibroGameDetailView) + add new scans su: `LibraryHub.test`, `HubToolkitsBody.test` (esistente sostituito), `PlayersLibraryView.test`, `GamesResultsGrid.test`, `CollectionGameGrid.test`, `GameNightPlanningLayout.test`. Bilancia coverage vs effort. |
+| **DEC-5** | DOM structure assertion only (NO visual regression) | Memoria sessione 31 DEC-6 — Visual Gate REMOVED 2026-05-20 high false-positive. Vitest test confirma `tagName === 'H2'` + className/style invariati. |
+| **DEC-6** | Defer NEEDS_INSPECTION 7 files | `entity-list-view` polymorphic primitive + `shared-games-grid` passthrough + adapters (MeepleChatCard via HomeFeed) → tracked in PR follow-up comment. Non blocca chiusura #1842. |
+| **DEC-7** | Variants in scope: GridCard + ListCard + FeaturedCard + HeroCard (4/6) — FocusCard già `<h2>` (no migration needed), CompactCard usa `<span>` (no heading element) | Audit: 4 variants render `<h3>` per il title (GridCard:78, ListCard:52, FeaturedCard:62, HeroCard:81). FocusCard:50 usa `<h2>` (design intent: full-focus page-hero card). CompactCard:30 usa `<span>` (compact ticker, no semantic heading). FocusCard accetta prop con default `2` per consistency; CompactCard skipped (no heading element to migrate). |
+
+---
+
+## 3. Architecture
+
+Modifichiamo il **primitive MeepleCard** aggiungendo prop additiva `headingLevel?: 2 | 3 | 4` su `MeepleCardProps`. Ogni variant (`GridCard.tsx`, `ListCard.tsx`, `CompactCard.tsx`, `FeaturedCard.tsx`, `FocusCard.tsx`, `HeroCard.tsx`) consuma il prop e renderizza l'heading tag corrispondente.
+
+Il prop è **type-safe** via TypeScript literal union `2 | 3 | 4` — TS impedisce passing valori invalid a compile-time.
+
+Dynamic tag rendering pattern (React idiomatic):
+
+```tsx
+const HeadingTag = `h${headingLevel ?? 3}` as const;
+return <HeadingTag className={...}>{title}</HeadingTag>;
+```
+
+Backwards compat: `headingLevel={undefined}` → default `3` (current behavior). Tutti i 25 SKIP consumer + 7 NEEDS_INSPECTION continuano render `<h3>` senza modifiche.
+
+**Per-consumer migration** (20 NEEDS_MIGRATION): aggiungi `headingLevel={2}` al call site. Tipicamente 1 line change per consumer.
+
+---
+
+## 4. Components & file map
+
+### Primitive changes (1 file types + 6 variants)
+
+| File | Change | What |
+|---|---|---|
+| `apps/web/src/components/ui/data-display/meeple-card/types.ts` | **edit** | Add `headingLevel?: 2 \| 3 \| 4` to `MeepleCardProps` with JSDoc explaining DEC-3 (per-consumer migration). Default 3 documented. |
+| `apps/web/src/components/ui/data-display/meeple-card/variants/GridCard.tsx` | **edit** | Destructure `headingLevel`. Render `<HeadingTag>` instead of hardcoded `<h3>` (line 78). |
+| `apps/web/src/components/ui/data-display/meeple-card/variants/ListCard.tsx` | **edit** | Same dynamic tag pattern. Line 52: `<h3>` → `<HeadingTag>`. |
+| `apps/web/src/components/ui/data-display/meeple-card/variants/FeaturedCard.tsx` | **edit** | Same dynamic tag pattern. Line 62: `<h3>` → `<HeadingTag>`. |
+| `apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx` | **edit** | Same dynamic tag pattern. Line 81: `<h3 className="text-2xl ...">` → `<HeadingTag className="text-2xl ...">`. |
+| `apps/web/src/components/ui/data-display/meeple-card/variants/FocusCard.tsx` | **edit** | Already renders `<h2>` (line 50) hardcoded. Migrate to `<HeadingTag>` with `default 2` (preserve current visual behavior). |
+| ~~CompactCard~~ | **skip** | Uses `<span>` (line 30), no heading element. Compact-ticker variant intentionally non-semantic. |
+
+### Consumer migration (20 NEEDS_MIGRATION files)
+
+| File | Action |
+|---|---|
+| `apps/web/src/components/features/agents/AgentsResultsGrid.tsx` | Pass `headingLevel={2}` to MeepleCard |
+| `apps/web/src/components/features/games/GamesResultsGrid.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/features/players/PlayersResultsGrid.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/features/library/LibraryHybridGrid.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/features/home/HomeFeed.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/library/MeepleLibraryGameCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/library/MeepleUserLibraryCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/catalog/MeepleGameCatalogCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/wishlist/MeepleWishlistCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/app/(authenticated)/library/wishlist/page.tsx` | Pass `headingLevel={2}` (via MeepleWishlistCard prop) |
+| `apps/web/src/app/(public)/library/shared/[token]/page.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadClient.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/chat/entry/AgentSelector.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/chat/entry/GameSelector.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/chat-unified/AgentCreationWizard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/game-night/MeepleEventCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/game-night/planning/MeepleGameNightCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/game-night/planning/MeepleDealtGameCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/game-night/planning/MeepleAISuggestionCard.tsx` | Pass `headingLevel={2}` |
+| `apps/web/src/components/library/private-game-detail/MeeplePausedSessionCard.tsx` | Pass `headingLevel={2}` |
+
+### Test re-enable (2 existing suppressions removed)
+
+| File | Action |
+|---|---|
+| `apps/web/src/app/(authenticated)/agents/_components/__tests__/AgentsLibraryView.test.tsx:359` | Remove `rules: { 'heading-order': { enabled: false } }` override. Comment cleanup. |
+| `apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx:160` | Same. |
+
+### New axe scans (5-8 key surfaces)
+
+| Test file | What |
+|---|---|
+| `apps/web/src/components/features/library-hub/__tests__/LibraryHub.test.tsx` | Add jest-axe scan with `heading-order` enabled (assumes file exists; otherwise create) |
+| `apps/web/src/components/features/library-hub/__tests__/HubToolkitsBody.test.tsx` | Same |
+| `apps/web/src/components/features/players/__tests__/PlayersResultsGrid.test.tsx` | Same (verify exists; create if missing) |
+| `apps/web/src/components/features/games/__tests__/GamesResultsGrid.test.tsx` | Same |
+| `apps/web/src/components/collection/__tests__/CollectionGameGrid.test.tsx` | Same |
+| `apps/web/src/components/game-night/planning/__tests__/GameNightPlanningLayout.test.tsx` | Same |
+
+### DOM smoke (visual stability)
+
+| Test file | What |
+|---|---|
+| `apps/web/src/components/ui/data-display/meeple-card/__tests__/heading-level.smoke.test.tsx` | NEW. Render each variant with `headingLevel={2}` vs default `3` → assert `tagName` swap correct + computed `font-family` / `font-size` / `font-weight` unchanged. 1 test per 6 variants. |
+
+---
+
+## 5. Data flow
+
+```
+Consumer (e.g. AgentsResultsGrid) → <MeepleCard headingLevel={2} {...props} />
+                ↓
+         MeepleCardImpl (variant default 'grid')
+                ↓
+            GridCard ({ headingLevel, title, ... })
+                ↓
+        const HeadingTag = `h${headingLevel ?? 3}` as const;
+        return (
+          ...
+          <HeadingTag className={...}>{title}</HeadingTag>
+          ...
+        );
+```
+
+TypeScript literal union `2 | 3 | 4` → enforces compile-time safety. Default fallback `?? 3` covers `undefined` (backwards compat) e edge case TS-bypass.
+
+---
+
+## 6. Error handling
+
+| Scenario | Behavior |
+|---|---|
+| `headingLevel` undefined | Default `3` (current behavior preserved) |
+| `headingLevel` invalid (e.g. `1` o `5`) | TypeScript blocks at compile-time (literal union) |
+| `headingLevel` invalid runtime bypass (e.g. via `as any`) | `as const` template literal infers `h${number}` → React renders correctly if valid HTML heading; else React warning. Acceptable since TS already guards. |
+| Multiple cards in same page | Each renders its own `<h2>` independently — multiple h2 siblings in same parent is WCAG-valid (heading-order ≥ siblings same level OK). |
+
+---
+
+## 7. Testing strategy
+
+### TDD per-variant (5 variants — CompactCard skipped)
+
+Per ogni variant edit (`GridCard`, `ListCard`, `FeaturedCard`, `HeroCard`, `FocusCard`):
+
+1. **Failing test**: assert `<h2>` rendered when `headingLevel={2}` passed; assert `<h3>` when omitted (for `GridCard/ListCard/FeaturedCard/HeroCard`); assert `<h2>` when omitted (for `FocusCard` — different default).
+2. **Implementation**: dynamic `HeadingTag = \`h${headingLevel ?? defaultLevel}\`` where `defaultLevel = 3` for grid/list/featured/hero, `2` for FocusCard.
+3. **Verify passing**.
+
+`CompactCard` is **out of scope** for TDD (no heading element).
+
+### Re-enable 2 existing suppressions
+
+Remove `rules: { 'heading-order': { enabled: false } }` from:
+- `AgentsLibraryView.test.tsx` (assumes `AgentsResultsGrid` passes `headingLevel={2}` post-migration)
+- `LibroGameDetailView.test.tsx` (assumes that view's MeepleCard passes `headingLevel={2}` — verify se è uno dei SKIP o NEEDS_MIGRATION)
+
+### Add 5-8 new axe scans (DEC-4)
+
+For each key surface, render with jest-axe scan **with heading-order rule ENABLED** (default axe config, no override). Verify 0 violations post-migration.
+
+### DOM structure smoke (DEC-5)
+
+`__tests__/heading-level.smoke.test.tsx` — 6 tests (1 per variant):
+
+```tsx
+it('GridCard renders h2 when headingLevel={2} (visual props unchanged)', () => {
+  const { rerender, getByText } = render(
+    <MeepleCard entity="game" title="X" variant="grid" />
+  );
+  const h3 = getByText('X');
+  expect(h3.tagName).toBe('H3');
+  const h3Classes = h3.className;
+
+  rerender(<MeepleCard entity="game" title="X" variant="grid" headingLevel={2} />);
+  const h2 = getByText('X');
+  expect(h2.tagName).toBe('H2');
+  expect(h2.className).toBe(h3Classes); // identical styling
+});
+```
+
+---
+
+## 8. Out of scope
+
+- ❌ **NEEDS_INSPECTION 7 files** — `entity-list-view` polymorphic primitive prop-passthrough, `shared-games-grid` passthrough, `MeepleChatCard` adapter, `MeepleContributorCard` deep-section, `MeepleParticipantCard` Scoreboard label, `PrivateGamesClient` unused-h1-context, `LibraryPanel` unused. Tracked as follow-up comment on PR.
+- ❌ **25 SKIP consumer** — single-card detail / admin / unused / internal / modal. No change needed.
+- ❌ **Visual regression test infra** — Visual Gate REMOVED 2026-05-20 (DEC-5).
+- ❌ **Option B alternative** — demote hero h1 → h2 + sr-only page h1 (issue body rejected).
+- ❌ **BE changes** — purely FE.
+- ❌ **`headingLevel={4}`** — out of scope, included only in type signature for future flexibility (h2/h3/h4 supported).
+
+---
+
+## 9. Rollout & risk
+
+### Risk matrix
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Visual regression on 20 migrated cards | Medium | Low | DEC-5 DOM smoke assertions verify className/font props unchanged; designer review post-preview-deploy (manual gate). |
+| `<h2>` font-size diverges from `<h3>` default in some Tailwind setups | Low | Low | Tailwind v4 doesn't apply default heading styles unless `@tailwindcss/typography` is enabled. Our v2 tokens use explicit `font-[var(--font-quicksand)] text-[0.95rem] font-bold` on the heading — same className regardless of tagName. |
+| axe-core still flags violations post-migration | Medium | Medium | New axe scans (DEC-4) catch this in CI before merge. If any surface still fails, re-audit + classify NEEDS_MIGRATION expansion. |
+| NEEDS_INSPECTION 7 files surface later as violations | Low | Medium | Follow-up PR; tracked in PR body comment. |
+| Adapter components (MeepleChatCard) miss the migration | Low | Low | DEC-6 documented; follow-up issue if axe re-enable on HomeFeed.test surfaces it. |
+
+### Rollback plan
+
+- Revert PR → primitive restored to current state, `<h3>` everywhere
+- Database: zero changes (FE-only)
+- No breaking changes for ANY consumer (additive prop, default backward-compat)
+
+---
+
+## 10. References
+
+- Issue: [#1842](https://github.com/meepleAi-app/meepleai-monorepo/issues/1842)
+- Source PR (suppression added): [#1841](https://github.com/meepleAi-app/meepleai-monorepo/pull/1841)
+- Origin issue (jest-axe coverage): [#1569](https://github.com/meepleAi-app/meepleai-monorepo/issues/1569)
+- Memory pattern P164: axe-rule-suppression-with-tracked-followup (documented sessione 29)
+- Audit completed: 2026-06-04 (20 NEEDS_MIGRATION + 25 SKIP + 7 NEEDS_INSPECTION)
+- Primitive: `apps/web/src/components/ui/data-display/meeple-card/`
+- Spec author: brainstorming session 2026-06-04


### PR DESCRIPTION
## Summary

Implements #1842 — adds `headingLevel?: 2 | 3 | 4` prop to `MeepleCard` (default `3`) and migrates 20 grid-below-h1-hero consumer surfaces. Closes the `heading-order` axe suppression debt from #1841 (P164 pattern) and #1481.

Surgical primitive prop addition per spec [`docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md`](docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md) and plan [`docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md`](docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md).

## Changes

- **types.ts** — Add `headingLevel?: 2 | 3 | 4` to `MeepleCardProps` (additive, backwards compat).
- **5 variants** — Dynamic `<HeadingTag>` rendering instead of hardcoded `<h3>` (or `<h2>` for FocusCard). CompactCard unchanged (uses `<span>`, no heading element).
  - GridCard / ListCard / FeaturedCard / HeroCard: default `3`
  - FocusCard: default `2` (preserves existing page-hero-level semantics)
- **20 consumers migrated** — Pass `headingLevel={2}` at call sites (4 batches × 5 files each):
  - Batch 1 (feature grids): AgentsResultsGrid, GamesResultsGrid, PlayersResultsGrid, LibraryHybridGrid, HomeFeed
  - Batch 2 (library/catalog): MeepleLibraryGameCard, MeepleUserLibraryCard, MeepleGameCatalogCard, MeepleWishlistCard, wishlist page
  - Batch 3 (public/chat): library/shared/[token]/page, GamebookUploadClient, AgentSelector, GameSelector, AgentCreationWizard
  - Batch 4 (game-night/paused): MeepleEventCard, MeepleGameNightCard, MeepleDealtGameCard, MeepleAISuggestionCard, MeeplePausedSessionCard
- **2 axe suppressions removed** — Re-enable `heading-order` rule on `AgentsLibraryView.test.tsx` + `LibroGameDetailView.test.tsx`.
- **Bonus heading fix** — `LibroGameDetailView.tsx` InfoPanel: `<h3>` → `<h2>` (h1→h3 skip caught by re-enabled rule, unrelated to MeepleCard but same WCAG family).
- **5 new axe scans added** — `LibraryHub`, `HubToolkitsBody`, `PlayersResultsGrid`, `GamesResultsGrid`, `GameNightPlanningLayout`.

## Decisions (locked in brainstorming 2026-06-04)

| ID | Decision |
|---|---|
| DEC-1 | Systematic audit of 59 consumers (issue body underestimated scope 2x — actual 20) |
| DEC-2 | Approach A — additive `headingLevel` prop, default 3 |
| DEC-3 | Per-consumer migration (NOT default change to 2) |
| DEC-4 | 5 new axe scans + 2 existing suppression re-enable |
| DEC-5 | DOM structure assertions only (no visual regression infra per Visual Gate REMOVED 2026-05-20) |
| DEC-6 | Defer 7 NEEDS_INSPECTION files to follow-up |
| DEC-7 | 4 variants migrate dynamic; FocusCard prop-accept with default 2; CompactCard skip (no heading) |

## Tests

- **5 new variant test blocks** (3-4 tests each) — 18 new assertions
- **1 cross-variant smoke test** — 15 tests (5 variants × 3 assertions)
- **1 contract test** — 3 assertions on `MeepleCardProps.headingLevel` type
- **2 existing axe suppressions removed** → rule re-enabled in production CI
- **5 new axe scans** cover key grid surfaces with heading-order rule enabled
- **Full meeple-card suite: 304 tests pass** (was 270, +34 new), typecheck 0 errors

## Pre-existing nested-interactive findings (out of scope)

T13 surfaced 2 pre-existing `nested-interactive` axe violations (button-in-button pattern):
- `LibraryHub` — `button[data-slot="library-grid-card"]` wraps MeepleCard
- `PlayersResultsGrid` — `<button data-slot="players-results-grid-item">` wraps MeepleCard

Both suppressed via P164 pattern with justification comments. Recommend separate follow-up issue. NOT introduced by this PR.

## Out of scope (deferred follow-up)

7 NEEDS_INSPECTION files (per spec DEC-6): `entity-list-view` polymorphic primitive, `shared-games-grid` passthrough, `MeepleChatCard` adapter (HomeFeed Chat Recenti), `MeepleContributorCard` deep-section, `MeepleParticipantCard` Scoreboard label, `PrivateGamesClient` unused-h1, `LibraryPanel` unused. Tracked for follow-up issue.

## Related

- Closes #1842
- Source debt: #1841 (P164 pattern), #1481 (earlier cluster)
- Origin coverage: #1569 (jest-axe agents-index)
- Spec: `docs/superpowers/specs/2026-06-04-meeple-card-heading-level-a11y-design.md`
- Plan: `docs/superpowers/plans/2026-06-04-meeple-card-heading-level-a11y.md`

## CI baseline notes

- If `Frontend Tests shard` fails per #1851 baseline (`AdvancedFilterPanel` flake), document in PR comment — NOT introduced by this PR.