### PR TITLE
feat(catalog-seed): #1903 M6 — SSE stream service + 8 admin endpoints

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJob.cs
@@ -64,21 +64,28 @@ public sealed class CatalogSeedFetchJob : IJob
         var aggregator = scope.ServiceProvider.GetRequiredService<ICatalogSeedAggregator>();
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
         var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        // Optional resolution — pre-M6.1 deployments won't have it registered and
+        // the job must keep working (tests stub the IServiceProvider). When not
+        // registered, SSE events are simply skipped.
+        var stream = scope.ServiceProvider.GetService<ICatalogSeedStreamService>();
 
-        await RunBatchAsync(repo, aggregator, uow, mediator, ct).ConfigureAwait(false);
+        await RunBatchAsync(repo, aggregator, uow, mediator, ct, stream).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Internal batch runner — extracted from <see cref="Execute"/> so unit tests
     /// can drive it directly without spinning up the Quartz scheduler. Mirrors
     /// <c>BackfillPdfCoversJob.RunBatchAsync</c> from issue #1873.
+    /// Issue #1903 M6.1: also broadcasts batch + per-item events via
+    /// <paramref name="stream"/> when supplied (null = legacy callers).
     /// </summary>
     internal async Task RunBatchAsync(
         ICatalogSeedDraftRepository repo,
         ICatalogSeedAggregator aggregator,
         IUnitOfWork uow,
         IMediator mediator,
-        CancellationToken ct)
+        CancellationToken ct,
+        ICatalogSeedStreamService? stream = null)
     {
         var batch = await repo.GetByStatusAsync("Pending", BatchSize, ct).ConfigureAwait(false);
         if (batch.Count == 0)
@@ -91,26 +98,66 @@ public sealed class CatalogSeedFetchJob : IJob
             "CatalogSeedFetchJob: picked up {Count} Pending drafts for fetching",
             batch.Count);
 
+        var batchId = Guid.NewGuid();
+        var batchStart = DateTime.UtcNow;
+        var succeeded = 0;
+        var failed = 0;
+
+        if (stream is not null)
+        {
+            var draftIds = new List<Guid>(batch.Count);
+            foreach (var d in batch)
+            {
+                draftIds.Add(d.Id);
+            }
+            await stream.PublishAsync(new BatchStartedEvent(batchId, draftIds, batchStart), ct).ConfigureAwait(false);
+        }
+
         for (var i = 0; i < batch.Count; i++)
         {
             ct.ThrowIfCancellationRequested();
             var draft = batch[i];
-            await ProcessOneAsync(draft, aggregator, uow, mediator, ct).ConfigureAwait(false);
+            var outcome = await ProcessOneAsync(draft, aggregator, uow, mediator, ct, stream).ConfigureAwait(false);
+            if (outcome)
+            {
+                succeeded++;
+            }
+            else
+            {
+                failed++;
+            }
 
             if (i < batch.Count - 1)
             {
                 await Task.Delay(DelayBetweenItemsMs, ct).ConfigureAwait(false);
             }
         }
+
+        if (stream is not null)
+        {
+            var completedAt = DateTime.UtcNow;
+            var totalMs = (completedAt - batchStart).TotalMilliseconds;
+            await stream.PublishAsync(
+                new BatchCompletedEvent(batchId, succeeded, failed, totalMs, completedAt),
+                ct).ConfigureAwait(false);
+        }
     }
 
-    private async Task ProcessOneAsync(
+    /// <summary>
+    /// Processes a single draft. Returns <c>true</c> on a successful fetch
+    /// (terminal <c>Fetched</c>), <c>false</c> otherwise (<c>FetchFailed</c> or
+    /// any caught exception). Used by <see cref="RunBatchAsync"/> for batch
+    /// success/failure tallying.
+    /// </summary>
+    private async Task<bool> ProcessOneAsync(
         CatalogSeedDraftEntity draft,
         ICatalogSeedAggregator aggregator,
         IUnitOfWork uow,
         IMediator mediator,
-        CancellationToken ct)
+        CancellationToken ct,
+        ICatalogSeedStreamService? stream = null)
     {
+        var perItemStart = DateTime.UtcNow;
         try
         {
             var query = new CatalogProviderQuery(draft.BggId, draft.WikidataQid, draft.SearchTermInput);
@@ -148,7 +195,25 @@ public sealed class CatalogSeedFetchJob : IJob
                 await mediator.Publish(
                     new CatalogSeedFetchedEvent(draft.Id, result.ProviderUsed, result.Provenance.Fields.Count),
                     ct).ConfigureAwait(false);
+
+                if (stream is not null)
+                {
+                    var durationMs = (DateTime.UtcNow - perItemStart).TotalMilliseconds;
+                    await stream.PublishAsync(new SeedEntryFetchedEvent(
+                        draft.Id, draft.BggId, result.ProviderUsed,
+                        result.Provenance.Fields.Count, durationMs, DateTime.UtcNow), ct).ConfigureAwait(false);
+                }
+
+                return true;
             }
+
+            // FetchFailed (empty-provider case): emit the failure event.
+            if (stream is not null)
+            {
+                await stream.PublishAsync(new SeedEntryFetchFailedEvent(
+                    draft.Id, draft.BggId, "EmptyProviderResponse", DateTime.UtcNow), ct).ConfigureAwait(false);
+            }
+            return false;
         }
         catch (OperationCanceledException)
         {
@@ -182,6 +247,28 @@ public sealed class CatalogSeedFetchJob : IJob
                     "CatalogSeedFetchJob: failed to persist FetchFailed status for draft {DraftId}",
                     draft.Id);
             }
+
+            if (stream is not null)
+            {
+                try
+                {
+                    await stream.PublishAsync(new SeedEntryFetchFailedEvent(
+                        draft.Id, draft.BggId, ex.GetType().Name, DateTime.UtcNow), ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+#pragma warning disable CA1031
+                catch (Exception streamEx)
+#pragma warning restore CA1031
+                {
+                    _logger.LogWarning(streamEx,
+                        "CatalogSeedFetchJob: failed to publish SeedEntryFetchFailedEvent for draft {DraftId}",
+                        draft.Id);
+                }
+            }
+            return false;
         }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/WikidataSearchQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/WikidataSearchQuery.cs
@@ -1,0 +1,26 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Issue #1903 M6.2 — proxy query for the Wikidata SPARQL search exposed to the
+/// admin catalog-seed UI. Wraps <c>WikidataCatalogProvider.FetchAsync</c> behind
+/// MediatR so the routing layer stays CQRS-compliant (endpoints use only
+/// <c>IMediator.Send</c>; no direct service injection).
+/// </summary>
+internal sealed record WikidataSearchQuery(string SearchTerm) : IQuery<WikidataSearchResult>;
+
+/// <summary>
+/// Result of a Wikidata search proxy call. Mirrors the shape of the underlying
+/// <c>CatalogProviderResult</c> so the admin UI can render the same per-field
+/// provenance preview it would for any other provider.
+/// </summary>
+/// <param name="Fields">
+/// Logical field map (e.g. "title", "yearPublished"). Empty when no match was
+/// found or the provider returned an error.
+/// </param>
+/// <param name="ErrorMessage">Non-null when the provider call failed.</param>
+internal sealed record WikidataSearchResult(
+    IReadOnlyDictionary<string, FieldProvenance> Fields,
+    string? ErrorMessage);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/WikidataSearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/WikidataSearchQueryHandler.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Issue #1903 M6.2 — handler for <see cref="WikidataSearchQuery"/>. Resolves
+/// the keyed <see cref="ICatalogProvider"/> registered under the key
+/// <c>"wikidata"</c> (see <c>SharedGameCatalogServiceExtensions.RegisterCatalogSeedProviders</c>)
+/// and forwards a free-text search term.
+/// </summary>
+internal sealed class WikidataSearchQueryHandler : IQueryHandler<WikidataSearchQuery, WikidataSearchResult>
+{
+    private readonly ICatalogProvider _wikidata;
+    private readonly ILogger<WikidataSearchQueryHandler> _logger;
+
+    public WikidataSearchQueryHandler(
+        [FromKeyedServices("wikidata")] ICatalogProvider wikidata,
+        ILogger<WikidataSearchQueryHandler> logger)
+    {
+        _wikidata = wikidata ?? throw new ArgumentNullException(nameof(wikidata));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<WikidataSearchResult> Handle(WikidataSearchQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.SearchTerm))
+        {
+            return new WikidataSearchResult(
+                new Dictionary<string, FieldProvenance>(StringComparer.Ordinal),
+                "SearchTerm must not be empty");
+        }
+
+        var providerResult = await _wikidata
+            .FetchAsync(new CatalogProviderQuery(null, null, request.SearchTerm), cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "WikidataSearchQuery: term={Term} matched {FieldCount} fields (error={Error})",
+            request.SearchTerm, providerResult.Fields.Count, providerResult.ErrorMessage ?? "none");
+
+        return new WikidataSearchResult(providerResult.Fields, providerResult.ErrorMessage);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamService.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -75,6 +76,16 @@ internal sealed class CatalogSeedStreamService : ICatalogSeedStreamService
         }
     }
 
+    /// <summary>
+    /// Subscribe to stream. New subscriber receives a replay of recent events
+    /// (up to <see cref="ReplayBufferSize"/>) followed by live events. Replay
+    /// uses an <c>OccurredAt</c> cutoff to prevent the "subscribe/publish seam"
+    /// race from delivering duplicate events — only events strictly before the
+    /// channel-registration timestamp are replayed; everything at or after the
+    /// cutoff arrives via the live channel. In the unlikely case two events
+    /// share the same <c>OccurredAt</c> microsecond, one may be duplicated;
+    /// acceptable for a diagnostic SSE stream.
+    /// </summary>
     /// <inheritdoc />
     public async IAsyncEnumerable<CatalogSeedStreamEvent> SubscribeAsync(
         [EnumeratorCancellation] CancellationToken ct)
@@ -89,6 +100,13 @@ internal sealed class CatalogSeedStreamService : ICatalogSeedStreamService
             });
 
         _subscribers[subscriberId] = channel;
+
+        // Mark cutoff: events with OccurredAt >= cutoff are guaranteed to reach
+        // the channel (since registration above happens-before any subsequent
+        // PublishAsync write). Replay only events strictly before cutoff to
+        // avoid double-delivery at the subscribe/publish seam.
+        var registrationCutoff = DateTime.UtcNow;
+
         _logger.LogDebug(
             "CatalogSeedStreamService: subscriber {SubscriberId} connected (total={Count})",
             subscriberId, _subscribers.Count);
@@ -100,7 +118,9 @@ internal sealed class CatalogSeedStreamService : ICatalogSeedStreamService
             List<CatalogSeedStreamEvent> snapshot;
             lock (_replayLock)
             {
-                snapshot = new List<CatalogSeedStreamEvent>(_replayBuffer);
+                snapshot = _replayBuffer
+                    .Where(e => e.OccurredAt < registrationCutoff)
+                    .ToList();
             }
 
             foreach (var replay in snapshot)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamService.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamService.cs
@@ -1,0 +1,137 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #1903 M6.1 — singleton, in-memory SSE event broadcaster for the admin
+/// catalog seed pipeline. Mirrors the pub/sub pattern of
+/// <c>PdfProgressStreamService</c> (DocumentProcessing BC).
+/// </summary>
+/// <remarks>
+/// <para>Each subscriber owns a bounded channel
+/// (<see cref="BoundedChannelFullMode.DropOldest"/>) so slow consumers cannot
+/// back-pressure the publisher. The replay buffer is capped at
+/// <see cref="ReplayBufferSize"/> entries (FIFO).</para>
+/// <para>Faulty subscribers are removed silently with a warning log — a
+/// single bad client must never stall job execution.</para>
+/// </remarks>
+internal sealed class CatalogSeedStreamService : ICatalogSeedStreamService
+{
+    private const int ReplayBufferSize = 200;
+    private const int SubscriberChannelCapacity = 100;
+
+    private readonly ConcurrentDictionary<Guid, Channel<CatalogSeedStreamEvent>> _subscribers = new();
+    private readonly LinkedList<CatalogSeedStreamEvent> _replayBuffer = new();
+    private readonly Lock _replayLock = new();
+    private readonly ILogger<CatalogSeedStreamService> _logger;
+
+    public CatalogSeedStreamService(ILogger<CatalogSeedStreamService> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task PublishAsync(CatalogSeedStreamEvent evt, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        AddToReplayBuffer(evt);
+
+        foreach (var (id, channel) in _subscribers)
+        {
+            try
+            {
+                // Fast path: non-blocking write succeeds when channel has slack.
+                if (channel.Writer.TryWrite(evt))
+                {
+                    continue;
+                }
+
+                // Slow path: bounded channel is full → DropOldest semantics will
+                // make room asynchronously. Await briefly to honour publisher CT.
+                await channel.Writer.WriteAsync(evt, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            // INFRASTRUCTURE BOUNDARY: a single faulty subscriber must not crash
+            // the publisher. Mirror of PdfProgressStreamService behaviour.
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogWarning(ex,
+                    "CatalogSeedStreamService: failed to write event {EventType} to subscriber {SubscriberId}; removing",
+                    evt.EventType, id);
+                if (_subscribers.TryRemove(id, out var removed))
+                {
+                    removed.Writer.TryComplete();
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<CatalogSeedStreamEvent> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var subscriberId = Guid.NewGuid();
+        var channel = Channel.CreateBounded<CatalogSeedStreamEvent>(
+            new BoundedChannelOptions(SubscriberChannelCapacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            });
+
+        _subscribers[subscriberId] = channel;
+        _logger.LogDebug(
+            "CatalogSeedStreamService: subscriber {SubscriberId} connected (total={Count})",
+            subscriberId, _subscribers.Count);
+
+        try
+        {
+            // Snapshot the replay buffer under lock so we don't observe a
+            // half-rotated linked list during enumeration.
+            List<CatalogSeedStreamEvent> snapshot;
+            lock (_replayLock)
+            {
+                snapshot = new List<CatalogSeedStreamEvent>(_replayBuffer);
+            }
+
+            foreach (var replay in snapshot)
+            {
+                yield return replay;
+            }
+
+            await foreach (var evt in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return evt;
+            }
+        }
+        finally
+        {
+            _subscribers.TryRemove(subscriberId, out _);
+            channel.Writer.TryComplete();
+            _logger.LogDebug(
+                "CatalogSeedStreamService: subscriber {SubscriberId} disconnected (remaining={Count})",
+                subscriberId, _subscribers.Count);
+        }
+    }
+
+    private void AddToReplayBuffer(CatalogSeedStreamEvent evt)
+    {
+        lock (_replayLock)
+        {
+            _replayBuffer.AddLast(evt);
+            while (_replayBuffer.Count > ReplayBufferSize)
+            {
+                _replayBuffer.RemoveFirst();
+            }
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogSeedStreamService.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogSeedStreamService.cs
@@ -1,0 +1,73 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #1903 M6.1: SSE event broadcaster for admin catalog seed pipeline.
+/// Subscribers receive a replay of the last N events + future live events.
+/// Pattern: mirrors <c>IPdfProgressStreamService</c> (DocumentProcessing BC) —
+/// in-memory pub/sub via <see cref="System.Threading.Channels.Channel"/>.
+/// </summary>
+/// <remarks>
+/// <para>Singleton registration: a single instance brokers all events across
+/// the process so the Quartz <c>CatalogSeedFetchJob</c> publisher and admin
+/// HTTP SSE subscribers share state. Per-subscriber bounded channels with
+/// <see cref="System.Threading.Channels.BoundedChannelFullMode.DropOldest"/>
+/// guarantee slow subscribers can never back-pressure the publisher.</para>
+/// <para>Replay buffer is bounded (200 events) — newly connecting admins
+/// catch up on the most recent batch activity without paging through DB
+/// records.</para>
+/// </remarks>
+internal interface ICatalogSeedStreamService
+{
+    /// <summary>
+    /// Publish an event to all active subscribers and append it to the replay
+    /// buffer. Never throws on subscriber faults — failed subscribers are
+    /// removed silently and logged at <c>Warning</c> level.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">When <paramref name="evt"/> is null.</exception>
+    Task PublishAsync(CatalogSeedStreamEvent evt, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribe to live events. The returned enumerable first replays the
+    /// existing buffered events (snapshot taken at subscribe time), then
+    /// yields live events as they are published. Auto-cleans the subscription
+    /// when the <paramref name="ct"/> cancels or the enumerator is disposed.
+    /// </summary>
+    IAsyncEnumerable<CatalogSeedStreamEvent> SubscribeAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Discriminated event base for the SSE stream. Concrete subtypes carry the
+/// payload; <see cref="EventType"/> drives the SSE <c>event:</c> field, and
+/// <see cref="OccurredAt"/> is included verbatim in the JSON payload.
+/// </summary>
+internal abstract record CatalogSeedStreamEvent(string EventType, DateTime OccurredAt);
+
+/// <summary>Emitted at the start of a CatalogSeedFetchJob batch.</summary>
+internal sealed record BatchStartedEvent(
+    Guid BatchId,
+    IReadOnlyList<Guid> DraftIds,
+    DateTime StartedAt) : CatalogSeedStreamEvent("batch.started", StartedAt);
+
+/// <summary>Emitted after a single draft is fetched successfully.</summary>
+internal sealed record SeedEntryFetchedEvent(
+    Guid DraftId,
+    int? BggId,
+    string ProviderUsed,
+    int FetchedFields,
+    double DurationMs,
+    DateTime OccurredAt) : CatalogSeedStreamEvent("seed.fetched", OccurredAt);
+
+/// <summary>Emitted after a single draft fetch fails (terminal FetchFailed status).</summary>
+internal sealed record SeedEntryFetchFailedEvent(
+    Guid DraftId,
+    int? BggId,
+    string ErrorType,
+    DateTime OccurredAt) : CatalogSeedStreamEvent("seed.failed", OccurredAt);
+
+/// <summary>Emitted at the end of a CatalogSeedFetchJob batch.</summary>
+internal sealed record BatchCompletedEvent(
+    Guid BatchId,
+    int Succeeded,
+    int Failed,
+    double TotalDurationMs,
+    DateTime CompletedAt) : CatalogSeedStreamEvent("batch.completed", CompletedAt);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -172,6 +172,11 @@ internal static class SharedGameCatalogServiceExtensions
         RegisterCatalogSeedProviders(services);
         RegisterCatalogSeedFetchJob(services);
 
+        // Issue #1903 M6.1: in-memory SSE event broadcaster for the admin
+        // catalog seed pipeline. Singleton so the Quartz job publisher and
+        // HTTP SSE subscribers share state across the process.
+        services.AddSingleton<ICatalogSeedStreamService, CatalogSeedStreamService>();
+
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 
         return services;

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -837,6 +837,7 @@ if (!app.Environment.IsProduction())
 app.MapAdminBulkImportEndpoints();       // Issue #4354: Bulk import endpoint routing
 app.MapAdminProviderEndpoints();         // Issue #936: Provider token probe observability
 v1Api.MapGroup("/admin/catalog-ingestion").MapAdminCatalogIngestionEndpoints(); // Admin bulk Excel import + enrichment
+v1Api.MapGroup("/admin/catalog/seeds").MapAdminCatalogSeedEndpoints();          // Issue #1903 M6.2: admin catalog seed pipeline
 app.MapPdfAnalyticsEndpoints();          // Issue #3715: PDF analytics dashboard
 app.MapChatAnalyticsEndpoints();         // Issue #3714: Chat analytics dashboard
 app.MapModelPerformanceEndpoints();      // Issue #3716: Model performance dashboard

--- a/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
@@ -187,6 +187,7 @@ internal static class AdminCatalogSeedEndpoints
     private static async Task HandleStream(
         HttpContext context,
         ICatalogSeedStreamService stream,
+        ILogger<Program> logger,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -226,10 +227,25 @@ internal static class AdminCatalogSeedEndpoints
             // Expected — client disconnected or server shutting down.
         }
 #pragma warning disable CA1031 // Do not catch general exception types
-        catch (Exception)
+        catch (Exception ex)
 #pragma warning restore CA1031
         {
-            // Transport-layer I/O failure during shutdown / disconnect — swallow.
+            // Transport-layer I/O failure during shutdown / disconnect. Log at
+            // Debug because OperationCanceledException + ObjectDisposedException
+            // on disconnect is the expected path — anything noisier would spam
+            // logs on every client navigation. Best-effort: connection may already
+            // be torn down so the logger call itself could throw.
+            try
+            {
+                logger.LogDebug(ex,
+                    "CatalogSeed SSE stream terminated for subscriber (likely client disconnect)");
+            }
+#pragma warning disable CA1031
+            catch
+#pragma warning restore CA1031
+            {
+                // Logger itself failed — nothing more we can do.
+            }
         }
     }
 

--- a/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
@@ -1,0 +1,273 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing.Admin;
+
+/// <summary>
+/// Issue #1903 M6.2 — Admin endpoints for the catalog seed pipeline. Routes
+/// under <c>/api/v1/admin/catalog/seeds</c>. All endpoints require an Admin
+/// session.
+/// </summary>
+/// <remarks>
+/// <para>CQRS compliance: every handler dispatches via <see cref="IMediator"/>;
+/// the only non-mediator dependency is <see cref="ICatalogSeedStreamService"/>
+/// for the SSE endpoint where streaming is an HTTP-level concern, not domain
+/// logic.</para>
+/// <para>Endpoint summary:</para>
+/// <list type="bullet">
+/// <item><c>POST    /</c> — enqueue a single seed draft</item>
+/// <item><c>POST    /bulk</c> — bulk enqueue (max 100 BGG ids)</item>
+/// <item><c>GET     /</c> — paginated list (filter by status)</item>
+/// <item><c>GET     /{id}</c> — single draft detail (incl. ProvenanceJson)</item>
+/// <item><c>POST    /{id}/approve</c> — transition Fetched → Approved</item>
+/// <item><c>POST    /{id}/reject</c> — soft-delete with reason</item>
+/// <item><c>GET     /stream</c> — SSE: batch + per-item events</item>
+/// <item><c>POST    /wikidata-search</c> — proxy SPARQL search for the UI picker</item>
+/// </list>
+/// </remarks>
+internal static class AdminCatalogSeedEndpoints
+{
+    private static readonly JsonSerializerOptions SseJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    public static RouteGroupBuilder MapAdminCatalogSeedEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/", HandleEnqueue)
+            .WithName("AdminCatalogSeed_Enqueue")
+            .WithTags("Admin", "CatalogSeed");
+
+        group.MapPost("/bulk", HandleBulkEnqueue)
+            .WithName("AdminCatalogSeed_BulkEnqueue")
+            .WithTags("Admin", "CatalogSeed");
+
+        group.MapGet("/", HandleList)
+            .WithName("AdminCatalogSeed_List")
+            .WithTags("Admin", "CatalogSeed");
+
+        group.MapGet("/{id:guid}", HandleGetById)
+            .WithName("AdminCatalogSeed_GetById")
+            .WithTags("Admin", "CatalogSeed");
+
+        group.MapPost("/{id:guid}/approve", HandleApprove)
+            .WithName("AdminCatalogSeed_Approve")
+            .WithTags("Admin", "CatalogSeed");
+
+        group.MapPost("/{id:guid}/reject", HandleReject)
+            .WithName("AdminCatalogSeed_Reject")
+            .WithTags("Admin", "CatalogSeed");
+
+        group.MapGet("/stream", HandleStream)
+            .WithName("AdminCatalogSeed_Stream")
+            .WithTags("Admin", "CatalogSeed")
+            .Produces(StatusCodes.Status200OK, contentType: "text/event-stream");
+
+        group.MapPost("/wikidata-search", HandleWikidataSearch)
+            .WithName("AdminCatalogSeed_WikidataSearch")
+            .WithTags("Admin", "CatalogSeed");
+
+        return group;
+    }
+
+    // =========================================================================
+    // Handlers
+    // =========================================================================
+
+    private static async Task<IResult> HandleEnqueue(
+        EnqueueCatalogSeedRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var command = new EnqueueCatalogSeedCommand(
+            BggId: request.BggId,
+            WikidataQid: request.WikidataQid,
+            SearchTermInput: request.SearchTermInput,
+            CreatedByUserId: session!.Principal!.Subject.Id);
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleBulkEnqueue(
+        BulkEnqueueRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var command = new BulkEnqueueCatalogSeedsCommand(
+            BggIds: request.BggIds,
+            CreatedByUserId: session!.Principal!.Subject.Id);
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleList(
+        [FromQuery] string? status,
+        [FromQuery] int? skip,
+        [FromQuery] int? take,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var query = new ListCatalogSeedsQuery(
+            StatusFilter: status,
+            Skip: skip ?? 0,
+            Take: take ?? 50);
+
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetById(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var dto = await mediator.Send(new GetCatalogSeedByIdQuery(id), ct).ConfigureAwait(false);
+        return dto is null ? Results.NotFound() : Results.Ok(dto);
+    }
+
+    private static async Task<IResult> HandleApprove(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator
+            .Send(new ApproveCatalogSeedCommand(id, session!.Principal!.Subject.Id), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleReject(
+        Guid id,
+        RejectRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        await mediator
+            .Send(new RejectCatalogSeedCommand(id, session!.Principal!.Subject.Id, request.Reason), ct)
+            .ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task HandleStream(
+        HttpContext context,
+        ICatalogSeedStreamService stream,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        // SSE handlers cannot return IResult once the body has started writing, so
+        // we set the status code directly on the response (mirror of
+        // AdminEventsEndpoints.HandleGetEventsStream).
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized)
+        {
+            context.Response.StatusCode = ExtractStatusCode(error);
+            return;
+        }
+
+        context.Response.Headers.ContentType = "text/event-stream";
+        context.Response.Headers.CacheControl = "no-cache";
+        context.Response.Headers.Connection = "keep-alive";
+        // Disable buffering at proxies; harmless on Caddy/Cloudflare Tunnel.
+        context.Response.Headers["X-Accel-Buffering"] = "no";
+
+        // Commit headers immediately so the client can start reading.
+        await context.Response.WriteAsync(":ok\n\n", ct).ConfigureAwait(false);
+        await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+
+        try
+        {
+            await foreach (var evt in stream.SubscribeAsync(ct).ConfigureAwait(false))
+            {
+                var json = JsonSerializer.Serialize<object>(evt, SseJsonOptions);
+                await context.Response.WriteAsync($"event: {evt.EventType}\n", ct).ConfigureAwait(false);
+                await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
+                await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — client disconnected or server shutting down.
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            // Transport-layer I/O failure during shutdown / disconnect — swallow.
+        }
+    }
+
+    private static async Task<IResult> HandleWikidataSearch(
+        WikidataSearchRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator
+            .Send(new WikidataSearchQuery(request.SearchTerm), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static int ExtractStatusCode(IResult? result)
+    {
+        if (result is IStatusCodeHttpResult sc) return sc.StatusCode ?? StatusCodes.Status401Unauthorized;
+        return StatusCodes.Status401Unauthorized;
+    }
+}
+
+/// <summary>Request body for <c>POST /api/v1/admin/catalog/seeds</c>.</summary>
+internal sealed record EnqueueCatalogSeedRequest(int? BggId, string? WikidataQid, string? SearchTermInput);
+
+/// <summary>Request body for <c>POST /api/v1/admin/catalog/seeds/bulk</c>.</summary>
+internal sealed record BulkEnqueueRequest(IReadOnlyList<int> BggIds);
+
+/// <summary>Request body for <c>POST /api/v1/admin/catalog/seeds/{id}/reject</c>.</summary>
+internal sealed record RejectRequest(string Reason);
+
+/// <summary>Request body for <c>POST /api/v1/admin/catalog/seeds/wikidata-search</c>.</summary>
+internal sealed record WikidataSearchRequest(string SearchTerm);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/WikidataSearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/WikidataSearchQueryHandlerTests.cs
@@ -1,0 +1,102 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="WikidataSearchQueryHandler"/> (Issue #1903 M6.2).
+/// Validates the CQRS-compliant proxy wrapper around the keyed Wikidata
+/// <c>ICatalogProvider</c> consumed by the admin catalog-seed UI picker.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WikidataSearchQueryHandlerTests
+{
+    private readonly Mock<ICatalogProvider> _wikidata = new();
+
+    private WikidataSearchQueryHandler CreateHandler() =>
+        new(_wikidata.Object, NullLogger<WikidataSearchQueryHandler>.Instance);
+
+    [Fact]
+    public async Task Handle_NullRequest_Throws()
+    {
+        var act = async () => await CreateHandler().Handle(null!, default);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Handle_EmptySearchTerm_ReturnsErrorResultWithoutCallingProvider()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new WikidataSearchQuery(""), default);
+
+        result.Fields.Should().BeEmpty();
+        result.ErrorMessage.Should().Be("SearchTerm must not be empty");
+        _wikidata.Verify(p => p.FetchAsync(
+            It.IsAny<CatalogProviderQuery>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceSearchTerm_ReturnsErrorResultWithoutCallingProvider()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new WikidataSearchQuery("   "), default);
+
+        result.Fields.Should().BeEmpty();
+        result.ErrorMessage.Should().Be("SearchTerm must not be empty");
+        _wikidata.Verify(p => p.FetchAsync(
+            It.IsAny<CatalogProviderQuery>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ValidSearchTerm_ForwardsToProviderAndProjectsResult()
+    {
+        var fields = new Dictionary<string, FieldProvenance>(StringComparer.Ordinal)
+        {
+            ["title"] = new FieldProvenance(
+                Provider: "wikidata",
+                SourceUrl: "https://www.wikidata.org/wiki/Q123",
+                SourceField: "labels.en",
+                FetchedAt: DateTime.UtcNow,
+                Value: "Catan"),
+        };
+        _wikidata
+            .Setup(p => p.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CatalogProviderResult(fields, RawPayloadJson: null, ErrorMessage: null));
+
+        var result = await CreateHandler().Handle(new WikidataSearchQuery("Catan"), default);
+
+        result.ErrorMessage.Should().BeNull();
+        result.Fields.Should().HaveCount(1);
+        result.Fields["title"].Value.Should().Be("Catan");
+
+        // Provider invoked with the search term forwarded into the SearchTerm slot,
+        // and BggId / WikidataQid left null (this is a search proxy, not a lookup).
+        _wikidata.Verify(p => p.FetchAsync(
+            It.Is<CatalogProviderQuery>(q =>
+                q.BggId == null && q.WikidataQid == null && q.SearchTerm == "Catan"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProviderReturnsError_PropagatesErrorMessage()
+    {
+        _wikidata
+            .Setup(p => p.FetchAsync(It.IsAny<CatalogProviderQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CatalogProviderResult.Empty("SPARQL timeout"));
+
+        var result = await CreateHandler().Handle(new WikidataSearchQuery("anything"), default);
+
+        result.Fields.Should().BeEmpty();
+        result.ErrorMessage.Should().Be("SPARQL timeout");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamServiceTests.cs
@@ -1,0 +1,256 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="CatalogSeedStreamService"/> (Issue #1903 M6.1).
+/// Covers: null-guard, replay-to-new-subscriber, live delivery, multi-subscriber
+/// fan-out, replay-buffer bounded eviction, and CT-driven subscriber cleanup.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CatalogSeedStreamServiceTests
+{
+    private static CatalogSeedStreamService CreateService() =>
+        new(NullLogger<CatalogSeedStreamService>.Instance);
+
+    private static BatchStartedEvent NewBatchStarted(Guid? id = null) =>
+        new(id ?? Guid.NewGuid(),
+            new[] { Guid.NewGuid(), Guid.NewGuid() },
+            DateTime.UtcNow);
+
+    [Fact]
+    public async Task PublishAsync_Throws_OnNullEvent()
+    {
+        var svc = CreateService();
+
+        var act = async () => await svc.PublishAsync(null!, default);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task PublishAsync_BeforeSubscribe_ReplaysToNewSubscriber()
+    {
+        var svc = CreateService();
+        var evt = NewBatchStarted();
+        await svc.PublishAsync(evt);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(150));
+
+        var received = new List<CatalogSeedStreamEvent>();
+        try
+        {
+            await foreach (var item in svc.SubscribeAsync(cts.Token))
+            {
+                received.Add(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected — CT cancels the subscriber loop after replay drains
+        }
+
+        received.Should().ContainSingle();
+        received[0].Should().Be(evt);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_LiveEvent_DeliveredToActiveSubscriber()
+    {
+        var svc = CreateService();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var received = new List<CatalogSeedStreamEvent>();
+        var consumer = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var item in svc.SubscribeAsync(cts.Token))
+                {
+                    received.Add(item);
+                    if (received.Count == 1)
+                    {
+                        await cts.CancelAsync();
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected on shutdown
+            }
+        });
+
+        // Brief yield so the subscriber gets registered before we publish.
+        await Task.Delay(50);
+
+        var evt = NewBatchStarted();
+        await svc.PublishAsync(evt);
+
+        await consumer.WaitAsync(TimeSpan.FromSeconds(2));
+
+        received.Should().ContainSingle();
+        received[0].Should().Be(evt);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_TwoSubscribers_BothReceiveLiveEvent()
+    {
+        var svc = CreateService();
+        using var cts1 = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var received1 = new List<CatalogSeedStreamEvent>();
+        var received2 = new List<CatalogSeedStreamEvent>();
+
+        async Task RunConsumer(CancellationTokenSource cts, List<CatalogSeedStreamEvent> sink)
+        {
+            try
+            {
+                await foreach (var item in svc.SubscribeAsync(cts.Token))
+                {
+                    sink.Add(item);
+                    if (sink.Count == 1)
+                    {
+                        await cts.CancelAsync();
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // shutdown path
+            }
+        }
+
+        var t1 = Task.Run(() => RunConsumer(cts1, received1));
+        var t2 = Task.Run(() => RunConsumer(cts2, received2));
+
+        await Task.Delay(80);
+
+        var evt = NewBatchStarted();
+        await svc.PublishAsync(evt);
+
+        await Task.WhenAll(t1, t2).WaitAsync(TimeSpan.FromSeconds(2));
+
+        received1.Should().ContainSingle().Which.Should().Be(evt);
+        received2.Should().ContainSingle().Which.Should().Be(evt);
+    }
+
+    [Fact]
+    public async Task ReplayBuffer_LimitedTo200Events_DiscardsOldest()
+    {
+        var svc = CreateService();
+
+        // Publish 250 events — the buffer should retain only the last 200.
+        var allEvents = new List<BatchStartedEvent>(250);
+        for (var i = 0; i < 250; i++)
+        {
+            var e = NewBatchStarted();
+            allEvents.Add(e);
+            await svc.PublishAsync(e);
+        }
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+        var replay = new List<CatalogSeedStreamEvent>();
+        try
+        {
+            await foreach (var item in svc.SubscribeAsync(cts.Token))
+            {
+                replay.Add(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected — replay drained, CT cancels
+        }
+
+        replay.Should().HaveCount(200);
+        // The 200 most-recent events should be the last 200 published.
+        replay.Should().Equal(allEvents.GetRange(50, 200));
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_CancellationToken_StopsEnumeration_AutoRemovesSubscriber()
+    {
+        var svc = CreateService();
+        using var cts = new CancellationTokenSource();
+
+        var consumer = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var _ in svc.SubscribeAsync(cts.Token))
+                {
+                    // never expect any event before we cancel
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+        });
+
+        // Let the subscriber register.
+        await Task.Delay(50);
+
+        // Cancel the subscriber — finally{} block must run and remove the channel.
+        await cts.CancelAsync();
+        await consumer.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // After cleanup, publishing must not throw — there are no live subscribers
+        // and the publish loop has nothing to write to.
+        var act = async () => await svc.PublishAsync(NewBatchStarted(), default);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task PublishAsync_AfterReplayDrain_DeliversLiveEvents()
+    {
+        // Edge-case check: a single subscriber should see BOTH the replay AND any
+        // subsequent live events arriving after the replay completes.
+        var svc = CreateService();
+        var replayEvt = NewBatchStarted();
+        await svc.PublishAsync(replayEvt);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var received = new List<CatalogSeedStreamEvent>();
+        var consumer = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var item in svc.SubscribeAsync(cts.Token))
+                {
+                    received.Add(item);
+                    if (received.Count == 2)
+                    {
+                        await cts.CancelAsync();
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+        });
+
+        await Task.Delay(80);
+        var liveEvt = NewBatchStarted();
+        await svc.PublishAsync(liveEvt);
+
+        await consumer.WaitAsync(TimeSpan.FromSeconds(2));
+
+        received.Should().HaveCount(2);
+        received[0].Should().Be(replayEvt);
+        received[1].Should().Be(liveEvt);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedStreamServiceTests.cs
@@ -212,6 +212,39 @@ public sealed class CatalogSeedStreamServiceTests
     }
 
     [Fact]
+    public async Task SubscribeAsync_PublishedBeforeSubscribe_DeliveredExactlyOnceViaReplay()
+    {
+        // Regression: PR #1913 review finding — subscribe/publish race could deliver
+        // the same event twice (once via replay snapshot, once via live channel).
+        // The cutoff-based dedup must ensure exactly-once delivery for events
+        // published strictly before SubscribeAsync registers its channel.
+        var svc = CreateService();
+        var evt = new BatchStartedEvent(
+            Guid.NewGuid(),
+            new[] { Guid.NewGuid() },
+            DateTime.UtcNow.AddSeconds(-1));
+
+        await svc.PublishAsync(evt);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var received = new List<CatalogSeedStreamEvent>();
+        try
+        {
+            await foreach (var item in svc.SubscribeAsync(cts.Token))
+            {
+                received.Add(item);
+                if (received.Count >= 1) break;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected if no more events arrive within the timeout
+        }
+
+        received.Should().ContainSingle().Which.Should().Be(evt);
+    }
+
+    [Fact]
     public async Task PublishAsync_AfterReplayDrain_DeliversLiveEvents()
     {
         // Edge-case check: a single subscriber should see BOTH the replay AND any


### PR DESCRIPTION
## Summary

M6 of issue #1903 (admin catalog seed). SSE stream service + 8 admin minimal-API endpoints. Builds on M5 (merged 0deeda8bf).

## What ships

| Task | Commit | Output |
|---|---|---|
| M6.1 | `4ed5efc6f` | `ICatalogSeedStreamService` (singleton, replay buffer 200, bounded channels DropOldest) + 4 event types + 7 unit tests + wired into `CatalogSeedFetchJob` (emits BatchStarted/SeedEntryFetched/SeedEntryFetchFailed/BatchCompleted) |
| M6.2 | `84ce254d6` | 8 admin endpoints (`AdminCatalogSeedEndpoints.cs`) + `WikidataSearchQuery` + handler with `[FromKeyedServices("wikidata")]` + 5 unit tests + DI registration + Program.cs wiring |

**12 new unit tests, 89 catalog-seed total cumulative, 0 build errors.**

## Endpoints exposed (all admin-only via `context.RequireAdminSession()`)

- `POST /api/v1/admin/catalog/seeds` — single enqueue
- `POST /api/v1/admin/catalog/seeds/bulk` — bulk (max 100)
- `GET /api/v1/admin/catalog/seeds?status=&skip=&take=` — paginated list
- `GET /api/v1/admin/catalog/seeds/{id}` — single
- `POST /api/v1/admin/catalog/seeds/{id}/approve`
- `POST /api/v1/admin/catalog/seeds/{id}/reject`
- `GET /api/v1/admin/catalog/seeds/stream` — SSE (text/event-stream)
- `POST /api/v1/admin/catalog/seeds/wikidata-search` — SPARQL proxy

## Architecture decisions

- **CQRS strict**: SPARQL proxy endpoint uses `WikidataSearchQuery` + handler (not direct provider injection) to honor CLAUDE.md "ENDPOINTS use ONLY IMediator.Send()" rule
- **`[FromKeyedServices("wikidata")]`** in handler ctor for keyed provider resolution
- **Auth pattern**: `context.RequireAdminSession()` (codebase convention, matches `AdminCatalogIngestionEndpoints`)
- **SSE**: `System.Threading.Lock` for replay buffer (MA0158), `Channel.CreateBounded` with `FullMode = DropOldest`
- **Job event emission**: `ICatalogSeedStreamService?` optional ctor param (nullable for backward compat with existing tests)

## What's NOT in this PR

- M7 (BggTosWatcherJob + AdminCatalogSeedEnabled feature flag) — next
- M8 (Frontend Admin UI + E2E)

## Test plan

- [x] 12/12 new unit tests pass (7 SSE + 5 WikidataSearchQueryHandler)
- [x] 89 catalog-seed tests cumulative all pass
- [x] Build 0 errors
- [ ] CI green

## Risk

MEDIUM — endpoints are now exposed. Without M7 feature flag, the Quartz job can fetch real BGG/Wikidata data on deploy. **Recommend**: do NOT deploy this PR alone to staging/prod without M7 ready (feature flag default false).