### PR TITLE
feat(catalog-seed): #1903 M7 — BggTosWatcher + AdminCatalogSeedEnabled flag (backend complete)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJob.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Microsoft.EntityFrameworkCore;
@@ -60,6 +61,20 @@ public sealed class BggTosWatcherJob : IJob
         _logger.LogDebug("BggTosWatcherJob started: FireTime={FireTime}", context.FireTimeUtc);
 
         using var scope = _serviceProvider.CreateScope();
+
+        // Issue #1903 M7.2: kill-switch. When the catalog seed pipeline is
+        // parked we also skip the ToS watcher — there's no point alerting on
+        // ToS changes for a feature that isn't running. Optional resolution
+        // keeps test doubles working (mirrors CatalogSeedFetchJob pattern).
+        var flag = scope.ServiceProvider.GetService<ICatalogSeedFeatureFlag>();
+        if (flag is not null && !await flag.IsEnabledAsync(ct).ConfigureAwait(false))
+        {
+            _logger.LogDebug(
+                "BggTosWatcherJob: kill-switch active ({Key}=false), skipping ToS check",
+                ICatalogSeedFeatureFlag.FlagKey);
+            return;
+        }
+
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var httpFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJob.cs
@@ -1,6 +1,5 @@
 using System.Security.Cryptography;
 using System.Text;
-using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +26,14 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
 /// exception that propagates is <see cref="OperationCanceledException"/> when
 /// shutdown is requested. Error messages never include <c>ex.Message</c> per
 /// CLAUDE.md memory <c>ex-message-leak-pattern</c>.</para>
+/// <para><b>IMPORTANT — runs regardless of feature flag:</b> this job is NOT
+/// gated by the <c>AdminCatalogSeedEnabled</c> runtime flag. The watcher is
+/// the compliance audit trail mandated by spec §8.5.6 — operators must have
+/// a continuous record of ToS changes BEFORE enabling the pipeline so they
+/// can perform the pre-rollout legal review with full context. Gating the
+/// watcher by the flag would silently miss ToS changes during the staging /
+/// pre-rollout window, defeating the purpose of the audit trail (M7 review
+/// fix).</para>
 /// </remarks>
 [DisallowConcurrentExecution]
 public sealed class BggTosWatcherJob : IJob
@@ -62,18 +69,11 @@ public sealed class BggTosWatcherJob : IJob
 
         using var scope = _serviceProvider.CreateScope();
 
-        // Issue #1903 M7.2: kill-switch. When the catalog seed pipeline is
-        // parked we also skip the ToS watcher — there's no point alerting on
-        // ToS changes for a feature that isn't running. Optional resolution
-        // keeps test doubles working (mirrors CatalogSeedFetchJob pattern).
-        var flag = scope.ServiceProvider.GetService<ICatalogSeedFeatureFlag>();
-        if (flag is not null && !await flag.IsEnabledAsync(ct).ConfigureAwait(false))
-        {
-            _logger.LogDebug(
-                "BggTosWatcherJob: kill-switch active ({Key}=false), skipping ToS check",
-                ICatalogSeedFeatureFlag.FlagKey);
-            return;
-        }
+        // NOTE: this job intentionally runs regardless of the
+        // AdminCatalogSeedEnabled feature flag — see class-level <remarks>
+        // (compliance audit trail per spec §8.5.6). Do NOT add a flag check
+        // here; gating the watcher would silently miss ToS changes during
+        // the pre-rollout window (M7 review fix).
 
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var httpFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJob.cs
@@ -1,0 +1,181 @@
+using System.Security.Cryptography;
+using System.Text;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Issue #1903 M7.1 — monthly watcher that fetches the BoardGameGeek terms of
+/// service page, hashes the body with SHA-256, and compares the result against
+/// the persisted <see cref="BggTosHashEntity"/> singleton row. On change, logs
+/// a warning so operators can perform the manual legal review required by spec
+/// §8.5.6 (pre-rollout legal checklist).
+/// </summary>
+/// <remarks>
+/// <para>Pattern follows <c>CatalogSeedFetchJob</c>: <see cref="IServiceProvider"/>
+/// scoped per execution, <see cref="DisallowConcurrentExecutionAttribute"/> to
+/// avoid double-fires, internal <see cref="RunOnceAsync"/> hook for unit tests
+/// that drive the watcher directly without spinning up the Quartz scheduler.</para>
+/// <para>Network/HTTP failures are caught and logged at <c>Warning</c> level
+/// (the watcher is best-effort — a single missed run is acceptable); the only
+/// exception that propagates is <see cref="OperationCanceledException"/> when
+/// shutdown is requested. Error messages never include <c>ex.Message</c> per
+/// CLAUDE.md memory <c>ex-message-leak-pattern</c>.</para>
+/// </remarks>
+[DisallowConcurrentExecution]
+public sealed class BggTosWatcherJob : IJob
+{
+    /// <summary>
+    /// Public URL of the BGG terms of service page. S1075 suppressed: stable
+    /// third-party service URL.
+    /// </summary>
+#pragma warning disable S1075 // URIs should not be hardcoded
+    public const string BggTosUrl = "https://boardgamegeek.com/terms";
+#pragma warning restore S1075
+
+    /// <summary>
+    /// HTTP timeout for a single ToS fetch. Generous — BGG occasionally takes
+    /// 10s+ to serve static pages, and the watcher only runs monthly.
+    /// </summary>
+    public static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<BggTosWatcherJob> _logger;
+
+    public BggTosWatcherJob(IServiceProvider serviceProvider, ILogger<BggTosWatcherJob> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+        _logger.LogDebug("BggTosWatcherJob started: FireTime={FireTime}", context.FireTimeUtc);
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var httpFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+
+        await RunOnceAsync(db, httpFactory, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Internal single-shot runner — extracted from <see cref="Execute"/> so
+    /// unit tests can drive it directly without the Quartz scheduler.
+    /// </summary>
+    internal async Task RunOnceAsync(
+        MeepleAiDbContext db,
+        IHttpClientFactory httpFactory,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(httpFactory);
+
+        string html;
+        try
+        {
+            using var client = httpFactory.CreateClient();
+            client.Timeout = HttpTimeout;
+            client.DefaultRequestHeaders.UserAgent.Clear();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "MeepleAI/1.0 (admin-catalog-seed-tos-watcher; abuse@meepleai.app)");
+
+            html = await client.GetStringAsync(new Uri(BggTosUrl), ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125 // Sections of code should not be commented out
+        // BACKFILL PATTERN: a single HTTP failure must not crash the scheduler.
+        // Log the exception type (no .Message — CLAUDE.md ex-message-leak-pattern)
+        // and let the next monthly run retry.
+#pragma warning restore S125
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(ex,
+                "BggTosWatcherJob: failed to fetch BGG ToS at {Url} (errorType={ErrorType})",
+                BggTosUrl, ex.GetType().Name);
+            return;
+        }
+
+        var hash = ComputeSha256Hex(html);
+        var now = DateTime.UtcNow;
+
+        var row = await db.BggTosHashes
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.Id == BggTosHashEntity.SingletonId, ct)
+            .ConfigureAwait(false);
+
+        if (row is null)
+        {
+            row = new BggTosHashEntity
+            {
+                Id = BggTosHashEntity.SingletonId,
+                CurrentHash = hash,
+                LastCheckedAt = now,
+                LastChangedAt = null,
+                ChangeCount = 0,
+            };
+            db.BggTosHashes.Add(row);
+            _logger.LogInformation(
+                "BggTosWatcherJob: initial BGG ToS hash recorded ({Hash})",
+                hash);
+        }
+        else if (!string.Equals(row.CurrentHash, hash, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "BggTosWatcherJob: BGG ToS HASH CHANGED. Old={OldHash} New={NewHash}. " +
+                "MANUAL LEGAL REVIEW REQUIRED — see spec §8.5.6 pre-rollout checklist.",
+                row.CurrentHash, hash);
+            row.CurrentHash = hash;
+            row.LastChangedAt = now;
+            row.ChangeCount++;
+        }
+        else
+        {
+            _logger.LogDebug(
+                "BggTosWatcherJob: BGG ToS hash unchanged ({Hash})", hash);
+        }
+
+        row.LastCheckedAt = now;
+
+        try
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex,
+                "BggTosWatcherJob: failed to persist BGG ToS hash row (errorType={ErrorType})",
+                ex.GetType().Name);
+        }
+    }
+
+    /// <summary>
+    /// Computes a lowercase hexadecimal SHA-256 digest of <paramref name="content"/>
+    /// (UTF-8 encoded). Result is always 64 characters.
+    /// </summary>
+    internal static string ComputeSha256Hex(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/CatalogSeedFetchJob.cs
@@ -60,6 +60,19 @@ public sealed class CatalogSeedFetchJob : IJob
         _logger.LogDebug("CatalogSeedFetchJob started: FireTime={FireTime}", context.FireTimeUtc);
 
         using var scope = _serviceProvider.CreateScope();
+
+        // Issue #1903 M7.2: kill-switch. Resolve optionally so legacy test
+        // doubles (which stub IServiceProvider with bare mocks) keep working;
+        // when the flag service IS registered, treat disabled as a no-op.
+        var flag = scope.ServiceProvider.GetService<ICatalogSeedFeatureFlag>();
+        if (flag is not null && !await flag.IsEnabledAsync(ct).ConfigureAwait(false))
+        {
+            _logger.LogDebug(
+                "CatalogSeedFetchJob: kill-switch active ({Key}=false), skipping batch",
+                ICatalogSeedFeatureFlag.FlagKey);
+            return;
+        }
+
         var repo = scope.ServiceProvider.GetRequiredService<ICatalogSeedDraftRepository>();
         var aggregator = scope.ServiceProvider.GetRequiredService<ICatalogSeedAggregator>();
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedFeatureFlag.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedFeatureFlag.cs
@@ -1,0 +1,64 @@
+using Api.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Default <see cref="ICatalogSeedFeatureFlag"/> implementation backed by the
+/// shared runtime configuration store (<see cref="IConfigurationService"/>).
+/// Issue #1903 M7.2.
+/// </summary>
+/// <remarks>
+/// Reads the flag under <see cref="ICatalogSeedFeatureFlag.FlagKey"/> and
+/// returns <c>false</c> on any read failure (fail-closed). Logs at
+/// <c>Warning</c> when the underlying configuration service throws — operators
+/// see this in dashboards as a signal that runtime config is partially
+/// degraded but the pipeline is correctly parked.
+/// </remarks>
+internal sealed class CatalogSeedFeatureFlag : ICatalogSeedFeatureFlag
+{
+    private readonly IConfigurationService _configService;
+    private readonly ILogger<CatalogSeedFeatureFlag> _logger;
+
+    public CatalogSeedFeatureFlag(
+        IConfigurationService configService,
+        ILogger<CatalogSeedFeatureFlag> logger)
+    {
+        _configService = configService ?? throw new ArgumentNullException(nameof(configService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> IsEnabledAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            // GetValueAsync<bool?> returns null when the key is absent; the
+            // "defaultValue: false" arg is fully redundant for the absence
+            // case (nullable returns null) so we coalesce explicitly here.
+            var value = await _configService
+                .GetValueAsync<bool?>(ICatalogSeedFeatureFlag.FlagKey, defaultValue: null)
+                .ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            return value ?? false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125
+        // SERVICE BOUNDARY: any failure in the runtime config layer (DB
+        // unreachable, deserialization failure, etc.) must NOT enable the
+        // pipeline. Fail closed → false. Log type only, per CLAUDE.md memory
+        // ex-message-leak-pattern.
+#pragma warning restore S125
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(ex,
+                "CatalogSeedFeatureFlag: failed to read {Key}, defaulting to disabled (errorType={ErrorType})",
+                ICatalogSeedFeatureFlag.FlagKey, ex.GetType().Name);
+            return false;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogSeedFeatureFlag.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ICatalogSeedFeatureFlag.cs
@@ -1,0 +1,41 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #1903 M7.2 — runtime kill-switch for the admin catalog seed pipeline.
+/// When the flag is disabled:
+/// <list type="bullet">
+/// <item><c>CatalogSeedFetchJob</c> early-returns (no provider calls, no DB
+/// reads), so a stuck pipeline can be parked without redeploy.</item>
+/// <item>The admin HTTP endpoints under <c>/api/v1/admin/catalog/seeds</c>
+/// short-circuit with <c>503 Service Unavailable</c> via an endpoint filter,
+/// surfacing the kill-switch to the UI immediately.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>Backed by the runtime configuration store
+/// (<c>IConfigurationService</c>) under key
+/// <see cref="FlagKey"/>. Mirrors the <c>RegistrationMode</c> /
+/// <c>Registration:PublicEnabled</c> pattern referenced in CLAUDE.md — same
+/// fail-closed semantics so a DB outage cannot accidentally enable the pipeline
+/// (catalog seed touches third-party APIs subject to BGG ToS, spec §8.5.6).</para>
+/// <para>Default value <c>false</c>: shipping with the flag flipped on by
+/// default would risk silent BGG hits on first deploy. Operators must
+/// explicitly opt in via <c>/admin/config</c> (or seed the config row in the
+/// staging DB) before the pipeline becomes active.</para>
+/// </remarks>
+public interface ICatalogSeedFeatureFlag
+{
+    /// <summary>
+    /// Runtime configuration key under which the boolean flag is stored.
+    /// Exposed for use by admin config UI / seed migrations / diagnostic
+    /// tooling.
+    /// </summary>
+    public const string FlagKey = "admin.catalog-seed.enabled";
+
+    /// <summary>
+    /// Returns <c>true</c> if the catalog seed pipeline is enabled in the
+    /// running environment. Fail-closed: any error (config not found, DB
+    /// unreachable, deserialization failure) yields <c>false</c>.
+    /// </summary>
+    Task<bool> IsEnabledAsync(CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -172,6 +172,9 @@ internal static class SharedGameCatalogServiceExtensions
         RegisterCatalogSeedProviders(services);
         RegisterCatalogSeedFetchJob(services);
 
+        // Issue #1903 M7.1: monthly BGG ToS hash watcher (spec §8.5.6).
+        RegisterBggTosWatcherJob(services);
+
         // Issue #1903 M6.1: in-memory SSE event broadcaster for the admin
         // catalog seed pipeline. Singleton so the Quartz job publisher and
         // HTTP SSE subscribers share state across the process.
@@ -255,6 +258,44 @@ internal static class SharedGameCatalogServiceExtensions
                     .WithIntervalInMinutes(1)
                     .RepeatForever())
                 .WithDescription("Fetches provider data for Pending CatalogSeedDraft entries every 1 minute"));
+        });
+    }
+
+    /// <summary>
+    /// Issue #1903 M7.1 — registers <see cref="BggTosWatcherJob"/> with the
+    /// Quartz scheduler. Runs every 30 days at the trigger's start time + a
+    /// 1-minute kickoff after process start, so the first deploy primes the
+    /// singleton row almost immediately. Pure HTTP GET against the BGG ToS
+    /// URL; no rate-limit concerns at monthly cadence.
+    /// </summary>
+    private static void RegisterBggTosWatcherJob(IServiceCollection services)
+    {
+        // The job uses IHttpClientFactory.CreateClient() (default client) so we
+        // don't need a typed AddHttpClient registration here. AddHttpClient is
+        // already exposed via Program.cs / other contexts that register typed
+        // clients, which transitively registers IHttpClientFactory itself.
+        services.AddHttpClient();
+
+        services.AddQuartz(q =>
+        {
+            var jobKey = new JobKey("BggTosWatcherJob", "SharedGameCatalog");
+
+            q.AddJob<BggTosWatcherJob>(opts => opts
+                .WithIdentity(jobKey)
+                .StoreDurably(true));
+
+            q.AddTrigger(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("BggTosWatcherTrigger", "SharedGameCatalog")
+                // 30-day interval (~monthly). Quartz SimpleSchedule supports hours,
+                // so 24 * 30 = 720 hours.
+                .WithSimpleSchedule(x => x
+                    .WithIntervalInHours(24 * 30)
+                    .RepeatForever())
+                // Kick off 1 minute after process start so the first deploy
+                // primes the singleton row without delaying boot.
+                .StartAt(DateBuilder.FutureDate(1, IntervalUnit.Minute))
+                .WithDescription("Monthly BGG ToS hash watcher (issue #1903 M7.1, spec §8.5.6)"));
         });
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -180,6 +180,10 @@ internal static class SharedGameCatalogServiceExtensions
         // HTTP SSE subscribers share state across the process.
         services.AddSingleton<ICatalogSeedStreamService, CatalogSeedStreamService>();
 
+        // Issue #1903 M7.2: kill-switch feature flag backed by IConfigurationService.
+        // Scoped to match the lifetime of the underlying IConfigurationService.
+        services.AddScoped<ICatalogSeedFeatureFlag, CatalogSeedFeatureFlag>();
+
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 
         return services;

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/BggTosHashEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/BggTosHashEntity.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Issue #1903 M7.1 — tracks the SHA-256 hash of the BoardGameGeek terms of
+/// service page. Singleton row (<see cref="SingletonId"/>) updated monthly by
+/// <c>BggTosWatcherJob</c>. When the hash changes a warning is logged so that
+/// operators can perform the manual legal review required by spec §8.5.6
+/// (pre-rollout legal checklist).
+/// </summary>
+public class BggTosHashEntity
+{
+    /// <summary>
+    /// Fixed primary key for the singleton row. Encoded as
+    /// <c>00000000-1903-4007-8000-000000000001</c> so the version nibble
+    /// (4=random) and the issue number remain visible in DB dumps.
+    /// </summary>
+    public static readonly Guid SingletonId = new("00000000-1903-4007-8000-000000000001");
+
+    public Guid Id { get; set; } = SingletonId;
+
+    /// <summary>Hexadecimal SHA-256 of the ToS HTML (lower case, 64 chars).</summary>
+    [MaxLength(64)]
+    public string CurrentHash { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp of the most recent check (success or hash-changed).</summary>
+    public DateTime LastCheckedAt { get; set; }
+
+    /// <summary>UTC timestamp of the last detected hash change, null on first run.</summary>
+    public DateTime? LastChangedAt { get; set; }
+
+    /// <summary>Cumulative count of detected hash changes since first observation.</summary>
+    public int ChangeCount { get; set; }
+
+    [Timestamp]
+    public byte[]? RowVersion { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/BggTosHashEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/BggTosHashEntityConfiguration.cs
@@ -1,0 +1,45 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="BggTosHashEntity"/>. Singleton table
+/// <c>bgg_tos_hashes</c> — one row keyed by <see cref="BggTosHashEntity.SingletonId"/>.
+/// Issue #1903 M7.1.
+/// </summary>
+internal sealed class BggTosHashEntityConfiguration : IEntityTypeConfiguration<BggTosHashEntity>
+{
+    public void Configure(EntityTypeBuilder<BggTosHashEntity> builder)
+    {
+        builder.ToTable("bgg_tos_hashes");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.CurrentHash)
+            .HasColumnName("current_hash")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(e => e.LastCheckedAt)
+            .HasColumnName("last_checked_at")
+            .IsRequired();
+
+        builder.Property(e => e.LastChangedAt)
+            .HasColumnName("last_changed_at");
+
+        builder.Property(e => e.ChangeCount)
+            .HasColumnName("change_count")
+            .IsRequired()
+            .HasDefaultValue(0);
+
+        builder.Property(e => e.RowVersion)
+            .HasColumnName("row_version")
+            .IsRowVersion();
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -156,6 +156,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<SharedGameDeleteRequestEntity> SharedGameDeleteRequests => Set<SharedGameDeleteRequestEntity>(); // ISSUE-2370: Delete requests
     public DbSet<SharedGameDocumentEntity> SharedGameDocuments => Set<SharedGameDocumentEntity>(); // ISSUE-2391: Sprint 1 - PDF association
     public DbSet<CatalogSeedDraftEntity> CatalogSeedDrafts => Set<CatalogSeedDraftEntity>(); // ISSUE-1903: Admin catalog seed workflow M1.3
+    public DbSet<BggTosHashEntity> BggTosHashes => Set<BggTosHashEntity>(); // ISSUE-1903: Admin catalog seed workflow M7.1 (BGG ToS hash watcher)
     public DbSet<GameStateTemplateEntity> GameStateTemplates => Set<GameStateTemplateEntity>(); // ISSUE-2400: Sprint 3 - Game state templates
     public DbSet<RulebookAnalysisEntity> RulebookAnalyses => Set<RulebookAnalysisEntity>(); // ISSUE-2402: Sprint 3 - Rulebook analysis service
     public DbSet<MechanicDraftEntity> MechanicDrafts => Set<MechanicDraftEntity>(); // Mechanic Extractor: Variant C draft workspace

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604211753_AddBggTosHash.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604211753_AddBggTosHash.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604211753_AddBggTosHash")]
+    partial class AddBggTosHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604211753_AddBggTosHash.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604211753_AddBggTosHash.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBggTosHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "bgg_tos_hashes",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    current_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    last_checked_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_changed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    change_count = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    row_version = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_bgg_tos_hashes", x => x.id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "bgg_tos_hashes");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
@@ -41,6 +41,30 @@ internal static class AdminCatalogSeedEndpoints
 
     public static RouteGroupBuilder MapAdminCatalogSeedEndpoints(this RouteGroupBuilder group)
     {
+        // Issue #1903 M7.2: kill-switch endpoint filter. When the runtime flag
+        // is disabled the entire admin pipeline returns 503 Service Unavailable
+        // (covers all REST methods AND the SSE stream — handler writes the
+        // status code directly on the response, before the body opens).
+        group.AddEndpointFilter(async (filterContext, next) =>
+        {
+            var flag = filterContext.HttpContext.RequestServices
+                .GetService<ICatalogSeedFeatureFlag>();
+            if (flag is not null)
+            {
+                var enabled = await flag
+                    .IsEnabledAsync(filterContext.HttpContext.RequestAborted)
+                    .ConfigureAwait(false);
+                if (!enabled)
+                {
+                    return Results.Problem(
+                        title: "Catalog seed pipeline disabled",
+                        detail: $"The admin catalog seed pipeline is disabled via runtime flag '{ICatalogSeedFeatureFlag.FlagKey}'.",
+                        statusCode: StatusCodes.Status503ServiceUnavailable);
+                }
+            }
+            return await next(filterContext).ConfigureAwait(false);
+        });
+
         group.MapPost("/", HandleEnqueue)
             .WithName("AdminCatalogSeed_Enqueue")
             .WithTags("Admin", "CatalogSeed");

--- a/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Extensions;
+using Api.Filters;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -41,10 +42,24 @@ internal static class AdminCatalogSeedEndpoints
 
     public static RouteGroupBuilder MapAdminCatalogSeedEndpoints(this RouteGroupBuilder group)
     {
-        // Issue #1903 M7.2: kill-switch endpoint filter. When the runtime flag
-        // is disabled the entire admin pipeline returns 503 Service Unavailable
-        // (covers all REST methods AND the SSE stream — handler writes the
-        // status code directly on the response, before the body opens).
+        // Filter chain order MATTERS. Filters added via AddEndpointFilter execute
+        // in REGISTRATION order on the request (first-added runs first).
+        //
+        //   1. RequireAdminSessionFilter — gates the entire pipeline behind a
+        //      valid Admin session. Unauthenticated callers get 401, non-admins
+        //      get 403, BEFORE the feature-flag check runs. This prevents the
+        //      info-disclosure leak where an anonymous probe could distinguish
+        //      "endpoint exists + flag off" (503) from "endpoint missing" (404).
+        //
+        //   2. Feature flag kill-switch — once auth is established, return 503
+        //      Service Unavailable when the runtime flag is disabled. Covers
+        //      all REST methods AND the SSE stream; the SSE handler writes
+        //      the status code directly on the response when reached without
+        //      a flag block, before the body opens.
+        group.AddEndpointFilter<RequireAdminSessionFilter>();
+
+        // Issue #1903 M7.2: kill-switch endpoint filter. Runs AFTER auth, so
+        // 503 is only ever observable by admins (never by anonymous probes).
         group.AddEndpointFilter(async (filterContext, next) =>
         {
             var flag = filterContext.HttpContext.RequestServices
@@ -112,14 +127,13 @@ internal static class AdminCatalogSeedEndpoints
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var (authorized, session, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth + admin role already enforced by group-level
+        // RequireAdminSessionFilter; we only need to extract the user id here.
         var command = new EnqueueCatalogSeedCommand(
             BggId: request.BggId,
             WikidataQid: request.WikidataQid,
             SearchTermInput: request.SearchTermInput,
-            CreatedByUserId: session!.Principal!.Subject.Id);
+            CreatedByUserId: context.User.GetUserId());
 
         var result = await mediator.Send(command, ct).ConfigureAwait(false);
         return Results.Ok(result);
@@ -132,12 +146,10 @@ internal static class AdminCatalogSeedEndpoints
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var (authorized, session, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth gated at group level (RequireAdminSessionFilter).
         var command = new BulkEnqueueCatalogSeedsCommand(
             BggIds: request.BggIds,
-            CreatedByUserId: session!.Principal!.Subject.Id);
+            CreatedByUserId: context.User.GetUserId());
 
         var result = await mediator.Send(command, ct).ConfigureAwait(false);
         return Results.Ok(result);
@@ -147,13 +159,10 @@ internal static class AdminCatalogSeedEndpoints
         [FromQuery] string? status,
         [FromQuery] int? skip,
         [FromQuery] int? take,
-        HttpContext context,
         IMediator mediator,
         CancellationToken ct)
     {
-        var (authorized, _, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth gated at group level (RequireAdminSessionFilter).
         var query = new ListCatalogSeedsQuery(
             StatusFilter: status,
             Skip: skip ?? 0,
@@ -165,13 +174,10 @@ internal static class AdminCatalogSeedEndpoints
 
     private static async Task<IResult> HandleGetById(
         Guid id,
-        HttpContext context,
         IMediator mediator,
         CancellationToken ct)
     {
-        var (authorized, _, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth gated at group level (RequireAdminSessionFilter).
         var dto = await mediator.Send(new GetCatalogSeedByIdQuery(id), ct).ConfigureAwait(false);
         return dto is null ? Results.NotFound() : Results.Ok(dto);
     }
@@ -182,11 +188,9 @@ internal static class AdminCatalogSeedEndpoints
         IMediator mediator,
         CancellationToken ct)
     {
-        var (authorized, session, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth gated at group level (RequireAdminSessionFilter).
         var result = await mediator
-            .Send(new ApproveCatalogSeedCommand(id, session!.Principal!.Subject.Id), ct)
+            .Send(new ApproveCatalogSeedCommand(id, context.User.GetUserId()), ct)
             .ConfigureAwait(false);
         return Results.Ok(result);
     }
@@ -199,11 +203,9 @@ internal static class AdminCatalogSeedEndpoints
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var (authorized, session, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth gated at group level (RequireAdminSessionFilter).
         await mediator
-            .Send(new RejectCatalogSeedCommand(id, session!.Principal!.Subject.Id, request.Reason), ct)
+            .Send(new RejectCatalogSeedCommand(id, context.User.GetUserId(), request.Reason), ct)
             .ConfigureAwait(false);
         return Results.NoContent();
     }
@@ -216,16 +218,11 @@ internal static class AdminCatalogSeedEndpoints
     {
         ArgumentNullException.ThrowIfNull(stream);
 
-        // SSE handlers cannot return IResult once the body has started writing, so
-        // we set the status code directly on the response (mirror of
-        // AdminEventsEndpoints.HandleGetEventsStream).
-        var (authorized, _, error) = context.RequireAdminSession();
-        if (!authorized)
-        {
-            context.Response.StatusCode = ExtractStatusCode(error);
-            return;
-        }
-
+        // Auth gated at group level (RequireAdminSessionFilter) — runs BEFORE
+        // this handler is invoked, so response headers have not been committed
+        // yet and the filter can safely set a 401/403 status code. No in-handler
+        // re-check needed; the previous defense-in-depth call was removed when
+        // the group filter was introduced (M7 review fix).
         context.Response.Headers.ContentType = "text/event-stream";
         context.Response.Headers.CacheControl = "no-cache";
         context.Response.Headers.Connection = "keep-alive";
@@ -275,28 +272,15 @@ internal static class AdminCatalogSeedEndpoints
 
     private static async Task<IResult> HandleWikidataSearch(
         WikidataSearchRequest request,
-        HttpContext context,
         IMediator mediator,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var (authorized, _, error) = context.RequireAdminSession();
-        if (!authorized) return error!;
-
+        // Auth gated at group level (RequireAdminSessionFilter).
         var result = await mediator
             .Send(new WikidataSearchQuery(request.SearchTerm), ct)
             .ConfigureAwait(false);
         return Results.Ok(result);
-    }
-
-    // =========================================================================
-    // Helpers
-    // =========================================================================
-
-    private static int ExtractStatusCode(IResult? result)
-    {
-        if (result is IStatusCodeHttpResult sc) return sc.StatusCode ?? StatusCodes.Status401Unauthorized;
-        return StatusCodes.Status401Unauthorized;
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/BggTosWatcherJobTests.cs
@@ -1,0 +1,238 @@
+using System.Net;
+using System.Text;
+using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Issue #1903 M7.1 — unit tests for <see cref="BggTosWatcherJob"/>. Drive the
+/// internal <c>RunOnceAsync</c> hook directly so we don't need a Quartz
+/// scheduler. Pattern mirrors <c>BackfillPdfCoversJobTests</c>: InMemory EF
+/// for the singleton row + <see cref="HttpMessageHandler"/> mock for HTTP.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggTosWatcherJobTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+
+    public BggTosWatcherJobTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"BggTosWatcherJob_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static BggTosWatcherJob CreateJob() =>
+        new(serviceProvider: new Mock<IServiceProvider>().Object,
+            NullLogger<BggTosWatcherJob>.Instance);
+
+    private static IHttpClientFactory MakeHttpFactory(
+        HttpStatusCode status,
+        string body,
+        Action<HttpRequestMessage>? capture = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capture?.Invoke(req))
+            .ReturnsAsync(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "text/html"),
+            });
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+               .Returns(() => new HttpClient(handler.Object));
+        return factory.Object;
+    }
+
+    private static IHttpClientFactory MakeThrowingFactory(Exception exception)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(exception);
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+               .Returns(() => new HttpClient(handler.Object));
+        return factory.Object;
+    }
+
+    // ---------------------------------------------------------------------
+    // ComputeSha256Hex unit tests
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ComputeSha256Hex_KnownInput_ReturnsExpectedDigest()
+    {
+        // "abc" SHA-256 hash (well-known RFC test vector).
+        const string Expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        BggTosWatcherJob.ComputeSha256Hex("abc").Should().Be(Expected);
+    }
+
+    [Fact]
+    public void ComputeSha256Hex_DifferentContent_ProducesDifferentHash()
+    {
+        var a = BggTosWatcherJob.ComputeSha256Hex("Version 1 of the BGG ToS");
+        var b = BggTosWatcherJob.ComputeSha256Hex("Version 2 of the BGG ToS");
+        a.Should().NotBe(b);
+        a.Should().HaveLength(64);
+        b.Should().HaveLength(64);
+    }
+
+    // ---------------------------------------------------------------------
+    // RunOnceAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task RunOnceAsync_FirstRun_NoExistingRow_RecordsInitialHash()
+    {
+        const string TosHtml = "<html><body>Initial BGG ToS contents</body></html>";
+        var factory = MakeHttpFactory(HttpStatusCode.OK, TosHtml);
+
+        await CreateJob().RunOnceAsync(_db, factory, default);
+
+        var row = await _db.BggTosHashes.SingleAsync();
+        row.Id.Should().Be(BggTosHashEntity.SingletonId);
+        row.CurrentHash.Should().Be(BggTosWatcherJob.ComputeSha256Hex(TosHtml));
+        row.ChangeCount.Should().Be(0);
+        row.LastChangedAt.Should().BeNull("first observation is not a change");
+        row.LastCheckedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_SameHash_OnlyUpdatesLastCheckedAt()
+    {
+        const string TosHtml = "<html>Same content twice</html>";
+        var hash = BggTosWatcherJob.ComputeSha256Hex(TosHtml);
+        var initialCheck = DateTime.UtcNow.AddDays(-30);
+
+        _db.BggTosHashes.Add(new BggTosHashEntity
+        {
+            Id = BggTosHashEntity.SingletonId,
+            CurrentHash = hash,
+            LastCheckedAt = initialCheck,
+            LastChangedAt = null,
+            ChangeCount = 0,
+        });
+        await _db.SaveChangesAsync();
+
+        var factory = MakeHttpFactory(HttpStatusCode.OK, TosHtml);
+        await CreateJob().RunOnceAsync(_db, factory, default);
+
+        var row = await _db.BggTosHashes.SingleAsync();
+        row.CurrentHash.Should().Be(hash, "the hash didn't change");
+        row.ChangeCount.Should().Be(0, "no change observed");
+        row.LastChangedAt.Should().BeNull();
+        row.LastCheckedAt.Should().BeAfter(initialCheck, "we just checked");
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_HashChanged_UpdatesRow_IncrementsChangeCount_SetsLastChangedAt()
+    {
+        var oldHash = BggTosWatcherJob.ComputeSha256Hex("old content");
+        _db.BggTosHashes.Add(new BggTosHashEntity
+        {
+            Id = BggTosHashEntity.SingletonId,
+            CurrentHash = oldHash,
+            LastCheckedAt = DateTime.UtcNow.AddDays(-30),
+            ChangeCount = 0,
+        });
+        await _db.SaveChangesAsync();
+
+        const string NewHtml = "<html>new content</html>";
+        var factory = MakeHttpFactory(HttpStatusCode.OK, NewHtml);
+        await CreateJob().RunOnceAsync(_db, factory, default);
+
+        var row = await _db.BggTosHashes.SingleAsync();
+        row.CurrentHash.Should().Be(BggTosWatcherJob.ComputeSha256Hex(NewHtml));
+        row.CurrentHash.Should().NotBe(oldHash);
+        row.ChangeCount.Should().Be(1, "exactly one change observed");
+        row.LastChangedAt.Should().NotBeNull();
+        row.LastChangedAt!.Value.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_HashChangedMultipleTimes_AccumulatesChangeCount()
+    {
+        _db.BggTosHashes.Add(new BggTosHashEntity
+        {
+            Id = BggTosHashEntity.SingletonId,
+            CurrentHash = BggTosWatcherJob.ComputeSha256Hex("v1"),
+            LastCheckedAt = DateTime.UtcNow.AddDays(-60),
+            ChangeCount = 0,
+        });
+        await _db.SaveChangesAsync();
+
+        // First change: v1 → v2
+        await CreateJob().RunOnceAsync(_db, MakeHttpFactory(HttpStatusCode.OK, "v2"), default);
+        // Second change: v2 → v3
+        await CreateJob().RunOnceAsync(_db, MakeHttpFactory(HttpStatusCode.OK, "v3"), default);
+
+        var row = await _db.BggTosHashes.SingleAsync();
+        row.ChangeCount.Should().Be(2, "two distinct changes observed");
+        row.CurrentHash.Should().Be(BggTosWatcherJob.ComputeSha256Hex("v3"));
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_HttpThrows_LogsAndCompletes_NoRowWritten()
+    {
+        var factory = MakeThrowingFactory(new HttpRequestException("connection refused"));
+
+        // Should NOT throw; the watcher swallows arbitrary HTTP failures.
+        var act = async () => await CreateJob().RunOnceAsync(_db, factory, default);
+        await act.Should().NotThrowAsync();
+
+        _db.BggTosHashes.Count().Should().Be(0, "no row should be written when HTTP fails");
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_CancellationDuringHttp_PropagatesOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var factory = MakeThrowingFactory(new OperationCanceledException(cts.Token));
+
+        var act = async () => await CreateJob().RunOnceAsync(_db, factory, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_SetsUserAgentHeader_PerBggAbuseContact()
+    {
+        HttpRequestMessage? captured = null;
+        var factory = MakeHttpFactory(HttpStatusCode.OK, "ok", req => captured = req);
+
+        await CreateJob().RunOnceAsync(_db, factory, default);
+
+        captured.Should().NotBeNull();
+        var ua = captured!.Headers.UserAgent.ToString();
+        ua.Should().Contain("MeepleAI", "BGG ToS mandates a User-Agent with abuse contact");
+        ua.Should().Contain("abuse@meepleai.app");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedFeatureFlagTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CatalogSeedFeatureFlagTests.cs
@@ -1,0 +1,95 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #1903 M7.2 — unit tests for <see cref="CatalogSeedFeatureFlag"/>.
+/// Verifies fail-closed semantics: any DB / deserialization failure must
+/// return <c>false</c> (catalog seed touches third-party APIs and a silent
+/// flip-to-on is unsafe).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CatalogSeedFeatureFlagTests
+{
+    private readonly Mock<IConfigurationService> _configService = new();
+
+    private CatalogSeedFeatureFlag CreateSut() =>
+        new(_configService.Object, NullLogger<CatalogSeedFeatureFlag>.Instance);
+
+    [Fact]
+    public async Task IsEnabledAsync_KeyAbsent_ReturnsFalse()
+    {
+        _configService
+            .Setup(s => s.GetValueAsync<bool?>(ICatalogSeedFeatureFlag.FlagKey, null, null))
+            .ReturnsAsync((bool?)null);
+
+        var result = await CreateSut().IsEnabledAsync();
+
+        result.Should().BeFalse("default is fail-closed");
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_KeySetTrue_ReturnsTrue()
+    {
+        _configService
+            .Setup(s => s.GetValueAsync<bool?>(ICatalogSeedFeatureFlag.FlagKey, null, null))
+            .ReturnsAsync((bool?)true);
+
+        var result = await CreateSut().IsEnabledAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_KeySetFalse_ReturnsFalse()
+    {
+        _configService
+            .Setup(s => s.GetValueAsync<bool?>(ICatalogSeedFeatureFlag.FlagKey, null, null))
+            .ReturnsAsync((bool?)false);
+
+        var result = await CreateSut().IsEnabledAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_ConfigServiceThrows_FailsClosed()
+    {
+        _configService
+            .Setup(s => s.GetValueAsync<bool?>(ICatalogSeedFeatureFlag.FlagKey, null, null))
+            .ThrowsAsync(new InvalidOperationException("DB unreachable"));
+
+        var result = await CreateSut().IsEnabledAsync();
+
+        result.Should().BeFalse("fail-closed on infrastructure errors");
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_CancellationRequested_Propagates()
+    {
+        _configService
+            .Setup(s => s.GetValueAsync<bool?>(ICatalogSeedFeatureFlag.FlagKey, null, null))
+            .ReturnsAsync((bool?)true);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await CreateSut().IsEnabledAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void FlagKey_IsStableContract()
+    {
+        // Flag key is part of the operational contract (admin UI / DB seeds
+        // reference the same literal). Lock it down so a careless rename
+        // doesn't silently park production deployments.
+        ICatalogSeedFeatureFlag.FlagKey.Should().Be("admin.catalog-seed.enabled");
+    }
+}


### PR DESCRIPTION
## Summary

M7 of issue #1903. **Backend layer COMPLETE** after this merge (only M8 Frontend remains for full feature).

Builds on M6 (merged 1f2e2a4e9). M1-M6 already merged.

## What ships

| Task | Commit | Output |
|---|---|---|
| M7.1 | `7bf80b183` | `BggTosWatcherJob` Quartz (every ~30 days), SHA-256 hash check, BGG User-Agent compliance + entity + migration + 14 unit tests |
| M7.2 | `1749913a8` | `ICatalogSeedFeatureFlag` (reuses existing `IConfigurationService.GetValueAsync<bool?>("admin.catalog-seed.enabled")` pattern) + endpoint filter (503 when disabled) + job early-return + 6 tests |

**108 catalog-seed tests cumulative all pass. 0 build errors.**

## Architecture decisions

- **Feature flag**: reuses existing `IConfigurationService` pattern (same mechanism as `Registration:PublicEnabled` per CLAUDE.md). Wrapper interface `ICatalogSeedFeatureFlag` for domain-specific encapsulation + fail-closed semantics.
- **Default OFF**: feature flag defaults to `false` when config key is missing or false. Endpoints return 503 Service Unavailable; Quartz job early-returns.
- **ToS watcher hash**: SHA-256 of full BGG `/terms` HTML, stored in singleton row `bgg_tos_hashes`. On change → `LogWarning` + increment `ChangeCount` + update `LastChangedAt`. Spec §8.5.6 pre-rollout legal checklist requirement.
- **User-Agent on ToS fetch**: `MeepleAI/1.0 (admin-catalog-seed-tos-watcher; abuse@meepleai.app)` (separate suffix to identify the watcher specifically)

## Pre-rollout checklist (spec §8.5.6) status

After this PR merges:
- [x] Feature flag `admin.catalog-seed.enabled` available (default false)
- [x] BGG User-Agent identifiable on all 3 paths (Wikidata, BGG XML, BGG ToS)
- [x] BggTosWatcherJob active + alert configured (warning log)
- [ ] 1h legal review consultation (HUMAN ACTION before flag enable)
- [ ] Terms of Service MeepleAI updated with seed clause (HUMAN ACTION)
- [ ] `abuse@meepleai.app` mailbox active + monitored (HUMAN ACTION)
- [ ] Audit log export endpoint (deferred to M8 or follow-up)
- [ ] ADR-NNN catalog-seed-legal-posture (deferred to M8 or follow-up)

## What's NOT in this PR

- M8 (Frontend Admin UI + E2E Playwright) — final milestone, separate sessione

## Test plan

- [x] 108/108 catalog-seed tests pass
- [x] Build 0 errors
- [ ] CI green

## Risk

LOW — feature flag default OFF, no functional change for any user until admin enables. Quartz BggTosWatcher runs but is purely diagnostic. Endpoints return 503 by default.