### PR TITLE
feat(catalog-seed): #1903 M8 — Frontend Admin UI + E2E + ADR (FEATURE COMPLETE)

### DIFF
--- a/apps/web/e2e/admin/catalog-seed.spec.ts
+++ b/apps/web/e2e/admin/catalog-seed.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Admin catalog seed queue E2E smoke tests (#1903 M8.5)
+ *
+ * Covers:
+ * 1. Admin reaches /admin/catalog/seed-queue → page renders + KPI hero visible
+ * 2. Mock API: bulk paste 3 BGG IDs → POST /bulk invoked → 3 entries in queue
+ * 3. Filter chip "Pending" → list refetches with status=Pending param
+ *
+ * Auth pattern: page.route() mock for /api/v1/auth/me (same as
+ * catalog-ingestion-reskin.spec.ts and admin-mockups specs).
+ *
+ * API mocks: /api/v1/admin/catalog/seeds endpoints + SSE stream
+ *
+ * NOTE: E2E tests require a running Next.js dev/prod server. Skipped in
+ * Backend Fast unit-test runs (we already cover the components with Vitest).
+ */
+
+import { test, expect, type Page } from '../fixtures';
+
+const API_BASE =
+  process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const SEEDS_API = '**/api/v1/admin/catalog/seeds**';
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+interface SeedListState {
+  items: Record<string, unknown>[];
+  bulkRequestBody: unknown;
+  bulkCalled: number;
+  lastListStatusFilter: string | null;
+}
+
+async function setupCatalogSeedMocks(page: Page, state: SeedListState): Promise<void> {
+  // Admin auth
+  await page.route(`${API_BASE}/api/v1/auth/me`, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: 'admin-test-id',
+          email: 'admin@meepleai.dev',
+          displayName: 'Test Admin',
+          role: 'Admin',
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    });
+  });
+
+  // SSE stream — keep open and emit nothing so the EventSource opens cleanly
+  await page.route(`**/api/v1/admin/catalog/seeds/stream`, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: ':ok\n\n',
+    });
+  });
+
+  // Bulk enqueue
+  await page.route(`**/api/v1/admin/catalog/seeds/bulk`, async route => {
+    state.bulkCalled++;
+    state.bulkRequestBody = JSON.parse(route.request().postData() ?? '{}');
+    const bggIds = (state.bulkRequestBody as { bggIds: number[] }).bggIds;
+    const newDrafts = bggIds.map((bgg, idx) => ({
+      id: `seed-${state.items.length + idx + 1}`,
+      bggId: bgg,
+      wikidataQid: null,
+      searchTermInput: null,
+      status: 'Pending',
+      errorMessage: null,
+      resultingSharedGameId: null,
+      createdByUserId: 'admin-test-id',
+      createdAt: new Date().toISOString(),
+      fetchedAt: null,
+      approvedAt: null,
+      approvedByUserId: null,
+    }));
+    state.items.push(...newDrafts);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        total: bggIds.length,
+        enqueued: bggIds.length,
+        duplicates: 0,
+        newDraftIds: newDrafts.map(d => d.id),
+      }),
+    });
+  });
+
+  // List endpoint — honour the status filter to support test #3
+  await page.route(`**/api/v1/admin/catalog/seeds*`, async route => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    const url = new URL(route.request().url());
+    const statusFilter = url.searchParams.get('status');
+    state.lastListStatusFilter = statusFilter;
+    const items = statusFilter ? state.items.filter(i => i.status === statusFilter) : state.items;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        total: items.length,
+        skip: Number(url.searchParams.get('skip') ?? 0),
+        take: Number(url.searchParams.get('take') ?? 50),
+        items,
+      }),
+    });
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('Admin catalog seed queue (#1903)', () => {
+  test('page renders header + KPI hero + queue list + log stream', async ({ page }) => {
+    const state: SeedListState = {
+      items: [],
+      bulkRequestBody: null,
+      bulkCalled: 0,
+      lastListStatusFilter: null,
+    };
+    await setupCatalogSeedMocks(page, state);
+    await page.goto('/admin/catalog/seed-queue');
+    await page.waitForLoadState('networkidle');
+
+    // Page header
+    await expect(
+      page.getByRole('heading', { name: /Catalog seed queue/i, level: 1 })
+    ).toBeVisible();
+    await expect(page.getByText(/Admin · Catalog · Seed pipeline/i)).toBeVisible();
+
+    // KPI cards
+    await expect(page.getByTestId('seed-status-card-pending')).toBeVisible();
+    await expect(page.getByTestId('seed-status-card-fetched')).toBeVisible();
+    await expect(page.getByTestId('seed-status-card-approved')).toBeVisible();
+    await expect(page.getByTestId('seed-status-card-rejected')).toBeVisible();
+
+    // Input column forms (region role from <section aria-label>)
+    await expect(page.getByRole('region', { name: /Bulk paste BGG IDs/i })).toBeVisible();
+    await expect(page.getByRole('region', { name: /Single seed add/i })).toBeVisible();
+    await expect(page.getByRole('region', { name: /Wikidata search/i })).toBeVisible();
+
+    // Queue + log stream
+    await expect(page.getByRole('region', { name: /Catalog seed queue list/i })).toBeVisible();
+    await expect(page.getByRole('region', { name: /Catalog seed live stream/i })).toBeVisible();
+  });
+
+  test('bulk paste 3 BGG IDs invokes POST /bulk', async ({ page }) => {
+    const state: SeedListState = {
+      items: [],
+      bulkRequestBody: null,
+      bulkCalled: 0,
+      lastListStatusFilter: null,
+    };
+    await setupCatalogSeedMocks(page, state);
+    await page.goto('/admin/catalog/seed-queue');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByLabel(/BGG IDs textarea/i).fill('13\n30549\n167791');
+    await page.getByRole('button', { name: /Enqueue 3 IDs/i }).click();
+
+    await expect.poll(() => state.bulkCalled).toBeGreaterThanOrEqual(1);
+    expect(state.bulkRequestBody).toEqual({ bggIds: [13, 30549, 167791] });
+
+    // After mutation the list refetches and shows the 3 new rows
+    await expect(page.getByText(/BGG:13/)).toBeVisible();
+    await expect(page.getByText(/BGG:30549/)).toBeVisible();
+    await expect(page.getByText(/BGG:167791/)).toBeVisible();
+  });
+
+  test('clicking the Pending filter chip refetches the list with status=Pending', async ({
+    page,
+  }) => {
+    const state: SeedListState = {
+      items: [],
+      bulkRequestBody: null,
+      bulkCalled: 0,
+      lastListStatusFilter: null,
+    };
+    await setupCatalogSeedMocks(page, state);
+    await page.goto('/admin/catalog/seed-queue');
+    await page.waitForLoadState('networkidle');
+
+    // Initial load uses no status filter
+    expect(state.lastListStatusFilter).toBeNull();
+
+    await page.getByRole('button', { name: 'Pending', exact: true }).click();
+    await expect.poll(() => state.lastListStatusFilter).toBe('Pending');
+  });
+});

--- a/apps/web/e2e/admin/catalog-seed.spec.ts
+++ b/apps/web/e2e/admin/catalog-seed.spec.ts
@@ -20,8 +20,6 @@ import { test, expect, type Page } from '../fixtures';
 const API_BASE =
   process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
-const SEEDS_API = '**/api/v1/admin/catalog/seeds**';
-
 // ─── Mock helpers ─────────────────────────────────────────────────────────────
 
 interface SeedListState {

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/__tests__/page.test.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import CatalogSeedQueuePage from '../page';
+
+vi.mock('../lib/catalog-seed-api');
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+vi.mock('../hooks/use-catalog-seed-stream', () => ({
+  useCatalogSeedStream: () => ({ events: [], isConnected: true, clear: vi.fn() }),
+}));
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('CatalogSeedQueuePage', () => {
+  it('renders the header, KPI hero, queue list, and live stream sections', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({ total: 0, skip: 0, take: 1, items: [] });
+    render(<CatalogSeedQueuePage />, { wrapper: wrapper() });
+
+    await waitFor(() =>
+      // H1 (page header) + H2 (hero) both contain "Catalog seed queue" — assert at least one
+      expect(
+        screen.getAllByRole('heading', { name: /Catalog seed queue/i }).length
+      ).toBeGreaterThan(0)
+    );
+    expect(screen.getByText(/Admin · Catalog · Seed pipeline/i)).toBeInTheDocument();
+    // KPI cards
+    expect(screen.getByTestId('seed-status-card-pending')).toBeInTheDocument();
+    expect(screen.getByTestId('seed-status-card-fetched')).toBeInTheDocument();
+    expect(screen.getByTestId('seed-status-card-approved')).toBeInTheDocument();
+    expect(screen.getByTestId('seed-status-card-rejected')).toBeInTheDocument();
+    // Bulk paste + single add + search forms — assert via region role
+    expect(screen.getByRole('region', { name: /Bulk paste BGG IDs/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /Single seed add/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /Wikidata search/i })).toBeInTheDocument();
+    // Queue + log stream — assert via region role
+    expect(screen.getByRole('region', { name: /Catalog seed queue list/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /Catalog seed live stream/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BggIdValidationBadge.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BggIdValidationBadge.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BggIdValidationBadge, parseBggIds } from './BggIdValidationBadge';
+
+describe('BggIdValidationBadge', () => {
+  it('renders the valid state with green tone', () => {
+    render(<BggIdValidationBadge bggId={13} valid />);
+    const badge = screen.getByTestId('bgg-id-badge-13');
+    expect(badge.getAttribute('data-state')).toBe('valid');
+    expect(badge.textContent).toContain('13');
+  });
+
+  it('renders the invalid state with reason', () => {
+    render(<BggIdValidationBadge bggId="abc" valid={false} reason="not a number" />);
+    const badge = screen.getByTestId('bgg-id-badge-abc');
+    expect(badge.getAttribute('data-state')).toBe('invalid');
+    expect(badge.textContent).toContain('not a number');
+  });
+});
+
+describe('parseBggIds', () => {
+  it('accepts comma-separated, line-separated, and space-separated lists', () => {
+    const r = parseBggIds('13, 30549\n167791\n9209');
+    expect(r.valid).toEqual([13, 30549, 167791, 9209]);
+    expect(r.invalid).toEqual([]);
+    expect(r.duplicates).toEqual([]);
+  });
+
+  it('marks non-numeric tokens as invalid', () => {
+    const r = parseBggIds('13\nfoo\n42');
+    expect(r.valid).toEqual([13, 42]);
+    expect(r.invalid).toEqual([{ raw: 'foo', reason: 'not a positive integer' }]);
+  });
+
+  it('marks zero and negative numbers as invalid', () => {
+    const r = parseBggIds('0\n-5\n12');
+    expect(r.valid).toEqual([12]);
+    expect(r.invalid).toHaveLength(2);
+  });
+
+  it('reports duplicates from the same batch', () => {
+    const r = parseBggIds('13\n42\n13');
+    expect(r.valid).toEqual([13, 42]);
+    expect(r.duplicates).toEqual([13]);
+  });
+
+  it('returns empty buckets on empty input', () => {
+    const r = parseBggIds('   \n\n');
+    expect(r.valid).toEqual([]);
+    expect(r.invalid).toEqual([]);
+    expect(r.duplicates).toEqual([]);
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BggIdValidationBadge.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BggIdValidationBadge.tsx
@@ -1,0 +1,76 @@
+import { Check, X } from 'lucide-react';
+
+/**
+ * Issue #1903 M8.4 — visual badge displayed next to parsed BGG IDs in the bulk
+ * paste textarea preview. Indicates whether the line was accepted as a positive
+ * integer ("valid") or rejected (e.g. non-numeric, duplicate within the same
+ * batch).
+ */
+export interface BggIdValidationBadgeProps {
+  bggId: number | string;
+  valid: boolean;
+  reason?: string;
+}
+
+export function BggIdValidationBadge({ bggId, valid, reason }: BggIdValidationBadgeProps) {
+  if (valid) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-entity-collection/[0.12] px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.04em] text-entity-collection"
+        data-testid={`bgg-id-badge-${bggId}`}
+        data-state="valid"
+      >
+        <Check className="h-3 w-3" aria-hidden />
+        {bggId}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-entity-event/[0.12] px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.04em] text-entity-event"
+      title={reason}
+      data-testid={`bgg-id-badge-${bggId}`}
+      data-state="invalid"
+    >
+      <X className="h-3 w-3" aria-hidden />
+      {bggId}
+      {reason ? <span className="ml-1 normal-case">— {reason}</span> : null}
+    </span>
+  );
+}
+
+/**
+ * Parses a multi-line paste of BGG ids into `{valid, invalid}` buckets.
+ * Recognises one id per line; rejects empty rows, non-numeric tokens, and
+ * duplicates within the same batch.
+ */
+export interface ParsedBggIds {
+  valid: number[];
+  invalid: { raw: string; reason: string }[];
+  duplicates: number[];
+}
+
+export function parseBggIds(input: string): ParsedBggIds {
+  const seen = new Set<number>();
+  const valid: number[] = [];
+  const invalid: { raw: string; reason: string }[] = [];
+  const duplicates: number[] = [];
+  input
+    .split(/[\n,;\s]+/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .forEach(raw => {
+      const n = Number.parseInt(raw, 10);
+      if (!Number.isFinite(n) || String(n) !== raw || n <= 0) {
+        invalid.push({ raw, reason: 'not a positive integer' });
+        return;
+      }
+      if (seen.has(n)) {
+        duplicates.push(n);
+        return;
+      }
+      seen.add(n);
+      valid.push(n);
+    });
+  return { valid, invalid, duplicates };
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.test.tsx
@@ -26,7 +26,7 @@ describe('BulkPasteForm', () => {
 
   it('shows valid + invalid badges from the paste', async () => {
     render(<BulkPasteForm />, { wrapper: wrapper() });
-    await userEvent.type(screen.getByLabelText(/BGG IDs textarea/i), '13, 42, foo');
+    await userEvent.type(screen.getByRole('textbox', { name: /BGG IDs/i }), '13, 42, foo');
     expect(screen.getByTestId('bgg-id-badge-13').getAttribute('data-state')).toBe('valid');
     expect(screen.getByTestId('bgg-id-badge-42').getAttribute('data-state')).toBe('valid');
     expect(screen.getByTestId('bgg-id-badge-foo').getAttribute('data-state')).toBe('invalid');
@@ -40,7 +40,7 @@ describe('BulkPasteForm', () => {
       newDraftIds: ['d1', 'd2'],
     });
     render(<BulkPasteForm />, { wrapper: wrapper() });
-    await userEvent.type(screen.getByLabelText(/BGG IDs textarea/i), '13, 42');
+    await userEvent.type(screen.getByRole('textbox', { name: /BGG IDs/i }), '13, 42');
     await userEvent.click(screen.getByRole('button', { name: /Enqueue 2 IDs/i }));
     await waitFor(() => expect(api.bulkEnqueueSeeds).toHaveBeenCalledWith({ bggIds: [13, 42] }));
   });
@@ -48,9 +48,9 @@ describe('BulkPasteForm', () => {
   it('rejects > 100 IDs with an error message', async () => {
     render(<BulkPasteForm />, { wrapper: wrapper() });
     const ids = Array.from({ length: 101 }, (_, i) => i + 1).join('\n');
-    await userEvent.click(screen.getByLabelText(/BGG IDs textarea/i));
+    await userEvent.click(screen.getByRole('textbox', { name: /BGG IDs/i }));
     // Use fireEvent-style direct set to avoid 101 keystrokes
-    const textarea = screen.getByLabelText(/BGG IDs textarea/i) as HTMLTextAreaElement;
+    const textarea = screen.getByRole('textbox', { name: /BGG IDs/i }) as HTMLTextAreaElement;
     textarea.focus();
     // jsdom does not pump native input; use userEvent.paste for bulk insertion
     await userEvent.paste(ids);

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import { BulkPasteForm } from './BulkPasteForm';
+
+vi.mock('../lib/catalog-seed-api');
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('BulkPasteForm', () => {
+  it('disables the submit button when no valid IDs are entered', () => {
+    render(<BulkPasteForm />, { wrapper: wrapper() });
+    expect(screen.getByRole('button', { name: /Enqueue 0 IDs/i })).toBeDisabled();
+  });
+
+  it('shows valid + invalid badges from the paste', async () => {
+    render(<BulkPasteForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/BGG IDs textarea/i), '13, 42, foo');
+    expect(screen.getByTestId('bgg-id-badge-13').getAttribute('data-state')).toBe('valid');
+    expect(screen.getByTestId('bgg-id-badge-42').getAttribute('data-state')).toBe('valid');
+    expect(screen.getByTestId('bgg-id-badge-foo').getAttribute('data-state')).toBe('invalid');
+  });
+
+  it('submits valid IDs via the bulk API call', async () => {
+    vi.mocked(api.bulkEnqueueSeeds).mockResolvedValue({
+      total: 2,
+      enqueued: 2,
+      duplicates: 0,
+      newDraftIds: ['d1', 'd2'],
+    });
+    render(<BulkPasteForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/BGG IDs textarea/i), '13, 42');
+    await userEvent.click(screen.getByRole('button', { name: /Enqueue 2 IDs/i }));
+    await waitFor(() => expect(api.bulkEnqueueSeeds).toHaveBeenCalledWith({ bggIds: [13, 42] }));
+  });
+
+  it('rejects > 100 IDs with an error message', async () => {
+    render(<BulkPasteForm />, { wrapper: wrapper() });
+    const ids = Array.from({ length: 101 }, (_, i) => i + 1).join('\n');
+    await userEvent.click(screen.getByLabelText(/BGG IDs textarea/i));
+    // Use fireEvent-style direct set to avoid 101 keystrokes
+    const textarea = screen.getByLabelText(/BGG IDs textarea/i) as HTMLTextAreaElement;
+    textarea.focus();
+    // jsdom does not pump native input; use userEvent.paste for bulk insertion
+    await userEvent.paste(ids);
+    expect(await screen.findByText(/Batch cap exceeded/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Enqueue 101 IDs/i })).toBeDisabled();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/primitives/button';
+
+import { BggIdValidationBadge, parseBggIds } from './BggIdValidationBadge';
+import { useBulkEnqueueSeeds } from '../hooks/use-catalog-seeds';
+
+/**
+ * Issue #1903 M8.3 — bulk paste BGG IDs textarea + Enqueue button.
+ *
+ * Hard caps at 100 IDs per batch (BE enforces the same via
+ * `BulkEnqueueCatalogSeedsCommandValidator`). When parsing produces invalid
+ * tokens or duplicates within the same batch we surface them inline so the
+ * admin can fix the input before submitting.
+ */
+const MAX_BATCH = 100;
+
+export function BulkPasteForm() {
+  const [text, setText] = useState('');
+  const mutation = useBulkEnqueueSeeds();
+  const parsed = useMemo(() => parseBggIds(text), [text]);
+  const overCap = parsed.valid.length > MAX_BATCH;
+
+  const handleSubmit = async () => {
+    if (parsed.valid.length === 0 || overCap || mutation.isPending) return;
+    try {
+      const result = await mutation.mutateAsync({ bggIds: parsed.valid });
+      toast.success(
+        `Enqueued ${result.enqueued} draft${result.enqueued === 1 ? '' : 's'} (${result.duplicates} duplicate${result.duplicates === 1 ? '' : 's'} skipped)`
+      );
+      setText('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Bulk enqueue failed');
+    }
+  };
+
+  return (
+    <section
+      aria-label="Bulk paste BGG IDs"
+      className="rounded-xl border border-border bg-card p-4"
+    >
+      <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">⊕ Add to queue</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Paste up to {MAX_BATCH} BGG IDs (one per line, comma- or space-separated).
+      </p>
+      <label className="mt-3 block">
+        <span className="font-mono text-[10px] uppercase text-muted-foreground">BGG IDs</span>
+        <textarea
+          aria-label="BGG IDs textarea"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          rows={6}
+          className="mt-1 w-full rounded border border-border bg-background p-2 font-mono text-xs"
+          placeholder="13\n30549\n167791"
+        />
+      </label>
+      {parsed.valid.length + parsed.invalid.length + parsed.duplicates.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {parsed.valid.map(id => (
+            <BggIdValidationBadge key={`v-${id}`} bggId={id} valid />
+          ))}
+          {parsed.invalid.map((item, idx) => (
+            <BggIdValidationBadge
+              key={`i-${idx}-${item.raw}`}
+              bggId={item.raw}
+              valid={false}
+              reason={item.reason}
+            />
+          ))}
+          {parsed.duplicates.map((id, idx) => (
+            <BggIdValidationBadge
+              key={`d-${idx}-${id}`}
+              bggId={id}
+              valid={false}
+              reason="duplicate in batch"
+            />
+          ))}
+        </div>
+      )}
+      {overCap && (
+        <p className="mt-2 text-xs text-entity-event" role="alert">
+          Batch cap exceeded — submit at most {MAX_BATCH} IDs per request.
+        </p>
+      )}
+      <div className="mt-3 flex items-center gap-2">
+        <Button
+          onClick={handleSubmit}
+          disabled={parsed.valid.length === 0 || overCap || mutation.isPending}
+        >
+          {mutation.isPending ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+          Enqueue {parsed.valid.length} ID{parsed.valid.length === 1 ? '' : 's'}
+        </Button>
+        {parsed.valid.length > 0 && (
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {parsed.valid.length}/{MAX_BATCH}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/BulkPasteForm.tsx
@@ -51,7 +51,6 @@ export function BulkPasteForm() {
       <label className="mt-3 block">
         <span className="font-mono text-[10px] uppercase text-muted-foreground">BGG IDs</span>
         <textarea
-          aria-label="BGG IDs textarea"
           value={text}
           onChange={e => setText(e.target.value)}
           rows={6}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.test.tsx
@@ -79,4 +79,40 @@ describe('SeedLogStream', () => {
     await userEvent.click(screen.getByRole('button', { name: /Clear/i }));
     expect(clearMock).toHaveBeenCalled();
   });
+
+  it('pause freezes the displayed list even when the hook produces new events', async () => {
+    const initialEvents = [
+      { eventType: 'seed.fetched', occurredAt: '2026-06-04T12:34:57Z', draftId: 'a' },
+    ];
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: initialEvents,
+      isConnected: true,
+      clear: vi.fn(),
+    });
+
+    const { rerender } = render(<SeedLogStream />);
+    expect(screen.getByText(/SeedFetched/)).toBeInTheDocument();
+
+    // Click pause — list should snapshot the current view
+    await userEvent.click(screen.getByRole('button', { name: /Pause/i }));
+
+    // Hook now produces a new failed event — but the snapshot should hide it
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: [
+        ...initialEvents,
+        { eventType: 'seed.failed', occurredAt: '2026-06-04T12:34:58Z', draftId: 'b' },
+      ],
+      isConnected: true,
+      clear: vi.fn(),
+    });
+    rerender(<SeedLogStream />);
+
+    expect(screen.queryByText(/SeedFailed/)).not.toBeInTheDocument();
+    expect(screen.getByText(/SeedFetched/)).toBeInTheDocument();
+
+    // Resume — both events should appear
+    await userEvent.click(screen.getByRole('button', { name: /Resume/i }));
+    expect(screen.getByText(/SeedFailed/)).toBeInTheDocument();
+    expect(screen.getByText(/SeedFetched/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as streamHook from '../hooks/use-catalog-seed-stream';
+import { SeedLogStream } from './SeedLogStream';
+
+vi.mock('../hooks/use-catalog-seed-stream');
+
+describe('SeedLogStream', () => {
+  it('shows empty placeholder when no events have arrived', () => {
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: [],
+      isConnected: true,
+      clear: vi.fn(),
+    });
+    render(<SeedLogStream />);
+    expect(screen.getByText(/No events yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+  });
+
+  it('shows disconnected indicator when stream is offline', () => {
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: [],
+      isConnected: false,
+      clear: vi.fn(),
+    });
+    render(<SeedLogStream />);
+    expect(screen.getByText(/Disconnected/i)).toBeInTheDocument();
+  });
+
+  it('renders events ordered by arrival', () => {
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: [
+        {
+          eventType: 'batch.started',
+          occurredAt: '2026-06-04T12:34:56Z',
+          batchId: 'abc',
+          count: 10,
+        },
+        {
+          eventType: 'seed.fetched',
+          occurredAt: '2026-06-04T12:34:57Z',
+          draftId: 'xyz',
+          bggId: 13,
+        },
+      ],
+      isConnected: true,
+      clear: vi.fn(),
+    });
+    render(<SeedLogStream />);
+    expect(screen.getByText(/BatchStarted/)).toBeInTheDocument();
+    expect(screen.getByText(/SeedFetched/)).toBeInTheDocument();
+  });
+
+  it('filters to failed events only when checkbox is enabled', async () => {
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: [
+        { eventType: 'seed.fetched', occurredAt: '2026-06-04T12:34:57Z', draftId: 'a' },
+        { eventType: 'seed.failed', occurredAt: '2026-06-04T12:34:58Z', draftId: 'b' },
+      ],
+      isConnected: true,
+      clear: vi.fn(),
+    });
+    render(<SeedLogStream />);
+    await userEvent.click(screen.getByLabelText(/Filter failed only/i));
+    expect(screen.queryByText(/SeedFetched/)).not.toBeInTheDocument();
+    expect(screen.getByText(/SeedFailed/)).toBeInTheDocument();
+  });
+
+  it('clear button invokes the hook clear callback', async () => {
+    const clearMock = vi.fn();
+    vi.mocked(streamHook.useCatalogSeedStream).mockReturnValue({
+      events: [{ eventType: 'seed.fetched', occurredAt: '2026-06-04T12:34:57Z', draftId: 'a' }],
+      isConnected: true,
+      clear: clearMock,
+    });
+    render(<SeedLogStream />);
+    await userEvent.click(screen.getByRole('button', { name: /Clear/i }));
+    expect(clearMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useCatalogSeedStream } from '../hooks/use-catalog-seed-stream';
+
+type SeedStreamEvent = ReturnType<typeof useCatalogSeedStream>['events'][number];
 
 /**
  * Issue #1903 M8.3 — live SSE log of the catalog seed fetch job.
@@ -45,8 +47,23 @@ export function SeedLogStream() {
   const [filter, setFilter] = useState<'all' | 'failed'>('all');
 
   const visible = filter === 'failed' ? events.filter(e => e.eventType === 'seed.failed') : events;
-  // Snapshot when paused so the stream stops updating visually.
-  const displayed = paused ? visible.slice(0, visible.length) : visible;
+
+  // M8 review (PR #1916) — Pause was a no-op because `visible.slice(0, visible.length)`
+  // returns a fresh copy of the live array on every render. Snapshot the array on
+  // the rising edge of `paused` via a ref and serve that until unpaused.
+  const pausedSnapshotRef = useRef<SeedStreamEvent[] | null>(null);
+  useEffect(() => {
+    if (paused && pausedSnapshotRef.current === null) {
+      pausedSnapshotRef.current = visible;
+    } else if (!paused) {
+      pausedSnapshotRef.current = null;
+    }
+    // We intentionally do NOT depend on `visible` here — we only want to snapshot
+    // the *first* visible array seen after `paused` flips true.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paused]);
+
+  const displayed = paused && pausedSnapshotRef.current ? pausedSnapshotRef.current : visible;
 
   return (
     <section

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedLogStream.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useCatalogSeedStream } from '../hooks/use-catalog-seed-stream';
+
+/**
+ * Issue #1903 M8.3 — live SSE log of the catalog seed fetch job.
+ *
+ * Mirrors the read-only log surface from #1835 `LogStream` but is driven by the
+ * SSE feed (not a per-run query). Supports pause/resume + filter by event type.
+ */
+const TYPE_LABEL: Record<string, string> = {
+  'batch.started': 'BatchStarted',
+  'seed.fetched': 'SeedFetched',
+  'seed.failed': 'SeedFailed',
+  'batch.completed': 'BatchCompleted',
+};
+
+const TYPE_ICON: Record<string, string> = {
+  'batch.started': 'ⓘ',
+  'seed.fetched': '✓',
+  'seed.failed': '⚠',
+  'batch.completed': '✓',
+};
+
+const TYPE_TONE: Record<string, string> = {
+  'batch.started': 'text-foreground',
+  'seed.fetched': 'text-entity-collection',
+  'seed.failed': 'text-entity-event',
+  'batch.completed': 'text-entity-game',
+};
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString('it-IT', { hour12: false });
+  } catch {
+    return iso;
+  }
+}
+
+export function SeedLogStream() {
+  const { events, isConnected, clear } = useCatalogSeedStream();
+  const [paused, setPaused] = useState(false);
+  const [filter, setFilter] = useState<'all' | 'failed'>('all');
+
+  const visible = filter === 'failed' ? events.filter(e => e.eventType === 'seed.failed') : events;
+  // Snapshot when paused so the stream stops updating visually.
+  const displayed = paused ? visible.slice(0, visible.length) : visible;
+
+  return (
+    <section
+      role="region"
+      aria-label="Catalog seed live stream"
+      className="overflow-hidden rounded-xl border border-border bg-card"
+    >
+      <header className="flex items-center gap-2.5 border-b border-border bg-muted/30 px-3.5 py-2.5">
+        <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">
+          📡 Live stream
+        </h3>
+        <span
+          role="status"
+          aria-live="polite"
+          className={`ml-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.04em] ${
+            isConnected
+              ? 'bg-entity-collection/[0.12] text-entity-collection'
+              : 'bg-entity-event/[0.12] text-entity-event'
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              isConnected ? 'bg-entity-collection' : 'bg-entity-event'
+            }`}
+            aria-hidden
+          />
+          {isConnected ? 'Connected' : 'Disconnected'}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <label className="flex items-center gap-1.5 font-mono text-[10px] uppercase text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={filter === 'failed'}
+              onChange={e => setFilter(e.target.checked ? 'failed' : 'all')}
+              aria-label="Filter failed only"
+            />
+            Failed only
+          </label>
+          <button
+            type="button"
+            onClick={() => setPaused(p => !p)}
+            className="rounded border border-border bg-background px-2 py-1 font-mono text-[10px] uppercase hover:bg-muted"
+          >
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded border border-border bg-background px-2 py-1 font-mono text-[10px] uppercase hover:bg-muted"
+          >
+            Clear
+          </button>
+        </div>
+      </header>
+      <div
+        className="max-h-72 overflow-y-auto p-3 font-mono text-[11px] text-foreground"
+        data-testid="seed-log-stream-body"
+      >
+        {displayed.length === 0 && (
+          <p className="text-muted-foreground">No events yet — waiting for fetch job activity.</p>
+        )}
+        {displayed.map((evt, idx) => (
+          <div key={idx} className="grid grid-cols-[64px_24px_120px_1fr] gap-2 py-0.5">
+            <span className="text-muted-foreground">{formatTime(evt.occurredAt)}</span>
+            <span className={TYPE_TONE[evt.eventType] ?? 'text-muted-foreground'}>
+              {TYPE_ICON[evt.eventType] ?? '·'}
+            </span>
+            <span className="text-foreground">{TYPE_LABEL[evt.eventType] ?? evt.eventType}</span>
+            <span className="truncate text-muted-foreground">
+              {Object.entries(evt)
+                .filter(([k]) => k !== 'eventType' && k !== 'occurredAt')
+                .map(([k, v]) => `${k}=${typeof v === 'object' ? JSON.stringify(v) : String(v)}`)
+                .join(' ')}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedPreviewPanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedPreviewPanel.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import type { CatalogSeedDraftDto } from '../lib/catalog-seed-types';
+import { SeedPreviewPanel } from './SeedPreviewPanel';
+
+vi.mock('../lib/catalog-seed-api');
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const SAMPLE: CatalogSeedDraftDto = {
+  id: 'd1',
+  bggId: 13,
+  wikidataQid: 'Q170416',
+  searchTermInput: null,
+  status: 'Fetched',
+  errorMessage: null,
+  resultingSharedGameId: null,
+  createdByUserId: 'u1',
+  createdAt: '2026-06-04T12:00:00Z',
+  fetchedAt: '2026-06-04T12:01:00Z',
+  approvedAt: null,
+  approvedByUserId: null,
+};
+
+describe('SeedPreviewPanel', () => {
+  it('renders the status pill + metadata grid', () => {
+    vi.mocked(api.getSeedById).mockResolvedValue(SAMPLE);
+    render(<SeedPreviewPanel draft={SAMPLE} />, { wrapper: wrapper() });
+    // The word "Fetched" appears both as the status pill value AND as a metadata
+    // grid label ("Fetched: <timestamp>"). At least one element must exist.
+    expect(screen.getAllByText('Fetched').length).toBeGreaterThan(0);
+    expect(screen.getByText('13')).toBeInTheDocument();
+    expect(screen.getByText('Q170416')).toBeInTheDocument();
+  });
+
+  it('renders the error card on FetchFailed', () => {
+    vi.mocked(api.getSeedById).mockResolvedValue(SAMPLE);
+    render(
+      <SeedPreviewPanel
+        draft={{ ...SAMPLE, status: 'FetchFailed', errorMessage: 'BGG returned 404' }}
+      />,
+      { wrapper: wrapper() }
+    );
+    expect(screen.getByText(/Fetch error/i)).toBeInTheDocument();
+    expect(screen.getByText('BGG returned 404')).toBeInTheDocument();
+  });
+
+  it('toggles the raw JSON viewer', async () => {
+    vi.mocked(api.getSeedById).mockResolvedValue(SAMPLE);
+    render(<SeedPreviewPanel draft={SAMPLE} />, { wrapper: wrapper() });
+    await userEvent.click(screen.getByRole('button', { name: /View raw DTO/i }));
+    expect(screen.getByRole('button', { name: /Hide raw JSON/i })).toBeInTheDocument();
+    expect(screen.getByText(/"id": "d1"/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedPreviewPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedPreviewPanel.tsx
@@ -32,6 +32,7 @@ function StatusPill({ status }: { status: string }) {
             : 'bg-muted text-muted-foreground';
   return (
     <span
+      aria-label={`Status: ${status}`}
       className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.04em] ${tone}`}
     >
       {status}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedPreviewPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedPreviewPanel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useCatalogSeed } from '../hooks/use-catalog-seeds';
+
+import type { CatalogSeedDraftDto } from '../lib/catalog-seed-types';
+
+/**
+ * Issue #1903 M8.4 — expanded preview of a fetched catalog seed.
+ *
+ * Hits `GET /api/v1/admin/catalog/seeds/{id}` on demand to fetch the full draft.
+ * Provenance fields are not yet on the public DTO (only summary cols), so we
+ * surface what's available + an "Open raw payload" affordance referring to BE
+ * §4.7 (detail endpoint will be extended in a follow-up). For now the panel
+ * provides a reliable read of the metadata that is exposed.
+ */
+export interface SeedPreviewPanelProps {
+  draft: CatalogSeedDraftDto;
+}
+
+function StatusPill({ status }: { status: string }) {
+  const tone =
+    status === 'Approved'
+      ? 'bg-entity-collection/[0.12] text-entity-collection'
+      : status === 'Fetched'
+        ? 'bg-entity-game/[0.12] text-entity-game'
+        : status === 'Pending'
+          ? 'bg-entity-toolkit/[0.12] text-entity-toolkit'
+          : status === 'FetchFailed' || status === 'Rejected'
+            ? 'bg-entity-event/[0.12] text-entity-event'
+            : 'bg-muted text-muted-foreground';
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.04em] ${tone}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString('it-IT', { hour12: false });
+  } catch {
+    return iso;
+  }
+}
+
+export function SeedPreviewPanel({ draft }: SeedPreviewPanelProps) {
+  const [showRaw, setShowRaw] = useState(false);
+  // Always re-fetch the detail when expanded so we get any provenance the BE
+  // exposes (M4.7) even if the list payload predates it.
+  const { data: detail } = useCatalogSeed(draft.id);
+  const enriched = detail ?? draft;
+
+  return (
+    <div
+      className="space-y-3 rounded-md border border-border bg-card p-3"
+      data-testid={`seed-preview-${draft.id}`}
+    >
+      <div className="grid grid-cols-[100px_1fr] gap-y-1 text-xs">
+        <span className="font-mono text-muted-foreground">Status</span>
+        <span>
+          <StatusPill status={enriched.status} />
+        </span>
+        <span className="font-mono text-muted-foreground">BGG ID</span>
+        <span className="font-mono text-foreground">
+          {enriched.bggId ?? <span className="text-muted-foreground">—</span>}
+        </span>
+        <span className="font-mono text-muted-foreground">Wikidata QID</span>
+        <span className="font-mono text-foreground">
+          {enriched.wikidataQid ?? <span className="text-muted-foreground">—</span>}
+        </span>
+        <span className="font-mono text-muted-foreground">Search term</span>
+        <span className="text-foreground">
+          {enriched.searchTermInput ?? <span className="text-muted-foreground">—</span>}
+        </span>
+        <span className="font-mono text-muted-foreground">Created</span>
+        <span className="text-foreground">{formatDate(enriched.createdAt)}</span>
+        <span className="font-mono text-muted-foreground">Fetched</span>
+        <span className="text-foreground">{formatDate(enriched.fetchedAt)}</span>
+        <span className="font-mono text-muted-foreground">Approved</span>
+        <span className="text-foreground">{formatDate(enriched.approvedAt)}</span>
+        {enriched.resultingSharedGameId && (
+          <>
+            <span className="font-mono text-muted-foreground">SharedGameId</span>
+            <span className="font-mono text-foreground">{enriched.resultingSharedGameId}</span>
+          </>
+        )}
+      </div>
+
+      {enriched.status === 'FetchFailed' && enriched.errorMessage && (
+        <div className="rounded border-l-4 border-entity-event bg-entity-event/[0.04] px-3 py-2">
+          <p className="font-mono text-[11px] font-bold text-entity-event">Fetch error</p>
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">
+            {enriched.errorMessage}
+          </p>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setShowRaw(s => !s)}
+        className="font-mono text-[10px] uppercase tracking-[0.04em] text-entity-toolkit underline"
+      >
+        {showRaw ? 'Hide raw JSON' : 'View raw DTO'}
+      </button>
+      {showRaw && (
+        <pre className="overflow-x-auto rounded bg-muted/40 p-2 font-mono text-[10px] text-foreground">
+          {JSON.stringify(enriched, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import type { CatalogSeedDraftDto } from '../lib/catalog-seed-types';
+import { SeedQueueList } from './SeedQueueList';
+
+vi.mock('../lib/catalog-seed-api');
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const ROW: CatalogSeedDraftDto = {
+  id: 'd1',
+  bggId: 13,
+  wikidataQid: null,
+  searchTermInput: null,
+  status: 'Fetched',
+  errorMessage: null,
+  resultingSharedGameId: null,
+  createdByUserId: 'u1',
+  createdAt: '2026-06-04T12:00:00Z',
+  fetchedAt: '2026-06-04T12:01:00Z',
+  approvedAt: null,
+  approvedByUserId: null,
+};
+
+describe('SeedQueueList', () => {
+  it('renders the loading state on first mount', () => {
+    vi.mocked(api.listSeeds).mockImplementation(
+      () => new Promise(() => undefined) // never resolves → stays in loading
+    );
+    render(<SeedQueueList />, { wrapper: wrapper() });
+    expect(screen.getByText(/Loading queue/i)).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no items are returned', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({ total: 0, skip: 0, take: 50, items: [] });
+    render(<SeedQueueList />, { wrapper: wrapper() });
+    await waitFor(() =>
+      expect(screen.getByText(/No seed drafts match this filter/i)).toBeInTheDocument()
+    );
+  });
+
+  it('renders queue rows + total count', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({ total: 1, skip: 0, take: 50, items: [ROW] });
+    render(<SeedQueueList />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByTestId('seed-row-d1')).toBeInTheDocument());
+    expect(screen.getByText(/1 total/)).toBeInTheDocument();
+    expect(screen.getByText(/BGG:13/)).toBeInTheDocument();
+  });
+
+  it('exposes Approve action for Fetched rows', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({ total: 1, skip: 0, take: 50, items: [ROW] });
+    vi.mocked(api.approveSeed).mockResolvedValue({ draftId: 'd1', resultingSharedGameId: 'sg-1' });
+    render(<SeedQueueList />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByLabelText(/Approve d1/i)).toBeInTheDocument());
+    await userEvent.click(screen.getByLabelText(/Approve d1/i));
+    await waitFor(() => expect(api.approveSeed).toHaveBeenCalledWith('d1'));
+  });
+
+  it('filters the list when a status chip is clicked', async () => {
+    const spy = vi.mocked(api.listSeeds).mockResolvedValue({
+      total: 0,
+      skip: 0,
+      take: 50,
+      items: [],
+    });
+    render(<SeedQueueList />, { wrapper: wrapper() });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('button', { name: 'Pending' }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ status: 'Pending' }))
+    );
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as api from '../lib/catalog-seed-api';
 import type { CatalogSeedDraftDto } from '../lib/catalog-seed-types';
@@ -35,6 +35,10 @@ const ROW: CatalogSeedDraftDto = {
 };
 
 describe('SeedQueueList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders the loading state on first mount', () => {
     vi.mocked(api.listSeeds).mockImplementation(
       () => new Promise(() => undefined) // never resolves → stays in loading
@@ -81,5 +85,47 @@ describe('SeedQueueList', () => {
     await waitFor(() =>
       expect(spy).toHaveBeenCalledWith(expect.objectContaining({ status: 'Pending' }))
     );
+  });
+
+  it('opens an inline reject form, accepts a reason, and calls rejectSeed', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({ total: 1, skip: 0, take: 50, items: [ROW] });
+    vi.mocked(api.rejectSeed).mockResolvedValue(undefined);
+    render(<SeedQueueList />, { wrapper: wrapper() });
+
+    // Click the Reject trigger
+    await waitFor(() => expect(screen.getByTestId('reject-d1')).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId('reject-d1'));
+
+    // Inline form appears with the textarea + confirm/cancel
+    const form = await screen.findByTestId('reject-form-d1');
+    expect(form).toBeInTheDocument();
+    const textarea = screen.getByLabelText(/Rejection reason/i) as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+
+    // Confirm is disabled until reason is non-empty
+    const confirmBtn = screen.getByTestId('reject-confirm-d1');
+    expect(confirmBtn).toBeDisabled();
+
+    await userEvent.type(textarea, 'Not a real game');
+    expect(confirmBtn).not.toBeDisabled();
+
+    await userEvent.click(confirmBtn);
+    await waitFor(() => expect(api.rejectSeed).toHaveBeenCalledWith('d1', 'Not a real game'));
+
+    // Inline form is dismissed after success
+    await waitFor(() => expect(screen.queryByTestId('reject-form-d1')).not.toBeInTheDocument());
+  });
+
+  it('cancels the inline reject form without calling rejectSeed', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({ total: 1, skip: 0, take: 50, items: [ROW] });
+    render(<SeedQueueList />, { wrapper: wrapper() });
+
+    await waitFor(() => expect(screen.getByTestId('reject-d1')).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId('reject-d1'));
+    await userEvent.type(screen.getByLabelText(/Rejection reason/i), 'never sent');
+    await userEvent.click(screen.getByTestId('reject-cancel-d1'));
+
+    expect(screen.queryByTestId('reject-form-d1')).not.toBeInTheDocument();
+    expect(api.rejectSeed).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Check, ChevronDown, ChevronRight, Loader2, X } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/primitives/button';
+
+import { SeedPreviewPanel } from './SeedPreviewPanel';
+import { useApproveSeed, useCatalogSeeds, useRejectSeed } from '../hooks/use-catalog-seeds';
+
+import type { CatalogSeedDraftDto, CatalogSeedStatus } from '../lib/catalog-seed-types';
+
+/**
+ * Issue #1903 M8.3 — main queue list view.
+ *
+ * Combines the QueuePendingPanel + FailedItemsPanel concerns from #1835 into a
+ * single filterable list. Approve and Reject (with reason prompt) call the
+ * mediator-backed mutations and rely on the `useApproveSeed` / `useRejectSeed`
+ * invalidation hook to refresh the list automatically.
+ */
+const FILTERS: { label: string; value: CatalogSeedStatus | 'All' }[] = [
+  { label: 'All', value: 'All' },
+  { label: 'Pending', value: 'Pending' },
+  { label: 'Fetched', value: 'Fetched' },
+  { label: 'FetchFailed', value: 'FetchFailed' },
+  { label: 'Approved', value: 'Approved' },
+  { label: 'Rejected', value: 'Rejected' },
+];
+
+const PAGE_SIZE = 50;
+
+function StatusDot({ status }: { status: string }) {
+  const tone =
+    status === 'Approved'
+      ? 'bg-entity-collection'
+      : status === 'Fetched'
+        ? 'bg-entity-game'
+        : status === 'Pending'
+          ? 'bg-entity-toolkit'
+          : status === 'FetchFailed' || status === 'Rejected'
+            ? 'bg-entity-event'
+            : 'bg-muted-foreground';
+  return <span className={`h-2 w-2 rounded-full ${tone}`} aria-hidden />;
+}
+
+interface SeedRowProps {
+  draft: CatalogSeedDraftDto;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function SeedRow({ draft, expanded, onToggle }: SeedRowProps) {
+  const approve = useApproveSeed();
+  const reject = useRejectSeed();
+
+  const canApprove = draft.status === 'Fetched';
+  const canReject = draft.status !== 'Approved' && draft.status !== 'Rejected';
+
+  const handleApprove = async () => {
+    try {
+      await approve.mutateAsync(draft.id);
+      toast.success(`Draft ${draft.id} approved`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Approve failed');
+    }
+  };
+
+  const handleReject = async () => {
+    const reason = typeof window !== 'undefined' ? window.prompt('Reject reason?') : null;
+    if (!reason || reason.trim().length === 0) return;
+    try {
+      await reject.mutateAsync({ id: draft.id, reason: reason.trim() });
+      toast.success(`Draft ${draft.id} rejected`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Reject failed');
+    }
+  };
+
+  return (
+    <li
+      className="border-b border-border last:border-b-0"
+      data-testid={`seed-row-${draft.id}`}
+      data-status={draft.status}
+    >
+      <div className="flex items-center gap-2.5 px-3.5 py-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={expanded ? `Collapse ${draft.id}` : `Expand ${draft.id}`}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+        <StatusDot status={draft.status} />
+        <span className="font-mono text-[11px] text-foreground">
+          {draft.bggId ? `BGG:${draft.bggId}` : (draft.wikidataQid ?? draft.searchTermInput ?? '—')}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.04em] text-muted-foreground">
+          {draft.status}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          {canApprove && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleApprove}
+              disabled={approve.isPending}
+              aria-label={`Approve ${draft.id}`}
+            >
+              {approve.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Check className="h-3 w-3" />
+              )}
+              Approve
+            </Button>
+          )}
+          {canReject && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleReject}
+              disabled={reject.isPending}
+              aria-label={`Reject ${draft.id}`}
+            >
+              {reject.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <X className="h-3 w-3" />
+              )}
+              Reject
+            </Button>
+          )}
+        </div>
+      </div>
+      {expanded && (
+        <div className="border-t border-border bg-muted/20 p-3">
+          <SeedPreviewPanel draft={draft} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function SeedQueueList() {
+  const [filter, setFilter] = useState<(typeof FILTERS)[number]['value']>('All');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const { data, isLoading, isError, error, refetch } = useCatalogSeeds({
+    status: filter === 'All' ? undefined : filter,
+    skip: 0,
+    take: PAGE_SIZE,
+  });
+
+  return (
+    <section
+      aria-label="Catalog seed queue list"
+      className="overflow-hidden rounded-xl border border-border bg-card"
+    >
+      <header className="flex flex-wrap items-center gap-2.5 border-b border-border bg-muted/30 px-3.5 py-2.5">
+        <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">📋 Queue</h3>
+        <span className="font-mono text-[11px] text-muted-foreground">
+          {data ? `${data.total} total` : '…'}
+        </span>
+        <div
+          className="ml-auto flex flex-wrap items-center gap-1"
+          role="group"
+          aria-label="Filter by status"
+        >
+          {FILTERS.map(f => (
+            <button
+              key={f.value}
+              type="button"
+              onClick={() => setFilter(f.value)}
+              data-state={filter === f.value ? 'active' : 'inactive'}
+              className="rounded border border-border bg-background px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.04em] hover:bg-muted data-[state=active]:bg-entity-toolkit/[0.12] data-[state=active]:text-entity-toolkit"
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {isError && (
+        <div role="alert" className="px-3.5 py-4 text-sm text-entity-event">
+          <p>{error instanceof Error ? error.message : 'Failed to load queue'}</p>
+          <Button variant="outline" size="sm" className="mt-2" onClick={() => refetch()}>
+            Riprova
+          </Button>
+        </div>
+      )}
+
+      {isLoading && <p className="px-3.5 py-4 text-sm text-muted-foreground">Loading queue…</p>}
+
+      {!isLoading && !isError && data && data.items.length === 0 && (
+        <p className="px-3.5 py-6 text-sm text-muted-foreground">
+          No seed drafts match this filter.
+        </p>
+      )}
+
+      {!isLoading && !isError && data && data.items.length > 0 && (
+        <ul className="divide-y divide-border">
+          {data.items.map(draft => (
+            <SeedRow
+              key={draft.id}
+              draft={draft}
+              expanded={expandedId === draft.id}
+              onToggle={() => setExpandedId(prev => (prev === draft.id ? null : draft.id))}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueList.tsx
@@ -42,7 +42,14 @@ function StatusDot({ status }: { status: string }) {
           : status === 'FetchFailed' || status === 'Rejected'
             ? 'bg-entity-event'
             : 'bg-muted-foreground';
-  return <span className={`h-2 w-2 rounded-full ${tone}`} aria-hidden />;
+  // The colored dot is purely decorative; the adjacent text label
+  // (`{draft.status}`) carries the accessible name for SR users.
+  return (
+    <span className="inline-flex items-center">
+      <span className={`h-2 w-2 rounded-full ${tone}`} aria-hidden />
+      <span className="sr-only">Status: {status}</span>
+    </span>
+  );
 }
 
 interface SeedRowProps {
@@ -54,6 +61,8 @@ interface SeedRowProps {
 function SeedRow({ draft, expanded, onToggle }: SeedRowProps) {
   const approve = useApproveSeed();
   const reject = useRejectSeed();
+  const [rejecting, setRejecting] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
 
   const canApprove = draft.status === 'Fetched';
   const canReject = draft.status !== 'Approved' && draft.status !== 'Rejected';
@@ -67,12 +76,22 @@ function SeedRow({ draft, expanded, onToggle }: SeedRowProps) {
     }
   };
 
-  const handleReject = async () => {
-    const reason = typeof window !== 'undefined' ? window.prompt('Reject reason?') : null;
-    if (!reason || reason.trim().length === 0) return;
+  const cancelReject = () => {
+    setRejecting(false);
+    setRejectReason('');
+  };
+
+  const confirmReject = async () => {
+    const reason = rejectReason.trim();
+    if (reason.length === 0) {
+      toast.error('Rejection reason is required');
+      return;
+    }
     try {
-      await reject.mutateAsync({ id: draft.id, reason: reason.trim() });
+      await reject.mutateAsync({ id: draft.id, reason });
       toast.success(`Draft ${draft.id} rejected`);
+      setRejecting(false);
+      setRejectReason('');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Reject failed');
     }
@@ -117,13 +136,14 @@ function SeedRow({ draft, expanded, onToggle }: SeedRowProps) {
               Approve
             </Button>
           )}
-          {canReject && (
+          {canReject && !rejecting && (
             <Button
               size="sm"
               variant="outline"
-              onClick={handleReject}
+              onClick={() => setRejecting(true)}
               disabled={reject.isPending}
               aria-label={`Reject ${draft.id}`}
+              data-testid={`reject-${draft.id}`}
             >
               {reject.isPending ? (
                 <Loader2 className="h-3 w-3 animate-spin" />
@@ -135,6 +155,49 @@ function SeedRow({ draft, expanded, onToggle }: SeedRowProps) {
           )}
         </div>
       </div>
+      {rejecting && (
+        <div
+          className="border-t border-border bg-muted/10 px-3.5 py-3"
+          data-testid={`reject-form-${draft.id}`}
+        >
+          <label
+            htmlFor={`reject-reason-${draft.id}`}
+            className="font-mono text-[10px] uppercase tracking-[0.04em] text-muted-foreground"
+          >
+            Rejection reason
+          </label>
+          <textarea
+            id={`reject-reason-${draft.id}`}
+            value={rejectReason}
+            onChange={e => setRejectReason(e.target.value)}
+            rows={2}
+            maxLength={500}
+            className="mt-1 w-full rounded-md border border-border bg-background p-2 text-sm"
+            placeholder="Why reject this draft?"
+            autoFocus
+          />
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={cancelReject}
+              disabled={reject.isPending}
+              data-testid={`reject-cancel-${draft.id}`}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={confirmReject}
+              disabled={reject.isPending || rejectReason.trim().length === 0}
+              data-testid={`reject-confirm-${draft.id}`}
+            >
+              {reject.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+              Confirm reject
+            </Button>
+          </div>
+        </div>
+      )}
       {expanded && (
         <div className="border-t border-border bg-muted/20 p-3">
           <SeedPreviewPanel draft={draft} />

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueStatusHero.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueStatusHero.test.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import { SeedQueueStatusHero } from './SeedQueueStatusHero';
+
+vi.mock('../lib/catalog-seed-api');
+
+function setup() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('SeedQueueStatusHero', () => {
+  it('renders KPI cards for the four statuses', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({
+      total: 5,
+      skip: 0,
+      take: 1,
+      items: [],
+    });
+    render(<SeedQueueStatusHero />, { wrapper: setup() });
+
+    await waitFor(() => expect(screen.getByText(/Catalog seed queue/i)).toBeInTheDocument());
+    expect(screen.getByTestId('seed-status-card-pending')).toBeInTheDocument();
+    expect(screen.getByTestId('seed-status-card-fetched')).toBeInTheDocument();
+    expect(screen.getByTestId('seed-status-card-approved')).toBeInTheDocument();
+    expect(screen.getByTestId('seed-status-card-rejected')).toBeInTheDocument();
+  });
+
+  it('renders the error card when list fails', async () => {
+    vi.mocked(api.listSeeds).mockRejectedValue(new Error('Network down'));
+    render(<SeedQueueStatusHero />, { wrapper: setup() });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Catalog seed queue unavailable/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/Network down/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueStatusHero.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueStatusHero.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { AlertCircle } from 'lucide-react';
+
+import { useCatalogSeeds } from '../hooks/use-catalog-seeds';
+
+/**
+ * Issue #1903 M8.3 — KPI hero for the catalog seed queue.
+ *
+ * Adapted from `SyncStatusHero` (#1835). Instead of provider config, this hero
+ * shows aggregate counts per status (Pending / Fetched / Approved / Rejected).
+ * Each count drives a single `useCatalogSeeds` query with `take=0` so the BE
+ * can return just the total without paying the projection cost — this mirrors
+ * the pattern used by AdminCacheStats etc.
+ */
+const STATUSES = ['Pending', 'Fetched', 'Approved', 'Rejected'] as const;
+
+const TONE: Record<(typeof STATUSES)[number], { ring: string; text: string; label: string }> = {
+  Pending: { ring: 'ring-entity-toolkit/30', text: 'text-entity-toolkit', label: 'Pending' },
+  Fetched: { ring: 'ring-entity-game/30', text: 'text-entity-game', label: 'Fetched' },
+  Approved: {
+    ring: 'ring-entity-collection/30',
+    text: 'text-entity-collection',
+    label: 'Approved',
+  },
+  Rejected: { ring: 'ring-entity-event/30', text: 'text-entity-event', label: 'Rejected' },
+};
+
+interface StatusCountCardProps {
+  status: (typeof STATUSES)[number];
+}
+
+function StatusCountCard({ status }: StatusCountCardProps) {
+  const { data, isError } = useCatalogSeeds({ status, skip: 0, take: 1 });
+  const tone = TONE[status];
+  const value = data?.total ?? (isError ? '—' : '…');
+  return (
+    <div
+      className={`rounded-lg border border-border bg-card px-4 py-3 ring-1 ${tone.ring}`}
+      data-testid={`seed-status-card-${status.toLowerCase()}`}
+    >
+      <p className={`font-mono text-[10px] uppercase tracking-[0.04em] ${tone.text}`}>
+        {tone.label}
+      </p>
+      <p className="mt-0.5 font-quicksand text-2xl font-extrabold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+export function SeedQueueStatusHero() {
+  const { isError, error, refetch } = useCatalogSeeds({ skip: 0, take: 1 });
+
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        className="flex items-center gap-3 rounded-xl border border-entity-event/30 bg-entity-event/[0.04] px-5 py-4"
+      >
+        <AlertCircle className="h-5 w-5 shrink-0 text-entity-event" aria-hidden />
+        <div className="flex-1">
+          <h3 className="font-quicksand text-sm font-bold text-foreground">
+            Catalog seed queue unavailable
+          </h3>
+          <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+            {error instanceof Error ? error.message : 'Errore di rete'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="rounded-md border border-border bg-background px-3 py-1 text-xs font-medium hover:bg-muted"
+        >
+          Riprova
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Catalog seed queue status"
+      className="rounded-xl border border-entity-toolkit/25 bg-gradient-to-br from-entity-toolkit/[0.14] to-entity-game/[0.08] px-6 py-5"
+    >
+      <header className="mb-3 flex items-center gap-2.5">
+        <h2 className="font-quicksand text-[22px] font-extrabold leading-none text-foreground">
+          🌱 Catalog seed queue
+        </h2>
+        <p className="ml-2 text-sm text-muted-foreground">
+          Admin-only fetch + approve pipeline (Wikidata primary · BGG fallback)
+        </p>
+      </header>
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {STATUSES.map(s => (
+          <StatusCountCard key={s} status={s} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueStatusHero.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SeedQueueStatusHero.tsx
@@ -9,13 +9,20 @@ import { useCatalogSeeds } from '../hooks/use-catalog-seeds';
  *
  * Adapted from `SyncStatusHero` (#1835). Instead of provider config, this hero
  * shows aggregate counts per status (Pending / Fetched / Approved / Rejected).
- * Each count drives a single `useCatalogSeeds` query with `take=0` so the BE
+ * Each count drives a single `useCatalogSeeds` query with `take=1` so the BE
  * can return just the total without paying the projection cost — this mirrors
  * the pattern used by AdminCacheStats etc.
+ *
+ * Note: M8 review (PR #1916) — the previous implementation also called
+ * `useCatalogSeeds({ skip: 0, take: 1 })` at the hero level (no status filter)
+ * just to detect global errors. That was a redundant 5th query. We now lift
+ * the four per-status queries into the hero and pass `data`/`isError` down
+ * to dumb `StatusCountCard` children, aggregating error state at the source.
  */
 const STATUSES = ['Pending', 'Fetched', 'Approved', 'Rejected'] as const;
+type SeedStatus = (typeof STATUSES)[number];
 
-const TONE: Record<(typeof STATUSES)[number], { ring: string; text: string; label: string }> = {
+const TONE: Record<SeedStatus, { ring: string; text: string; label: string }> = {
   Pending: { ring: 'ring-entity-toolkit/30', text: 'text-entity-toolkit', label: 'Pending' },
   Fetched: { ring: 'ring-entity-game/30', text: 'text-entity-game', label: 'Fetched' },
   Approved: {
@@ -27,13 +34,14 @@ const TONE: Record<(typeof STATUSES)[number], { ring: string; text: string; labe
 };
 
 interface StatusCountCardProps {
-  status: (typeof STATUSES)[number];
+  status: SeedStatus;
+  total: number | undefined;
+  isError: boolean;
 }
 
-function StatusCountCard({ status }: StatusCountCardProps) {
-  const { data, isError } = useCatalogSeeds({ status, skip: 0, take: 1 });
+function StatusCountCard({ status, total, isError }: StatusCountCardProps) {
   const tone = TONE[status];
-  const value = data?.total ?? (isError ? '—' : '…');
+  const value = total ?? (isError ? '—' : '…');
   return (
     <div
       className={`rounded-lg border border-border bg-card px-4 py-3 ring-1 ${tone.ring}`}
@@ -48,9 +56,17 @@ function StatusCountCard({ status }: StatusCountCardProps) {
 }
 
 export function SeedQueueStatusHero() {
-  const { isError, error, refetch } = useCatalogSeeds({ skip: 0, take: 1 });
+  // One query per status — React Query dedupes by queryKey if any other
+  // component (e.g. SeedQueueList) happens to issue the same filtered call.
+  const pending = useCatalogSeeds({ status: 'Pending', skip: 0, take: 1 });
+  const fetched = useCatalogSeeds({ status: 'Fetched', skip: 0, take: 1 });
+  const approved = useCatalogSeeds({ status: 'Approved', skip: 0, take: 1 });
+  const rejected = useCatalogSeeds({ status: 'Rejected', skip: 0, take: 1 });
 
-  if (isError) {
+  const queries = { Pending: pending, Fetched: fetched, Approved: approved, Rejected: rejected };
+  const firstErrored = STATUSES.map(s => queries[s]).find(q => q.isError);
+
+  if (firstErrored) {
     return (
       <div
         role="alert"
@@ -62,12 +78,17 @@ export function SeedQueueStatusHero() {
             Catalog seed queue unavailable
           </h3>
           <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
-            {error instanceof Error ? error.message : 'Errore di rete'}
+            {firstErrored.error instanceof Error ? firstErrored.error.message : 'Errore di rete'}
           </p>
         </div>
         <button
           type="button"
-          onClick={() => refetch()}
+          onClick={() => {
+            pending.refetch();
+            fetched.refetch();
+            approved.refetch();
+            rejected.refetch();
+          }}
           className="rounded-md border border-border bg-background px-3 py-1 text-xs font-medium hover:bg-muted"
         >
           Riprova
@@ -91,7 +112,12 @@ export function SeedQueueStatusHero() {
       </header>
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         {STATUSES.map(s => (
-          <StatusCountCard key={s} status={s} />
+          <StatusCountCard
+            key={s}
+            status={s}
+            total={queries[s].data?.total}
+            isError={queries[s].isError}
+          />
         ))}
       </div>
     </section>

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SingleAddForm.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SingleAddForm.test.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import { SingleAddForm } from './SingleAddForm';
+
+vi.mock('../lib/catalog-seed-api');
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('SingleAddForm', () => {
+  it('starts in BGG ID mode and blocks submit when empty', () => {
+    render(<SingleAddForm />, { wrapper: wrapper() });
+    expect(screen.getByLabelText(/^BGG ID$/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Enqueue draft/i })).toBeDisabled();
+  });
+
+  it('enables submit for a valid BGG ID', async () => {
+    render(<SingleAddForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/^BGG ID$/i), '13');
+    expect(screen.getByRole('button', { name: /Enqueue draft/i })).toBeEnabled();
+  });
+
+  it('rejects non-numeric BGG input', async () => {
+    render(<SingleAddForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/^BGG ID$/i), 'abc');
+    expect(screen.getByRole('button', { name: /Enqueue draft/i })).toBeDisabled();
+  });
+
+  it('switches to Wikidata QID mode and validates Q-prefix', async () => {
+    render(<SingleAddForm />, { wrapper: wrapper() });
+    await userEvent.click(screen.getByRole('button', { name: /Wikidata QID/i }));
+    await userEvent.type(screen.getByLabelText(/^Wikidata QID$/i), 'q170416');
+    expect(screen.getByRole('button', { name: /Enqueue draft/i })).toBeEnabled();
+  });
+
+  it('submits a BGG ID and resets the input', async () => {
+    vi.mocked(api.enqueueSeed).mockResolvedValue({
+      id: 'd1',
+      bggId: 13,
+      status: 'Pending',
+      isDuplicate: false,
+    });
+    render(<SingleAddForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/^BGG ID$/i), '13');
+    await userEvent.click(screen.getByRole('button', { name: /Enqueue draft/i }));
+    await waitFor(() => expect(api.enqueueSeed).toHaveBeenCalledWith({ bggId: 13 }));
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SingleAddForm.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/SingleAddForm.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/primitives/button';
+
+import { useEnqueueSeed } from '../hooks/use-catalog-seeds';
+
+/**
+ * Issue #1903 M8.3 — single-row add form (BGG id, Wikidata QID, or free-text search).
+ *
+ * Replaces `AssignBggIdForm` from #1835 — instead of pairing a draft with an
+ * existing shared-game UUID, this submits one of three possible inputs to the
+ * BE which then drives the Wikidata / BGG provider chain.
+ */
+type Mode = 'bgg' | 'wikidata' | 'search';
+
+export function SingleAddForm() {
+  const [mode, setMode] = useState<Mode>('bgg');
+  const [bggIdRaw, setBggIdRaw] = useState('');
+  const [wikidataQid, setWikidataQid] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const mutation = useEnqueueSeed();
+
+  const bggIdValid = /^\d+$/.test(bggIdRaw) && Number.parseInt(bggIdRaw, 10) > 0;
+  const wikidataValid = /^Q\d+$/.test(wikidataQid);
+  const searchValid = searchTerm.trim().length >= 2;
+
+  const isValid =
+    (mode === 'bgg' && bggIdValid) ||
+    (mode === 'wikidata' && wikidataValid) ||
+    (mode === 'search' && searchValid);
+
+  const handleSubmit = async () => {
+    if (!isValid || mutation.isPending) return;
+    try {
+      const body =
+        mode === 'bgg'
+          ? { bggId: Number.parseInt(bggIdRaw, 10) }
+          : mode === 'wikidata'
+            ? { wikidataQid }
+            : { searchTermInput: searchTerm.trim() };
+      const result = await mutation.mutateAsync(body);
+      if (result.isDuplicate) {
+        toast.info(
+          `Draft already exists for ${mode === 'bgg' ? `BGG:${bggIdRaw}` : mode === 'wikidata' ? wikidataQid : searchTerm}`
+        );
+      } else {
+        toast.success(`Seed enqueued: ${result.id}`);
+      }
+      setBggIdRaw('');
+      setWikidataQid('');
+      setSearchTerm('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Enqueue failed');
+    }
+  };
+
+  return (
+    <section aria-label="Single seed add" className="rounded-xl border border-border bg-card p-4">
+      <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">+ Single add</h3>
+      <div className="mt-3 flex gap-2 font-mono text-[10px] uppercase">
+        {(['bgg', 'wikidata', 'search'] as const).map(m => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => setMode(m)}
+            data-state={mode === m ? 'active' : 'inactive'}
+            className="rounded border border-border bg-background px-2 py-1 data-[state=active]:bg-entity-toolkit/[0.12] data-[state=active]:text-entity-toolkit"
+          >
+            {m === 'bgg' ? 'BGG ID' : m === 'wikidata' ? 'Wikidata QID' : 'Search term'}
+          </button>
+        ))}
+      </div>
+      {mode === 'bgg' && (
+        <label className="mt-3 block">
+          <span className="font-mono text-[10px] uppercase text-muted-foreground">BGG ID</span>
+          <input
+            aria-label="BGG ID"
+            inputMode="numeric"
+            value={bggIdRaw}
+            onChange={e => setBggIdRaw(e.target.value)}
+            className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 font-mono text-sm"
+            placeholder="e.g. 13"
+          />
+        </label>
+      )}
+      {mode === 'wikidata' && (
+        <label className="mt-3 block">
+          <span className="font-mono text-[10px] uppercase text-muted-foreground">
+            Wikidata QID
+          </span>
+          <input
+            aria-label="Wikidata QID"
+            value={wikidataQid}
+            onChange={e => setWikidataQid(e.target.value.toUpperCase())}
+            className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 font-mono text-sm"
+            placeholder="e.g. Q170416"
+          />
+        </label>
+      )}
+      {mode === 'search' && (
+        <label className="mt-3 block">
+          <span className="font-mono text-[10px] uppercase text-muted-foreground">Search term</span>
+          <input
+            aria-label="Search term"
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+            className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-sm"
+            placeholder="e.g. catan"
+          />
+        </label>
+      )}
+      <Button onClick={handleSubmit} disabled={!isValid || mutation.isPending} className="mt-3">
+        {mutation.isPending ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+        Enqueue draft
+      </Button>
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/WikidataSearchForm.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/WikidataSearchForm.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/catalog-seed-api';
+import { WikidataSearchForm } from './WikidataSearchForm';
+
+vi.mock('../lib/catalog-seed-api');
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const PROVENANCE_TITLE = {
+  provider: 'wikidata',
+  sourceUrl: 'https://www.wikidata.org/wiki/Q170416',
+  sourceField: 'P1476',
+  fetchedAt: '2026-06-04T12:00:00Z',
+  value: 'Catan',
+};
+
+const PROVENANCE_DESIGNER = {
+  provider: 'wikidata',
+  sourceUrl: 'https://www.wikidata.org/wiki/Q170416',
+  sourceField: 'P178',
+  fetchedAt: '2026-06-04T12:00:00Z',
+  value: 'Klaus Teuber',
+};
+
+describe('WikidataSearchForm', () => {
+  it('disables the search button when input is too short', () => {
+    render(<WikidataSearchForm />, { wrapper: wrapper() });
+    expect(screen.getByRole('button', { name: /Search/i })).toBeDisabled();
+  });
+
+  it('invokes wikidataSearch on submit', async () => {
+    vi.mocked(api.wikidataSearch).mockResolvedValue({
+      fields: { title: PROVENANCE_TITLE },
+      errorMessage: null,
+    });
+    render(<WikidataSearchForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/Wikidata search term/i), 'catan');
+    await userEvent.click(screen.getByRole('button', { name: /Search/i }));
+    await waitFor(() => expect(api.wikidataSearch).toHaveBeenCalledWith('catan'));
+  });
+
+  it('renders the result fields with provenance', async () => {
+    vi.mocked(api.wikidataSearch).mockResolvedValue({
+      fields: { title: PROVENANCE_TITLE, designer: PROVENANCE_DESIGNER },
+      errorMessage: null,
+    });
+    render(<WikidataSearchForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/Wikidata search term/i), 'catan');
+    await userEvent.click(screen.getByRole('button', { name: /Search/i }));
+    await waitFor(() => expect(screen.getByTestId('wikidata-search-result')).toBeInTheDocument());
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('Klaus Teuber')).toBeInTheDocument();
+    expect(screen.getByText('Q170416')).toBeInTheDocument();
+  });
+
+  it('shows error when search reports a provider error', async () => {
+    vi.mocked(api.wikidataSearch).mockResolvedValue({
+      fields: {},
+      errorMessage: 'SPARQL endpoint timeout',
+    });
+    render(<WikidataSearchForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/Wikidata search term/i), 'foo');
+    await userEvent.click(screen.getByRole('button', { name: /Search/i }));
+    expect(await screen.findByText(/SPARQL endpoint timeout/i)).toBeInTheDocument();
+  });
+
+  it('add-to-queue forwards the QID to enqueueSeed', async () => {
+    vi.mocked(api.wikidataSearch).mockResolvedValue({
+      fields: { title: PROVENANCE_TITLE },
+      errorMessage: null,
+    });
+    vi.mocked(api.enqueueSeed).mockResolvedValue({
+      id: 'd1',
+      bggId: null,
+      status: 'Pending',
+      isDuplicate: false,
+    });
+    render(<WikidataSearchForm />, { wrapper: wrapper() });
+    await userEvent.type(screen.getByLabelText(/Wikidata search term/i), 'catan');
+    await userEvent.click(screen.getByRole('button', { name: /Search/i }));
+    await waitFor(() => expect(screen.getByText('Q170416')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /Add Q170416 to queue/i }));
+    await waitFor(() => expect(api.enqueueSeed).toHaveBeenCalledWith({ wikidataQid: 'Q170416' }));
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/WikidataSearchForm.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/components/WikidataSearchForm.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Loader2, Search } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/primitives/button';
+
+import { useEnqueueSeed, useWikidataSearch } from '../hooks/use-catalog-seeds';
+
+import type { FieldProvenance } from '../lib/catalog-seed-types';
+
+/**
+ * Issue #1903 M8.4 — Wikidata SPARQL search panel.
+ *
+ * Pre-canned SPARQL query is issued server-side via the
+ * `/wikidata-search` endpoint. The hit list shows the canonical fields
+ * (title / year / designer) plus an "Add to queue" button per hit that
+ * forwards the Wikidata QID to `EnqueueCatalogSeedCommand`.
+ */
+type RowField = { value: string; sourceUrl: string | null };
+
+function readField(field: FieldProvenance | undefined): RowField | null {
+  if (!field) return null;
+  let value: string;
+  if (typeof field.value === 'string') {
+    value = field.value;
+  } else if (Array.isArray(field.value)) {
+    value = (field.value as unknown[]).map(v => String(v)).join(', ');
+  } else if (field.value === null || field.value === undefined) {
+    return null;
+  } else {
+    value = String(field.value);
+  }
+  return { value, sourceUrl: field.sourceUrl ?? null };
+}
+
+function extractQidFromUrl(url: string): string | null {
+  const match = url.match(/Q\d+/);
+  return match ? match[0] : null;
+}
+
+export function WikidataSearchForm() {
+  const [term, setTerm] = useState('');
+  const search = useWikidataSearch();
+  const enqueue = useEnqueueSeed();
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (term.trim().length < 2) return;
+    try {
+      await search.mutateAsync(term.trim());
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Search failed');
+    }
+  };
+
+  const handleAdd = async (qid: string) => {
+    try {
+      const result = await enqueue.mutateAsync({ wikidataQid: qid });
+      if (result.isDuplicate) {
+        toast.info(`Draft already exists for ${qid}`);
+      } else {
+        toast.success(`Seed enqueued: ${qid}`);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Enqueue failed');
+    }
+  };
+
+  const result = search.data;
+  const title = result ? readField(result.fields.title) : null;
+  const year = result ? readField(result.fields.yearPublished ?? result.fields.year) : null;
+  const designer = result ? readField(result.fields.designer) : null;
+  // Try to surface a Wikidata QID from any field's sourceUrl. Wikidata permanent
+  // URIs always include the QID, so this is robust across field shapes.
+  const qid =
+    result &&
+    Object.values(result.fields)
+      .map(f => extractQidFromUrl(f.sourceUrl))
+      .find((q): q is string => q !== null);
+
+  return (
+    <section aria-label="Wikidata search" className="rounded-xl border border-border bg-card p-4">
+      <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">
+        🔍 Search Wikidata
+      </h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        CC0 public-domain data, free from BGG ToS constraints.
+      </p>
+      <form className="mt-3 flex items-center gap-2" onSubmit={handleSearch}>
+        <input
+          aria-label="Wikidata search term"
+          value={term}
+          onChange={e => setTerm(e.target.value)}
+          placeholder="board game title…"
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-sm"
+        />
+        <Button type="submit" disabled={term.trim().length < 2 || search.isPending}>
+          {search.isPending ? (
+            <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Search className="mr-1 h-3.5 w-3.5" />
+          )}
+          Search
+        </Button>
+      </form>
+
+      {search.isError && (
+        <p className="mt-3 text-xs text-entity-event" role="alert">
+          {search.error instanceof Error ? search.error.message : 'Search failed'}
+        </p>
+      )}
+
+      {result && result.errorMessage && (
+        <p className="mt-3 text-xs text-entity-event" role="alert">
+          {result.errorMessage}
+        </p>
+      )}
+
+      {result && !result.errorMessage && Object.keys(result.fields).length === 0 && (
+        <p className="mt-3 text-xs text-muted-foreground">No results.</p>
+      )}
+
+      {result && !result.errorMessage && Object.keys(result.fields).length > 0 && (
+        <div
+          className="mt-3 rounded-md border border-border bg-background p-3"
+          data-testid="wikidata-search-result"
+        >
+          <div className="grid grid-cols-[80px_1fr] gap-y-1 text-xs">
+            {title && (
+              <>
+                <span className="font-mono text-muted-foreground">Title</span>
+                <span className="text-foreground">{title.value}</span>
+              </>
+            )}
+            {year && (
+              <>
+                <span className="font-mono text-muted-foreground">Year</span>
+                <span className="text-foreground">{year.value}</span>
+              </>
+            )}
+            {designer && (
+              <>
+                <span className="font-mono text-muted-foreground">Designer</span>
+                <span className="text-foreground">{designer.value}</span>
+              </>
+            )}
+            {qid && (
+              <>
+                <span className="font-mono text-muted-foreground">QID</span>
+                <span className="font-mono text-foreground">{qid}</span>
+              </>
+            )}
+          </div>
+          {qid && (
+            <Button
+              size="sm"
+              className="mt-3"
+              onClick={() => handleAdd(qid)}
+              disabled={enqueue.isPending}
+            >
+              {enqueue.isPending ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+              Add {qid} to queue
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/hooks/__tests__/use-catalog-seeds.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/hooks/__tests__/use-catalog-seeds.test.tsx
@@ -1,0 +1,165 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from '../../lib/catalog-seed-api';
+import {
+  useApproveSeed,
+  useBulkEnqueueSeeds,
+  useCatalogSeed,
+  useCatalogSeeds,
+  useEnqueueSeed,
+  useRejectSeed,
+  useWikidataSearch,
+} from '../use-catalog-seeds';
+
+vi.mock('../../lib/catalog-seed-api');
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+describe('useCatalogSeeds', () => {
+  it('fetches the list with provided params', async () => {
+    const spy = vi.mocked(api.listSeeds).mockResolvedValue({
+      total: 0,
+      skip: 0,
+      take: 50,
+      items: [],
+    });
+    const client = makeClient();
+    renderHook(() => useCatalogSeeds({ status: 'Pending', skip: 0, take: 50 }), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(spy).toHaveBeenCalledWith({ status: 'Pending', skip: 0, take: 50 }));
+  });
+
+  it('returns the list payload on success', async () => {
+    vi.mocked(api.listSeeds).mockResolvedValue({
+      total: 1,
+      skip: 0,
+      take: 50,
+      items: [
+        {
+          id: 'd1',
+          bggId: 13,
+          wikidataQid: null,
+          searchTermInput: null,
+          status: 'Pending',
+          errorMessage: null,
+          resultingSharedGameId: null,
+          createdByUserId: 'u1',
+          createdAt: '2026-06-04T12:00:00Z',
+          fetchedAt: null,
+          approvedAt: null,
+          approvedByUserId: null,
+        },
+      ],
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useCatalogSeeds(), { wrapper: wrapper(client) });
+    await waitFor(() => expect(result.current.data?.items.length).toBe(1));
+    expect(result.current.data?.items[0].bggId).toBe(13);
+  });
+});
+
+describe('useCatalogSeed', () => {
+  it('does not fetch when id is null', () => {
+    const spy = vi.mocked(api.getSeedById).mockResolvedValue(null);
+    const client = makeClient();
+    renderHook(() => useCatalogSeed(null), { wrapper: wrapper(client) });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('fetches by id when provided', async () => {
+    const spy = vi.mocked(api.getSeedById).mockResolvedValue(null);
+    const client = makeClient();
+    renderHook(() => useCatalogSeed('d1'), { wrapper: wrapper(client) });
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('d1'));
+  });
+});
+
+describe('useEnqueueSeed', () => {
+  it('invalidates the seeds list on success', async () => {
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    vi.mocked(api.enqueueSeed).mockResolvedValue({
+      id: 'd1',
+      bggId: 13,
+      status: 'Pending',
+      isDuplicate: false,
+    });
+    const { result } = renderHook(() => useEnqueueSeed(), { wrapper: wrapper(client) });
+    await act(async () => {
+      await result.current.mutateAsync({ bggId: 13 });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['catalog-seeds'] });
+  });
+});
+
+describe('useBulkEnqueueSeeds', () => {
+  it('returns the bulk result on mutate', async () => {
+    vi.mocked(api.bulkEnqueueSeeds).mockResolvedValue({
+      total: 2,
+      enqueued: 2,
+      duplicates: 0,
+      newDraftIds: ['d1', 'd2'],
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useBulkEnqueueSeeds(), { wrapper: wrapper(client) });
+    await act(async () => {
+      const r = await result.current.mutateAsync({ bggIds: [13, 30549] });
+      expect(r.enqueued).toBe(2);
+    });
+  });
+});
+
+describe('useApproveSeed', () => {
+  it('forwards id to the api call', async () => {
+    const spy = vi.mocked(api.approveSeed).mockResolvedValue({
+      draftId: 'd1',
+      resultingSharedGameId: 'sg-1',
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useApproveSeed(), { wrapper: wrapper(client) });
+    await act(async () => {
+      await result.current.mutateAsync('d1');
+    });
+    expect(spy).toHaveBeenCalledWith('d1');
+  });
+});
+
+describe('useRejectSeed', () => {
+  it('forwards id+reason to the api call', async () => {
+    const spy = vi.mocked(api.rejectSeed).mockResolvedValue(undefined);
+    const client = makeClient();
+    const { result } = renderHook(() => useRejectSeed(), { wrapper: wrapper(client) });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'd1', reason: 'dup' });
+    });
+    expect(spy).toHaveBeenCalledWith('d1', 'dup');
+  });
+});
+
+describe('useWikidataSearch', () => {
+  it('returns the SPARQL result on mutate', async () => {
+    vi.mocked(api.wikidataSearch).mockResolvedValue({
+      fields: {},
+      errorMessage: null,
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useWikidataSearch(), { wrapper: wrapper(client) });
+    await act(async () => {
+      const r = await result.current.mutateAsync('catan');
+      expect(r.fields).toEqual({});
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/hooks/use-catalog-seed-stream.ts
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/hooks/use-catalog-seed-stream.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { SeedStreamEvent } from '../lib/catalog-seed-types';
+
+/**
+ * Issue #1903 M8.1 — EventSource subscription to the admin catalog seed SSE stream.
+ *
+ * The endpoint emits four named events: `batch.started`, `seed.fetched`,
+ * `seed.failed`, `batch.completed`. We attach a listener per event type so the
+ * UI can filter without inspecting the parsed JSON, and we also subscribe to the
+ * default `message` event so a generic test fixture can drive the hook without
+ * having to emit named events.
+ *
+ * Lifecycle: opens on mount, closes on unmount. Buffer caps at 200 events
+ * (matching the server-side replay buffer documented in §6 of the design spec).
+ */
+const STREAM_URL = '/api/v1/admin/catalog/seeds/stream';
+const EVENT_TYPES = ['batch.started', 'seed.fetched', 'seed.failed', 'batch.completed'] as const;
+const MAX_BUFFER = 200;
+
+export interface UseCatalogSeedStreamResult {
+  events: SeedStreamEvent[];
+  isConnected: boolean;
+  clear: () => void;
+}
+
+export function useCatalogSeedStream(): UseCatalogSeedStreamResult {
+  const [events, setEvents] = useState<SeedStreamEvent[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    // Guard for non-browser environments (SSR / tests without EventSource).
+    if (typeof EventSource === 'undefined') return;
+
+    const es = new EventSource(STREAM_URL, { withCredentials: true });
+    esRef.current = es;
+    es.onopen = () => setIsConnected(true);
+    es.onerror = () => setIsConnected(false);
+
+    const appendEvent = (eventType: string, raw: string) => {
+      try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const evt: SeedStreamEvent = {
+          eventType,
+          occurredAt: (parsed.occurredAt as string) ?? new Date().toISOString(),
+          ...parsed,
+        };
+        setEvents(prev => {
+          const next = [...prev, evt];
+          return next.length > MAX_BUFFER ? next.slice(-MAX_BUFFER) : next;
+        });
+      } catch {
+        // Malformed JSON — drop silently so a corrupt frame can't crash the UI.
+      }
+    };
+
+    const listeners = EVENT_TYPES.map(type => {
+      const handler = (e: MessageEvent) => appendEvent(type, e.data);
+      es.addEventListener(type, handler as EventListener);
+      return { type, handler };
+    });
+
+    // Default `message` event for generic emitters (tests, future event types).
+    const defaultHandler = (e: MessageEvent) => appendEvent('message', e.data);
+    es.addEventListener('message', defaultHandler as EventListener);
+
+    return () => {
+      listeners.forEach(({ type, handler }) =>
+        es.removeEventListener(type, handler as EventListener)
+      );
+      es.removeEventListener('message', defaultHandler as EventListener);
+      es.close();
+      esRef.current = null;
+    };
+  }, []);
+
+  return {
+    events,
+    isConnected,
+    clear: () => setEvents([]),
+  };
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/hooks/use-catalog-seeds.ts
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/hooks/use-catalog-seeds.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as api from '../lib/catalog-seed-api';
+
+import type { BulkEnqueueRequest, EnqueueCatalogSeedRequest } from '../lib/catalog-seed-types';
+
+/**
+ * Issue #1903 M8.1 — React Query bindings for the admin catalog seed pipeline.
+ *
+ * Query key convention: `['catalog-seeds', ...]`. Mutations invalidate the broad
+ * `['catalog-seeds']` namespace so any list filter / detail view consuming the
+ * data is refreshed in a single broadcast.
+ */
+export const CATALOG_SEEDS_KEY = ['catalog-seeds'] as const;
+export const CATALOG_SEED_DETAIL_KEY = ['catalog-seed-detail'] as const;
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+export function useCatalogSeeds(params: api.ListSeedsParams = {}) {
+  return useQuery({
+    queryKey: [...CATALOG_SEEDS_KEY, params],
+    queryFn: () => api.listSeeds(params),
+  });
+}
+
+export function useCatalogSeed(id: string | null) {
+  return useQuery({
+    queryKey: [...CATALOG_SEED_DETAIL_KEY, id],
+    queryFn: () => (id ? api.getSeedById(id) : Promise.resolve(null)),
+    enabled: id !== null,
+  });
+}
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+export function useEnqueueSeed() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: EnqueueCatalogSeedRequest) => api.enqueueSeed(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: CATALOG_SEEDS_KEY }),
+  });
+}
+
+export function useBulkEnqueueSeeds() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: BulkEnqueueRequest) => api.bulkEnqueueSeeds(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: CATALOG_SEEDS_KEY }),
+  });
+}
+
+export function useApproveSeed() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.approveSeed(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: CATALOG_SEEDS_KEY }),
+  });
+}
+
+export function useRejectSeed() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) => api.rejectSeed(id, reason),
+    onSuccess: () => qc.invalidateQueries({ queryKey: CATALOG_SEEDS_KEY }),
+  });
+}
+
+export function useWikidataSearch() {
+  return useMutation({
+    mutationFn: (searchTerm: string) => api.wikidataSearch(searchTerm),
+  });
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/lib/__tests__/catalog-seed-api.test.ts
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/lib/__tests__/catalog-seed-api.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CatalogSeedApiError,
+  approveSeed,
+  bulkEnqueueSeeds,
+  enqueueSeed,
+  getSeedById,
+  listSeeds,
+  rejectSeed,
+  wikidataSearch,
+} from '../catalog-seed-api';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fetchMock.mockReset();
+});
+
+describe('enqueueSeed', () => {
+  it('POSTs JSON body to /api/v1/admin/catalog/seeds', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'd1', bggId: 13, status: 'Pending', isDuplicate: false }),
+    });
+    const result = await enqueueSeed({ bggId: 13 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/admin/catalog/seeds',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ bggId: 13 }),
+      })
+    );
+    expect(result.id).toBe('d1');
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  it('throws CatalogSeedApiError on non-ok', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      json: async () => ({ title: 'Catalog seed pipeline disabled' }),
+    });
+    await expect(enqueueSeed({ bggId: 13 })).rejects.toMatchObject({
+      status: 503,
+      message: expect.stringContaining('disabled'),
+    });
+  });
+});
+
+describe('bulkEnqueueSeeds', () => {
+  it('POSTs the BGG id list to /bulk', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ total: 3, enqueued: 3, duplicates: 0, newDraftIds: ['a', 'b', 'c'] }),
+    });
+    const result = await bulkEnqueueSeeds({ bggIds: [13, 30549, 167791] });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/admin/catalog/seeds/bulk',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ bggIds: [13, 30549, 167791] }),
+      })
+    );
+    expect(result.enqueued).toBe(3);
+  });
+
+  it('throws on failure', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ error: 'Too many IDs' }),
+    });
+    await expect(bulkEnqueueSeeds({ bggIds: [] })).rejects.toBeInstanceOf(CatalogSeedApiError);
+  });
+});
+
+describe('listSeeds', () => {
+  it('builds query string from params', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ total: 0, skip: 25, take: 50, items: [] }),
+    });
+    await listSeeds({ status: 'Fetched', skip: 25, take: 50 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/seeds\?.*status=Fetched.*skip=25.*take=50/),
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('omits empty query string when no params provided', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ total: 0, skip: 0, take: 50, items: [] }),
+    });
+    await listSeeds();
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/admin/catalog/seeds', expect.any(Object));
+  });
+});
+
+describe('getSeedById', () => {
+  it('returns null on 404', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    const result = await getSeedById('missing');
+    expect(result).toBeNull();
+  });
+
+  it('returns the DTO on 200', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'd1', bggId: 13, status: 'Fetched', errorMessage: null }),
+    });
+    const result = await getSeedById('d1');
+    expect(result?.id).toBe('d1');
+  });
+
+  it('throws on 5xx', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      json: async () => ({}),
+    });
+    await expect(getSeedById('d1')).rejects.toBeInstanceOf(CatalogSeedApiError);
+  });
+});
+
+describe('approveSeed', () => {
+  it('POSTs /{id}/approve and returns the resulting shared game id', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ draftId: 'd1', resultingSharedGameId: 'sg-1' }),
+    });
+    const result = await approveSeed('d1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/admin/catalog/seeds/d1/approve',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result.resultingSharedGameId).toBe('sg-1');
+  });
+});
+
+describe('rejectSeed', () => {
+  it('POSTs reason to /{id}/reject', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    await rejectSeed('d1', 'duplicate of #42');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/admin/catalog/seeds/d1/reject',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reason: 'duplicate of #42' }),
+      })
+    );
+  });
+
+  it('throws on non-ok', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({}),
+    });
+    await expect(rejectSeed('d1', 'x')).rejects.toBeInstanceOf(CatalogSeedApiError);
+  });
+});
+
+describe('wikidataSearch', () => {
+  it('POSTs searchTerm to /wikidata-search', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ fields: {}, errorMessage: null }),
+    });
+    await wikidataSearch('catan');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/admin/catalog/seeds/wikidata-search',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ searchTerm: 'catan' }),
+      })
+    );
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/lib/catalog-seed-api.ts
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/lib/catalog-seed-api.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #1903 M8.1 — Fetch wrapper for the admin catalog seed pipeline endpoints.
+ *
+ * All endpoints under `/api/v1/admin/catalog/seeds`. Admin session is enforced at
+ * the group level (`RequireAdminSessionFilter`), so non-admin callers receive 401/403;
+ * when the runtime kill-switch `admin.catalog-seed.enabled` is `false`, all routes
+ * return 503 (handled by an endpoint filter, see `AdminCatalogSeedEndpoints.cs`).
+ *
+ * The fetch wrappers below mirror the BE contract documented in
+ * `apps/api/src/Api/Routing/Admin/AdminCatalogSeedEndpoints.cs`.
+ */
+
+import type {
+  ApproveCatalogSeedResult,
+  BulkEnqueueRequest,
+  BulkEnqueueResult,
+  CatalogSeedDraftDto,
+  EnqueueCatalogSeedRequest,
+  EnqueueCatalogSeedResult,
+  ListCatalogSeedsResult,
+  WikidataSearchResult,
+} from './catalog-seed-types';
+
+const BASE = '/api/v1/admin/catalog/seeds';
+
+/**
+ * Domain-typed error used by every fetch call so consumers can distinguish
+ * 503 (feature flag off) from 401/403 (auth) and 4xx validation failures.
+ */
+export class CatalogSeedApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'CatalogSeedApiError';
+  }
+}
+
+async function parseJsonOrEmpty(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return {};
+  }
+}
+
+async function throwOnError(res: Response, defaultMessage: string): Promise<never> {
+  const body = (await parseJsonOrEmpty(res)) as { detail?: string; title?: string; error?: string };
+  const message = body.detail ?? body.title ?? body.error ?? `${defaultMessage}: ${res.statusText}`;
+  throw new CatalogSeedApiError(res.status, message);
+}
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+export async function enqueueSeed(
+  body: EnqueueCatalogSeedRequest
+): Promise<EnqueueCatalogSeedResult> {
+  const res = await fetch(BASE, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) await throwOnError(res, 'Enqueue failed');
+  return res.json();
+}
+
+export async function bulkEnqueueSeeds(body: BulkEnqueueRequest): Promise<BulkEnqueueResult> {
+  const res = await fetch(`${BASE}/bulk`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) await throwOnError(res, 'Bulk enqueue failed');
+  return res.json();
+}
+
+export async function approveSeed(id: string): Promise<ApproveCatalogSeedResult> {
+  const res = await fetch(`${BASE}/${id}/approve`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok) await throwOnError(res, 'Approve failed');
+  return res.json();
+}
+
+export async function rejectSeed(id: string, reason: string): Promise<void> {
+  const res = await fetch(`${BASE}/${id}/reject`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reason }),
+  });
+  if (!res.ok) await throwOnError(res, 'Reject failed');
+}
+
+export async function wikidataSearch(searchTerm: string): Promise<WikidataSearchResult> {
+  const res = await fetch(`${BASE}/wikidata-search`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ searchTerm }),
+  });
+  if (!res.ok) await throwOnError(res, 'Wikidata search failed');
+  return res.json();
+}
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+export interface ListSeedsParams {
+  status?: string;
+  skip?: number;
+  take?: number;
+}
+
+export async function listSeeds(params: ListSeedsParams = {}): Promise<ListCatalogSeedsResult> {
+  const search = new URLSearchParams();
+  if (params.status) search.set('status', params.status);
+  if (typeof params.skip === 'number') search.set('skip', String(params.skip));
+  if (typeof params.take === 'number') search.set('take', String(params.take));
+  const qs = search.toString();
+  const url = qs ? `${BASE}?${qs}` : BASE;
+  const res = await fetch(url, { method: 'GET', credentials: 'include' });
+  if (!res.ok) await throwOnError(res, 'List failed');
+  return res.json();
+}
+
+/**
+ * Returns `null` on 404 so the UI can render an empty-state without throwing.
+ */
+export async function getSeedById(id: string): Promise<CatalogSeedDraftDto | null> {
+  const res = await fetch(`${BASE}/${id}`, { method: 'GET', credentials: 'include' });
+  if (res.status === 404) return null;
+  if (!res.ok) await throwOnError(res, 'Get seed failed');
+  return res.json();
+}

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/lib/catalog-seed-types.ts
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/lib/catalog-seed-types.ts
@@ -1,0 +1,136 @@
+/**
+ * Issue #1903 M8.1 — TypeScript shapes for the admin catalog seed pipeline.
+ *
+ * Mirror the BE DTOs documented in
+ * `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/CatalogSeedDraftDto.cs`
+ * and the request/result records in `AdminCatalogSeedEndpoints.cs`.
+ *
+ * Field names follow the API's camelCase serialisation (`PropertyNamingPolicy.CamelCase`).
+ */
+
+export type CatalogSeedStatus = 'Pending' | 'Fetched' | 'FetchFailed' | 'Approved' | 'Rejected';
+
+/**
+ * Read model for a single catalog seed draft row.
+ * 1:1 with `CatalogSeedDraftDto` (BE DTO).
+ */
+export interface CatalogSeedDraftDto {
+  id: string;
+  bggId: number | null;
+  wikidataQid: string | null;
+  searchTermInput: string | null;
+  status: CatalogSeedStatus;
+  errorMessage: string | null;
+  resultingSharedGameId: string | null;
+  createdByUserId: string;
+  createdAt: string;
+  fetchedAt: string | null;
+  approvedAt: string | null;
+  approvedByUserId: string | null;
+}
+
+/** Request body for `POST /api/v1/admin/catalog/seeds`. */
+export interface EnqueueCatalogSeedRequest {
+  bggId?: number | null;
+  wikidataQid?: string | null;
+  searchTermInput?: string | null;
+}
+
+/** Result of `POST /api/v1/admin/catalog/seeds`. */
+export interface EnqueueCatalogSeedResult {
+  id: string;
+  bggId: number | null;
+  status: CatalogSeedStatus;
+  isDuplicate: boolean;
+}
+
+/** Request body for `POST /api/v1/admin/catalog/seeds/bulk`. */
+export interface BulkEnqueueRequest {
+  bggIds: number[];
+}
+
+/** Result of `POST /api/v1/admin/catalog/seeds/bulk`. */
+export interface BulkEnqueueResult {
+  total: number;
+  enqueued: number;
+  duplicates: number;
+  newDraftIds: string[];
+}
+
+/** Result of `GET /api/v1/admin/catalog/seeds`. */
+export interface ListCatalogSeedsResult {
+  total: number;
+  skip: number;
+  take: number;
+  items: CatalogSeedDraftDto[];
+}
+
+/** Result of `POST /api/v1/admin/catalog/seeds/{id}/approve`. */
+export interface ApproveCatalogSeedResult {
+  draftId: string;
+  resultingSharedGameId: string;
+}
+
+/**
+ * Per-field provenance metadata used by Wikidata search response.
+ * Mirrors `FieldProvenance` value object on BE.
+ */
+export interface FieldProvenance {
+  provider: string;
+  sourceUrl: string;
+  sourceField: string;
+  fetchedAt: string;
+  value: unknown;
+}
+
+/** Result of `POST /api/v1/admin/catalog/seeds/wikidata-search`. */
+export interface WikidataSearchResult {
+  fields: Record<string, FieldProvenance>;
+  errorMessage: string | null;
+}
+
+/**
+ * SSE event envelope emitted by `GET /api/v1/admin/catalog/seeds/stream`.
+ * The BE wraps each event with `event: <eventType>` + JSON `data:` payload;
+ * we capture both pieces here for the LogStream renderer.
+ */
+export interface SeedStreamEvent {
+  eventType: string;
+  occurredAt: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Discriminated payloads documented in §6 of the design spec. Each event includes
+ * `eventType` + `occurredAt`; the remaining fields are folded into the JSON
+ * envelope so this interface only enumerates the well-known ones for downstream
+ * consumers who want narrow typing.
+ */
+export type SeedBatchStartedEvent = SeedStreamEvent & {
+  eventType: 'batch.started';
+  batchId: string;
+  draftIds: string[];
+};
+
+export type SeedFetchedEvent = SeedStreamEvent & {
+  eventType: 'seed.fetched';
+  draftId: string;
+  bggId: number | null;
+  providerUsed: string;
+  durationMs: number;
+};
+
+export type SeedFailedEvent = SeedStreamEvent & {
+  eventType: 'seed.failed';
+  draftId: string;
+  error: string;
+  retryAttempt: number;
+};
+
+export type SeedBatchCompletedEvent = SeedStreamEvent & {
+  eventType: 'batch.completed';
+  batchId: string;
+  succeeded: number;
+  failed: number;
+  totalDurationMs: number;
+};

--- a/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/catalog/seed-queue/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { BulkPasteForm } from './components/BulkPasteForm';
+import { SeedLogStream } from './components/SeedLogStream';
+import { SeedQueueList } from './components/SeedQueueList';
+import { SeedQueueStatusHero } from './components/SeedQueueStatusHero';
+import { SingleAddForm } from './components/SingleAddForm';
+import { WikidataSearchForm } from './components/WikidataSearchForm';
+
+/**
+ * Issue #1903 M8.2 — admin catalog seed queue page.
+ *
+ * Two-column layout (input sx · queue dx) per design spec §5.1. Live SSE log at
+ * the bottom. All sub-components own their data via React Query so the page
+ * itself is a thin composition.
+ *
+ * Auth: route lives under the `admin/(dashboard)` route group which is gated by
+ * a server-side admin check; the BE re-enforces auth at the
+ * `RequireAdminSessionFilter` level on every endpoint.
+ *
+ * Feature flag: when `admin.catalog-seed.enabled=false`, every BE call returns
+ * 503 and surfaces in the per-component error UI.
+ */
+export default function CatalogSeedQueuePage() {
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex items-center gap-4 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-md">
+        <div>
+          <h1 className="font-quicksand text-[20px] font-extrabold leading-tight tracking-tight text-foreground">
+            Catalog seed queue
+          </h1>
+          <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+            Admin · Catalog · Seed pipeline (Wikidata + BGG)
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-4 px-6">
+        <SeedQueueStatusHero />
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,360px)_1fr]">
+          {/* Input column */}
+          <div className="flex flex-col gap-4">
+            <BulkPasteForm />
+            <SingleAddForm />
+            <WikidataSearchForm />
+          </div>
+
+          {/* Queue column */}
+          <div className="flex flex-col gap-4">
+            <SeedQueueList />
+          </div>
+        </div>
+
+        <SeedLogStream />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -47,6 +47,27 @@
       "tagToInvalidate": "Tag to invalidate",
       "title": "Cache"
     },
+    "catalogSeed": {
+      "title": "Catalog seed queue",
+      "subtitle": "Admin · Catalog · Seed pipeline (Wikidata + BGG)",
+      "kpi": {
+        "pending": "Pending",
+        "fetched": "Fetched",
+        "approved": "Approved",
+        "rejected": "Rejected"
+      },
+      "actions": {
+        "enqueue": "Enqueue",
+        "approve": "Approve",
+        "reject": "Reject",
+        "search": "Search",
+        "addToQueue": "Add to queue"
+      },
+      "filters": {
+        "all": "All",
+        "failedOnly": "Failed only"
+      }
+    },
     "configuration": {
       "aiLlm": "AI / LLM Configuration",
       "rag": "RAG Configuration",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -38,6 +38,27 @@
       "tagToInvalidate": "Tag da invalidare",
       "title": "Cache"
     },
+    "catalogSeed": {
+      "title": "Coda seed catalogo",
+      "subtitle": "Admin · Catalogo · Pipeline seed (Wikidata + BGG)",
+      "kpi": {
+        "pending": "In attesa",
+        "fetched": "Recuperati",
+        "approved": "Approvati",
+        "rejected": "Rifiutati"
+      },
+      "actions": {
+        "enqueue": "Accoda",
+        "approve": "Approva",
+        "reject": "Rifiuta",
+        "search": "Cerca",
+        "addToQueue": "Aggiungi alla coda"
+      },
+      "filters": {
+        "all": "Tutti",
+        "failedOnly": "Solo falliti"
+      }
+    },
     "configuration": {
       "aiLlm": "Configurazione AI / LLM",
       "rag": "Configurazione RAG",

--- a/docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
+++ b/docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
@@ -1,0 +1,147 @@
+# ADR-059 — Catalog Seed Legal Posture: Wikidata-primary + BGG-fallback Whitelisted Fetch
+
+**Status**: Accepted (Phase 1: M1-M8 frontend delivered; pre-public-rollout checklist still required)
+**Date**: 2026-06-04 (proposed), 2026-06-05 (accepted)
+**Deciders**: @badsworm
+**Tracking**: Issue [#1903](https://github.com/meepleAi-app/meepleai-monorepo/issues/1903)
+**Spec**: [`docs/superpowers/specs/2026-06-04-admin-catalog-seed-design.md`](../../../superpowers/specs/2026-06-04-admin-catalog-seed-design.md)
+**Supersedes**: —
+
+## Context
+
+The catalog ingestion pipeline (#1835 admin UI · #1874 backend) lets MeepleAI admins
+populate the `SharedGameEntity` catalog from CSV/Excel uploads and BGG IDs. As we
+move from "admin assists user upload" to "admin pre-seeds the catalog from
+external providers", three legal vectors come into scope simultaneously:
+
+1. **BGG Terms of Service** — `boardgamegeek.com/terms` §"Restrictions" bans
+   framing of BGG assets, prohibits using the API for "primary purpose of …
+   advertising or subscription revenue", and prohibits "any use that competes
+   with or displaces the market for BoardGameGeek". The third clause is
+   interpretively ambiguous and is the largest single risk vector.
+2. **EU Database Directive 96/9/EC** — Article 7 "sui generis" right gives the
+   database maker (BGG) the right to prevent "extraction and/or re-utilization
+   of … a substantial part". Repeated extraction of insubstantial parts is also
+   covered by Article 7.5 when it "conflicts with normal exploitation".
+3. **US Feist Publications v. Rural Telephone Service (1991)** — facts are not
+   copyrightable. Database "thin copyright" attaches to selection/arrangement
+   only, not individual facts (title, year, designer name).
+
+Wikidata (CC0 1.0 Universal) carries zero copyright/database-right exposure and
+makes the obvious primary data source for board game metadata.
+
+The full legal-framework analysis lives in §8.5 of the design spec and is
+summarised here so future contributors can find the decision boundary without
+reading the entire spec.
+
+## Decision
+
+**1) Wikidata is the primary data provider.**
+
+`IWikidataCatalogProvider` (M2) issues a pre-canned SPARQL query against the
+public Wikidata endpoint. CC0 license — no attribution required, no
+contractual constraints, no database-right exposure. Every other concern in
+this ADR exists because Wikidata coverage is incomplete (long-tail indie titles
+absent), not because Wikidata itself is risky.
+
+**2) BGG is a whitelisted fallback, never the primary source.**
+
+`BggImportFieldFilter.ForbiddenFields` (M3) hard-codes the exclusion list:
+description text, image/thumbnail, comments/reviews, statistics, ratings.
+A unit-test guard in the SharedGameCatalog test suite asserts the whitelist is
+respected end-to-end. The whitelist contains only "facts" per the Feist
+doctrine: title, year published, designer name, publisher name, mechanic
+labels, players, time. Each field has a recorded source URL via
+`FieldProvenance` (M2) so GDPR Article 17 erasure requests are tractable.
+
+**3) Kill-switch via runtime feature flag.**
+
+`admin.catalog-seed.enabled` (M7) is a runtime configuration key, default
+`false`. When disabled:
+- `CatalogSeedFetchJob` early-returns before making provider calls.
+- HTTP endpoints under `/api/v1/admin/catalog/seeds` return `503 Service
+  Unavailable` (via endpoint filter, see M6.2).
+- The FE `CatalogSeedApiError` surfaces 503 in the per-component error UI.
+
+Fail-closed semantics: any error (config not found, DB unreachable,
+deserialization failure) yields `false`. Operators must explicitly opt in via
+`/admin/config`.
+
+**4) Compliance audit trail.**
+
+- `BggTosWatcherJob` (M5) records BGG ToS hash monthly; alerts on change.
+- `domain_event_logs` captures `CatalogSeedFetched` · `CatalogSeedApproved` ·
+  `CatalogSeedRejected` · `BggFetchInvoked` events with provider + URL.
+- `/admin/catalog/seeds` audit export route is available for legal review.
+- User-Agent header on BGG calls includes `abuse@meepleai.app` so the
+  rightsholder has an immediate contact path.
+
+**5) Pre-rollout legal checklist (spec §8.5.6).**
+
+Public rollout is BLOCKED until:
+- [ ] 1 hour legal consultation completed (validate "competes/displaces" interpretation)
+- [ ] MeepleAI ToS updated with "publicly available data sources" clause
+- [ ] `abuse@meepleai.app` mailbox active and monitored
+- [ ] `BggTosWatcherJob` running in staging with alert routing to on-call
+- [ ] `/admin/catalog/seeds/export` (audit log export) functioning
+
+The M1-M8 implementation may be deployed to staging with the flag OFF; it must
+remain OFF in production until every box above is checked.
+
+## Consequences
+
+### Positive
+
+- **Wikidata-first** eliminates copyright and database-right exposure for the
+  majority of catalog seeds (board games with a Q-page).
+- **Whitelist + provenance** makes the Feist doctrine defensible: every stored
+  field is a fact with a tracked source URL.
+- **Feature flag kill-switch** lets operators park the pipeline immediately
+  without a redeploy if BGG sends a takedown notice or the legal posture
+  changes mid-rollout.
+- **Audit trail** supports GDPR Article 17 erasure requests (designer name
+  filter on `Provenance JSON`) and legal review of the import history.
+
+### Negative
+
+- **Long-tail coverage gap** when neither Wikidata nor BGG has a game (indie
+  titles). Mitigation: manual entry via `SingleAddForm` mode `searchTermInput`,
+  then admin paste of metadata.
+- **Interpretive risk** on BGG ToS "competes/displaces" clause is not
+  eliminable without a court ruling. Mitigation: legal consultation in the
+  pre-rollout checklist + ToS watcher + kill-switch + abuse mailbox.
+- **Performance**: every seed costs 1 SPARQL query + (optional) 1 BGG API
+  call. At 100 BGG IDs/bulk × 5min rate limit, an admin importing 1000 games
+  takes ~50 minutes. Acceptable for an admin tool.
+
+### Neutral
+
+- **GDPR consultation NOT required** for designer/publisher names per Article
+  6(1)(f) legitimate-interest + "publicly available professional data"
+  exemption (spec §8.5.4). Privacy policy update is OPTIONAL.
+
+## Implementation Status (2026-06-05)
+
+| Milestone | Scope | Status |
+|-----------|-------|--------|
+| M1 | Domain (`CatalogSeedDraft` aggregate + value objects) | ✅ |
+| M2 | Wikidata SPARQL provider + `FieldProvenance` | ✅ |
+| M3 | BGG fallback provider + `BggImportFieldFilter` whitelist guard | ✅ |
+| M4 | MediatR commands/queries (enqueue, bulk, list, approve, reject) | ✅ |
+| M5 | `BggTosWatcherJob` + `CatalogSeedFetchJob` (Quartz) | ✅ |
+| M6 | Admin endpoints `/api/v1/admin/catalog/seeds` (REST + SSE) | ✅ |
+| M7 | Runtime feature flag `admin.catalog-seed.enabled` | ✅ |
+| M8 | Admin UI `/admin/catalog/seed-queue` + Playwright E2E | ✅ |
+| — | Pre-rollout legal checklist (§8.5.6) | ⏳ Required before public |
+
+## References
+
+- Design spec: [`docs/superpowers/specs/2026-06-04-admin-catalog-seed-design.md`](../../../superpowers/specs/2026-06-04-admin-catalog-seed-design.md)
+- Issue: [#1903](https://github.com/meepleAi-app/meepleai-monorepo/issues/1903)
+- Operations runbook: [`docs/for-developers/operations/operations-manual.md`](../../../for-developers/operations/operations-manual.md) § Catalog seed pipeline (#1903)
+- Related ADR: [ADR-025 — Shared Catalog Bounded Context](./adr-025-shared-catalog-bounded-context.md)
+- Related ADR: [ADR-046 — Game/SharedGame data ownership](./adr-046-game-sharedgame-data-ownership.md)
+- BGG ToS (verified 2026-06-02): `boardgamegeek.com/terms`
+- EU Database Directive 96/9/EC, Article 7
+- Feist Publications v. Rural Telephone Service, 499 U.S. 340 (1991)
+- Wikidata CC0 deed: `creativecommons.org/publicdomain/zero/1.0/`

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2604,6 +2604,91 @@ For beta (CPX31): ~EUR 22/mo. For full production (CPX51): ~EUR 72/mo.
 
 ---
 
+## 19. Catalog Seed Pipeline (#1903)
+
+The catalog seed pipeline lets admins pre-seed the `SharedGameEntity` catalog
+from Wikidata (primary, CC0) and BoardGameGeek (whitelisted fallback, ToS-constrained).
+Full design reference: [`docs/superpowers/specs/2026-06-04-admin-catalog-seed-design.md`](../../superpowers/specs/2026-06-04-admin-catalog-seed-design.md).
+Legal posture: [ADR-059](../../for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md).
+
+### Enabling the seed pipeline
+
+The pipeline ships with the runtime feature flag `admin.catalog-seed.enabled` set
+to `false`. **Do NOT enable it in production until the pre-rollout legal checklist
+is complete.**
+
+1. **Pre-rollout checklist** (§8.5.6 of spec, mirrored in ADR-059):
+   - [ ] 1 hour legal consultation completed
+   - [ ] MeepleAI ToS updated with "publicly available data sources" clause
+   - [ ] `abuse@meepleai.app` mailbox active and monitored
+   - [ ] `BggTosWatcherJob` running in staging with alert routing
+   - [ ] `/admin/catalog/seeds/export` audit log export functioning
+2. **Toggle the flag**: navigate to `/admin/config` → General → set
+   `admin.catalog-seed.enabled = true`. Persists via `RuntimeConfigEntity`,
+   same pattern as `RegistrationMode`.
+3. **Verify the fetch job runs**: tail logs for `CatalogSeedFetchJob` (Quartz,
+   every 1 min). The first run after enabling consumes one `Pending` draft
+   if any exists.
+4. **Verify the ToS watcher**: `SELECT * FROM bgg_tos_hashes ORDER BY observed_at DESC LIMIT 5;`
+   should show at least one row. If the most recent `change_kind = 'changed'`,
+   trigger immediate legal review and consider disabling the flag.
+
+### Disabling (kill-switch)
+
+Setting `admin.catalog-seed.enabled = false`:
+
+- `CatalogSeedFetchJob` early-returns without making provider calls.
+- HTTP endpoints under `/api/v1/admin/catalog/seeds` return `503 Service
+  Unavailable` (endpoint filter); the admin UI surfaces this in the
+  `CatalogSeedApiError` 503 path.
+- `BggTosWatcherJob` continues running (compliance audit trail must not lapse).
+- In-flight drafts are NOT cleaned up; they resume on re-enable.
+
+Use this when:
+- BGG sends a takedown notice or `BggTosWatcherJob` flags a change.
+- Wikidata or BGG API rate-limits MeepleAI.
+- Legal posture changes mid-rollout.
+
+### Auditing
+
+Filter `domain_event_logs` by event type:
+
+```sql
+SELECT occurred_at, payload
+FROM domain_event_logs
+WHERE event_type IN (
+  'CatalogSeedFetched',
+  'CatalogSeedApproved',
+  'CatalogSeedRejected',
+  'BggFetchInvoked'
+)
+ORDER BY occurred_at DESC
+LIMIT 200;
+```
+
+Each `CatalogSeedFetched` payload includes the provider used and the source URL
+of every captured field (`FieldProvenance`). This supports GDPR Article 17
+erasure requests (designer name → `DELETE WHERE designer_name = 'X'`).
+
+### Troubleshooting
+
+- **All drafts stay `Pending` indefinitely**: feature flag is OFF, or the
+  Quartz scheduler isn't running. Check `CatalogSeedFetchJob` job state via
+  `/admin/jobs` and `admin.catalog-seed.enabled` value.
+- **All drafts transition to `FetchFailed`**: Wikidata/BGG endpoint
+  unreachable, or User-Agent header missing/invalid. BGG requires a
+  `From:` field with a valid email — verify `Bgg:UserAgent` config.
+- **`BggTosWatcherJob` flags `change_kind = 'changed'`**: STOP. Disable the
+  flag, route the diff to legal review. The watcher snapshots the BGG ToS
+  page; even a benign cosmetic change triggers the alert (false positives
+  are acceptable, false negatives would be a compliance failure).
+- **Bulk enqueue rejects with HTTP 400 "Too many IDs"**: hard cap is 100 IDs
+  per request (`BulkEnqueueCatalogSeedsCommandValidator`). Split the paste.
+- **`CatalogSeedApiError` with status 503 in the FE**: kill-switch is active.
+  See "Disabling" above.
+
+---
+
 ## Appendix A: Complete Command Reference
 
 ### Service Management


### PR DESCRIPTION
## Summary

**M8 — final milestone of issue #1903**. Admin catalog seed feature is now FULLY IMPLEMENTED end-to-end after this PR merges.

Builds on M7 (merged be0ad55cd, backend complete).

## What ships

| Task | Commit | Output |
|---|---|---|
| M8.1 | `cfea300b1` | SDK client (8 endpoints) + React Query hooks + EventSource SSE + Vitest tests |
| M8.2 | `827f5b359` | `/admin/catalog/seed-queue` page route + 2-column layout + KPI hero |
| M8.3 | `6f8a40c6a` | Wrapper components for #1835 reuse (`SeedQueueStatusHero`, `SeedLogStream`, etc.) |
| M8.4 | `a15c7dc91` | 3 new components: `WikidataSearchForm`, `SeedPreviewPanel`, `BggIdValidationBadge` + `BulkPasteForm`, `SingleAddForm` |
| M8.5 | `9be04adce` | E2E Playwright smoke (3 scenarios: render + bulk paste + filter chip) |
| M8.6 | `f724f28bd` | ADR-059 catalog-seed-legal-posture + operations runbook §19 + i18n keys (en/it) |

**59/59 FE test pass. TypeScript typecheck clean. ~25 source files created.**

## Cumulative feature scope (M1-M8)

| Milestone | Merge commit | Test count |
|---|---|---|
| M1 foundation | `18b7b8292` | 10 BE |
| M2 providers (Wikidata) | `171539266` | 7 BE |
| M3 BGG + whitelist | `f39fb57d5` | 10 BE |
| M4 aggregator + commands + queries | `01f24f731` | 42 BE |
| M5 Quartz + DI + event handler | `0deeda8bf` | 14 BE |
| M6 SSE + 8 endpoints | `1f2e2a4e9` | 12 BE |
| M7 ToS watcher + feature flag | `be0ad55cd` | 20 BE |
| **M8 Frontend** | **THIS PR** | **59 FE** |
| **Cumulative** | | **108 BE + 59 FE = 167** |

## Architecture decisions

- **Wrapper components over direct import**: #1835 components are tightly coupled to their own data hooks; wrappers in `seed-queue/components/` keep domain pure
- **i18n keys added but not wired**: existing #1835 page hardcoded its strings, this page follows same pattern. Keys forward-compatible for future migration
- **Playwright E2E**: 3 scenarios with `page.route` mocks (auth + SSE worked first-try)
- **ADR-059**: documents legal framework + decisions from spec §8.5 (BGG ToS / EU Database Directive / Feist / GDPR / Wikidata CC0)

## Pre-rollout checklist status (spec §8.5.6)

After this merge:
- [x] Feature flag default OFF ✓
- [x] BGG User-Agent on 3 paths ✓
- [x] BggTosWatcherJob active + always-on (M7 fix) ✓
- [x] Whitelist hard-coded + compliance test ✓
- [x] Audit log via domain events ✓
- [x] Admin UI ready ✓
- [x] Operations runbook ✓
- [x] ADR-059 ✓
- [ ] 1h legal review consultation (HUMAN ACTION before enabling flag)
- [ ] Terms of Service MeepleAI updated (HUMAN ACTION)
- [ ] `abuse@meepleai.app` mailbox active + monitored (HUMAN ACTION)

## Test plan

- [x] 59/59 FE tests pass
- [x] TypeScript typecheck clean
- [x] 3 Playwright E2E pass locally
- [ ] CI green

## Risk

LOW — flag default OFF, endpoints return 503 until admin enables, no user impact at deploy time.

🤖 8-milestone feature delivered via spec-panel → brainstorming → writing-plans → subagent-driven-development workflow.