### PR TITLE
feat(admin-catalog): #1880 error states for SyncStatusHero + SyncRunTimeline

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncRunTimeline.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncRunTimeline.test.tsx
@@ -89,3 +89,54 @@ describe('SyncRunTimeline', () => {
     await waitFor(() => expect(screen.getByText(/Nessun run/i)).toBeInTheDocument());
   });
 });
+
+describe('SyncRunTimeline — error state (#1880)', () => {
+  function setupError(errorMessage = '500 Internal Server Error') {
+    vi.mocked(api.fetchCatalogSyncRuns).mockRejectedValue(new Error(errorMessage));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    };
+  }
+
+  it('renders distinct error alert (NOT empty state) when /runs fetch fails', async () => {
+    const { wrapper } = setupError('500 Internal Server Error');
+    render(<SyncRunTimeline onDrillDown={vi.fn()} />, { wrapper });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Impossibile caricare la timeline/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/500 Internal Server Error/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Riprova/i })).toBeInTheDocument();
+    // Critically: empty state semantics differ from error semantics
+    expect(screen.queryByText(/Nessun run registrato/i)).not.toBeInTheDocument();
+  });
+
+  it('refetches when Retry clicked (recovers after transient error)', async () => {
+    vi.mocked(api.fetchCatalogSyncRuns)
+      .mockRejectedValueOnce(new Error('502 Bad Gateway'))
+      .mockResolvedValue({
+        items: [sampleRun({ id: 'r1' })],
+        total: 1,
+        page: 1,
+        pageSize: 12,
+        hasMore: false,
+      });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    render(<SyncRunTimeline onDrillDown={vi.fn()} />, { wrapper });
+    await waitFor(() =>
+      expect(screen.getByText(/Impossibile caricare la timeline/i)).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Riprova/i }));
+    // After Retry the component transitions to the populated rendering; we do not
+    // assert call-count because keepPreviousData + visibility refetch can fire extras.
+    await waitFor(() => expect(screen.getByText('BGG full sync')).toBeInTheDocument());
+    expect(screen.queryByText(/Impossibile caricare la timeline/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncRunTimeline.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncRunTimeline.tsx
@@ -1,5 +1,7 @@
 'use client';
-import { ChevronRight } from 'lucide-react';
+import { AlertCircle, ChevronRight } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
 
 import { formatDuration, parseTimeSpanToMs } from '../_utils/run-formatter';
 import { useCatalogSyncRuns } from '../hooks/use-catalog-sync-runs';
@@ -28,9 +30,34 @@ function successRate(runs: CatalogSyncRunSummary[]): string {
 }
 
 export function SyncRunTimeline({ onDrillDown }: SyncRunTimelineProps) {
-  const { data, isLoading } = useCatalogSyncRuns();
+  const { data, isLoading, isError, error, refetch } = useCatalogSyncRuns();
 
   if (isLoading) return <div className="h-40 animate-pulse rounded-xl bg-card/60" />;
+  // Issue #1880: distinguish fetch error from empty state (both had `!data` true).
+  if (isError) {
+    return (
+      <section
+        role="alert"
+        className="overflow-hidden rounded-xl border border-entity-event/30 bg-card"
+      >
+        <header className="flex items-center gap-2.5 border-b border-border bg-muted/30 px-3.5 py-2.5">
+          <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">
+            Sync history
+          </h3>
+        </header>
+        <div className="flex items-center gap-3 px-4 py-6">
+          <AlertCircle className="h-4 w-4 shrink-0 text-entity-event" aria-hidden />
+          <p className="flex-1 text-sm text-entity-event">
+            Impossibile caricare la timeline (
+            {error instanceof Error ? error.message : 'errore di rete'})
+          </p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            Riprova
+          </Button>
+        </div>
+      </section>
+    );
+  }
   if (!data || data.items.length === 0) {
     return (
       <section className="overflow-hidden rounded-xl border border-border bg-card">

--- a/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncStatusHero.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncStatusHero.test.tsx
@@ -205,3 +205,55 @@ describe('SyncStatusHero — trigger flow', () => {
     expect(onOpenManualModal).toHaveBeenCalled();
   });
 });
+
+describe('SyncStatusHero — error state (#1880)', () => {
+  function setupError(errorMessage = '500 Internal Server Error') {
+    vi.mocked(api.fetchCatalogSyncStatus).mockRejectedValue(new Error(errorMessage));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    };
+  }
+
+  it('renders alert card with error message + Retry button when /status fetch fails', async () => {
+    const { wrapper } = setupError('500 Internal Server Error');
+    render(<SyncStatusHero />, { wrapper });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Impossibile caricare lo stato sync/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/500 Internal Server Error/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Riprova/i })).toBeInTheDocument();
+    // NOT the skeleton pulse anymore
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('refetches when Retry clicked (recovers after transient error)', async () => {
+    vi.mocked(api.fetchCatalogSyncStatus)
+      .mockRejectedValueOnce(new Error('502 Bad Gateway'))
+      .mockResolvedValue({
+        status: 'idle',
+        lastRun: null,
+        currentRun: null,
+        cumulative: { gamesTotal: 4812 },
+        nextScheduled: null,
+      } as never);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    render(<SyncStatusHero />, { wrapper });
+    await waitFor(() =>
+      expect(screen.getByText(/Impossibile caricare lo stato sync/i)).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Riprova/i }));
+    // After Retry the component transitions out of the error branch and renders the
+    // populated status card. We do not assert call-count because the hook also
+    // refetches when document visibility changes during the test setup.
+    await waitFor(() => expect(screen.getByText(/Giochi importati totali/)).toBeInTheDocument());
+    expect(screen.queryByText(/Impossibile caricare lo stato sync/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncStatusHero.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog-ingestion/components/SyncStatusHero.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 
-import { Loader2, Play } from 'lucide-react';
+import { AlertCircle, Loader2, Play } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/primitives/button';
@@ -28,12 +28,35 @@ interface SyncStatusHeroProps {
 }
 
 export function SyncStatusHero({ onOpenCsvModal, onOpenManualModal }: SyncStatusHeroProps) {
-  const { data } = useCatalogSyncStatus();
+  const { data, isError, error, refetch } = useCatalogSyncStatus();
   const [provider, setProvider] = useState<CatalogSyncProvider>('BggApi');
   const [batchSize, setBatchSize] = useState('100');
   const [rateLimit, setRateLimit] = useState('60/min');
   const [autoRetry, setAutoRetry] = useState(true);
   const [isTriggering, setIsTriggering] = useState(false);
+
+  // Issue #1880: distinguish "loading" (skeleton) from "broken" (error card).
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        className="flex items-center gap-3 rounded-xl border border-entity-event/30 bg-entity-event/[0.04] px-5 py-4"
+      >
+        <AlertCircle className="h-5 w-5 shrink-0 text-entity-event" aria-hidden />
+        <div className="flex-1">
+          <h3 className="font-quicksand text-sm font-bold text-foreground">
+            Impossibile caricare lo stato sync
+          </h3>
+          <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+            {error instanceof Error ? error.message : 'Errore di rete'}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          Riprova
+        </Button>
+      </div>
+    );
+  }
 
   if (!data) return <div className="h-40 animate-pulse rounded-xl bg-card/60" />;
 


### PR DESCRIPTION
Closes #1880 — both components fell through to either an indefinite skeleton pulse (`SyncStatusHero`) or a silent empty-state-looking-like-error (`SyncRunTimeline`) on /status or /runs 5xx failures. Admins had no way to distinguish "loading" from "broken" and no Retry affordance.

## `SyncStatusHero.tsx`

Surface `useCatalogSyncStatus()` `isError` / `error` / `refetch`. When `isError`:
- Render a `role="alert"` card with `AlertCircle` icon, "Impossibile caricare lo stato sync" heading + the error message in monospace text.
- Inline `Riprova` button calls `refetch()`.

The error branch precedes the existing `if (!data)` skeleton so transient errors no longer leave the user staring at a pulse.

## `SyncRunTimeline.tsx`

Surface `useCatalogSyncRuns()` `isError` / `error` / `refetch`. When `isError`, render a `role="alert"` section with header + body **distinct** from the "Nessun run registrato" empty state (which had been silently absorbing 5xx errors). Same Retry affordance.

## Tests (+4 vs baseline, 84→88)

**`SyncStatusHero.test.tsx`** — new `describe('— error state (#1880)')`:
- error card renders with the thrown message + `Riprova` button when `/status` rejects.
- `Riprova` click recovers (component re-renders with populated state, error card disappears).

**`SyncRunTimeline.test.tsx`** — new `describe('— error state (#1880)')`:
- error section renders distinctly from empty state (asserts "Nessun run registrato" is NOT present in the error branch).
- `Riprova` click recovers.

## Verification

- `pnpm vitest run "src/app/admin/(dashboard)/catalog-ingestion/"` → **88/88 passed** (16 files; was 84/84 after #1879).
- `pnpm typecheck` → 0 errors.

## Test plan

- [ ] CI green.
- [ ] Smoke `/admin/catalog-ingestion` while `/status` 5xx: expect error card with Retry, not skeleton.
- [ ] Smoke while `/runs` 5xx: expect error alert, not "Nessun run registrato".

🤖 Generated with [Claude Code](https://claude.com/claude-code)