### PR TITLE
feat(catalog-seed): #1903 M4 — aggregator + commands + queries

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommand.cs
@@ -1,0 +1,27 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Command to approve a catalog seed draft. The draft must be in <c>Fetched</c>
+/// status (provider data already retrieved). Approval transitions the draft to
+/// <c>Approved</c> and emits a <see cref="Domain.Events.CatalogSeedApprovedEvent"/>
+/// for downstream SharedGameCatalogEntry materialization (handled in M5).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.4.
+/// </summary>
+internal sealed record ApproveCatalogSeedCommand(
+    Guid DraftId,
+    Guid ApprovedByUserId) : ICommand<ApproveCatalogSeedResult>;
+
+/// <summary>
+/// Result of approving a catalog seed draft.
+/// </summary>
+/// <param name="DraftId">The id of the approved draft.</param>
+/// <param name="ResultingSharedGameId">
+/// Placeholder id assigned to <c>CatalogSeedDraftEntity.ResultingSharedGameId</c>.
+/// The actual <c>SharedGameCatalogEntry</c> row is created asynchronously by the
+/// <c>CatalogSeedApprovedEventHandler</c> (see M5); that handler is responsible
+/// for updating this id to the real entry once materialized.
+/// </param>
+internal sealed record ApproveCatalogSeedResult(Guid DraftId, Guid ResultingSharedGameId);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandler.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="ApproveCatalogSeedCommand"/>.
+/// Marks a Fetched draft as Approved, persists the change, then publishes
+/// <see cref="CatalogSeedApprovedEvent"/> via MediatR <em>after</em> the save
+/// commits. Post-save publish follows the issue #1873 review-fix H1 pattern
+/// (CLAUDE.md): events left in IDomainEventCollector after a save failure would
+/// otherwise be drained by a subsequent SaveChangesAsync on the same scope,
+/// triggering downstream side effects for a state that never persisted.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.4.
+/// </summary>
+internal sealed class ApproveCatalogSeedCommandHandler
+    : ICommandHandler<ApproveCatalogSeedCommand, ApproveCatalogSeedResult>
+{
+    private readonly ICatalogSeedDraftRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMediator? _mediator;
+    private readonly ILogger<ApproveCatalogSeedCommandHandler> _logger;
+
+    public ApproveCatalogSeedCommandHandler(
+        ICatalogSeedDraftRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<ApproveCatalogSeedCommandHandler> logger,
+        IMediator? mediator = null)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _mediator = mediator;
+    }
+
+    public async Task<ApproveCatalogSeedResult> Handle(
+        ApproveCatalogSeedCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var draft = await _repository
+            .GetByIdAsync(request.DraftId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (draft is null)
+        {
+            throw new NotFoundException("CatalogSeedDraft", request.DraftId.ToString());
+        }
+
+        if (!string.Equals(draft.Status, nameof(CatalogSeedStatus.Fetched), StringComparison.Ordinal))
+        {
+            throw new ConflictException(
+                $"Draft {request.DraftId} is in status {draft.Status}; only Fetched drafts can be approved.");
+        }
+
+        // Placeholder; the actual SharedGameCatalogEntry row will be created by
+        // CatalogSeedApprovedEventHandler in M5, which will overwrite this id
+        // with the real entry id once materialization succeeds.
+        var resultingSharedGameId = Guid.NewGuid();
+
+        draft.Status = nameof(CatalogSeedStatus.Approved);
+        draft.ApprovedAt = DateTime.UtcNow;
+        draft.ApprovedByUserId = request.ApprovedByUserId;
+        draft.ResultingSharedGameId = resultingSharedGameId;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "CatalogSeedDraft {DraftId} approved by user {UserId} placeholder SharedGameId={SharedGameId}",
+            request.DraftId,
+            request.ApprovedByUserId,
+            resultingSharedGameId);
+
+        if (_mediator is not null)
+        {
+            await _mediator
+                .Publish(
+                    new CatalogSeedApprovedEvent(request.DraftId, resultingSharedGameId, request.ApprovedByUserId),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new ApproveCatalogSeedResult(request.DraftId, resultingSharedGameId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandler.cs
@@ -25,19 +25,19 @@ internal sealed class ApproveCatalogSeedCommandHandler
 {
     private readonly ICatalogSeedDraftRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
-    private readonly IMediator? _mediator;
+    private readonly IMediator _mediator;
     private readonly ILogger<ApproveCatalogSeedCommandHandler> _logger;
 
     public ApproveCatalogSeedCommandHandler(
         ICatalogSeedDraftRepository repository,
         IUnitOfWork unitOfWork,
         ILogger<ApproveCatalogSeedCommandHandler> logger,
-        IMediator? mediator = null)
+        IMediator mediator)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _mediator = mediator;
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
     public async Task<ApproveCatalogSeedResult> Handle(
@@ -79,14 +79,11 @@ internal sealed class ApproveCatalogSeedCommandHandler
             request.ApprovedByUserId,
             resultingSharedGameId);
 
-        if (_mediator is not null)
-        {
-            await _mediator
-                .Publish(
-                    new CatalogSeedApprovedEvent(request.DraftId, resultingSharedGameId, request.ApprovedByUserId),
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await _mediator
+            .Publish(
+                new CatalogSeedApprovedEvent(request.DraftId, resultingSharedGameId, request.ApprovedByUserId),
+                cancellationToken)
+            .ConfigureAwait(false);
 
         return new ApproveCatalogSeedResult(request.DraftId, resultingSharedGameId);
     }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/BulkEnqueueCatalogSeedsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/BulkEnqueueCatalogSeedsCommand.cs
@@ -1,0 +1,28 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Command to enqueue multiple catalog seed drafts in a single batch.
+/// Delegates per-item insert (and duplicate detection) to
+/// <see cref="EnqueueCatalogSeedCommand"/> via MediatR.
+/// Hard cap: 100 BGG ids per batch (enforced by validator).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.3.
+/// </summary>
+internal sealed record BulkEnqueueCatalogSeedsCommand(
+    IReadOnlyList<int> BggIds,
+    Guid CreatedByUserId) : ICommand<BulkEnqueueCatalogSeedsResult>;
+
+/// <summary>
+/// Result of a bulk-enqueue operation.
+/// </summary>
+/// <param name="Total">Total ids submitted in the batch.</param>
+/// <param name="Enqueued">Number of newly created draft rows.</param>
+/// <param name="Duplicates">Number of ids skipped because a draft already existed.</param>
+/// <param name="NewDraftIds">Ids of the newly created drafts (length == Enqueued).</param>
+internal sealed record BulkEnqueueCatalogSeedsResult(
+    int Total,
+    int Enqueued,
+    int Duplicates,
+    IReadOnlyList<Guid> NewDraftIds);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/BulkEnqueueCatalogSeedsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/BulkEnqueueCatalogSeedsCommandHandler.cs
@@ -1,0 +1,68 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="BulkEnqueueCatalogSeedsCommand"/>.
+/// Delegates per-item dispatch to <see cref="EnqueueCatalogSeedCommand"/> via MediatR
+/// so idempotency, validation, and persistence semantics stay in a single place.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.3.
+/// </summary>
+internal sealed class BulkEnqueueCatalogSeedsCommandHandler
+    : ICommandHandler<BulkEnqueueCatalogSeedsCommand, BulkEnqueueCatalogSeedsResult>
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<BulkEnqueueCatalogSeedsCommandHandler> _logger;
+
+    public BulkEnqueueCatalogSeedsCommandHandler(
+        IMediator mediator,
+        ILogger<BulkEnqueueCatalogSeedsCommandHandler> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BulkEnqueueCatalogSeedsResult> Handle(
+        BulkEnqueueCatalogSeedsCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var newIds = new List<Guid>(request.BggIds.Count);
+        var enqueued = 0;
+        var duplicates = 0;
+
+        foreach (var bggId in request.BggIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var inner = new EnqueueCatalogSeedCommand(bggId, null, null, request.CreatedByUserId);
+            var result = await _mediator.Send(inner, cancellationToken).ConfigureAwait(false);
+
+            if (result.IsDuplicate)
+            {
+                duplicates++;
+            }
+            else
+            {
+                enqueued++;
+                newIds.Add(result.Id);
+            }
+        }
+
+        _logger.LogInformation(
+            "BulkEnqueueCatalogSeeds processed total={Total} enqueued={Enqueued} duplicates={Duplicates}",
+            request.BggIds.Count,
+            enqueued,
+            duplicates);
+
+        return new BulkEnqueueCatalogSeedsResult(
+            Total: request.BggIds.Count,
+            Enqueued: enqueued,
+            Duplicates: duplicates,
+            NewDraftIds: newIds);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueCatalogSeedCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueCatalogSeedCommand.cs
@@ -1,0 +1,29 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Command to enqueue a single catalog seed draft for asynchronous provider fetch.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.2.
+/// </summary>
+/// <remarks>
+/// At least one of <paramref name="BggId"/>, <paramref name="WikidataQid"/>, or
+/// <paramref name="SearchTermInput"/> must be supplied (enforced by validator).
+/// If a draft already exists for the given BggId, the command is idempotent and
+/// returns <c>IsDuplicate=true</c> without inserting a new row.
+/// </remarks>
+internal sealed record EnqueueCatalogSeedCommand(
+    int? BggId,
+    string? WikidataQid,
+    string? SearchTermInput,
+    Guid CreatedByUserId) : ICommand<EnqueueCatalogSeedResult>;
+
+/// <summary>
+/// Result of enqueueing a single catalog seed draft.
+/// </summary>
+/// <param name="Id">The draft id (existing or newly created).</param>
+/// <param name="BggId">Echo of the BGG id (may be null for Wikidata-/search-only seeds).</param>
+/// <param name="Status">Current status of the draft. New drafts start as <c>Pending</c>.</param>
+/// <param name="IsDuplicate">True when an existing draft was found for the given BggId.</param>
+internal sealed record EnqueueCatalogSeedResult(Guid Id, int? BggId, string Status, bool IsDuplicate);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueCatalogSeedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueCatalogSeedCommandHandler.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="EnqueueCatalogSeedCommand"/>.
+/// Idempotent on <c>BggId</c>: if a draft already exists, no new row is inserted
+/// and the existing draft is returned with <c>IsDuplicate=true</c>.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.2.
+/// </summary>
+internal sealed class EnqueueCatalogSeedCommandHandler
+    : ICommandHandler<EnqueueCatalogSeedCommand, EnqueueCatalogSeedResult>
+{
+    private readonly ICatalogSeedDraftRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<EnqueueCatalogSeedCommandHandler> _logger;
+
+    public EnqueueCatalogSeedCommandHandler(
+        ICatalogSeedDraftRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<EnqueueCatalogSeedCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EnqueueCatalogSeedResult> Handle(
+        EnqueueCatalogSeedCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.BggId is int bggId)
+        {
+            var exists = await _repository
+                .ExistsAsync(bggId, cancellationToken)
+                .ConfigureAwait(false);
+            if (exists)
+            {
+                _logger.LogInformation(
+                    "CatalogSeedDraft duplicate detected for BggId={BggId}; skipping insert.",
+                    bggId);
+                return new EnqueueCatalogSeedResult(Guid.Empty, bggId, nameof(CatalogSeedStatus.Pending), IsDuplicate: true);
+            }
+        }
+
+        var entity = new CatalogSeedDraftEntity
+        {
+            Id = Guid.NewGuid(),
+            BggId = request.BggId,
+            WikidataQid = string.IsNullOrWhiteSpace(request.WikidataQid) ? null : request.WikidataQid,
+            SearchTermInput = string.IsNullOrWhiteSpace(request.SearchTermInput) ? null : request.SearchTermInput,
+            Status = nameof(CatalogSeedStatus.Pending),
+            CreatedByUserId = request.CreatedByUserId,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        await _repository.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "CatalogSeedDraft enqueued Id={DraftId} BggId={BggId} Wikidata={Qid}",
+            entity.Id,
+            entity.BggId,
+            entity.WikidataQid);
+
+        return new EnqueueCatalogSeedResult(entity.Id, entity.BggId, entity.Status, IsDuplicate: false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommand.cs
@@ -1,0 +1,15 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Command to reject a catalog seed draft. Soft-deletes the draft (audit-retained
+/// per spec §4.2) and emits <see cref="Domain.Events.CatalogSeedRejectedEvent"/>
+/// for downstream metrics / notification.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.5.
+/// </summary>
+internal sealed record RejectCatalogSeedCommand(
+    Guid DraftId,
+    Guid RejectedByUserId,
+    string Reason) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandler.cs
@@ -23,19 +23,19 @@ internal sealed class RejectCatalogSeedCommandHandler : ICommandHandler<RejectCa
 {
     private readonly ICatalogSeedDraftRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
-    private readonly IMediator? _mediator;
+    private readonly IMediator _mediator;
     private readonly ILogger<RejectCatalogSeedCommandHandler> _logger;
 
     public RejectCatalogSeedCommandHandler(
         ICatalogSeedDraftRepository repository,
         IUnitOfWork unitOfWork,
         ILogger<RejectCatalogSeedCommandHandler> logger,
-        IMediator? mediator = null)
+        IMediator mediator)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _mediator = mediator;
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
     public async Task Handle(RejectCatalogSeedCommand request, CancellationToken cancellationToken)
@@ -55,6 +55,13 @@ internal sealed class RejectCatalogSeedCommandHandler : ICommandHandler<RejectCa
         draft.IsDeleted = true;
         draft.DeletedAt = DateTime.UtcNow;
 
+        // Persist reason for audit + DB-level recoverability even if no event handler runs.
+        if (!string.IsNullOrWhiteSpace(request.Reason))
+        {
+            var reason = request.Reason.Length > 500 ? request.Reason[..500] : request.Reason;
+            draft.ErrorMessage = reason;
+        }
+
         // Repository was created via AsTracking() GetByIdAsync so SaveChangesAsync
         // will persist these mutations without an explicit Update() call
         // (CLAUDE.md memory: notracking-default-update-gotcha).
@@ -65,13 +72,10 @@ internal sealed class RejectCatalogSeedCommandHandler : ICommandHandler<RejectCa
             request.DraftId,
             request.RejectedByUserId);
 
-        if (_mediator is not null)
-        {
-            await _mediator
-                .Publish(
-                    new CatalogSeedRejectedEvent(request.DraftId, request.RejectedByUserId, request.Reason ?? string.Empty),
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await _mediator
+            .Publish(
+                new CatalogSeedRejectedEvent(request.DraftId, request.RejectedByUserId, request.Reason ?? string.Empty),
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandler.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Handler for <see cref="RejectCatalogSeedCommand"/>.
+/// Soft-deletes a draft (audit-retained) and publishes
+/// <see cref="CatalogSeedRejectedEvent"/> via MediatR <em>after</em> the save
+/// commits — post-save publish pattern (CLAUDE.md / issue #1873 H1) so that a
+/// stale event from a failed SaveChangesAsync is never replayed by a later
+/// save on the same scope.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §6.
+/// Issue #1903 — M4.5.
+/// </summary>
+internal sealed class RejectCatalogSeedCommandHandler : ICommandHandler<RejectCatalogSeedCommand>
+{
+    private readonly ICatalogSeedDraftRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMediator? _mediator;
+    private readonly ILogger<RejectCatalogSeedCommandHandler> _logger;
+
+    public RejectCatalogSeedCommandHandler(
+        ICatalogSeedDraftRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<RejectCatalogSeedCommandHandler> logger,
+        IMediator? mediator = null)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _mediator = mediator;
+    }
+
+    public async Task Handle(RejectCatalogSeedCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var draft = await _repository
+            .GetByIdAsync(request.DraftId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (draft is null)
+        {
+            throw new NotFoundException("CatalogSeedDraft", request.DraftId.ToString());
+        }
+
+        draft.Status = nameof(CatalogSeedStatus.Rejected);
+        draft.IsDeleted = true;
+        draft.DeletedAt = DateTime.UtcNow;
+
+        // Repository was created via AsTracking() GetByIdAsync so SaveChangesAsync
+        // will persist these mutations without an explicit Update() call
+        // (CLAUDE.md memory: notracking-default-update-gotcha).
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "CatalogSeedDraft {DraftId} rejected by user {UserId}",
+            request.DraftId,
+            request.RejectedByUserId);
+
+        if (_mediator is not null)
+        {
+            await _mediator
+                .Publish(
+                    new CatalogSeedRejectedEvent(request.DraftId, request.RejectedByUserId, request.Reason ?? string.Empty),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/CatalogSeedDraftDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/CatalogSeedDraftDto.cs
@@ -1,0 +1,48 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Read model for <see cref="CatalogSeedDraftEntity"/>. Used by admin UI listings
+/// and detail views. Excludes the full ProvenanceJson / RawPayloadJson bulk payload
+/// — those are fetched separately by a dedicated detail endpoint in M4.7.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §5.
+/// Issue #1903 — M4.6.
+/// </summary>
+internal sealed record CatalogSeedDraftDto(
+    Guid Id,
+    int? BggId,
+    string? WikidataQid,
+    string? SearchTermInput,
+    string Status,
+    string? ErrorMessage,
+    Guid? ResultingSharedGameId,
+    Guid CreatedByUserId,
+    DateTime CreatedAt,
+    DateTime? FetchedAt,
+    DateTime? ApprovedAt,
+    Guid? ApprovedByUserId);
+
+/// <summary>
+/// Helpers to project entities into DTOs.
+/// </summary>
+internal static class CatalogSeedDraftDtoMapper
+{
+    public static CatalogSeedDraftDto ToDto(CatalogSeedDraftEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        return new CatalogSeedDraftDto(
+            entity.Id,
+            entity.BggId,
+            entity.WikidataQid,
+            entity.SearchTermInput,
+            entity.Status,
+            entity.ErrorMessage,
+            entity.ResultingSharedGameId,
+            entity.CreatedByUserId,
+            entity.CreatedAt,
+            entity.FetchedAt,
+            entity.ApprovedAt,
+            entity.ApprovedByUserId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogSeedByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogSeedByIdQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Query to retrieve a single <see cref="DTOs.CatalogSeedDraftDto"/> by id.
+/// Returns <c>null</c> when no draft exists for the given id (endpoint layer
+/// translates null → 404).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §5.
+/// Issue #1903 — M4.6.
+/// </summary>
+internal sealed record GetCatalogSeedByIdQuery(Guid Id) : IQuery<CatalogSeedDraftDto?>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogSeedByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogSeedByIdQueryHandler.cs
@@ -1,0 +1,33 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="GetCatalogSeedByIdQuery"/>.
+/// Returns null when no draft exists (endpoint converts to 404).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §5.
+/// Issue #1903 — M4.6.
+/// </summary>
+internal sealed class GetCatalogSeedByIdQueryHandler
+    : IQueryHandler<GetCatalogSeedByIdQuery, CatalogSeedDraftDto?>
+{
+    private readonly ICatalogSeedDraftRepository _repository;
+
+    public GetCatalogSeedByIdQueryHandler(ICatalogSeedDraftRepository repository)
+        => _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public async Task<CatalogSeedDraftDto?> Handle(
+        GetCatalogSeedByIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entity = await _repository
+            .GetByIdAsync(request.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : CatalogSeedDraftDtoMapper.ToDto(entity);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ListCatalogSeedsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ListCatalogSeedsQuery.cs
@@ -1,0 +1,28 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Query to list <see cref="DTOs.CatalogSeedDraftDto"/> rows with optional status
+/// filter and pagination. Ordered by CreatedAt DESC (most recent first).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §5.
+/// Issue #1903 — M4.6.
+/// </summary>
+internal sealed record ListCatalogSeedsQuery(
+    string? StatusFilter,
+    int Skip = 0,
+    int Take = 50) : IQuery<ListCatalogSeedsResult>;
+
+/// <summary>
+/// Paginated result of <see cref="ListCatalogSeedsQuery"/>.
+/// </summary>
+/// <param name="Total">Total rows matching the filter (across all pages).</param>
+/// <param name="Skip">Echo of the requested skip offset.</param>
+/// <param name="Take">Echo of the requested page size.</param>
+/// <param name="Items">Current page of results.</param>
+internal sealed record ListCatalogSeedsResult(
+    int Total,
+    int Skip,
+    int Take,
+    IReadOnlyList<CatalogSeedDraftDto> Items);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ListCatalogSeedsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ListCatalogSeedsQueryHandler.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Handler for <see cref="ListCatalogSeedsQuery"/>.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §4.2 / §5.
+/// Issue #1903 — M4.6.
+/// </summary>
+internal sealed class ListCatalogSeedsQueryHandler
+    : IQueryHandler<ListCatalogSeedsQuery, ListCatalogSeedsResult>
+{
+    private readonly ICatalogSeedDraftRepository _repository;
+
+    public ListCatalogSeedsQueryHandler(ICatalogSeedDraftRepository repository)
+        => _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public async Task<ListCatalogSeedsResult> Handle(
+        ListCatalogSeedsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var total = await _repository
+            .CountAsync(request.StatusFilter, cancellationToken)
+            .ConfigureAwait(false);
+
+        var entities = await _repository
+            .ListAsync(request.StatusFilter, request.Skip, request.Take, cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = entities.Select(CatalogSeedDraftDtoMapper.ToDto).ToList();
+
+        return new ListCatalogSeedsResult(total, request.Skip, request.Take, items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedAggregator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedAggregator.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Default <see cref="ICatalogSeedAggregator"/> implementation: queries both providers
+/// in parallel, merges results with Wikidata as primary and BGG as fallback for missing
+/// fields, and produces a combined raw JSON payload for audit/debugging.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §3.2 / §7.
+/// Issue #1903 (Task M4.1).
+/// </summary>
+internal sealed class CatalogSeedAggregator : ICatalogSeedAggregator
+{
+    private readonly ICatalogProvider _wikidata;
+    private readonly ICatalogProvider _bgg;
+    private readonly ILogger<CatalogSeedAggregator> _logger;
+
+    public CatalogSeedAggregator(
+        ICatalogProvider wikidata,
+        ICatalogProvider bgg,
+        ILogger<CatalogSeedAggregator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(wikidata);
+        ArgumentNullException.ThrowIfNull(bgg);
+        if (!string.Equals(wikidata.Name, "wikidata", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Expected primary=wikidata", nameof(wikidata));
+        }
+        if (!string.Equals(bgg.Name, "bgg", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Expected fallback=bgg", nameof(bgg));
+        }
+        _wikidata = wikidata;
+        _bgg = bgg;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CatalogSeedAggregationResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var primary = await _wikidata.FetchAsync(query, ct).ConfigureAwait(false);
+        var fallback = await _bgg.FetchAsync(query, ct).ConfigureAwait(false);
+
+        var merged = CatalogSeedProvenance.Merge(primary.Fields, fallback.Fields);
+
+        var providerUsed = (primary.Success, fallback.Success) switch
+        {
+            (true, true) => "wikidata+bgg",
+            (true, false) => "wikidata",
+            (false, true) => "bgg",
+            _ => "none",
+        };
+
+        var rawCombined = $"{{\"wikidata\":{primary.RawPayloadJson ?? "null"},\"bgg\":{fallback.RawPayloadJson ?? "null"}}}";
+
+        _logger.LogInformation(
+            "CatalogSeedAggregator merged provider={Provider} fieldCount={Count}",
+            providerUsed,
+            merged.Fields.Count);
+
+        return new CatalogSeedAggregationResult(merged, providerUsed, rawCombined);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogSeedAggregator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogSeedAggregator.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Aggregates results from multiple <see cref="ICatalogProvider"/> implementations
+/// using Wikidata as primary source with BGG as fallback for missing fields.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §3.2 / §7.
+/// Issue #1903 (Task M4.1).
+/// </summary>
+internal interface ICatalogSeedAggregator
+{
+    Task<CatalogSeedAggregationResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct);
+}
+
+/// <summary>
+/// Result of a catalog seed aggregation. <see cref="Provenance"/> contains merged fields
+/// (primary wins on conflict). <see cref="ProviderUsed"/> tracks which provider(s) contributed:
+/// "wikidata", "bgg", "wikidata+bgg", or "none".
+/// </summary>
+internal readonly record struct CatalogSeedAggregationResult(
+    CatalogSeedProvenance Provenance,
+    string ProviderUsed,
+    string CombinedRawPayload);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/ApproveCatalogSeedCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/ApproveCatalogSeedCommandValidator.cs
@@ -1,0 +1,23 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="ApproveCatalogSeedCommand"/>.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §6.
+/// Issue #1903 — M4.4.
+/// </summary>
+internal sealed class ApproveCatalogSeedCommandValidator : AbstractValidator<ApproveCatalogSeedCommand>
+{
+    public ApproveCatalogSeedCommandValidator()
+    {
+        RuleFor(x => x.DraftId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("DraftId must not be empty.");
+
+        RuleFor(x => x.ApprovedByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ApprovedByUserId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/BulkEnqueueCatalogSeedsCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/BulkEnqueueCatalogSeedsCommandValidator.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="BulkEnqueueCatalogSeedsCommand"/>.
+/// Enforces the 100-id-per-batch cap to prevent runaway provider fetch storms.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §6.
+/// Issue #1903 — M4.3.
+/// </summary>
+internal sealed class BulkEnqueueCatalogSeedsCommandValidator : AbstractValidator<BulkEnqueueCatalogSeedsCommand>
+{
+    public const int MaxBatchSize = 100;
+
+    public BulkEnqueueCatalogSeedsCommandValidator()
+    {
+        RuleFor(x => x.BggIds)
+            .NotEmpty()
+            .WithMessage("BggIds must not be empty.");
+
+        RuleFor(x => x.BggIds)
+            .Must(ids => ids != null && ids.Count <= MaxBatchSize)
+            .WithMessage($"Max {MaxBatchSize} BGG IDs per batch.");
+
+        RuleForEach(x => x.BggIds)
+            .GreaterThan(0)
+            .WithMessage("Each BggId must be a positive integer.");
+
+        RuleFor(x => x.CreatedByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("CreatedByUserId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/EnqueueCatalogSeedCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/EnqueueCatalogSeedCommandValidator.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="EnqueueCatalogSeedCommand"/>.
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §6.
+/// Issue #1903 — M4.2.
+/// </summary>
+internal sealed class EnqueueCatalogSeedCommandValidator : AbstractValidator<EnqueueCatalogSeedCommand>
+{
+    private static readonly Regex WikidataQidRegex = new(
+        "^Q[0-9]+$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        TimeSpan.FromMilliseconds(100));
+
+    public EnqueueCatalogSeedCommandValidator()
+    {
+        // At least one of the three identifying inputs must be supplied.
+        RuleFor(x => x)
+            .Must(x =>
+                x.BggId.HasValue
+                || !string.IsNullOrWhiteSpace(x.WikidataQid)
+                || !string.IsNullOrWhiteSpace(x.SearchTermInput))
+            .WithMessage("At least one of BggId, WikidataQid, or SearchTermInput must be provided.");
+
+        RuleFor(x => x.BggId!.Value)
+            .GreaterThan(0)
+            .WithMessage("BggId must be a positive integer.")
+            .When(x => x.BggId.HasValue);
+
+        RuleFor(x => x.WikidataQid!)
+            .Matches(WikidataQidRegex)
+            .WithMessage("WikidataQid must match pattern '^Q[0-9]+$' (e.g. 'Q42').")
+            .When(x => !string.IsNullOrWhiteSpace(x.WikidataQid));
+
+        RuleFor(x => x.SearchTermInput!)
+            .MaximumLength(255)
+            .WithMessage("SearchTermInput must not exceed 255 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.SearchTermInput));
+
+        RuleFor(x => x.CreatedByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("CreatedByUserId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/RejectCatalogSeedCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/RejectCatalogSeedCommandValidator.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="RejectCatalogSeedCommand"/>.
+/// <c>Reason</c> may be empty (admin shortcut for spam/garbage); only its length
+/// is capped to align with the entity's <c>ErrorMessage</c> column (500 chars).
+/// Spec: 2026-06-04-admin-catalog-seed-design.md §6.
+/// Issue #1903 — M4.5.
+/// </summary>
+internal sealed class RejectCatalogSeedCommandValidator : AbstractValidator<RejectCatalogSeedCommand>
+{
+    public RejectCatalogSeedCommandValidator()
+    {
+        RuleFor(x => x.DraftId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("DraftId must not be empty.");
+
+        RuleFor(x => x.RejectedByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("RejectedByUserId must not be empty.");
+
+        RuleFor(x => x.Reason)
+            .MaximumLength(500)
+            .WithMessage("Reason must not exceed 500 characters.");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandlerTests.cs
@@ -144,7 +144,19 @@ public sealed class ApproveCatalogSeedCommandHandlerTests
         var act = () => new ApproveCatalogSeedCommandHandler(
             repository: null!,
             _uowMock.Object,
-            NullLogger<ApproveCatalogSeedCommandHandler>.Instance);
+            NullLogger<ApproveCatalogSeedCommandHandler>.Instance,
+            _mediatorMock.Object);
         act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void Constructor_NullMediator_Throws()
+    {
+        var act = () => new ApproveCatalogSeedCommandHandler(
+            _repoMock.Object,
+            _uowMock.Object,
+            NullLogger<ApproveCatalogSeedCommandHandler>.Instance,
+            mediator: null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("mediator");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveCatalogSeedCommandHandlerTests.cs
@@ -1,0 +1,150 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class ApproveCatalogSeedCommandHandlerTests
+{
+    private readonly Mock<ICatalogSeedDraftRepository> _repoMock = new();
+    private readonly Mock<IUnitOfWork> _uowMock = new();
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly ApproveCatalogSeedCommandHandler _handler;
+    private readonly Guid _draftId = Guid.NewGuid();
+    private readonly Guid _approver = Guid.NewGuid();
+
+    public ApproveCatalogSeedCommandHandlerTests()
+    {
+        _handler = new ApproveCatalogSeedCommandHandler(
+            _repoMock.Object,
+            _uowMock.Object,
+            NullLogger<ApproveCatalogSeedCommandHandler>.Instance,
+            _mediatorMock.Object);
+    }
+
+    private static CatalogSeedDraftEntity FetchedDraft(Guid id) => new()
+    {
+        Id = id,
+        BggId = 174430,
+        Status = nameof(CatalogSeedStatus.Fetched),
+        ProvenanceJson = "{}",
+        CreatedByUserId = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+        FetchedAt = DateTime.UtcNow.AddMinutes(-1),
+    };
+
+    [Fact]
+    public async Task Handle_FetchedDraft_TransitionsToApprovedAndPublishesEvent()
+    {
+        var draft = FetchedDraft(_draftId);
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var result = await _handler.Handle(
+            new ApproveCatalogSeedCommand(_draftId, _approver),
+            TestContext.Current.CancellationToken);
+
+        result.DraftId.Should().Be(_draftId);
+        result.ResultingSharedGameId.Should().NotBeEmpty();
+
+        draft.Status.Should().Be(nameof(CatalogSeedStatus.Approved));
+        draft.ApprovedAt.Should().NotBeNull();
+        draft.ApprovedByUserId.Should().Be(_approver);
+        draft.ResultingSharedGameId.Should().Be(result.ResultingSharedGameId);
+
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(
+            m => m.Publish(
+                It.Is<CatalogSeedApprovedEvent>(e => e.DraftId == _draftId && e.ApprovedByUserId == _approver),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DraftStatusNotFetched_ThrowsConflictException()
+    {
+        var draft = FetchedDraft(_draftId);
+        draft.Status = nameof(CatalogSeedStatus.Pending);
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+
+        var act = () => _handler.Handle(
+            new ApproveCatalogSeedCommand(_draftId, _approver),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage($"*{_draftId}*Pending*");
+
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mediatorMock.Verify(
+            m => m.Publish(It.IsAny<CatalogSeedApprovedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DraftNotFound_ThrowsNotFoundException()
+    {
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogSeedDraftEntity?)null);
+
+        var act = () => _handler.Handle(
+            new ApproveCatalogSeedCommand(_draftId, _approver),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mediatorMock.Verify(
+            m => m.Publish(It.IsAny<CatalogSeedApprovedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SaveThrows_DoesNotPublishEvent()
+    {
+        var draft = FetchedDraft(_draftId);
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db boom"));
+
+        var act = () => _handler.Handle(
+            new ApproveCatalogSeedCommand(_draftId, _approver),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("db boom");
+
+        // Critical post-save-publish invariant (issue #1873 H1):
+        // event MUST NOT fire if SaveChangesAsync threw.
+        _mediatorMock.Verify(
+            m => m.Publish(It.IsAny<CatalogSeedApprovedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NullCommand_ThrowsArgumentNullException()
+    {
+        var act = () => _handler.Handle(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+
+    [Fact]
+    public void Constructor_NullRepo_Throws()
+    {
+        var act = () => new ApproveCatalogSeedCommandHandler(
+            repository: null!,
+            _uowMock.Object,
+            NullLogger<ApproveCatalogSeedCommandHandler>.Instance);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/BulkEnqueueCatalogSeedsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/BulkEnqueueCatalogSeedsCommandHandlerTests.cs
@@ -1,0 +1,138 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BulkEnqueueCatalogSeedsCommandHandlerTests
+{
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly BulkEnqueueCatalogSeedsCommandHandler _handler;
+    private readonly Guid _actor = Guid.NewGuid();
+
+    public BulkEnqueueCatalogSeedsCommandHandlerTests()
+    {
+        _handler = new BulkEnqueueCatalogSeedsCommandHandler(
+            _mediatorMock.Object,
+            NullLogger<BulkEnqueueCatalogSeedsCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_AllNew_ReturnsEnqueuedCountAndIds()
+    {
+        var bggIds = new[] { 1, 2, 3 };
+        var generatedIds = bggIds.ToDictionary(b => b, _ => Guid.NewGuid());
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<EnqueueCatalogSeedCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((object req, CancellationToken _) =>
+            {
+                var c = (EnqueueCatalogSeedCommand)req;
+                return new EnqueueCatalogSeedResult(
+                    generatedIds[c.BggId!.Value],
+                    c.BggId,
+                    nameof(CatalogSeedStatus.Pending),
+                    IsDuplicate: false);
+            });
+
+        var result = await _handler.Handle(
+            new BulkEnqueueCatalogSeedsCommand(bggIds, _actor),
+            TestContext.Current.CancellationToken);
+
+        result.Total.Should().Be(3);
+        result.Enqueued.Should().Be(3);
+        result.Duplicates.Should().Be(0);
+        result.NewDraftIds.Should().BeEquivalentTo(generatedIds.Values);
+
+        _mediatorMock.Verify(
+            m => m.Send(It.IsAny<EnqueueCatalogSeedCommand>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task Handle_MixDuplicates_ReportsBothCounters()
+    {
+        var bggIds = new[] { 10, 20, 30 };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<EnqueueCatalogSeedCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((object req, CancellationToken _) =>
+            {
+                var c = (EnqueueCatalogSeedCommand)req;
+                var isDup = c.BggId == 20; // middle id is duplicate
+                return new EnqueueCatalogSeedResult(
+                    isDup ? Guid.Empty : Guid.NewGuid(),
+                    c.BggId,
+                    nameof(CatalogSeedStatus.Pending),
+                    IsDuplicate: isDup);
+            });
+
+        var result = await _handler.Handle(
+            new BulkEnqueueCatalogSeedsCommand(bggIds, _actor),
+            TestContext.Current.CancellationToken);
+
+        result.Total.Should().Be(3);
+        result.Enqueued.Should().Be(2);
+        result.Duplicates.Should().Be(1);
+        result.NewDraftIds.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Handle_NullCommand_ThrowsArgumentNullException()
+    {
+        var act = () => _handler.Handle(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+
+    [Fact]
+    public void Validator_BatchTooLarge_FailsAt100Cap()
+    {
+        var validator = new BulkEnqueueCatalogSeedsCommandValidator();
+        var ids = Enumerable.Range(1, 101).ToArray();
+        var cmd = new BulkEnqueueCatalogSeedsCommand(ids, _actor);
+
+        var result = validator.TestValidate(cmd);
+
+        result.ShouldHaveValidationErrorFor(x => x.BggIds)
+            .WithErrorMessage("Max 100 BGG IDs per batch.");
+    }
+
+    [Fact]
+    public void Validator_ExactlyCap_PassesBatchSize()
+    {
+        var validator = new BulkEnqueueCatalogSeedsCommandValidator();
+        var ids = Enumerable.Range(1, 100).ToArray();
+        var cmd = new BulkEnqueueCatalogSeedsCommand(ids, _actor);
+
+        var result = validator.TestValidate(cmd);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.BggIds);
+    }
+
+    [Fact]
+    public void Validator_EmptyBatch_Fails()
+    {
+        var validator = new BulkEnqueueCatalogSeedsCommandValidator();
+        var cmd = new BulkEnqueueCatalogSeedsCommand(Array.Empty<int>(), _actor);
+
+        var result = validator.TestValidate(cmd);
+
+        result.ShouldHaveValidationErrorFor(x => x.BggIds);
+    }
+
+    [Fact]
+    public void Constructor_NullMediator_Throws()
+    {
+        var act = () => new BulkEnqueueCatalogSeedsCommandHandler(
+            mediator: null!,
+            NullLogger<BulkEnqueueCatalogSeedsCommandHandler>.Instance);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("mediator");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueCatalogSeedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnqueueCatalogSeedCommandHandlerTests.cs
@@ -1,0 +1,121 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class EnqueueCatalogSeedCommandHandlerTests
+{
+    private readonly Mock<ICatalogSeedDraftRepository> _repoMock = new(MockBehavior.Strict);
+    private readonly Mock<IUnitOfWork> _uowMock = new();
+    private readonly EnqueueCatalogSeedCommandHandler _handler;
+    private readonly Guid _actor = Guid.NewGuid();
+
+    public EnqueueCatalogSeedCommandHandlerTests()
+    {
+        _handler = new EnqueueCatalogSeedCommandHandler(
+            _repoMock.Object,
+            _uowMock.Object,
+            NullLogger<EnqueueCatalogSeedCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_NewBggId_InsertsPendingDraftAndSaves()
+    {
+        const int bggId = 174430;
+        _repoMock.Setup(r => r.ExistsAsync(bggId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        CatalogSeedDraftEntity? captured = null;
+        _repoMock
+            .Setup(r => r.AddAsync(It.IsAny<CatalogSeedDraftEntity>(), It.IsAny<CancellationToken>()))
+            .Callback<CatalogSeedDraftEntity, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var cmd = new EnqueueCatalogSeedCommand(bggId, null, null, _actor);
+        var result = await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        result.IsDuplicate.Should().BeFalse();
+        result.BggId.Should().Be(bggId);
+        result.Status.Should().Be(nameof(CatalogSeedStatus.Pending));
+        result.Id.Should().NotBeEmpty();
+
+        captured.Should().NotBeNull();
+        captured!.BggId.Should().Be(bggId);
+        captured.Status.Should().Be(nameof(CatalogSeedStatus.Pending));
+        captured.CreatedByUserId.Should().Be(_actor);
+
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingBggId_ReturnsDuplicateWithoutInsert()
+    {
+        const int bggId = 13;
+        _repoMock.Setup(r => r.ExistsAsync(bggId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var cmd = new EnqueueCatalogSeedCommand(bggId, null, null, _actor);
+        var result = await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        result.IsDuplicate.Should().BeTrue();
+        result.BggId.Should().Be(bggId);
+
+        _repoMock.Verify(
+            r => r.AddAsync(It.IsAny<CatalogSeedDraftEntity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NullCommand_ThrowsArgumentNullException()
+    {
+        var act = () => _handler.Handle(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+
+    [Fact]
+    public async Task Handle_WikidataOnly_InsertsDraft()
+    {
+        _repoMock
+            .Setup(r => r.AddAsync(It.IsAny<CatalogSeedDraftEntity>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var cmd = new EnqueueCatalogSeedCommand(BggId: null, WikidataQid: "Q42", SearchTermInput: null, _actor);
+        var result = await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        result.IsDuplicate.Should().BeFalse();
+        result.BggId.Should().BeNull();
+
+        // ExistsAsync only consulted when BggId is set
+        _repoMock.Verify(r => r.ExistsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void Constructor_WithNullRepo_Throws()
+    {
+        var act = () => new EnqueueCatalogSeedCommandHandler(
+            repository: null!,
+            _uowMock.Object,
+            NullLogger<EnqueueCatalogSeedCommandHandler>.Instance);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void Constructor_WithNullUow_Throws()
+    {
+        var act = () => new EnqueueCatalogSeedCommandHandler(
+            _repoMock.Object,
+            unitOfWork: null!,
+            NullLogger<EnqueueCatalogSeedCommandHandler>.Instance);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("unitOfWork");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandlerTests.cs
@@ -46,17 +46,19 @@ public sealed class RejectCatalogSeedCommandHandlerTests
     [Fact]
     public async Task Handle_ExistingDraft_SoftDeletesAndPublishesEvent()
     {
+        const string reason = "Duplicate of BGG:13";
         var draft = Draft(_draftId);
         _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
         _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
         await _handler.Handle(
-            new RejectCatalogSeedCommand(_draftId, _rejecter, "spam"),
+            new RejectCatalogSeedCommand(_draftId, _rejecter, reason),
             TestContext.Current.CancellationToken);
 
         draft.Status.Should().Be(nameof(CatalogSeedStatus.Rejected));
         draft.IsDeleted.Should().BeTrue();
         draft.DeletedAt.Should().NotBeNull();
+        draft.ErrorMessage.Should().Be(reason);
 
         _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
         _mediatorMock.Verify(
@@ -64,9 +66,28 @@ public sealed class RejectCatalogSeedCommandHandlerTests
                 It.Is<CatalogSeedRejectedEvent>(e =>
                     e.DraftId == _draftId
                     && e.RejectedByUserId == _rejecter
-                    && e.Reason == "spam"),
+                    && e.Reason == reason),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyReason_DoesNotOverwriteErrorMessage()
+    {
+        var draft = new CatalogSeedDraftEntity
+        {
+            Id = Guid.NewGuid(),
+            Status = "Fetched",
+            ErrorMessage = "pre-existing",
+            CreatedByUserId = Guid.NewGuid(),
+        };
+        _repoMock.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var cmd = new RejectCatalogSeedCommand(draft.Id, Guid.NewGuid(), Reason: "");
+        await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        draft.ErrorMessage.Should().Be("pre-existing");
     }
 
     [Fact]
@@ -111,5 +132,16 @@ public sealed class RejectCatalogSeedCommandHandlerTests
     {
         var act = () => _handler.Handle(null!, TestContext.Current.CancellationToken);
         await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+
+    [Fact]
+    public void Constructor_NullMediator_Throws()
+    {
+        var act = () => new RejectCatalogSeedCommandHandler(
+            _repoMock.Object,
+            _uowMock.Object,
+            NullLogger<RejectCatalogSeedCommandHandler>.Instance,
+            mediator: null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("mediator");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/RejectCatalogSeedCommandHandlerTests.cs
@@ -1,0 +1,115 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class RejectCatalogSeedCommandHandlerTests
+{
+    private readonly Mock<ICatalogSeedDraftRepository> _repoMock = new();
+    private readonly Mock<IUnitOfWork> _uowMock = new();
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly RejectCatalogSeedCommandHandler _handler;
+    private readonly Guid _draftId = Guid.NewGuid();
+    private readonly Guid _rejecter = Guid.NewGuid();
+
+    public RejectCatalogSeedCommandHandlerTests()
+    {
+        _handler = new RejectCatalogSeedCommandHandler(
+            _repoMock.Object,
+            _uowMock.Object,
+            NullLogger<RejectCatalogSeedCommandHandler>.Instance,
+            _mediatorMock.Object);
+    }
+
+    private static CatalogSeedDraftEntity Draft(Guid id) => new()
+    {
+        Id = id,
+        BggId = 9999,
+        Status = nameof(CatalogSeedStatus.Fetched),
+        CreatedByUserId = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task Handle_ExistingDraft_SoftDeletesAndPublishesEvent()
+    {
+        var draft = Draft(_draftId);
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        await _handler.Handle(
+            new RejectCatalogSeedCommand(_draftId, _rejecter, "spam"),
+            TestContext.Current.CancellationToken);
+
+        draft.Status.Should().Be(nameof(CatalogSeedStatus.Rejected));
+        draft.IsDeleted.Should().BeTrue();
+        draft.DeletedAt.Should().NotBeNull();
+
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(
+            m => m.Publish(
+                It.Is<CatalogSeedRejectedEvent>(e =>
+                    e.DraftId == _draftId
+                    && e.RejectedByUserId == _rejecter
+                    && e.Reason == "spam"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DraftNotFound_ThrowsNotFoundException()
+    {
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogSeedDraftEntity?)null);
+
+        var act = () => _handler.Handle(
+            new RejectCatalogSeedCommand(_draftId, _rejecter, ""),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mediatorMock.Verify(
+            m => m.Publish(It.IsAny<CatalogSeedRejectedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SaveThrows_DoesNotPublishEvent()
+    {
+        var draft = Draft(_draftId);
+        _repoMock.Setup(r => r.GetByIdAsync(_draftId, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _uowMock.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db boom"));
+
+        var act = () => _handler.Handle(
+            new RejectCatalogSeedCommand(_draftId, _rejecter, ""),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("db boom");
+
+        _mediatorMock.Verify(
+            m => m.Publish(It.IsAny<CatalogSeedRejectedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NullCommand_Throws()
+    {
+        var act = () => _handler.Handle(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/CatalogSeedQueriesTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/CatalogSeedQueriesTests.cs
@@ -1,0 +1,177 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CatalogSeedQueriesTests
+{
+    private readonly Mock<ICatalogSeedDraftRepository> _repoMock = new();
+
+    private static CatalogSeedDraftEntity Draft(Guid id, string status, int? bggId = 174430) => new()
+    {
+        Id = id,
+        BggId = bggId,
+        Status = status,
+        CreatedByUserId = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+    };
+
+    // ---------------- ListCatalogSeedsQuery ----------------
+
+    [Fact]
+    public async Task ListHandler_NoFilter_ReturnsAllPagedItems()
+    {
+        var d1 = Draft(Guid.NewGuid(), nameof(CatalogSeedStatus.Pending));
+        var d2 = Draft(Guid.NewGuid(), nameof(CatalogSeedStatus.Fetched));
+        _repoMock.Setup(r => r.CountAsync(null, It.IsAny<CancellationToken>())).ReturnsAsync(2);
+        _repoMock.Setup(r => r.ListAsync(null, 0, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { d1, d2 });
+
+        var handler = new ListCatalogSeedsQueryHandler(_repoMock.Object);
+        var result = await handler.Handle(
+            new ListCatalogSeedsQuery(StatusFilter: null),
+            TestContext.Current.CancellationToken);
+
+        result.Total.Should().Be(2);
+        result.Skip.Should().Be(0);
+        result.Take.Should().Be(50);
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Id.Should().Be(d1.Id);
+        result.Items[1].Status.Should().Be(nameof(CatalogSeedStatus.Fetched));
+    }
+
+    [Fact]
+    public async Task ListHandler_WithStatusFilter_FiltersAndPaginates()
+    {
+        var d1 = Draft(Guid.NewGuid(), nameof(CatalogSeedStatus.Fetched));
+        _repoMock.Setup(r => r.CountAsync("Fetched", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        _repoMock.Setup(r => r.ListAsync("Fetched", 10, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { d1 });
+
+        var handler = new ListCatalogSeedsQueryHandler(_repoMock.Object);
+        var result = await handler.Handle(
+            new ListCatalogSeedsQuery("Fetched", Skip: 10, Take: 20),
+            TestContext.Current.CancellationToken);
+
+        result.Total.Should().Be(1);
+        result.Skip.Should().Be(10);
+        result.Take.Should().Be(20);
+        result.Items.Should().ContainSingle().Which.Status.Should().Be(nameof(CatalogSeedStatus.Fetched));
+    }
+
+    [Fact]
+    public async Task ListHandler_EmptyResult_ReturnsEmptyItems()
+    {
+        _repoMock.Setup(r => r.CountAsync("Rejected", It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        _repoMock.Setup(r => r.ListAsync("Rejected", 0, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CatalogSeedDraftEntity>());
+
+        var handler = new ListCatalogSeedsQueryHandler(_repoMock.Object);
+        var result = await handler.Handle(
+            new ListCatalogSeedsQuery("Rejected"),
+            TestContext.Current.CancellationToken);
+
+        result.Total.Should().Be(0);
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListHandler_NullQuery_Throws()
+    {
+        var handler = new ListCatalogSeedsQueryHandler(_repoMock.Object);
+        var act = () => handler.Handle(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+
+    [Fact]
+    public void ListHandler_NullRepo_Throws()
+    {
+        var act = () => new ListCatalogSeedsQueryHandler(repository: null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    // ---------------- GetCatalogSeedByIdQuery ----------------
+
+    [Fact]
+    public async Task GetByIdHandler_ExistingId_ReturnsDto()
+    {
+        var id = Guid.NewGuid();
+        var entity = Draft(id, nameof(CatalogSeedStatus.Fetched), bggId: 13);
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+
+        var handler = new GetCatalogSeedByIdQueryHandler(_repoMock.Object);
+        var result = await handler.Handle(new GetCatalogSeedByIdQuery(id), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id);
+        result.BggId.Should().Be(13);
+        result.Status.Should().Be(nameof(CatalogSeedStatus.Fetched));
+    }
+
+    [Fact]
+    public async Task GetByIdHandler_MissingId_ReturnsNull()
+    {
+        var id = Guid.NewGuid();
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogSeedDraftEntity?)null);
+
+        var handler = new GetCatalogSeedByIdQueryHandler(_repoMock.Object);
+        var result = await handler.Handle(new GetCatalogSeedByIdQuery(id), TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdHandler_NullQuery_Throws()
+    {
+        var handler = new GetCatalogSeedByIdQueryHandler(_repoMock.Object);
+        var act = () => handler.Handle(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("request");
+    }
+
+    // ---------------- Mapper ----------------
+
+    [Fact]
+    public void DtoMapper_MapsAllFields()
+    {
+        var entity = new CatalogSeedDraftEntity
+        {
+            Id = Guid.NewGuid(),
+            BggId = 174430,
+            WikidataQid = "Q42",
+            SearchTermInput = "gloomhaven",
+            Status = nameof(CatalogSeedStatus.Approved),
+            ErrorMessage = "test",
+            ResultingSharedGameId = Guid.NewGuid(),
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = new DateTime(2026, 6, 4, 12, 0, 0, DateTimeKind.Utc),
+            FetchedAt = new DateTime(2026, 6, 4, 12, 5, 0, DateTimeKind.Utc),
+            ApprovedAt = new DateTime(2026, 6, 4, 12, 10, 0, DateTimeKind.Utc),
+            ApprovedByUserId = Guid.NewGuid(),
+        };
+
+        var dto = CatalogSeedDraftDtoMapper.ToDto(entity);
+
+        dto.Id.Should().Be(entity.Id);
+        dto.BggId.Should().Be(entity.BggId);
+        dto.WikidataQid.Should().Be(entity.WikidataQid);
+        dto.SearchTermInput.Should().Be(entity.SearchTermInput);
+        dto.Status.Should().Be(entity.Status);
+        dto.ErrorMessage.Should().Be(entity.ErrorMessage);
+        dto.ResultingSharedGameId.Should().Be(entity.ResultingSharedGameId);
+        dto.CreatedByUserId.Should().Be(entity.CreatedByUserId);
+        dto.CreatedAt.Should().Be(entity.CreatedAt);
+        dto.FetchedAt.Should().Be(entity.FetchedAt);
+        dto.ApprovedAt.Should().Be(entity.ApprovedAt);
+        dto.ApprovedByUserId.Should().Be(entity.ApprovedByUserId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedAggregatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedAggregatorTests.cs
@@ -1,0 +1,103 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CatalogSeedAggregatorTests
+{
+    private static FieldProvenance FP(string provider, string field, object value)
+        => new(provider, "http://example.test", field, DateTime.UtcNow, value);
+
+    private static ICatalogProvider StubProvider(string name, IReadOnlyDictionary<string, FieldProvenance> fields, string? error = null)
+    {
+        var m = new Mock<ICatalogProvider>();
+        m.SetupGet(p => p.Name).Returns(name);
+        m.Setup(p => p.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CatalogProviderResult(fields, "{}", error));
+        return m.Object;
+    }
+
+    [Fact]
+    public async Task FetchAsync_PrimaryOnly_WhenAllFieldsResolved()
+    {
+        var wd = StubProvider("wikidata", new Dictionary<string, FieldProvenance>
+        {
+            ["title"] = FP("wikidata", "labels.en", "Catan"),
+            ["yearPublished"] = FP("wikidata", "P577", 1995),
+        });
+        var bgg = StubProvider("bgg", new Dictionary<string, FieldProvenance>());
+
+        var agg = new CatalogSeedAggregator(wd, bgg, NullLogger<CatalogSeedAggregator>.Instance);
+        var result = await agg.FetchAsync(new CatalogProviderQuery(13, null, null), default);
+
+        result.Provenance.GetValue<string>("title").Should().Be("Catan");
+        result.Provenance.GetProvider("title").Should().Be("wikidata");
+        result.ProviderUsed.Should().Be("wikidata");
+    }
+
+    [Fact]
+    public async Task FetchAsync_PrimaryAndFallback_WhenWikidataMissing()
+    {
+        var wd = StubProvider("wikidata", new Dictionary<string, FieldProvenance>
+        {
+            ["title"] = FP("wikidata", "labels.en", "Catan"),
+        });
+        var bgg = StubProvider("bgg", new Dictionary<string, FieldProvenance>
+        {
+            ["mechanics"] = FP("bgg", "boardgamemechanic", new List<string> { "Trading" }),
+            ["title"] = FP("bgg", "name", "Settlers of Catan"),
+        });
+
+        var agg = new CatalogSeedAggregator(wd, bgg, NullLogger<CatalogSeedAggregator>.Instance);
+        var result = await agg.FetchAsync(new CatalogProviderQuery(13, null, null), default);
+
+        result.Provenance.GetValue<string>("title").Should().Be("Catan");          // wd wins
+        result.Provenance.GetProvider("mechanics").Should().Be("bgg");             // bgg fills missing
+        result.ProviderUsed.Should().Be("wikidata+bgg");
+    }
+
+    [Fact]
+    public async Task FetchAsync_FallbackOnly_WhenWikidataFailed()
+    {
+        var wd = StubProvider("wikidata", new Dictionary<string, FieldProvenance>(), error: "not found");
+        var bgg = StubProvider("bgg", new Dictionary<string, FieldProvenance>
+        {
+            ["title"] = FP("bgg", "name", "MyIndie"),
+        });
+
+        var agg = new CatalogSeedAggregator(wd, bgg, NullLogger<CatalogSeedAggregator>.Instance);
+        var result = await agg.FetchAsync(new CatalogProviderQuery(50000, null, null), default);
+
+        result.Provenance.GetValue<string>("title").Should().Be("MyIndie");
+        result.ProviderUsed.Should().Be("bgg");
+    }
+
+    [Fact]
+    public async Task FetchAsync_BothFailed_ReturnsEmptyProvenance()
+    {
+        var wd = StubProvider("wikidata", new Dictionary<string, FieldProvenance>(), error: "fail-wd");
+        var bgg = StubProvider("bgg", new Dictionary<string, FieldProvenance>(), error: "fail-bgg");
+
+        var agg = new CatalogSeedAggregator(wd, bgg, NullLogger<CatalogSeedAggregator>.Instance);
+        var result = await agg.FetchAsync(new CatalogProviderQuery(99999, null, null), default);
+
+        result.Provenance.Fields.Should().BeEmpty();
+        result.ProviderUsed.Should().Be("none");
+    }
+
+    [Fact]
+    public void Constructor_WrongProviderName_ThrowsArgumentException()
+    {
+        var wrongPrimary = StubProvider("bgg", new Dictionary<string, FieldProvenance>());
+        var bgg = StubProvider("bgg", new Dictionary<string, FieldProvenance>());
+
+        var act = () => new CatalogSeedAggregator(wrongPrimary, bgg, NullLogger<CatalogSeedAggregator>.Instance);
+        act.Should().Throw<ArgumentException>().WithMessage("*wikidata*");
+    }
+}


### PR DESCRIPTION
## Summary

M4 of issue #1903 (admin catalog seed). Application layer: aggregator + 4 commands + 2 queries + DTOs. Builds on M3 (merged f39fb57d5).

## What ships

| Task | Commit | Output |
|---|---|---|
| M4.1 | `bc235572d` | `ICatalogSeedAggregator` + impl (Wikidata primary + BGG fallback merge) + 5 tests |
| M4.2 | `8c2ed07e2` | `EnqueueCatalogSeedCommand` + handler + validator + 6 tests |
| M4.3 | `3e6c19e51` | `BulkEnqueueCatalogSeedsCommand` (max 100/batch) + 7 tests |
| M4.4 | `1d85b2c65` | `ApproveCatalogSeedCommand` + post-save event publish (#1873 H1 pattern) + 6 tests |
| M4.5 | `ffb5d087d` | `RejectCatalogSeedCommand` + soft-delete + post-save event + 4 tests |
| M4.6 | `829fce035` | `ListCatalogSeedsQuery` + `GetCatalogSeedByIdQuery` + `CatalogSeedDraftDto` + 9 tests |

**32 new unit tests, all passing. 0 build errors. 68 CatalogSeed* tests total (cumulative across M1-M4).**

## Architecture decisions

- **Approve handler** uses **simpler decoupled approach**: handler mutates draft + emits `CatalogSeedApprovedEvent` post-save. `SharedGameCatalogEntry` materialization deferred to `CatalogSeedApprovedEventHandler` in M5 (clean separation). `ResultingSharedGameId` placeholder NewGuid is overwritten by M5 event handler.
- **Post-save event publish** via `IMediator.Publish` (NOT pre-save via IDomainEventCollector) — per #1873 review fix H1 pattern, avoids stale event on save failure
- **MA0009 ReDoS guard**: Wikidata regex validator uses 100ms timeout + RegexOptions.CultureInvariant
- **ListCatalogSeedsResult** record (no PagedResult<T> in shared kernel)
- **DI registration NOT in this PR** — explicitly deferred to M5.2 with all Quartz wiring

## What's NOT in this PR

- M5 (Quartz CatalogSeedFetchJob + DI registration)
- M6 (SSE + Admin endpoints)
- M7 (BggTosWatcher + feature flag)
- M8 (Frontend)

## Test plan

- [x] 32/32 new tests pass (5 + 6 + 7 + 6 + 4 + 9 + 5 aggregator = 42, was 32 in M4.2-M4.6 only)
- [x] Build 0 errors
- [ ] CI green

## Risk

LOW — services not yet registered in DI (M5.2). Endpoints not yet exposed (M6).