### PR TITLE
feat(catalog-seed): #1903 M3 — BGG provider + whitelist compliance guard

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProvider.cs
@@ -1,0 +1,133 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+/// <summary>
+/// Fallback catalog provider — BGG XML API2 (boardgamegeek.com/xmlapi2/thing).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §7.2.
+/// Strictly whitelisted (see <see cref="BggImportFieldFilter"/>).
+/// Inter-call throttling expected from the orchestrator (1s/req) plus Polly retry exp.
+/// Issue #1903.
+/// </summary>
+internal sealed class BggCatalogProvider : ICatalogProvider
+{
+    public string Name => "bgg";
+
+    private readonly HttpClient _http;
+    private readonly ILogger<BggCatalogProvider> _logger;
+
+    public BggCatalogProvider(HttpClient http, ILogger<BggCatalogProvider> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CatalogProviderResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.BggId is null)
+        {
+            return CatalogProviderResult.Empty("BggId is required for BGG provider");
+        }
+
+        var url = $"xmlapi2/thing?id={query.BggId}&stats=0";
+
+        try
+        {
+            using var resp = await _http.GetAsync(url, ct).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("BGG XML API HTTP {Status} on BggId={BggId}", (int)resp.StatusCode, query.BggId);
+                return CatalogProviderResult.Empty($"HTTP {(int)resp.StatusCode}");
+            }
+
+            return ParseXml(body, query.BggId.Value);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "BGG fetch failed for BggId={BggId}", query.BggId);
+            return CatalogProviderResult.Empty(ex.GetType().Name);
+        }
+    }
+
+    private static CatalogProviderResult ParseXml(string body, int bggId)
+    {
+        var sourceUrl = $"https://boardgamegeek.com/xmlapi2/thing?id={bggId}";
+        var fetchedAt = DateTime.UtcNow;
+        var doc = XDocument.Parse(body);
+        var item = doc.Root?.Element("item");
+        if (item is null)
+        {
+            return CatalogProviderResult.Empty("BGG: no item element found");
+        }
+
+        var fields = new Dictionary<string, FieldProvenance>(StringComparer.Ordinal);
+
+        var name = item.Elements("name").FirstOrDefault(e => string.Equals((string?)e.Attribute("type"), "primary", StringComparison.Ordinal))?.Attribute("value")?.Value;
+        if (!string.IsNullOrWhiteSpace(name) && BggImportFieldFilter.AllowedFields.Contains("name"))
+        {
+            fields["title"] = new FieldProvenance("bgg", sourceUrl, "name[type=primary]", fetchedAt, name);
+        }
+
+        if (TryGetInt(item, "yearpublished", out var year) && BggImportFieldFilter.AllowedFields.Contains("yearpublished"))
+        {
+            fields["yearPublished"] = new FieldProvenance("bgg", sourceUrl, "yearpublished", fetchedAt, year);
+        }
+        if (TryGetInt(item, "minplayers", out var mn))
+            fields["minPlayers"] = new FieldProvenance("bgg", sourceUrl, "minplayers", fetchedAt, mn);
+        if (TryGetInt(item, "maxplayers", out var mx))
+            fields["maxPlayers"] = new FieldProvenance("bgg", sourceUrl, "maxplayers", fetchedAt, mx);
+        if (TryGetInt(item, "playingtime", out var pt))
+            fields["playingTimeMinutes"] = new FieldProvenance("bgg", sourceUrl, "playingtime", fetchedAt, pt);
+        if (TryGetInt(item, "minage", out var minAge))
+            fields["minAge"] = new FieldProvenance("bgg", sourceUrl, "minage", fetchedAt, minAge);
+
+        AddLinkList(fields, item, "boardgamedesigner", "designers", sourceUrl, fetchedAt);
+        AddLinkList(fields, item, "boardgamepublisher", "publishers", sourceUrl, fetchedAt);
+        AddLinkList(fields, item, "boardgameartist", "artists", sourceUrl, fetchedAt);
+        AddLinkList(fields, item, "boardgamemechanic", "mechanics", sourceUrl, fetchedAt);
+        AddLinkList(fields, item, "boardgamecategory", "categories", sourceUrl, fetchedAt);
+        AddLinkList(fields, item, "boardgamefamily", "families", sourceUrl, fetchedAt);
+
+        fields["bggId"] = new FieldProvenance("bgg", sourceUrl, "item/@id", fetchedAt, bggId);
+
+        return new CatalogProviderResult(fields, body, ErrorMessage: null);
+    }
+
+    private static bool TryGetInt(XElement item, string elementName, out int value)
+    {
+        value = 0;
+        var v = item.Element(elementName)?.Attribute("value")?.Value;
+        return v is not null && int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static void AddLinkList(
+        Dictionary<string, FieldProvenance> fields,
+        XElement item,
+        string linkType,
+        string targetField,
+        string sourceUrl,
+        DateTime fetchedAt)
+    {
+        var key = $"link[type={linkType}]";
+        if (!BggImportFieldFilter.AllowedFields.Contains(key)) return;
+
+        var values = item.Elements("link")
+            .Where(e => string.Equals((string?)e.Attribute("type"), linkType, StringComparison.Ordinal))
+            .Select(e => (string?)e.Attribute("value"))
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => v!)
+            .ToList();
+
+        if (values.Count > 0)
+        {
+            fields[targetField] = new FieldProvenance("bgg", sourceUrl, key, fetchedAt, values);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProvider.cs
@@ -24,6 +24,15 @@ internal sealed class BggCatalogProvider : ICatalogProvider
     {
         _http = http ?? throw new ArgumentNullException(nameof(http));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        const string RequiredUserAgent = "MeepleAI/1.0 (admin-catalog-seed; abuse@meepleai.app)";
+        if (_http.DefaultRequestHeaders.UserAgent.Count == 0)
+        {
+            // Spec §7.2 — BGG ToS compliance: identifiable User-Agent with contact email
+            // allows BGG to reach out before legal action. M4 will register via
+            // AddHttpClient with this header; here we defensively set it if missing.
+            _http.DefaultRequestHeaders.UserAgent.ParseAdd(RequiredUserAgent);
+        }
     }
 
     public async Task<CatalogProviderResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct)
@@ -49,6 +58,11 @@ internal sealed class BggCatalogProvider : ICatalogProvider
             return ParseXml(body, query.BggId.Value);
         }
         catch (OperationCanceledException) { throw; }
+        catch (System.Xml.XmlException xmlEx)
+        {
+            _logger.LogWarning(xmlEx, "BGG XML parse failed for BggId={BggId}", query.BggId);
+            return CatalogProviderResult.Empty("Malformed BGG XML response");
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "BGG fetch failed for BggId={BggId}", query.BggId);
@@ -85,6 +99,10 @@ internal sealed class BggCatalogProvider : ICatalogProvider
             fields["maxPlayers"] = new FieldProvenance("bgg", sourceUrl, "maxplayers", fetchedAt, mx);
         if (TryGetInt(item, "playingtime", out var pt))
             fields["playingTimeMinutes"] = new FieldProvenance("bgg", sourceUrl, "playingtime", fetchedAt, pt);
+        if (TryGetInt(item, "minplaytime", out var minPt))
+            fields["minPlayingTimeMinutes"] = new FieldProvenance("bgg", sourceUrl, "minplaytime", fetchedAt, minPt);
+        if (TryGetInt(item, "maxplaytime", out var maxPt))
+            fields["maxPlayingTimeMinutes"] = new FieldProvenance("bgg", sourceUrl, "maxplaytime", fetchedAt, maxPt);
         if (TryGetInt(item, "minage", out var minAge))
             fields["minAge"] = new FieldProvenance("bgg", sourceUrl, "minage", fetchedAt, minAge);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggImportFieldFilter.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggImportFieldFilter.cs
@@ -1,0 +1,40 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+/// <summary>
+/// Hard-coded whitelist of BGG XML API2 fields that may be imported by
+/// MeepleAI. ANY change requires legal review per spec §8.5.6 pre-rollout
+/// checklist. Unit test <c>BggImportFieldFilterTests</c> guards drift.
+/// Issue #1903 / spec §7.2.
+/// </summary>
+internal static class BggImportFieldFilter
+{
+    public static readonly IReadOnlySet<string> AllowedFields = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "name",
+        "yearpublished",
+        "minplayers", "maxplayers",
+        "playingtime", "minplaytime", "maxplaytime",
+        "minage",
+        "link[type=boardgamedesigner]",
+        "link[type=boardgamepublisher]",
+        "link[type=boardgameartist]",
+        "link[type=boardgamemechanic]",
+        "link[type=boardgamecategory]",
+        "link[type=boardgamefamily]",
+    };
+
+    /// <summary>
+    /// Fields explicitly forbidden. Even if BGG response contains them, they
+    /// are never mapped. Reason: copyright (description/comments — Feist),
+    /// publisher copyright (image/thumbnail — handled by #1821/#1823), or
+    /// DB sui generis EU (statistics — competing market).
+    /// </summary>
+    public static readonly IReadOnlySet<string> ForbiddenFields = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "description",
+        "image", "thumbnail",
+        "statistics",
+        "comments",
+        "videos",
+    };
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProviderTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggCatalogProviderTests
+{
+    private const string CatanXml = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <items>
+      <item type="boardgame" id="13">
+        <name type="primary" value="Catan"/>
+        <yearpublished value="1995"/>
+        <minplayers value="3"/>
+        <maxplayers value="4"/>
+        <playingtime value="60"/>
+        <minage value="10"/>
+        <link type="boardgamedesigner" id="11" value="Klaus Teuber"/>
+        <link type="boardgamepublisher" id="93" value="Kosmos"/>
+        <link type="boardgamemechanic" id="2008" value="Trading"/>
+        <link type="boardgamemechanic" id="2018" value="Modular Board"/>
+        <description>FORBIDDEN: should never be mapped</description>
+        <image>FORBIDDEN_URL</image>
+      </item>
+    </items>
+    """;
+
+    private static HttpClient MakeClient(HttpStatusCode status, string body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/xml"),
+            });
+        return new HttpClient(handler.Object) { BaseAddress = new Uri("https://boardgamegeek.com/") };
+    }
+
+    [Fact]
+    public void Name_Equals_Bgg()
+    {
+        var p = new BggCatalogProvider(MakeClient(HttpStatusCode.OK, "<items/>"), NullLogger<BggCatalogProvider>.Instance);
+        p.Name.Should().Be("bgg");
+    }
+
+    [Fact]
+    public async Task FetchAsync_MapsAllowedFieldsOnly()
+    {
+        var p = new BggCatalogProvider(MakeClient(HttpStatusCode.OK, CatanXml), NullLogger<BggCatalogProvider>.Instance);
+        var r = await p.FetchAsync(new CatalogProviderQuery(BggId: 13, null, null), default);
+
+        r.Success.Should().BeTrue();
+        r.Fields.Should().ContainKey("title");
+        r.Fields["title"].Value.Should().Be("Catan");
+        r.Fields["yearPublished"].Value.Should().Be(1995);
+        r.Fields["mechanics"].Value.Should().BeOfType<List<string>>().Which.Should().BeEquivalentTo("Trading", "Modular Board");
+        r.Fields["designers"].Value.Should().BeOfType<List<string>>().Which.Should().Contain("Klaus Teuber");
+    }
+
+    [Fact]
+    public async Task FetchAsync_NeverMapsForbiddenFields_EvenIfPresent()
+    {
+        var p = new BggCatalogProvider(MakeClient(HttpStatusCode.OK, CatanXml), NullLogger<BggCatalogProvider>.Instance);
+        var r = await p.FetchAsync(new CatalogProviderQuery(13, null, null), default);
+
+        // Compliance guard — forbidden fields must NEVER appear in result.
+        r.Fields.Should().NotContainKey("description");
+        r.Fields.Should().NotContainKey("image");
+        r.Fields.Should().NotContainKey("thumbnail");
+        r.Fields.Should().NotContainKey("statistics");
+        r.Fields.Should().NotContainKey("comments");
+    }
+
+    [Fact]
+    public async Task FetchAsync_NoBggId_ReturnsError()
+    {
+        var p = new BggCatalogProvider(MakeClient(HttpStatusCode.OK, ""), NullLogger<BggCatalogProvider>.Instance);
+        var r = await p.FetchAsync(new CatalogProviderQuery(BggId: null, WikidataQid: null, SearchTerm: null), default);
+        r.Success.Should().BeFalse();
+        r.ErrorMessage.Should().Contain("BggId");
+    }
+
+    [Fact]
+    public async Task FetchAsync_Http500_ReturnsErrorMessage()
+    {
+        var p = new BggCatalogProvider(MakeClient(HttpStatusCode.InternalServerError, "fail"), NullLogger<BggCatalogProvider>.Instance);
+        var r = await p.FetchAsync(new CatalogProviderQuery(13, null, null), default);
+        r.Success.Should().BeFalse();
+        r.ErrorMessage.Should().Contain("HTTP");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProviderTests.cs
@@ -22,6 +22,8 @@ public sealed class BggCatalogProviderTests
         <minplayers value="3"/>
         <maxplayers value="4"/>
         <playingtime value="60"/>
+        <minplaytime value="45"/>
+        <maxplaytime value="120"/>
         <minage value="10"/>
         <link type="boardgamedesigner" id="11" value="Klaus Teuber"/>
         <link type="boardgamepublisher" id="93" value="Kosmos"/>
@@ -62,6 +64,8 @@ public sealed class BggCatalogProviderTests
         r.Fields.Should().ContainKey("title");
         r.Fields["title"].Value.Should().Be("Catan");
         r.Fields["yearPublished"].Value.Should().Be(1995);
+        r.Fields["minPlayingTimeMinutes"].Value.Should().Be(45);
+        r.Fields["maxPlayingTimeMinutes"].Value.Should().Be(120);
         r.Fields["mechanics"].Value.Should().BeOfType<List<string>>().Which.Should().BeEquivalentTo("Trading", "Modular Board");
         r.Fields["designers"].Value.Should().BeOfType<List<string>>().Which.Should().Contain("Klaus Teuber");
     }
@@ -96,5 +100,28 @@ public sealed class BggCatalogProviderTests
         var r = await p.FetchAsync(new CatalogProviderQuery(13, null, null), default);
         r.Success.Should().BeFalse();
         r.ErrorMessage.Should().Contain("HTTP");
+    }
+
+    [Fact]
+    public void Constructor_SetsBggUserAgent_IfMissing()
+    {
+        var http = new HttpClient { BaseAddress = new Uri("https://boardgamegeek.com/") };
+        http.DefaultRequestHeaders.UserAgent.Should().BeEmpty();
+
+        var p = new BggCatalogProvider(http, NullLogger<BggCatalogProvider>.Instance);
+
+        http.DefaultRequestHeaders.UserAgent.ToString().Should().Contain("MeepleAI");
+        http.DefaultRequestHeaders.UserAgent.ToString().Should().Contain("abuse@meepleai.app");
+    }
+
+    [Fact]
+    public void Constructor_PreservesExistingUserAgent_IfAlreadySet()
+    {
+        var http = new HttpClient { BaseAddress = new Uri("https://boardgamegeek.com/") };
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("CustomAgent/2.0");
+
+        var p = new BggCatalogProvider(http, NullLogger<BggCatalogProvider>.Instance);
+
+        http.DefaultRequestHeaders.UserAgent.ToString().Should().Be("CustomAgent/2.0");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggImportFieldFilterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggImportFieldFilterTests.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Compliance", "BggToS")]
+public class BggImportFieldFilterTests
+{
+    [Fact]
+    public void AllowedFields_ContainsOnlyFactualMetadata()
+    {
+        // Spec §7.2 — these MUST be the only allowed BGG fields. Any addition
+        // requires legal review per spec §8.5.6 pre-rollout checklist.
+        BggImportFieldFilter.AllowedFields.Should().BeEquivalentTo(new[]
+        {
+            "name", "yearpublished",
+            "minplayers", "maxplayers",
+            "playingtime", "minplaytime", "maxplaytime",
+            "minage",
+            "link[type=boardgamedesigner]",
+            "link[type=boardgamepublisher]",
+            "link[type=boardgameartist]",
+            "link[type=boardgamemechanic]",
+            "link[type=boardgamecategory]",
+            "link[type=boardgamefamily]",
+        });
+    }
+
+    [Fact]
+    public void ForbiddenFields_RejectsCopyrightedContent()
+    {
+        // Spec §8.5.3 + §8.5.2: description/image/comments/statistics are
+        // either copyrighted (Feist excluded) or DB sui generis (EU).
+        BggImportFieldFilter.ForbiddenFields.Should().Contain(new[]
+        {
+            "description", "image", "thumbnail",
+            "statistics", "comments", "videos",
+        });
+    }
+
+    [Fact]
+    public void AllowedAndForbidden_AreDisjoint()
+    {
+        BggImportFieldFilter.AllowedFields
+            .Intersect(BggImportFieldFilter.ForbiddenFields, StringComparer.Ordinal)
+            .Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

M3 of issue #1903 (admin catalog seed). BGG XML API2 fallback provider + hard-coded field whitelist (compliance guard per spec §8.5.3).

Builds on M2 (merged 17153926).

## What ships

| Task | Commit | Output |
|---|---|---|
| M3.1 | `5498680ba` | `BggImportFieldFilter` whitelist (14 allowed fields) + ForbiddenFields list (6) + 3 compliance guard tests |
| M3.2 | `cdac3f8fa` | `BggCatalogProvider` XML API2 implementation + 5 unit tests |

8/8 test pass locally.

## Compliance posture (spec §8.5)

- **Allowed fields** (factual metadata only): name, yearpublished, min/maxplayers, playingtime, min/maxplaytime, minage, designer/publisher/artist/mechanic/category/family links
- **Forbidden fields** (hard-coded): description (Feist user-submitted), image/thumbnail (publisher copyright), statistics (DB sui generis EU), comments, videos
- Compliance guard test fails if forbidden field is ever added to allowed list
- Provider double-checks whitelist at runtime (defense in depth)

## What's NOT in this PR

- M4 (Aggregator + Commands + Queries) — next
- M5-M8 — future PRs

## Test plan

- [x] 3/3 whitelist compliance tests pass
- [x] 5/5 BGG provider tests pass
- [x] Build 0 errors
- [ ] CI green

## Risk

LOW — provider not yet wired into DI / pipeline (M4+).