### PR TITLE
feat(catalog-sync-be): #1874 enrichment queue + failed items aggregator endpoints

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueEnrichmentCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueEnrichmentCommand.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure.Services;
@@ -46,17 +47,20 @@ internal sealed class EnqueueEnrichmentCommandHandler
 {
     private readonly ISharedGameRepository _repository;
     private readonly IBggImportQueueService _queueService;
+    private readonly IEnrichmentQueueRepository _enrichmentQueueRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<EnqueueEnrichmentCommandHandler> _logger;
 
     public EnqueueEnrichmentCommandHandler(
         ISharedGameRepository repository,
         IBggImportQueueService queueService,
+        IEnrichmentQueueRepository enrichmentQueueRepository,
         IUnitOfWork unitOfWork,
         ILogger<EnqueueEnrichmentCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _queueService = queueService ?? throw new ArgumentNullException(nameof(queueService));
+        _enrichmentQueueRepository = enrichmentQueueRepository ?? throw new ArgumentNullException(nameof(enrichmentQueueRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -95,6 +99,21 @@ internal sealed class EnqueueEnrichmentCommandHandler
             .EnqueueEnrichmentBatchAsync(items, command.UserId, cancellationToken)
             .ConfigureAwait(false);
 
+        // Issue #1874: also persist EnrichmentQueueEntry aggregates so the admin
+        // Queue Pending panel can surface what's in flight. One entry per eligible
+        // game, Priority=Normal, Reason="manual enqueue", QueuedBy=command.UserId.
+        var queueEntries = eligible
+            .Select(g => EnrichmentQueueEntry.Enqueue(
+                g.Id,
+                EnrichmentPriority.Normal,
+                "manual enqueue",
+                command.UserId))
+            .ToList();
+
+        await _enrichmentQueueRepository
+            .AddRangeAsync(queueEntries, cancellationToken)
+            .ConfigureAwait(false);
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
@@ -114,17 +133,20 @@ internal sealed class EnqueueAllSkeletonsCommandHandler
 {
     private readonly ISharedGameRepository _repository;
     private readonly IBggImportQueueService _queueService;
+    private readonly IEnrichmentQueueRepository _enrichmentQueueRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<EnqueueAllSkeletonsCommandHandler> _logger;
 
     public EnqueueAllSkeletonsCommandHandler(
         ISharedGameRepository repository,
         IBggImportQueueService queueService,
+        IEnrichmentQueueRepository enrichmentQueueRepository,
         IUnitOfWork unitOfWork,
         ILogger<EnqueueAllSkeletonsCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _queueService = queueService ?? throw new ArgumentNullException(nameof(queueService));
+        _enrichmentQueueRepository = enrichmentQueueRepository ?? throw new ArgumentNullException(nameof(enrichmentQueueRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -161,6 +183,20 @@ internal sealed class EnqueueAllSkeletonsCommandHandler
 
         var (batchId, enqueued) = await _queueService
             .EnqueueEnrichmentBatchAsync(items, command.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Issue #1874: persist EnrichmentQueueEntry aggregates for the batch.
+        // Priority=Stale, Reason="stale skeletons batch", QueuedBy=null (system sweep).
+        var queueEntries = eligible
+            .Select(g => EnrichmentQueueEntry.Enqueue(
+                g.Id,
+                EnrichmentPriority.Stale,
+                "stale skeletons batch",
+                queuedBy: null))
+            .ToList();
+
+        await _enrichmentQueueRepository
+            .AddRangeAsync(queueEntries, cancellationToken)
             .ConfigureAwait(false);
 
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/EnrichmentQueries.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/EnrichmentQueries.cs
@@ -1,0 +1,125 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+// ── DTOs ────────────────────────────────────────────────────────────
+
+public sealed record EnrichmentQueueItem(
+    Guid SharedGameId,
+    string Title,
+    EnrichmentPriority Priority,
+    DateTimeOffset QueuedAt,
+    string Reason,
+    Guid? QueuedBy);
+
+public sealed record EnrichmentQueueResult(
+    IReadOnlyList<EnrichmentQueueItem> Items,
+    int Total);
+
+public sealed record FailedItem(
+    Guid SharedGameId,
+    string Title,
+    string ErrorCode,
+    string ErrorDetail,
+    DateTimeOffset LastAttemptAt,
+    int RetryCount);
+
+public sealed record FailedItemsResult(
+    IReadOnlyList<FailedItem> Items,
+    int Total);
+
+// ── Queries ─────────────────────────────────────────────────────────
+
+public sealed record GetEnrichmentQueueQuery(EnrichmentPriority? Priority, int Limit)
+    : IQuery<EnrichmentQueueResult>;
+
+public sealed record GetFailedItemsQuery(int Days, int Limit)
+    : IQuery<FailedItemsResult>;
+
+// ── Validators ──────────────────────────────────────────────────────
+
+public sealed class GetEnrichmentQueueQueryValidator : AbstractValidator<GetEnrichmentQueueQuery>
+{
+    public GetEnrichmentQueueQueryValidator()
+    {
+        RuleFor(x => x.Limit).InclusiveBetween(1, 100);
+    }
+}
+
+public sealed class GetFailedItemsQueryValidator : AbstractValidator<GetFailedItemsQuery>
+{
+    public GetFailedItemsQueryValidator()
+    {
+        RuleFor(x => x.Days).InclusiveBetween(1, 365);
+        RuleFor(x => x.Limit).InclusiveBetween(1, 100);
+    }
+}
+
+// ── Handlers ────────────────────────────────────────────────────────
+
+internal sealed class GetEnrichmentQueueQueryHandler
+    : IQueryHandler<GetEnrichmentQueueQuery, EnrichmentQueueResult>
+{
+    private readonly IEnrichmentQueueRepository _repository;
+
+    public GetEnrichmentQueueQueryHandler(IEnrichmentQueueRepository repository)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+        _repository = repository;
+    }
+
+    public async Task<EnrichmentQueueResult> Handle(
+        GetEnrichmentQueueQuery query, CancellationToken cancellationToken)
+    {
+        var (rows, total) = await _repository
+            .GetPendingAsync(query.Priority, query.Limit, cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = rows
+            .Select(r => new EnrichmentQueueItem(
+                SharedGameId: r.Entry.SharedGameId,
+                Title: r.SharedGameTitle,
+                Priority: r.Entry.Priority,
+                QueuedAt: r.Entry.QueuedAt,
+                Reason: r.Entry.Reason,
+                QueuedBy: r.Entry.QueuedByUserId))
+            .ToList();
+
+        return new EnrichmentQueueResult(items, total);
+    }
+}
+
+internal sealed class GetFailedItemsQueryHandler
+    : IQueryHandler<GetFailedItemsQuery, FailedItemsResult>
+{
+    private readonly IEnrichmentAttemptRepository _repository;
+
+    public GetFailedItemsQueryHandler(IEnrichmentAttemptRepository repository)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+        _repository = repository;
+    }
+
+    public async Task<FailedItemsResult> Handle(
+        GetFailedItemsQuery query, CancellationToken cancellationToken)
+    {
+        var (rows, total) = await _repository
+            .GetFailedAggregatesAsync(query.Days, query.Limit, cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = rows
+            .Select(r => new FailedItem(
+                SharedGameId: r.SharedGameId,
+                Title: r.SharedGameTitle,
+                ErrorCode: r.ErrorCode,
+                ErrorDetail: r.ErrorDetail,
+                LastAttemptAt: r.LastAttemptAt,
+                RetryCount: r.RetryCount))
+            .ToList();
+
+        return new FailedItemsResult(items, total);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentAttempt.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentAttempt.cs
@@ -1,0 +1,168 @@
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root for a single BGG enrichment attempt outcome (#1874).
+/// One row per attempt (success or failure). Multiple attempts for the same
+/// <see cref="SharedGameId"/> over time are expected; the <see cref="RetryCount"/>
+/// disambiguates the chain.
+/// </summary>
+/// <remarks>
+/// Used by:
+/// <list type="bullet">
+///   <item>Admin Failed Items panel (aggregates last attempt per shared game).</item>
+///   <item>BggImportQueueBackgroundService (records each iteration).</item>
+/// </list>
+/// </remarks>
+public sealed class EnrichmentAttempt : AggregateRoot<Guid>
+{
+    public Guid SharedGameId { get; private set; }
+
+    /// <summary>Reference to the <see cref="CatalogSyncRun"/> when the attempt is part of cron / triggered run; <c>null</c> for manual one-offs.</summary>
+    public Guid? CatalogSyncRunId { get; private set; }
+
+    public DateTimeOffset AttemptedAt { get; private set; }
+
+    public bool Success { get; private set; }
+
+    /// <summary>Machine-readable error code (e.g. "BGG_API_RATE_LIMIT_429"). Null on success.</summary>
+    public string? ErrorCode { get; private set; }
+
+    /// <summary>Human-readable error detail. Null on success.</summary>
+    public string? ErrorDetail { get; private set; }
+
+    /// <summary>0 = first try, N = N-th retry.</summary>
+    public int RetryCount { get; private set; }
+
+    // ===================================================
+    // Constructors
+    // ===================================================
+
+    private EnrichmentAttempt() : base() { }
+
+    private EnrichmentAttempt(
+        Guid id,
+        Guid sharedGameId,
+        Guid? catalogSyncRunId,
+        DateTimeOffset attemptedAt,
+        bool success,
+        string? errorCode,
+        string? errorDetail,
+        int retryCount)
+        : base(id)
+    {
+        SharedGameId = sharedGameId;
+        CatalogSyncRunId = catalogSyncRunId;
+        AttemptedAt = attemptedAt;
+        Success = success;
+        ErrorCode = errorCode;
+        ErrorDetail = errorDetail;
+        RetryCount = retryCount;
+    }
+
+    // ===================================================
+    // Factories
+    // ===================================================
+
+    /// <summary>Records a successful enrichment outcome.</summary>
+    public static EnrichmentAttempt RecordSuccess(
+        Guid sharedGameId,
+        Guid? catalogSyncRunId,
+        int retryCount)
+    {
+        ValidateBasics(sharedGameId, catalogSyncRunId, retryCount);
+
+        return new EnrichmentAttempt(
+            id: Guid.NewGuid(),
+            sharedGameId: sharedGameId,
+            catalogSyncRunId: catalogSyncRunId,
+            attemptedAt: DateTimeOffset.UtcNow,
+            success: true,
+            errorCode: null,
+            errorDetail: null,
+            retryCount: retryCount);
+    }
+
+    /// <summary>Records a failed enrichment outcome with structured error context.</summary>
+    public static EnrichmentAttempt RecordFailure(
+        Guid sharedGameId,
+        Guid? catalogSyncRunId,
+        string errorCode,
+        string errorDetail,
+        int retryCount)
+    {
+        ValidateBasics(sharedGameId, catalogSyncRunId, retryCount);
+
+        if (string.IsNullOrWhiteSpace(errorCode))
+        {
+            throw new ArgumentException("Error code is required for failure attempts.", nameof(errorCode));
+        }
+
+        if (errorCode.Length > 100)
+        {
+            throw new ArgumentException("Error code must be 100 characters or fewer.", nameof(errorCode));
+        }
+
+        if (string.IsNullOrWhiteSpace(errorDetail))
+        {
+            throw new ArgumentException("Error detail is required for failure attempts.", nameof(errorDetail));
+        }
+
+        return new EnrichmentAttempt(
+            id: Guid.NewGuid(),
+            sharedGameId: sharedGameId,
+            catalogSyncRunId: catalogSyncRunId,
+            attemptedAt: DateTimeOffset.UtcNow,
+            success: false,
+            errorCode: errorCode,
+            errorDetail: errorDetail,
+            retryCount: retryCount);
+    }
+
+    /// <summary>Repository hydration — bypasses invariants.</summary>
+    public static EnrichmentAttempt Reconstitute(
+        Guid id,
+        Guid sharedGameId,
+        Guid? catalogSyncRunId,
+        DateTimeOffset attemptedAt,
+        bool success,
+        string? errorCode,
+        string? errorDetail,
+        int retryCount)
+    {
+        return new EnrichmentAttempt
+        {
+            Id = id,
+            SharedGameId = sharedGameId,
+            CatalogSyncRunId = catalogSyncRunId,
+            AttemptedAt = attemptedAt,
+            Success = success,
+            ErrorCode = errorCode,
+            ErrorDetail = errorDetail,
+            RetryCount = retryCount,
+        };
+    }
+
+    // ===================================================
+    // Helpers
+    // ===================================================
+
+    private static void ValidateBasics(Guid sharedGameId, Guid? catalogSyncRunId, int retryCount)
+    {
+        if (sharedGameId == Guid.Empty)
+        {
+            throw new ArgumentException("SharedGameId cannot be Guid.Empty.", nameof(sharedGameId));
+        }
+
+        if (catalogSyncRunId.HasValue && catalogSyncRunId.Value == Guid.Empty)
+        {
+            throw new ArgumentException("CatalogSyncRunId cannot be Guid.Empty (use null when manual).", nameof(catalogSyncRunId));
+        }
+
+        if (retryCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(retryCount), retryCount, "RetryCount must be non-negative.");
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentQueueEntry.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentQueueEntry.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root for a single queued enrichment request (#1874).
+/// Each entry represents one BGG enrichment job waiting to be picked up by
+/// <c>BggImportQueueBackgroundService</c>. Multiple entries for the same
+/// <see cref="SharedGameId"/> are permitted (legitimate re-queue scenarios).
+/// </summary>
+/// <remarks>
+/// Lifecycle: Enqueue → MarkProcessed (idempotent).
+/// Surfaced by the admin Queue Pending panel in /admin/catalog-ingestion.
+/// </remarks>
+public sealed class EnrichmentQueueEntry : AggregateRoot<Guid>
+{
+    // === Identity / metadata ===
+
+    public Guid SharedGameId { get; private set; }
+
+    public EnrichmentPriority Priority { get; private set; }
+
+    public DateTimeOffset QueuedAt { get; private set; }
+
+    /// <summary>Human-readable reason (e.g. "v2.1 errata", "stale 30gg", "manual retry").</summary>
+    public string Reason { get; private set; } = string.Empty;
+
+    /// <summary>User who queued the entry; <c>null</c> for system / cron / background sweeps.</summary>
+    public Guid? QueuedByUserId { get; private set; }
+
+    // === Lifecycle state ===
+
+    public bool IsProcessed { get; private set; }
+
+    public DateTimeOffset? ProcessedAt { get; private set; }
+
+    // ===================================================
+    // Constructors
+    // ===================================================
+
+    /// <summary>EF Core / repository reconstitution — do not call directly.</summary>
+    private EnrichmentQueueEntry() : base() { }
+
+    private EnrichmentQueueEntry(
+        Guid id,
+        Guid sharedGameId,
+        EnrichmentPriority priority,
+        string reason,
+        Guid? queuedByUserId,
+        DateTimeOffset queuedAt)
+        : base(id)
+    {
+        SharedGameId = sharedGameId;
+        Priority = priority;
+        Reason = reason;
+        QueuedByUserId = queuedByUserId;
+        QueuedAt = queuedAt;
+        IsProcessed = false;
+    }
+
+    // ===================================================
+    // Factory
+    // ===================================================
+
+    /// <summary>
+    /// Queues a new enrichment request for <paramref name="sharedGameId"/> at the given priority.
+    /// </summary>
+    /// <param name="sharedGameId">Target shared game. Must not be <see cref="Guid.Empty"/>.</param>
+    /// <param name="priority">High / Normal / Stale.</param>
+    /// <param name="reason">Non-empty rationale (≤ 200 chars).</param>
+    /// <param name="queuedBy">User id; <c>null</c> for system/cron-triggered batches.</param>
+    public static EnrichmentQueueEntry Enqueue(
+        Guid sharedGameId,
+        EnrichmentPriority priority,
+        string reason,
+        Guid? queuedBy)
+    {
+        if (sharedGameId == Guid.Empty)
+        {
+            throw new ArgumentException("SharedGameId cannot be Guid.Empty.", nameof(sharedGameId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Reason is required.", nameof(reason));
+        }
+
+        if (reason.Length > 200)
+        {
+            throw new ArgumentException("Reason must be 200 characters or fewer.", nameof(reason));
+        }
+
+        if (queuedBy.HasValue && queuedBy.Value == Guid.Empty)
+        {
+            throw new ArgumentException("QueuedByUserId cannot be Guid.Empty (use null for system).", nameof(queuedBy));
+        }
+
+        return new EnrichmentQueueEntry(
+            id: Guid.NewGuid(),
+            sharedGameId: sharedGameId,
+            priority: priority,
+            reason: reason,
+            queuedByUserId: queuedBy,
+            queuedAt: DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Repository hydration — bypasses invariants. Caller must guarantee state validity.
+    /// </summary>
+    public static EnrichmentQueueEntry Reconstitute(
+        Guid id,
+        Guid sharedGameId,
+        EnrichmentPriority priority,
+        string reason,
+        Guid? queuedByUserId,
+        DateTimeOffset queuedAt,
+        bool isProcessed,
+        DateTimeOffset? processedAt)
+    {
+        return new EnrichmentQueueEntry
+        {
+            Id = id,
+            SharedGameId = sharedGameId,
+            Priority = priority,
+            Reason = reason,
+            QueuedByUserId = queuedByUserId,
+            QueuedAt = queuedAt,
+            IsProcessed = isProcessed,
+            ProcessedAt = processedAt,
+        };
+    }
+
+    // ===================================================
+    // Lifecycle
+    // ===================================================
+
+    /// <summary>
+    /// Marks the entry as processed. Idempotent — re-calling is a no-op.
+    /// Stamps <see cref="ProcessedAt"/> on first call.
+    /// </summary>
+    public void MarkProcessed()
+    {
+        if (IsProcessed) return;
+        IsProcessed = true;
+        ProcessedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/EnrichmentPriority.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/EnrichmentPriority.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Priority bucket for queued BGG enrichment work (#1874).
+/// Ordered High → Normal → Stale; the queue endpoint sorts DESC by this enum, ASC by QueuedAt.
+/// </summary>
+public enum EnrichmentPriority
+{
+    /// <summary>Stale skeletons batch (background sweep).</summary>
+    Stale = 0,
+
+    /// <summary>Default manual / per-game enqueue.</summary>
+    Normal = 1,
+
+    /// <summary>Forced retry, errata import, urgent admin intervention.</summary>
+    High = 2,
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IEnrichmentAttemptRepository.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for <see cref="EnrichmentAttempt"/> (#1874).
+/// </summary>
+public interface IEnrichmentAttemptRepository
+{
+    /// <summary>Stages a new attempt record for insertion.</summary>
+    Task AddAsync(EnrichmentAttempt attempt, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the latest failed attempt per shared game within the trailing <paramref name="days"/> window,
+    /// joined with the shared-game title. Soft-deleted shared games are excluded. Capped at
+    /// <paramref name="limit"/> rows (caller caps at 100).
+    /// </summary>
+    Task<(IReadOnlyList<FailedItemAggregate> Items, int Total)> GetFailedAggregatesAsync(
+        int days,
+        int limit,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Read-model projection for the admin Failed Items panel: one row per shared game whose most
+/// recent attempt was a failure within the time window.
+/// </summary>
+public sealed record FailedItemAggregate(
+    Guid SharedGameId,
+    string SharedGameTitle,
+    string ErrorCode,
+    string ErrorDetail,
+    DateTimeOffset LastAttemptAt,
+    int RetryCount);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IEnrichmentQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IEnrichmentQueueRepository.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for <see cref="EnrichmentQueueEntry"/> (#1874).
+/// </summary>
+public interface IEnrichmentQueueRepository
+{
+    /// <summary>Stages a new queue entry for insertion. Persistence at SaveChangesAsync.</summary>
+    Task AddAsync(EnrichmentQueueEntry entry, CancellationToken cancellationToken = default);
+
+    /// <summary>Stages a batch insert (used by enqueue-all-skeletons batch).</summary>
+    Task AddRangeAsync(IEnumerable<EnrichmentQueueEntry> entries, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns pending (IsProcessed=false) entries joined with their shared-game title,
+    /// ordered by Priority DESC + QueuedAt ASC. Filters by <paramref name="priority"/> when supplied,
+    /// limits to <paramref name="limit"/> rows (caller caps at 100), and skips entries whose shared
+    /// game has been soft-deleted.
+    /// </summary>
+    Task<(IReadOnlyList<EnrichmentQueueEntryWithTitle> Items, int Total)> GetPendingAsync(
+        EnrichmentPriority? priority,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Persists changes to a previously loaded entry (e.g. MarkProcessed).</summary>
+    Task UpdateAsync(EnrichmentQueueEntry entry, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Read-model projection joining <see cref="EnrichmentQueueEntry"/> with the shared-game title
+/// to avoid an N+1 round-trip from the query handler.
+/// </summary>
+public sealed record EnrichmentQueueEntryWithTitle(
+    EnrichmentQueueEntry Entry,
+    string SharedGameTitle);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -50,6 +50,8 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<ICertificationThresholdsConfigRepository, CertificationThresholdsConfigRepository>(); // ADR-051 Sprint 1 / Task 15: thresholds config
         services.AddScoped<IMechanicRecalcJobRepository, MechanicRecalcJobRepository>(); // ADR-051 Sprint 2 / Task 7: async recalc job persistence + SKIP LOCKED claim
         services.AddScoped<ICatalogSyncRunRepository, CatalogSyncRunRepository>(); // #1861: F4-A6 catalog sync run history
+        services.AddScoped<IEnrichmentQueueRepository, EnrichmentQueueRepository>(); // #1874: queued BGG enrichment requests
+        services.AddScoped<IEnrichmentAttemptRepository, EnrichmentAttemptRepository>(); // #1874: BGG enrichment outcome history
         services.AddScoped<IShareRequestRepository, ShareRequestRepository>(); // Issue #2724: CreateShareRequest
         services.AddScoped<IBadgeRepository, BadgeRepository>(); // Issue #2731: Badge gamification system
         services.AddScoped<IUserBadgeRepository, UserBadgeRepository>(); // Issue #2731: User badge awards

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentAttemptRepository.cs
@@ -1,0 +1,120 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core repository for <see cref="EnrichmentAttempt"/> (#1874).
+/// </summary>
+internal sealed class EnrichmentAttemptRepository : RepositoryBase, IEnrichmentAttemptRepository
+{
+    public EnrichmentAttemptRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(EnrichmentAttempt attempt, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+
+        await DbContext.EnrichmentAttempts.AddAsync(new()
+        {
+            Id = attempt.Id,
+            SharedGameId = attempt.SharedGameId,
+            CatalogSyncRunId = attempt.CatalogSyncRunId,
+            AttemptedAt = attempt.AttemptedAt,
+            Success = attempt.Success,
+            ErrorCode = attempt.ErrorCode,
+            ErrorDetail = attempt.ErrorDetail,
+            RetryCount = attempt.RetryCount,
+        }, cancellationToken).ConfigureAwait(false);
+
+        CollectDomainEvents(attempt);
+    }
+
+    public async Task<(IReadOnlyList<FailedItemAggregate> Items, int Total)> GetFailedAggregatesAsync(
+        int days,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        if (days < 1 || days > 365)
+        {
+            throw new ArgumentOutOfRangeException(nameof(days), days, "Days must be 1-365.");
+        }
+
+        if (limit < 1 || limit > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), limit, "Limit must be 1-100.");
+        }
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-days);
+
+        // Stage 1 (DB): for each shared game with at least one failed attempt in the window,
+        // find the MAX(attempted_at). EF translates this GroupBy + Max cleanly.
+        var maxPerGame = await (
+            from attempt in DbContext.EnrichmentAttempts.AsNoTracking()
+            where !attempt.Success && attempt.AttemptedAt >= cutoff
+            join game in DbContext.SharedGames.AsNoTracking() on attempt.SharedGameId equals game.Id
+            group attempt by attempt.SharedGameId into g
+            select new { SharedGameId = g.Key, LastAt = g.Max(a => a.AttemptedAt) })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var total = maxPerGame.Count;
+
+        if (total == 0)
+        {
+            return (Array.Empty<FailedItemAggregate>(), 0);
+        }
+
+        // Stage 2 (DB): fetch the corresponding attempt + game-title rows for those pairs.
+        // Translated into a single IN over composite key tuples on PG.
+        var topGameIds = maxPerGame
+            .OrderByDescending(x => x.LastAt)
+            .Take(limit)
+            .Select(x => x.SharedGameId)
+            .ToList();
+
+        var topTimestamps = maxPerGame
+            .Where(x => topGameIds.Contains(x.SharedGameId))
+            .ToDictionary(x => x.SharedGameId, x => x.LastAt);
+
+        var rows = await (
+            from attempt in DbContext.EnrichmentAttempts.AsNoTracking()
+            join game in DbContext.SharedGames.AsNoTracking() on attempt.SharedGameId equals game.Id
+            where topGameIds.Contains(attempt.SharedGameId) && !attempt.Success
+            select new
+            {
+                attempt.SharedGameId,
+                game.Title,
+                attempt.ErrorCode,
+                attempt.ErrorDetail,
+                attempt.AttemptedAt,
+                attempt.RetryCount,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Stage 3 (memory): keep only the row matching the per-game MAX timestamp.
+        var items = topGameIds
+            .Select(gid =>
+            {
+                var lastAt = topTimestamps[gid];
+                var row = rows.First(r => r.SharedGameId == gid && r.AttemptedAt == lastAt);
+                return new FailedItemAggregate(
+                    SharedGameId: row.SharedGameId,
+                    SharedGameTitle: row.Title,
+                    ErrorCode: row.ErrorCode ?? string.Empty,
+                    ErrorDetail: row.ErrorDetail ?? string.Empty,
+                    LastAttemptAt: row.AttemptedAt,
+                    RetryCount: row.RetryCount);
+            })
+            .ToList();
+
+        return (items, total);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepository.cs
@@ -1,0 +1,125 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core repository for <see cref="EnrichmentQueueEntry"/> (#1874).
+/// </summary>
+internal sealed class EnrichmentQueueRepository : RepositoryBase, IEnrichmentQueueRepository
+{
+    public EnrichmentQueueRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(EnrichmentQueueEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        await DbContext.EnrichmentQueueEntries
+            .AddAsync(MapToEntity(entry), cancellationToken)
+            .ConfigureAwait(false);
+
+        CollectDomainEvents(entry);
+    }
+
+    public async Task AddRangeAsync(IEnumerable<EnrichmentQueueEntry> entries, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var list = entries.ToList();
+        var mapped = list.Select(MapToEntity).ToList();
+
+        await DbContext.EnrichmentQueueEntries
+            .AddRangeAsync(mapped, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var entry in list)
+        {
+            CollectDomainEvents(entry);
+        }
+    }
+
+    public async Task<(IReadOnlyList<EnrichmentQueueEntryWithTitle> Items, int Total)> GetPendingAsync(
+        EnrichmentPriority? priority,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        if (limit < 1 || limit > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), limit, "Limit must be 1-100.");
+        }
+
+        // Join queue entries with shared_games to fetch title in one pass.
+        // The HasQueryFilter on SharedGameEntity already excludes soft-deleted rows,
+        // so the inner-join semantics drop entries whose game has been removed.
+        var baseQuery =
+            from entry in DbContext.EnrichmentQueueEntries.AsNoTracking()
+            join game in DbContext.SharedGames.AsNoTracking() on entry.SharedGameId equals game.Id
+            where !entry.IsProcessed
+            select new { entry, game.Title };
+
+        if (priority.HasValue)
+        {
+            baseQuery = baseQuery.Where(x => x.entry.Priority == priority.Value);
+        }
+
+        var total = await baseQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        var rows = await baseQuery
+            .OrderByDescending(x => x.entry.Priority)
+            .ThenBy(x => x.entry.QueuedAt)
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = rows
+            .Select(r => new EnrichmentQueueEntryWithTitle(MapToDomain(r.entry), r.Title))
+            .ToList();
+
+        return (items, total);
+    }
+
+    public Task UpdateAsync(EnrichmentQueueEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var entity = MapToEntity(entry);
+        DbContext.EnrichmentQueueEntries.Update(entity);
+
+        CollectDomainEvents(entry);
+        return Task.CompletedTask;
+    }
+
+    // === Mapping ===
+
+    private static EnrichmentQueueEntry MapToDomain(EnrichmentQueueEntryEntity e) =>
+        EnrichmentQueueEntry.Reconstitute(
+            id: e.Id,
+            sharedGameId: e.SharedGameId,
+            priority: e.Priority,
+            reason: e.Reason,
+            queuedByUserId: e.QueuedByUserId,
+            queuedAt: e.QueuedAt,
+            isProcessed: e.IsProcessed,
+            processedAt: e.ProcessedAt);
+
+    private static EnrichmentQueueEntryEntity MapToEntity(EnrichmentQueueEntry e) => new()
+    {
+        Id = e.Id,
+        SharedGameId = e.SharedGameId,
+        Priority = e.Priority,
+        Reason = e.Reason,
+        QueuedByUserId = e.QueuedByUserId,
+        QueuedAt = e.QueuedAt,
+        IsProcessed = e.IsProcessed,
+        ProcessedAt = e.ProcessedAt,
+    };
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/EnrichmentAttemptEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/EnrichmentAttemptEntityConfiguration.cs
@@ -1,0 +1,73 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="EnrichmentAttemptEntity"/> (#1874).
+/// Table <c>enrichment_attempts</c>: BGG enrichment outcome history (success / failure).
+/// </summary>
+internal sealed class EnrichmentAttemptEntityConfiguration : IEntityTypeConfiguration<EnrichmentAttemptEntity>
+{
+    public void Configure(EntityTypeBuilder<EnrichmentAttemptEntity> builder)
+    {
+        builder.ToTable("enrichment_attempts");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.SharedGameId)
+            .HasColumnName("shared_game_id")
+            .IsRequired();
+
+        builder.Property(e => e.CatalogSyncRunId)
+            .HasColumnName("catalog_sync_run_id");
+
+        builder.Property(e => e.AttemptedAt)
+            .HasColumnName("attempted_at")
+            .IsRequired();
+
+        builder.Property(e => e.Success)
+            .HasColumnName("success")
+            .IsRequired();
+
+        builder.Property(e => e.ErrorCode)
+            .HasColumnName("error_code")
+            .HasMaxLength(100);
+
+        builder.Property(e => e.ErrorDetail)
+            .HasColumnName("error_detail");
+
+        builder.Property(e => e.RetryCount)
+            .HasColumnName("retry_count")
+            .HasDefaultValue(0)
+            .IsRequired();
+
+        // === Indexes ===
+        // Primary access patterns:
+        // 1. Failed items panel: WHERE success=false AND attempted_at >= cutoff GROUP BY shared_game_id
+        builder.HasIndex(e => new { e.SharedGameId, e.AttemptedAt })
+            .HasDatabaseName("ix_enrichment_attempts_shared_game_attempted_at")
+            .IsDescending(false, true);
+
+        builder.HasIndex(e => new { e.Success, e.AttemptedAt })
+            .HasDatabaseName("ix_enrichment_attempts_success_attempted_at")
+            .IsDescending(false, true);
+
+        // === FKs ===
+        builder.HasOne(e => e.SharedGame)
+            .WithMany()
+            .HasForeignKey(e => e.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // CatalogSyncRun FK is nullable + Restrict so orphan history rows are preserved when a run is purged
+        builder.HasOne(e => e.CatalogSyncRun)
+            .WithMany()
+            .HasForeignKey(e => e.CatalogSyncRunId)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/EnrichmentQueueEntryEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/EnrichmentQueueEntryEntityConfiguration.cs
@@ -1,0 +1,83 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="EnrichmentQueueEntryEntity"/> (#1874).
+/// Table <c>enrichment_queue_entries</c>: queued BGG enrichment requests.
+/// </summary>
+internal sealed class EnrichmentQueueEntryEntityConfiguration : IEntityTypeConfiguration<EnrichmentQueueEntryEntity>
+{
+    public void Configure(EntityTypeBuilder<EnrichmentQueueEntryEntity> builder)
+    {
+        builder.ToTable("enrichment_queue_entries", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_enrichment_queue_entries_priority_range",
+                "priority BETWEEN 0 AND 2");
+        });
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.SharedGameId)
+            .HasColumnName("shared_game_id")
+            .IsRequired();
+
+        // Sentinel = -1 (not a valid EnrichmentPriority) so EF does NOT treat 0 (Stale)
+        // as the "unset" default and therefore always emits Priority in INSERT statements.
+        // Without this, Stale entries would be silently mapped to whatever the column
+        // default is. No HasDefaultValue on the column itself either.
+        builder.Property(e => e.Priority)
+            .HasColumnName("priority")
+            .HasSentinel((EnrichmentPriority)(-1))
+            .IsRequired();
+
+        builder.Property(e => e.QueuedAt)
+            .HasColumnName("queued_at")
+            .IsRequired();
+
+        builder.Property(e => e.Reason)
+            .HasColumnName("reason")
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(e => e.QueuedByUserId)
+            .HasColumnName("queued_by_user_id");
+
+        builder.Property(e => e.IsProcessed)
+            .HasColumnName("is_processed")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(e => e.ProcessedAt)
+            .HasColumnName("processed_at");
+
+        // === Indexes ===
+        // Primary access pattern: queue listing ordered by priority DESC, queued_at ASC, filtered by IsProcessed=false
+        builder.HasIndex(e => new { e.IsProcessed, e.Priority, e.QueuedAt })
+            .HasDatabaseName("ix_enrichment_queue_entries_pending_listing")
+            .HasFilter("is_processed = false");
+
+        builder.HasIndex(e => e.SharedGameId)
+            .HasDatabaseName("ix_enrichment_queue_entries_shared_game_id");
+
+        // === FKs ===
+        builder.HasOne(e => e.SharedGame)
+            .WithMany()
+            .HasForeignKey(e => e.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(e => e.QueuedByUser)
+            .WithMany()
+            .HasForeignKey(e => e.QueuedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/EnrichmentAttemptEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/EnrichmentAttemptEntity.cs
@@ -1,0 +1,28 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.EnrichmentAttempt"/> (#1874).
+/// Plain POCO — all invariants enforced by the domain aggregate.
+/// </summary>
+public class EnrichmentAttemptEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid SharedGameId { get; set; }
+
+    public Guid? CatalogSyncRunId { get; set; }
+
+    public DateTimeOffset AttemptedAt { get; set; }
+
+    public bool Success { get; set; }
+
+    public string? ErrorCode { get; set; }
+
+    public string? ErrorDetail { get; set; }
+
+    public int RetryCount { get; set; }
+
+    // === Navigation ===
+    public SharedGameEntity? SharedGame { get; set; }
+    public CatalogSyncRunEntity? CatalogSyncRun { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/EnrichmentQueueEntryEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/EnrichmentQueueEntryEntity.cs
@@ -1,0 +1,31 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.EnrichmentQueueEntry"/> (#1874).
+/// Plain POCO — all invariants enforced by the domain aggregate.
+/// </summary>
+public class EnrichmentQueueEntryEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid SharedGameId { get; set; }
+
+    /// <summary>Persisted as int: 0=Stale, 1=Normal, 2=High.</summary>
+    public EnrichmentPriority Priority { get; set; }
+
+    public DateTimeOffset QueuedAt { get; set; }
+
+    public string Reason { get; set; } = string.Empty;
+
+    public Guid? QueuedByUserId { get; set; }
+
+    public bool IsProcessed { get; set; }
+
+    public DateTimeOffset? ProcessedAt { get; set; }
+
+    // === Navigation ===
+    public SharedGameEntity? SharedGame { get; set; }
+    public UserEntity? QueuedByUser { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -170,6 +170,8 @@ public class MeepleAiDbContext : DbContext
     public DbSet<CertificationThresholdsConfigEntity> CertificationThresholdsConfigs => Set<CertificationThresholdsConfigEntity>(); // ADR-051 Sprint 1 / M2.0: singleton thresholds config
     public DbSet<MechanicRecalcJobEntity> MechanicRecalcJobs => Set<MechanicRecalcJobEntity>(); // ADR-051 Sprint 2 / M2.1: async recalc pipeline jobs
     public DbSet<CatalogSyncRunEntity> CatalogSyncRuns => Set<CatalogSyncRunEntity>(); // #1861: F4-A6 catalog sync run history (BGG / CSV / Manual)
+    public DbSet<EnrichmentQueueEntryEntity> EnrichmentQueueEntries => Set<EnrichmentQueueEntryEntity>(); // #1874: queued BGG enrichment requests
+    public DbSet<EnrichmentAttemptEntity> EnrichmentAttempts => Set<EnrichmentAttemptEntity>(); // #1874: BGG enrichment outcome history
     public DbSet<QuickQuestionEntity> QuickQuestions => Set<QuickQuestionEntity>(); // ISSUE-2401: Sprint 3 - Quick questions AI generation
     public DbSet<UserLibraryEntryEntity> UserLibraryEntries => Set<UserLibraryEntryEntity>(); // User Library feature
     public DbSet<WishlistItemEntity> WishlistItems => Set<WishlistItemEntity>(); // ISSUE-3917: Wishlist management

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604154416_Add_EnrichmentQueueAndAttempts.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604154416_Add_EnrichmentQueueAndAttempts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604154416_Add_EnrichmentQueueAndAttempts")]
+    partial class Add_EnrichmentQueueAndAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604154416_Add_EnrichmentQueueAndAttempts.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604154416_Add_EnrichmentQueueAndAttempts.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_EnrichmentQueueAndAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "enrichment_attempts",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    shared_game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    catalog_sync_run_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    attempted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    success = table.Column<bool>(type: "boolean", nullable: false),
+                    error_code = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    error_detail = table.Column<string>(type: "text", nullable: true),
+                    retry_count = table.Column<int>(type: "integer", nullable: false, defaultValue: 0)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_enrichment_attempts", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_enrichment_attempts_catalog_sync_runs_catalog_sync_run_id",
+                        column: x => x.catalog_sync_run_id,
+                        principalTable: "catalog_sync_runs",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_enrichment_attempts_shared_games_shared_game_id",
+                        column: x => x.shared_game_id,
+                        principalTable: "shared_games",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "enrichment_queue_entries",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    shared_game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    priority = table.Column<int>(type: "integer", nullable: false),
+                    queued_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    reason = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    queued_by_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    is_processed = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    processed_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_enrichment_queue_entries", x => x.id);
+                    table.CheckConstraint("ck_enrichment_queue_entries_priority_range", "priority BETWEEN 0 AND 2");
+                    table.ForeignKey(
+                        name: "FK_enrichment_queue_entries_shared_games_shared_game_id",
+                        column: x => x.shared_game_id,
+                        principalTable: "shared_games",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_enrichment_queue_entries_users_queued_by_user_id",
+                        column: x => x.queued_by_user_id,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_enrichment_attempts_catalog_sync_run_id",
+                table: "enrichment_attempts",
+                column: "catalog_sync_run_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_enrichment_attempts_shared_game_attempted_at",
+                table: "enrichment_attempts",
+                columns: new[] { "shared_game_id", "attempted_at" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_enrichment_attempts_success_attempted_at",
+                table: "enrichment_attempts",
+                columns: new[] { "success", "attempted_at" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_enrichment_queue_entries_pending_listing",
+                table: "enrichment_queue_entries",
+                columns: new[] { "is_processed", "priority", "queued_at" },
+                filter: "is_processed = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_enrichment_queue_entries_queued_by_user_id",
+                table: "enrichment_queue_entries",
+                column: "queued_by_user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_enrichment_queue_entries_shared_game_id",
+                table: "enrichment_queue_entries",
+                column: "shared_game_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "enrichment_attempts");
+
+            migrationBuilder.DropTable(
+                name: "enrichment_queue_entries");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AdminCatalogIngestionEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminCatalogIngestionEndpoints.cs
@@ -333,6 +333,56 @@ internal static class AdminCatalogIngestionEndpoints
             return operation;
         });
 
+        // ============================================================
+        // #1874 — Enrichment queue + failed items aggregator
+        // ============================================================
+
+        // GET /api/v1/admin/catalog-ingestion/enrichment-queue?priority=&limit=
+        group.MapGet("/enrichment-queue", async (
+            [FromQuery] EnrichmentPriority? priority,
+            [FromQuery] int? limit,
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var query = new GetEnrichmentQueueQuery(priority, limit ?? 25);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetEnrichmentQueue")
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "Enrichment queue (pending entries)";
+            operation.Description = "Returns queued BGG enrichment requests sorted by Priority DESC, QueuedAt ASC. Filters by priority when supplied. Default limit=25 (1-100).";
+            return operation;
+        });
+
+        // GET /api/v1/admin/catalog-ingestion/failed-items?days=&limit=
+        group.MapGet("/failed-items", async (
+            [FromQuery] int? days,
+            [FromQuery] int? limit,
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var query = new GetFailedItemsQuery(days ?? 30, limit ?? 50);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetFailedItems")
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "Failed enrichment items (aggregated)";
+            operation.Description = "Returns the most recent failed enrichment attempt per shared game within the trailing N days. Default days=30 (1-365), default limit=50 (1-100).";
+            return operation;
+        });
+
         return group;
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EnqueueEnrichmentCommandTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EnqueueEnrichmentCommandTests.cs
@@ -22,6 +22,7 @@ public class EnqueueEnrichmentCommandTests
 {
     private readonly Mock<ISharedGameRepository> _mockRepository;
     private readonly Mock<IBggImportQueueService> _mockQueueService;
+    private readonly Mock<IEnrichmentQueueRepository> _mockEnrichmentQueueRepository;
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<EnqueueEnrichmentCommandHandler>> _mockEnqueueLogger;
     private readonly Mock<ILogger<EnqueueAllSkeletonsCommandHandler>> _mockAllSkeletonsLogger;
@@ -37,6 +38,7 @@ public class EnqueueEnrichmentCommandTests
     {
         _mockRepository = new Mock<ISharedGameRepository>();
         _mockQueueService = new Mock<IBggImportQueueService>();
+        _mockEnrichmentQueueRepository = new Mock<IEnrichmentQueueRepository>();
         _mockUnitOfWork = new Mock<IUnitOfWork>();
         _mockEnqueueLogger = new Mock<ILogger<EnqueueEnrichmentCommandHandler>>();
         _mockAllSkeletonsLogger = new Mock<ILogger<EnqueueAllSkeletonsCommandHandler>>();
@@ -45,12 +47,14 @@ public class EnqueueEnrichmentCommandTests
         _enqueueHandler = new EnqueueEnrichmentCommandHandler(
             _mockRepository.Object,
             _mockQueueService.Object,
+            _mockEnrichmentQueueRepository.Object,
             _mockUnitOfWork.Object,
             _mockEnqueueLogger.Object);
 
         _allSkeletonsHandler = new EnqueueAllSkeletonsCommandHandler(
             _mockRepository.Object,
             _mockQueueService.Object,
+            _mockEnrichmentQueueRepository.Object,
             _mockUnitOfWork.Object,
             _mockAllSkeletonsLogger.Object);
 
@@ -100,6 +104,19 @@ public class EnqueueEnrichmentCommandTests
 
         _mockUnitOfWork.Verify(
             u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Issue #1874 — EnrichmentQueueEntry must be persisted with
+        // Priority=Normal, QueuedBy=admin user, Reason="manual enqueue".
+        _mockEnrichmentQueueRepository.Verify(
+            r => r.AddRangeAsync(
+                It.Is<IEnumerable<EnrichmentQueueEntry>>(entries =>
+                    entries.Any(e =>
+                        e.SharedGameId == gameId &&
+                        e.Priority == EnrichmentPriority.Normal &&
+                        e.QueuedByUserId == AdminUserId &&
+                        e.Reason == "manual enqueue")),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -224,6 +241,19 @@ public class EnqueueEnrichmentCommandTests
 
         _mockUnitOfWork.Verify(
             u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Issue #1874 — batch enqueue with Priority=Stale, QueuedBy=null (system),
+        // Reason="stale skeletons batch".
+        _mockEnrichmentQueueRepository.Verify(
+            r => r.AddRangeAsync(
+                It.Is<IEnumerable<EnrichmentQueueEntry>>(entries =>
+                    entries.Count() == 3 &&
+                    entries.All(e =>
+                        e.Priority == EnrichmentPriority.Stale &&
+                        e.QueuedByUserId == null &&
+                        e.Reason == "stale skeletons batch")),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/EnrichmentQueryHandlersTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/EnrichmentQueryHandlersTests.cs
@@ -1,0 +1,127 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests for #1874 enrichment query handlers (with mocked repositories).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1874")]
+public sealed class EnrichmentQueryHandlersTests
+{
+    [Fact]
+    public async Task GetEnrichmentQueueQueryHandler_MapsRepoOutputToDto()
+    {
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var entry = EnrichmentQueueEntry.Enqueue(gameId, EnrichmentPriority.High, "errata", userId);
+
+        var repoMock = new Mock<IEnrichmentQueueRepository>();
+        repoMock
+            .Setup(r => r.GetPendingAsync(It.IsAny<EnrichmentPriority?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<EnrichmentQueueEntryWithTitle>)new[]
+            {
+                new EnrichmentQueueEntryWithTitle(entry, "Twilight Imperium 4E"),
+            }, 1));
+
+        var handler = new GetEnrichmentQueueQueryHandler(repoMock.Object);
+
+        var result = await handler.Handle(
+            new GetEnrichmentQueueQuery(EnrichmentPriority.High, 25),
+            CancellationToken.None);
+
+        result.Total.Should().Be(1);
+        result.Items.Should().HaveCount(1);
+        result.Items[0].SharedGameId.Should().Be(gameId);
+        result.Items[0].Title.Should().Be("Twilight Imperium 4E");
+        result.Items[0].Priority.Should().Be(EnrichmentPriority.High);
+        result.Items[0].Reason.Should().Be("errata");
+        result.Items[0].QueuedBy.Should().Be(userId);
+
+        repoMock.Verify(
+            r => r.GetPendingAsync(EnrichmentPriority.High, 25, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEnrichmentQueueQueryHandler_EmptyResult_ReturnsEmptyList()
+    {
+        var repoMock = new Mock<IEnrichmentQueueRepository>();
+        repoMock
+            .Setup(r => r.GetPendingAsync(It.IsAny<EnrichmentPriority?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Array.Empty<EnrichmentQueueEntryWithTitle>(), 0));
+
+        var handler = new GetEnrichmentQueueQueryHandler(repoMock.Object);
+
+        var result = await handler.Handle(
+            new GetEnrichmentQueueQuery(null, 25),
+            CancellationToken.None);
+
+        result.Total.Should().Be(0);
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetFailedItemsQueryHandler_MapsRepoAggregatesToDto()
+    {
+        var gameId = Guid.NewGuid();
+        var when = DateTimeOffset.UtcNow.AddDays(-2);
+
+        var repoMock = new Mock<IEnrichmentAttemptRepository>();
+        repoMock
+            .Setup(r => r.GetFailedAggregatesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<FailedItemAggregate>)new[]
+            {
+                new FailedItemAggregate(
+                    gameId,
+                    "Gloomhaven JOTL",
+                    "SCHEMA_MISMATCH",
+                    "Field 'designer' missing",
+                    when,
+                    1),
+            }, 1));
+
+        var handler = new GetFailedItemsQueryHandler(repoMock.Object);
+
+        var result = await handler.Handle(
+            new GetFailedItemsQuery(30, 50),
+            CancellationToken.None);
+
+        result.Total.Should().Be(1);
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Title.Should().Be("Gloomhaven JOTL");
+        result.Items[0].ErrorCode.Should().Be("SCHEMA_MISMATCH");
+        result.Items[0].RetryCount.Should().Be(1);
+        result.Items[0].LastAttemptAt.Should().Be(when);
+    }
+
+    [Fact]
+    public void GetEnrichmentQueueQueryValidator_RejectsLimitOutOfRange()
+    {
+        var validator = new GetEnrichmentQueueQueryValidator();
+
+        validator.Validate(new GetEnrichmentQueueQuery(null, 0)).IsValid.Should().BeFalse();
+        validator.Validate(new GetEnrichmentQueueQuery(null, 101)).IsValid.Should().BeFalse();
+        validator.Validate(new GetEnrichmentQueueQuery(null, 25)).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetFailedItemsQueryValidator_RejectsBoundsOutOfRange()
+    {
+        var validator = new GetFailedItemsQueryValidator();
+
+        validator.Validate(new GetFailedItemsQuery(0, 50)).IsValid.Should().BeFalse();
+        validator.Validate(new GetFailedItemsQuery(366, 50)).IsValid.Should().BeFalse();
+        validator.Validate(new GetFailedItemsQuery(30, 0)).IsValid.Should().BeFalse();
+        validator.Validate(new GetFailedItemsQuery(30, 101)).IsValid.Should().BeFalse();
+        validator.Validate(new GetFailedItemsQuery(30, 50)).IsValid.Should().BeTrue();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentAttemptTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentAttemptTests.cs
@@ -1,0 +1,129 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Domain unit tests for <see cref="EnrichmentAttempt"/> (#1874).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1874")]
+public sealed class EnrichmentAttemptTests
+{
+    private static readonly Guid GameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid RunId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    [Fact]
+    public void RecordSuccess_BuildsCleanAttempt()
+    {
+        var attempt = EnrichmentAttempt.RecordSuccess(GameId, RunId, retryCount: 0);
+
+        attempt.Id.Should().NotBeEmpty();
+        attempt.SharedGameId.Should().Be(GameId);
+        attempt.CatalogSyncRunId.Should().Be(RunId);
+        attempt.Success.Should().BeTrue();
+        attempt.ErrorCode.Should().BeNull();
+        attempt.ErrorDetail.Should().BeNull();
+        attempt.RetryCount.Should().Be(0);
+        attempt.AttemptedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, precision: TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void RecordSuccess_AllowsNullRunId_ForManualOneOff()
+    {
+        var attempt = EnrichmentAttempt.RecordSuccess(GameId, catalogSyncRunId: null, retryCount: 2);
+
+        attempt.CatalogSyncRunId.Should().BeNull();
+        attempt.RetryCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void RecordFailure_BuildsAttemptWithErrorDetails()
+    {
+        var attempt = EnrichmentAttempt.RecordFailure(
+            GameId, RunId, "BGG_API_RATE_LIMIT_429", "4 retry esauriti", retryCount: 3);
+
+        attempt.Success.Should().BeFalse();
+        attempt.ErrorCode.Should().Be("BGG_API_RATE_LIMIT_429");
+        attempt.ErrorDetail.Should().Be("4 retry esauriti");
+        attempt.RetryCount.Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RecordFailure_RejectsBlankErrorCode(string errorCode)
+    {
+        var act = () => EnrichmentAttempt.RecordFailure(
+            GameId, RunId, errorCode, "detail", retryCount: 0);
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*Error code*");
+    }
+
+    [Fact]
+    public void RecordFailure_RejectsErrorCodeOver100Chars()
+    {
+        var act = () => EnrichmentAttempt.RecordFailure(
+            GameId, RunId, new string('x', 101), "detail", retryCount: 0);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RecordFailure_RejectsBlankErrorDetail(string detail)
+    {
+        var act = () => EnrichmentAttempt.RecordFailure(
+            GameId, RunId, "ERR", detail, retryCount: 0);
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*Error detail*");
+    }
+
+    [Fact]
+    public void RecordSuccess_ThrowsOnEmptySharedGameId()
+    {
+        var act = () => EnrichmentAttempt.RecordSuccess(Guid.Empty, RunId, retryCount: 0);
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*SharedGameId*");
+    }
+
+    [Fact]
+    public void RecordSuccess_ThrowsOnEmptyRunGuid()
+    {
+        var act = () => EnrichmentAttempt.RecordSuccess(GameId, catalogSyncRunId: Guid.Empty, retryCount: 0);
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*CatalogSyncRunId*");
+    }
+
+    [Fact]
+    public void RecordSuccess_ThrowsOnNegativeRetryCount()
+    {
+        var act = () => EnrichmentAttempt.RecordSuccess(GameId, RunId, retryCount: -1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Reconstitute_RestoresFailureSnapshot()
+    {
+        var when = DateTimeOffset.UtcNow.AddDays(-1);
+        var attempt = EnrichmentAttempt.Reconstitute(
+            id: Guid.NewGuid(),
+            sharedGameId: GameId,
+            catalogSyncRunId: RunId,
+            attemptedAt: when,
+            success: false,
+            errorCode: "SCHEMA_MISMATCH",
+            errorDetail: "Field 'designer' missing",
+            retryCount: 1);
+
+        attempt.Success.Should().BeFalse();
+        attempt.AttemptedAt.Should().Be(when);
+        attempt.ErrorCode.Should().Be("SCHEMA_MISMATCH");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentQueueEntryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/EnrichmentQueueEntryTests.cs
@@ -1,0 +1,134 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Domain unit tests for <see cref="EnrichmentQueueEntry"/> (#1874).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1874")]
+public sealed class EnrichmentQueueEntryTests
+{
+    private static readonly Guid GameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Enqueue_CreatesEntryWithExpectedState()
+    {
+        var entry = EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Normal, "manual enqueue", UserId);
+
+        entry.Id.Should().NotBeEmpty();
+        entry.SharedGameId.Should().Be(GameId);
+        entry.Priority.Should().Be(EnrichmentPriority.Normal);
+        entry.Reason.Should().Be("manual enqueue");
+        entry.QueuedByUserId.Should().Be(UserId);
+        entry.QueuedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, precision: TimeSpan.FromSeconds(2));
+        entry.IsProcessed.Should().BeFalse();
+        entry.ProcessedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Enqueue_AllowsNullQueuedBy_ForCronOrSystem()
+    {
+        var entry = EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Stale, "stale skeletons batch", queuedBy: null);
+
+        entry.QueuedByUserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Enqueue_ThrowsOnEmptySharedGameId()
+    {
+        var act = () => EnrichmentQueueEntry.Enqueue(
+            Guid.Empty, EnrichmentPriority.Normal, "reason", UserId);
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*SharedGameId*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Enqueue_ThrowsOnEmptyOrWhitespaceReason(string reason)
+    {
+        var act = () => EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Normal, reason, UserId);
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*Reason*");
+    }
+
+    [Fact]
+    public void Enqueue_ThrowsOnReasonOver200Chars()
+    {
+        var act = () => EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Normal, new string('x', 201), UserId);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Enqueue_ThrowsOnEmptyQueuedByGuid()
+    {
+        var act = () => EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Normal, "reason", queuedBy: Guid.Empty);
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*QueuedByUserId*");
+    }
+
+    [Fact]
+    public void MarkProcessed_FlipsFlagAndStampsTimestamp()
+    {
+        var entry = EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Normal, "manual enqueue", UserId);
+
+        entry.MarkProcessed();
+
+        entry.IsProcessed.Should().BeTrue();
+        entry.ProcessedAt.Should().NotBeNull();
+        entry.ProcessedAt!.Value.Should().BeCloseTo(DateTimeOffset.UtcNow, precision: TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void MarkProcessed_IsIdempotent()
+    {
+        var entry = EnrichmentQueueEntry.Enqueue(
+            GameId, EnrichmentPriority.Normal, "reason", UserId);
+
+        entry.MarkProcessed();
+        var firstTimestamp = entry.ProcessedAt;
+
+        entry.MarkProcessed();
+
+        entry.ProcessedAt.Should().Be(firstTimestamp, "re-calling must be a no-op");
+    }
+
+    [Fact]
+    public void Reconstitute_RestoresStateWithoutInvariantsRunning()
+    {
+        var queuedAt = DateTimeOffset.UtcNow.AddHours(-3);
+        var processedAt = DateTimeOffset.UtcNow.AddHours(-1);
+
+        var entry = EnrichmentQueueEntry.Reconstitute(
+            id: Guid.NewGuid(),
+            sharedGameId: GameId,
+            priority: EnrichmentPriority.High,
+            reason: "hist",
+            queuedByUserId: UserId,
+            queuedAt: queuedAt,
+            isProcessed: true,
+            processedAt: processedAt);
+
+        entry.Priority.Should().Be(EnrichmentPriority.High);
+        entry.IsProcessed.Should().BeTrue();
+        entry.ProcessedAt.Should().Be(processedAt);
+        entry.QueuedAt.Should().Be(queuedAt);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentAttemptRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentAttemptRepositoryIntegrationTests.cs
@@ -1,0 +1,200 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Integration tests for <see cref="EnrichmentAttemptRepository"/> (#1874).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1874")]
+public sealed class EnrichmentAttemptRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private EnrichmentAttemptRepository _repository = null!;
+    private Guid _testUserId;
+    private Guid _gameAlphaId;
+    private Guid _gameBetaId;
+    private string _databaseName = null!;
+
+    public EnrichmentAttemptRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_enrichatt_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(connectionString);
+        await _dbContext.Database.MigrateAsync();
+
+        _testUserId = Guid.NewGuid();
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = _testUserId,
+            Email = $"enrich-att-{Guid.NewGuid():N}@meepleai.test",
+            Role = "Admin",
+            Tier = "Free",
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        _gameAlphaId = await SeedSharedGameAsync("Twilight Imperium 4E");
+        _gameBetaId = await SeedSharedGameAsync("Gloomhaven JOTL");
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        _repository = new EnrichmentAttemptRepository(_dbContext, CreateEventCollector());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact]
+    public async Task GetFailedAggregatesAsync_NoAttempts_ReturnsEmptyResult()
+    {
+        var (items, total) = await _repository.GetFailedAggregatesAsync(days: 30, limit: 50);
+
+        items.Should().BeEmpty();
+        total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetFailedAggregatesAsync_AggregatesByGame_KeepsMostRecentFailureRow()
+    {
+        // Game alpha: 4 attempts (3 failed with retry 0/1/2, then 1 final fail with retry 3)
+        await PersistFailureAsync(_gameAlphaId, "BGG_API_RATE_LIMIT_429", "first try", retryCount: 0, ageSeconds: 1000);
+        await PersistFailureAsync(_gameAlphaId, "BGG_API_RATE_LIMIT_429", "second try", retryCount: 1, ageSeconds: 800);
+        await PersistFailureAsync(_gameAlphaId, "BGG_API_RATE_LIMIT_429", "third try", retryCount: 2, ageSeconds: 600);
+        await PersistFailureAsync(_gameAlphaId, "BGG_API_RATE_LIMIT_429", "final", retryCount: 3, ageSeconds: 100);
+
+        // Game beta: 1 failure SCHEMA_MISMATCH
+        await PersistFailureAsync(_gameBetaId, "SCHEMA_MISMATCH", "field missing", retryCount: 1, ageSeconds: 200);
+
+        var (items, total) = await _repository.GetFailedAggregatesAsync(days: 30, limit: 50);
+
+        total.Should().Be(2);
+        items.Should().HaveCount(2);
+        items.Should().BeInDescendingOrder(i => i.LastAttemptAt);
+
+        var alpha = items.Single(i => i.SharedGameId == _gameAlphaId);
+        alpha.SharedGameTitle.Should().Be("Twilight Imperium 4E");
+        alpha.ErrorCode.Should().Be("BGG_API_RATE_LIMIT_429");
+        alpha.RetryCount.Should().Be(3, "the most recent failure's retry count is surfaced");
+
+        var beta = items.Single(i => i.SharedGameId == _gameBetaId);
+        beta.ErrorCode.Should().Be("SCHEMA_MISMATCH");
+        beta.RetryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetFailedAggregatesAsync_FiltersByDaysWindow()
+    {
+        // Beta: failed 7 days ago — inside 7d window
+        await PersistFailureAsync(_gameBetaId, "ERR_RECENT", "recent", retryCount: 0, ageSeconds: 3 * 86400);
+        // Alpha: failed 14 days ago — OUTSIDE 7d window
+        await PersistFailureAsync(_gameAlphaId, "ERR_OLD", "old", retryCount: 0, ageSeconds: 14 * 86400);
+
+        var (items, total) = await _repository.GetFailedAggregatesAsync(days: 7, limit: 50);
+
+        total.Should().Be(1);
+        items.Should().HaveCount(1);
+        items[0].SharedGameId.Should().Be(_gameBetaId);
+    }
+
+    [Fact]
+    public async Task GetFailedAggregatesAsync_IgnoresSuccessfulAttempts()
+    {
+        await PersistSuccessAsync(_gameAlphaId, retryCount: 2);
+
+        var (items, total) = await _repository.GetFailedAggregatesAsync(days: 30, limit: 50);
+
+        items.Should().BeEmpty();
+        total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AddAsync_SuccessAttempt_PersistsAllFields()
+    {
+        var attempt = EnrichmentAttempt.RecordSuccess(_gameAlphaId, catalogSyncRunId: null, retryCount: 0);
+
+        await _repository.AddAsync(attempt);
+        await _dbContext.SaveChangesAsync();
+
+        var persisted = await _dbContext.EnrichmentAttempts.FindAsync(attempt.Id);
+        persisted.Should().NotBeNull();
+        persisted!.Success.Should().BeTrue();
+        persisted.ErrorCode.Should().BeNull();
+        persisted.CatalogSyncRunId.Should().BeNull();
+    }
+
+    // ===== helpers =====
+
+    private async Task<Guid> SeedSharedGameAsync(string title)
+    {
+        var id = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            YearPublished = 2020,
+            Description = "test",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = "https://example.com/img.jpg",
+            ThumbnailUrl = "https://example.com/thumb.jpg",
+            CreatedBy = _testUserId,
+            CreatedAt = DateTime.UtcNow,
+            IsDeleted = false,
+        });
+        return id;
+    }
+
+    private async Task PersistFailureAsync(Guid sharedGameId, string code, string detail, int retryCount, int ageSeconds)
+    {
+        var attempt = EnrichmentAttempt.RecordFailure(sharedGameId, catalogSyncRunId: null, code, detail, retryCount);
+        await _repository.AddAsync(attempt);
+        await _dbContext.SaveChangesAsync();
+
+        // Backdate the persisted timestamp
+        var entity = await _dbContext.EnrichmentAttempts.FindAsync(attempt.Id);
+        entity!.AttemptedAt = DateTimeOffset.UtcNow.AddSeconds(-ageSeconds);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    private async Task PersistSuccessAsync(Guid sharedGameId, int retryCount)
+    {
+        var attempt = EnrichmentAttempt.RecordSuccess(sharedGameId, catalogSyncRunId: null, retryCount);
+        await _repository.AddAsync(attempt);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    private static IDomainEventCollector CreateEventCollector()
+    {
+        var mock = new Mock<IDomainEventCollector>();
+        mock.Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+        return mock.Object;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepositoryIntegrationTests.cs
@@ -1,0 +1,242 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Integration tests for <see cref="EnrichmentQueueRepository"/> (#1874).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1874")]
+public sealed class EnrichmentQueueRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private EnrichmentQueueRepository _repository = null!;
+    private Guid _testUserId;
+    private Guid _gameAlphaId;
+    private Guid _gameBetaId;
+    private Guid _gameGammaId;
+    private string _databaseName = null!;
+
+    public EnrichmentQueueRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_enrichqueue_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(connectionString);
+        await _dbContext.Database.MigrateAsync();
+
+        _testUserId = Guid.NewGuid();
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = _testUserId,
+            Email = $"enrich-q-{Guid.NewGuid():N}@meepleai.test",
+            Role = "Admin",
+            Tier = "Free",
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        _gameAlphaId = await SeedSharedGameAsync("Alpha Game");
+        _gameBetaId = await SeedSharedGameAsync("Beta Game");
+        _gameGammaId = await SeedSharedGameAsync("Gamma Game");
+
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        _repository = new EnrichmentQueueRepository(_dbContext, CreateEventCollector());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_EmptyQueue_ReturnsEmptyResult()
+    {
+        var (items, total) = await _repository.GetPendingAsync(priority: null, limit: 25);
+
+        items.Should().BeEmpty();
+        total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_OrdersByPriorityDescThenQueuedAtAsc()
+    {
+        // Queue order: stale (oldest), normal, high — expect ordering high → normal → stale.
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Stale, "stale skeletons", null, addedSecondsAgo: 30);
+        await EnqueueAsync(_gameBetaId, EnrichmentPriority.Normal, "manual enqueue", _testUserId, addedSecondsAgo: 20);
+        await EnqueueAsync(_gameGammaId, EnrichmentPriority.High, "errata", _testUserId, addedSecondsAgo: 10);
+
+        var (items, total) = await _repository.GetPendingAsync(priority: null, limit: 25);
+
+        total.Should().Be(3);
+        items.Should().HaveCount(3);
+        items[0].Entry.Priority.Should().Be(EnrichmentPriority.High);
+        items[1].Entry.Priority.Should().Be(EnrichmentPriority.Normal);
+        items[2].Entry.Priority.Should().Be(EnrichmentPriority.Stale);
+
+        items[0].SharedGameTitle.Should().Be("Gamma Game");
+        items[1].SharedGameTitle.Should().Be("Beta Game");
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_FilterByPriority_ReturnsOnlyMatching()
+    {
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.High, "errata", _testUserId);
+        await EnqueueAsync(_gameBetaId, EnrichmentPriority.Normal, "manual", _testUserId);
+        await EnqueueAsync(_gameGammaId, EnrichmentPriority.Stale, "stale", null);
+
+        var (items, total) = await _repository.GetPendingAsync(priority: EnrichmentPriority.High, limit: 25);
+
+        total.Should().Be(1);
+        items.Should().HaveCount(1);
+        items[0].Entry.Priority.Should().Be(EnrichmentPriority.High);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_ExcludesProcessedEntries()
+    {
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Normal, "manual", _testUserId);
+        await EnqueueAsync(_gameBetaId, EnrichmentPriority.Normal, "manual", _testUserId);
+
+        // Mark one as processed
+        var (loaded, _) = await _repository.GetPendingAsync(priority: null, limit: 25);
+        var first = loaded[0].Entry;
+        first.MarkProcessed();
+        await _repository.UpdateAsync(first);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var (items, total) = await _repository.GetPendingAsync(priority: null, limit: 25);
+
+        total.Should().Be(1);
+        items.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_ExcludesEntriesForSoftDeletedSharedGames()
+    {
+        // Mark gameAlpha as soft-deleted post-seed
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Normal, "for deleted", _testUserId);
+        await EnqueueAsync(_gameBetaId, EnrichmentPriority.Normal, "alive", _testUserId);
+
+        var deleted = await _dbContext.SharedGames.IgnoreQueryFilters()
+            .FirstAsync(g => g.Id == _gameAlphaId);
+        deleted.IsDeleted = true;
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var (items, total) = await _repository.GetPendingAsync(priority: null, limit: 25);
+
+        total.Should().Be(1, "entries pointing to soft-deleted shared games must be filtered out");
+        items.Should().OnlyContain(i => i.Entry.SharedGameId == _gameBetaId);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_LimitCapsResults()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            var id = await SeedSharedGameAsync($"Game {i}");
+            await _dbContext.SaveChangesAsync();
+            await EnqueueAsync(id, EnrichmentPriority.Normal, $"#{i}", _testUserId);
+        }
+
+        var (items, total) = await _repository.GetPendingAsync(priority: null, limit: 2);
+
+        total.Should().Be(5);
+        items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AddRangeAsync_PersistsMultipleEntries()
+    {
+        var entries = new[]
+        {
+            EnrichmentQueueEntry.Enqueue(_gameAlphaId, EnrichmentPriority.Stale, "batch a", null),
+            EnrichmentQueueEntry.Enqueue(_gameBetaId, EnrichmentPriority.Stale, "batch b", null),
+        };
+
+        await _repository.AddRangeAsync(entries);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var (items, total) = await _repository.GetPendingAsync(priority: EnrichmentPriority.Stale, limit: 25);
+
+        total.Should().Be(2);
+    }
+
+    // ===== helpers =====
+
+    private async Task<Guid> SeedSharedGameAsync(string title)
+    {
+        var id = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            YearPublished = 2020,
+            Description = "test",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = "https://example.com/img.jpg",
+            ThumbnailUrl = "https://example.com/thumb.jpg",
+            CreatedBy = _testUserId,
+            CreatedAt = DateTime.UtcNow,
+            IsDeleted = false,
+        });
+        return id;
+    }
+
+    private async Task EnqueueAsync(
+        Guid sharedGameId,
+        EnrichmentPriority priority,
+        string reason,
+        Guid? queuedBy,
+        int addedSecondsAgo = 0)
+    {
+        var entry = EnrichmentQueueEntry.Enqueue(sharedGameId, priority, reason, queuedBy);
+        await _repository.AddAsync(entry);
+        await _dbContext.SaveChangesAsync();
+
+        // Backdate when needed so ordering tests can rely on QueuedAt ASC.
+        if (addedSecondsAgo > 0)
+        {
+            var entity = await _dbContext.EnrichmentQueueEntries.FindAsync(entry.Id);
+            entity!.QueuedAt = DateTimeOffset.UtcNow.AddSeconds(-addedSecondsAgo);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    private static IDomainEventCollector CreateEventCollector()
+    {
+        var mock = new Mock<IDomainEventCollector>();
+        mock.Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+        return mock.Object;
+    }
+}


### PR DESCRIPTION
Closes #1874 — BE foundation for the SP5 F4-A6 admin catalog page's "Queue pending re-sync" + "Failed items last 30gg" panels (#1835 will consume these once they ship).

Parent epic: #1833 (F4 Ondata Ops). Follow-up of #1861 (CatalogSyncRun BE foundation, MERGED in PR #1865).

## Scope

| Layer | What |
|---|---|
| Domain | 2 aggregates (`EnrichmentQueueEntry`, `EnrichmentAttempt`) + `EnrichmentPriority` enum + 22 unit tests |
| Infrastructure | 2 entities + 2 EF configs + 1 migration + 2 repositories + DI registration + 12 integration tests |
| Application | 2 query handlers + DTOs + validators + 5 unit tests |
| Routing | 2 endpoints `GET /enrichment-queue` + `GET /failed-items` |
| Hook integration | `EnqueueEnrichmentCommandHandler` + `EnqueueAllSkeletonsCommandHandler` persist `EnrichmentQueueEntry` |

## Out of scope (deferred to follow-up)

`BggImportQueueBackgroundService` attempt-recording integration (Spec §4 hook 3). The service is a 424-line BackgroundService with retry/cleanup logic; a surgical integration needs its own integration tests and would inflate this PR significantly. Filing as a separate issue.

## Notable design decisions

**Priority enum ordering** — chose `Stale=0, Normal=1, High=2` rather than the spec's literal "High | Normal | Stale" order. The Pending listing sorts `OrderByDescending(Priority).ThenBy(QueuedAt)`, so High(2) sorts first naturally. The enum ordinal is part of the DB contract (persisted as int).

**EF `HasSentinel((EnrichmentPriority)(-1))` on Priority** — without this, EF treats 0 (Stale) as the "unset default" and would silently apply the column default during INSERT. The sentinel forces EF to always emit Priority in the INSERT statement. No `HasDefaultValue` on the column itself.

**Failed-items aggregation runs as a two-stage query** — Stage 1 in the DB: `GroupBy + Max(AttemptedAt)`. Stage 2: pull only the matching attempt + game-title rows by `Contains(topGameIds)`. Stage 3 in memory: pick the row matching the per-game MAX timestamp. Avoids the un-translatable `OrderByDescending().Select().First()` inside GroupBy.

**Migration `20260604154416_Add_EnrichmentQueueAndAttempts`** — partial index on `is_processed = false` for the pending-listing path, descending indices for `attempted_at` listings, check constraint on the priority range.

**FK design** — both new entities `Cascade` on shared_games (matching the BC convention). `enrichment_attempts.catalog_sync_run_id` is nullable + `SetNull` so attempt history survives sync-run cleanup.

## Endpoints

```
GET /api/v1/admin/catalog-ingestion/enrichment-queue?priority=&limit=
  Default limit=25, bounds 1-100. Sorted Priority DESC + QueuedAt ASC.

GET /api/v1/admin/catalog-ingestion/failed-items?days=&limit=
  Default days=30 (1-365), default limit=50 (1-100).
  One row per shared game with at least one failed attempt in the window.
```

Both `RequireAdminSession`.

## Verification

- **1117** SharedGameCatalog unit tests pass (no regressions from `EnqueueEnrichmentCommandHandler` constructor signature change).
- **12** new integration tests pass against real PG via Testcontainers, covering: priority ordering, priority filter, processed exclusion, soft-delete filter, limit cap, AddRangeAsync batch persist, failure aggregation, time-window filter, successful-attempt exclusion.
- Build clean.

## Test plan

- [ ] CI green (Backend Fast, Migration Safety Gate)
- [ ] Smoke: run `POST /enqueue-enrichment` with N shared games → confirm `EnrichmentQueueEntry` rows visible via `GET /enrichment-queue`.
- [ ] Smoke: run `POST /enqueue-all-skeletons` → confirm batch entries with `Priority=Stale, Reason="stale skeletons batch", QueuedBy=null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)