### PR TITLE
feat(catalog-seed): #1903 M2 — ICatalogProvider interface + WikidataCatalogProvider

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogProvider.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Strategy contract for a single catalog data provider (Wikidata, BGG, etc.).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §3.2 / §7.
+/// Issue #1903.
+/// </summary>
+internal interface ICatalogProvider
+{
+    /// <summary>Provider identifier: "wikidata" | "bgg".</summary>
+    string Name { get; }
+
+    Task<CatalogProviderResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct);
+}
+
+/// <summary>
+/// Query input for a provider lookup. At least one of <see cref="BggId"/>,
+/// <see cref="WikidataQid"/> or <see cref="SearchTerm"/> must be set.
+/// </summary>
+internal sealed record CatalogProviderQuery(int? BggId, string? WikidataQid, string? SearchTerm);
+
+/// <summary>
+/// Provider lookup result. <see cref="Fields"/> maps logical field name
+/// (e.g. "title", "yearPublished", "mechanics") to its <see cref="FieldProvenance"/>.
+/// On error, <see cref="ErrorMessage"/> is non-null and <see cref="Fields"/> is empty.
+/// </summary>
+internal sealed record CatalogProviderResult(
+    IReadOnlyDictionary<string, FieldProvenance> Fields,
+    string? RawPayloadJson,
+    string? ErrorMessage)
+{
+    public bool Success => ErrorMessage is null && Fields.Count > 0;
+    public static CatalogProviderResult Empty(string error) =>
+        new(new Dictionary<string, FieldProvenance>(StringComparer.Ordinal), null, error);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,14 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
     public string Name => "wikidata";
 
     private const string SparqlPath = "sparql";
+
+    // Validates Wikidata QID format (Q followed by digits) before SPARQL interpolation.
+    // Anchored, no backtracking — DoS-safe. Timeout is defensive.
+    private static readonly Regex WikidataQidPattern = new(
+        @"^Q\d+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(200));
+
     private readonly HttpClient _http;
     private readonly ILogger<WikidataCatalogProvider> _logger;
 
@@ -33,6 +42,11 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
         if (query.BggId is null && query.WikidataQid is null && string.IsNullOrWhiteSpace(query.SearchTerm))
         {
             return CatalogProviderResult.Empty("Missing query parameters");
+        }
+
+        if (query.WikidataQid is not null && !WikidataQidPattern.IsMatch(query.WikidataQid))
+        {
+            return CatalogProviderResult.Empty("Invalid WikidataQid format");
         }
 
         var sparql = BuildSparql(query);
@@ -75,7 +89,7 @@ SELECT ?game ?gameLabel ?yearPublished ?designerLabel ?publisherLabel
 WHERE {{
   {bind}
   OPTIONAL {{ ?game wdt:P577 ?yearPublished. }}
-  OPTIONAL {{ ?game wdt:P178 ?designer. }}
+  OPTIONAL {{ ?game wdt:P3300 ?designer. }}
   OPTIONAL {{ ?game wdt:P123 ?publisher. }}
   OPTIONAL {{ ?game wdt:P1873 ?minPlayers. }}
   OPTIONAL {{ ?game wdt:P1872 ?maxPlayers. }}
@@ -132,7 +146,7 @@ LIMIT 1";
         var designer = Get("designerLabel");
         if (!string.IsNullOrWhiteSpace(designer))
         {
-            fields["designers"] = new FieldProvenance("wikidata", sourceUrl, "P178", fetchedAt, new List<string> { designer });
+            fields["designers"] = new FieldProvenance("wikidata", sourceUrl, "P3300", fetchedAt, new List<string> { designer });
         }
 
         var publisher = Get("publisherLabel");

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -1,0 +1,159 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+/// <summary>
+/// Primary catalog provider — Wikidata SPARQL endpoint.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §7.1.
+/// License: CC0 (all data) — no attribution required.
+/// Issue #1903.
+/// </summary>
+internal sealed class WikidataCatalogProvider : ICatalogProvider
+{
+    public string Name => "wikidata";
+
+    private const string SparqlPath = "sparql";
+    private readonly HttpClient _http;
+    private readonly ILogger<WikidataCatalogProvider> _logger;
+
+    public WikidataCatalogProvider(HttpClient http, ILogger<WikidataCatalogProvider> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CatalogProviderResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.BggId is null && query.WikidataQid is null && string.IsNullOrWhiteSpace(query.SearchTerm))
+        {
+            return CatalogProviderResult.Empty("Missing query parameters");
+        }
+
+        var sparql = BuildSparql(query);
+
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, $"{SparqlPath}?query={Uri.EscapeDataString(sparql)}&format=json");
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/sparql-results+json"));
+
+            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Wikidata SPARQL HTTP {Status} on query: {Sparql}", (int)resp.StatusCode, sparql);
+                return CatalogProviderResult.Empty($"HTTP {(int)resp.StatusCode}");
+            }
+
+            return ParseResponse(body, query, sourceUrl: BuildSourceUrl(query));
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Wikidata fetch failed");
+            return CatalogProviderResult.Empty(ex.GetType().Name);
+        }
+    }
+
+    private static string BuildSparql(CatalogProviderQuery q)
+    {
+        var bind = q.BggId.HasValue
+            ? $"?game wdt:P2339 \"{q.BggId.Value}\"."
+            : q.WikidataQid is not null
+                ? $"BIND(wd:{q.WikidataQid} AS ?game)"
+                : $"?game rdfs:label \"{q.SearchTerm}\"@en.";
+
+        return $@"
+SELECT ?game ?gameLabel ?yearPublished ?designerLabel ?publisherLabel
+       ?minPlayers ?maxPlayers ?playingTimeMinutes
+WHERE {{
+  {bind}
+  OPTIONAL {{ ?game wdt:P577 ?yearPublished. }}
+  OPTIONAL {{ ?game wdt:P178 ?designer. }}
+  OPTIONAL {{ ?game wdt:P123 ?publisher. }}
+  OPTIONAL {{ ?game wdt:P1873 ?minPlayers. }}
+  OPTIONAL {{ ?game wdt:P1872 ?maxPlayers. }}
+  OPTIONAL {{ ?game wdt:P2047 ?playingTimeMinutes. }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language ""en"". }}
+}}
+LIMIT 1";
+    }
+
+    private static string BuildSourceUrl(CatalogProviderQuery q)
+    {
+        if (q.WikidataQid is not null) return $"https://www.wikidata.org/wiki/{q.WikidataQid}";
+        if (q.BggId.HasValue) return $"https://query.wikidata.org/?bggid={q.BggId}";
+        return "https://query.wikidata.org/";
+    }
+
+    private static CatalogProviderResult ParseResponse(string body, CatalogProviderQuery q, string sourceUrl)
+    {
+        var fetchedAt = DateTime.UtcNow;
+        using var doc = JsonDocument.Parse(body);
+        var bindings = doc.RootElement
+            .GetProperty("results")
+            .GetProperty("bindings");
+
+        if (bindings.GetArrayLength() == 0)
+        {
+            return CatalogProviderResult.Empty("Wikidata: entity not found");
+        }
+
+        var row = bindings[0];
+        var fields = new Dictionary<string, FieldProvenance>(StringComparer.Ordinal);
+
+        string? Get(string key) => row.TryGetProperty(key, out var el) && el.TryGetProperty("value", out var v) ? v.GetString() : null;
+
+        var title = Get("gameLabel");
+        if (!string.IsNullOrWhiteSpace(title))
+        {
+            fields["title"] = new FieldProvenance("wikidata", sourceUrl, "labels.en", fetchedAt, title);
+        }
+
+        var gameUri = Get("game");
+        if (gameUri is not null && gameUri.StartsWith("http://www.wikidata.org/entity/", StringComparison.Ordinal))
+        {
+            var qid = gameUri["http://www.wikidata.org/entity/".Length..];
+            fields["wikidataQid"] = new FieldProvenance("wikidata", sourceUrl, "item URI", fetchedAt, qid);
+        }
+
+        var yearRaw = Get("yearPublished");
+        if (yearRaw is not null && DateTimeOffset.TryParse(yearRaw, System.Globalization.CultureInfo.InvariantCulture, out var dt))
+        {
+            fields["yearPublished"] = new FieldProvenance("wikidata", sourceUrl, "P577", fetchedAt, dt.Year);
+        }
+
+        var designer = Get("designerLabel");
+        if (!string.IsNullOrWhiteSpace(designer))
+        {
+            fields["designers"] = new FieldProvenance("wikidata", sourceUrl, "P178", fetchedAt, new List<string> { designer });
+        }
+
+        var publisher = Get("publisherLabel");
+        if (!string.IsNullOrWhiteSpace(publisher))
+        {
+            fields["publishers"] = new FieldProvenance("wikidata", sourceUrl, "P123", fetchedAt, new List<string> { publisher });
+        }
+
+        if (int.TryParse(Get("minPlayers"), System.Globalization.CultureInfo.InvariantCulture, out var mn))
+        {
+            fields["minPlayers"] = new FieldProvenance("wikidata", sourceUrl, "P1873", fetchedAt, mn);
+        }
+        if (int.TryParse(Get("maxPlayers"), System.Globalization.CultureInfo.InvariantCulture, out var mx))
+        {
+            fields["maxPlayers"] = new FieldProvenance("wikidata", sourceUrl, "P1872", fetchedAt, mx);
+        }
+        if (int.TryParse(Get("playingTimeMinutes"), System.Globalization.CultureInfo.InvariantCulture, out var pt))
+        {
+            fields["playingTimeMinutes"] = new FieldProvenance("wikidata", sourceUrl, "P2047", fetchedAt, pt);
+        }
+
+        return new CatalogProviderResult(fields, body, ErrorMessage: null);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
@@ -82,4 +82,45 @@ public sealed class WikidataCatalogProviderTests
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Contain("HTTP");
     }
+
+    [Fact]
+    public async Task FetchAsync_AllNullInputs_ReturnsMissingParametersError()
+    {
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance);
+
+        var result = await provider.FetchAsync(new CatalogProviderQuery(null, null, null), default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Missing");
+    }
+
+    [Fact]
+    public async Task FetchAsync_InvalidWikidataQid_ReturnsValidationError()
+    {
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance);
+
+        var result = await provider.FetchAsync(new CatalogProviderQuery(null, "Q123} . ?x ?y ?z", null), default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Invalid");
+    }
+
+    [Fact]
+    public async Task FetchAsync_ByValidWikidataQid_BuildsBindQuery()
+    {
+        // Sanity: a valid QID format does NOT trigger validation error.
+        const string body = """
+        { "results": { "bindings": [{
+          "game":        {"value": "http://www.wikidata.org/entity/Q98056728"},
+          "gameLabel":   {"value": "Catan"}
+        }]}}
+        """;
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance);
+
+        var result = await provider.FetchAsync(new CatalogProviderQuery(null, "Q98056728", null), default);
+
+        result.Success.Should().BeTrue();
+        result.Fields["title"].Value.Should().Be("Catan");
+        result.Fields["wikidataQid"].Value.Should().Be("Q98056728");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WikidataCatalogProviderTests
+{
+    private static HttpClient MakeClient(HttpStatusCode status, string body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/sparql-results+json"),
+            });
+        return new HttpClient(handler.Object) { BaseAddress = new Uri("https://query.wikidata.org/") };
+    }
+
+    [Fact]
+    public void Name_Equals_Wikidata()
+    {
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance);
+        provider.Name.Should().Be("wikidata");
+    }
+
+    [Fact]
+    public async Task FetchAsync_ByBggId_MapsCoreFields()
+    {
+        const string body = """
+        { "results": { "bindings": [{
+          "game":        {"value": "http://www.wikidata.org/entity/Q98056728"},
+          "gameLabel":   {"value": "Catan"},
+          "yearPublished":{"value": "1995-01-01T00:00:00Z","datatype":"http://www.w3.org/2001/XMLSchema#dateTime"},
+          "designerLabel":{"value": "Klaus Teuber"},
+          "publisherLabel":{"value": "Kosmos"},
+          "minPlayers":  {"value": "3"},
+          "maxPlayers":  {"value": "4"},
+          "playingTimeMinutes":{"value": "60"}
+        }]}}
+        """;
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance);
+        var result = await provider.FetchAsync(new CatalogProviderQuery(BggId: 13, null, null), default);
+
+        result.Success.Should().BeTrue();
+        result.Fields["title"].Value.Should().Be("Catan");
+        result.Fields["title"].Provider.Should().Be("wikidata");
+        result.Fields["yearPublished"].Value.Should().Be(1995);
+        result.Fields["designers"].Value.Should().BeOfType<List<string>>()
+            .Which.Should().Contain("Klaus Teuber");
+        result.Fields["minPlayers"].Value.Should().Be(3);
+        result.Fields["maxPlayers"].Value.Should().Be(4);
+        result.Fields["playingTimeMinutes"].Value.Should().Be(60);
+        result.Fields["wikidataQid"].Value.Should().Be("Q98056728");
+    }
+
+    [Fact]
+    public async Task FetchAsync_NoResults_ReturnsEmptyWithError()
+    {
+        const string body = """{"results":{"bindings":[]}}""";
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance);
+        var result = await provider.FetchAsync(new CatalogProviderQuery(99999, null, null), default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task FetchAsync_HttpError_ReturnsErrorMessage()
+    {
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.InternalServerError, "boom"), NullLogger<WikidataCatalogProvider>.Instance);
+        var result = await provider.FetchAsync(new CatalogProviderQuery(13, null, null), default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("HTTP");
+    }
+}


### PR DESCRIPTION
## Summary

M2 of issue #1903 (admin catalog seed, 8 milestone plan). Implements provider abstraction + primary Wikidata SPARQL provider.

Builds on M1 (PR #1905 merged 18b7b8292).

## What ships

| Task | Commit | Output |
|---|---|---|
| M2.1 | `76629f90f` | `ICatalogProvider` interface + `CatalogProviderQuery`/`CatalogProviderResult` records (37 lines) |
| M2.2 | `e7121aec3` | `WikidataCatalogProvider` (SPARQL HttpClient, 161 lines) + 4 unit tests passing locally |

## Wikidata provider details

- **Endpoint**: `https://query.wikidata.org/sparql`
- **License**: CC0 (zero attribution required, zero legal risk per spec §8.5.5)
- **Lookup modes**: by BGG ID (P2339), Wikidata QID, or English label
- **Mapped fields** (with full provenance: provider/sourceUrl/sourceField/fetchedAt):
  - `title` (labels.en)
  - `wikidataQid` (item URI)
  - `yearPublished` (P577)
  - `designers[]` (P178)
  - `publishers[]` (P123)
  - `minPlayers`/`maxPlayers` (P1873/P1872)
  - `playingTimeMinutes` (P2047)
- **Error handling**: HTTP non-success → `CatalogProviderResult.Empty("HTTP N")`. Exception leak avoided via `ex.GetType().Name` per memory `ex-message-leak-pattern`.

## What's NOT in this PR

- M3 (BGG provider + whitelist guard) — next PR
- M4-M8 — future PRs

## Test plan

- [x] 4/4 unit tests pass locally (`WikidataCatalogProviderTests`)
- [x] Build 0 errors
- [ ] CI green

## Risk

LOW — provider not yet wired into DI / pipeline (that's M4+). This PR adds isolated provider implementation only.