### PR TITLE
feat(document-processing): #1831 follow-up PdfCoverOrphanRecoveryJob (orphan recovery)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
@@ -1,0 +1,168 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services.Pdf;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// Issue #1831 follow-up — orphan recovery for L4 PDF covers. Detects PDFs
+/// with <c>CoverGenerationStatus=Generated</c> whose R2 preview object is
+/// missing (deleted out-of-band, R2 lifecycle policy expiry, operator mistake)
+/// and resets them to <c>Pending</c> so the existing
+/// <see cref="BackfillPdfCoversJob"/> picks them up for re-generation on its
+/// next run.
+/// </summary>
+/// <remarks>
+/// <para>Deferred from PR #1873 where the AC item was listed as
+/// "Failed is terminal today, manual reset". This job automates the
+/// orphan-detection loop without requiring operator intervention.</para>
+/// <para>Daily cadence (03:00 UTC) because orphans are rare. The HEAD check
+/// via <see cref="IBlobStorageService.ExistsAsync"/> is cheap, but bounded by
+/// <see cref="BatchSize"/> = 50 per run to avoid runaway scans on very large
+/// catalogs. The inter-item sleep of <see cref="DelayBetweenItemsMs"/> = 1000ms
+/// keeps the blob storage call rate at ~1 RPS.</para>
+/// </remarks>
+[DisallowConcurrentExecution]
+public sealed class PdfCoverOrphanRecoveryJob : IJob
+{
+    /// <summary>
+    /// Maximum number of PDFs checked in a single job run. Keeps the blob
+    /// storage scan rate well below 1 RPS even with the default 1000ms delay.
+    /// </summary>
+    public const int BatchSize = 50;
+
+    /// <summary>
+    /// Sleep between individual existence checks in ms. Throttles the R2 call
+    /// rate to roughly 1 RPS to avoid storage quota bursts.
+    /// </summary>
+    public const int DelayBetweenItemsMs = 1000;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<PdfCoverOrphanRecoveryJob> _logger;
+
+    public PdfCoverOrphanRecoveryJob(
+        IServiceProvider serviceProvider,
+        ILogger<PdfCoverOrphanRecoveryJob> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+        _logger.LogDebug("PdfCoverOrphanRecoveryJob started: FireTime={FireTime}", context.FireTimeUtc);
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+
+        await RunBatchAsync(db, blob, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Internal batch runner — extracted from <see cref="Execute"/> so unit
+    /// tests can drive it directly without spinning up the Quartz scheduler.
+    /// </summary>
+    internal async Task RunBatchAsync(
+        MeepleAiDbContext db,
+        IBlobStorageService blob,
+        CancellationToken ct)
+    {
+        var generatedStatus = nameof(PdfCoverGenerationStatus.Generated);
+
+        // AsTracking: override global NoTracking (PERF-06) so mutations persist.
+        // Filter: Generated + non-null CoverR2Key only. OrderBy UpdatedAt for
+        // stable pagination across daily runs (oldest checked first).
+        var batch = await db.PdfDocuments
+            .AsTracking()
+            .Where(p => p.CoverGenerationStatus == generatedStatus && p.CoverR2Key != null)
+            .OrderBy(p => p.UpdatedAt)
+            .Take(BatchSize)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (batch.Count == 0)
+        {
+            _logger.LogDebug("PdfCoverOrphanRecoveryJob: no eligible PDFs to check");
+            return;
+        }
+
+        _logger.LogDebug(
+            "PdfCoverOrphanRecoveryJob: checking {Count} Generated PDFs for orphan covers",
+            batch.Count);
+
+        var orphanCount = 0;
+
+        for (var i = 0; i < batch.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var pdf = batch[i];
+
+            try
+            {
+                // Check for the preview variant as the canonical existence signal.
+                // If preview is missing, thumb is likely gone too — reset for full re-generation.
+                var previewFileId = $"{pdf.CoverR2Key}-preview.webp";
+                var exists = await blob.ExistsAsync(
+                    previewFileId,
+                    BlobCategory.GameImage,
+                    pdf.CoverR2Key!,
+                    ct).ConfigureAwait(false);
+
+                if (!exists)
+                {
+                    _logger.LogWarning(
+                        "PdfCoverOrphanRecoveryJob: orphan cover detected — resetting to Pending. " +
+                        "PdfDocumentId={Id}, OrphanKey={Key}",
+                        pdf.Id, pdf.CoverR2Key);
+
+                    pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Pending);
+                    pdf.CoverR2Key = null;
+                    pdf.CoverGenerationError = null;
+                    pdf.CoverPageIndex = null;
+                    pdf.UpdatedAt = DateTime.UtcNow;
+                    orphanCount++;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            // ORPHAN-RECOVERY PATTERN: per-item failures must not abort the batch — log
+            // and skip so a single unreachable R2 key doesn't block the full scan.
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogWarning(ex,
+                    "PdfCoverOrphanRecoveryJob: failed to check existence for PDF {Id} with key {Key}; skipping",
+                    pdf.Id, pdf.CoverR2Key);
+            }
+
+            // Sleep between items, but skip the trailing delay after the last item.
+            if (i < batch.Count - 1)
+            {
+                await Task.Delay(DelayBetweenItemsMs, ct).ConfigureAwait(false);
+            }
+        }
+
+        if (orphanCount > 0)
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "PdfCoverOrphanRecoveryJob: reset {Count} orphan cover(s) to Pending for re-generation",
+                orphanCount);
+        }
+        else
+        {
+            _logger.LogDebug("PdfCoverOrphanRecoveryJob: no orphan covers found in this batch");
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -184,6 +184,9 @@ internal static class DocumentProcessingServiceExtensions
         // Issue #1831: Register Quartz job for L4 PDF cover backfill (every 30 minutes)
         RegisterBackfillPdfCoversJob(services);
 
+        // Issue #1831 follow-up: Register Quartz job for orphan cover recovery (daily at 03:00 UTC)
+        RegisterPdfCoverOrphanRecoveryJob(services);
+
         return services;
     }
 
@@ -209,6 +212,30 @@ internal static class DocumentProcessingServiceExtensions
                     .WithIntervalInMinutes(30)
                     .RepeatForever())
                 .WithDescription("Backfills L4 PDF covers for PDFs whose ingestion completed without a cover")
+            );
+        });
+    }
+
+    /// <summary>
+    /// Issue #1831 follow-up — registers <see cref="Api.BoundedContexts.DocumentProcessing.Application.Jobs.PdfCoverOrphanRecoveryJob"/>
+    /// with the Quartz scheduler. Runs daily at 03:00 UTC to scan PDFs with
+    /// <c>CoverGenerationStatus=Generated</c> whose R2 object is missing and
+    /// reset them to <c>Pending</c> for re-generation by <see cref="Api.BoundedContexts.DocumentProcessing.Application.Jobs.BackfillPdfCoversJob"/>.
+    /// </summary>
+    private static void RegisterPdfCoverOrphanRecoveryJob(IServiceCollection services)
+    {
+        services.AddQuartz(q =>
+        {
+            var jobKey = new Quartz.JobKey("PdfCoverOrphanRecoveryJob", "DocumentProcessing");
+
+            q.AddJob<Api.BoundedContexts.DocumentProcessing.Application.Jobs.PdfCoverOrphanRecoveryJob>(opts =>
+                opts.WithIdentity(jobKey));
+
+            q.AddTrigger(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("PdfCoverOrphanRecoveryTrigger", "DocumentProcessing")
+                .WithCronSchedule("0 0 3 * * ?") // Daily at 03:00 UTC
+                .WithDescription("Detects Generated PDF covers whose R2 object is missing and resets them to Pending for re-generation")
             );
         });
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
@@ -1,0 +1,164 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IBlobStorageService> _blob = new();
+
+    public PdfCoverOrphanRecoveryJobTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"PdfCoverOrphanRecoveryJob_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private PdfCoverOrphanRecoveryJob CreateJob() =>
+        new(new Mock<IServiceProvider>().Object, NullLogger<PdfCoverOrphanRecoveryJob>.Instance);
+
+    private PdfDocumentEntity SeedPdf(
+        string? coverR2Key = null,
+        string coverStatus = "Generated",
+        DateTime? updatedAt = null)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            CoverGenerationStatus = coverStatus,
+            CoverR2Key = coverR2Key,
+            UpdatedAt = updatedAt ?? DateTime.UtcNow,
+        };
+        _db.PdfDocuments.Add(pdf);
+        _db.SaveChanges();
+        return pdf;
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_NoGeneratedPdfs_NoOp()
+    {
+        // No PDFs in DB at all → ExistsAsync must never be called
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        _blob.Verify(b => b.ExistsAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_AllGeneratedExist_NoReset()
+    {
+        // 3 PDFs, all with CoverR2Key, all returning true from ExistsAsync
+        SeedPdf(coverR2Key: "pdf-cover-aaa");
+        SeedPdf(coverR2Key: "pdf-cover-bbb");
+        SeedPdf(coverR2Key: "pdf-cover-ccc");
+
+        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(true);
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        // All statuses must remain Generated, keys must remain set
+        var all = _db.PdfDocuments.AsNoTracking().ToList();
+        all.Should().AllSatisfy(p =>
+        {
+            p.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated));
+            p.CoverR2Key.Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_OrphanDetected_ResetsToPending()
+    {
+        // 1 PDF with key, ExistsAsync returns false → orphan → reset all 4 fields
+        var orphan = SeedPdf(coverR2Key: "pdf-cover-missing");
+        orphan.CoverGenerationError = "stale-error";
+        orphan.CoverPageIndex = 2;
+        _db.SaveChanges();
+
+        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(false);
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        var reset = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == orphan.Id);
+        reset.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending));
+        reset.CoverR2Key.Should().BeNull();
+        reset.CoverGenerationError.Should().BeNull();
+        reset.CoverPageIndex.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_BatchSizeLimit_ProcessesMaxBatchSize()
+    {
+        // 51 Generated PDFs — only BatchSize (50) should be checked
+        for (var i = 0; i < 51; i++)
+        {
+            SeedPdf(coverR2Key: $"pdf-cover-{i:D2}", updatedAt: DateTime.UtcNow.AddMinutes(-i));
+        }
+
+        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(true); // All exist → no resets, only call count matters
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        _blob.Verify(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(PdfCoverOrphanRecoveryJob.BatchSize));
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_ExistsAsyncThrows_LogsAndContinuesBatch()
+    {
+        // First PDF: ExistsAsync throws → skip (stays Generated)
+        // Second PDF: ExistsAsync returns false → reset to Pending
+        var first = SeedPdf(coverR2Key: "pdf-cover-throws", updatedAt: DateTime.UtcNow.AddMinutes(-10));
+        var second = SeedPdf(coverR2Key: "pdf-cover-missing", updatedAt: DateTime.UtcNow);
+
+        _blob.SetupSequence(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ThrowsAsync(new InvalidOperationException("Network error"))
+             .ReturnsAsync(false);
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        var firstResult = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == first.Id);
+        firstResult.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated),
+            "exception on first item must not corrupt its status — skip and continue");
+
+        var secondResult = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == second.Id);
+        secondResult.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending),
+            "second orphan must be reset despite first item throwing");
+        secondResult.CoverR2Key.Should().BeNull();
+    }
+}

--- a/docs/superpowers/plans/2026-06-04-pdf-cover-orphan-recovery.md
+++ b/docs/superpowers/plans/2026-06-04-pdf-cover-orphan-recovery.md
@@ -1,0 +1,441 @@
+# PDF Cover Orphan Recovery Job — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `PdfCoverOrphanRecoveryJob` Quartz daily job that detects PDFs with `CoverGenerationStatus=Generated` but R2 object missing, and resets them to `Pending` for re-generation via existing `BackfillPdfCoversJob`.
+
+**Architecture:** New Quartz job in `DocumentProcessing.Application.Jobs`. Mirrors `BackfillPdfCoversJob` pattern (DisallowConcurrentExecution, internal RunBatchAsync for testing, scoped DI). Single file + test file + DI registration extension.
+
+**Tech Stack:** .NET 9, Quartz, EF Core, MediatR (not used here), Moq + xUnit for tests.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-04-pdf-cover-orphan-recovery-design.md` (commit `6d77e4780`).
+
+---
+
+## File Structure
+
+### New files
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs` (~150 LOC)
+- `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs` (~200 LOC)
+
+### Modified
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/DocumentProcessingServiceExtensions.cs` (add `RegisterPdfCoverOrphanRecoveryJob` method + invocation)
+
+---
+
+## Task 1: PdfCoverOrphanRecoveryJob + Tests + DI registration
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/DocumentProcessingServiceExtensions.cs`
+
+- [ ] **Step 1: Read reference pattern**
+
+```bash
+cat apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+cat apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs | head -100
+grep -A5 "RegisterPdfProcessingQueueJob\|RegisterBackfillPdfCoversJob" apps/api/src/Api/BoundedContexts/DocumentProcessing/DocumentProcessingServiceExtensions.cs
+```
+
+Understand:
+- Job structure (DisallowConcurrentExecution attribute, ServiceProvider scope, internal RunBatchAsync)
+- DI registration pattern (`RegisterXxxJob` helper)
+- Test pattern (Moq for IBlobStorageService, in-memory MeepleAiDbContext)
+
+- [ ] **Step 2: Write the failing test file**
+
+```csharp
+// apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
+using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class PdfCoverOrphanRecoveryJobTests
+{
+    private readonly Mock<IBlobStorageService> _blob = new();
+
+    [Fact]
+    public async Task RunBatchAsync_NoGeneratedPdfs_NoOp()
+    {
+        await using var db = CreateInMemoryDb();
+        var job = CreateJob();
+
+        await job.RunBatchAsync(db, _blob.Object, CancellationToken.None);
+
+        _blob.Verify(b => b.ExistsAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(),
+                                         It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                     Times.Never);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_AllGeneratedExist_NoReset()
+    {
+        await using var db = CreateInMemoryDb();
+        SeedPdf(db, "key-1", PdfCoverGenerationStatus.Generated);
+        SeedPdf(db, "key-2", PdfCoverGenerationStatus.Generated);
+        SeedPdf(db, "key-3", PdfCoverGenerationStatus.Generated);
+        await db.SaveChangesAsync();
+
+        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                                        It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(true);
+
+        var job = CreateJob();
+        await job.RunBatchAsync(db, _blob.Object, CancellationToken.None);
+
+        var unchanged = await db.PdfDocuments.AsNoTracking().ToListAsync();
+        Assert.All(unchanged, p => Assert.Equal(nameof(PdfCoverGenerationStatus.Generated), p.CoverGenerationStatus));
+        Assert.All(unchanged, p => Assert.NotNull(p.CoverR2Key));
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_OrphanDetected_ResetsToPending()
+    {
+        await using var db = CreateInMemoryDb();
+        var orphan = SeedPdf(db, "missing-key", PdfCoverGenerationStatus.Generated);
+        orphan.CoverGenerationError = "stale";
+        orphan.CoverPageIndex = 2;
+        await db.SaveChangesAsync();
+
+        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                                        It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(false);
+
+        var job = CreateJob();
+        await job.RunBatchAsync(db, _blob.Object, CancellationToken.None);
+
+        var reset = await db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == orphan.Id);
+        Assert.Equal(nameof(PdfCoverGenerationStatus.Pending), reset.CoverGenerationStatus);
+        Assert.Null(reset.CoverR2Key);
+        Assert.Null(reset.CoverGenerationError);
+        Assert.Null(reset.CoverPageIndex);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_BatchSizeLimit_ProcessesMaxBatchSize()
+    {
+        await using var db = CreateInMemoryDb();
+        // Seed 51 generated PDFs (one more than BatchSize = 50)
+        for (var i = 0; i < 51; i++)
+        {
+            SeedPdf(db, $"key-{i:D2}", PdfCoverGenerationStatus.Generated);
+        }
+        await db.SaveChangesAsync();
+
+        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                                        It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(true);
+
+        var job = CreateJob();
+        await job.RunBatchAsync(db, _blob.Object, CancellationToken.None);
+
+        _blob.Verify(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                                         It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                     Times.Exactly(PdfCoverOrphanRecoveryJob.BatchSize));
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_ExistsAsyncThrows_LogsAndContinuesBatch()
+    {
+        await using var db = CreateInMemoryDb();
+        var first = SeedPdf(db, "throws-key", PdfCoverGenerationStatus.Generated);
+        var second = SeedPdf(db, "missing-key", PdfCoverGenerationStatus.Generated);
+        await db.SaveChangesAsync();
+
+        _blob.SetupSequence(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
+                                                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ThrowsAsync(new InvalidOperationException("Network error"))
+             .ReturnsAsync(false);
+
+        var job = CreateJob();
+        await job.RunBatchAsync(db, _blob.Object, CancellationToken.None);
+
+        // First item should remain Generated (skipped due to exception)
+        var firstResult = await db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == first.Id);
+        Assert.Equal(nameof(PdfCoverGenerationStatus.Generated), firstResult.CoverGenerationStatus);
+
+        // Second item should be reset (orphan detected)
+        var secondResult = await db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == second.Id);
+        Assert.Equal(nameof(PdfCoverGenerationStatus.Pending), secondResult.CoverGenerationStatus);
+        Assert.Null(secondResult.CoverR2Key);
+    }
+
+    // === Helpers ===
+
+    private static MeepleAiDbContext CreateInMemoryDb()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new MeepleAiDbContext(options);
+    }
+
+    private static PdfDocumentEntity SeedPdf(MeepleAiDbContext db, string coverKey, PdfCoverGenerationStatus status)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            FilePath = "test/path.pdf",
+            FileSize = 1000,
+            OriginalFileName = "test.pdf",
+            ContentType = "application/pdf",
+            UploadedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            ProcessingState = nameof(PdfProcessingState.Ready),
+            CoverGenerationStatus = nameof(status),
+            CoverR2Key = coverKey,
+        };
+        db.PdfDocuments.Add(pdf);
+        return pdf;
+    }
+
+    private static PdfCoverOrphanRecoveryJob CreateJob()
+    {
+        // ServiceProvider is unused by RunBatchAsync; pass null-equivalent
+        var sp = new Mock<IServiceProvider>().Object;
+        return new PdfCoverOrphanRecoveryJob(sp, NullLogger<PdfCoverOrphanRecoveryJob>.Instance);
+    }
+}
+```
+
+**IMPORTANT before writing**: Read the existing `BackfillPdfCoversJobTests.cs` test setup to verify if `MeepleAiDbContext` In-Memory DB pattern is OK or if Testcontainers Postgres is required (HasQueryFilter / specific Postgres functions may not work in-memory).
+
+If In-Memory fails due to EF Core feature constraints, mock `IPdfDocumentRepository` instead (if exists) or use the same pattern from BackfillPdfCoversJobTests.
+
+- [ ] **Step 3: Run test to verify failure**
+
+```bash
+dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~PdfCoverOrphanRecoveryJobTests" --no-build 2>&1 | tail -10
+```
+
+Expected: COMPILE ERROR — `PdfCoverOrphanRecoveryJob` doesn't exist yet.
+
+- [ ] **Step 4: Implement PdfCoverOrphanRecoveryJob**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using Api.Services.Pdf;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// Issue #1831 follow-up — orphan recovery for L4 PDF covers. Detects PDFs
+/// with <c>CoverGenerationStatus=Generated</c> but the R2 object missing
+/// (deleted out-of-band, R2 lifecycle policy expiry, manual ops mistake) and
+/// resets them to <c>Pending</c> so the existing
+/// <see cref="BackfillPdfCoversJob"/> picks them up for re-generation.
+/// </summary>
+/// <remarks>
+/// <para>Deferred from PR #1873 where the AC item ⏸ was listed as
+/// "Failed is terminal today, manual reset". This job automates that
+/// orphan-detection loop without operator intervention.</para>
+/// <para>Daily cadence (03:00 UTC) because orphans are rare. The HEAD check
+/// via <see cref="IBlobStorageService.ExistsAsync"/> is cheap, but bounded by
+/// <see cref="BatchSize"/> = 50 per run to avoid runaway scans on very large
+/// catalogs. Inter-item sleep of <see cref="DelayBetweenItemsMs"/> = 1000ms
+/// keeps the blob storage call rate at ~1 RPS.</para>
+/// </remarks>
+[DisallowConcurrentExecution]
+public sealed class PdfCoverOrphanRecoveryJob : IJob
+{
+    public const int BatchSize = 50;
+    public const int DelayBetweenItemsMs = 1000;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<PdfCoverOrphanRecoveryJob> _logger;
+
+    public PdfCoverOrphanRecoveryJob(
+        IServiceProvider serviceProvider,
+        ILogger<PdfCoverOrphanRecoveryJob> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+        _logger.LogDebug("PdfCoverOrphanRecoveryJob started: FireTime={FireTime}", context.FireTimeUtc);
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+
+        await RunBatchAsync(db, blob, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Internal batch runner — extracted from <see cref="Execute"/> so unit
+    /// tests can drive it directly without spinning up the Quartz scheduler.
+    /// </summary>
+    internal async Task RunBatchAsync(
+        MeepleAiDbContext db,
+        IBlobStorageService blob,
+        CancellationToken ct)
+    {
+        var generatedStatus = nameof(PdfCoverGenerationStatus.Generated);
+
+        var batch = await db.PdfDocuments
+            .AsTracking()
+            .Where(p => p.CoverGenerationStatus == generatedStatus && p.CoverR2Key != null)
+            .OrderBy(p => p.UpdatedAt)
+            .Take(BatchSize)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (batch.Count == 0)
+        {
+            _logger.LogDebug("PdfCoverOrphanRecoveryJob: no eligible PDFs in queue");
+            return;
+        }
+
+        var orphanCount = 0;
+        for (var i = 0; i < batch.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var pdf = batch[i];
+            try
+            {
+                var exists = await blob.ExistsAsync(
+                    $"{pdf.CoverR2Key}-preview.webp",
+                    BlobCategory.GameImage,
+                    pdf.CoverR2Key!,
+                    ct).ConfigureAwait(false);
+
+                if (!exists)
+                {
+                    _logger.LogWarning(
+                        "Orphan PDF cover detected, resetting to Pending: PdfDocumentId={Id}, OrphanKey={Key}",
+                        pdf.Id, pdf.CoverR2Key);
+
+                    pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Pending);
+                    pdf.CoverR2Key = null;
+                    pdf.CoverGenerationError = null;
+                    pdf.CoverPageIndex = null;
+                    pdf.UpdatedAt = DateTimeOffset.UtcNow;
+                    orphanCount++;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to check existence for PDF {Id} with key {Key}; skipping in this batch",
+                    pdf.Id, pdf.CoverR2Key);
+            }
+
+            // Sleep between items (skip after last item to avoid trailing delay)
+            if (i < batch.Count - 1)
+            {
+                await Task.Delay(DelayBetweenItemsMs, ct).ConfigureAwait(false);
+            }
+        }
+
+        if (orphanCount > 0)
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation("PdfCoverOrphanRecoveryJob: reset {Count} orphan covers to Pending", orphanCount);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Register Quartz job in DocumentProcessingServiceExtensions**
+
+Find the existing `RegisterBackfillPdfCoversJob` private method in `DocumentProcessingServiceExtensions.cs` and add a sibling method `RegisterPdfCoverOrphanRecoveryJob`, then invoke it in the configurator block (same place as the backfill registration).
+
+```csharp
+// In DocumentProcessingServiceExtensions.cs (add new method + invoke):
+
+private static void RegisterPdfCoverOrphanRecoveryJob(IServiceCollectionQuartzConfigurator quartz)
+{
+    var jobKey = new JobKey(nameof(PdfCoverOrphanRecoveryJob));
+    quartz.AddJob<PdfCoverOrphanRecoveryJob>(opts => opts.WithIdentity(jobKey));
+    quartz.AddTrigger(opts => opts
+        .ForJob(jobKey)
+        .WithIdentity($"{nameof(PdfCoverOrphanRecoveryJob)}-trigger")
+        .WithCronSchedule("0 0 3 * * ?")); // Daily at 03:00 UTC
+}
+```
+
+And in the existing Quartz configurator block, after `RegisterBackfillPdfCoversJob(q);`:
+```csharp
+RegisterPdfCoverOrphanRecoveryJob(q);
+```
+
+- [ ] **Step 6: Run build + tests**
+
+```bash
+dotnet build apps/api/src/Api 2>&1 | tail -5
+# Expected: BUILD SUCCEEDED
+
+dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~PdfCoverOrphanRecoveryJobTests" 2>&1 | tail -15
+# Expected: 5/5 PASS
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs \
+        apps/api/src/Api/BoundedContexts/DocumentProcessing/DocumentProcessingServiceExtensions.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
+git commit -m "feat(document-processing): #1831 follow-up PdfCoverOrphanRecoveryJob daily orphan detection"
+```
+
+## Self-Review Checklist
+
+- [ ] Job has `[DisallowConcurrentExecution]` attribute
+- [ ] Constants `BatchSize = 50`, `DelayBetweenItemsMs = 1000`
+- [ ] Internal `RunBatchAsync` method (testable without Quartz scheduler)
+- [ ] Query filters on `CoverGenerationStatus = Generated AND CoverR2Key != null`
+- [ ] OrderBy `UpdatedAt` for stable ordering
+- [ ] `ExistsAsync` called with correct fileId (`{CoverR2Key}-preview.webp`), category `GameImage`, resourceKey (`CoverR2Key`)
+- [ ] On orphan: reset all 4 cover fields + UpdatedAt
+- [ ] `OperationCanceledException` re-thrown; other exceptions logged + continue
+- [ ] Sleep between items (skip after last)
+- [ ] SaveChangesAsync only if orphanCount > 0 (avoid empty save)
+- [ ] Log warning per orphan + info summary after batch
+- [ ] Quartz registered with daily 03:00 UTC cron
+- [ ] 5 unit tests cover all spec scenarios
+- [ ] Build + tests pass
+
+## Spec coverage check (all AC mapped)
+
+| AC | Task step |
+|---|---|
+| Quartz job with DisallowConcurrentExecution | Step 4 |
+| Daily cron 03:00 UTC | Step 5 |
+| Internal RunBatchAsync | Step 4 |
+| BatchSize=50, Delay=1000 | Step 4 |
+| Query filter + ordering | Step 4 |
+| ExistsAsync per-item | Step 4 |
+| Reset fields on orphan | Step 4 |
+| Log warning + info | Step 4 |
+| Exception handling | Step 4 |
+| 5 unit tests | Step 2 |
+| DI registration | Step 5 |

--- a/docs/superpowers/specs/2026-06-04-pdf-cover-orphan-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-04-pdf-cover-orphan-recovery-design.md
@@ -1,0 +1,170 @@
+# PDF Cover Orphan Recovery Job — Design
+
+**Status**: Spec — pending implementation
+**Issue**: #1831 follow-up (deferred from PR #1873)
+**Effort estimate**: ~1.5-2h
+**Date**: 2026-06-04
+**Branch**: `feature/issue-1831-orphan-recovery-followup` (parent: `main-dev`)
+
+## Summary
+
+PR #1873 closed the bulk of #1831 AC but explicitly deferred orphan recovery: PDFs with `CoverGenerationStatus=Generated` and `CoverR2Key` set but the R2 object missing (e.g., deleted out-of-band, R2 bucket lifecycle policy expiry, manual ops mistake). Operators currently must reset manually to `Pending` for re-generation.
+
+This spec introduces a daily Quartz job `PdfCoverOrphanRecoveryJob` that detects orphans (HEAD check via `IBlobStorageService.ExistsAsync`) and resets the entity to `Pending` so the existing `BackfillPdfCoversJob` (every 30min) picks it up for re-generation.
+
+## Goals & Non-goals
+
+### Goals
+- Detect orphans automatically without operator intervention
+- Reset orphan entity to clean `Pending` state (null all cover fields)
+- Re-generation happens via existing `BackfillPdfCoversJob` (no duplication of extraction logic)
+- Daily cadence (orphans are rare; no need for hourly scan)
+
+### Non-goals
+- Re-generate inline (delegate to `BackfillPdfCoversJob`)
+- Detect orphans in real-time (lazy daily check sufficient)
+- Manual admin endpoint (potential future, out of scope here)
+- Track orphan detection metrics in dedicated table (audit via log only, sufficient for diagnostic)
+
+## Architecture
+
+### File structure
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs` (~150 LOC)
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs` (~200 LOC, 5 unit tests)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/DocumentProcessingServiceExtensions.cs` (register Quartz job)
+
+### Algorithm
+
+```csharp
+public async Task Execute(IJobExecutionContext context)
+{
+    using var scope = _serviceProvider.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+    await RunBatchAsync(db, blob, context.CancellationToken);
+}
+
+internal async Task RunBatchAsync(MeepleAiDbContext db, IBlobStorageService blob, CancellationToken ct)
+{
+    var generatedStatus = nameof(PdfCoverGenerationStatus.Generated);
+    
+    var batch = await db.PdfDocuments
+        .AsTracking()
+        .Where(p => p.CoverGenerationStatus == generatedStatus && p.CoverR2Key != null)
+        .OrderBy(p => p.UpdatedAt)
+        .Take(BatchSize)
+        .ToListAsync(ct);
+    
+    if (batch.Count == 0) return;
+    
+    var orphanCount = 0;
+    foreach (var pdf in batch)
+    {
+        ct.ThrowIfCancellationRequested();
+        try
+        {
+            var exists = await blob.ExistsAsync(
+                $"{pdf.CoverR2Key}-preview.webp",
+                BlobCategory.GameImage,
+                pdf.CoverR2Key,
+                ct);
+            
+            if (!exists)
+            {
+                _logger.LogWarning(
+                    "Orphan PDF cover detected, resetting to Pending: PdfDocumentId={Id}, OrphanKey={Key}",
+                    pdf.Id, pdf.CoverR2Key);
+                
+                pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Pending);
+                pdf.CoverR2Key = null;
+                pdf.CoverGenerationError = null;
+                pdf.CoverPageIndex = null;
+                orphanCount++;
+            }
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to check existence for PDF {Id} with key {Key}; skipping in this batch",
+                pdf.Id, pdf.CoverR2Key);
+        }
+        await Task.Delay(DelayBetweenItemsMs, ct);
+    }
+    
+    if (orphanCount > 0)
+    {
+        await db.SaveChangesAsync(ct);
+    }
+}
+```
+
+### Configuration constants
+
+| Constant | Value | Rationale |
+|---|---|---|
+| `BatchSize` | 50 | Higher than backfill (5) because HEAD check is faster than extraction; still bounded to prevent runaway scans |
+| `DelayBetweenItemsMs` | 1000 | Gentle 1 RPS on blob storage (orphan check is HEAD; cheap) |
+| Schedule | `0 0 3 * * ?` Quartz cron | Daily at 03:00 UTC (low traffic) |
+
+### Quartz registration
+
+In `DocumentProcessingServiceExtensions`:
+```csharp
+private static void RegisterPdfCoverOrphanRecoveryJob(IServiceCollectionQuartzConfigurator quartz)
+{
+    var jobKey = new JobKey(nameof(PdfCoverOrphanRecoveryJob));
+    quartz.AddJob<PdfCoverOrphanRecoveryJob>(opts => opts.WithIdentity(jobKey));
+    quartz.AddTrigger(opts => opts
+        .ForJob(jobKey)
+        .WithIdentity($"{nameof(PdfCoverOrphanRecoveryJob)}-trigger")
+        .WithCronSchedule("0 0 3 * * ?")); // Daily at 03:00 UTC
+}
+```
+
+## Failure modes
+
+| Failure | Recovery |
+|---|---|
+| `ExistsAsync` throws | Log warning, skip this item, continue batch (best-effort) |
+| `SaveChangesAsync` throws | Quartz retries job per `DisallowConcurrentExecution`; orphan detection re-runs next day |
+| `OperationCanceledException` | Re-throw to honor cancellation |
+| Job runs past 03:00 next day | `DisallowConcurrentExecution` prevents overlap |
+
+## Test plan
+
+5 unit tests in `PdfCoverOrphanRecoveryJobTests`:
+
+1. **`RunBatchAsync_NoGeneratedPdfs_NoOp`** — empty query result → ExistsAsync never called, no SaveChangesAsync
+2. **`RunBatchAsync_AllGeneratedExist_NoReset`** — 3 entities, all `ExistsAsync` returns true → 0 resets, no SaveChangesAsync (orphanCount == 0)
+3. **`RunBatchAsync_OrphanDetected_ResetsToPending`** — 1 entity, ExistsAsync returns false → entity reset (Pending + nullified fields) + SaveChangesAsync called
+4. **`RunBatchAsync_BatchSizeLimit_ProcessesMax50`** — seed 51 entities, only 50 processed (ordering by UpdatedAt)
+5. **`RunBatchAsync_ExistsAsyncThrows_LogsAndContinues`** — first item throws, second item processed → no propagation, 1 orphan detected
+
+## Acceptance criteria
+
+- [ ] `PdfCoverOrphanRecoveryJob` Quartz job created with `[DisallowConcurrentExecution]` attribute
+- [ ] Daily cron schedule `0 0 3 * * ?` (03:00 UTC)
+- [ ] Internal `RunBatchAsync` method for direct unit testing
+- [ ] BatchSize=50, DelayBetweenItemsMs=1000 constants
+- [ ] Query: `CoverGenerationStatus=Generated AND CoverR2Key NOT NULL`, ordered by `UpdatedAt`
+- [ ] Per-item: `ExistsAsync({CoverR2Key}-preview.webp, GameImage, CoverR2Key)` check
+- [ ] On orphan: reset `CoverGenerationStatus=Pending`, null `CoverR2Key` + `CoverGenerationError` + `CoverPageIndex`
+- [ ] Log warning with PdfDocumentId + orphan key
+- [ ] OperationCanceledException re-thrown; other exceptions logged + continue batch
+- [ ] 5 unit tests pass (covering AC scenarios)
+- [ ] DI registration in `DocumentProcessingServiceExtensions`
+
+## Out of scope (deferred future work)
+
+- Admin on-demand endpoint to trigger orphan recovery manually
+- Telemetry dashboard for orphan rate over time
+- Bidirectional check (orphan blobs in R2 without corresponding DB entries — would require R2 ListObjects, expensive)
+- Multi-region check (single R2 bucket assumed)
+- Re-generation inline (delegated to BackfillPdfCoversJob)
+
+## References
+
+- Source issue: [#1831](https://github.com/meepleAi-app/meepleai-monorepo/issues/1831) AC item ⏸ deferred in PR #1873
+- Pattern reference: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs` (mirror Quartz job structure)
+- Interface: `IBlobStorageService.ExistsAsync` at `apps/api/src/Api/Services/Pdf/IBlobStorageService.cs:123`


### PR DESCRIPTION
## Summary

Implements the orphan recovery follow-up deferred from PR #1873 of #1831. Detects PDFs with \`CoverGenerationStatus=Generated\` but R2 object missing, and resets them to \`Pending\` so the existing \`BackfillPdfCoversJob\` re-generates them.

## Context

PR #1873 closed the bulk of #1831 AC but explicitly listed orphan recovery as deferred:
> \"⏸ Orphan recovery (CoverR2Key set but R2 object missing) — deferred. Failed is terminal today; manual reset-to-Pending if an operator wants a fresh attempt after addressing the root cause.\"

This PR automates that manual reset loop.

## Architecture

- **New Quartz job** \`PdfCoverOrphanRecoveryJob\` (Daily 03:00 UTC, \`DisallowConcurrentExecution\`)
- **Query**: \`CoverGenerationStatus = Generated AND CoverR2Key NOT NULL\`, ordered by \`UpdatedAt\`, batch 50
- **Per-item**: \`IBlobStorageService.ExistsAsync\` HEAD check for \`{CoverR2Key}-preview.webp\`
- **On orphan**: reset all 4 cover fields (\`CoverGenerationStatus=Pending\`, \`CoverR2Key=null\`, \`CoverGenerationError=null\`, \`CoverPageIndex=null\`) + \`UpdatedAt=UtcNow\`
- **Best-effort**: \`OperationCanceledException\` re-thrown; other exceptions logged + continue batch
- **Re-generation**: delegated to existing \`BackfillPdfCoversJob\` (every 30min) which picks up the \`Pending\` status

## Design decisions

- **Separate job** (vs extending \`BackfillPdfCoversJob\`): single responsibility, slower cadence justified for HEAD scan, separate metrics
- **Daily cadence**: orphans are rare; no need for hourly
- **Check preview.webp only**: \`PdfCoverExtractor\` uploads thumb+preview atomically (either both exist or neither)
- **Reset all cover fields**: clean re-generation state via \`BackfillPdfCoversJob\`
- **BatchSize 50, DelayBetweenItemsMs 1000**: gentler than backfill (5+500) because HEAD is cheap but bounded

## Test plan

5 unit tests in \`PdfCoverOrphanRecoveryJobTests\`:
- [x] \`RunBatchAsync_NoGeneratedPdfs_NoOp\`
- [x] \`RunBatchAsync_AllGeneratedExist_NoReset\`
- [x] \`RunBatchAsync_OrphanDetected_ResetsToPending\`
- [x] \`RunBatchAsync_BatchSizeLimit_ProcessesMaxBatchSize\`
- [x] \`RunBatchAsync_ExistsAsyncThrows_LogsAndContinuesBatch\`

5/5 PASS locally. Build clean (0 warnings, 0 errors).

## Pipeline

- **Pipeline**: superpowers full-chain (brainstorm → spec compact → plan 1-task → subagent-driven 1 sonnet implementer)
- **Spec**: \`docs/superpowers/specs/2026-06-04-pdf-cover-orphan-recovery-design.md\` (commit \`6d77e4780\`)
- **Plan**: \`docs/superpowers/plans/2026-06-04-pdf-cover-orphan-recovery.md\` (commit \`3246d676c\`)
- **Impl**: commit \`ff7ab4fae\`
- **3 commits, ~310 LOC source + 130 LOC tests + 600 LOC docs**

## Out of scope (deferred future work)

- Admin on-demand endpoint to trigger orphan recovery manually
- Telemetry dashboard for orphan rate over time
- Bidirectional check (orphan blobs in R2 without DB entries — would require R2 ListObjects, expensive)
- Re-generation inline (delegated to BackfillPdfCoversJob by design)

Closes the deferred AC item from PR #1873 (umbrella #1821 fully closed already; #1831 sub-issue fully closed via #1873).

🤖 Generated with [Claude Code](https://claude.com/claude-code)