### PR TITLE
feat(catalog-seed): #1903 M5 — Quartz job + DI + ApprovedEventHandler

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandler.cs
@@ -1,0 +1,147 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+/// <summary>
+/// Issue #1903 M5.3 — materialises a <see cref="SharedGame"/> aggregate when an
+/// admin approves a <see cref="CatalogSeedDraftEntity"/>, and overwrites the
+/// placeholder <c>ResultingSharedGameId</c> set by
+/// <see cref="ApproveCatalogSeedCommandHandler"/> with the actual aggregate Id.
+/// </summary>
+/// <remarks>
+/// <para>Closes the M4.4 placeholder gap. The approval handler runs first (M4.4),
+/// persists the draft as <c>Approved</c> with <c>ResultingSharedGameId =
+/// Guid.NewGuid()</c>, then publishes <see cref="CatalogSeedApprovedEvent"/>;
+/// this handler resolves that event, creates the SharedGame, and rewrites the
+/// FK on the draft.</para>
+/// <para><b>Mapping strategy</b>: uses <see cref="SharedGame.CreateSkeleton"/>
+/// because catalog-seed provenance (BGG + Wikidata merge) frequently lacks the
+/// strict fields required by <see cref="SharedGame.Create"/> — notably an
+/// absolute <c>imageUrl</c>, a non-empty <c>description</c>, a year > 1900, and
+/// positive player counts. The resulting aggregate lands in
+/// <c>GameDataStatus.Skeleton</c> + <c>GameStatus.Draft</c>, ready for the
+/// BGG-enrichment pipeline (issue #1874) or manual editing to lift it to
+/// <c>Enriched</c> / <c>PendingApproval</c>.</para>
+/// <para><b>Idempotency</b>: if a SharedGame already exists for the draft's
+/// <c>BggId</c>, this handler logs and skips creation but still rewrites the
+/// draft's <c>ResultingSharedGameId</c> to point at the existing aggregate so
+/// audit consistency is preserved.</para>
+/// <para><b>What stays as a follow-up</b>: enriching the skeleton in-line from
+/// provenance fields like <c>yearPublished</c>, <c>minPlayers</c>, etc. would
+/// require either a partial <c>EnrichFromProvenance</c> domain method or a
+/// state-machine transition Skeleton → Enriching → Enriched that the seed
+/// pipeline can drive. Both are deliberately out of scope for M5 — the existing
+/// BGG enrichment queue (#1874) handles this once a BggId is on the aggregate.</para>
+/// </remarks>
+internal sealed class CatalogSeedApprovedEventHandler : INotificationHandler<CatalogSeedApprovedEvent>
+{
+    private readonly ICatalogSeedDraftRepository _drafts;
+    private readonly ISharedGameRepository _games;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<CatalogSeedApprovedEventHandler> _logger;
+
+    public CatalogSeedApprovedEventHandler(
+        ICatalogSeedDraftRepository drafts,
+        ISharedGameRepository games,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        ILogger<CatalogSeedApprovedEventHandler> logger)
+    {
+        _drafts = drafts ?? throw new ArgumentNullException(nameof(drafts));
+        _games = games ?? throw new ArgumentNullException(nameof(games));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(CatalogSeedApprovedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var draft = await _drafts.GetByIdAsync(notification.DraftId, cancellationToken).ConfigureAwait(false);
+        if (draft is null)
+        {
+            _logger.LogWarning(
+                "CatalogSeedApprovedEvent for draft {DraftId} but draft not found — race condition or test artefact, skipping",
+                notification.DraftId);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(draft.ProvenanceJson))
+        {
+            _logger.LogWarning(
+                "CatalogSeedApprovedEvent for draft {DraftId} but ProvenanceJson is empty — cannot materialise SharedGame",
+                notification.DraftId);
+            return;
+        }
+
+        CatalogSeedProvenance provenance;
+        try
+        {
+            provenance = CatalogSeedProvenance.FromJson(draft.ProvenanceJson);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            _logger.LogError(ex,
+                "CatalogSeedApprovedEvent for draft {DraftId}: ProvenanceJson is malformed, skipping",
+                notification.DraftId);
+            return;
+        }
+
+        var title = provenance.GetValue<string>("title");
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            _logger.LogWarning(
+                "CatalogSeedApprovedEvent for draft {DraftId}: title missing in provenance — cannot materialise SharedGame",
+                notification.DraftId);
+            return;
+        }
+
+        // Idempotency: if a draft was approved twice, or if a SharedGame already
+        // exists for the same BGG ID (collision with prior import path), reuse it.
+        SharedGame? existing = null;
+        if (draft.BggId.HasValue)
+        {
+            existing = await _games.GetByBggIdAsync(draft.BggId.Value, cancellationToken).ConfigureAwait(false);
+        }
+
+        Guid materialisedId;
+        if (existing is not null)
+        {
+            materialisedId = existing.Id;
+            _logger.LogInformation(
+                "CatalogSeedApprovedEventHandler: SharedGame already exists for BggId={BggId} (Id={SharedGameId}); reusing for draft {DraftId}",
+                draft.BggId, existing.Id, notification.DraftId);
+        }
+        else
+        {
+            var skeleton = SharedGame.CreateSkeleton(
+                title: title,
+                createdBy: notification.ApprovedByUserId,
+                timeProvider: _timeProvider,
+                bggId: draft.BggId);
+
+            await _games.AddAsync(skeleton, cancellationToken).ConfigureAwait(false);
+            materialisedId = skeleton.Id;
+
+            _logger.LogInformation(
+                "CatalogSeedApprovedEventHandler: created SharedGame {SharedGameId} (Skeleton) for draft {DraftId} title='{Title}' BggId={BggId}",
+                skeleton.Id, notification.DraftId, title, draft.BggId);
+        }
+
+        // Overwrite the placeholder ResultingSharedGameId from M4.4 with the real Id.
+        // The repo returned the draft AsTracking() so a SaveChangesAsync persists the change.
+        draft.ResultingSharedGameId = materialisedId;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJob.cs
@@ -1,0 +1,187 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Issue #1903 M5: picks <c>Pending</c> <see cref="CatalogSeedDraftEntity"/>
+/// entries, invokes <see cref="ICatalogSeedAggregator"/> (Wikidata primary + BGG
+/// fallback), persists provenance / raw_payload, and publishes
+/// <see cref="CatalogSeedFetchedEvent"/> on success. Runs every 1 minute via
+/// Quartz. Batch size 10 with 1s inter-item throttle to respect BGG's ~30 req/min
+/// rate limit.
+/// </summary>
+/// <remarks>
+/// <para>Pattern mirror of <c>BackfillPdfCoversJob</c> (issue #1873): same
+/// service-provider scoping, per-item try/catch with terminal failure status,
+/// and internal <see cref="RunBatchAsync"/> hook for unit tests that drive the
+/// batch without spinning up the Quartz scheduler.</para>
+/// <para>Per-item failures land the draft in terminal <c>FetchFailed</c> with
+/// the exception type name in <c>ErrorMessage</c> (no <c>ex.Message</c> leak —
+/// CLAUDE.md memory <c>ex-message-leak-pattern</c>). Operators must manually
+/// reset to <c>Pending</c> to retry.</para>
+/// </remarks>
+[DisallowConcurrentExecution]
+public sealed class CatalogSeedFetchJob : IJob
+{
+    /// <summary>
+    /// Maximum number of drafts processed in a single job run. Combined with the
+    /// 1-minute trigger and 1s inter-item delay this caps throughput at ~10/min,
+    /// safely below BGG's documented ~30 req/min ceiling.
+    /// </summary>
+    public const int BatchSize = 10;
+
+    /// <summary>
+    /// Sleep between individual drafts in a single batch run. Respects BGG XMLAPI2
+    /// throttling (spec 2026-06-04-admin-catalog-seed-design.md §7.2).
+    /// </summary>
+    public const int DelayBetweenItemsMs = 1000;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<CatalogSeedFetchJob> _logger;
+
+    public CatalogSeedFetchJob(IServiceProvider serviceProvider, ILogger<CatalogSeedFetchJob> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+        _logger.LogDebug("CatalogSeedFetchJob started: FireTime={FireTime}", context.FireTimeUtc);
+
+        using var scope = _serviceProvider.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ICatalogSeedDraftRepository>();
+        var aggregator = scope.ServiceProvider.GetRequiredService<ICatalogSeedAggregator>();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await RunBatchAsync(repo, aggregator, uow, mediator, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Internal batch runner — extracted from <see cref="Execute"/> so unit tests
+    /// can drive it directly without spinning up the Quartz scheduler. Mirrors
+    /// <c>BackfillPdfCoversJob.RunBatchAsync</c> from issue #1873.
+    /// </summary>
+    internal async Task RunBatchAsync(
+        ICatalogSeedDraftRepository repo,
+        ICatalogSeedAggregator aggregator,
+        IUnitOfWork uow,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var batch = await repo.GetByStatusAsync("Pending", BatchSize, ct).ConfigureAwait(false);
+        if (batch.Count == 0)
+        {
+            _logger.LogDebug("CatalogSeedFetchJob: no Pending drafts in queue");
+            return;
+        }
+
+        _logger.LogInformation(
+            "CatalogSeedFetchJob: picked up {Count} Pending drafts for fetching",
+            batch.Count);
+
+        for (var i = 0; i < batch.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var draft = batch[i];
+            await ProcessOneAsync(draft, aggregator, uow, mediator, ct).ConfigureAwait(false);
+
+            if (i < batch.Count - 1)
+            {
+                await Task.Delay(DelayBetweenItemsMs, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task ProcessOneAsync(
+        CatalogSeedDraftEntity draft,
+        ICatalogSeedAggregator aggregator,
+        IUnitOfWork uow,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        try
+        {
+            var query = new CatalogProviderQuery(draft.BggId, draft.WikidataQid, draft.SearchTermInput);
+            var result = await aggregator.FetchAsync(query, ct).ConfigureAwait(false);
+
+            if (result.Provenance.Fields.Count == 0)
+            {
+                draft.Status = "FetchFailed";
+                draft.ErrorMessage = $"No provider returned data (providerUsed={result.ProviderUsed})";
+                draft.FetchedAt = DateTime.UtcNow;
+                _logger.LogWarning(
+                    "CatalogSeedFetchJob: no provider data for draft {DraftId} (providerUsed={Provider})",
+                    draft.Id, result.ProviderUsed);
+            }
+            else
+            {
+                draft.Status = "Fetched";
+                draft.ProvenanceJson = result.Provenance.ToJson();
+                draft.RawPayloadJson = result.CombinedRawPayload;
+                draft.FetchedAt = DateTime.UtcNow;
+                draft.ErrorMessage = null;
+                _logger.LogInformation(
+                    "CatalogSeedFetchJob: fetched draft {DraftId} via {Provider} (fieldCount={Count})",
+                    draft.Id, result.ProviderUsed, result.Provenance.Fields.Count);
+            }
+
+            await uow.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            // Publish only after successful save — same post-save publish ordering
+            // as ApproveCatalogSeedCommandHandler (review-fix H1 pattern, CLAUDE.md
+            // pitfall #2620). Avoids triggering downstream side effects for a draft
+            // whose Fetched status never persisted.
+            if (string.Equals(draft.Status, "Fetched", StringComparison.Ordinal))
+            {
+                await mediator.Publish(
+                    new CatalogSeedFetchedEvent(draft.Id, result.ProviderUsed, result.Provenance.Fields.Count),
+                    ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125 // Sections of code should not be commented out
+        // BACKFILL PATTERN (mirror of BackfillPdfCoversJob): per-item failures
+        // must not abort the batch — log, mark the entity FetchFailed, and
+        // continue with the next draft so a single pathological provider response
+        // doesn't stall the queue. ErrorMessage carries only the exception TYPE
+        // (no .Message) per CLAUDE.md memory ex-message-leak-pattern.
+#pragma warning restore S125
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(ex,
+                "CatalogSeedFetchJob: unexpected error processing draft {DraftId}",
+                draft.Id);
+            draft.Status = "FetchFailed";
+            var detail = $"{ex.GetType().Name}: see logs";
+            draft.ErrorMessage = detail.Length > 500 ? detail[..500] : detail;
+            draft.FetchedAt = DateTime.UtcNow;
+            try
+            {
+                await uow.SaveChangesAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception saveEx)
+            {
+                _logger.LogError(saveEx,
+                    "CatalogSeedFetchJob: failed to persist FetchFailed status for draft {DraftId}",
+                    draft.Id);
+            }
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -6,11 +6,13 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Services.BackgroundAnaly
 using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Quartz;
 
 // Issue #3918: Catalog Trending Analytics Service
@@ -165,9 +167,90 @@ internal static class SharedGameCatalogServiceExtensions
                 .WithDescription("Runs every 15 min to evict shared-game detail tags for top-N most-viewed games and the search-games list tag"));
         });
 
+        // Issue #1903 M5.2: register HttpClients, keyed catalog providers,
+        // aggregator, and Quartz CatalogSeedFetchJob.
+        RegisterCatalogSeedProviders(services);
+        RegisterCatalogSeedFetchJob(services);
+
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 
         return services;
+    }
+
+    /// <summary>
+    /// Issue #1903 M5.2 — registers Wikidata SPARQL + BGG XMLAPI2 HttpClients with
+    /// the spec-mandated <c>User-Agent</c> (admin-catalog-seed; abuse@meepleai.app),
+    /// then exposes the providers as keyed <see cref="ICatalogProvider"/> services
+    /// (<c>"wikidata"</c> primary, <c>"bgg"</c> fallback) so
+    /// <see cref="ICatalogSeedAggregator"/> can resolve them explicitly without
+    /// relying on registration order.
+    /// </summary>
+    /// <remarks>
+    /// Spec: 2026-06-04-admin-catalog-seed-design.md §7. The User-Agent string is
+    /// mandatory per BGG ToS so they can reach out before legal escalation.
+    /// </remarks>
+    private static void RegisterCatalogSeedProviders(IServiceCollection services)
+    {
+        const string CatalogUserAgent = "MeepleAI/1.0 (admin-catalog-seed; abuse@meepleai.app)";
+
+        // Spec-mandated public endpoints (2026-06-04-admin-catalog-seed-design.md §7).
+        // S1075 suppressed: these are stable third-party service URLs, not internal infra.
+#pragma warning disable S1075 // URIs should not be hardcoded
+        const string WikidataBaseUrl = "https://query.wikidata.org/";
+        const string BggBaseUrl = "https://boardgamegeek.com/";
+#pragma warning restore S1075
+
+        services.AddHttpClient<WikidataCatalogProvider>(client =>
+        {
+            client.BaseAddress = new Uri(WikidataBaseUrl);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(CatalogUserAgent);
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+
+        services.AddHttpClient<BggCatalogProvider>(client =>
+        {
+            client.BaseAddress = new Uri(BggBaseUrl);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(CatalogUserAgent);
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+
+        // Keyed registration so CatalogSeedAggregator can resolve "wikidata" (primary)
+        // and "bgg" (fallback) explicitly — avoids relying on registration order.
+        services.AddKeyedScoped<ICatalogProvider>("wikidata", (sp, _) =>
+            sp.GetRequiredService<WikidataCatalogProvider>());
+        services.AddKeyedScoped<ICatalogProvider>("bgg", (sp, _) =>
+            sp.GetRequiredService<BggCatalogProvider>());
+
+        services.AddScoped<ICatalogSeedAggregator>(sp =>
+        {
+            var wikidata = sp.GetRequiredKeyedService<ICatalogProvider>("wikidata");
+            var bgg = sp.GetRequiredKeyedService<ICatalogProvider>("bgg");
+            var logger = sp.GetRequiredService<ILogger<CatalogSeedAggregator>>();
+            return new CatalogSeedAggregator(wikidata, bgg, logger);
+        });
+    }
+
+    /// <summary>
+    /// Issue #1903 M5.2 — registers <see cref="CatalogSeedFetchJob"/> with the
+    /// Quartz scheduler. Runs every 1 minute to fetch provider data for
+    /// <c>Pending</c> drafts (batch size 10, 1s inter-item throttle per spec §7).
+    /// </summary>
+    private static void RegisterCatalogSeedFetchJob(IServiceCollection services)
+    {
+        services.AddQuartz(q =>
+        {
+            var jobKey = new JobKey("CatalogSeedFetchJob", "SharedGameCatalog");
+
+            q.AddJob<CatalogSeedFetchJob>(opts => opts.WithIdentity(jobKey));
+
+            q.AddTrigger(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("CatalogSeedFetchTrigger", "SharedGameCatalog")
+                .WithSimpleSchedule(x => x
+                    .WithIntervalInMinutes(1)
+                    .RepeatForever())
+                .WithDescription("Fetches provider data for Pending CatalogSeedDraft entries every 1 minute"));
+        });
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandlerTests.cs
@@ -1,0 +1,216 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CatalogSeedApprovedEventHandlerTests
+{
+    private readonly Mock<ICatalogSeedDraftRepository> _drafts = new();
+    private readonly Mock<ISharedGameRepository> _games = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly TimeProvider _time = TimeProvider.System;
+
+    private CatalogSeedApprovedEventHandler Handler() =>
+        new(_drafts.Object, _games.Object, _uow.Object, _time,
+            NullLogger<CatalogSeedApprovedEventHandler>.Instance);
+
+    private static string ProvenanceWithTitle(string title)
+    {
+        var fields = new Dictionary<string, FieldProvenance>(StringComparer.Ordinal)
+        {
+            ["title"] = new FieldProvenance(
+                Provider: "wikidata",
+                SourceUrl: "https://www.wikidata.org/wiki/Q123",
+                SourceField: "labels.en",
+                FetchedAt: DateTime.UtcNow,
+                Value: title),
+            ["yearPublished"] = new FieldProvenance(
+                Provider: "wikidata",
+                SourceUrl: "https://www.wikidata.org/wiki/Q123",
+                SourceField: "P577",
+                FetchedAt: DateTime.UtcNow,
+                Value: 1995),
+        };
+        return new CatalogSeedProvenance(fields).ToJson();
+    }
+
+    private static CatalogSeedDraftEntity SeedFetchedDraft(
+        int? bggId = 12345,
+        string? provenanceJson = null,
+        string title = "Catan")
+    {
+        return new CatalogSeedDraftEntity
+        {
+            Id = Guid.NewGuid(),
+            BggId = bggId,
+            Status = "Approved", // M4.4 already set this before publishing the event
+            ProvenanceJson = provenanceJson ?? ProvenanceWithTitle(title),
+            ResultingSharedGameId = Guid.NewGuid(), // M4.4 placeholder we will overwrite
+            ApprovedAt = DateTime.UtcNow,
+            ApprovedByUserId = Guid.NewGuid(),
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+        };
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CreatesSkeletonAndOverwritesResultingId()
+    {
+        var draft = SeedFetchedDraft();
+        var placeholderId = draft.ResultingSharedGameId!.Value;
+        var approvedByUserId = Guid.NewGuid();
+
+        _drafts.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _games.Setup(r => r.GetByBggIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync((SharedGame?)null);
+
+        SharedGame? added = null;
+        _games.Setup(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()))
+              .Callback<SharedGame, CancellationToken>((g, _) => added = g)
+              .Returns(Task.CompletedTask);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draft.Id, placeholderId, approvedByUserId),
+            default);
+
+        added.Should().NotBeNull();
+        added!.Title.Should().Be("Catan");
+        added.BggId.Should().Be(12345);
+        added.CreatedBy.Should().Be(approvedByUserId);
+
+        draft.ResultingSharedGameId.Should().Be(added.Id, "the placeholder must be overwritten with the real aggregate Id");
+        draft.ResultingSharedGameId.Should().NotBe(placeholderId);
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DraftNotFound_LogsAndReturns()
+    {
+        var draftId = Guid.NewGuid();
+        _drafts.Setup(r => r.GetByIdAsync(draftId, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((CatalogSeedDraftEntity?)null);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draftId, Guid.NewGuid(), Guid.NewGuid()),
+            default);
+
+        _games.Verify(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyProvenance_LogsAndReturns()
+    {
+        var draft = SeedFetchedDraft();
+        draft.ProvenanceJson = null;
+
+        _drafts.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draft.Id, draft.ResultingSharedGameId!.Value, Guid.NewGuid()),
+            default);
+
+        _games.Verify(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MalformedProvenanceJson_LogsAndReturns()
+    {
+        var draft = SeedFetchedDraft();
+        draft.ProvenanceJson = "{ not valid json";
+
+        _drafts.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draft.Id, draft.ResultingSharedGameId!.Value, Guid.NewGuid()),
+            default);
+
+        _games.Verify(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MissingTitleInProvenance_LogsAndReturns()
+    {
+        var draft = SeedFetchedDraft();
+        // Build a provenance with no "title" key
+        var fieldsNoTitle = new Dictionary<string, FieldProvenance>(StringComparer.Ordinal)
+        {
+            ["yearPublished"] = new FieldProvenance(
+                Provider: "wikidata",
+                SourceUrl: "https://www.wikidata.org/wiki/Q123",
+                SourceField: "P577",
+                FetchedAt: DateTime.UtcNow,
+                Value: 1995),
+        };
+        draft.ProvenanceJson = new CatalogSeedProvenance(fieldsNoTitle).ToJson();
+
+        _drafts.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draft.Id, draft.ResultingSharedGameId!.Value, Guid.NewGuid()),
+            default);
+
+        _games.Verify(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SharedGameAlreadyExistsForBggId_ReusesExistingAndOverwritesPlaceholder()
+    {
+        var draft = SeedFetchedDraft(bggId: 12345);
+        var placeholderId = draft.ResultingSharedGameId!.Value;
+        var approvedByUserId = Guid.NewGuid();
+
+        // Existing aggregate (reuse path — idempotency for double-approval / collision with prior import)
+        var existing = SharedGame.CreateSkeleton("Catan", Guid.NewGuid(), TimeProvider.System, bggId: 12345);
+
+        _drafts.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+        _games.Setup(r => r.GetByBggIdAsync(12345, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draft.Id, placeholderId, approvedByUserId),
+            default);
+
+        _games.Verify(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()), Times.Never);
+        draft.ResultingSharedGameId.Should().Be(existing.Id, "should reuse existing aggregate Id, overwriting placeholder");
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoBggId_StillCreatesSkeletonByTitleOnly()
+    {
+        // Catalog seed pure-Wikidata path (no BggId)
+        var draft = SeedFetchedDraft(bggId: null, title: "Pandemic");
+
+        _drafts.Setup(r => r.GetByIdAsync(draft.Id, It.IsAny<CancellationToken>())).ReturnsAsync(draft);
+
+        SharedGame? added = null;
+        _games.Setup(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()))
+              .Callback<SharedGame, CancellationToken>((g, _) => added = g)
+              .Returns(Task.CompletedTask);
+
+        await Handler().Handle(
+            new CatalogSeedApprovedEvent(draft.Id, draft.ResultingSharedGameId!.Value, Guid.NewGuid()),
+            default);
+
+        added.Should().NotBeNull();
+        added!.Title.Should().Be("Pandemic");
+        added.BggId.Should().BeNull();
+        // GetByBggIdAsync should not have been called when BggId is null
+        _games.Verify(r => r.GetByBggIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJobTests.cs
@@ -1,0 +1,213 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CatalogSeedFetchJobTests
+{
+    private readonly Mock<ICatalogSeedDraftRepository> _repo = new();
+    private readonly Mock<ICatalogSeedAggregator> _aggregator = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IMediator> _mediator = new();
+
+    private CatalogSeedFetchJob CreateJob() =>
+        new(serviceProvider: new Mock<IServiceProvider>().Object,
+            NullLogger<CatalogSeedFetchJob>.Instance);
+
+    private static CatalogSeedDraftEntity SeedDraft(int? bggId = 12345, string? qid = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            BggId = bggId,
+            WikidataQid = qid,
+            Status = "Pending",
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+    private static CatalogSeedAggregationResult SuccessResult(string provider = "wikidata+bgg")
+    {
+        var fields = new Dictionary<string, FieldProvenance>(StringComparer.Ordinal)
+        {
+            ["title"] = new FieldProvenance(
+                Provider: "wikidata",
+                SourceUrl: "https://www.wikidata.org/wiki/Q123",
+                SourceField: "labels.en",
+                FetchedAt: DateTime.UtcNow,
+                Value: "Catan"),
+            ["yearPublished"] = new FieldProvenance(
+                Provider: "wikidata",
+                SourceUrl: "https://www.wikidata.org/wiki/Q123",
+                SourceField: "P577",
+                FetchedAt: DateTime.UtcNow,
+                Value: 1995),
+        };
+        return new CatalogSeedAggregationResult(
+            new CatalogSeedProvenance(fields),
+            provider,
+            CombinedRawPayload: "{\"wikidata\":{},\"bgg\":{}}");
+    }
+
+    private static CatalogSeedAggregationResult EmptyResult() =>
+        new(
+            new CatalogSeedProvenance(new Dictionary<string, FieldProvenance>(StringComparer.Ordinal)),
+            ProviderUsed: "none",
+            CombinedRawPayload: "{\"wikidata\":null,\"bgg\":null}");
+
+    [Fact]
+    public async Task RunBatchAsync_NoEligibleDrafts_DoesNothing()
+    {
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(Array.Empty<CatalogSeedDraftEntity>());
+
+        await CreateJob().RunBatchAsync(_repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, default);
+
+        _aggregator.Verify(a => a.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mediator.Verify(m => m.Publish(It.IsAny<CatalogSeedFetchedEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_Pending_Single_PopulatesFetched_PublishesEvent()
+    {
+        var draft = SeedDraft();
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<CatalogSeedDraftEntity> { draft });
+
+        var result = SuccessResult();
+        _aggregator.Setup(a => a.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(result);
+
+        await CreateJob().RunBatchAsync(_repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, default);
+
+        draft.Status.Should().Be("Fetched");
+        draft.ProvenanceJson.Should().NotBeNullOrWhiteSpace();
+        draft.RawPayloadJson.Should().NotBeNullOrWhiteSpace();
+        draft.FetchedAt.Should().NotBeNull();
+        draft.ErrorMessage.Should().BeNull();
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mediator.Verify(m => m.Publish(
+            It.Is<CatalogSeedFetchedEvent>(e =>
+                e.DraftId == draft.Id &&
+                e.ProviderUsed == "wikidata+bgg" &&
+                e.FetchedFields == 2),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_AggregatorReturnsEmpty_MarksFetchFailed_NoEvent()
+    {
+        var draft = SeedDraft();
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<CatalogSeedDraftEntity> { draft });
+
+        _aggregator.Setup(a => a.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(EmptyResult());
+
+        await CreateJob().RunBatchAsync(_repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, default);
+
+        draft.Status.Should().Be("FetchFailed");
+        draft.ErrorMessage.Should().NotBeNullOrEmpty();
+        draft.ErrorMessage!.Should().Contain("providerUsed=none");
+        draft.FetchedAt.Should().NotBeNull();
+        draft.ProvenanceJson.Should().BeNull();
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mediator.Verify(m => m.Publish(It.IsAny<CatalogSeedFetchedEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_AggregatorThrows_MarksFetchFailed_NoEvent()
+    {
+        var draft = SeedDraft();
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<CatalogSeedDraftEntity> { draft });
+
+        _aggregator.Setup(a => a.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+                   .ThrowsAsync(new HttpRequestException("network down"));
+
+        await CreateJob().RunBatchAsync(_repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, default);
+
+        draft.Status.Should().Be("FetchFailed");
+        // ex-message-leak-pattern: ErrorMessage holds exception TYPE, not Message
+        draft.ErrorMessage.Should().NotBeNullOrEmpty();
+        draft.ErrorMessage!.Should().Contain(nameof(HttpRequestException));
+        draft.ErrorMessage.Should().NotContain("network down");
+        draft.FetchedAt.Should().NotBeNull();
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mediator.Verify(m => m.Publish(It.IsAny<CatalogSeedFetchedEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_RepoCalledWithBatchSize10()
+    {
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(Array.Empty<CatalogSeedDraftEntity>());
+
+        await CreateJob().RunBatchAsync(_repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, default);
+
+        // Batch size constant must be 10 — enforces spec §7 throughput cap of ~10/min
+        CatalogSeedFetchJob.BatchSize.Should().Be(10);
+
+        _repo.Verify(r => r.GetByStatusAsync("Pending", 10, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_CancellationToken_PropagatesOperationCanceledException()
+    {
+        var draft1 = SeedDraft();
+        var draft2 = SeedDraft();
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<CatalogSeedDraftEntity> { draft1, draft2 });
+
+        using var cts = new CancellationTokenSource();
+        // Cancel immediately so the second iteration of the loop trips ThrowIfCancellationRequested
+        await cts.CancelAsync();
+
+        var act = async () => await CreateJob().RunBatchAsync(
+            _repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_MultipleDrafts_ProcessesAllInOrder()
+    {
+        var d1 = SeedDraft(bggId: 1);
+        var d2 = SeedDraft(bggId: 2);
+        var d3 = SeedDraft(bggId: 3);
+
+        _repo.Setup(r => r.GetByStatusAsync("Pending", CatalogSeedFetchJob.BatchSize, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new List<CatalogSeedDraftEntity> { d1, d2, d3 });
+
+        _aggregator.Setup(a => a.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(SuccessResult("wikidata"));
+
+        // Override the inter-item delay implicitly by not waiting — Task.Delay
+        // honours the cancellation token but here token is default, so the test
+        // tolerates the 1s * (n-1) wall clock cost. Three drafts ≈ 2s.
+        await CreateJob().RunBatchAsync(_repo.Object, _aggregator.Object, _uow.Object, _mediator.Object, default);
+
+        d1.Status.Should().Be("Fetched");
+        d2.Status.Should().Be("Fetched");
+        d3.Status.Should().Be("Fetched");
+
+        _aggregator.Verify(a => a.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(3));
+        _mediator.Verify(m => m.Publish(It.IsAny<CatalogSeedFetchedEvent>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+    }
+}


### PR DESCRIPTION
## Summary

M5 of issue #1903 (admin catalog seed). Wires the providers + aggregator into a working background pipeline. Builds on M4 (merged 01f24f731).

## What ships

| Task | Commit | Output |
|---|---|---|
| M5.1 | `c45a1c4c3` | `CatalogSeedFetchJob` Quartz `IJob` (batch 10/min, 1s inter-item, BackfillPdfCoversJob pattern) + 7 unit tests |
| M5.2 | `eb5dc80d8` | DI registration: HttpClients (Wikidata + BGG with User-Agent) + keyed providers + ICatalogSeedAggregator + Quartz job |
| M5.3 | `d12efc6f2` | `CatalogSeedApprovedEventHandler` materialises SharedGame.CreateSkeleton() + overwrites M4.4 placeholder + 7 unit tests |

**14 new unit tests pass locally. 85 total CatalogSeed* tests cumulative.**

## Architecture decisions

- **`SharedGame.CreateSkeleton()`** chosen over `Create()` in event handler (M5.3): factory `Create()` enforces strict validation (absolute imageUrl, year > 1900, players > 0, non-empty description) that catalog-seed provenance often cannot satisfy. Skeleton path lands in `GameDataStatus.Skeleton` / `GameStatus.Draft`, ready for BGG enrichment queue (#1874) to complete.
- **Idempotency**: on `BggId` collision with prior import, M5.3 handler reuses existing aggregate and overwrites placeholder for audit consistency.
- **Keyed services**: `ICatalogProvider` registered as keyed (`"wikidata"` primary, `"bgg"` fallback) to make aggregator wiring explicit and decouple from registration order.
- **HttpClient User-Agent**: spec §7.2 `MeepleAI/1.0 (admin-catalog-seed; abuse@meepleai.app)` set at DI level for both providers.
- **MediatR auto-discovery**: handlers + new event handler picked up by `Program.cs` assembly scanner.

## What's NOT in this PR

- M6 (SSE Stream Service + Admin endpoints, 8 endpoints)
- M7 (BggTosWatcherJob + AdminCatalogSeedEnabled feature flag)
- M8 (Frontend Admin UI + E2E)

## Test plan

- [x] 85/85 CatalogSeed tests pass locally (incl. 14 new)
- [x] Build 0 errors
- [ ] CI green

## Risk

LOW-MEDIUM — Quartz job is registered + active. Without M7 feature flag, the job will start running on deploy. However, queue is empty (no admin endpoints to create drafts yet), so job is harmless until M6 ships endpoints + M7 ships kill-switch.