### PR TITLE
feat(asse-a): #1896 semantic alignment v2.1 — invariants #10/#11/#13/#14/#15 + polymorphic ScoreType (DEC-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,9 @@ Quando tocchi i bounded context **`SessionTracking`** o **`GameManagement`** (su
 - Invariante max 1 live per GameNight (parallel play out of scope MVP)
 - Sidebar 2 voci game-related: Library (personale) + Games (catalogo, Discover come default tab)
 
-**Asse A v2 implementation** (umbrella #1895 sub-issue #1896): plan TDD in [`docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`](./docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md). Effort M+ ~12gg, 14 task TDD bite-sized (vs v1 XL 18gg, post-discovery rewrite eliminating ~33% over-scoped task assumendo backend scratch).
+**Asse A v2 implementation** (umbrella #1895 sub-issue #1896): plan TDD in [`docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`](./docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md). Plan v2.1 effort ~10.5gg dopo discovery WP4 già shipped upstream (#2053+#1629+#5005). **Stato shipped 2026-06-05 sessione 32**: WP1 (max 1 live) + WP2 (Session.StartedAt+invariante #15+X-Warning-Code+mapping doc) + WP3 (polymorphic ScoreType 4 strategies + UpdateSessionScoresCommand + IDOR guard) + WP4 audit-only + WP5 acceptance. Branch `feature/issue-1896-semantic-alignment` con ~15 commit (12 feat + 2 fix + 3 docs/audit). ~80+ unit test added, 0 regression. Security: 1 HIGH IDOR finding identificato post-merge T10 + fixato in `c1efb4fb6`.
+
+**Backend semantic mapping** (sezione "Backend Mapping" nel domain model spec): demo "GameNight" ↔ backend `GameNightEvent`, demo "tagged player" ↔ `GameNightEvent.PreInvite` (Draft, no event), demo "invited player" ↔ `Publish()` (raises events → email via `GameNightEmailService`), demo `Session.IsLive` ↔ `StartedAt != null && FinalizedAt == null`. Invariante #10 enforcement via `GameNightEvent.StartCurrentSession()` guard → `MaxLiveSessionsExceededException` (HTTP 409 via middleware). Invariante #15 wire via `SessionStartedHandler : INotificationHandler<SessionStartedDomainEvent>`.
 
 Companion: [gap report demo Claude Design](./docs/for-developers/audits/2026-06-04-claude-design-gap-report.md) (38 gap classificati 5-cat: ROUTE/STATE/CTA/ENTITY/TOKEN).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,9 +329,9 @@ Run `pnpm lint:tokens` to regenerate the inventory in `audits/2026-05-12-token-v
 
 ### Domain Model — GameNight / Session
 
-**Reference**: [`docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md`](./docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md) — 20 invarianti consolidate (9 fatti + 11 derivate), 5 tensioni risolte 2026-06-04.
+**Reference**: [`docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md`](./docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md) — 20 invarianti consolidate (9 fatti + 11 derivate), 5 tensioni risolte 2026-06-04. **Vedi anche § Backend Mapping** per la riconciliazione term demo ↔ backend (`GameNightEvent` aggregate, `Session` aggregate, `GameNightRsvp` vs `GameNightInvitation`).
 
-Quando tocchi i bounded context **`SessionTracking`** o **`GameManagement`** (sub-aggregate GameNight), questo spec è la source of truth per:
+Quando tocchi i bounded context **`SessionTracking`** o **`GameManagement`** (sub-aggregate GameNight `GameNightEvent`), questo spec è la source of truth per:
 - Cardinalità GameNight 1→N Session
 - 3 timestamp Session distinti (createdAt always, startedAt/completedAt nullable)
 - State machine GameNight (planned → in-progress via first Session, → completed manuale)
@@ -339,6 +339,8 @@ Quando tocchi i bounded context **`SessionTracking`** o **`GameManagement`** (su
 - Tagging vs RSVP a 5 fasi (tag silente → "Invia inviti" esplicito → pending → confermato)
 - Invariante max 1 live per GameNight (parallel play out of scope MVP)
 - Sidebar 2 voci game-related: Library (personale) + Games (catalogo, Discover come default tab)
+
+**Asse A v2 implementation** (umbrella #1895 sub-issue #1896): plan TDD in [`docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`](./docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md). Effort M+ ~12gg, 14 task TDD bite-sized (vs v1 XL 18gg, post-discovery rewrite eliminating ~33% over-scoped task assumendo backend scratch).
 
 Companion: [gap report demo Claude Design](./docs/for-developers/audits/2026-06-04-claude-design-gap-report.md) (38 gap classificati 5-cat: ROUTE/STATE/CTA/ENTITY/TOKEN).
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionStartedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionStartedHandler.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Asse A semantic alignment #1896 (WP2 T3): subscribes to
+/// <see cref="SessionStartedDomainEvent"/> (raised by <c>Session.OpenLiveMode()</c>)
+/// and triggers <see cref="GameNightEvent"/> transition
+/// <c>Published → InProgress</c> for the parent game night (invariante #15).
+///
+/// <para>Behavior:
+/// <list type="bullet">
+///   <item>Standalone Session (not linked to any GameNightEvent) → no-op + debug log.</item>
+///   <item>Parent GameNightEvent already <c>InProgress</c> → no-op (idempotent path
+///         inside <see cref="GameNightEvent.HandleFirstSessionStarted"/>).</item>
+///   <item>Parent GameNightEvent in <c>Published</c> → transition to
+///         <c>InProgress</c>, set <c>UpdatedAt</c>, persist via repository.</item>
+///   <item>Parent GameNightEvent in invalid state (Draft/Cancelled/Completed/Corrupted)
+///         → <see cref="InvalidOperationException"/> bubbles up to the dispatcher.</item>
+/// </list></para>
+/// </summary>
+internal sealed class SessionStartedHandler : INotificationHandler<SessionStartedDomainEvent>
+{
+    private readonly IGameNightEventRepository _gameNightRepository;
+    private readonly ILogger<SessionStartedHandler> _logger;
+
+    public SessionStartedHandler(
+        IGameNightEventRepository gameNightRepository,
+        ILogger<SessionStartedHandler> logger)
+    {
+        _gameNightRepository = gameNightRepository ?? throw new ArgumentNullException(nameof(gameNightRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(SessionStartedDomainEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var gameNight = await _gameNightRepository
+            .FindByLinkedSessionIdAsync(notification.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (gameNight is null)
+        {
+            _logger.LogDebug(
+                "SessionStartedDomainEvent for standalone Session {SessionId} — no parent GameNightEvent",
+                notification.SessionId);
+            return;
+        }
+
+        gameNight.HandleFirstSessionStarted(notification.SessionId);
+        await _gameNightRepository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "SessionStartedDomainEvent: GameNightEvent {GameNightId} transitioned to InProgress via Session {SessionId}",
+            gameNight.Id,
+            notification.SessionId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionStartedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionStartedHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -21,17 +22,25 @@ namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
 ///   <item>Parent GameNightEvent in invalid state (Draft/Cancelled/Completed/Corrupted)
 ///         → <see cref="InvalidOperationException"/> bubbles up to the dispatcher.</item>
 /// </list></para>
+///
+/// <para>Persistence note: dispatched post-<c>SaveChangesAsync()</c> of the outer
+/// SessionTracking transaction, so calls its own <see cref="IUnitOfWork.SaveChangesAsync"/>
+/// to flush the staged GameNightEvent.Status update. Without this commit, the change
+/// tracker would be discarded at request scope end (final code review CRITICAL fix).</para>
 /// </summary>
 internal sealed class SessionStartedHandler : INotificationHandler<SessionStartedDomainEvent>
 {
     private readonly IGameNightEventRepository _gameNightRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<SessionStartedHandler> _logger;
 
     public SessionStartedHandler(
         IGameNightEventRepository gameNightRepository,
+        IUnitOfWork unitOfWork,
         ILogger<SessionStartedHandler> logger)
     {
         _gameNightRepository = gameNightRepository ?? throw new ArgumentNullException(nameof(gameNightRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -53,6 +62,7 @@ internal sealed class SessionStartedHandler : INotificationHandler<SessionStarte
 
         gameNight.HandleFirstSessionStarted(notification.SessionId);
         await _gameNightRepository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "SessionStartedDomainEvent: GameNightEvent {GameNightId} transitioned to InProgress via Session {SessionId}",

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -416,6 +416,46 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Invariante #15 (Asse A semantic alignment, WP2 T3): trigger transition
+    /// Published → InProgress when the first Session in the game night becomes live.
+    ///
+    /// <para>Behavior:
+    /// <list type="bullet">
+    ///   <item>Published → InProgress (typical first-session-started case).</item>
+    ///   <item>InProgress → no-op (idempotent: AdHoc events start as InProgress, or
+    ///         subsequent sessions started after the first don't transition again).</item>
+    ///   <item>Other status (Draft/Cancelled/Completed/Corrupted) → throws.</item>
+    /// </list></para>
+    ///
+    /// <para>Called by <c>GameManagement.SessionStartedHandler</c>
+    /// (MediatR <c>INotificationHandler</c>) when a
+    /// <see cref="Api.BoundedContexts.SessionTracking.Domain.Events.SessionStartedDomainEvent"/>
+    /// is raised by <c>Session.OpenLiveMode()</c>.</para>
+    /// </summary>
+    /// <param name="sessionId">The Session aggregate ID that started (informational for events/logs).</param>
+    /// <exception cref="InvalidOperationException">When status is Draft/Cancelled/Completed/Corrupted.</exception>
+    public void HandleFirstSessionStarted(Guid sessionId)
+    {
+        ThrowIfCorrupted();
+
+        if (Status == GameNightStatus.Published)
+        {
+            Status = GameNightStatus.InProgress;
+            UpdatedAt = DateTimeOffset.UtcNow;
+            return;
+        }
+
+        if (Status == GameNightStatus.InProgress)
+        {
+            return; // idempotent
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot start session {sessionId} on GameNightEvent {Id}: status is {Status}. " +
+            $"Invariant #15 requires Published or InProgress status.");
+    }
+
+    /// <summary>
     /// Internal method to restore sessions list from persistence.
     /// </summary>
     internal void RestoreSessions(IEnumerable<GameNightSession> sessions)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.SharedKernel.Domain.Entities;
 
 namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
@@ -362,10 +363,18 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
 
     /// <summary>
     /// Starts the first pending session.
+    /// Enforces invariante #10 (GameNight/Session domain model): a GameNightEvent
+    /// can have at most 1 GameNightSession in InProgress at a time.
     /// </summary>
+    /// <exception cref="MaxLiveSessionsExceededException">
+    /// Thrown when another session is already in InProgress status on this event.
+    /// </exception>
     public void StartCurrentSession()
     {
         ThrowIfCorrupted();
+
+        if (_sessions.Any(s => s.Status == GameNightSessionStatus.InProgress))
+            throw new MaxLiveSessionsExceededException(Id);
 
         var session = _sessions.FirstOrDefault(s => s.Status == GameNightSessionStatus.Pending)
             ?? throw new InvalidOperationException("No pending session to start.");

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
@@ -23,4 +23,15 @@ internal interface IGameNightEventRepository : IRepository<GameNightEvent, Guid>
     /// </summary>
     Task<IReadOnlyList<GameNightEvent>> GetEventsNeedingReminderAsync(
         DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds the GameNightEvent aggregate containing a linked Session
+    /// (matched via <c>GameNightSession.SessionId</c>). Returns null if the Session
+    /// is standalone (not linked to any GameNight).
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>SessionStartedHandler</c> (Asse A WP2 T3, invariante #15) to locate
+    /// the parent game night when a Session transitions to live mode.
+    /// </remarks>
+    Task<GameNightEvent?> FindByLinkedSessionIdAsync(Guid sessionId, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
@@ -15,7 +15,7 @@ public sealed class MaxLiveSessionsExceededException : DomainException
     public Guid GameNightEventId { get; }
 
     public MaxLiveSessionsExceededException(Guid gameNightEventId)
-        : base($"GameNightEvent {gameNightEventId} already has an active live session (invariante #10: max 1 live).")
+        : base($"GameNightEvent {gameNightEventId} already has an active live session. At most 1 session may be InProgress at a time (invariant #10).")
     {
         GameNightEventId = gameNightEventId;
     }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
@@ -1,4 +1,5 @@
-using Api.SharedKernel.Domain.Exceptions;
+using System.Diagnostics.CodeAnalysis;
+using Api.Middleware.Exceptions;
 
 namespace Api.BoundedContexts.GameManagement.Domain.Exceptions;
 
@@ -7,13 +8,19 @@ namespace Api.BoundedContexts.GameManagement.Domain.Exceptions;
 /// GameNightEvent that already has an active live session. Enforces invariante #10
 /// of the GameNight/Session domain model: a GameNightEvent can have at most 1
 /// GameNightSession in InProgress at a time.
+///
+/// <para>Extends <see cref="ConflictException"/> so the HTTP layer auto-maps this
+/// to <c>409 Conflict</c> via the exception middleware (final code review IMPORTANT fix —
+/// previously extended <see cref="Api.SharedKernel.Domain.Exceptions.DomainException"/>
+/// which maps to 400 Bad Request, violating spec WP1 T1 contract).</para>
 /// </summary>
-public sealed class MaxLiveSessionsExceededException : DomainException
+public sealed class MaxLiveSessionsExceededException : ConflictException
 {
     public const string Code = "MAX_LIVE_SESSIONS_EXCEEDED";
 
     public Guid GameNightEventId { get; }
 
+    [SetsRequiredMembers]
     public MaxLiveSessionsExceededException(Guid gameNightEventId)
         : base($"GameNightEvent {gameNightEventId} already has an active live session. At most 1 session may be InProgress at a time (invariant #10).")
     {

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
@@ -1,0 +1,22 @@
+using Api.SharedKernel.Domain.Exceptions;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when attempting to start a second live (InProgress) session on a
+/// GameNightEvent that already has an active live session. Enforces invariante #10
+/// of the GameNight/Session domain model: a GameNightEvent can have at most 1
+/// GameNightSession in InProgress at a time.
+/// </summary>
+public sealed class MaxLiveSessionsExceededException : DomainException
+{
+    public const string Code = "MAX_LIVE_SESSIONS_EXCEEDED";
+
+    public Guid GameNightEventId { get; }
+
+    public MaxLiveSessionsExceededException(Guid gameNightEventId)
+        : base($"GameNightEvent {gameNightEventId} already has an active live session (invariante #10: max 1 live).")
+    {
+        GameNightEventId = gameNightEventId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -150,6 +150,23 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .AnyAsync(e => e.Id == id, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<GameNightEvent?> FindByLinkedSessionIdAsync(
+        Guid sessionId, CancellationToken cancellationToken = default)
+    {
+        // No AsNoTracking — the caller (SessionStartedHandler, invariante #15) mutates
+        // the aggregate via HandleFirstSessionStarted and persists via UpdateAsync,
+        // so the entity must be tracked end-to-end for change detection on Status/UpdatedAt.
+        var entity = await DbContext.GameNightEvents
+            .Include(e => e.Rsvps)
+            .Include(e => e.Sessions)
+            .FirstOrDefaultAsync(
+                e => e.Sessions.Any(s => s.SessionId == sessionId),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
     private static GameNightEventEntity MapToPersistence(GameNightEvent domain)
     {
         ArgumentNullException.ThrowIfNull(domain);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommand.cs
@@ -9,5 +9,6 @@ public record FinalizeSessionCommand(
 
 public record FinalizeSessionResult(
     Guid? WinnerId,
-    Dictionary<Guid, decimal> FinalScores
+    Dictionary<Guid, decimal> FinalScores,
+    bool LiveActiveWarning = false
 );

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
@@ -195,9 +195,31 @@ public class FinalizeSessionCommandHandler : IRequestHandler<FinalizeSessionComm
         // Channel — it does NOT go through MediatR — so there is no dual-dispatch risk.
         await _syncService.PublishEventAsync(request.SessionId, sessionFinalizedEvent, cancellationToken).ConfigureAwait(false);
 
+        // Invariante #13 (#1896 WP2 T4): detect a coexisting live session linked to the same
+        // GameNightEvent. When present, the response will carry X-Warning-Code:
+        // SAVED_WHILE_LIVE_ACTIVE so the FE can surface a non-blocking toast informing the
+        // user that draft+live siblings coexist. The operation itself is NOT blocked — 200 OK.
+        // Reuses gameNightId already resolved on line 150 (avoids a second round-trip).
+        // IsLive == (StartedAt != null && FinalizedAt == null). We exclude the current session
+        // by Id (its FinalizedAt was just set, but explicit exclusion is defensive against
+        // tracking-state ambiguity in InMemory provider used by unit tests).
+        bool liveActiveWarning = false;
+        if (gameNightId is not null)
+        {
+            liveActiveWarning = await _db.SessionTrackingSessions
+                .AsNoTracking()
+                .Where(s => s.Id != session.Id)
+                .Where(s => s.StartedAt != null && s.FinalizedAt == null)
+                .Where(s => _db.GameNightSessions.Any(link =>
+                    link.SessionId == s.Id && link.GameNightEventId == gameNightId))
+                .AnyAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         return new FinalizeSessionResult(
             winnerId != Guid.Empty ? winnerId : null,
-            finalScores
+            finalScores,
+            LiveActiveWarning: liveActiveWarning
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommand.cs
@@ -1,0 +1,31 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Asse A semantic alignment #1896 (T10, DEC-1): polymorphic mid-game score update.
+///
+/// <para>Distinct from <see cref="UpdateScoreCommand"/> (which adds a single per-participant
+/// score entry to the score history) — this command replaces the session's polymorphic
+/// <c>ScoringType</c> + <c>ScoreData</c> payload atomically. Validation is delegated to
+/// FluentValidation + <c>ScoringStrategyFactory</c> (T6+T7+T8) so each <see cref="ScoreType"/>
+/// enforces its own schema (Points / BinaryWin / Objectives / Ranking).</para>
+///
+/// <para>Use <c>FinalizeSessionCommand</c> for final-rank submission with session-status transition
+/// to <c>Finalized</c>; this command keeps the session in its current status.</para>
+/// </summary>
+public record UpdateSessionScoresCommand(
+    Guid SessionId,
+    ScoreType ScoringType,
+    string ScoreData
+) : IRequest<UpdateSessionScoresResult>;
+
+/// <summary>
+/// Result payload for <see cref="UpdateSessionScoresCommand"/>: echoes the persisted
+/// scoring type and surfaces the computed winner (when the strategy can determine one).
+/// </summary>
+public record UpdateSessionScoresResult(
+    Guid SessionId,
+    ScoreType ScoringType,
+    Guid? ComputedWinnerId);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommand.cs
@@ -18,7 +18,8 @@ namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 public record UpdateSessionScoresCommand(
     Guid SessionId,
     ScoreType ScoringType,
-    string ScoreData
+    string ScoreData,
+    Guid RequestedBy
 ) : IRequest<UpdateSessionScoresResult>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandHandler.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Asse A semantic alignment #1896 (T10, DEC-1): handler for polymorphic mid-game
+/// score update. Loads the session, delegates to <c>Session.SetScores</c> (T9 — raises
+/// <see cref="Api.BoundedContexts.SessionTracking.Domain.Events.SessionScoresUpdatedEvent"/>),
+/// persists via UoW, then computes the winner (when single) via the matching strategy.
+///
+/// <para>JSON schema validation already enforced upstream by
+/// <see cref="UpdateSessionScoresCommandValidator"/> in the MediatR FluentValidation
+/// behavior pipeline — this handler trusts the payload's structural validity.</para>
+/// </summary>
+public class UpdateSessionScoresCommandHandler
+    : IRequestHandler<UpdateSessionScoresCommand, UpdateSessionScoresResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ScoringStrategyFactory _factory;
+
+    public UpdateSessionScoresCommandHandler(
+        ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
+        ScoringStrategyFactory factory)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+    }
+
+    public async Task<UpdateSessionScoresResult> Handle(
+        UpdateSessionScoresCommand request,
+        CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        // Domain method enforces non-empty ScoreData + raises SessionScoresUpdatedEvent.
+        // Validation of JSON schema vs ScoringType has already been performed by
+        // UpdateSessionScoresCommandValidator in the FluentValidation pipeline.
+        session.SetScores(request.ScoringType, request.ScoreData);
+
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Compute winner via the matching strategy (null when undetermined: ties /
+        // cooperative all-win or all-lose / empty payload — strategy-specific).
+        var strategy = _factory.GetStrategy(request.ScoringType);
+        var winnerId = strategy.ComputeWinnerPlayerId(request.ScoreData);
+
+        return new UpdateSessionScoresResult(session.Id, request.ScoringType, winnerId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandHandler.cs
@@ -40,6 +40,16 @@ public class UpdateSessionScoresCommandHandler
         var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Session {request.SessionId} not found");
 
+        // IDOR guard (security review high-priority): only the session owner or a registered
+        // participant (User-linked) can mutate polymorphic scores. Mirrors the pattern used by
+        // ExportSessionHandlers + AdvanceTurnCommandHandler.
+        if (session.UserId != request.RequestedBy &&
+            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        {
+            throw new ForbiddenException(
+                $"User {request.RequestedBy} is not authorized to update scores for session {request.SessionId}.");
+        }
+
         // Domain method enforces non-empty ScoreData + raises SessionScoresUpdatedEvent.
         // Validation of JSON schema vs ScoringType has already been performed by
         // UpdateSessionScoresCommandValidator in the FluentValidation pipeline.

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandValidator.cs
@@ -26,6 +26,10 @@ public class UpdateSessionScoresCommandValidator : AbstractValidator<UpdateSessi
             .NotEmpty()
             .WithMessage("SessionId is required");
 
+        RuleFor(x => x.RequestedBy)
+            .NotEmpty()
+            .WithMessage("RequestedBy is required (extracted from authenticated user claims)");
+
         RuleFor(x => x.ScoreData)
             .Cascade(CascadeMode.Stop)
             .NotEmpty()

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdateSessionScoresCommandValidator.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Asse A semantic alignment #1896 (T10, DEC-1): FluentValidation rule that delegates
+/// JSON schema validation to the matching <see cref="IScoringStrategy"/> resolved via
+/// <see cref="ScoringStrategyFactory"/>.
+///
+/// <para>Per-rule semantics:
+/// <list type="bullet">
+///   <item><c>SessionId</c>: not empty.</item>
+///   <item><c>ScoreData</c>: not empty AND must pass the polymorphic strategy validator
+///   (Points/BinaryWin/Objectives/Ranking schema check).</item>
+/// </list>
+/// </para>
+/// </summary>
+public class UpdateSessionScoresCommandValidator : AbstractValidator<UpdateSessionScoresCommand>
+{
+    public UpdateSessionScoresCommandValidator(ScoringStrategyFactory factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("SessionId is required");
+
+        RuleFor(x => x.ScoreData)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage("ScoreData is required")
+            .Custom((scoreData, context) =>
+            {
+                var cmd = context.InstanceToValidate;
+                IScoringStrategy strategy;
+                try
+                {
+                    strategy = factory.GetStrategy(cmd.ScoringType);
+                }
+                catch (ArgumentOutOfRangeException ex)
+                {
+                    context.AddFailure(nameof(UpdateSessionScoresCommand.ScoringType), ex.Message);
+                    return;
+                }
+
+                var result = strategy.Validate(scoreData);
+                if (!result.IsValid)
+                {
+                    foreach (var err in result.Errors)
+                    {
+                        context.AddFailure(nameof(UpdateSessionScoresCommand.ScoreData), err);
+                    }
+                }
+            });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -105,6 +105,20 @@ public class Session : IDomainEventSource
     public bool IsLive => StartedAt.HasValue && FinalizedAt is null;
 
     /// <summary>
+    /// Polymorphic scoring type for this session (Asse A semantic alignment #1896, T9,
+    /// DEC-1). Defaults to <see cref="ScoreType.Points"/>. Updated via
+    /// <see cref="SetScores"/> together with <see cref="ScoreData"/>.
+    /// </summary>
+    public ScoreType ScoringType { get; private set; } = ScoreType.Points;
+
+    /// <summary>
+    /// Polymorphic score data as JSON string (persisted as JSONB). Shape varies by
+    /// <see cref="ScoringType"/> — validated by the corresponding IScoringStrategy in
+    /// the application layer (T10). Default = empty JSON object <c>"{}"</c>.
+    /// </summary>
+    public string ScoreData { get; private set; } = "{}";
+
+    /// <summary>
     /// Soft delete flag.
     /// </summary>
     public bool IsDeleted { get; private set; }
@@ -421,6 +435,31 @@ public class Session : IDomainEventSource
             var winner = _participants.First(p => p.Id == winnerId.Value);
             winner.SetFinalRank(1);
         }
+    }
+
+    /// <summary>
+    /// Sets the polymorphic score data for this session and raises a
+    /// <see cref="Events.SessionScoresUpdatedEvent"/>.
+    ///
+    /// <para>Asse A semantic alignment #1896 (T9, DEC-1): supersedes any prior
+    /// <see cref="ScoringType"/>/<see cref="ScoreData"/> assignment. JSON validation
+    /// against the per-type schema is performed by FluentValidation in the
+    /// application layer (T10 — <c>SaveSessionCommandHandler</c>); this method only
+    /// guards the trivial empty-string invariant.</para>
+    /// </summary>
+    /// <param name="scoringType">Polymorphic scoring type (Points, BinaryWin, Objectives, Ranking).</param>
+    /// <param name="scoreData">JSON string carrying the per-type score payload. Must not be empty.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="scoreData"/> is null, empty, or whitespace.</exception>
+    public void SetScores(ScoreType scoringType, string scoreData)
+    {
+        if (string.IsNullOrWhiteSpace(scoreData))
+            throw new ArgumentException("ScoreData cannot be empty.", nameof(scoreData));
+
+        ScoringType = scoringType;
+        ScoreData = scoreData;
+        UpdatedAt = DateTime.UtcNow;
+
+        AddDomainEvent(new Events.SessionScoresUpdatedEvent(Id, scoringType, scoreData));
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -89,6 +89,22 @@ public class Session : IDomainEventSource
     public DateTime? FinalizedAt { get; private set; }
 
     /// <summary>
+    /// When the session transitioned to live mode (via <see cref="OpenLiveMode"/>).
+    /// Null until live mode is opened. Distinct from <see cref="CreatedAt"/> (Asse A
+    /// semantic alignment #1896, invariante #11 — 3 distinct timestamps: createdAt
+    /// always, startedAt/completedAt nullable).
+    /// </summary>
+    public DateTime? StartedAt { get; private set; }
+
+    /// <summary>
+    /// True when the session is currently in live mode: <see cref="StartedAt"/> is set
+    /// AND <see cref="FinalizedAt"/> is still null. Used to enforce invariante #14
+    /// (max 1 live session per GameNight at any given moment) at the GameNight level.
+    /// Computed property (not persisted).
+    /// </summary>
+    public bool IsLive => StartedAt.HasValue && FinalizedAt is null;
+
+    /// <summary>
     /// Soft delete flag.
     /// </summary>
     public bool IsDeleted { get; private set; }
@@ -318,6 +334,45 @@ public class Session : IDomainEventSource
         // Sync IsOwner flag with Host role
         participant.IsOwner = newRole == ParticipantRole.Host;
         UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Transitions the session to live mode.
+    /// Sets <see cref="StartedAt"/> = UtcNow and raises a
+    /// <see cref="Events.SessionStartedDomainEvent"/> so that
+    /// <c>GameManagement.SessionStartedHandler</c> (T3) can transition the parent
+    /// <c>GameNight</c> from <c>Published</c> → <c>InProgress</c> (invariante #15).
+    ///
+    /// <para>Invariante #11 (Asse A semantic alignment #1896): Session has 3 distinct
+    /// timestamps — <see cref="CreatedAt"/> always, <see cref="StartedAt"/> nullable
+    /// (set here), <see cref="FinalizedAt"/> nullable (set by <see cref="Finalize"/>).
+    /// </para>
+    ///
+    /// <para>Invariante #14: max 1 live session per GameNight at any given moment —
+    /// enforced at the GameNight aggregate (T3 handler) before allowing a
+    /// <see cref="Events.SessionStartedDomainEvent"/> to trigger the GameNight transition.</para>
+    /// </summary>
+    /// <exception cref="ConflictException">Thrown when the session is already in live mode
+    /// or when it has already been finalized.</exception>
+    public void OpenLiveMode()
+    {
+        if (IsLive)
+            throw new ConflictException(
+                $"Session {Id} is already in live mode (StartedAt={StartedAt:O}).");
+        if (FinalizedAt.HasValue)
+            throw new ConflictException(
+                $"Session {Id} is already finalized (FinalizedAt={FinalizedAt:O}). Cannot open live mode.");
+
+        StartedAt = DateTime.UtcNow;
+        UpdatedAt = StartedAt;
+
+        AddDomainEvent(new Events.SessionStartedDomainEvent
+        {
+            SessionId = Id,
+            UserId = UserId,
+            GameId = GameId,
+            StartedAt = StartedAt.Value
+        });
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ScoreType.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ScoreType.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+/// <summary>
+/// DEC-1: Polymorphic scoring type for board game sessions. Each ScoreType
+/// maps to an IScoringStrategy implementation that validates + computes
+/// winner from JSON score_data. Stored in sessions.scoring_type column.
+/// Default = Points (covers ~50% catalog board games).
+/// </summary>
+public enum ScoreType
+{
+    /// <summary>Punti numerici per player (Wingspan, Catan, Azul).</summary>
+    [Description("Punti numerici per player")]
+    Points = 0,
+
+    /// <summary>Winner/Loser binario (cooperativo Pandemic, Forbidden Island).</summary>
+    [Description("Winner/Loser binario (cooperativo)")]
+    BinaryWin = 1,
+
+    /// <summary>Obiettivi completati per player (T.I.M.E. Stories, Sherlock Holmes).</summary>
+    [Description("Obiettivi completati per player")]
+    Objectives = 2,
+
+    /// <summary>Posizione 1..N per player (giochi a corsa, racing games).</summary>
+    [Description("Posizione 1..N per player")]
+    Ranking = 3,
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdatedEvent.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.SharedKernel.Domain.Interfaces;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Events;
+
+/// <summary>
+/// Domain event raised when <see cref="Entities.Session.SetScores"/> updates the
+/// session's polymorphic score data.
+///
+/// <para>Asse A semantic alignment #1896 (T9, DEC-1): records the moment the
+/// session's <c>ScoringType</c> + <c>ScoreData</c> were (re)assigned. Downstream
+/// consumers may react to score updates for invariante #15 (GameNight aggregate
+/// state transitions) or for notification flows. Currently no handler is wired;
+/// T10 will integrate this event with the <c>SaveSessionCommandHandler</c> path
+/// that performs FluentValidation against the polymorphic scoring strategies.</para>
+///
+/// <para>Mapper conventions (consistent with <see cref="SessionStartedDomainEvent"/>,
+/// <see cref="SessionCreatedEvent"/>, <see cref="SessionFinalizedEvent"/>): AggregateType
+/// is derived from the type name ("SessionScoresUpdated"); <see cref="AggregateId"/>
+/// aliases <see cref="SessionId"/>; payload is camelCase.</para>
+/// </summary>
+public record SessionScoresUpdatedEvent(
+    Guid SessionId,
+    ScoreType ScoringType,
+    string ScoreData) : IDomainEvent
+{
+    /// <summary>
+    /// IDomainEvent occurrence time — set to UtcNow at construction.
+    /// </summary>
+    public DateTime OccurredAt { get; init; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Unique identifier for this event instance (IDomainEvent — idempotency).
+    /// </summary>
+    public Guid EventId { get; init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Aggregate id read by the DomainEventLog mapper — alias over <see cref="SessionId"/>.
+    /// </summary>
+    public Guid AggregateId => SessionId;
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionStartedDomainEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionStartedDomainEvent.cs
@@ -1,0 +1,61 @@
+using Api.SharedKernel.Domain.Interfaces;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a <see cref="Entities.Session"/> transitions to live mode
+/// via <see cref="Entities.Session.OpenLiveMode"/>.
+///
+/// <para>Asse A semantic alignment #1896 (T2): records the timestamp at which the session
+/// became "live" (i.e. <c>StartedAt</c> set, <c>FinalizedAt</c> still null). Invariants
+/// #11 (Session has 3 distinct timestamps: createdAt always, startedAt/completedAt nullable)
+/// and #14 (max 1 live session per GameNight at any given moment) — invariant #14 is
+/// enforced by GameManagement.SessionStartedHandler (T3) which validates the parent
+/// GameNight has no other live Session before transitioning Published → InProgress.</para>
+///
+/// <para>Listener: <c>GameManagement.SessionStartedHandler</c> (added in T3) triggers
+/// <c>GameNightEvent</c> transition <c>Published → InProgress</c> (invariante #15).</para>
+///
+/// <para>Mapper conventions (consistent with <see cref="SessionCreatedEvent"/>,
+/// <see cref="SessionFinalizedEvent"/>): AggregateType derived "SessionStarted";
+/// AggregateId/UserId read via reflection; payload camelCase.
+/// <see cref="OccurredAt"/> and <see cref="AggregateId"/> alias the existing
+/// <see cref="StartedAt"/>/<see cref="SessionId"/> so no duplicate state is stored.</para>
+/// </summary>
+public record SessionStartedDomainEvent : IDomainEvent
+{
+    /// <summary>
+    /// Session unique identifier.
+    /// </summary>
+    public Guid SessionId { get; init; }
+
+    /// <summary>
+    /// User who owns the session (mapper reads this for the UserId column).
+    /// </summary>
+    public Guid UserId { get; init; }
+
+    /// <summary>
+    /// Game reference.
+    /// </summary>
+    public Guid GameId { get; init; }
+
+    /// <summary>
+    /// When the session was transitioned to live mode.
+    /// </summary>
+    public DateTime StartedAt { get; init; }
+
+    /// <summary>
+    /// Unique identifier for this event instance (IDomainEvent — idempotency).
+    /// </summary>
+    public Guid EventId { get; init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// IDomainEvent occurrence time — alias over <see cref="StartedAt"/>.
+    /// </summary>
+    public DateTime OccurredAt => StartedAt;
+
+    /// <summary>
+    /// Aggregate id read by the DomainEventLog mapper — alias over <see cref="SessionId"/>.
+    /// </summary>
+    public Guid AggregateId => SessionId;
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// DEC-1 stub: Binary win/loss scoring strategy (filled in T7).
+/// Handles cooperative all-win/all-lose outcomes (Pandemic, Forbidden Island).
+/// </summary>
+public sealed class BinaryWinScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.BinaryWin;
+
+    public ScoringValidationResult Validate(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T7");
+
+    public string Serialize(object scoreData) =>
+        throw new NotSupportedException("Filled in T7");
+
+    public object Deserialize(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T7");
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T7");
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs
@@ -1,24 +1,84 @@
+using System.Text.Json;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
 
 /// <summary>
-/// DEC-1 stub: Binary win/loss scoring strategy (filled in T7).
-/// Handles cooperative all-win/all-lose outcomes (Pandemic, Forbidden Island).
+/// DEC-1: Binary win/loss scoring (cooperative Pandemic, Forbidden Island).
+/// Winner = single IsWinner=true player. Cooperative all-win or all-lose = null winner.
 /// </summary>
 public sealed class BinaryWinScoringStrategy : IScoringStrategy
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     public ScoreType Type => ScoreType.BinaryWin;
 
-    public ScoringValidationResult Validate(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T7");
+    public ScoringValidationResult Validate(string scoreDataJson)
+    {
+        if (string.IsNullOrWhiteSpace(scoreDataJson))
+            return ScoringValidationResult.Failed("scoreDataJson cannot be empty");
 
-    public string Serialize(object scoreData) =>
-        throw new NotSupportedException("Filled in T7");
+        BinaryWinScoreData? data;
+        try
+        {
+            data = JsonSerializer.Deserialize<BinaryWinScoreData>(scoreDataJson, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            return ScoringValidationResult.Failed($"Invalid JSON: {ex.Message}");
+        }
 
-    public object Deserialize(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T7");
+        if (data?.Results is null || data.Results.Count == 0)
+            return ScoringValidationResult.Failed("No results provided");
 
-    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T7");
+        var errors = new List<string>();
+        if (data.Results.Any(r => r.PlayerId == Guid.Empty))
+            errors.Add("PlayerId cannot be empty");
+        if (data.Results.GroupBy(r => r.PlayerId).Any(g => g.Count() > 1))
+            errors.Add("Duplicate playerId in results");
+
+        return errors.Count > 0
+            ? ScoringValidationResult.Failed(errors)
+            : ScoringValidationResult.Valid();
+    }
+
+    public string Serialize(object scoreData)
+    {
+        if (scoreData is not BinaryWinScoreData data)
+            throw new ArgumentException(
+                $"Expected BinaryWinScoreData, got {scoreData?.GetType().Name ?? "null"}",
+                nameof(scoreData));
+        return JsonSerializer.Serialize(data, JsonOptions);
+    }
+
+    public object Deserialize(string scoreDataJson)
+    {
+        var data = JsonSerializer.Deserialize<BinaryWinScoreData>(scoreDataJson, JsonOptions)
+            ?? throw new JsonException("Failed to deserialize BinaryWinScoreData");
+        return data;
+    }
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson)
+    {
+        var data = (BinaryWinScoreData)Deserialize(scoreDataJson);
+        if (data.Results.Count == 0) return null;
+
+        var winners = data.Results.Where(r => r.IsWinner).ToList();
+        // Single winner = that player; cooperative all-win or all-lose = null
+        return winners.Count == 1 ? winners[0].PlayerId : null;
+    }
 }
+
+/// <summary>
+/// JSON payload for ScoreType.BinaryWin sessions.
+/// </summary>
+public record BinaryWinScoreData(IReadOnlyList<BinaryPlayerResult> Results);
+
+/// <summary>
+/// Single player's binary win/lose result.
+/// </summary>
+public record BinaryPlayerResult(Guid PlayerId, bool IsWinner);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/IScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/IScoringStrategy.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// DEC-1: Strategy pattern for polymorphic session scoring.
+/// Each implementation validates and processes JSON score_data per ScoreType.
+/// Concrete strategies: PointsScoringStrategy, BinaryWinScoringStrategy,
+/// ObjectivesScoringStrategy, RankingScoringStrategy (T7, T8 implementation).
+/// </summary>
+public interface IScoringStrategy
+{
+    /// <summary>The ScoreType this strategy handles.</summary>
+    ScoreType Type { get; }
+
+    /// <summary>
+    /// Validates a JSON score_data payload against the strategy's schema.
+    /// Returns ScoringValidationResult.Valid() or .Failed(errors).
+    /// </summary>
+    ScoringValidationResult Validate(string scoreDataJson);
+
+    /// <summary>
+    /// Serializes a strongly-typed score data object to JSON for persistence.
+    /// </summary>
+    string Serialize(object scoreData);
+
+    /// <summary>
+    /// Deserializes a JSON score_data payload to a strongly-typed object.
+    /// </summary>
+    object Deserialize(string scoreDataJson);
+
+    /// <summary>
+    /// Computes the winner playerId from the score_data. Returns null when
+    /// no single winner can be determined (e.g., cooperative all-win/all-lose,
+    /// or tied scores).
+    /// </summary>
+    Guid? ComputeWinnerPlayerId(string scoreDataJson);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs
@@ -1,24 +1,90 @@
+using System.Text.Json;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
 
 /// <summary>
-/// DEC-1 stub: Objectives-based scoring strategy (filled in T8).
-/// Handles per-player objective completion counts (T.I.M.E. Stories, Sherlock Holmes).
+/// DEC-1: Objectives-based scoring (T.I.M.E. Stories, Sherlock Holmes Consulting Detective).
+/// Each player has a list of completed objective names. Winner = player with most objectives.
+/// Ties (multiple players with same highest count) = null winner.
 /// </summary>
 public sealed class ObjectivesScoringStrategy : IScoringStrategy
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     public ScoreType Type => ScoreType.Objectives;
 
-    public ScoringValidationResult Validate(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T8");
+    public ScoringValidationResult Validate(string scoreDataJson)
+    {
+        if (string.IsNullOrWhiteSpace(scoreDataJson))
+            return ScoringValidationResult.Failed("scoreDataJson cannot be empty");
 
-    public string Serialize(object scoreData) =>
-        throw new NotSupportedException("Filled in T8");
+        ObjectivesScoreData? data;
+        try
+        {
+            data = JsonSerializer.Deserialize<ObjectivesScoreData>(scoreDataJson, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            return ScoringValidationResult.Failed($"Invalid JSON: {ex.Message}");
+        }
 
-    public object Deserialize(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T8");
+        if (data?.CompletedByPlayer is null || data.CompletedByPlayer.Count == 0)
+            return ScoringValidationResult.Failed("No players provided");
 
-    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T8");
+        var errors = new List<string>();
+        if (data.CompletedByPlayer.Any(p => p.PlayerId == Guid.Empty))
+            errors.Add("PlayerId cannot be empty");
+        if (data.CompletedByPlayer.GroupBy(p => p.PlayerId).Any(g => g.Count() > 1))
+            errors.Add("Duplicate playerId in completedByPlayer");
+        // Objectives list può essere empty per player (player non ha completato nulla = OK semanticamente)
+        if (data.CompletedByPlayer.Any(p => p.Objectives is null))
+            errors.Add("Objectives list cannot be null (use empty list)");
+        if (data.CompletedByPlayer.Any(p => p.Objectives is not null && p.Objectives.Any(string.IsNullOrWhiteSpace)))
+            errors.Add("Objective names cannot be empty/whitespace");
+
+        return errors.Count > 0
+            ? ScoringValidationResult.Failed(errors)
+            : ScoringValidationResult.Valid();
+    }
+
+    public string Serialize(object scoreData)
+    {
+        if (scoreData is not ObjectivesScoreData data)
+            throw new ArgumentException(
+                $"Expected ObjectivesScoreData, got {scoreData?.GetType().Name ?? "null"}",
+                nameof(scoreData));
+        return JsonSerializer.Serialize(data, JsonOptions);
+    }
+
+    public object Deserialize(string scoreDataJson)
+    {
+        var data = JsonSerializer.Deserialize<ObjectivesScoreData>(scoreDataJson, JsonOptions)
+            ?? throw new JsonException("Failed to deserialize ObjectivesScoreData");
+        return data;
+    }
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson)
+    {
+        var data = (ObjectivesScoreData)Deserialize(scoreDataJson);
+        if (data.CompletedByPlayer.Count == 0) return null;
+
+        var maxCount = data.CompletedByPlayer.Max(p => p.Objectives.Count);
+        var winners = data.CompletedByPlayer.Where(p => p.Objectives.Count == maxCount).ToList();
+        return winners.Count == 1 ? winners[0].PlayerId : null; // tie = null
+    }
 }
+
+/// <summary>
+/// JSON payload for ScoreType.Objectives sessions.
+/// </summary>
+public record ObjectivesScoreData(IReadOnlyList<PlayerObjectives> CompletedByPlayer);
+
+/// <summary>
+/// Single player's completed objective list.
+/// </summary>
+public record PlayerObjectives(Guid PlayerId, IReadOnlyList<string> Objectives);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// DEC-1 stub: Objectives-based scoring strategy (filled in T8).
+/// Handles per-player objective completion counts (T.I.M.E. Stories, Sherlock Holmes).
+/// </summary>
+public sealed class ObjectivesScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.Objectives;
+
+    public ScoringValidationResult Validate(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T8");
+
+    public string Serialize(object scoreData) =>
+        throw new NotSupportedException("Filled in T8");
+
+    public object Deserialize(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T8");
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T8");
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// DEC-1 stub: Points scoring strategy (filled in T7).
+/// Handles numeric points per player (Wingspan, Catan, Azul).
+/// </summary>
+public sealed class PointsScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.Points;
+
+    public ScoringValidationResult Validate(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T7");
+
+    public string Serialize(object scoreData) =>
+        throw new NotSupportedException("Filled in T7");
+
+    public object Deserialize(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T7");
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T7");
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs
@@ -1,24 +1,86 @@
+using System.Text.Json;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
 
 /// <summary>
-/// DEC-1 stub: Points scoring strategy (filled in T7).
-/// Handles numeric points per player (Wingspan, Catan, Azul).
+/// DEC-1: Numeric points scoring (Wingspan, Catan, Azul, etc.).
+/// Winner = player with highest points. Ties = null winner.
 /// </summary>
 public sealed class PointsScoringStrategy : IScoringStrategy
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     public ScoreType Type => ScoreType.Points;
 
-    public ScoringValidationResult Validate(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T7");
+    public ScoringValidationResult Validate(string scoreDataJson)
+    {
+        if (string.IsNullOrWhiteSpace(scoreDataJson))
+            return ScoringValidationResult.Failed("scoreDataJson cannot be empty");
 
-    public string Serialize(object scoreData) =>
-        throw new NotSupportedException("Filled in T7");
+        PointsScoreData? data;
+        try
+        {
+            data = JsonSerializer.Deserialize<PointsScoreData>(scoreDataJson, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            return ScoringValidationResult.Failed($"Invalid JSON: {ex.Message}");
+        }
 
-    public object Deserialize(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T7");
+        if (data?.Scores is null || data.Scores.Count == 0)
+            return ScoringValidationResult.Failed("No scores provided");
 
-    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T7");
+        var errors = new List<string>();
+        if (data.Scores.Any(s => s.Points < 0))
+            errors.Add("Points must be non-negative");
+        if (data.Scores.Any(s => s.PlayerId == Guid.Empty))
+            errors.Add("PlayerId cannot be empty");
+        if (data.Scores.GroupBy(s => s.PlayerId).Any(g => g.Count() > 1))
+            errors.Add("Duplicate playerId in scores");
+
+        return errors.Count > 0
+            ? ScoringValidationResult.Failed(errors)
+            : ScoringValidationResult.Valid();
+    }
+
+    public string Serialize(object scoreData)
+    {
+        if (scoreData is not PointsScoreData data)
+            throw new ArgumentException(
+                $"Expected PointsScoreData, got {scoreData?.GetType().Name ?? "null"}",
+                nameof(scoreData));
+        return JsonSerializer.Serialize(data, JsonOptions);
+    }
+
+    public object Deserialize(string scoreDataJson)
+    {
+        var data = JsonSerializer.Deserialize<PointsScoreData>(scoreDataJson, JsonOptions)
+            ?? throw new JsonException("Failed to deserialize PointsScoreData");
+        return data;
+    }
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson)
+    {
+        var data = (PointsScoreData)Deserialize(scoreDataJson);
+        if (data.Scores.Count == 0) return null;
+
+        var maxPoints = data.Scores.Max(s => s.Points);
+        var winners = data.Scores.Where(s => s.Points == maxPoints).ToList();
+        return winners.Count == 1 ? winners[0].PlayerId : null; // tie = null
+    }
 }
+
+/// <summary>
+/// JSON payload for ScoreType.Points sessions.
+/// </summary>
+public record PointsScoreData(IReadOnlyList<PlayerScore> Scores);
+
+/// <summary>
+/// Single player's numeric points entry.
+/// </summary>
+public record PlayerScore(Guid PlayerId, int Points);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs
@@ -1,24 +1,93 @@
+using System.Text.Json;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
 
 /// <summary>
-/// DEC-1 stub: Ranking-based scoring strategy (filled in T8).
-/// Handles per-player position 1..N (racing games, time trials).
+/// DEC-1: Ranking-based scoring (racing games, time trials).
+/// Each player has integer position 1..N. Winner = player at position 1.
+/// Validation: distinct positions, sequential 1..N (no gaps), N == player count.
 /// </summary>
 public sealed class RankingScoringStrategy : IScoringStrategy
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     public ScoreType Type => ScoreType.Ranking;
 
-    public ScoringValidationResult Validate(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T8");
+    public ScoringValidationResult Validate(string scoreDataJson)
+    {
+        if (string.IsNullOrWhiteSpace(scoreDataJson))
+            return ScoringValidationResult.Failed("scoreDataJson cannot be empty");
 
-    public string Serialize(object scoreData) =>
-        throw new NotSupportedException("Filled in T8");
+        RankingScoreData? data;
+        try
+        {
+            data = JsonSerializer.Deserialize<RankingScoreData>(scoreDataJson, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            return ScoringValidationResult.Failed($"Invalid JSON: {ex.Message}");
+        }
 
-    public object Deserialize(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T8");
+        if (data?.Positions is null || data.Positions.Count == 0)
+            return ScoringValidationResult.Failed("No positions provided");
 
-    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
-        throw new NotSupportedException("Filled in T8");
+        var errors = new List<string>();
+        if (data.Positions.Any(p => p.PlayerId == Guid.Empty))
+            errors.Add("PlayerId cannot be empty");
+        if (data.Positions.GroupBy(p => p.PlayerId).Any(g => g.Count() > 1))
+            errors.Add("Duplicate playerId in positions");
+        if (data.Positions.Any(p => p.Position < 1))
+            errors.Add("Position must be >= 1");
+
+        // Sequential 1..N + distinct (only check if no Position<1 errors, to avoid cascading)
+        if (!data.Positions.Any(p => p.Position < 1))
+        {
+            var positions = data.Positions.Select(p => p.Position).OrderBy(x => x).ToList();
+            var expected = Enumerable.Range(1, data.Positions.Count).ToList();
+            if (!positions.SequenceEqual(expected))
+                errors.Add($"Positions must be sequential 1..{data.Positions.Count}, distinct, no gaps");
+        }
+
+        return errors.Count > 0
+            ? ScoringValidationResult.Failed(errors)
+            : ScoringValidationResult.Valid();
+    }
+
+    public string Serialize(object scoreData)
+    {
+        if (scoreData is not RankingScoreData data)
+            throw new ArgumentException(
+                $"Expected RankingScoreData, got {scoreData?.GetType().Name ?? "null"}",
+                nameof(scoreData));
+        return JsonSerializer.Serialize(data, JsonOptions);
+    }
+
+    public object Deserialize(string scoreDataJson)
+    {
+        var data = JsonSerializer.Deserialize<RankingScoreData>(scoreDataJson, JsonOptions)
+            ?? throw new JsonException("Failed to deserialize RankingScoreData");
+        return data;
+    }
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson)
+    {
+        var data = (RankingScoreData)Deserialize(scoreDataJson);
+        var first = data.Positions.FirstOrDefault(p => p.Position == 1);
+        return first?.PlayerId; // distinct positions validated, so always 1 winner if valid
+    }
 }
+
+/// <summary>
+/// JSON payload for ScoreType.Ranking sessions.
+/// </summary>
+public record RankingScoreData(IReadOnlyList<PlayerRanking> Positions);
+
+/// <summary>
+/// Single player's ranking position (1-based).
+/// </summary>
+public record PlayerRanking(Guid PlayerId, int Position);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// DEC-1 stub: Ranking-based scoring strategy (filled in T8).
+/// Handles per-player position 1..N (racing games, time trials).
+/// </summary>
+public sealed class RankingScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.Ranking;
+
+    public ScoringValidationResult Validate(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T8");
+
+    public string Serialize(object scoreData) =>
+        throw new NotSupportedException("Filled in T8");
+
+    public object Deserialize(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T8");
+
+    public Guid? ComputeWinnerPlayerId(string scoreDataJson) =>
+        throw new NotSupportedException("Filled in T8");
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactory.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactory.cs
@@ -1,0 +1,20 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// DEC-1: Factory dispatch for IScoringStrategy implementations based on ScoreType.
+/// Used by SaveSessionCommandValidator (T10) and SessionScoresUpdated event handlers.
+/// </summary>
+public sealed class ScoringStrategyFactory
+{
+    public IScoringStrategy GetStrategy(ScoreType type) => type switch
+    {
+        ScoreType.Points => new PointsScoringStrategy(),
+        ScoreType.BinaryWin => new BinaryWinScoringStrategy(),
+        ScoreType.Objectives => new ObjectivesScoringStrategy(),
+        ScoreType.Ranking => new RankingScoringStrategy(),
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type,
+            $"Unknown ScoreType: {type}"),
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringValidationResult.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringValidationResult.cs
@@ -1,0 +1,16 @@
+namespace Api.BoundedContexts.SessionTracking.Domain.Scoring;
+
+/// <summary>
+/// Result of IScoringStrategy.Validate(). Encapsulates IsValid flag + error list.
+/// Internal to Scoring namespace (no shared kernel dependency).
+/// </summary>
+public sealed record ScoringValidationResult(bool IsValid, IReadOnlyList<string> Errors)
+{
+    public static ScoringValidationResult Valid() => new(true, Array.Empty<string>());
+
+    public static ScoringValidationResult Failed(string error) =>
+        new(false, new[] { error });
+
+    public static ScoringValidationResult Failed(IEnumerable<string> errors) =>
+        new(false, errors.ToList().AsReadOnly());
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Health;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
@@ -84,6 +85,11 @@ internal static class SessionTrackingServiceExtensions
         // Singleton: NTextCatLanguageDetectionService loads ~2.4MB profile once at startup
         // and is thread-safe (RankedLanguageIdentifier is read-only post-construction).
         services.AddSingleton<ILanguageDetectionService, NTextCatLanguageDetectionService>();
+
+        // Asse A semantic alignment #1896 (T10, DEC-1): polymorphic scoring strategy factory.
+        // Singleton — instantiates stateless strategies on demand (no internal state, thread-safe).
+        // Consumed by UpdateSessionScoresCommandValidator + UpdateSessionScoresCommandHandler.
+        services.AddSingleton<ScoringStrategyFactory>();
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -61,6 +61,23 @@ public class SessionConfiguration : IEntityTypeConfiguration<SessionEntity>
         builder.Property(s => s.StartedAt)
             .HasColumnName("started_at");
 
+        // Asse A semantic alignment #1896 (T9, DEC-1): Session.ScoringType — polymorphic
+        // scoring type string ("Points" | "BinaryWin" | "Objectives" | "Ranking").
+        // Defaults to "Points" (covers ~50% catalog board games).
+        builder.Property(s => s.ScoringType)
+            .HasColumnName("scoring_type")
+            .HasMaxLength(20)
+            .HasDefaultValue("Points")
+            .IsRequired();
+
+        // Asse A semantic alignment #1896 (T9, DEC-1): Session.ScoreData — polymorphic
+        // score data as JSONB. Shape varies by ScoringType. Default '{}'.
+        builder.Property(s => s.ScoreData)
+            .HasColumnName("score_data")
+            .HasColumnType("jsonb")
+            .HasDefaultValueSql("'{}'::jsonb")
+            .IsRequired();
+
         builder.Property(s => s.IsDeleted)
             .HasColumnName("is_deleted")
             .IsRequired()

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -56,6 +56,11 @@ public class SessionConfiguration : IEntityTypeConfiguration<SessionEntity>
         builder.Property(s => s.FinalizedAt)
             .HasColumnName("finalized_at");
 
+        // Asse A semantic alignment #1896 (T2): Session.StartedAt — when the session
+        // transitioned to live mode via OpenLiveMode(). Invariante #11.
+        builder.Property(s => s.StartedAt)
+            .HasColumnName("started_at");
+
         builder.Property(s => s.IsDeleted)
             .HasColumnName("is_deleted")
             .IsRequired()

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
@@ -23,6 +23,7 @@ internal static class SessionMapper
             SessionDate = domain.SessionDate,
             Location = domain.Location,
             FinalizedAt = domain.FinalizedAt,
+            StartedAt = domain.StartedAt,
             IsDeleted = domain.IsDeleted,
             DeletedAt = domain.DeletedAt,
             CreatedAt = domain.CreatedAt,
@@ -56,6 +57,7 @@ internal static class SessionMapper
         typeof(Session).GetProperty(nameof(Session.SessionDate))!.SetValue(session, entity.SessionDate);
         typeof(Session).GetProperty(nameof(Session.Location))!.SetValue(session, entity.Location);
         typeof(Session).GetProperty(nameof(Session.FinalizedAt))!.SetValue(session, entity.FinalizedAt);
+        typeof(Session).GetProperty(nameof(Session.StartedAt))!.SetValue(session, entity.StartedAt);
         typeof(Session).GetProperty(nameof(Session.IsDeleted))!.SetValue(session, entity.IsDeleted);
         typeof(Session).GetProperty(nameof(Session.DeletedAt))!.SetValue(session, entity.DeletedAt);
         typeof(Session).GetProperty(nameof(Session.CreatedAt))!.SetValue(session, entity.CreatedAt);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Infrastructure.Entities.SessionTracking;
 
 namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
@@ -24,6 +25,8 @@ internal static class SessionMapper
             Location = domain.Location,
             FinalizedAt = domain.FinalizedAt,
             StartedAt = domain.StartedAt,
+            ScoringType = domain.ScoringType.ToString(),
+            ScoreData = domain.ScoreData,
             IsDeleted = domain.IsDeleted,
             DeletedAt = domain.DeletedAt,
             CreatedAt = domain.CreatedAt,
@@ -58,6 +61,8 @@ internal static class SessionMapper
         typeof(Session).GetProperty(nameof(Session.Location))!.SetValue(session, entity.Location);
         typeof(Session).GetProperty(nameof(Session.FinalizedAt))!.SetValue(session, entity.FinalizedAt);
         typeof(Session).GetProperty(nameof(Session.StartedAt))!.SetValue(session, entity.StartedAt);
+        typeof(Session).GetProperty(nameof(Session.ScoringType))!.SetValue(session, Enum.Parse<ScoreType>(entity.ScoringType));
+        typeof(Session).GetProperty(nameof(Session.ScoreData))!.SetValue(session, entity.ScoreData);
         typeof(Session).GetProperty(nameof(Session.IsDeleted))!.SetValue(session, entity.IsDeleted);
         typeof(Session).GetProperty(nameof(Session.DeletedAt))!.SetValue(session, entity.DeletedAt);
         typeof(Session).GetProperty(nameof(Session.CreatedAt))!.SetValue(session, entity.CreatedAt);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -111,6 +111,9 @@ public class SessionRepository : RepositoryBase, ISessionRepository
         existing.Status = session.Status.ToString();
         existing.Location = session.Location;
         existing.FinalizedAt = session.FinalizedAt;
+        // Asse A semantic alignment #1896 (T2): propagate StartedAt so OpenLiveMode()
+        // domain transitions are persisted by UpdateAsync. Invariante #11.
+        existing.StartedAt = session.StartedAt;
         existing.IsDeleted = session.IsDeleted;
         existing.DeletedAt = session.DeletedAt;
         existing.UpdatedAt = session.UpdatedAt;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -114,6 +114,10 @@ public class SessionRepository : RepositoryBase, ISessionRepository
         // Asse A semantic alignment #1896 (T2): propagate StartedAt so OpenLiveMode()
         // domain transitions are persisted by UpdateAsync. Invariante #11.
         existing.StartedAt = session.StartedAt;
+        // Asse A semantic alignment #1896 (T9, DEC-1): propagate polymorphic
+        // ScoringType + ScoreData so SetScores() domain transitions are persisted.
+        existing.ScoringType = session.ScoringType.ToString();
+        existing.ScoreData = session.ScoreData;
         existing.IsDeleted = session.IsDeleted;
         existing.DeletedAt = session.DeletedAt;
         existing.UpdatedAt = session.UpdatedAt;

--- a/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
@@ -27,6 +27,14 @@ public class SessionEntity
     public string? Location { get; set; }
 
     public DateTime? FinalizedAt { get; set; }
+
+    /// <summary>
+    /// When the session transitioned to live mode (via Session.OpenLiveMode).
+    /// Null until live mode is opened. Asse A semantic alignment #1896 (T2,
+    /// invariante #11) — column <c>started_at</c>.
+    /// </summary>
+    public DateTime? StartedAt { get; set; }
+
     public bool IsDeleted { get; set; }
     public DateTime? DeletedAt { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
@@ -35,6 +35,22 @@ public class SessionEntity
     /// </summary>
     public DateTime? StartedAt { get; set; }
 
+    /// <summary>
+    /// Polymorphic scoring type for the session — one of <see cref="Api.BoundedContexts.SessionTracking.Domain.Enums.ScoreType"/>
+    /// values stored as string ("Points", "BinaryWin", "Objectives", "Ranking").
+    /// Asse A semantic alignment #1896 (T9, DEC-1) — column <c>scoring_type</c>.
+    /// Default = "Points".
+    /// </summary>
+    [MaxLength(20)]
+    public string ScoringType { get; set; } = "Points";
+
+    /// <summary>
+    /// Polymorphic score data as JSONB. Shape varies by <see cref="ScoringType"/>.
+    /// Asse A semantic alignment #1896 (T9, DEC-1) — column <c>score_data</c>.
+    /// Default = "{}".
+    /// </summary>
+    public string ScoreData { get; set; } = "{}";
+
     public bool IsDeleted { get; set; }
     public DateTime? DeletedAt { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604185208_AddSessionStartedAt.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604185208_AddSessionStartedAt.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604185208_AddSessionStartedAt")]
+    partial class AddSessionStartedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604185208_AddSessionStartedAt.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604185208_AddSessionStartedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionStartedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "started_at",
+                table: "session_tracking_sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "started_at",
+                table: "session_tracking_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604205354_AddSessionScoringType.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604205354_AddSessionScoringType.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604205354_AddSessionScoringType")]
+    partial class AddSessionScoringType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260604205354_AddSessionScoringType.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260604205354_AddSessionScoringType.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionScoringType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "score_data",
+                table: "session_tracking_sessions",
+                type: "jsonb",
+                nullable: false,
+                defaultValueSql: "'{}'::jsonb");
+
+            migrationBuilder.AddColumn<string>(
+                name: "scoring_type",
+                table: "session_tracking_sessions",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Points");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "score_data",
+                table: "session_tracking_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "scoring_type",
+                table: "session_tracking_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
@@ -90,10 +90,19 @@ internal static class SessionCommandEndpoints
         group.MapPut("/game-sessions/{sessionId:guid}/scores-polymorphic", async (
             Guid sessionId,
             UpdateSessionScoresRequest request,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var command = new UpdateSessionScoresCommand(sessionId, request.ScoringType, request.ScoreData);
+            // IDOR guard (security review high-priority): extract authenticated user id
+            // from claims; handler verifies the caller is the session owner or a participant.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var command = new UpdateSessionScoresCommand(sessionId, request.ScoringType, request.ScoreData, userId);
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
@@ -101,10 +110,11 @@ internal static class SessionCommandEndpoints
         .WithName("UpdateSessionScoresPolymorphic")
         .WithTags("SessionTracking")
         .WithSummary("Update session polymorphic scores (Points/BinaryWin/Objectives/Ranking)")
-        .WithDescription("Asse A #1896 (T10): replaces ScoringType + ScoreData atomically with per-type JSON schema validation.")
+        .WithDescription("Asse A #1896 (T10): replaces ScoringType + ScoreData atomically with per-type JSON schema validation. Caller must be session owner or registered participant (IDOR-protected).")
         .Produces(200)
         .Produces(400)
         .Produces(401)
+        .Produces(403)
         .Produces(404);
     }
 

--- a/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
@@ -123,6 +123,7 @@ internal static class SessionCommandEndpoints
             Guid sessionId,
             FinalizeSessionCommand command,
             IMediator mediator,
+            HttpResponse response,
             CancellationToken ct) =>
         {
             if (sessionId != command.SessionId)
@@ -131,6 +132,15 @@ internal static class SessionCommandEndpoints
             }
 
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            // Invariante #13 (#1896 WP2 T4): non-blocking warning header for FE toast when
+            // a draft+live session coexist in the same GameNightEvent. The operation itself
+            // succeeded (200 OK); the header is purely informational.
+            if (result.LiveActiveWarning)
+            {
+                response.Headers.Append("X-Warning-Code", "SAVED_WHILE_LIVE_ACTIVE");
+            }
+
             return Results.Ok(result);
         })
         .RequireAuthenticatedUser()

--- a/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Extensions;
 using MediatR;
 
@@ -13,11 +14,20 @@ internal static class SessionCommandEndpoints
     {
         MapCreateSessionEndpoint(group);
         MapUpdateScoreEndpoint(group);
+        MapUpdateSessionScoresEndpoint(group); // T10 #1896 — polymorphic
         MapAddParticipantEndpoint(group);
         MapAddNoteEndpoint(group);
         MapFinalizeSessionEndpoint(group);
         MapRollDiceEndpoint(group);
     }
+
+    /// <summary>
+    /// Asse A semantic alignment #1896 (T10, DEC-1): request DTO for the polymorphic
+    /// scores update endpoint. Distinct from <see cref="UpdateScoreCommand"/> (per-participant
+    /// score entry) — this carries the polymorphic <c>ScoringType</c> + <c>ScoreData</c>
+    /// JSON payload validated by per-type IScoringStrategy.
+    /// </summary>
+    public record UpdateSessionScoresRequest(ScoreType ScoringType, string ScoreData);
 
     private static void MapCreateSessionEndpoint(RouteGroupBuilder group)
     {
@@ -59,6 +69,39 @@ internal static class SessionCommandEndpoints
         .WithName("UpdateScore")
         .WithTags("SessionTracking")
         .WithSummary("Update participant score")
+        .Produces(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(404);
+    }
+
+    /// <summary>
+    /// Asse A semantic alignment #1896 (T10, DEC-1): polymorphic mid-game score update
+    /// endpoint. Mounted at <c>/game-sessions/{id}/scores-polymorphic</c> to avoid clashing
+    /// with the legacy <see cref="UpdateScoreCommand"/> endpoint at
+    /// <c>/game-sessions/{id}/scores</c> (per-participant score entry).
+    ///
+    /// <para>Payload: <c>{ scoringType: Points|BinaryWin|Objectives|Ranking, scoreData: "JSON string" }</c>.
+    /// FluentValidation enforces per-type JSON schema via <c>ScoringStrategyFactory</c>.
+    /// Returns the computed winner playerId when a single winner can be determined.</para>
+    /// </summary>
+    private static void MapUpdateSessionScoresEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPut("/game-sessions/{sessionId:guid}/scores-polymorphic", async (
+            Guid sessionId,
+            UpdateSessionScoresRequest request,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var command = new UpdateSessionScoresCommand(sessionId, request.ScoringType, request.ScoreData);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("UpdateSessionScoresPolymorphic")
+        .WithTags("SessionTracking")
+        .WithSummary("Update session polymorphic scores (Points/BinaryWin/Objectives/Ranking)")
+        .WithDescription("Asse A #1896 (T10): replaces ScoringType + ScoreData atomically with per-type JSON schema validation.")
         .Produces(200)
         .Produces(400)
         .Produces(401)

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventInvariant15Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventInvariant15Tests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Tests for invariante #15 of the GameNight/Session domain model:
+/// HandleFirstSessionStarted transitions GameNightEvent.Status from Published → InProgress
+/// when the first child Session becomes live. Idempotent on InProgress, throws otherwise.
+///
+/// See docs/superpowers/specs/2026-06-04-asse-a-semantic-alignment.md WP2 T3.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+public class GameNightEventInvariant15Tests
+{
+    [Fact]
+    public void HandleFirstSessionStarted_OnPublished_TransitionsToInProgress()
+    {
+        // Arrange: Published GameNight (typical first-session-started case)
+        var gn = GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Test Night",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(1));
+        gn.Publish(new List<Guid> { Guid.NewGuid() });
+        // Status = Published
+
+        // Act
+        gn.HandleFirstSessionStarted(sessionId: Guid.NewGuid());
+
+        // Assert
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+        gn.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void HandleFirstSessionStarted_OnDraft_Throws()
+    {
+        // Arrange: Draft GameNight (default after Create, before Publish)
+        var gn = GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Test Night",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(1));
+        // Status = Draft
+
+        // Act
+        var act = () => gn.HandleFirstSessionStarted(Guid.NewGuid());
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Draft*");
+    }
+
+    [Fact]
+    public void HandleFirstSessionStarted_OnInProgress_IsIdempotent_NoStateChange()
+    {
+        // Arrange: AdHoc GameNight starts directly in InProgress (no Publish phase)
+        var gn = GameNightEvent.CreateAdHoc(
+            organizerId: Guid.NewGuid(),
+            title: "Test AdHoc",
+            firstGameId: Guid.NewGuid());
+        // Status = InProgress
+        var originalUpdatedAt = gn.UpdatedAt;
+
+        // Act
+        gn.HandleFirstSessionStarted(Guid.NewGuid());
+
+        // Assert: status stays InProgress, UpdatedAt not bumped (true idempotency)
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+        gn.UpdatedAt.Should().Be(originalUpdatedAt);
+    }
+
+    [Fact]
+    public void HandleFirstSessionStarted_OnCompleted_Throws()
+    {
+        // Arrange: AdHoc → InProgress → CompleteAdHoc → Completed
+        var gn = GameNightEvent.CreateAdHoc(
+            organizerId: Guid.NewGuid(),
+            title: "Test Night",
+            firstGameId: Guid.NewGuid());
+        gn.CompleteAdHoc();
+        // Status = Completed
+
+        // Act
+        var act = () => gn.HandleFirstSessionStarted(Guid.NewGuid());
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Completed*");
+    }
+
+    [Fact]
+    public void HandleFirstSessionStarted_OnCancelled_Throws()
+    {
+        // Arrange: Draft → Cancel → Cancelled
+        var gn = GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Test Night",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(1));
+        gn.Cancel();
+        // Status = Cancelled
+
+        // Act
+        var act = () => gn.HandleFirstSessionStarted(Guid.NewGuid());
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cancelled*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventMaxLiveTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventMaxLiveTests.cs
@@ -1,0 +1,97 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Tests for invariante #10 of the GameNight/Session domain model:
+/// a GameNightEvent can have at most 1 GameNightSession in InProgress at a time.
+/// See docs/superpowers/specs/2026-06-04-asse-a-semantic-alignment.md WP1 T1.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+public class GameNightEventMaxLiveTests
+{
+    private static GameNightEvent CreatePublishedEventWithTwoSessions()
+    {
+        var evt = GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Test Night",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(1),
+            gameIds: new List<Guid> { Guid.NewGuid(), Guid.NewGuid() });
+        evt.Publish(new List<Guid> { Guid.NewGuid() });
+        evt.AddSession(Guid.NewGuid(), Guid.NewGuid(), "Wingspan");
+        evt.AddSession(Guid.NewGuid(), Guid.NewGuid(), "Catan");
+        return evt;
+    }
+
+    [Fact]
+    public void StartCurrentSession_WhenAnotherLiveActive_ThrowsMaxLiveSessionsExceededException()
+    {
+        // Arrange: Published GameNight with 2 sessions, first one started → InProgress
+        var gn = CreatePublishedEventWithTwoSessions();
+        gn.StartCurrentSession(); // First session goes InProgress, second stays Pending
+
+        // Act: try to start second session while first is still InProgress
+        var act = () => gn.StartCurrentSession();
+
+        // Assert: throws invariante #10 violation
+        act.Should().Throw<MaxLiveSessionsExceededException>()
+            .Where(ex => ex.GameNightEventId == gn.Id);
+    }
+
+    [Fact]
+    public void StartCurrentSession_WithoutOtherLive_Succeeds()
+    {
+        // Arrange: Published GameNight with single pending session
+        var gn = GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Test",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(1));
+        gn.Publish(new List<Guid> { Guid.NewGuid() });
+        gn.AddSession(Guid.NewGuid(), Guid.NewGuid(), "Wingspan");
+
+        // Act
+        var act = () => gn.StartCurrentSession();
+
+        // Assert: succeeds and session is InProgress
+        act.Should().NotThrow();
+        gn.Sessions[0].Status.Should().Be(GameNightSessionStatus.InProgress);
+    }
+
+    [Fact]
+    public void StartCurrentSession_AfterCompletingPreviousLive_Succeeds()
+    {
+        // Arrange: realistic flow — complete first session, then start second
+        var gn = CreatePublishedEventWithTwoSessions();
+        gn.StartCurrentSession(); // Wingspan InProgress
+        gn.CompleteCurrentSession(winnerId: null); // Wingspan Completed
+
+        // Act
+        var act = () => gn.StartCurrentSession(); // Should start Catan
+
+        // Assert: succeeds — completed sessions don't count as "live"
+        act.Should().NotThrow();
+        gn.Sessions[0].Status.Should().Be(GameNightSessionStatus.Completed);
+        gn.Sessions[1].Status.Should().Be(GameNightSessionStatus.InProgress);
+    }
+
+    [Fact]
+    public void MaxLiveSessionsExceededException_ExposesCorrectErrorCode()
+    {
+        MaxLiveSessionsExceededException.Code.Should().Be("MAX_LIVE_SESSIONS_EXCEEDED");
+    }
+
+    [Fact]
+    public void MaxLiveSessionsExceededException_StoresGameNightEventId()
+    {
+        var id = Guid.NewGuid();
+        var ex = new MaxLiveSessionsExceededException(id);
+        ex.GameNightEventId.Should().Be(id);
+        ex.Message.Should().Contain(id.ToString());
+        ex.Message.Should().Contain("invariante #10");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventMaxLiveTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventMaxLiveTests.cs
@@ -92,6 +92,6 @@ public class GameNightEventMaxLiveTests
         var ex = new MaxLiveSessionsExceededException(id);
         ex.GameNightEventId.Should().Be(id);
         ex.Message.Should().Contain(id.ToString());
-        ex.Message.Should().Contain("invariante #10");
+        ex.Message.Should().Contain("invariant #10");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/FinalizeSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/FinalizeSessionCommandHandlerTests.cs
@@ -4,6 +4,8 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Infrastructure.Entities.SessionTracking;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -98,5 +100,126 @@ public class FinalizeSessionCommandHandlerTests
         Assert.NotNull(result);
         _sessionRepoMock.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Invariante #13 (#1896 WP2 T4) — LiveActiveWarning ─────────────────────
+    //
+    // FinalizeSession must surface a non-blocking warning (X-Warning-Code:
+    // SAVED_WHILE_LIVE_ACTIVE in the HTTP layer; LiveActiveWarning=true in the
+    // result DTO) when another Session linked to the SAME GameNightEvent is still
+    // live (StartedAt != null && FinalizedAt == null) at the moment of finalize.
+    //
+    // The operation itself is NOT blocked — the FE consumes the header to show a
+    // toast informing the user that draft+live siblings coexist. Standalone
+    // sessions (no GameNight link) MUST always return LiveActiveWarning=false.
+
+    [Fact]
+    public async Task Handle_CoexistingLiveSessionSameGameNight_SetsLiveActiveWarningTrue()
+    {
+        // Arrange — current session being finalized + a sibling live session in the same GameNight
+        var userId = Guid.NewGuid();
+        var gameNightEventId = Guid.NewGuid();
+
+        var sessionBeingFinalized = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
+        var participantId = sessionBeingFinalized.Participants.First().Id;
+
+        var liveSiblingId = Guid.NewGuid();
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = liveSiblingId,
+            UserId = userId,
+            GameId = Guid.NewGuid(),
+            Status = "Active",
+            SessionCode = "LIVES1",
+            SessionType = "Generic",
+            SessionDate = DateTime.UtcNow.AddMinutes(-30),
+            StartedAt = DateTime.UtcNow.AddMinutes(-25),  // ← IsLive
+            FinalizedAt = null,                            // ← IsLive
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId
+        });
+
+        // Link BOTH sessions (the one being finalized + the live sibling) to the same GameNight
+        _db.GameNightSessions.Add(new GameNightSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            GameNightEventId = gameNightEventId,
+            SessionId = sessionBeingFinalized.Id,
+            GameId = Guid.NewGuid(),
+            GameTitle = "Finalize-Game",
+            PlayOrder = 0,
+            Status = "Pending"
+        });
+        _db.GameNightSessions.Add(new GameNightSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            GameNightEventId = gameNightEventId,
+            SessionId = liveSiblingId,
+            GameId = Guid.NewGuid(),
+            GameTitle = "Live-Sibling-Game",
+            PlayOrder = 1,
+            Status = "Pending"
+        });
+        await _db.SaveChangesAsync();
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionBeingFinalized.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sessionBeingFinalized);
+        _scoreRepoMock.Setup(r => r.GetBySessionIdAsync(sessionBeingFinalized.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<ScoreEntry>());
+
+        var ranks = new Dictionary<Guid, int> { { participantId, 1 } };
+        var command = new FinalizeSessionCommand(sessionBeingFinalized.Id, ranks);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — warning flag must be true so the endpoint emits X-Warning-Code header
+        Assert.True(
+            result.LiveActiveWarning,
+            "Coexisting live sibling in the same GameNight must trigger LiveActiveWarning=true (#1896 invariante #13)");
+    }
+
+    [Fact]
+    public async Task Handle_StandaloneSessionNoGameNightLink_SetsLiveActiveWarningFalse()
+    {
+        // Arrange — session NOT linked to any GameNight; sibling live sessions exist
+        // but are unlinked → warning must NOT fire (gameNightId resolves to null,
+        // short-circuiting the sibling query).
+        var userId = Guid.NewGuid();
+        var sessionBeingFinalized = Session.Create(userId, Guid.NewGuid(), SessionType.Generic);
+        var participantId = sessionBeingFinalized.Participants.First().Id;
+
+        // Seed a live session — but DO NOT link it (or the current one) to any GameNight.
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = Guid.NewGuid(),
+            Status = "Active",
+            SessionCode = "STAND1",
+            SessionType = "Generic",
+            SessionDate = DateTime.UtcNow.AddMinutes(-30),
+            StartedAt = DateTime.UtcNow.AddMinutes(-25),  // ← IsLive, but unlinked
+            FinalizedAt = null,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId
+        });
+        await _db.SaveChangesAsync();
+
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionBeingFinalized.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sessionBeingFinalized);
+        _scoreRepoMock.Setup(r => r.GetBySessionIdAsync(sessionBeingFinalized.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<ScoreEntry>());
+
+        var ranks = new Dictionary<Guid, int> { { participantId, 1 } };
+        var command = new FinalizeSessionCommand(sessionBeingFinalized.Id, ranks);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — no GameNight link means no warning, regardless of other live sessions.
+        Assert.False(
+            result.LiveActiveWarning,
+            "Standalone session (no GameNight link) must always return LiveActiveWarning=false (#1896 invariante #13)");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/UpdateSessionScoresCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/UpdateSessionScoresCommandHandlerTests.cs
@@ -1,0 +1,205 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
+
+/// <summary>
+/// Asse A semantic alignment #1896 (T10, DEC-1): unit tests for the polymorphic
+/// score update handler. Covers the 4 ScoreType variants round-trip through
+/// <c>Session.SetScores</c> + IScoringStrategy.ComputeWinnerPlayerId.
+///
+/// <para>Full HTTP integration test (Testcontainers Postgres + auth seed) is deferred —
+/// these unit tests with Moq cover the happy path + the 4 polymorphic schemas via the
+/// real <see cref="ScoringStrategyFactory"/>. Schema validation is covered separately
+/// by <c>UpdateSessionScoresCommandValidatorTests</c>.</para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class UpdateSessionScoresCommandHandlerTests
+{
+    private static readonly Guid PlayerA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid PlayerB = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+    private readonly Mock<ISessionRepository> _sessionRepoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly ScoringStrategyFactory _factory = new();
+    private readonly UpdateSessionScoresCommandHandler _handler;
+
+    public UpdateSessionScoresCommandHandlerTests()
+    {
+        _handler = new UpdateSessionScoresCommandHandler(
+            _sessionRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _factory);
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFoundException()
+    {
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Session?)null);
+
+        var cmd = new UpdateSessionScoresCommand(
+            Guid.NewGuid(),
+            ScoreType.Points,
+            $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""");
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(cmd, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_ValidPointsScoring_PersistsAndReturnsWinner()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":42},{"playerId":"{{PlayerB}}","points":15}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.SessionId.Should().Be(session.Id);
+        result.ScoringType.Should().Be(ScoreType.Points);
+        result.ComputedWinnerId.Should().Be(PlayerA);
+        session.ScoringType.Should().Be(ScoreType.Points);
+        session.ScoreData.Should().Be(json);
+        _sessionRepoMock.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TiedPointsScoring_ReturnsNullWinner()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":50},{"playerId":"{{PlayerB}}","points":50}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.ComputedWinnerId.Should().BeNull("ties yield null winner per PointsScoringStrategy");
+    }
+
+    [Fact]
+    public async Task Handle_BinaryWinScoring_PersistsAndReturnsWinner()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true},{"playerId":"{{PlayerB}}","isWinner":false}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.BinaryWin, json);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.ScoringType.Should().Be(ScoreType.BinaryWin);
+        result.ComputedWinnerId.Should().Be(PlayerA);
+        session.ScoringType.Should().Be(ScoreType.BinaryWin);
+        session.ScoreData.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task Handle_CooperativeAllWin_ReturnsNullWinner()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true},{"playerId":"{{PlayerB}}","isWinner":true}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.BinaryWin, json);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.ComputedWinnerId.Should().BeNull("cooperative all-win yields null per BinaryWinScoringStrategy");
+    }
+
+    [Fact]
+    public async Task Handle_ObjectivesScoring_PersistsAndReturnsWinner()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"completedByPlayer":[{"playerId":"{{PlayerA}}","objectives":["A","B","C"]},{"playerId":"{{PlayerB}}","objectives":["A"]}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Objectives, json);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.ScoringType.Should().Be(ScoreType.Objectives);
+        result.ComputedWinnerId.Should().Be(PlayerA);
+        session.ScoringType.Should().Be(ScoreType.Objectives);
+        session.ScoreData.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task Handle_RankingScoring_PersistsAndReturnsWinner()
+    {
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1},{"playerId":"{{PlayerB}}","position":2}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Ranking, json);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.ScoringType.Should().Be(ScoreType.Ranking);
+        result.ComputedWinnerId.Should().Be(PlayerA);
+        session.ScoringType.Should().Be(ScoreType.Ranking);
+        session.ScoreData.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task Handle_AllFourScoreTypes_RoundTripPersistsScoringTypeAndData()
+    {
+        // Single-test sweep: verify that all 4 ScoreType values round-trip through SetScores
+        // (handler → Session.SetScores → UpdateAsync → SaveChangesAsync) without exception
+        // AND that the ScoringType + ScoreData are written back to the aggregate.
+        var cases = new[]
+        {
+            (Type: ScoreType.Points,
+             Json: $$"""{"scores":[{"playerId":"{{PlayerA}}","points":1}]}"""),
+            (Type: ScoreType.BinaryWin,
+             Json: $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true}]}"""),
+            (Type: ScoreType.Objectives,
+             Json: $$"""{"completedByPlayer":[{"playerId":"{{PlayerA}}","objectives":["X"]}]}"""),
+            (Type: ScoreType.Ranking,
+             Json: $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1}]}"""),
+        };
+
+        foreach (var (type, json) in cases)
+        {
+            var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+            _sessionRepoMock
+                .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(session);
+
+            var cmd = new UpdateSessionScoresCommand(session.Id, type, json);
+            var result = await _handler.Handle(cmd, CancellationToken.None);
+
+            result.ScoringType.Should().Be(type, $"round-trip for {type} should echo ScoringType");
+            session.ScoringType.Should().Be(type, $"Session.ScoringType should equal {type} after SetScores");
+            session.ScoreData.Should().Be(json, $"Session.ScoreData should equal payload for {type}");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/UpdateSessionScoresCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/UpdateSessionScoresCommandHandlerTests.cs
@@ -52,7 +52,8 @@ public class UpdateSessionScoresCommandHandlerTests
         var cmd = new UpdateSessionScoresCommand(
             Guid.NewGuid(),
             ScoreType.Points,
-            $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""");
+            $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""",
+            Guid.NewGuid());
 
         await Assert.ThrowsAsync<NotFoundException>(
             () => _handler.Handle(cmd, CancellationToken.None));
@@ -67,7 +68,7 @@ public class UpdateSessionScoresCommandHandlerTests
             .ReturnsAsync(session);
 
         var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":42},{"playerId":"{{PlayerB}}","points":15}]}""";
-        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json);
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json, session.UserId);
 
         var result = await _handler.Handle(cmd, CancellationToken.None);
 
@@ -89,7 +90,7 @@ public class UpdateSessionScoresCommandHandlerTests
             .ReturnsAsync(session);
 
         var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":50},{"playerId":"{{PlayerB}}","points":50}]}""";
-        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json);
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json, session.UserId);
 
         var result = await _handler.Handle(cmd, CancellationToken.None);
 
@@ -105,7 +106,7 @@ public class UpdateSessionScoresCommandHandlerTests
             .ReturnsAsync(session);
 
         var json = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true},{"playerId":"{{PlayerB}}","isWinner":false}]}""";
-        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.BinaryWin, json);
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.BinaryWin, json, session.UserId);
 
         var result = await _handler.Handle(cmd, CancellationToken.None);
 
@@ -124,7 +125,7 @@ public class UpdateSessionScoresCommandHandlerTests
             .ReturnsAsync(session);
 
         var json = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true},{"playerId":"{{PlayerB}}","isWinner":true}]}""";
-        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.BinaryWin, json);
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.BinaryWin, json, session.UserId);
 
         var result = await _handler.Handle(cmd, CancellationToken.None);
 
@@ -140,7 +141,7 @@ public class UpdateSessionScoresCommandHandlerTests
             .ReturnsAsync(session);
 
         var json = $$"""{"completedByPlayer":[{"playerId":"{{PlayerA}}","objectives":["A","B","C"]},{"playerId":"{{PlayerB}}","objectives":["A"]}]}""";
-        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Objectives, json);
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Objectives, json, session.UserId);
 
         var result = await _handler.Handle(cmd, CancellationToken.None);
 
@@ -159,7 +160,7 @@ public class UpdateSessionScoresCommandHandlerTests
             .ReturnsAsync(session);
 
         var json = $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1},{"playerId":"{{PlayerB}}","position":2}]}""";
-        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Ranking, json);
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Ranking, json, session.UserId);
 
         var result = await _handler.Handle(cmd, CancellationToken.None);
 
@@ -167,6 +168,74 @@ public class UpdateSessionScoresCommandHandlerTests
         result.ComputedWinnerId.Should().Be(PlayerA);
         session.ScoringType.Should().Be(ScoreType.Ranking);
         session.ScoreData.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task Handle_RequestedByIsNotOwnerNorParticipant_ThrowsForbiddenException()
+    {
+        // IDOR guard (security review HIGH finding): mutation MUST be blocked when caller
+        // is neither the session.UserId nor a User-linked participant.
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""";
+        var unauthorizedUser = Guid.NewGuid(); // not the session.UserId, not a participant
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json, unauthorizedUser);
+
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(cmd, CancellationToken.None));
+
+        // Verify mutation did NOT occur
+        _sessionRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RequestedByIsSessionOwner_Succeeds()
+    {
+        var ownerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json, ownerId);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        session.ScoringType.Should().Be(ScoreType.Points);
+    }
+
+    [Fact]
+    public async Task Handle_RequestedByIsRegisteredParticipant_Succeeds()
+    {
+        // Owner is different from participant; participant has User-linked identity.
+        // Session.Create already adds the owner as first User-linked participant — we
+        // add a second User-linked participant and verify they can mutate scores.
+        var ownerId = Guid.NewGuid();
+        var participantUserId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+
+        session.AddParticipant(
+            Api.BoundedContexts.SessionTracking.Domain.ValueObjects.ParticipantInfo.Create(
+                displayName: "Player2", isOwner: false, joinOrder: 2),
+            userId: participantUserId);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""";
+        var cmd = new UpdateSessionScoresCommand(session.Id, ScoreType.Points, json, participantUserId);
+
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        session.ScoringType.Should().Be(ScoreType.Points);
     }
 
     [Fact]
@@ -194,7 +263,7 @@ public class UpdateSessionScoresCommandHandlerTests
                 .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(session);
 
-            var cmd = new UpdateSessionScoresCommand(session.Id, type, json);
+            var cmd = new UpdateSessionScoresCommand(session.Id, type, json, session.UserId);
             var result = await _handler.Handle(cmd, CancellationToken.None);
 
             result.ScoringType.Should().Be(type, $"round-trip for {type} should echo ScoringType");

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/UpdateSessionScoresCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/UpdateSessionScoresCommandValidatorTests.cs
@@ -1,0 +1,145 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Validators;
+
+/// <summary>
+/// Asse A semantic alignment #1896 (T10, DEC-1): validates that
+/// <see cref="UpdateSessionScoresCommandValidator"/> delegates JSON schema validation
+/// to the matching <see cref="IScoringStrategy"/> per <see cref="ScoreType"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class UpdateSessionScoresCommandValidatorTests
+{
+    private readonly ScoringStrategyFactory _factory = new();
+    private readonly UpdateSessionScoresCommandValidator _validator;
+
+    private static readonly Guid PlayerA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid PlayerB = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+    public UpdateSessionScoresCommandValidatorTests()
+    {
+        _validator = new UpdateSessionScoresCommandValidator(_factory);
+    }
+
+    [Fact]
+    public void Validate_ValidPointsScoreData_ReturnsValid()
+    {
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":50},{"playerId":"{{PlayerB}}","points":30}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_NegativePointsScoreData_ReturnsInvalid()
+    {
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":-5}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.ScoreData)
+            && e.ErrorMessage.Contains("non-negative", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_BinaryWinSchemaAppliedAsPoints_ReturnsInvalid()
+    {
+        // BinaryWin payload (results[].isWinner) submitted with ScoringType=Points (expects scores[].points)
+        var binaryWinJson = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, binaryWinJson);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.ScoreData));
+    }
+
+    [Fact]
+    public void Validate_ValidBinaryWinScoreData_ReturnsValid()
+    {
+        var json = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true},{"playerId":"{{PlayerB}}","isWinner":false}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.BinaryWin, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidObjectivesScoreData_ReturnsValid()
+    {
+        var json = $$"""{"completedByPlayer":[{"playerId":"{{PlayerA}}","objectives":["Obj1","Obj2"]},{"playerId":"{{PlayerB}}","objectives":["Obj1"]}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Objectives, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidRankingScoreData_ReturnsValid()
+    {
+        var json = $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1},{"playerId":"{{PlayerB}}","position":2}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Ranking, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_RankingWithDuplicatePosition_ReturnsInvalid()
+    {
+        var json = $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1},{"playerId":"{{PlayerB}}","position":1}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Ranking, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.ScoreData));
+    }
+
+    [Fact]
+    public void Validate_EmptyScoreData_ReturnsInvalid()
+    {
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, string.Empty);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.ScoreData));
+    }
+
+    [Fact]
+    public void Validate_EmptySessionId_ReturnsInvalid()
+    {
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.Empty, ScoreType.Points, json);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.SessionId));
+    }
+
+    [Fact]
+    public void Validate_MalformedJson_ReturnsInvalid()
+    {
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, "{ not valid json");
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.ScoreData));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/UpdateSessionScoresCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/UpdateSessionScoresCommandValidatorTests.cs
@@ -31,7 +31,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_ValidPointsScoreData_ReturnsValid()
     {
         var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":50},{"playerId":"{{PlayerB}}","points":30}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -42,7 +42,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_NegativePointsScoreData_ReturnsInvalid()
     {
         var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":-5}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -56,7 +56,7 @@ public class UpdateSessionScoresCommandValidatorTests
     {
         // BinaryWin payload (results[].isWinner) submitted with ScoringType=Points (expects scores[].points)
         var binaryWinJson = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, binaryWinJson);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, binaryWinJson, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -68,7 +68,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_ValidBinaryWinScoreData_ReturnsValid()
     {
         var json = $$"""{"results":[{"playerId":"{{PlayerA}}","isWinner":true},{"playerId":"{{PlayerB}}","isWinner":false}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.BinaryWin, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.BinaryWin, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -79,7 +79,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_ValidObjectivesScoreData_ReturnsValid()
     {
         var json = $$"""{"completedByPlayer":[{"playerId":"{{PlayerA}}","objectives":["Obj1","Obj2"]},{"playerId":"{{PlayerB}}","objectives":["Obj1"]}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Objectives, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Objectives, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -90,7 +90,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_ValidRankingScoreData_ReturnsValid()
     {
         var json = $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1},{"playerId":"{{PlayerB}}","position":2}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Ranking, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Ranking, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -101,7 +101,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_RankingWithDuplicatePosition_ReturnsInvalid()
     {
         var json = $$"""{"positions":[{"playerId":"{{PlayerA}}","position":1},{"playerId":"{{PlayerB}}","position":1}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Ranking, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Ranking, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -112,7 +112,7 @@ public class UpdateSessionScoresCommandValidatorTests
     [Fact]
     public void Validate_EmptyScoreData_ReturnsInvalid()
     {
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, string.Empty);
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, string.Empty, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -124,7 +124,7 @@ public class UpdateSessionScoresCommandValidatorTests
     public void Validate_EmptySessionId_ReturnsInvalid()
     {
         var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""";
-        var cmd = new UpdateSessionScoresCommand(Guid.Empty, ScoreType.Points, json);
+        var cmd = new UpdateSessionScoresCommand(Guid.Empty, ScoreType.Points, json, Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
@@ -135,11 +135,25 @@ public class UpdateSessionScoresCommandValidatorTests
     [Fact]
     public void Validate_MalformedJson_ReturnsInvalid()
     {
-        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, "{ not valid json");
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, "{ not valid json", Guid.NewGuid());
 
         var result = _validator.Validate(cmd);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.ScoreData));
+    }
+
+    [Fact]
+    public void Validate_EmptyRequestedBy_ReturnsInvalid()
+    {
+        // IDOR guard: RequestedBy is extracted from authenticated user claims and MUST
+        // never be Guid.Empty (endpoint short-circuits 401 in that case, but defense-in-depth).
+        var json = $$"""{"scores":[{"playerId":"{{PlayerA}}","points":10}]}""";
+        var cmd = new UpdateSessionScoresCommand(Guid.NewGuid(), ScoreType.Points, json, Guid.Empty);
+
+        var result = _validator.Validate(cmd);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateSessionScoresCommand.RequestedBy));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionSetScoresTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionSetScoresTests.cs
@@ -1,0 +1,118 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Unit tests for <see cref="Session.ScoringType"/>, <see cref="Session.ScoreData"/>,
+/// and <see cref="Session.SetScores"/>.
+///
+/// <para>Asse A semantic alignment #1896 (T9, DEC-1): validates the polymorphic
+/// scoring fields (default = Points/"{}") and the <see cref="SessionScoresUpdatedEvent"/>
+/// raised by <see cref="Session.SetScores"/>. T10 will integrate this domain method
+/// with the <c>SaveSessionCommandHandler</c> + per-type FluentValidation.</para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionSetScoresTests
+{
+    [Fact]
+    public void NewSession_DefaultsToPointsScoringType_EmptyJsonScoreData()
+    {
+        var session = CreateValidSession();
+
+        session.ScoringType.Should().Be(ScoreType.Points,
+            because: "DEC-1 — default ScoringType for a new session is Points (~50% catalog coverage)");
+        session.ScoreData.Should().Be("{}",
+            because: "DEC-1 — default ScoreData is an empty JSON object until SetScores is called");
+    }
+
+    [Fact]
+    public void SetScores_UpdatesBothFields_RaisesDomainEvent()
+    {
+        var session = CreateValidSession();
+        session.ClearDomainEvents(); // discard the Create-time event(s)
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":42}]}""";
+
+        session.SetScores(ScoreType.Points, json);
+
+        session.ScoringType.Should().Be(ScoreType.Points);
+        session.ScoreData.Should().Be(json,
+            because: "SetScores must overwrite ScoreData with the new JSON payload");
+
+        var domainEvent = session.DomainEvents
+            .OfType<SessionScoresUpdatedEvent>()
+            .Should().ContainSingle(
+                because: "SetScores must enqueue exactly one SessionScoresUpdatedEvent")
+            .Subject;
+
+        domainEvent.SessionId.Should().Be(session.Id,
+            because: "the event SessionId must match the session whose scores were updated");
+        domainEvent.ScoringType.Should().Be(ScoreType.Points);
+        domainEvent.ScoreData.Should().Be(json);
+        domainEvent.AggregateId.Should().Be(session.Id,
+            because: "AggregateId aliases SessionId for the DomainEventLog mapper");
+        domainEvent.EventId.Should().NotBe(Guid.Empty,
+            because: "each domain event must carry a unique identifier for idempotency");
+    }
+
+    [Fact]
+    public void SetScores_WithBinaryWinScoringType_PersistsType()
+    {
+        var session = CreateValidSession();
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true}]}""";
+
+        session.SetScores(ScoreType.BinaryWin, json);
+
+        session.ScoringType.Should().Be(ScoreType.BinaryWin,
+            because: "DEC-1 — BinaryWin is a first-class ScoringType for cooperative games (Pandemic, Forbidden Island)");
+        session.ScoreData.Should().Be(json);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void SetScores_WithEmptyOrWhitespaceScoreData_Throws(string? scoreData)
+    {
+        var session = CreateValidSession();
+
+        var act = () => session.SetScores(ScoreType.Points, scoreData!);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*ScoreData cannot be empty*",
+                because: "DEC-1 — SetScores must guard against empty/whitespace JSON payloads (richer per-type validation happens in T10)");
+    }
+
+    [Fact]
+    public void SetScores_CalledTwice_OverwritesAndRaisesSecondEvent()
+    {
+        var session = CreateValidSession();
+        session.SetScores(ScoreType.Points, "{\"first\":true}");
+        session.ClearDomainEvents();
+
+        var newJson = """{"scores":[]}""";
+        session.SetScores(ScoreType.Ranking, newJson);
+
+        session.ScoringType.Should().Be(ScoreType.Ranking,
+            because: "DEC-1 — SetScores supersedes any prior ScoringType");
+        session.ScoreData.Should().Be(newJson,
+            because: "DEC-1 — SetScores supersedes any prior ScoreData");
+        session.DomainEvents
+            .OfType<SessionScoresUpdatedEvent>()
+            .Should().ContainSingle(
+                because: "each SetScores invocation must enqueue exactly one event (idempotency at the call site)");
+    }
+
+    private static Session CreateValidSession()
+    {
+        return Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.Generic);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionStartedAtTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionStartedAtTests.cs
@@ -1,0 +1,129 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Unit tests for <see cref="Session.StartedAt"/>, <see cref="Session.IsLive"/>,
+/// and <see cref="Session.OpenLiveMode"/>.
+///
+/// <para>Asse A semantic alignment #1896 (T2): validates invariante #11 (3 distinct
+/// timestamps — CreatedAt always, StartedAt/FinalizedAt nullable) and the domain
+/// event raised on the Published → InProgress GameNight transition trigger
+/// (invariante #14 enforcement happens at the GameNight aggregate, T3).</para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionStartedAtTests
+{
+    [Fact]
+    public void NewSession_HasNullStartedAt_IsNotLive()
+    {
+        var session = CreateValidSession();
+
+        session.StartedAt.Should().BeNull(
+            because: "invariante #11 — StartedAt is nullable and unset until OpenLiveMode is called");
+        session.IsLive.Should().BeFalse(
+            because: "a session that has not opened live mode is not live");
+    }
+
+    [Fact]
+    public void OpenLiveMode_SetsStartedAtToUtcNow_AndMakesSessionLive()
+    {
+        var session = CreateValidSession();
+        var before = DateTime.UtcNow;
+
+        session.OpenLiveMode();
+
+        session.StartedAt.Should().NotBeNull(
+            because: "OpenLiveMode must populate the StartedAt timestamp (invariante #11)");
+        session.StartedAt!.Value.Should().BeOnOrAfter(before,
+            because: "StartedAt is set to UtcNow at the moment OpenLiveMode is invoked");
+        session.StartedAt.Value.Kind.Should().Be(DateTimeKind.Utc,
+            because: "all session timestamps are stored as UTC for consistency");
+        session.IsLive.Should().BeTrue(
+            because: "IsLive computed property is true when StartedAt set and FinalizedAt null");
+    }
+
+    [Fact]
+    public void OpenLiveMode_RaisesSessionStartedDomainEvent_WithExpectedPayload()
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var session = Session.Create(userId, gameId, SessionType.GameSpecific);
+        session.ClearDomainEvents(); // discard any creation-time events
+
+        session.OpenLiveMode();
+
+        var domainEvent = session.DomainEvents
+            .OfType<SessionStartedDomainEvent>()
+            .Should().ContainSingle(
+                because: "OpenLiveMode must enqueue exactly one SessionStartedDomainEvent for the GameNight handler (T3, invariante #15)")
+            .Subject;
+
+        domainEvent.SessionId.Should().Be(session.Id);
+        domainEvent.UserId.Should().Be(userId);
+        domainEvent.GameId.Should().Be(gameId);
+        domainEvent.StartedAt.Should().Be(session.StartedAt!.Value,
+            because: "the event StartedAt must reflect the same instant the session was marked live");
+        domainEvent.OccurredAt.Should().Be(domainEvent.StartedAt,
+            because: "OccurredAt is an alias over StartedAt (IDomainEvent contract)");
+        domainEvent.AggregateId.Should().Be(session.Id,
+            because: "AggregateId aliases SessionId for the DomainEventLog mapper");
+        domainEvent.EventId.Should().NotBe(Guid.Empty,
+            because: "each domain event must carry a unique identifier for idempotency");
+    }
+
+    [Fact]
+    public void OpenLiveMode_OnAlreadyLiveSession_ThrowsConflictException()
+    {
+        var session = CreateValidSession();
+        session.OpenLiveMode();
+
+        var act = session.OpenLiveMode;
+
+        act.Should().Throw<ConflictException>()
+            .WithMessage("*already in live mode*",
+                because: "calling OpenLiveMode on a live session is a state-machine violation");
+    }
+
+    [Fact]
+    public void OpenLiveMode_OnFinalizedSession_ThrowsConflictException()
+    {
+        var session = CreateValidSession();
+        session.Finalize(); // transitions to Finalized status + sets FinalizedAt
+
+        var act = session.OpenLiveMode;
+
+        act.Should().Throw<ConflictException>()
+            .WithMessage("*already finalized*",
+                because: "a finalized session cannot transition back to live mode (invariante #11 — terminal state)");
+    }
+
+    [Fact]
+    public void IsLive_IsFalseAfterFinalize_EvenIfStartedAtWasSet()
+    {
+        var session = CreateValidSession();
+        session.OpenLiveMode();
+        session.IsLive.Should().BeTrue();
+
+        session.Finalize();
+
+        session.IsLive.Should().BeFalse(
+            because: "IsLive requires FinalizedAt == null; once finalized, the session is no longer live");
+        session.StartedAt.Should().NotBeNull(
+            because: "StartedAt remains populated for historical/audit reasons even after finalization");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static Session CreateValidSession() =>
+        Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategyTests.cs
@@ -1,0 +1,151 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Scoring;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class BinaryWinScoringStrategyTests
+{
+    private readonly BinaryWinScoringStrategy _sut = new();
+
+    [Fact]
+    public void Type_IsBinaryWin()
+    {
+        _sut.Type.Should().Be(ScoreType.BinaryWin);
+    }
+
+    [Fact]
+    public void Validate_SingleWinner_ReturnsValid()
+    {
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true},{"playerId":"00000000-0000-0000-0000-000000000002","isWinner":false}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_MultipleWinners_ReturnsValid()
+    {
+        // Cooperative all-win is a legitimate outcome
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true},{"playerId":"00000000-0000-0000-0000-000000000002","isWinner":true}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_AllLose_ReturnsValid()
+    {
+        // Cooperative all-lose is a legitimate outcome
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":false},{"playerId":"00000000-0000-0000-0000-000000000002","isWinner":false}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_EmptyResults_ReturnsInvalid()
+    {
+        var json = """{"results":[]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("No results"));
+    }
+
+    [Fact]
+    public void Validate_EmptyJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_MalformedJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("not json");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Invalid JSON"));
+    }
+
+    [Fact]
+    public void Validate_EmptyPlayerId_ReturnsInvalid()
+    {
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000000","isWinner":true}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("PlayerId cannot be empty"));
+    }
+
+    [Fact]
+    public void Validate_DuplicatePlayer_ReturnsInvalid()
+    {
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true},{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":false}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Duplicate"));
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_SingleWinner_ReturnsThatPlayer()
+    {
+        var winner = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var loser = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var json = $$"""{"results":[{"playerId":"{{winner}}","isWinner":true},{"playerId":"{{loser}}","isWinner":false}]}""";
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(winner);
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_AllLose_ReturnsNull()
+    {
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":false},{"playerId":"00000000-0000-0000-0000-000000000002","isWinner":false}]}""";
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_AllWin_ReturnsNull()
+    {
+        var json = """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true},{"playerId":"00000000-0000-0000-0000-000000000002","isWinner":true}]}""";
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_RoundTrip()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var original = new BinaryWinScoreData(new[]
+        {
+            new BinaryPlayerResult(p1, true),
+            new BinaryPlayerResult(p2, false),
+        });
+
+        var json = _sut.Serialize(original);
+        var roundtrip = (BinaryWinScoreData)_sut.Deserialize(json);
+
+        roundtrip.Results.Should().HaveCount(2);
+        roundtrip.Results[0].PlayerId.Should().Be(p1);
+        roundtrip.Results[0].IsWinner.Should().BeTrue();
+        roundtrip.Results[1].PlayerId.Should().Be(p2);
+        roundtrip.Results[1].IsWinner.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Serialize_WrongType_Throws()
+    {
+        var act = () => _sut.Serialize(new { foo = "bar" });
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Expected BinaryWinScoreData*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategyTests.cs
@@ -1,0 +1,243 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Scoring;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class ObjectivesScoringStrategyTests
+{
+    private readonly ObjectivesScoringStrategy _sut = new();
+
+    [Fact]
+    public void Type_IsObjectives()
+    {
+        _sut.Type.Should().Be(ScoreType.Objectives);
+    }
+
+    [Fact]
+    public void Validate_ValidJson_ReturnsValid()
+    {
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": ["Find clue A", "Solve riddle B"] },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "objectives": ["Find clue A"] },
+                { "playerId": "00000000-0000-0000-0000-000000000003", "objectives": ["Find clue A", "Solve riddle B", "Confront suspect"] }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_EmptyObjectivesList_ReturnsValid()
+    {
+        // A player who has not completed any objective yet is semantically OK.
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": [] },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "objectives": ["Goal 1"] }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_NullObjectivesList_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": null }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Objectives list cannot be null"));
+    }
+
+    [Fact]
+    public void Validate_EmptyObjectiveName_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": ["valid", "   "] }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Objective names cannot be empty"));
+    }
+
+    [Fact]
+    public void Validate_DuplicatePlayer_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": ["A"] },
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": ["B"] }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Duplicate playerId"));
+    }
+
+    [Fact]
+    public void Validate_EmptyPlayerId_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000000", "objectives": ["A"] }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("PlayerId cannot be empty"));
+    }
+
+    [Fact]
+    public void Validate_EmptyJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WhitespaceJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("   ");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EmptyCompletedByPlayerArray_ReturnsInvalid()
+    {
+        var json = """{"completedByPlayer":[]}""";
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("No players"));
+    }
+
+    [Fact]
+    public void Validate_MalformedJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("not json");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Invalid JSON"));
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_ReturnsPlayerWithMostObjectives()
+    {
+        var winner = Guid.Parse("00000000-0000-0000-0000-000000000003");
+        var p1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var p2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var json = $$"""
+            {
+              "completedByPlayer": [
+                { "playerId": "{{p1}}", "objectives": ["A"] },
+                { "playerId": "{{p2}}", "objectives": ["A", "B"] },
+                { "playerId": "{{winner}}", "objectives": ["A", "B", "C"] }
+              ]
+            }
+            """;
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(winner);
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_OnTie_ReturnsNull()
+    {
+        var json = """
+            {
+              "completedByPlayer": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "objectives": ["A", "B"] },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "objectives": ["X", "Y"] }
+              ]
+            }
+            """;
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_SinglePlayer_ReturnsThatPlayer()
+    {
+        var only = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var json = $$"""
+            {
+              "completedByPlayer": [
+                { "playerId": "{{only}}", "objectives": [] }
+              ]
+            }
+            """;
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(only);
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_RoundTrip()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var original = new ObjectivesScoreData(new[]
+        {
+            new PlayerObjectives(p1, new[] { "Find map", "Defeat boss" }),
+            new PlayerObjectives(p2, new[] { "Find map" }),
+        });
+
+        var json = _sut.Serialize(original);
+        var roundtrip = (ObjectivesScoreData)_sut.Deserialize(json);
+
+        roundtrip.CompletedByPlayer.Should().HaveCount(2);
+        roundtrip.CompletedByPlayer[0].PlayerId.Should().Be(p1);
+        roundtrip.CompletedByPlayer[0].Objectives.Should().BeEquivalentTo(new[] { "Find map", "Defeat boss" });
+        roundtrip.CompletedByPlayer[1].PlayerId.Should().Be(p2);
+        roundtrip.CompletedByPlayer[1].Objectives.Should().BeEquivalentTo(new[] { "Find map" });
+    }
+
+    [Fact]
+    public void Serialize_WrongType_Throws()
+    {
+        var act = () => _sut.Serialize(new { foo = "bar" });
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Expected ObjectivesScoreData*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategyTests.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Scoring;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class PointsScoringStrategyTests
+{
+    private readonly PointsScoringStrategy _sut = new();
+
+    [Fact]
+    public void Type_IsPoints()
+    {
+        _sut.Type.Should().Be(ScoreType.Points);
+    }
+
+    [Fact]
+    public void Validate_ValidJson_ReturnsValid()
+    {
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":42}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_NegativeScore_ReturnsInvalid()
+    {
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":-5}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("non-negative"));
+    }
+
+    [Fact]
+    public void Validate_DuplicatePlayer_ReturnsInvalid()
+    {
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":10},{"playerId":"00000000-0000-0000-0000-000000000001","points":20}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Duplicate"));
+    }
+
+    [Fact]
+    public void Validate_EmptyPlayerId_ReturnsInvalid()
+    {
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000000","points":10}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("PlayerId cannot be empty"));
+    }
+
+    [Fact]
+    public void Validate_EmptyJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WhitespaceJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("   ");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EmptyScoresArray_ReturnsInvalid()
+    {
+        var json = """{"scores":[]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("No scores"));
+    }
+
+    [Fact]
+    public void Validate_MalformedJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("not json");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Invalid JSON"));
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_ReturnsHighestScorePlayer()
+    {
+        var winner = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var loser = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var json = $$"""{"scores":[{"playerId":"{{loser}}","points":10},{"playerId":"{{winner}}","points":50}]}""";
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(winner);
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_OnTie_ReturnsNull()
+    {
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":10},{"playerId":"00000000-0000-0000-0000-000000000002","points":10}]}""";
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_SinglePlayer_ReturnsThatPlayer()
+    {
+        var only = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var json = $$"""{"scores":[{"playerId":"{{only}}","points":0}]}""";
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(only);
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_RoundTrip()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var original = new PointsScoreData(new[]
+        {
+            new PlayerScore(p1, 42),
+            new PlayerScore(p2, 30),
+        });
+
+        var json = _sut.Serialize(original);
+        var roundtrip = (PointsScoreData)_sut.Deserialize(json);
+
+        roundtrip.Scores.Should().HaveCount(2);
+        roundtrip.Scores[0].PlayerId.Should().Be(p1);
+        roundtrip.Scores[0].Points.Should().Be(42);
+        roundtrip.Scores[1].PlayerId.Should().Be(p2);
+        roundtrip.Scores[1].Points.Should().Be(30);
+    }
+
+    [Fact]
+    public void Serialize_WrongType_Throws()
+    {
+        var act = () => _sut.Serialize(new { foo = "bar" });
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Expected PointsScoreData*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategyTests.cs
@@ -1,0 +1,247 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Scoring;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class RankingScoringStrategyTests
+{
+    private readonly RankingScoringStrategy _sut = new();
+
+    [Fact]
+    public void Type_IsRanking()
+    {
+        _sut.Type.Should().Be(ScoreType.Ranking);
+    }
+
+    [Fact]
+    public void Validate_ValidJson_ReturnsValid()
+    {
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": 2 },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "position": 1 },
+                { "playerId": "00000000-0000-0000-0000-000000000003", "position": 3 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_DuplicatePosition_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": 1 },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "position": 1 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("sequential"));
+    }
+
+    [Fact]
+    public void Validate_GapInPositions_ReturnsInvalid()
+    {
+        // 3 players but positions 1, 3, 5 (gaps + no sequential up to N=3)
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": 1 },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "position": 3 },
+                { "playerId": "00000000-0000-0000-0000-000000000003", "position": 5 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("sequential"));
+    }
+
+    [Fact]
+    public void Validate_ZeroPosition_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": 0 },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "position": 1 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Position must be >= 1"));
+    }
+
+    [Fact]
+    public void Validate_NegativePosition_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": -3 },
+                { "playerId": "00000000-0000-0000-0000-000000000002", "position": 1 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Position must be >= 1"));
+    }
+
+    [Fact]
+    public void Validate_DuplicatePlayer_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": 1 },
+                { "playerId": "00000000-0000-0000-0000-000000000001", "position": 2 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Duplicate playerId"));
+    }
+
+    [Fact]
+    public void Validate_EmptyPlayerId_ReturnsInvalid()
+    {
+        var json = """
+            {
+              "positions": [
+                { "playerId": "00000000-0000-0000-0000-000000000000", "position": 1 }
+              ]
+            }
+            """;
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("PlayerId cannot be empty"));
+    }
+
+    [Fact]
+    public void Validate_EmptyJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WhitespaceJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("   ");
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EmptyPositionsArray_ReturnsInvalid()
+    {
+        var json = """{"positions":[]}""";
+
+        var result = _sut.Validate(json);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("No positions"));
+    }
+
+    [Fact]
+    public void Validate_MalformedJson_ReturnsInvalid()
+    {
+        var result = _sut.Validate("not json");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Invalid JSON"));
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_ReturnsPosition1Player()
+    {
+        var winner = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var second = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var third = Guid.Parse("00000000-0000-0000-0000-000000000003");
+        var json = $$"""
+            {
+              "positions": [
+                { "playerId": "{{second}}", "position": 2 },
+                { "playerId": "{{winner}}", "position": 1 },
+                { "playerId": "{{third}}", "position": 3 }
+              ]
+            }
+            """;
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(winner);
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_SinglePlayer_ReturnsThatPlayer()
+    {
+        var only = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var json = $$"""
+            {
+              "positions": [
+                { "playerId": "{{only}}", "position": 1 }
+              ]
+            }
+            """;
+
+        var result = _sut.ComputeWinnerPlayerId(json);
+
+        result.Should().Be(only);
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_RoundTrip()
+    {
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var original = new RankingScoreData(new[]
+        {
+            new PlayerRanking(p1, 1),
+            new PlayerRanking(p2, 2),
+        });
+
+        var json = _sut.Serialize(original);
+        var roundtrip = (RankingScoreData)_sut.Deserialize(json);
+
+        roundtrip.Positions.Should().HaveCount(2);
+        roundtrip.Positions[0].PlayerId.Should().Be(p1);
+        roundtrip.Positions[0].Position.Should().Be(1);
+        roundtrip.Positions[1].PlayerId.Should().Be(p2);
+        roundtrip.Positions[1].Position.Should().Be(2);
+    }
+
+    [Fact]
+    public void Serialize_WrongType_Throws()
+    {
+        var act = () => _sut.Serialize(new { foo = "bar" });
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Expected RankingScoreData*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactoryTests.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Scoring;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Scoring;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class ScoringStrategyFactoryTests
+{
+    private readonly ScoringStrategyFactory _sut = new();
+
+    [Theory]
+    [InlineData(ScoreType.Points, typeof(PointsScoringStrategy))]
+    [InlineData(ScoreType.BinaryWin, typeof(BinaryWinScoringStrategy))]
+    [InlineData(ScoreType.Objectives, typeof(ObjectivesScoringStrategy))]
+    [InlineData(ScoreType.Ranking, typeof(RankingScoringStrategy))]
+    public void GetStrategy_ReturnsExpectedStrategyForEachScoreType(
+        ScoreType type, Type expectedStrategyType)
+    {
+        var strategy = _sut.GetStrategy(type);
+        strategy.Should().BeOfType(expectedStrategyType);
+        strategy.Type.Should().Be(type);
+    }
+
+    [Fact]
+    public void GetStrategy_OnUnknownType_Throws()
+    {
+        var act = () => _sut.GetStrategy((ScoreType)999);
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Unknown ScoreType*");
+    }
+
+    [Fact]
+    public void ScoringValidationResult_Valid_HasEmptyErrors()
+    {
+        var result = ScoringValidationResult.Valid();
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ScoringValidationResult_Failed_SingleError_ContainsError()
+    {
+        var result = ScoringValidationResult.Failed("test error");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Be("test error");
+    }
+
+    [Fact]
+    public void ScoringValidationResult_Failed_MultipleErrors_ContainsAll()
+    {
+        var result = ScoringValidationResult.Failed(new[] { "err1", "err2" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(2).And.ContainInOrder("err1", "err2");
+    }
+}

--- a/docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md
+++ b/docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md
@@ -262,9 +262,40 @@ Tensioni meno gravi emerse durante la risoluzione delle 5 principali. Non blocca
 
 ---
 
+## Backend Mapping (terminologia demo ↔ codice)
+
+> Aggiunto post asse A v2 implementation (sessione 32, 2026-06-04). Riconcilia i termini usati in questo doc con le entità reali del backend, evitando confusione downstream.
+
+| Demo term | Backend term | Note |
+|-----------|--------------|------|
+| GameNight (Planned) | `GameNightEvent` con `Status = Published` | Dopo `Publish()` call sends invitations e crea RSVPs |
+| GameNight (Planned, ad-hoc) | `GameNightEvent.CreateAdHoc()` factory | Skip RSVP, direct `Status = InProgress` (no Published phase) |
+| GameNight (InProgress) | `GameNightEvent.Status = InProgress` | Via `HandleFirstSessionStarted` (T3 invariante #15) o `CreateAdHoc` |
+| GameNight (Completed) | `GameNightEvent.Status = Completed` | Via `Complete()` (Published path) o `CompleteAdHoc()` (AdHoc path) |
+| Session (created) | `Session` aggregate (`CreatedAt` valorizzato, `StartedAt = null`) | Draft mode equivalent (default after `Session.Create()`) |
+| Session (live) | `Session.IsLive` = `StartedAt != null && FinalizedAt == null` | Via `Session.OpenLiveMode()` (T2) — raises `SessionStartedDomainEvent` |
+| Session (completed) | `Session` con `FinalizedAt` valorizzato | Via `session.Finalize()` |
+| Player tagged (no notification) | `GameNightEvent.PreInvite(userIds)` | Status=Draft, creates RSVPs Pending, **no events emitted** |
+| Player invited (notification sent) | `GameNightEvent.Publish(invitedUserIds)` | Draft→Published, raises `GameNightPublishedEvent` → triggers `GameNightEmailService.SendGameNightInvitationEmailAsync` |
+| GameNightPlayer.RsvpStatus.Pending | `GameNightRsvp.Status = Pending` | Default dopo Publish/AddInvitees |
+| GameNightPlayer.RsvpStatus.Confirmed | `GameNightRsvp.Accept()` → `Status = Accepted` | Via responder action |
+| Max 1 live invariant (#10) | Guard in `GameNightEvent.StartCurrentSession()` → `MaxLiveSessionsExceededException` (Code `MAX_LIVE_SESSIONS_EXCEEDED`) | T1 implementation |
+| First-session-started transition (#15) | `GameNightEvent.HandleFirstSessionStarted(sessionId)` chiamato da `SessionStartedHandler` (MediatR) on `SessionStartedDomainEvent` | T3 implementation; standalone Session = no-op, idempotent su InProgress |
+| Draft+live warning header (#13) | `FinalizeSessionResult.LiveActiveWarning = true` → endpoint set `X-Warning-Code: SAVED_WHILE_LIVE_ACTIVE` | T4 implementation; non-bloccante |
+
+**Note semantiche aggiuntive**:
+- "Tagged" demo è il **PreInvite** backend (Draft phase, RSVP creati ma no notifica → user non vede).
+- "Invited" demo è la transizione **Publish**/`AddInvitees` (Published phase, eventi → email + notifica → user vede).
+- Il backend ha 3 stati intermedi che il demo collassa: `Draft` + `Cancelled` + `Corrupted` non hanno equivalente demo (l'umbrella tratta `Cancelled` come fuori-flusso, `Corrupted` come guard interno).
+- Il backend ha **2 tipi di "invitation"**: `GameNightRsvp` (per User-linked) e `GameNightInvitation` (token-based per email guest, issue #607 Wave A.5a + #1169). Il demo confonde i due → in v2 sono solo "invited player" generico, ma il backend deve gestire entrambi i flow.
+
+---
+
 ## Riferimenti
 
 - **Gap report demo**: [`2026-06-04-claude-design-gap-report.md`](../audits/2026-06-04-claude-design-gap-report.md)
 - **Mockup canonici**: `admin-mockups/design_files/sp4-dashboard.html`, `sp4-game-detail.html`, `sp4-sessions-index.html`, `sp4-session-skeleton-live.html`, `sp7-game-night-create.html`, `sp7-game-night-detail-rsvp.html`, `sp7-game-night-live.html`
-- **Bounded context backend**: `apps/api/src/Api/BoundedContexts/SessionTracking/` + `BoundedContexts/GameManagement/Domain/GameNight*`
+- **Bounded context backend**: `apps/api/src/Api/BoundedContexts/SessionTracking/` + `BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/`
 - **Mockup index**: [`admin-mockups/MOCKUPS_INDEX.md`](../../../admin-mockups/MOCKUPS_INDEX.md)
+- **Plan asse A implementation**: [`docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`](../../superpowers/plans/2026-06-04-asse-a-semantic-alignment.md)
+- **Spec consolidato spec-panel**: [`docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md`](../../superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md)

--- a/docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md
+++ b/docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md
@@ -1,0 +1,2268 @@
+# Asse A — Semantic Alignment GameNight/Session Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implementare le 20 invarianti del dominio GameNight/Session + polymorphic ScoreType (DEC-1) + notification system in-app+email (DEC-5) nei bounded context `SessionTracking` e `GameManagement` per allineare il backend alla demo Claude Design 2026-06-04.
+
+**Architecture:** EF Core migrations 3-step pattern (ALTER NULL → UPDATE → ALTER NOT NULL) + DDD aggregate refactor con factory methods + Strategy pattern per polymorphic scoring + transactional in-app notification + Resend email transactional fallback.
+
+**Tech Stack:** .NET 9 · ASP.NET Minimal APIs + MediatR · EF Core (pgvector) · FluentValidation · xUnit + Testcontainers · Resend (email transactional)
+
+**Issue**: [#1896](https://github.com/meepleAi-app/meepleai-monorepo/issues/1896) (parent umbrella [#1895](https://github.com/meepleAi-app/meepleai-monorepo/issues/1895))
+**Spec consolidato**: [`docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md`](../specs/2026-06-04-claude-design-alignment-spec-panel-review.md) (Sezione 4 — Asse A)
+**Domain model**: [`docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md`](../../for-developers/specs/2026-06-04-gamenight-session-domain-model.md) (20 invarianti)
+**Effort target**: XL ~15 gg dev + 3 gg test/review = 18 gg totali
+
+---
+
+## Work Packages
+
+| WP | Scope | Effort | Critical path | Sub-task |
+|----|-------|--------|---------------|----------|
+| **WP1** | Migration EF Core 3-step | S+S+S+S+M | YES (blocca tutti) | T1–T5 |
+| **WP2** | Session invarianti #11/#12/#13/#14 | M+S+S+M | YES (blocca WP4) | T6–T9 |
+| **WP3** | State machine GameNight #8/#15/#16/#17 | L+M+M | YES (blocca WP6 notification flow) | T10–T12 |
+| **WP4** | Invariante #10 max 1 live | M+S | NO (parallelo WP3) | T13–T14 |
+| **WP5** | Polymorphic ScoreType (DEC-1) | M+M+M+M+L | NO (parallelo WP3+WP4) | T15–T19 |
+| **WP6** | Notification system (DEC-5) | M+M+L+L | NO (parallelo WP4+WP5) | T20–T23 |
+| **WP7** | OpenAPI + acceptance | S+M | YES (chiude WP) | T24–T25 |
+
+**Mix-model hint (P120)**: 12 haiku (mechanical TDD) + 13 sonnet (judgment design). Vedi hint per task.
+
+**Total**: 25 task TDD bite-sized. ~18 gg effort realistic.
+
+---
+
+## File Structure
+
+### New files
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/ScoreType.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/IScoringStrategy.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactory.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdated.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedDomainEvent.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandValidator.cs`
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightStatus.cs`
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/RsvpStatus.cs`
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs`
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/SendInvitations/SendGameNightInvitationsCommand.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Notification.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/IEmailSender.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/ResendEmailSender.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/Templates/GameNightInvitationTemplate.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Application/SendInvitationNotification/SendInvitationNotificationCommandHandler.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/NotificationEndpoints.cs`
+- `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionTimestamps.cs`
+- `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightStatus.cs`
+- `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightPlayerRsvp.cs`
+- `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionPolymorphicScoring.cs`
+- `apps/api/src/Api/Migrations/YYYYMMDD_CreateNotificationsTable.cs`
+- `infra/secrets/email.secret.example`
+- Test files mirror under `apps/api/tests/Api.Tests/`
+
+### Modified files
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs` (factory methods + invarianti)
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNight.cs` (state machine + aggregate guard)
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightPlayer.cs` (IsTagged/IsInvited/RsvpStatus)
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandHandler.cs` (warning header)
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/GetSessionsByGameNight/GetSessionsByGameNightQueryHandler.cs` (sort ASC)
+- `apps/api/src/Api/Infrastructure/Persistence/ApplicationDbContext.cs` (DbSet<Notification>, configurations)
+- `apps/api/src/Api/Program.cs` (DI: `IEmailSender → ResendEmailSender`)
+- `apps/api/src/Api/openapi.yaml` (new error codes + DTO updates)
+- `apps/api/src/Api/Routing/RouteRegistrar.cs` (register notification endpoints)
+- `CLAUDE.md` (Domain Model section: update con stato post-impl)
+
+---
+
+## WP1 — Migration EF Core 3-step
+
+> **Spec reference**: Sezione 4 Asse A — "Migration (MAJ-1 fix: 3-step pattern)".
+> **Invarianti coperte**: foundation per #10/#11/#15/#16/#17/#18 + DEC-1/DEC-5.
+> **Critical path**: blocca tutti gli altri WP.
+
+### Task 1: Migration sessions timestamps (#11)
+
+**Mix-model**: haiku · **Effort**: S (~3h)
+
+**Files:**
+- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionTimestamps.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/MigrationTests.cs`
+
+- [ ] **Step 1: Generate migration scaffold**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddSessionTimestamps --output-dir Migrations
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+// MigrationTests.cs
+[Fact]
+public async Task AddSessionTimestamps_AddsThreeNullableColumns_ThenNotNullOnCreatedAt()
+{
+    using var fixture = await TestcontainersFixture.CreateAsync();
+    await fixture.MigrateAsync(targetMigration: "AddSessionTimestamps");
+
+    using var conn = fixture.GetConnection();
+    var columns = await conn.QueryAsync<dynamic>(
+        "SELECT column_name, is_nullable FROM information_schema.columns " +
+        "WHERE table_name = 'sessions' AND column_name IN ('created_at', 'started_at', 'completed_at')"
+    );
+    columns.Should().HaveCount(3);
+    columns.First(c => c.column_name == "created_at").is_nullable.Should().Be("NO");
+    columns.First(c => c.column_name == "started_at").is_nullable.Should().Be("YES");
+    columns.First(c => c.column_name == "completed_at").is_nullable.Should().Be("YES");
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+dotnet test --filter "FullyQualifiedName~AddSessionTimestamps" -v normal
+```
+Expected: FAIL — migration not implemented
+
+- [ ] **Step 4: Implement migration with 3-step pattern**
+
+```csharp
+// YYYYMMDD_AddSessionTimestamps.cs
+public partial class AddSessionTimestamps : Migration
+{
+    protected override void Up(MigrationBuilder b)
+    {
+        // Step 1: ALTER nullable
+        b.AddColumn<DateTimeOffset?>("created_at", "sessions", nullable: true);
+        b.AddColumn<DateTimeOffset?>("started_at", "sessions", nullable: true);
+        b.AddColumn<DateTimeOffset?>("completed_at", "sessions", nullable: true);
+
+        // Step 2: UPDATE backfill
+        b.Sql("UPDATE sessions SET created_at = updated_at;");
+        b.Sql("UPDATE sessions SET completed_at = updated_at WHERE status = 'completed';");
+
+        // Step 3: ALTER NOT NULL only for created_at + DEFAULT
+        b.AlterColumn<DateTimeOffset>("created_at", "sessions",
+            nullable: false, defaultValueSql: "now()");
+    }
+
+    protected override void Down(MigrationBuilder b)
+    {
+        b.DropColumn("completed_at", "sessions");
+        b.DropColumn("started_at", "sessions");
+        b.DropColumn("created_at", "sessions");
+    }
+}
+```
+
+- [ ] **Step 5: Update SessionEntity + ApplicationDbContext config**
+
+```csharp
+// SessionEntity.cs (or via Session aggregate root)
+public DateTimeOffset CreatedAt { get; private set; }
+public DateTimeOffset? StartedAt { get; private set; }
+public DateTimeOffset? CompletedAt { get; private set; }
+
+// ApplicationDbContext.cs OnModelCreating
+modelBuilder.Entity<SessionEntity>(b =>
+{
+    b.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
+    b.Property(e => e.StartedAt).HasColumnName("started_at");
+    b.Property(e => e.CompletedAt).HasColumnName("completed_at");
+});
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+dotnet test --filter "FullyQualifiedName~AddSessionTimestamps" -v normal
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Migrations/*AddSessionTimestamps* \
+        apps/api/src/Api/BoundedContexts/SessionTracking/ \
+        apps/api/src/Api/Infrastructure/Persistence/ApplicationDbContext.cs \
+        apps/api/tests/Api.Tests/Integration/SessionTracking/MigrationTests.cs
+git commit -m "feat(session-tracking): #1896 add Session.CreatedAt/StartedAt/CompletedAt (invariante #11)"
+```
+
+**Self-review checklist**:
+- [ ] Migration usa 3-step pattern (no circular DEFAULT now() + UPDATE)
+- [ ] `created_at` NOT NULL, `started_at`/`completed_at` NULL
+- [ ] Backfill SQL idempotente (eseguibile più volte senza errori)
+- [ ] Down migration drop columns in ordine inverso
+- [ ] EF Core entity config snake_case mapping
+
+---
+
+### Task 2: Migration game_nights status (#8 + #15)
+
+**Mix-model**: haiku · **Effort**: S (~2h)
+
+**Files:**
+- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightStatus.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/MigrationTests.cs`
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddGameNightStatus --output-dir Migrations
+```
+
+- [ ] **Step 2: Write failing integration test**
+
+```csharp
+[Fact]
+public async Task AddGameNightStatus_BackfillsCompletedForPastWithSessions_PlannedOtherwise()
+{
+    using var fixture = await TestcontainersFixture.CreateAsync();
+    await fixture.SeedAsync(seed =>
+    {
+        seed.AddGameNight(date: DateTimeOffset.UtcNow.AddDays(-10), hasSession: true);
+        seed.AddGameNight(date: DateTimeOffset.UtcNow.AddDays(-5), hasSession: false);
+        seed.AddGameNight(date: DateTimeOffset.UtcNow.AddDays(+5), hasSession: false);
+    });
+    await fixture.MigrateAsync(targetMigration: "AddGameNightStatus");
+
+    using var conn = fixture.GetConnection();
+    var statuses = await conn.QueryAsync<(Guid Id, string Status)>(
+        "SELECT id, status FROM game_nights ORDER BY date"
+    );
+    statuses.ElementAt(0).Status.Should().Be("Completed");
+    statuses.ElementAt(1).Status.Should().Be("Planned");
+    statuses.ElementAt(2).Status.Should().Be("Planned");
+}
+```
+
+- [ ] **Step 3: Run test → FAIL**
+
+- [ ] **Step 4: Implement migration**
+
+```csharp
+public partial class AddGameNightStatus : Migration
+{
+    protected override void Up(MigrationBuilder b)
+    {
+        b.AddColumn<string>("status", "game_nights",
+            maxLength: 20, nullable: true);
+
+        b.Sql(@"
+            UPDATE game_nights SET status = 'Completed'
+            WHERE date < now() AND EXISTS (
+                SELECT 1 FROM sessions WHERE game_night_id = game_nights.id
+            );
+        ");
+        b.Sql("UPDATE game_nights SET status = 'Planned' WHERE date >= now() OR status IS NULL;");
+
+        b.AlterColumn<string>("status", "game_nights",
+            maxLength: 20, nullable: false, defaultValue: "Planned");
+    }
+
+    protected override void Down(MigrationBuilder b) =>
+        b.DropColumn("status", "game_nights");
+}
+```
+
+- [ ] **Step 5: Run test → PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 add GameNight.Status enum (invariante #8 + #15)"
+```
+
+**Self-review**:
+- [ ] Backfill 'Completed' solo per `date < now() AND hasSession`
+- [ ] Fallback 'Planned' per status NULL
+- [ ] DEFAULT 'Planned' applicato dopo backfill
+
+---
+
+### Task 3: Migration game_night_players RSVP (#16 + #17)
+
+**Mix-model**: haiku · **Effort**: S (~3h)
+
+**Files:**
+- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightPlayerRsvp.cs`
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+dotnet ef migrations add AddGameNightPlayerRsvp --output-dir Migrations
+```
+
+- [ ] **Step 2: Write failing test**
+
+```csharp
+[Fact]
+public async Task AddGameNightPlayerRsvp_BackfillsExistingAsInvitedAndConfirmed_BackwardsCompat()
+{
+    using var fixture = await TestcontainersFixture.CreateAsync();
+    var existingPlayerId = await fixture.SeedAsync(seed =>
+        seed.AddGameNightPlayer()).Result;
+
+    await fixture.MigrateAsync(targetMigration: "AddGameNightPlayerRsvp");
+
+    using var conn = fixture.GetConnection();
+    var row = await conn.QuerySingleAsync<(bool IsTagged, bool IsInvited, string RsvpStatus)>(
+        "SELECT is_tagged, is_invited, rsvp_status FROM game_night_players WHERE id = @id",
+        new { id = existingPlayerId }
+    );
+    row.IsTagged.Should().BeTrue();
+    row.IsInvited.Should().BeTrue();
+    row.RsvpStatus.Should().Be("Confirmed");
+}
+```
+
+- [ ] **Step 3: Run test → FAIL**
+
+- [ ] **Step 4: Implement migration with MAJ-2 backwards-compat**
+
+```csharp
+public partial class AddGameNightPlayerRsvp : Migration
+{
+    protected override void Up(MigrationBuilder b)
+    {
+        // MAJ-2: existing players are already auto-invited + auto-confirmed (legacy pattern)
+        b.AddColumn<bool>("is_tagged", "game_night_players",
+            nullable: false, defaultValue: true);
+        b.AddColumn<bool>("is_invited", "game_night_players",
+            nullable: false, defaultValue: true);
+        b.AddColumn<string>("rsvp_status", "game_night_players",
+            maxLength: 20, nullable: false, defaultValue: "Confirmed");
+    }
+
+    protected override void Down(MigrationBuilder b)
+    {
+        b.DropColumn("rsvp_status", "game_night_players");
+        b.DropColumn("is_invited", "game_night_players");
+        b.DropColumn("is_tagged", "game_night_players");
+    }
+}
+```
+
+- [ ] **Step 5: Run test → PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 add GameNightPlayer RSVP fields (invariante #16 + #17)
+
+MAJ-2 backwards-compat: existing players backfilled as IsInvited=true + RsvpStatus=Confirmed
+(legacy auto-shared pattern preserved)."
+```
+
+---
+
+### Task 4: Migration sessions polymorphic scoring (DEC-1 foundation)
+
+**Mix-model**: haiku · **Effort**: S (~2h)
+
+**Files:**
+- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionPolymorphicScoring.cs`
+
+- [ ] **Step 1: Generate migration**
+
+- [ ] **Step 2: Write failing test for column existence + backfill**
+
+```csharp
+[Fact]
+public async Task AddSessionPolymorphicScoring_AddsColumnsAndBackfillsExistingAsPoints()
+{
+    using var fixture = await TestcontainersFixture.CreateAsync();
+    await fixture.SeedAsync(seed => seed.AddSessions(count: 3));
+
+    await fixture.MigrateAsync(targetMigration: "AddSessionPolymorphicScoring");
+
+    using var conn = fixture.GetConnection();
+    var rows = await conn.QueryAsync<(string ScoringType, string ScoreData)>(
+        "SELECT scoring_type, score_data::text FROM sessions"
+    );
+    rows.Should().HaveCount(3);
+    rows.All(r => r.ScoringType == "Points").Should().BeTrue();
+    rows.All(r => r.ScoreData == "{}").Should().BeTrue();
+}
+```
+
+- [ ] **Step 3: Run → FAIL**
+
+- [ ] **Step 4: Implement migration**
+
+```csharp
+public partial class AddSessionPolymorphicScoring : Migration
+{
+    protected override void Up(MigrationBuilder b)
+    {
+        b.AddColumn<string>("scoring_type", "sessions",
+            maxLength: 20, nullable: false, defaultValue: "Points");
+        b.AddColumn<string>("score_data", "sessions",
+            type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb");
+    }
+
+    protected override void Down(MigrationBuilder b)
+    {
+        b.DropColumn("score_data", "sessions");
+        b.DropColumn("scoring_type", "sessions");
+    }
+}
+```
+
+- [ ] **Step 5: Run → PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 add Session.ScoringType/ScoreData (DEC-1 polymorphic)"
+```
+
+---
+
+### Task 5: Migration notifications table (DEC-5 foundation)
+
+**Mix-model**: haiku · **Effort**: M (~4h)
+
+**Files:**
+- Create: `apps/api/src/Api/Migrations/YYYYMMDD_CreateNotificationsTable.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Notification.cs`
+
+- [ ] **Step 1: Generate migration**
+
+- [ ] **Step 2: Write failing test for table + indexes**
+
+```csharp
+[Fact]
+public async Task CreateNotificationsTable_HasExpectedSchemaAndIndexes()
+{
+    using var fixture = await TestcontainersFixture.CreateAsync();
+    await fixture.MigrateAsync(targetMigration: "CreateNotificationsTable");
+
+    using var conn = fixture.GetConnection();
+
+    var columns = await conn.QueryAsync<dynamic>(
+        "SELECT column_name, data_type FROM information_schema.columns " +
+        "WHERE table_name = 'notifications'"
+    );
+    columns.Select(c => c.column_name).Should().Contain(
+        new[] { "id", "recipient_user_id", "type", "payload", "read_at", "created_at" }
+    );
+
+    var indexes = await conn.QueryAsync<string>(
+        "SELECT indexname FROM pg_indexes WHERE tablename = 'notifications'"
+    );
+    indexes.Should().Contain("idx_notifications_recipient_created");
+    indexes.Should().Contain("idx_notifications_recipient_unread");
+}
+```
+
+- [ ] **Step 3: Run → FAIL**
+
+- [ ] **Step 4: Implement migration + entity**
+
+```csharp
+public partial class CreateNotificationsTable : Migration
+{
+    protected override void Up(MigrationBuilder b)
+    {
+        b.CreateTable("notifications", t => new
+        {
+            Id = t.Column<Guid>(nullable: false, defaultValueSql: "gen_random_uuid()"),
+            RecipientUserId = t.Column<Guid>("recipient_user_id", nullable: false),
+            Type = t.Column<string>(maxLength: 50, nullable: false),
+            Payload = t.Column<string>(type: "jsonb", nullable: false),
+            ReadAt = t.Column<DateTimeOffset?>("read_at", nullable: true),
+            CreatedAt = t.Column<DateTimeOffset>("created_at",
+                nullable: false, defaultValueSql: "now()"),
+        }, constraints: t =>
+        {
+            t.PrimaryKey("pk_notifications", x => x.Id);
+            t.ForeignKey("fk_notifications_users",
+                x => x.RecipientUserId, "users", "id", onDelete: ReferentialAction.Cascade);
+        });
+
+        b.CreateIndex("idx_notifications_recipient_created",
+            "notifications", new[] { "recipient_user_id", "created_at" },
+            descending: new[] { false, true });
+        b.CreateIndex("idx_notifications_recipient_unread",
+            "notifications", "recipient_user_id",
+            filter: "read_at IS NULL");
+    }
+
+    protected override void Down(MigrationBuilder b) => b.DropTable("notifications");
+}
+```
+
+```csharp
+// BoundedContexts/UserNotifications/Domain/Notification.cs
+public sealed class Notification
+{
+    public Guid Id { get; private set; }
+    public Guid RecipientUserId { get; private set; }
+    public string Type { get; private set; } = default!;
+    public string Payload { get; private set; } = default!; // JSON
+    public DateTimeOffset? ReadAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    private Notification() { } // EF
+
+    public static Notification Create(Guid recipientUserId, string type, string payloadJson)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            throw new ArgumentException("Type required", nameof(type));
+        return new Notification
+        {
+            Id = Guid.NewGuid(),
+            RecipientUserId = recipientUserId,
+            Type = type,
+            Payload = payloadJson,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    public void MarkAsRead()
+    {
+        if (ReadAt is null) ReadAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+- [ ] **Step 5: Update ApplicationDbContext**
+
+```csharp
+public DbSet<Notification> Notifications => Set<Notification>();
+
+// OnModelCreating
+modelBuilder.Entity<Notification>(b =>
+{
+    b.ToTable("notifications");
+    b.HasKey(e => e.Id);
+    b.Property(e => e.RecipientUserId).HasColumnName("recipient_user_id");
+    b.Property(e => e.Type).HasColumnName("type").HasMaxLength(50).IsRequired();
+    b.Property(e => e.Payload).HasColumnName("payload").HasColumnType("jsonb").IsRequired();
+    b.Property(e => e.ReadAt).HasColumnName("read_at");
+    b.Property(e => e.CreatedAt).HasColumnName("created_at");
+});
+```
+
+- [ ] **Step 6: Run → PASS**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(user-notifications): #1896 create notifications table + Notification entity (DEC-5)"
+```
+
+---
+
+## WP2 — Session invarianti #11/#12/#13/#14
+
+> **Spec reference**: Sezione 4 Asse A — "Modello Session (3 timestamp distinti)" + invarianti #12/#13/#14.
+> **Critical path**: blocca WP4 (max 1 live aggregate guard).
+
+### Task 6: Session.OpenLiveMode factory + invariante #14
+
+**Mix-model**: sonnet · **Effort**: M (~6h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Domain/SessionTests.cs`
+
+- [ ] **Step 1: Write failing unit tests**
+
+```csharp
+public class SessionOpenLiveModeTests
+{
+    [Fact]
+    public void OpenLiveMode_OnDraft_SetsStartedAtToNow_AndReturnsLiveSession()
+    {
+        var draft = Session.CreateDraft(gameNightId: Guid.NewGuid(), gameId: Guid.NewGuid());
+        var beforeNow = DateTimeOffset.UtcNow;
+
+        var live = draft.OpenLiveMode();
+
+        live.StartedAt.Should().NotBeNull();
+        live.StartedAt!.Value.Should().BeOnOrAfter(beforeNow);
+        live.CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void OpenLiveMode_OnSessionWithStartedAt_Throws()
+    {
+        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
+        draft.OpenLiveMode();
+
+        var act = () => draft.OpenLiveMode();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already in live mode*");
+    }
+
+    [Fact]
+    public void StartedAt_IsNeverSetByConstructorOrDraftFactory()
+    {
+        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
+        draft.StartedAt.Should().BeNull(); // invariante #14
+    }
+}
+```
+
+- [ ] **Step 2: Run tests → FAIL** (method not exists)
+
+- [ ] **Step 3: Implement Session.OpenLiveMode + invariante #14**
+
+```csharp
+public sealed class Session
+{
+    public Guid Id { get; private set; }
+    public Guid GameNightId { get; private set; }
+    public Guid GameId { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset? StartedAt { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+
+    private Session() { } // EF
+
+    public static Session CreateDraft(Guid gameNightId, Guid gameId) => new()
+    {
+        Id = Guid.NewGuid(),
+        GameNightId = gameNightId,
+        GameId = gameId,
+        CreatedAt = DateTimeOffset.UtcNow,
+        // StartedAt + CompletedAt deliberately NULL (invariante #14)
+    };
+
+    public Session OpenLiveMode()
+    {
+        if (StartedAt is not null)
+            throw new InvalidOperationException(
+                $"Session {Id} is already in live mode (StartedAt={StartedAt}).");
+        StartedAt = DateTimeOffset.UtcNow;
+        return this;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 Session.OpenLiveMode factory + invariante #14 (StartedAt derived)"
+```
+
+**Self-review**:
+- [ ] StartedAt NEVER set by constructor/CreateDraft
+- [ ] OpenLiveMode throws if already live
+- [ ] Factory method pattern (MIN-6 clarified)
+- [ ] DateTimeOffset.UtcNow direct (no clock abstraction MVP, document trade-off)
+
+---
+
+### Task 7: Session.Save() invariante #11 completedAt valorizzato
+
+**Mix-model**: haiku · **Effort**: S (~3h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Domain/SessionTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+public class SessionSaveTests
+{
+    [Fact]
+    public void Save_OnDraft_SetsCompletedAtToNow()
+    {
+        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
+        var beforeNow = DateTimeOffset.UtcNow;
+
+        draft.Save();
+
+        draft.CompletedAt.Should().NotBeNull();
+        draft.CompletedAt!.Value.Should().BeOnOrAfter(beforeNow);
+    }
+
+    [Fact]
+    public void Save_OnLive_PreservesStartedAt_AndSetsCompletedAt()
+    {
+        var session = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid()).OpenLiveMode();
+        var startedAt = session.StartedAt;
+
+        session.Save();
+
+        session.StartedAt.Should().Be(startedAt);
+        session.CompletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Save_OnAlreadySaved_Throws()
+    {
+        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
+        draft.Save();
+
+        var act = () => draft.Save();
+        act.Should().Throw<InvalidOperationException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement Session.Save**
+
+```csharp
+public void Save()
+{
+    if (CompletedAt is not null)
+        throw new InvalidOperationException(
+            $"Session {Id} is already saved (CompletedAt={CompletedAt}).");
+    CompletedAt = DateTimeOffset.UtcNow;
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 Session.Save() valorizza CompletedAt (invariante #11)"
+```
+
+---
+
+### Task 8: GetSessionsByGameNightQuery sort createdAt ASC (invariante #12)
+
+**Mix-model**: haiku · **Effort**: S (~2h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/GetSessionsByGameNight/GetSessionsByGameNightQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/GetSessionsByGameNightQueryHandlerTests.cs`
+
+- [ ] **Step 1: Write failing integration test**
+
+```csharp
+[Fact]
+public async Task Handle_ReturnsSessions_OrderedByCreatedAtAscending()
+{
+    using var fixture = await TestcontainersFixture.CreateAsync();
+    var gameNightId = Guid.NewGuid();
+    await fixture.SeedAsync(seed =>
+    {
+        seed.AddSession(gameNightId, createdAt: DateTimeOffset.UtcNow.AddMinutes(-30));
+        seed.AddSession(gameNightId, createdAt: DateTimeOffset.UtcNow);
+        seed.AddSession(gameNightId, createdAt: DateTimeOffset.UtcNow.AddMinutes(-15));
+    });
+
+    var handler = fixture.Resolve<GetSessionsByGameNightQueryHandler>();
+    var result = await handler.Handle(new GetSessionsByGameNightQuery(gameNightId), CT.None);
+
+    result.Should().HaveCount(3);
+    result.Should().BeInAscendingOrder(s => s.CreatedAt);
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (current sort is updated_at desc o nessuno)
+
+- [ ] **Step 3: Update handler**
+
+```csharp
+public async Task<IReadOnlyList<SessionDto>> Handle(
+    GetSessionsByGameNightQuery query, CancellationToken ct)
+{
+    return await _db.Sessions
+        .Where(s => s.GameNightId == query.GameNightId)
+        .OrderBy(s => s.CreatedAt) // invariante #12 deterministic
+        .Select(s => SessionDto.FromEntity(s))
+        .ToListAsync(ct);
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 sort sessions by CreatedAt ASC (invariante #12)"
+```
+
+---
+
+### Task 9: SaveSessionCommand + X-Warning-Code header (invariante #13)
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Routing/SessionEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/SaveSessionEndpointTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+[Fact]
+public async Task SaveSession_WithActiveLive_Returns200_WithWarningHeader()
+{
+    using var app = await TestApp.CreateAsync();
+    var gn = await app.SeedGameNightAsync();
+    var liveSession = await app.OpenLiveSessionAsync(gn.Id, gameId: Guid.NewGuid());
+    var draft = await app.CreateDraftSessionAsync(gn.Id, gameId: Guid.NewGuid());
+
+    var response = await app.Client.PutAsync(
+        $"/api/v1/sessions/{draft.Id}/save",
+        JsonContent.Create(new SaveSessionRequest { ScoringType = "Points", ScoreData = "{}" }));
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    response.Headers.GetValues("X-Warning-Code").Should().ContainSingle("SAVED_WHILE_LIVE_ACTIVE");
+}
+
+[Fact]
+public async Task SaveSession_WithoutActiveLive_Returns200_NoWarningHeader()
+{
+    using var app = await TestApp.CreateAsync();
+    var gn = await app.SeedGameNightAsync();
+    var draft = await app.CreateDraftSessionAsync(gn.Id, gameId: Guid.NewGuid());
+
+    var response = await app.Client.PutAsync(
+        $"/api/v1/sessions/{draft.Id}/save",
+        JsonContent.Create(new SaveSessionRequest { ScoringType = "Points", ScoreData = "{}" }));
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    response.Headers.Contains("X-Warning-Code").Should().BeFalse();
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (handler non emette warning)
+
+- [ ] **Step 3: Update handler to return warning flag + endpoint to map to header**
+
+```csharp
+public record SaveSessionResult(SessionDto Session, bool LiveActiveWarning);
+
+public async Task<SaveSessionResult> Handle(SaveSessionCommand cmd, CancellationToken ct)
+{
+    var session = await _db.Sessions.FindAsync(new object?[] { cmd.SessionId }, ct)
+        ?? throw new NotFoundException($"Session {cmd.SessionId} not found");
+    session.Save();
+
+    bool liveActive = await _db.Sessions.AnyAsync(s =>
+        s.GameNightId == session.GameNightId &&
+        s.StartedAt != null &&
+        s.CompletedAt == null &&
+        s.Id != session.Id, ct);
+
+    await _db.SaveChangesAsync(ct);
+    return new SaveSessionResult(SessionDto.FromEntity(session), liveActive);
+}
+```
+
+```csharp
+// SessionEndpoints.cs
+app.MapPut("/api/v1/sessions/{id:guid}/save", async (
+    Guid id, SaveSessionRequest req, IMediator m, HttpResponse response) =>
+{
+    var result = await m.Send(new SaveSessionCommand(id, req.ScoringType, req.ScoreData));
+    if (result.LiveActiveWarning)
+        response.Headers.Append("X-Warning-Code", "SAVED_WHILE_LIVE_ACTIVE");
+    return Results.Ok(result.Session);
+});
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 SaveSession X-Warning-Code header on live coexistence (invariante #13)"
+```
+
+---
+
+## WP3 — State machine GameNight #8/#15/#16/#17
+
+> **Spec reference**: Sezione 4 Asse A — "State machine GameNight" + Tagging vs RSVP a 5 fasi.
+> **Critical path**: blocca WP6 notification flow (SendInvitations comand triggers notification).
+
+### Task 10: GameNight state machine + SessionCreatedDomainEvent handler (invariante #15)
+
+**Mix-model**: sonnet · **Effort**: L (~8h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightStatus.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedDomainEvent.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNight.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightStateMachineTests.cs`
+
+- [ ] **Step 1: Write failing unit tests**
+
+```csharp
+public class GameNightStateMachineTests
+{
+    [Fact]
+    public void NewGameNight_HasStatusPlanned()
+    {
+        var gn = GameNight.Create(ownerId: Guid.NewGuid(), date: DateTimeOffset.UtcNow.AddDays(7));
+        gn.Status.Should().Be(GameNightStatus.Planned);
+    }
+
+    [Fact]
+    public void FirstSessionCreated_TransitionsToInProgress_InvariantE15()
+    {
+        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow.AddDays(1));
+        var draftEvent = new SessionCreatedDomainEvent(gn.Id, sessionId: Guid.NewGuid(), isLive: false);
+
+        gn.HandleSessionCreated(draftEvent);
+
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+    }
+
+    [Fact]
+    public void FirstSessionLiveCreated_TransitionsToInProgress_InvariantE15()
+    {
+        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        var liveEvent = new SessionCreatedDomainEvent(gn.Id, sessionId: Guid.NewGuid(), isLive: true);
+
+        gn.HandleSessionCreated(liveEvent);
+
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+    }
+
+    [Fact]
+    public void SubsequentSessionCreated_StaysInProgress()
+    {
+        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
+        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+    }
+
+    [Fact]
+    public void MarkAsCompleted_FromInProgress_TransitionsToCompleted()
+    {
+        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
+
+        gn.MarkAsCompleted();
+
+        gn.Status.Should().Be(GameNightStatus.Completed);
+    }
+
+    [Fact]
+    public void MarkAsCompleted_FromPlanned_Throws()
+    {
+        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        var act = () => gn.MarkAsCompleted();
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Planned*");
+    }
+
+    [Fact]
+    public void NoBackwardTransition_CompletedCantGoBackToInProgress()
+    {
+        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
+        gn.MarkAsCompleted();
+
+        var act = () => gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
+        act.Should().Throw<InvalidOperationException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement enum + event + aggregate logic**
+
+```csharp
+// GameNightStatus.cs
+public enum GameNightStatus { Planned, InProgress, Completed }
+
+// SessionCreatedDomainEvent.cs
+public record SessionCreatedDomainEvent(Guid GameNightId, Guid SessionId, bool IsLive);
+
+// GameNight.cs (partial)
+public GameNightStatus Status { get; private set; } = GameNightStatus.Planned;
+
+public void HandleSessionCreated(SessionCreatedDomainEvent evt)
+{
+    if (evt.GameNightId != Id)
+        throw new InvalidOperationException("Event for different GameNight");
+    if (Status == GameNightStatus.Completed)
+        throw new InvalidOperationException(
+            $"GameNight {Id} is Completed, cannot accept new sessions.");
+    if (Status == GameNightStatus.Planned)
+        Status = GameNightStatus.InProgress; // invariante #15
+    // If already InProgress: no-op (subsequent sessions don't change state)
+}
+
+public void MarkAsCompleted()
+{
+    if (Status != GameNightStatus.InProgress)
+        throw new InvalidOperationException(
+            $"Cannot mark Planned GameNight {Id} as Completed. Status={Status}.");
+    Status = GameNightStatus.Completed;
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Wire SessionCreatedDomainEvent into Session.CreateDraft + Session.OpenLiveMode**
+
+```csharp
+// Session.cs
+public IReadOnlyList<object> DomainEvents => _events;
+private readonly List<object> _events = new();
+
+public static Session CreateDraft(Guid gameNightId, Guid gameId)
+{
+    var s = new Session { /* ... */ };
+    s._events.Add(new SessionCreatedDomainEvent(gameNightId, s.Id, isLive: false));
+    return s;
+}
+
+public Session OpenLiveMode()
+{
+    if (StartedAt is not null) throw new InvalidOperationException(/* ... */);
+    StartedAt = DateTimeOffset.UtcNow;
+    // If created via OpenLiveMode directly (not draft → live), emit IsLive=true
+    if (CreatedAt >= StartedAt.Value.AddSeconds(-1))
+        _events.Add(new SessionCreatedDomainEvent(GameNightId, Id, isLive: true));
+    return this;
+}
+```
+
+- [ ] **Step 6: Add MediatR INotification handler dispatching event to GameNight aggregate**
+
+```csharp
+// In SessionTracking/Application/EventHandlers/SessionCreatedHandler.cs
+public class SessionCreatedHandler : INotificationHandler<SessionCreatedDomainEvent>
+{
+    private readonly IGameNightRepository _repo;
+    public SessionCreatedHandler(IGameNightRepository repo) => _repo = repo;
+
+    public async Task Handle(SessionCreatedDomainEvent evt, CancellationToken ct)
+    {
+        var gn = await _repo.GetByIdAsync(evt.GameNightId, ct)
+            ?? throw new NotFoundException($"GameNight {evt.GameNightId} not found");
+        gn.HandleSessionCreated(evt);
+        await _repo.SaveAsync(gn, ct);
+    }
+}
+```
+
+- [ ] **Step 7: Run all unit + integration tests**
+
+```bash
+dotnet test --filter "BoundedContext=GameManagement|BoundedContext=SessionTracking"
+```
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 GameNight state machine + SessionCreatedDomainEvent (invariante #15)"
+```
+
+**Self-review**:
+- [ ] Invariante #15 esplicita: trigger ON FIRST Session creation (draft OR live)
+- [ ] No backward transition Completed → InProgress
+- [ ] MediatR INotification dispatch via DomainEvents collection
+- [ ] Aggregate repository pattern preserved
+
+---
+
+### Task 11: GameNightPlayer.IsTagged/IsInvited/RsvpStatus + invariante #16 separation
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/RsvpStatus.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightPlayer.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightPlayerRsvpTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+public class GameNightPlayerRsvpTests
+{
+    [Fact]
+    public void TagPlayer_SetsIsTaggedTrue_IsInvitedFalse_RsvpPending()
+    {
+        var player = GameNightPlayer.Tag(playerId: Guid.NewGuid());
+        player.IsTagged.Should().BeTrue();
+        player.IsInvited.Should().BeFalse();
+        player.RsvpStatus.Should().Be(RsvpStatus.Pending);
+    }
+
+    [Fact]
+    public void Invite_OnTaggedPlayer_SetsIsInvitedTrue_StaysRsvpPending()
+    {
+        var player = GameNightPlayer.Tag(Guid.NewGuid());
+        player.Invite();
+        player.IsTagged.Should().BeTrue();
+        player.IsInvited.Should().BeTrue();
+        player.RsvpStatus.Should().Be(RsvpStatus.Pending);
+    }
+
+    [Fact]
+    public void ConfirmRsvp_OnInvited_SetsConfirmed()
+    {
+        var player = GameNightPlayer.Tag(Guid.NewGuid());
+        player.Invite();
+        player.ConfirmRsvp();
+        player.RsvpStatus.Should().Be(RsvpStatus.Confirmed);
+    }
+
+    [Fact]
+    public void DeclineRsvp_OnInvited_SetsDeclined()
+    {
+        var player = GameNightPlayer.Tag(Guid.NewGuid());
+        player.Invite();
+        player.DeclineRsvp();
+        player.RsvpStatus.Should().Be(RsvpStatus.Declined);
+    }
+
+    [Fact]
+    public void ConfirmRsvp_OnNotInvited_Throws()
+    {
+        var player = GameNightPlayer.Tag(Guid.NewGuid());
+        var act = () => player.ConfirmRsvp();
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not yet invited*");
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement**
+
+```csharp
+public enum RsvpStatus { Pending, Confirmed, Declined }
+
+public sealed class GameNightPlayer
+{
+    public Guid Id { get; private set; }
+    public Guid PlayerId { get; private set; }
+    public bool IsTagged { get; private set; }
+    public bool IsInvited { get; private set; }
+    public RsvpStatus RsvpStatus { get; private set; }
+
+    private GameNightPlayer() { }
+
+    public static GameNightPlayer Tag(Guid playerId) => new()
+    {
+        Id = Guid.NewGuid(),
+        PlayerId = playerId,
+        IsTagged = true,
+        IsInvited = false,
+        RsvpStatus = RsvpStatus.Pending,
+    };
+
+    public void Invite()
+    {
+        if (!IsTagged) throw new InvalidOperationException("Player not tagged");
+        IsInvited = true;
+    }
+
+    public void ConfirmRsvp()
+    {
+        if (!IsInvited) throw new InvalidOperationException("Player not yet invited");
+        RsvpStatus = RsvpStatus.Confirmed;
+    }
+
+    public void DeclineRsvp()
+    {
+        if (!IsInvited) throw new InvalidOperationException("Player not yet invited");
+        RsvpStatus = RsvpStatus.Declined;
+    }
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 GameNightPlayer IsTagged/IsInvited/RsvpStatus separation (invariante #16)"
+```
+
+---
+
+### Task 12: SendGameNightInvitationsCommand + 5-fase flow
+
+**Mix-model**: sonnet · **Effort**: M (~6h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/SendInvitations/SendGameNightInvitationsCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/SendInvitations/SendGameNightInvitationsCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/SendGameNightInvitationsTests.cs`
+
+- [ ] **Step 1: Write failing integration test**
+
+```csharp
+[Fact]
+public async Task SendInvitations_TransitionsAllTaggedToInvited_DoesNotChangeRsvp()
+{
+    using var app = await TestApp.CreateAsync();
+    var gnId = await app.SeedGameNightAsync(taggedPlayers: 3);
+
+    await app.Client.PostAsync($"/api/v1/game-nights/{gnId}/send-invitations", null);
+
+    var players = await app.GetGameNightPlayersAsync(gnId);
+    players.Should().HaveCount(3);
+    players.All(p => p.IsTagged).Should().BeTrue();
+    players.All(p => p.IsInvited).Should().BeTrue();
+    players.All(p => p.RsvpStatus == "Pending").Should().BeTrue();
+}
+
+[Fact]
+public async Task SendInvitations_IsIdempotent_DoesntCreateDuplicateNotifications()
+{
+    using var app = await TestApp.CreateAsync();
+    var gnId = await app.SeedGameNightAsync(taggedPlayers: 2);
+
+    await app.Client.PostAsync($"/api/v1/game-nights/{gnId}/send-invitations", null);
+    await app.Client.PostAsync($"/api/v1/game-nights/{gnId}/send-invitations", null);
+
+    var notifs = await app.GetNotificationsForGameNightAsync(gnId);
+    notifs.Should().HaveCount(2); // not 4
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement command + handler**
+
+```csharp
+public record SendGameNightInvitationsCommand(Guid GameNightId) : IRequest<int>;
+
+public class SendGameNightInvitationsCommandHandler : IRequestHandler<SendGameNightInvitationsCommand, int>
+{
+    private readonly IGameNightRepository _gnRepo;
+    private readonly IMediator _mediator;
+
+    public SendGameNightInvitationsCommandHandler(IGameNightRepository repo, IMediator m)
+    {
+        _gnRepo = repo;
+        _mediator = m;
+    }
+
+    public async Task<int> Handle(SendGameNightInvitationsCommand cmd, CancellationToken ct)
+    {
+        var gn = await _gnRepo.GetByIdAsync(cmd.GameNightId, ct)
+            ?? throw new NotFoundException($"GameNight {cmd.GameNightId}");
+
+        var toInvite = gn.Players.Where(p => p.IsTagged && !p.IsInvited).ToList();
+        foreach (var player in toInvite)
+        {
+            player.Invite();
+            // dispatch notification command (will be implemented in WP6)
+            await _mediator.Send(new SendInvitationNotificationCommand(
+                gameNightId: gn.Id,
+                recipientPlayerId: player.PlayerId
+            ), ct);
+        }
+
+        await _gnRepo.SaveAsync(gn, ct);
+        return toInvite.Count;
+    }
+}
+```
+
+- [ ] **Step 4: Add endpoint via Routing**
+
+```csharp
+// GameNightEndpoints.cs
+app.MapPost("/api/v1/game-nights/{id:guid}/send-invitations",
+    async (Guid id, IMediator m) =>
+        Results.Ok(new { invitedCount = await m.Send(new SendGameNightInvitationsCommand(id)) }));
+```
+
+- [ ] **Step 5: Run → PASS** (notification handler stub in WP6 may not be ready — use temporary mock)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 SendGameNightInvitations command + idempotent flow (invariante #17)"
+```
+
+---
+
+## WP4 — Invariante #10 max 1 live
+
+> **Spec reference**: Sezione 4 Asse A — "Invariante max 1 live".
+
+### Task 13: MaxLiveSessionsExceededException + aggregate guard
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNight.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightMaxLiveTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+[Fact]
+public void OpenLiveSession_WhenAnotherLiveActive_Throws_MaxLiveSessionsExceededException()
+{
+    var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+    var firstLive = Session.CreateDraft(gn.Id, Guid.NewGuid()).OpenLiveMode();
+    var secondDraft = Session.CreateDraft(gn.Id, Guid.NewGuid());
+
+    var act = () => gn.OpenLiveSession(secondDraft, currentlyLive: new[] { firstLive });
+
+    act.Should().Throw<MaxLiveSessionsExceededException>()
+        .Where(ex => ex.ErrorCode == "MAX_LIVE_SESSIONS_EXCEEDED")
+        .Where(ex => ex.GameNightId == gn.Id);
+}
+
+[Fact]
+public void OpenLiveSession_WithNoActiveLive_Succeeds()
+{
+    var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
+    var draft = Session.CreateDraft(gn.Id, Guid.NewGuid());
+
+    var act = () => gn.OpenLiveSession(draft, currentlyLive: Array.Empty<Session>());
+
+    act.Should().NotThrow();
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement exception + guard**
+
+```csharp
+public class MaxLiveSessionsExceededException : DomainException
+{
+    public Guid GameNightId { get; }
+    public override string ErrorCode => "MAX_LIVE_SESSIONS_EXCEEDED";
+
+    public MaxLiveSessionsExceededException(Guid gameNightId)
+        : base($"GameNight {gameNightId} already has an active live session.")
+    {
+        GameNightId = gameNightId;
+    }
+}
+
+// GameNight.cs
+public Session OpenLiveSession(Session draft, IEnumerable<Session> currentlyLive)
+{
+    if (currentlyLive.Any(s => s.StartedAt != null && s.CompletedAt == null))
+        throw new MaxLiveSessionsExceededException(Id);
+    return draft.OpenLiveMode();
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 MaxLiveSessionsExceededException + aggregate guard (invariante #10)"
+```
+
+---
+
+### Task 14: API endpoint POST /game-nights/{id}/sessions/{sessionId}/live → 409
+
+**Mix-model**: sonnet · **Effort**: S (~3h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Routing/GameNightEndpoints.cs`
+- Modify: `apps/api/src/Api/Infrastructure/ExceptionHandling/DomainExceptionMiddleware.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/OpenLiveSessionEndpointTests.cs`
+
+- [ ] **Step 1: Write failing integration test**
+
+```csharp
+[Fact]
+public async Task POST_OpenLiveSession_With_ExistingLive_Returns409_WithErrorCode()
+{
+    using var app = await TestApp.CreateAsync();
+    var gn = await app.SeedGameNightAsync();
+    await app.OpenLiveSessionAsync(gn.Id, gameId: Guid.NewGuid());
+    var secondDraft = await app.CreateDraftSessionAsync(gn.Id, gameId: Guid.NewGuid());
+
+    var response = await app.Client.PostAsync(
+        $"/api/v1/game-nights/{gn.Id}/sessions/{secondDraft.Id}/live", null);
+
+    response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    var body = await response.Content.ReadFromJsonAsync<ErrorDto>();
+    body!.Code.Should().Be("MAX_LIVE_SESSIONS_EXCEEDED");
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Add endpoint + middleware mapping**
+
+```csharp
+// GameNightEndpoints.cs
+app.MapPost("/api/v1/game-nights/{gnId:guid}/sessions/{sId:guid}/live",
+    async (Guid gnId, Guid sId, IMediator m) =>
+        Results.Ok(await m.Send(new OpenLiveSessionCommand(gnId, sId))));
+```
+
+```csharp
+// DomainExceptionMiddleware.cs
+catch (MaxLiveSessionsExceededException ex)
+{
+    context.Response.StatusCode = StatusCodes.Status409Conflict;
+    await context.Response.WriteAsJsonAsync(new ErrorDto(ex.ErrorCode, ex.Message));
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 POST live session returns 409 MAX_LIVE_SESSIONS_EXCEEDED"
+```
+
+---
+
+## WP5 — Polymorphic ScoreType (DEC-1)
+
+> **Spec reference**: Sezione 4 Asse A — "DEC-1 — Polymorphic ScoreType".
+
+### Task 15: ScoreType enum + IScoringStrategy + factory skeleton
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/ScoreType.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/IScoringStrategy.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactory.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Scoring/ScoringStrategyFactoryTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+[Theory]
+[InlineData(ScoreType.Points, typeof(PointsScoringStrategy))]
+[InlineData(ScoreType.BinaryWin, typeof(BinaryWinScoringStrategy))]
+[InlineData(ScoreType.Objectives, typeof(ObjectivesScoringStrategy))]
+[InlineData(ScoreType.Ranking, typeof(RankingScoringStrategy))]
+public void GetStrategy_ReturnsExpectedStrategyForEachScoreType(
+    ScoreType type, Type expectedStrategyType)
+{
+    var factory = new ScoringStrategyFactory();
+    var strategy = factory.GetStrategy(type);
+    strategy.Should().BeOfType(expectedStrategyType);
+}
+
+[Fact]
+public void GetStrategy_OnUnknownType_Throws()
+{
+    var factory = new ScoringStrategyFactory();
+    var act = () => factory.GetStrategy((ScoreType)999);
+    act.Should().Throw<ArgumentOutOfRangeException>();
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (types don't exist)
+
+- [ ] **Step 3: Create types**
+
+```csharp
+public enum ScoreType
+{
+    [Description("Punti numerici per player")]
+    Points = 0,
+    [Description("Winner/Loser binario (cooperativo)")]
+    BinaryWin = 1,
+    [Description("Obiettivi completati per player")]
+    Objectives = 2,
+    [Description("Posizione 1..N per player")]
+    Ranking = 3,
+}
+
+public interface IScoringStrategy
+{
+    ScoreType Type { get; }
+    ValidationResult Validate(string scoreDataJson);
+    string Serialize(object scoreData);
+    object Deserialize(string scoreDataJson);
+    Guid? ComputeWinnerPlayerId(string scoreDataJson);
+}
+
+// Placeholder skeletons for 4 strategies (filled in T16+T17)
+public class PointsScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.Points;
+    public ValidationResult Validate(string s) => throw new NotImplementedException();
+    public string Serialize(object d) => throw new NotImplementedException();
+    public object Deserialize(string s) => throw new NotImplementedException();
+    public Guid? ComputeWinnerPlayerId(string s) => throw new NotImplementedException();
+}
+// Same for Binary/Objectives/Ranking
+
+public class ScoringStrategyFactory
+{
+    public IScoringStrategy GetStrategy(ScoreType type) => type switch
+    {
+        ScoreType.Points => new PointsScoringStrategy(),
+        ScoreType.BinaryWin => new BinaryWinScoringStrategy(),
+        ScoreType.Objectives => new ObjectivesScoringStrategy(),
+        ScoreType.Ranking => new RankingScoringStrategy(),
+        _ => throw new ArgumentOutOfRangeException(nameof(type)),
+    };
+}
+```
+
+- [ ] **Step 4: Run → PASS** (factory dispatch works, strategies stubbed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 ScoreType enum + IScoringStrategy + factory (DEC-1 skeleton)"
+```
+
+---
+
+### Task 16: PointsScoringStrategy + BinaryWinScoringStrategy
+
+**Mix-model**: sonnet · **Effort**: M (~6h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Scoring/PointsScoringStrategyTests.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Scoring/BinaryWinScoringStrategyTests.cs`
+
+- [ ] **Step 1: Write failing tests for Points (5 cases)**
+
+```csharp
+public class PointsScoringStrategyTests
+{
+    private readonly PointsScoringStrategy _sut = new();
+
+    [Fact]
+    public void Validate_ValidJson_ReturnsValid()
+    {
+        var json = """{"scores":[{"playerId":"a1","points":42},{"playerId":"b2","points":30}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_NegativeScore_ReturnsInvalid()
+    {
+        var json = """{"scores":[{"playerId":"a1","points":-5}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.Contains("non-negative"));
+    }
+
+    [Fact]
+    public void Validate_DuplicatePlayer_ReturnsInvalid()
+    {
+        var json = """{"scores":[{"playerId":"a1","points":10},{"playerId":"a1","points":20}]}""";
+        var result = _sut.Validate(json);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_ReturnsHighestScorePlayer()
+    {
+        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":10},{"playerId":"00000000-0000-0000-0000-000000000002","points":50}]}""";
+        var winner = _sut.ComputeWinnerPlayerId(json);
+        winner.Should().Be(Guid.Parse("00000000-0000-0000-0000-000000000002"));
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_RoundTrip()
+    {
+        var data = new PointsScoreData
+        {
+            Scores = new[] { new PlayerScore(Guid.NewGuid(), 42) }
+        };
+        var json = _sut.Serialize(data);
+        var back = (PointsScoreData)_sut.Deserialize(json);
+        back.Scores.Should().HaveCount(1);
+        back.Scores[0].Points.Should().Be(42);
+    }
+}
+```
+
+- [ ] **Step 2: Write failing tests for BinaryWin (5 cases)**
+
+```csharp
+public class BinaryWinScoringStrategyTests
+{
+    private readonly BinaryWinScoringStrategy _sut = new();
+
+    [Fact]
+    public void Validate_AllWin_ReturnsValid() { /* cooperativo, all win */ }
+
+    [Fact]
+    public void Validate_AllLose_ReturnsValid() { /* cooperativo, all lose */ }
+
+    [Fact]
+    public void Validate_MixedWinLose_ReturnsValid() { /* competitivo binary */ }
+
+    [Fact]
+    public void Validate_EmptyPlayerList_ReturnsInvalid() { /* edge */ }
+
+    [Fact]
+    public void ComputeWinnerPlayerId_ReturnsNull_WhenCooperativeAllWin() { /* no single winner */ }
+}
+```
+
+- [ ] **Step 3: Run → FAIL**
+
+- [ ] **Step 4: Implement both strategies**
+
+```csharp
+public record PointsScoreData(PlayerScore[] Scores);
+public record PlayerScore(Guid PlayerId, int Points);
+
+public class PointsScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.Points;
+
+    public ValidationResult Validate(string json)
+    {
+        try
+        {
+            var data = JsonSerializer.Deserialize<PointsScoreData>(json);
+            if (data?.Scores is null || data.Scores.Length == 0)
+                return ValidationResult.Failed("No scores provided");
+            var errors = new List<string>();
+            if (data.Scores.Any(s => s.Points < 0)) errors.Add("Points must be non-negative");
+            var grouped = data.Scores.GroupBy(s => s.PlayerId);
+            if (grouped.Any(g => g.Count() > 1)) errors.Add("Duplicate playerId");
+            return errors.Any() ? ValidationResult.Failed(errors) : ValidationResult.Valid();
+        }
+        catch (JsonException ex) { return ValidationResult.Failed($"Invalid JSON: {ex.Message}"); }
+    }
+
+    public string Serialize(object data) => JsonSerializer.Serialize((PointsScoreData)data);
+    public object Deserialize(string json) => JsonSerializer.Deserialize<PointsScoreData>(json)!;
+
+    public Guid? ComputeWinnerPlayerId(string json)
+    {
+        var data = (PointsScoreData)Deserialize(json);
+        return data.Scores.OrderByDescending(s => s.Points).FirstOrDefault()?.PlayerId;
+    }
+}
+
+// BinaryWin
+public record BinaryWinScoreData(BinaryPlayerResult[] Results);
+public record BinaryPlayerResult(Guid PlayerId, bool IsWinner);
+
+public class BinaryWinScoringStrategy : IScoringStrategy
+{
+    public ScoreType Type => ScoreType.BinaryWin;
+    public ValidationResult Validate(string json) { /* similar */ }
+    public string Serialize(object d) => JsonSerializer.Serialize((BinaryWinScoreData)d);
+    public object Deserialize(string j) => JsonSerializer.Deserialize<BinaryWinScoreData>(j)!;
+    public Guid? ComputeWinnerPlayerId(string json)
+    {
+        var data = (BinaryWinScoreData)Deserialize(json);
+        var winners = data.Results.Where(r => r.IsWinner).ToList();
+        // If single winner: return; if all-win (cooperative) or all-lose: return null
+        return winners.Count == 1 ? winners.Single().PlayerId : null;
+    }
+}
+```
+
+- [ ] **Step 5: Run → PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 Points + BinaryWin scoring strategies (DEC-1)"
+```
+
+---
+
+### Task 17: ObjectivesScoringStrategy + RankingScoringStrategy
+
+**Mix-model**: sonnet · **Effort**: M (~6h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs`
+- Test: corresponding test classes
+
+- [ ] **Step 1-6**: Same pattern as Task 16, 5 test cases per strategy.
+
+**Objectives logic**: each player has list of completed objectives (string names). Winner = player with most objectives completed. Ties = null winner.
+
+**Ranking logic**: each player has integer position (1..N). Winner = position 1. Validate distinct positions, sequential 1..N.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 Objectives + Ranking scoring strategies (DEC-1)"
+```
+
+---
+
+### Task 18: SaveSessionCommand polymorphic scoreData + FluentValidation rule
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandValidator.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/SaveSessionCommandValidatorTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+public class SaveSessionCommandValidatorTests
+{
+    private readonly SaveSessionCommandValidator _sut = new(new ScoringStrategyFactory());
+
+    [Fact]
+    public void Validate_PointsScoreData_Valid_ReturnsValid()
+    {
+        var cmd = new SaveSessionCommand(
+            SessionId: Guid.NewGuid(),
+            ScoringType: ScoreType.Points,
+            ScoreData: """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":50}]}"""
+        );
+        var result = _sut.Validate(cmd);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_BinaryWinScoreData_AppliedAsPoints_ReturnsInvalid()
+    {
+        var cmd = new SaveSessionCommand(
+            SessionId: Guid.NewGuid(),
+            ScoringType: ScoreType.Points,
+            ScoreData: """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true}]}"""
+        );
+        var result = _sut.Validate(cmd);
+        result.IsValid.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement command + validator**
+
+```csharp
+public record SaveSessionCommand(
+    Guid SessionId,
+    ScoreType ScoringType,
+    string ScoreData
+) : IRequest<SaveSessionResult>;
+
+public class SaveSessionCommandValidator : AbstractValidator<SaveSessionCommand>
+{
+    public SaveSessionCommandValidator(ScoringStrategyFactory factory)
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.ScoreData)
+            .NotEmpty()
+            .Custom((scoreData, context) =>
+            {
+                var cmd = context.InstanceToValidate;
+                var strategy = factory.GetStrategy(cmd.ScoringType);
+                var result = strategy.Validate(scoreData);
+                if (!result.IsValid)
+                    foreach (var err in result.Errors)
+                        context.AddFailure("ScoreData", err);
+            });
+    }
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 SaveSessionCommand polymorphic ScoreData + FluentValidation (DEC-1)"
+```
+
+---
+
+### Task 19: Session.SetScores + SessionScoresUpdated + integration round-trip
+
+**Mix-model**: sonnet · **Effort**: L (~8h)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdated.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/PolymorphicScoringRoundTripTests.cs`
+
+- [ ] **Step 1: Write failing integration test (4 scoring types round-trip via API)**
+
+```csharp
+[Theory]
+[InlineData("Points", """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":50}]}""")]
+[InlineData("BinaryWin", """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true}]}""")]
+[InlineData("Objectives", """{"completedByPlayer":[{"playerId":"00000000-0000-0000-0000-000000000001","objectives":["A","B"]}]}""")]
+[InlineData("Ranking", """{"positions":[{"playerId":"00000000-0000-0000-0000-000000000001","position":1}]}""")]
+public async Task SaveSession_WithPolymorphicScoring_RoundTripViaAPI(string scoringType, string scoreData)
+{
+    using var app = await TestApp.CreateAsync();
+    var gnId = await app.SeedGameNightAsync();
+    var draft = await app.CreateDraftSessionAsync(gnId, gameId: Guid.NewGuid());
+
+    var response = await app.Client.PutAsJsonAsync(
+        $"/api/v1/sessions/{draft.Id}/save",
+        new { scoringType, scoreData });
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var fetched = await app.Client.GetFromJsonAsync<SessionDto>(
+        $"/api/v1/sessions/{draft.Id}");
+    fetched!.ScoringType.Should().Be(scoringType);
+    fetched.ScoreData.Should().Be(scoreData);
+}
+```
+
+- [ ] **Step 2: Add Session.SetScores domain method**
+
+```csharp
+public void SetScores(ScoreType scoringType, string scoreData)
+{
+    ScoringType = scoringType;
+    ScoreData = scoreData;
+    _events.Add(new SessionScoresUpdated(Id, scoringType, scoreData));
+}
+```
+
+- [ ] **Step 3: Update SaveSessionCommandHandler to call SetScores**
+
+- [ ] **Step 4: Run → PASS** (all 4 scoring types round-trip)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 Session.SetScores + round-trip 4 ScoreType (DEC-1)"
+```
+
+---
+
+## WP6 — Notification system (DEC-5)
+
+> **Spec reference**: Sezione 4 Asse A — "DEC-5 — Notification system".
+
+### Task 20: Notification repository + UserNotifications bounded context wiring
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/Repositories/INotificationRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Repositories/NotificationRepository.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationRepositoryTests.cs`
+
+- [ ] Standard repository pattern + CRUD operations + integration test against Testcontainers postgres.
+
+```bash
+git commit -m "feat(user-notifications): #1896 Notification repository (DEC-5)"
+```
+
+---
+
+### Task 21: GET /notifications + PATCH read endpoints
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/GetNotifications/GetNotificationsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/MarkAsRead/MarkAsReadCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/NotificationEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationEndpointsTests.cs`
+
+- [ ] Endpoint contract:
+  - `GET /api/v1/notifications?page=N&size=M` → `PagedResult<NotificationDto>`
+  - `PATCH /api/v1/notifications/{id}/read` → `204 No Content`
+  - `POST /api/v1/notifications/mark-all-read` → `{ markedCount }`
+
+```bash
+git commit -m "feat(user-notifications): #1896 inbox endpoints GET + PATCH read (DEC-5)"
+```
+
+---
+
+### Task 22: IEmailSender + ResendEmailSender + GameNightInvitation template
+
+**Mix-model**: sonnet · **Effort**: L (~8h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/IEmailSender.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/ResendEmailSender.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/Templates/GameNightInvitationTemplate.cs`
+- Create: `infra/secrets/email.secret.example`
+- Test: `apps/api/tests/Api.Tests/Unit/UserNotifications/Email/ResendEmailSenderTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+[Fact]
+public async Task ResendEmailSender_SendAsync_PostsToResendAPI_WithApiKey()
+{
+    var mockHttp = new MockHttpMessageHandler();
+    mockHttp.When("https://api.resend.com/emails")
+        .Respond(HttpStatusCode.OK, JsonContent.Create(new { id = "test-msg-id" }));
+    var sender = new ResendEmailSender(
+        new HttpClient(mockHttp),
+        new ResendOptions { ApiKey = "re_test" });
+
+    var template = GameNightInvitationTemplate.Render(
+        recipientName: "Anna",
+        hostName: "Marco",
+        gameNightName: "Sabato a casa Marco",
+        date: new DateTimeOffset(2026, 6, 14, 20, 0, 0, TimeSpan.Zero),
+        location: "Roma");
+
+    await sender.SendAsync(
+        toEmail: "anna@example.com",
+        subject: "Marco ti ha invitato",
+        htmlBody: template.Html,
+        plainTextBody: template.PlainText);
+
+    mockHttp.GetMatchCount(/* request */).Should().Be(1);
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement**
+
+```csharp
+public interface IEmailSender
+{
+    Task<string> SendAsync(string toEmail, string subject, string htmlBody, string plainTextBody, CancellationToken ct = default);
+}
+
+public class ResendOptions { public string ApiKey { get; set; } = default!; public string FromEmail { get; set; } = "noreply@meepleai.app"; }
+
+public class ResendEmailSender : IEmailSender
+{
+    private readonly HttpClient _http;
+    private readonly ResendOptions _options;
+
+    public ResendEmailSender(HttpClient http, ResendOptions options)
+    {
+        _http = http;
+        _options = options;
+        _http.DefaultRequestHeaders.Authorization = new("Bearer", options.ApiKey);
+    }
+
+    public async Task<string> SendAsync(string to, string subject, string html, string text, CancellationToken ct = default)
+    {
+        var payload = new
+        {
+            from = _options.FromEmail,
+            to = new[] { to },
+            subject,
+            html,
+            text,
+        };
+        var response = await _http.PostAsJsonAsync("https://api.resend.com/emails", payload, ct);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ResendResponse>(cancellationToken: ct);
+        return result!.Id;
+    }
+    private record ResendResponse(string Id);
+}
+
+public static class GameNightInvitationTemplate
+{
+    public record Rendered(string Html, string PlainText);
+
+    public static Rendered Render(
+        string recipientName, string hostName, string gameNightName,
+        DateTimeOffset date, string location)
+    {
+        var formattedDate = date.ToString("dddd d MMMM yyyy 'alle' HH:mm",
+            CultureInfo.GetCultureInfo("it-IT"));
+
+        var html = $"""
+            <h1>Ciao {recipientName}!</h1>
+            <p><strong>{hostName}</strong> ti ha invitato a una serata:</p>
+            <p><strong>{gameNightName}</strong> · {formattedDate} · {location}</p>
+            <p><a href="https://meepleai.app/game-nights">Conferma RSVP</a></p>
+            """;
+        var text = $"""
+            Ciao {recipientName}!
+            {hostName} ti ha invitato a {gameNightName} ({formattedDate}, {location}).
+            Conferma RSVP: https://meepleai.app/game-nights
+            """;
+        return new Rendered(html, text);
+    }
+}
+```
+
+- [ ] **Step 4: Update infra/secrets/email.secret.example**
+
+```bash
+# Email transactional provider (Resend)
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+RESEND_FROM_EMAIL=noreply@meepleai.app
+```
+
+- [ ] **Step 5: Register DI in Program.cs**
+
+```csharp
+builder.Services.Configure<ResendOptions>(builder.Configuration.GetSection("Resend"));
+builder.Services.AddHttpClient<IEmailSender, ResendEmailSender>();
+```
+
+- [ ] **Step 6: Run → PASS**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(user-notifications): #1896 IEmailSender + ResendEmailSender + invitation template (DEC-5)"
+```
+
+**Self-review**:
+- [ ] HttpClient with Resend bearer auth
+- [ ] Idempotent (Resend SDK provides message-id, no double-send on retry)
+- [ ] Email template Italian-localized
+- [ ] HTML + plain text both provided
+
+---
+
+### Task 23: SendInvitationNotificationCommand handler in-app+email
+
+**Mix-model**: sonnet · **Effort**: L (~8h)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/SendInvitationNotification/SendInvitationNotificationCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/SendInvitationNotification/SendInvitationNotificationCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/SendInvitationFlowTests.cs`
+
+- [ ] **Step 1: Write failing integration test**
+
+```csharp
+[Fact]
+public async Task SendInvitationCommand_CreatesInAppNotification_AndCallsEmailSender()
+{
+    using var app = await TestApp.CreateAsync(services =>
+    {
+        services.AddSingleton<IEmailSender>(Substitute.For<IEmailSender>());
+    });
+    var emailSender = app.Resolve<IEmailSender>();
+    var (gnId, recipientPlayerId) = await app.SeedGameNightWithInvitedPlayerAsync();
+
+    await app.Mediator.Send(new SendInvitationNotificationCommand(gnId, recipientPlayerId));
+
+    var notifs = await app.Db.Notifications.Where(n => n.Type == "GameNightInvitation").ToListAsync();
+    notifs.Should().ContainSingle();
+    notifs[0].Payload.Should().Contain(gnId.ToString());
+
+    await emailSender.Received(1).SendAsync(
+        Arg.Any<string>(), Arg.Is<string>(s => s.Contains("invitato")),
+        Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+}
+
+[Fact]
+public async Task SendInvitationCommand_EmailFails_StillCommitsInAppNotification()
+{
+    using var app = await TestApp.CreateAsync(services =>
+    {
+        var failingEmail = Substitute.For<IEmailSender>();
+        failingEmail.SendAsync(default!, default!, default!, default!, default)
+            .ReturnsForAnyArgs(Task.FromException<string>(new HttpRequestException("Resend down")));
+        services.AddSingleton(failingEmail);
+    });
+    var (gnId, recipientPlayerId) = await app.SeedGameNightWithInvitedPlayerAsync();
+
+    await app.Mediator.Send(new SendInvitationNotificationCommand(gnId, recipientPlayerId));
+
+    var notifs = await app.Db.Notifications.ToListAsync();
+    notifs.Should().ContainSingle(); // in-app saved despite email failure
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement handler**
+
+```csharp
+public record SendInvitationNotificationCommand(Guid GameNightId, Guid RecipientPlayerId) : IRequest;
+
+public class SendInvitationNotificationCommandHandler : IRequestHandler<SendInvitationNotificationCommand>
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IEmailSender _email;
+    private readonly ILogger<SendInvitationNotificationCommandHandler> _logger;
+
+    public SendInvitationNotificationCommandHandler(
+        ApplicationDbContext db, IEmailSender email, ILogger<SendInvitationNotificationCommandHandler> logger)
+    {
+        _db = db; _email = email; _logger = logger;
+    }
+
+    public async Task Handle(SendInvitationNotificationCommand cmd, CancellationToken ct)
+    {
+        var gn = await _db.GameNights.FindAsync(new object?[] { cmd.GameNightId }, ct)
+            ?? throw new NotFoundException($"GameNight {cmd.GameNightId}");
+        var player = await _db.Players.FindAsync(new object?[] { cmd.RecipientPlayerId }, ct)
+            ?? throw new NotFoundException($"Player {cmd.RecipientPlayerId}");
+        if (player.UserId is null) return; // guest, no notification
+
+        // 1. In-app notification (transactional)
+        var payload = JsonSerializer.Serialize(new
+        {
+            gameNightId = gn.Id,
+            gameNightName = gn.Name,
+            hostName = (await _db.Users.FindAsync(new object?[] { gn.OwnerId }, ct))?.DisplayName,
+            date = gn.Date,
+            location = gn.Location,
+        });
+        var notif = Notification.Create(
+            recipientUserId: player.UserId.Value,
+            type: "GameNightInvitation",
+            payloadJson: payload);
+        _db.Notifications.Add(notif);
+        await _db.SaveChangesAsync(ct);
+
+        // 2. Email (best-effort, doesn't block in-app)
+        try
+        {
+            var rendered = GameNightInvitationTemplate.Render(
+                recipientName: player.Name,
+                hostName: (await _db.Users.FindAsync(new object?[] { gn.OwnerId }, ct))!.DisplayName,
+                gameNightName: gn.Name,
+                date: gn.Date,
+                location: gn.Location);
+
+            var user = await _db.Users.FindAsync(new object?[] { player.UserId.Value }, ct);
+            await _email.SendAsync(
+                toEmail: user!.Email,
+                subject: $"Marco ti ha invitato a {gn.Name}",
+                htmlBody: rendered.Html,
+                plainTextBody: rendered.PlainText,
+                ct: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Email send failed for notification {NotifId}, in-app committed", notif.Id);
+            // Swallow — in-app is the source of truth
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(user-notifications): #1896 SendInvitationNotificationCommand in-app+email (DEC-5)"
+```
+
+---
+
+## WP7 — OpenAPI + final acceptance
+
+### Task 24: OpenAPI yaml updates + new error codes
+
+**Mix-model**: haiku · **Effort**: S (~3h)
+
+**Files:**
+- Modify: `apps/api/src/Api/openapi.yaml` (or wherever OpenAPI lives)
+- Test: `apps/api/tests/Api.Tests/Integration/OpenApiContractTests.cs`
+
+- [ ] Add new error code definitions, polymorphic ScoreData schema, Notification DTOs, X-Warning-Code header.
+
+```bash
+git commit -m "docs(api): #1896 OpenAPI updates + new error codes + polymorphic DTOs"
+```
+
+---
+
+### Task 25: Final spec compliance review + CLAUDE.md update
+
+**Mix-model**: haiku · **Effort**: M (~4h)
+
+**Files:**
+- Modify: `CLAUDE.md` (Domain Model — GameNight / Session section)
+- Modify: `docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md` (changelog inline)
+
+- [ ] **Step 1**: Run full test suite
+```bash
+dotnet test
+```
+Expected: PASS
+
+- [ ] **Step 2**: Update CLAUDE.md section "Domain Model — GameNight / Session" con stato post-impl: tutte 20 invarianti coperte + ScoreType polimorfico + Notification.
+
+- [ ] **Step 3**: Update spec consolidato changelog
+```markdown
+- 2026-06-XX: asse A implementation complete — 25 task TDD shipped via PR #YYYY
+```
+
+- [ ] **Step 4**: Verify Definition of Done umbrella:
+  - 20 invarianti implementate e testate
+  - DEC-1 ScoreType 4 strategies + 4 unit class + 1 integration test
+  - DEC-5 Notification + `/notifications` + email Resend operativo
+
+- [ ] **Step 5**: Final commit
+```bash
+git commit -m "docs(claude-design-alignment): #1896 asse A complete — 25 task shipped, spec updated"
+```
+
+---
+
+## Self-Review Checklist (post-plan)
+
+**Spec coverage**:
+- [x] WP1 covers Migration EF Core 3-step (MAJ-1 fix)
+- [x] WP2 covers invarianti #11/#12/#13/#14
+- [x] WP3 covers state machine #8/#15/#16/#17
+- [x] WP4 covers invariante #10 + MIN-1 rename
+- [x] WP5 covers DEC-1 polymorphic ScoreType (4 strategies)
+- [x] WP6 covers DEC-5 Notification (in-app + email Resend)
+- [x] WP7 covers OpenAPI updates + final acceptance
+- [x] MAJ-2 backwards-compat documented in T3
+- [x] MIN-6 factory method clarified in T6
+
+**Placeholder scan**: no TBD, no "implement later", no "similar to Task N", no untyped methods.
+
+**Type consistency**:
+- `IScoringStrategy.ComputeWinnerPlayerId` returns `Guid?` consistently across T15/T16/T17/T19
+- `RsvpStatus` enum values consistent across T3/T11/T12
+- `GameNightStatus` consistent across T2/T10
+- `SaveSessionResult` record consistent across T9/T19
+
+**Critical path identification**:
+- WP1 → WP2 → WP4 (max 1 live needs Session.OpenLiveMode)
+- WP1 → WP3 → WP6 (SendGameNightInvitations triggers notification)
+- WP5 parallelizable with WP3+WP4 (no shared aggregate)
+- WP6 parallelizable with WP5 (different bounded context)
+- WP7 closes WP
+
+**Effort verification**:
+- WP1: 3+2+3+2+4 = 14h ≈ 2gg
+- WP2: 6+3+2+5 = 16h ≈ 2gg
+- WP3: 8+5+6 = 19h ≈ 2.5gg
+- WP4: 5+3 = 8h ≈ 1gg
+- WP5: 5+6+6+5+8 = 30h ≈ 4gg
+- WP6: 5+5+8+8 = 26h ≈ 3.5gg
+- WP7: 3+4 = 7h ≈ 1gg
+- **Total**: ~16gg dev + ~3gg buffer review/CI fix = ~19gg, in linea con stima 15+3=18gg ✓
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — Dispatch fresh subagent per task with mix-model (haiku/sonnet), review between tasks, ~3-4 settimane elapsed time per asse A.
+
+**2. Inline Execution** — Execute tasks in current session sequentially, batch checkpoints. Non praticabile per asse A (XL).
+
+**Recommended sequence**: WP1 (must be first) → WP2 + WP5 parallel (con 2 dev) → WP3 + WP4 + WP6 parallel → WP7 final.

--- a/docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md
+++ b/docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md
@@ -1,713 +1,304 @@
-# Asse A — Semantic Alignment GameNight/Session Implementation Plan
+# Asse A — Semantic Alignment GameNight/Session Implementation Plan (v2)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implementare le 20 invarianti del dominio GameNight/Session + polymorphic ScoreType (DEC-1) + notification system in-app+email (DEC-5) nei bounded context `SessionTracking` e `GameManagement` per allineare il backend alla demo Claude Design 2026-06-04.
+> **🚨 v2 — REWRITE post-discovery 2026-06-04**: il plan v1 assumeva backend scratch ma molte entità esistono già (issue #42 GameNightEvent+GameNightRsvp, #44/#47 GameNightEmailService, #607 token-based GameNightInvitation, Notification aggregate in UserNotifications). Plan v2 è focused **solo sui gap reali**. Effort rebaseline da XL ~15gg a **M+ ~10gg** (-33%). Vedi [Gap Analysis](#gap-analysis-backend-vs-plan-v1) sotto.
 
-**Architecture:** EF Core migrations 3-step pattern (ALTER NULL → UPDATE → ALTER NOT NULL) + DDD aggregate refactor con factory methods + Strategy pattern per polymorphic scoring + transactional in-app notification + Resend email transactional fallback.
+**Goal:** Coprire i gap dell'asse A (DEC-1 Polymorphic ScoreType, invariante #10 max 1 live, invariante #11 Session.StartedAt, invariante #15 first-session trigger verify, invariante #13 draft+live warning, /notifications REST endpoint expand, Resend provider swap se necessario) sopra il backend esistente.
 
-**Tech Stack:** .NET 9 · ASP.NET Minimal APIs + MediatR · EF Core (pgvector) · FluentValidation · xUnit + Testcontainers · Resend (email transactional)
+**Architecture:** EF Core migrations additive (no rebuild esistente) + DDD domain logic extension su `GameNightEvent`/`Session` aggregate esistenti + Strategy pattern nuovo per polymorphic scoring + extend notification REST/email pipeline.
+
+**Tech Stack:** .NET 9 · ASP.NET Minimal APIs + MediatR · EF Core (pgvector) · FluentValidation · xUnit + Testcontainers · IEmailService (existing wrapper) o Resend (se swap)
 
 **Issue**: [#1896](https://github.com/meepleAi-app/meepleai-monorepo/issues/1896) (parent umbrella [#1895](https://github.com/meepleAi-app/meepleai-monorepo/issues/1895))
 **Spec consolidato**: [`docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md`](../specs/2026-06-04-claude-design-alignment-spec-panel-review.md) (Sezione 4 — Asse A)
 **Domain model**: [`docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md`](../../for-developers/specs/2026-06-04-gamenight-session-domain-model.md) (20 invarianti)
-**Effort target**: XL ~15 gg dev + 3 gg test/review = 18 gg totali
+**Effort target rebaseline**: M+ ~10 gg dev + 2 gg test/review = **12 gg totali** (vs v1 18 gg)
 
 ---
 
-## Work Packages
+## Gap Analysis: backend vs plan v1
+
+| Spec area | Stato backend reale | Plan v2 azione |
+|-----------|-------------------|----------------|
+| `GameNightEvent` aggregate (= GameNight nel demo) | ✅ ESISTE — Status enum 5 valori (Draft/Published/Cancelled/Completed/InProgress), CreateAdHoc factory, Complete/CompleteAdHoc/Cancel/AddInvitees/PreInvite methods, domain events wired | **SKIP** — semantic mapping nel doc |
+| `GameNightRsvp` per-user | ✅ ESISTE — RsvpStatus enum (Pending/Accepted/Declined/Maybe), Accept/Decline/SetMaybe methods | **SKIP** |
+| `GameNightInvitation` token-based public (email guest) | ✅ ESISTE — Issue #607 token-based + #1169 RespondedByName, idempotent Accept/Decline | **SKIP** — è gestito da flow separato |
+| `GameNightSession` link entity | ✅ ESISTE — Pending/InProgress/Completed/Skipped, StartedAt/CompletedAt, WinnerId, Start()/Complete()/Skip() | **SKIP** |
+| `Session` aggregate (SessionTracking) | ✅ ESISTE — CreatedAt/FinalizedAt/SessionStatus/Participants/IDomainEventSource. **MANCA: StartedAt** | **WP2 T2** add StartedAt |
+| `ScoreEntry` polymorphic | ❌ Single-shape (decimal value + round + category). NON polymorphic | **WP3** NEW DEC-1 ScoreType |
+| Max 1 live invariant aggregate guard | ❌ NON ESISTE | **WP1 T1** NEW |
+| Invariante #15 first-session triggers Planned→InProgress | ⚠️ PARZIALE (CreateAdHoc va direttamente InProgress, ma non c'è trigger automatic da Session creation per GameNight non-AdHoc) | **WP2 T3** wire trigger |
+| Invariante #13 draft+live coexistence warning | ❌ NON ESISTE | **WP2 T4** add X-Warning-Code header |
+| Tagged vs Invited semantic distinction | ⚠️ MAPPING — PreInvite (Draft, no event) ≈ Tagged + Publish (Draft→Published + events) ≈ Invited | **WP2 T5** documentation + DTO labels |
+| `Notification` aggregate in UserNotifications | ✅ ESISTE — entity + repository | **WP4 T11** verify schema + extend |
+| `/notifications` REST endpoints (GET inbox + PATCH read) | ⚠️ DA VERIFICARE — potrebbero esistere o no | **WP4 T12** verify + add if missing |
+| `GameNightEmailService` invitation email | ✅ ESISTE — IEmailService wrapper (SMTP o altro provider) | **WP4 T13** verify Resend swap necessità |
+| `RESEND_API_KEY` secret + ResendEmailSender | ❓ DA VERIFICARE provider attuale | **WP4 T13** if not Resend, swap |
+
+**Plan v1 → v2 simplification**:
+- WP1 v1 (5 migration tasks): → **WP1 v2 (1 task)** solo per max 1 live invariant. Altre migration **non necessarie** (entità esistono).
+- WP2 v1 (Session invarianti, 4 task): → **WP2 v2 (4 task)** focused su Session.StartedAt + invariante #15 wiring + warning header + tagged/invited mapping.
+- WP3 v1 (GameNight state machine, 3 task): **MERGED in WP2 v2** (semantic mapping doc + invariante #15 wire). Niente new entity.
+- WP4 v1 (max 1 live): **PROMOSSA WP1 v2** (è il vero gap critical).
+- WP5 v1 (ScoreType polimorfico, 5 task): → **WP3 v2 (5 task)** invariata, è il core nuovo lavoro.
+- WP6 v1 (Notification, 4 task): → **WP4 v2 (3 task)** focused su /notifications endpoint expand + Resend swap se necessario. Entity ESISTE già.
+- WP7 v1 (OpenAPI): → **WP5 v2 (1 task)** standard.
+
+**Total tasks**: v1 25 → **v2 14**. Effort 18gg → 12gg.
+
+---
+
+## Work Packages v2
 
 | WP | Scope | Effort | Critical path | Sub-task |
 |----|-------|--------|---------------|----------|
-| **WP1** | Migration EF Core 3-step | S+S+S+S+M | YES (blocca tutti) | T1–T5 |
-| **WP2** | Session invarianti #11/#12/#13/#14 | M+S+S+M | YES (blocca WP4) | T6–T9 |
-| **WP3** | State machine GameNight #8/#15/#16/#17 | L+M+M | YES (blocca WP6 notification flow) | T10–T12 |
-| **WP4** | Invariante #10 max 1 live | M+S | NO (parallelo WP3) | T13–T14 |
-| **WP5** | Polymorphic ScoreType (DEC-1) | M+M+M+M+L | NO (parallelo WP3+WP4) | T15–T19 |
-| **WP6** | Notification system (DEC-5) | M+M+L+L | NO (parallelo WP4+WP5) | T20–T23 |
-| **WP7** | OpenAPI + acceptance | S+M | YES (chiude WP) | T24–T25 |
+| **WP1** | Max 1 live aggregate guard (invariante #10) | M | YES | T1 |
+| **WP2** | Session.StartedAt + invariante #15 wire + warning header + semantic mapping doc | M | YES | T2–T5 |
+| **WP3** | Polymorphic ScoreType (DEC-1) — 4 strategies + factory + migration + DTO + integration | L | NO (parallelo WP1+WP2) | T6–T10 |
+| **WP4** | Notification system extension — /notifications endpoints + Resend swap verify | M | NO (parallelo WP3) | T11–T13 |
+| **WP5** | OpenAPI + acceptance | S | YES (chiude WP) | T14 |
 
-**Mix-model hint (P120)**: 12 haiku (mechanical TDD) + 13 sonnet (judgment design). Vedi hint per task.
+**Mix-model hint (P120)**: 5 haiku (mechanical) + 9 sonnet (judgment / domain logic / strategy design).
 
-**Total**: 25 task TDD bite-sized. ~18 gg effort realistic.
+**Total**: 14 task TDD bite-sized. ~12 gg effort realistic.
 
 ---
 
 ## File Structure
 
 ### New files
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/ScoreType.cs`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ScoreType.cs`
 - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/IScoringStrategy.cs`
 - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/PointsScoringStrategy.cs`
 - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/BinaryWinScoringStrategy.cs`
 - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ObjectivesScoringStrategy.cs`
 - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs`
 - `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactory.cs`
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdated.cs`
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedDomainEvent.cs`
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandValidator.cs`
-- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightStatus.cs`
-- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/RsvpStatus.cs`
 - `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs`
-- `apps/api/src/Api/BoundedContexts/GameManagement/Application/SendInvitations/SendGameNightInvitationsCommand.cs`
-- `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Notification.cs`
-- `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/IEmailSender.cs`
-- `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/ResendEmailSender.cs`
-- `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/Templates/GameNightInvitationTemplate.cs`
-- `apps/api/src/Api/BoundedContexts/UserNotifications/Application/SendInvitationNotification/SendInvitationNotificationCommandHandler.cs`
-- `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/NotificationEndpoints.cs`
-- `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionTimestamps.cs`
-- `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightStatus.cs`
-- `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightPlayerRsvp.cs`
-- `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionPolymorphicScoring.cs`
-- `apps/api/src/Api/Migrations/YYYYMMDD_CreateNotificationsTable.cs`
-- `infra/secrets/email.secret.example`
-- Test files mirror under `apps/api/tests/Api.Tests/`
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionStartedDomainEvent.cs`
+- `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDD_AddSessionStartedAt.cs`
+- `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDD_AddSessionScoringType.cs`
+- `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/NotificationEndpoints.cs` (if missing)
+- Test mirrors in `apps/api/tests/Api.Tests/`
 
 ### Modified files
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs` (factory methods + invarianti)
-- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNight.cs` (state machine + aggregate guard)
-- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightPlayer.cs` (IsTagged/IsInvited/RsvpStatus)
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandHandler.cs` (warning header)
-- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/GetSessionsByGameNight/GetSessionsByGameNightQueryHandler.cs` (sort ASC)
-- `apps/api/src/Api/Infrastructure/Persistence/ApplicationDbContext.cs` (DbSet<Notification>, configurations)
-- `apps/api/src/Api/Program.cs` (DI: `IEmailSender → ResendEmailSender`)
-- `apps/api/src/Api/openapi.yaml` (new error codes + DTO updates)
-- `apps/api/src/Api/Routing/RouteRegistrar.cs` (register notification endpoints)
-- `CLAUDE.md` (Domain Model section: update con stato post-impl)
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs` (add StartedAt + OpenLiveMode factory)
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs` (add OpenLiveSession aggregate guard for invariante #10 + HandleFirstSessionStarted for invariante #15)
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/` (new handler: SessionStarted → GameNight.HandleFirstSessionStarted)
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/` (X-Warning-Code header)
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/ScoreEntry.cs` (or new model — polymorphic via ScoreType)
+- `apps/api/src/Api/BoundedContexts/UserNotifications/` (verify + extend if missing)
+- `apps/api/src/Api/Infrastructure/Services/` (verify IEmailService concrete = Resend? if not, swap)
+- `apps/api/src/Api/openapi.yaml` (new error codes, ScoreType DTO, X-Warning-Code, /notifications expand)
+- `docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md` (mapping doc: backend term ↔ demo term)
+- `CLAUDE.md` (Domain Model section update)
 
 ---
 
-## WP1 — Migration EF Core 3-step
+## WP1 — Max 1 live aggregate guard (invariante #10)
 
-> **Spec reference**: Sezione 4 Asse A — "Migration (MAJ-1 fix: 3-step pattern)".
-> **Invarianti coperte**: foundation per #10/#11/#15/#16/#17/#18 + DEC-1/DEC-5.
-> **Critical path**: blocca tutti gli altri WP.
-
-### Task 1: Migration sessions timestamps (#11)
-
-**Mix-model**: haiku · **Effort**: S (~3h)
-
-**Files:**
-- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionTimestamps.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/MigrationTests.cs`
-
-- [ ] **Step 1: Generate migration scaffold**
-
-```bash
-cd apps/api/src/Api
-dotnet ef migrations add AddSessionTimestamps --output-dir Migrations
-```
-
-- [ ] **Step 2: Write the failing test**
-
-```csharp
-// MigrationTests.cs
-[Fact]
-public async Task AddSessionTimestamps_AddsThreeNullableColumns_ThenNotNullOnCreatedAt()
-{
-    using var fixture = await TestcontainersFixture.CreateAsync();
-    await fixture.MigrateAsync(targetMigration: "AddSessionTimestamps");
-
-    using var conn = fixture.GetConnection();
-    var columns = await conn.QueryAsync<dynamic>(
-        "SELECT column_name, is_nullable FROM information_schema.columns " +
-        "WHERE table_name = 'sessions' AND column_name IN ('created_at', 'started_at', 'completed_at')"
-    );
-    columns.Should().HaveCount(3);
-    columns.First(c => c.column_name == "created_at").is_nullable.Should().Be("NO");
-    columns.First(c => c.column_name == "started_at").is_nullable.Should().Be("YES");
-    columns.First(c => c.column_name == "completed_at").is_nullable.Should().Be("YES");
-}
-```
-
-- [ ] **Step 3: Run test to verify it fails**
-
-```bash
-dotnet test --filter "FullyQualifiedName~AddSessionTimestamps" -v normal
-```
-Expected: FAIL — migration not implemented
-
-- [ ] **Step 4: Implement migration with 3-step pattern**
-
-```csharp
-// YYYYMMDD_AddSessionTimestamps.cs
-public partial class AddSessionTimestamps : Migration
-{
-    protected override void Up(MigrationBuilder b)
-    {
-        // Step 1: ALTER nullable
-        b.AddColumn<DateTimeOffset?>("created_at", "sessions", nullable: true);
-        b.AddColumn<DateTimeOffset?>("started_at", "sessions", nullable: true);
-        b.AddColumn<DateTimeOffset?>("completed_at", "sessions", nullable: true);
-
-        // Step 2: UPDATE backfill
-        b.Sql("UPDATE sessions SET created_at = updated_at;");
-        b.Sql("UPDATE sessions SET completed_at = updated_at WHERE status = 'completed';");
-
-        // Step 3: ALTER NOT NULL only for created_at + DEFAULT
-        b.AlterColumn<DateTimeOffset>("created_at", "sessions",
-            nullable: false, defaultValueSql: "now()");
-    }
-
-    protected override void Down(MigrationBuilder b)
-    {
-        b.DropColumn("completed_at", "sessions");
-        b.DropColumn("started_at", "sessions");
-        b.DropColumn("created_at", "sessions");
-    }
-}
-```
-
-- [ ] **Step 5: Update SessionEntity + ApplicationDbContext config**
-
-```csharp
-// SessionEntity.cs (or via Session aggregate root)
-public DateTimeOffset CreatedAt { get; private set; }
-public DateTimeOffset? StartedAt { get; private set; }
-public DateTimeOffset? CompletedAt { get; private set; }
-
-// ApplicationDbContext.cs OnModelCreating
-modelBuilder.Entity<SessionEntity>(b =>
-{
-    b.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
-    b.Property(e => e.StartedAt).HasColumnName("started_at");
-    b.Property(e => e.CompletedAt).HasColumnName("completed_at");
-});
-```
-
-- [ ] **Step 6: Run test to verify it passes**
-
-```bash
-dotnet test --filter "FullyQualifiedName~AddSessionTimestamps" -v normal
-```
-Expected: PASS
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add apps/api/src/Api/Migrations/*AddSessionTimestamps* \
-        apps/api/src/Api/BoundedContexts/SessionTracking/ \
-        apps/api/src/Api/Infrastructure/Persistence/ApplicationDbContext.cs \
-        apps/api/tests/Api.Tests/Integration/SessionTracking/MigrationTests.cs
-git commit -m "feat(session-tracking): #1896 add Session.CreatedAt/StartedAt/CompletedAt (invariante #11)"
-```
-
-**Self-review checklist**:
-- [ ] Migration usa 3-step pattern (no circular DEFAULT now() + UPDATE)
-- [ ] `created_at` NOT NULL, `started_at`/`completed_at` NULL
-- [ ] Backfill SQL idempotente (eseguibile più volte senza errori)
-- [ ] Down migration drop columns in ordine inverso
-- [ ] EF Core entity config snake_case mapping
-
----
-
-### Task 2: Migration game_nights status (#8 + #15)
-
-**Mix-model**: haiku · **Effort**: S (~2h)
-
-**Files:**
-- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightStatus.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/MigrationTests.cs`
-
-- [ ] **Step 1: Generate migration**
-
-```bash
-cd apps/api/src/Api
-dotnet ef migrations add AddGameNightStatus --output-dir Migrations
-```
-
-- [ ] **Step 2: Write failing integration test**
-
-```csharp
-[Fact]
-public async Task AddGameNightStatus_BackfillsCompletedForPastWithSessions_PlannedOtherwise()
-{
-    using var fixture = await TestcontainersFixture.CreateAsync();
-    await fixture.SeedAsync(seed =>
-    {
-        seed.AddGameNight(date: DateTimeOffset.UtcNow.AddDays(-10), hasSession: true);
-        seed.AddGameNight(date: DateTimeOffset.UtcNow.AddDays(-5), hasSession: false);
-        seed.AddGameNight(date: DateTimeOffset.UtcNow.AddDays(+5), hasSession: false);
-    });
-    await fixture.MigrateAsync(targetMigration: "AddGameNightStatus");
-
-    using var conn = fixture.GetConnection();
-    var statuses = await conn.QueryAsync<(Guid Id, string Status)>(
-        "SELECT id, status FROM game_nights ORDER BY date"
-    );
-    statuses.ElementAt(0).Status.Should().Be("Completed");
-    statuses.ElementAt(1).Status.Should().Be("Planned");
-    statuses.ElementAt(2).Status.Should().Be("Planned");
-}
-```
-
-- [ ] **Step 3: Run test → FAIL**
-
-- [ ] **Step 4: Implement migration**
-
-```csharp
-public partial class AddGameNightStatus : Migration
-{
-    protected override void Up(MigrationBuilder b)
-    {
-        b.AddColumn<string>("status", "game_nights",
-            maxLength: 20, nullable: true);
-
-        b.Sql(@"
-            UPDATE game_nights SET status = 'Completed'
-            WHERE date < now() AND EXISTS (
-                SELECT 1 FROM sessions WHERE game_night_id = game_nights.id
-            );
-        ");
-        b.Sql("UPDATE game_nights SET status = 'Planned' WHERE date >= now() OR status IS NULL;");
-
-        b.AlterColumn<string>("status", "game_nights",
-            maxLength: 20, nullable: false, defaultValue: "Planned");
-    }
-
-    protected override void Down(MigrationBuilder b) =>
-        b.DropColumn("status", "game_nights");
-}
-```
-
-- [ ] **Step 5: Run test → PASS**
-
-- [ ] **Step 6: Commit**
-
-```bash
-git commit -m "feat(game-management): #1896 add GameNight.Status enum (invariante #8 + #15)"
-```
-
-**Self-review**:
-- [ ] Backfill 'Completed' solo per `date < now() AND hasSession`
-- [ ] Fallback 'Planned' per status NULL
-- [ ] DEFAULT 'Planned' applicato dopo backfill
-
----
-
-### Task 3: Migration game_night_players RSVP (#16 + #17)
-
-**Mix-model**: haiku · **Effort**: S (~3h)
-
-**Files:**
-- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddGameNightPlayerRsvp.cs`
-
-- [ ] **Step 1: Generate migration**
-
-```bash
-dotnet ef migrations add AddGameNightPlayerRsvp --output-dir Migrations
-```
-
-- [ ] **Step 2: Write failing test**
-
-```csharp
-[Fact]
-public async Task AddGameNightPlayerRsvp_BackfillsExistingAsInvitedAndConfirmed_BackwardsCompat()
-{
-    using var fixture = await TestcontainersFixture.CreateAsync();
-    var existingPlayerId = await fixture.SeedAsync(seed =>
-        seed.AddGameNightPlayer()).Result;
-
-    await fixture.MigrateAsync(targetMigration: "AddGameNightPlayerRsvp");
-
-    using var conn = fixture.GetConnection();
-    var row = await conn.QuerySingleAsync<(bool IsTagged, bool IsInvited, string RsvpStatus)>(
-        "SELECT is_tagged, is_invited, rsvp_status FROM game_night_players WHERE id = @id",
-        new { id = existingPlayerId }
-    );
-    row.IsTagged.Should().BeTrue();
-    row.IsInvited.Should().BeTrue();
-    row.RsvpStatus.Should().Be("Confirmed");
-}
-```
-
-- [ ] **Step 3: Run test → FAIL**
-
-- [ ] **Step 4: Implement migration with MAJ-2 backwards-compat**
-
-```csharp
-public partial class AddGameNightPlayerRsvp : Migration
-{
-    protected override void Up(MigrationBuilder b)
-    {
-        // MAJ-2: existing players are already auto-invited + auto-confirmed (legacy pattern)
-        b.AddColumn<bool>("is_tagged", "game_night_players",
-            nullable: false, defaultValue: true);
-        b.AddColumn<bool>("is_invited", "game_night_players",
-            nullable: false, defaultValue: true);
-        b.AddColumn<string>("rsvp_status", "game_night_players",
-            maxLength: 20, nullable: false, defaultValue: "Confirmed");
-    }
-
-    protected override void Down(MigrationBuilder b)
-    {
-        b.DropColumn("rsvp_status", "game_night_players");
-        b.DropColumn("is_invited", "game_night_players");
-        b.DropColumn("is_tagged", "game_night_players");
-    }
-}
-```
-
-- [ ] **Step 5: Run test → PASS**
-
-- [ ] **Step 6: Commit**
-
-```bash
-git commit -m "feat(game-management): #1896 add GameNightPlayer RSVP fields (invariante #16 + #17)
-
-MAJ-2 backwards-compat: existing players backfilled as IsInvited=true + RsvpStatus=Confirmed
-(legacy auto-shared pattern preserved)."
-```
-
----
-
-### Task 4: Migration sessions polymorphic scoring (DEC-1 foundation)
-
-**Mix-model**: haiku · **Effort**: S (~2h)
-
-**Files:**
-- Create: `apps/api/src/Api/Migrations/YYYYMMDD_AddSessionPolymorphicScoring.cs`
-
-- [ ] **Step 1: Generate migration**
-
-- [ ] **Step 2: Write failing test for column existence + backfill**
-
-```csharp
-[Fact]
-public async Task AddSessionPolymorphicScoring_AddsColumnsAndBackfillsExistingAsPoints()
-{
-    using var fixture = await TestcontainersFixture.CreateAsync();
-    await fixture.SeedAsync(seed => seed.AddSessions(count: 3));
-
-    await fixture.MigrateAsync(targetMigration: "AddSessionPolymorphicScoring");
-
-    using var conn = fixture.GetConnection();
-    var rows = await conn.QueryAsync<(string ScoringType, string ScoreData)>(
-        "SELECT scoring_type, score_data::text FROM sessions"
-    );
-    rows.Should().HaveCount(3);
-    rows.All(r => r.ScoringType == "Points").Should().BeTrue();
-    rows.All(r => r.ScoreData == "{}").Should().BeTrue();
-}
-```
-
-- [ ] **Step 3: Run → FAIL**
-
-- [ ] **Step 4: Implement migration**
-
-```csharp
-public partial class AddSessionPolymorphicScoring : Migration
-{
-    protected override void Up(MigrationBuilder b)
-    {
-        b.AddColumn<string>("scoring_type", "sessions",
-            maxLength: 20, nullable: false, defaultValue: "Points");
-        b.AddColumn<string>("score_data", "sessions",
-            type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb");
-    }
-
-    protected override void Down(MigrationBuilder b)
-    {
-        b.DropColumn("score_data", "sessions");
-        b.DropColumn("scoring_type", "sessions");
-    }
-}
-```
-
-- [ ] **Step 5: Run → PASS**
-
-- [ ] **Step 6: Commit**
-
-```bash
-git commit -m "feat(session-tracking): #1896 add Session.ScoringType/ScoreData (DEC-1 polymorphic)"
-```
-
----
-
-### Task 5: Migration notifications table (DEC-5 foundation)
-
-**Mix-model**: haiku · **Effort**: M (~4h)
-
-**Files:**
-- Create: `apps/api/src/Api/Migrations/YYYYMMDD_CreateNotificationsTable.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Notification.cs`
-
-- [ ] **Step 1: Generate migration**
-
-- [ ] **Step 2: Write failing test for table + indexes**
-
-```csharp
-[Fact]
-public async Task CreateNotificationsTable_HasExpectedSchemaAndIndexes()
-{
-    using var fixture = await TestcontainersFixture.CreateAsync();
-    await fixture.MigrateAsync(targetMigration: "CreateNotificationsTable");
-
-    using var conn = fixture.GetConnection();
-
-    var columns = await conn.QueryAsync<dynamic>(
-        "SELECT column_name, data_type FROM information_schema.columns " +
-        "WHERE table_name = 'notifications'"
-    );
-    columns.Select(c => c.column_name).Should().Contain(
-        new[] { "id", "recipient_user_id", "type", "payload", "read_at", "created_at" }
-    );
-
-    var indexes = await conn.QueryAsync<string>(
-        "SELECT indexname FROM pg_indexes WHERE tablename = 'notifications'"
-    );
-    indexes.Should().Contain("idx_notifications_recipient_created");
-    indexes.Should().Contain("idx_notifications_recipient_unread");
-}
-```
-
-- [ ] **Step 3: Run → FAIL**
-
-- [ ] **Step 4: Implement migration + entity**
-
-```csharp
-public partial class CreateNotificationsTable : Migration
-{
-    protected override void Up(MigrationBuilder b)
-    {
-        b.CreateTable("notifications", t => new
-        {
-            Id = t.Column<Guid>(nullable: false, defaultValueSql: "gen_random_uuid()"),
-            RecipientUserId = t.Column<Guid>("recipient_user_id", nullable: false),
-            Type = t.Column<string>(maxLength: 50, nullable: false),
-            Payload = t.Column<string>(type: "jsonb", nullable: false),
-            ReadAt = t.Column<DateTimeOffset?>("read_at", nullable: true),
-            CreatedAt = t.Column<DateTimeOffset>("created_at",
-                nullable: false, defaultValueSql: "now()"),
-        }, constraints: t =>
-        {
-            t.PrimaryKey("pk_notifications", x => x.Id);
-            t.ForeignKey("fk_notifications_users",
-                x => x.RecipientUserId, "users", "id", onDelete: ReferentialAction.Cascade);
-        });
-
-        b.CreateIndex("idx_notifications_recipient_created",
-            "notifications", new[] { "recipient_user_id", "created_at" },
-            descending: new[] { false, true });
-        b.CreateIndex("idx_notifications_recipient_unread",
-            "notifications", "recipient_user_id",
-            filter: "read_at IS NULL");
-    }
-
-    protected override void Down(MigrationBuilder b) => b.DropTable("notifications");
-}
-```
-
-```csharp
-// BoundedContexts/UserNotifications/Domain/Notification.cs
-public sealed class Notification
-{
-    public Guid Id { get; private set; }
-    public Guid RecipientUserId { get; private set; }
-    public string Type { get; private set; } = default!;
-    public string Payload { get; private set; } = default!; // JSON
-    public DateTimeOffset? ReadAt { get; private set; }
-    public DateTimeOffset CreatedAt { get; private set; }
-
-    private Notification() { } // EF
-
-    public static Notification Create(Guid recipientUserId, string type, string payloadJson)
-    {
-        if (string.IsNullOrWhiteSpace(type))
-            throw new ArgumentException("Type required", nameof(type));
-        return new Notification
-        {
-            Id = Guid.NewGuid(),
-            RecipientUserId = recipientUserId,
-            Type = type,
-            Payload = payloadJson,
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
-    }
-
-    public void MarkAsRead()
-    {
-        if (ReadAt is null) ReadAt = DateTimeOffset.UtcNow;
-    }
-}
-```
-
-- [ ] **Step 5: Update ApplicationDbContext**
-
-```csharp
-public DbSet<Notification> Notifications => Set<Notification>();
-
-// OnModelCreating
-modelBuilder.Entity<Notification>(b =>
-{
-    b.ToTable("notifications");
-    b.HasKey(e => e.Id);
-    b.Property(e => e.RecipientUserId).HasColumnName("recipient_user_id");
-    b.Property(e => e.Type).HasColumnName("type").HasMaxLength(50).IsRequired();
-    b.Property(e => e.Payload).HasColumnName("payload").HasColumnType("jsonb").IsRequired();
-    b.Property(e => e.ReadAt).HasColumnName("read_at");
-    b.Property(e => e.CreatedAt).HasColumnName("created_at");
-});
-```
-
-- [ ] **Step 6: Run → PASS**
-
-- [ ] **Step 7: Commit**
-
-```bash
-git commit -m "feat(user-notifications): #1896 create notifications table + Notification entity (DEC-5)"
-```
-
----
-
-## WP2 — Session invarianti #11/#12/#13/#14
-
-> **Spec reference**: Sezione 4 Asse A — "Modello Session (3 timestamp distinti)" + invarianti #12/#13/#14.
-> **Critical path**: blocca WP4 (max 1 live aggregate guard).
-
-### Task 6: Session.OpenLiveMode factory + invariante #14
+### Task 1: MaxLiveSessionsExceededException + aggregate guard
 
 **Mix-model**: sonnet · **Effort**: M (~6h)
 
 **Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs`
-- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Domain/SessionTests.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs` (add OpenLiveSession method)
+- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightEventMaxLiveTests.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/OpenLiveSessionEndpointTests.cs`
 
-- [ ] **Step 1: Write failing unit tests**
+> Backend reference: `GameNightEvent` aggregate root has `Sessions` accessor (Collection of GameNightSession). Each `GameNightSession.Status` = Pending/InProgress/Completed/Skipped. Live = `Status == InProgress && CompletedAt == null`. **Invariante #10**: a GameNightEvent can have at most 1 GameNightSession in InProgress at a time.
+
+- [ ] **Step 1: Write failing unit test**
 
 ```csharp
-public class SessionOpenLiveModeTests
+public class GameNightEventMaxLiveTests
 {
     [Fact]
-    public void OpenLiveMode_OnDraft_SetsStartedAtToNow_AndReturnsLiveSession()
+    public void OpenLiveSession_WhenAnotherLiveActive_ThrowsMaxLiveSessionsExceededException()
     {
-        var draft = Session.CreateDraft(gameNightId: Guid.NewGuid(), gameId: Guid.NewGuid());
-        var beforeNow = DateTimeOffset.UtcNow;
+        var gn = GameNightEvent.CreateAdHoc(organizerId: Guid.NewGuid(), title: "Test", firstGameId: Guid.NewGuid());
+        var firstSession = gn.AttachSession(sessionId: Guid.NewGuid(), gameId: Guid.NewGuid(), gameTitle: "Wingspan", playOrder: 1);
+        firstSession.Start();
+        var secondSession = gn.AttachSession(sessionId: Guid.NewGuid(), gameId: Guid.NewGuid(), gameTitle: "Catan", playOrder: 2);
 
-        var live = draft.OpenLiveMode();
+        var act = () => gn.OpenLiveSession(secondSession.Id);
 
-        live.StartedAt.Should().NotBeNull();
-        live.StartedAt!.Value.Should().BeOnOrAfter(beforeNow);
-        live.CompletedAt.Should().BeNull();
+        act.Should().Throw<MaxLiveSessionsExceededException>()
+            .Where(ex => ex.ErrorCode == "MAX_LIVE_SESSIONS_EXCEEDED")
+            .Where(ex => ex.GameNightEventId == gn.Id);
     }
 
     [Fact]
-    public void OpenLiveMode_OnSessionWithStartedAt_Throws()
+    public void OpenLiveSession_WithoutOtherLive_Succeeds()
     {
-        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
-        draft.OpenLiveMode();
+        var gn = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Test", Guid.NewGuid());
+        var session = gn.AttachSession(Guid.NewGuid(), Guid.NewGuid(), "Wingspan", 1);
 
-        var act = () => draft.OpenLiveMode();
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*already in live mode*");
-    }
+        var act = () => gn.OpenLiveSession(session.Id);
 
-    [Fact]
-    public void StartedAt_IsNeverSetByConstructorOrDraftFactory()
-    {
-        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
-        draft.StartedAt.Should().BeNull(); // invariante #14
+        act.Should().NotThrow();
     }
 }
 ```
 
-- [ ] **Step 2: Run tests → FAIL** (method not exists)
+- [ ] **Step 2: Run → FAIL** (exception class non esiste, no guard logic)
 
-- [ ] **Step 3: Implement Session.OpenLiveMode + invariante #14**
+- [ ] **Step 3: Implement exception**
 
 ```csharp
-public sealed class Session
+// MaxLiveSessionsExceededException.cs
+namespace Api.BoundedContexts.GameManagement.Domain.Exceptions;
+
+public class MaxLiveSessionsExceededException : DomainException
 {
-    public Guid Id { get; private set; }
-    public Guid GameNightId { get; private set; }
-    public Guid GameId { get; private set; }
-    public DateTimeOffset CreatedAt { get; private set; }
-    public DateTimeOffset? StartedAt { get; private set; }
-    public DateTimeOffset? CompletedAt { get; private set; }
+    public Guid GameNightEventId { get; }
+    public override string ErrorCode => "MAX_LIVE_SESSIONS_EXCEEDED";
 
-    private Session() { } // EF
-
-    public static Session CreateDraft(Guid gameNightId, Guid gameId) => new()
+    public MaxLiveSessionsExceededException(Guid gameNightEventId)
+        : base($"GameNightEvent {gameNightEventId} already has an active live session.")
     {
-        Id = Guid.NewGuid(),
-        GameNightId = gameNightId,
-        GameId = gameId,
-        CreatedAt = DateTimeOffset.UtcNow,
-        // StartedAt + CompletedAt deliberately NULL (invariante #14)
-    };
-
-    public Session OpenLiveMode()
-    {
-        if (StartedAt is not null)
-            throw new InvalidOperationException(
-                $"Session {Id} is already in live mode (StartedAt={StartedAt}).");
-        StartedAt = DateTimeOffset.UtcNow;
-        return this;
+        GameNightEventId = gameNightEventId;
     }
 }
 ```
 
-- [ ] **Step 4: Run tests → PASS**
+- [ ] **Step 4: Add GameNightEvent.OpenLiveSession() aggregate method**
 
-- [ ] **Step 5: Commit**
+```csharp
+// GameNightEvent.cs (add method)
+public void OpenLiveSession(Guid gameNightSessionId)
+{
+    ThrowIfCorrupted();
+
+    var alreadyLive = Sessions.Any(s =>
+        s.Status == GameNightSessionStatus.InProgress);
+    if (alreadyLive)
+        throw new MaxLiveSessionsExceededException(Id);
+
+    var session = Sessions.FirstOrDefault(s => s.Id == gameNightSessionId)
+        ?? throw new InvalidOperationException($"GameNightSession {gameNightSessionId} not found in GameNightEvent {Id}");
+    session.Start();
+}
+```
+
+> Note: `GameNightSession.Start()` rimane internal. Esposto via `GameNightEvent.OpenLiveSession()` aggregate method che applica guard.
+
+- [ ] **Step 5: Run unit test → PASS**
+
+- [ ] **Step 6: Write failing integration test for HTTP 409**
+
+```csharp
+[Fact]
+public async Task POST_OpenLiveSession_With_ExistingLive_Returns409_WithErrorCode()
+{
+    using var app = await TestApp.CreateAsync();
+    var gn = await app.SeedGameNightWithSessionAsync();
+    await app.OpenLiveAsync(gn.Id, sessionId: gn.Sessions[0].Id);
+    var secondSession = await app.AddSecondSessionAsync(gn.Id);
+
+    var response = await app.Client.PostAsync(
+        $"/api/v1/game-nights/{gn.Id}/sessions/{secondSession.Id}/live", null);
+
+    response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    var body = await response.Content.ReadFromJsonAsync<ErrorDto>();
+    body!.Code.Should().Be("MAX_LIVE_SESSIONS_EXCEEDED");
+}
+```
+
+- [ ] **Step 7: Add endpoint + middleware mapping**
+
+```csharp
+// GameNightEndpoints.cs (or existing routing file)
+app.MapPost("/api/v1/game-nights/{gnId:guid}/sessions/{sId:guid}/live",
+    async (Guid gnId, Guid sId, IMediator m) =>
+        Results.Ok(await m.Send(new OpenLiveSessionCommand(gnId, sId))));
+
+// DomainExceptionMiddleware.cs (add catch)
+catch (MaxLiveSessionsExceededException ex)
+{
+    context.Response.StatusCode = StatusCodes.Status409Conflict;
+    await context.Response.WriteAsJsonAsync(new ErrorDto(ex.ErrorCode, ex.Message));
+}
+```
+
+- [ ] **Step 8: Run integration test → PASS**
+
+- [ ] **Step 9: Commit**
 
 ```bash
-git commit -m "feat(session-tracking): #1896 Session.OpenLiveMode factory + invariante #14 (StartedAt derived)"
+git commit -m "feat(game-management): #1896 invariante #10 max 1 live aggregate guard"
 ```
 
 **Self-review**:
-- [ ] StartedAt NEVER set by constructor/CreateDraft
-- [ ] OpenLiveMode throws if already live
-- [ ] Factory method pattern (MIN-6 clarified)
-- [ ] DateTimeOffset.UtcNow direct (no clock abstraction MVP, document trade-off)
+- [ ] Exception in Domain layer (not Application)
+- [ ] Aggregate method `OpenLiveSession()` invece di esponendo Start() pubblicamente
+- [ ] HTTP 409 mapping via middleware DomainException pattern
+- [ ] No migration needed (no new columns, query-time check)
 
 ---
 
-### Task 7: Session.Save() invariante #11 completedAt valorizzato
+## WP2 — Session.StartedAt + invariante #15 + warning header + semantic mapping
 
-**Mix-model**: haiku · **Effort**: S (~3h)
+### Task 2: Session.StartedAt + OpenLiveMode factory (invariante #11 + #14)
+
+**Mix-model**: sonnet · **Effort**: M (~6h)
+
+> Backend reference: `Session` aggregate in SessionTracking ha `CreatedAt` (DateTime UTC default), `FinalizedAt` (Complete equivalent), `SessionStatus`. **MANCA: StartedAt**. Plan demo dice 3 timestamp distinti.
 
 **Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs`
-- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Domain/SessionTests.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs` (add StartedAt + OpenLiveMode)
+- Create: `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDD_AddSessionStartedAt.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionStartedDomainEvent.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Domain/SessionStartedAtTests.cs`
 
-- [ ] **Step 1: Write failing tests**
+- [ ] **Step 1: Write failing unit test**
 
 ```csharp
-public class SessionSaveTests
+public class SessionStartedAtTests
 {
     [Fact]
-    public void Save_OnDraft_SetsCompletedAtToNow()
+    public void NewSession_HasNullStartedAt_NotInLiveMode()
     {
-        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
-        var beforeNow = DateTimeOffset.UtcNow;
-
-        draft.Save();
-
-        draft.CompletedAt.Should().NotBeNull();
-        draft.CompletedAt!.Value.Should().BeOnOrAfter(beforeNow);
+        var s = Session.Create(userId: Guid.NewGuid(), gameId: Guid.NewGuid(),
+            sessionType: SessionType.Generic);
+        s.StartedAt.Should().BeNull();
+        s.IsLive.Should().BeFalse();
     }
 
     [Fact]
-    public void Save_OnLive_PreservesStartedAt_AndSetsCompletedAt()
+    public void OpenLiveMode_SetsStartedAt_RaisesDomainEvent()
     {
-        var session = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid()).OpenLiveMode();
-        var startedAt = session.StartedAt;
+        var s = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        var beforeNow = DateTime.UtcNow;
 
-        session.Save();
+        s.OpenLiveMode();
 
-        session.StartedAt.Should().Be(startedAt);
-        session.CompletedAt.Should().NotBeNull();
+        s.StartedAt.Should().NotBeNull();
+        s.StartedAt!.Value.Should().BeOnOrAfter(beforeNow);
+        s.IsLive.Should().BeTrue();
+        s.DomainEvents.OfType<SessionStartedDomainEvent>().Should().ContainSingle();
     }
 
     [Fact]
-    public void Save_OnAlreadySaved_Throws()
+    public void OpenLiveMode_OnAlreadyLive_Throws()
     {
-        var draft = Session.CreateDraft(Guid.NewGuid(), Guid.NewGuid());
-        draft.Save();
+        var s = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        s.OpenLiveMode();
 
-        var act = () => draft.Save();
+        var act = () => s.OpenLiveMode();
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void OpenLiveMode_OnFinalized_Throws()
+    {
+        var s = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        // assuming Finalize method exists (FinalizedAt)
+        s.Finalize();
+
+        var act = () => s.OpenLiveMode();
         act.Should().Throw<InvalidOperationException>();
     }
 }
@@ -715,108 +306,219 @@ public class SessionSaveTests
 
 - [ ] **Step 2: Run → FAIL**
 
-- [ ] **Step 3: Implement Session.Save**
+- [ ] **Step 3: Add migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddSessionStartedAt --output-dir Infrastructure/Migrations
+```
 
 ```csharp
-public void Save()
+public partial class AddSessionStartedAt : Migration
 {
-    if (CompletedAt is not null)
+    protected override void Up(MigrationBuilder b) =>
+        b.AddColumn<DateTime?>("started_at", "sessions", nullable: true);
+
+    protected override void Down(MigrationBuilder b) =>
+        b.DropColumn("started_at", "sessions");
+}
+```
+
+- [ ] **Step 4: Update Session entity**
+
+```csharp
+// Session.cs (add)
+public DateTime? StartedAt { get; private set; }
+public bool IsLive => StartedAt.HasValue && FinalizedAt is null;
+
+public void OpenLiveMode()
+{
+    if (IsLive)
         throw new InvalidOperationException(
-            $"Session {Id} is already saved (CompletedAt={CompletedAt}).");
-    CompletedAt = DateTimeOffset.UtcNow;
+            $"Session {Id} is already in live mode (StartedAt={StartedAt}).");
+    if (FinalizedAt.HasValue)
+        throw new InvalidOperationException(
+            $"Session {Id} is already finalized. Cannot open live mode.");
+
+    StartedAt = DateTime.UtcNow;
+    AddDomainEvent(new SessionStartedDomainEvent(Id, UserId, GameId, StartedAt.Value));
 }
 ```
 
-- [ ] **Step 4: Run → PASS**
+```csharp
+// SessionStartedDomainEvent.cs
+public record SessionStartedDomainEvent(
+    Guid SessionId,
+    Guid UserId,
+    Guid GameId,
+    DateTime StartedAt) : IDomainEvent;
+```
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Update ApplicationDbContext Session mapping**
+
+```csharp
+// ApplicationDbContext.cs OnModelCreating Session config
+b.Property(e => e.StartedAt).HasColumnName("started_at");
+```
+
+- [ ] **Step 6: Run tests → PASS**
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git commit -m "feat(session-tracking): #1896 Session.Save() valorizza CompletedAt (invariante #11)"
+git commit -m "feat(session-tracking): #1896 Session.StartedAt + OpenLiveMode (invariante #11 + #14)"
 ```
+
+**Self-review**:
+- [ ] StartedAt nullable, valorizzato SOLO via OpenLiveMode (invariante #14 derived)
+- [ ] CreatedAt esistente preserved
+- [ ] FinalizedAt esistente = CompletedAt equivalent
+- [ ] Domain event raised (consistente con IDomainEventSource pattern già usato)
+- [ ] Migration additive (no breaking change)
 
 ---
 
-### Task 8: GetSessionsByGameNightQuery sort createdAt ASC (invariante #12)
-
-**Mix-model**: haiku · **Effort**: S (~2h)
-
-**Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/GetSessionsByGameNight/GetSessionsByGameNightQueryHandler.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/GetSessionsByGameNightQueryHandlerTests.cs`
-
-- [ ] **Step 1: Write failing integration test**
-
-```csharp
-[Fact]
-public async Task Handle_ReturnsSessions_OrderedByCreatedAtAscending()
-{
-    using var fixture = await TestcontainersFixture.CreateAsync();
-    var gameNightId = Guid.NewGuid();
-    await fixture.SeedAsync(seed =>
-    {
-        seed.AddSession(gameNightId, createdAt: DateTimeOffset.UtcNow.AddMinutes(-30));
-        seed.AddSession(gameNightId, createdAt: DateTimeOffset.UtcNow);
-        seed.AddSession(gameNightId, createdAt: DateTimeOffset.UtcNow.AddMinutes(-15));
-    });
-
-    var handler = fixture.Resolve<GetSessionsByGameNightQueryHandler>();
-    var result = await handler.Handle(new GetSessionsByGameNightQuery(gameNightId), CT.None);
-
-    result.Should().HaveCount(3);
-    result.Should().BeInAscendingOrder(s => s.CreatedAt);
-}
-```
-
-- [ ] **Step 2: Run → FAIL** (current sort is updated_at desc o nessuno)
-
-- [ ] **Step 3: Update handler**
-
-```csharp
-public async Task<IReadOnlyList<SessionDto>> Handle(
-    GetSessionsByGameNightQuery query, CancellationToken ct)
-{
-    return await _db.Sessions
-        .Where(s => s.GameNightId == query.GameNightId)
-        .OrderBy(s => s.CreatedAt) // invariante #12 deterministic
-        .Select(s => SessionDto.FromEntity(s))
-        .ToListAsync(ct);
-}
-```
-
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(session-tracking): #1896 sort sessions by CreatedAt ASC (invariante #12)"
-```
-
----
-
-### Task 9: SaveSessionCommand + X-Warning-Code header (invariante #13)
+### Task 3: Invariante #15 wire — SessionStarted triggers GameNight Planned→InProgress
 
 **Mix-model**: sonnet · **Effort**: M (~5h)
 
+> Backend reference: `GameNightEvent.CreateAdHoc()` va direttamente a InProgress (skip Draft+Published). Per non-AdHoc flow (Draft → Published), invariante #15 demo dice "first Session creates → Planned should become InProgress". Mapping: "Planned" demo = Published backend (post-RSVP). Quindi quando una Session sotto Published GameNight viene started, dovrebbe transition a InProgress.
+
 **Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandHandler.cs`
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Routing/SessionEndpoints.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/SaveSessionEndpointTests.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionStartedHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs` (add HandleFirstSessionStarted method)
+- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightEventInvariant15Tests.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/Invariant15IntegrationTests.cs`
 
 - [ ] **Step 1: Write failing test**
+
+```csharp
+public class GameNightEventInvariant15Tests
+{
+    [Fact]
+    public void HandleFirstSessionStarted_OnPublished_TransitionsToInProgress_Invariant15()
+    {
+        var gn = GameNightEvent.Create(organizerId: Guid.NewGuid(), title: "Test", scheduledAt: DateTimeOffset.UtcNow.AddDays(1));
+        gn.Publish(invitedUserIds: new List<Guid> { Guid.NewGuid() });
+        // Status = Published
+
+        gn.HandleFirstSessionStarted(sessionId: Guid.NewGuid());
+
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+    }
+
+    [Fact]
+    public void HandleFirstSessionStarted_OnDraft_Throws_InvalidOperationException()
+    {
+        var gn = GameNightEvent.Create(Guid.NewGuid(), "Test", DateTimeOffset.UtcNow.AddDays(1));
+        // Status = Draft
+        var act = () => gn.HandleFirstSessionStarted(Guid.NewGuid());
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void HandleFirstSessionStarted_OnInProgress_IsIdempotent_NoStateChange()
+    {
+        var gn = GameNightEvent.CreateAdHoc(Guid.NewGuid(), "Test", Guid.NewGuid());
+        // Status = InProgress already (AdHoc)
+        gn.HandleFirstSessionStarted(Guid.NewGuid());
+        gn.Status.Should().Be(GameNightStatus.InProgress);
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement HandleFirstSessionStarted on GameNightEvent**
+
+```csharp
+// GameNightEvent.cs (add)
+public void HandleFirstSessionStarted(Guid sessionId)
+{
+    ThrowIfCorrupted();
+
+    if (Status == GameNightStatus.Published)
+    {
+        Status = GameNightStatus.InProgress;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+    // Idempotent: InProgress → stay InProgress (already AdHoc or already started)
+    else if (Status == GameNightStatus.InProgress)
+    {
+        return;
+    }
+    else
+    {
+        throw new InvalidOperationException(
+            $"Cannot start session: GameNightEvent {Id} is in {Status} status (invariante #15 requires Published or InProgress).");
+    }
+}
+```
+
+- [ ] **Step 4: Wire MediatR INotificationHandler**
+
+```csharp
+// SessionStartedHandler.cs in GameManagement.Application.EventHandlers
+public class SessionStartedHandler : INotificationHandler<SessionStartedDomainEvent>
+{
+    private readonly IGameNightEventRepository _gnRepo;
+    private readonly IGameNightSessionRepository _gnsRepo;
+
+    public SessionStartedHandler(IGameNightEventRepository repo, IGameNightSessionRepository gnsRepo)
+    {
+        _gnRepo = repo;
+        _gnsRepo = gnsRepo;
+    }
+
+    public async Task Handle(SessionStartedDomainEvent evt, CancellationToken ct)
+    {
+        // SessionTracking Session is started → find parent GameNightEvent via GameNightSession link
+        var link = await _gnsRepo.FindBySessionIdAsync(evt.SessionId, ct);
+        if (link is null) return; // standalone session, no GN parent
+
+        var gn = await _gnRepo.GetByIdAsync(link.GameNightEventId, ct)
+            ?? throw new NotFoundException($"GameNightEvent {link.GameNightEventId}");
+        gn.HandleFirstSessionStarted(evt.SessionId);
+        await _gnRepo.SaveAsync(gn, ct);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests + integration test (end-to-end via mediator pipeline) → PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(game-management): #1896 invariante #15 wire — SessionStartedHandler transitions GameNight to InProgress"
+```
+
+---
+
+### Task 4: SaveSessionCommand + X-Warning-Code header (invariante #13)
+
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+> Demo invariante #13: salvare draft con live attiva è permesso ma backend ritorna `X-Warning-Code: SAVED_WHILE_LIVE_ACTIVE` header per frontend toast.
+
+**Files:**
+- Modify: existing SaveSessionCommandHandler in SessionTracking/Application/SaveSession
+- Modify: endpoint mapper to translate result to HTTP header
+- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/SaveSessionWarningHeaderTests.cs`
+
+- [ ] **Step 1: Write failing integration test**
 
 ```csharp
 [Fact]
 public async Task SaveSession_WithActiveLive_Returns200_WithWarningHeader()
 {
     using var app = await TestApp.CreateAsync();
-    var gn = await app.SeedGameNightAsync();
-    var liveSession = await app.OpenLiveSessionAsync(gn.Id, gameId: Guid.NewGuid());
-    var draft = await app.CreateDraftSessionAsync(gn.Id, gameId: Guid.NewGuid());
+    var gn = await app.SeedGameNightEventAsync();
+    var liveSession = await app.OpenLiveSessionAsync(gn.Id);
+    var draft = await app.CreateDraftSessionAsync(gn.Id);
 
-    var response = await app.Client.PutAsync(
+    var response = await app.Client.PutAsJsonAsync(
         $"/api/v1/sessions/{draft.Id}/save",
-        JsonContent.Create(new SaveSessionRequest { ScoringType = "Points", ScoreData = "{}" }));
+        new SaveSessionRequest { /* polymorphic scoring later in WP3 */ });
 
     response.StatusCode.Should().Be(HttpStatusCode.OK);
     response.Headers.GetValues("X-Warning-Code").Should().ContainSingle("SAVED_WHILE_LIVE_ACTIVE");
@@ -826,21 +528,21 @@ public async Task SaveSession_WithActiveLive_Returns200_WithWarningHeader()
 public async Task SaveSession_WithoutActiveLive_Returns200_NoWarningHeader()
 {
     using var app = await TestApp.CreateAsync();
-    var gn = await app.SeedGameNightAsync();
-    var draft = await app.CreateDraftSessionAsync(gn.Id, gameId: Guid.NewGuid());
+    var gn = await app.SeedGameNightEventAsync();
+    var draft = await app.CreateDraftSessionAsync(gn.Id);
 
-    var response = await app.Client.PutAsync(
+    var response = await app.Client.PutAsJsonAsync(
         $"/api/v1/sessions/{draft.Id}/save",
-        JsonContent.Create(new SaveSessionRequest { ScoringType = "Points", ScoreData = "{}" }));
+        new SaveSessionRequest { });
 
     response.StatusCode.Should().Be(HttpStatusCode.OK);
     response.Headers.Contains("X-Warning-Code").Should().BeFalse();
 }
 ```
 
-- [ ] **Step 2: Run → FAIL** (handler non emette warning)
+- [ ] **Step 2: Run → FAIL**
 
-- [ ] **Step 3: Update handler to return warning flag + endpoint to map to header**
+- [ ] **Step 3: Update handler to return result + flag**
 
 ```csharp
 public record SaveSessionResult(SessionDto Session, bool LiveActiveWarning);
@@ -848,598 +550,96 @@ public record SaveSessionResult(SessionDto Session, bool LiveActiveWarning);
 public async Task<SaveSessionResult> Handle(SaveSessionCommand cmd, CancellationToken ct)
 {
     var session = await _db.Sessions.FindAsync(new object?[] { cmd.SessionId }, ct)
-        ?? throw new NotFoundException($"Session {cmd.SessionId} not found");
-    session.Save();
+        ?? throw new NotFoundException($"Session {cmd.SessionId}");
+    session.Finalize(); // existing Complete-equivalent method
 
-    bool liveActive = await _db.Sessions.AnyAsync(s =>
-        s.GameNightId == session.GameNightId &&
-        s.StartedAt != null &&
-        s.CompletedAt == null &&
-        s.Id != session.Id, ct);
+    // Check sibling live via GameNightSession link
+    bool liveActive = await CheckSiblingLiveAsync(session, ct);
 
     await _db.SaveChangesAsync(ct);
     return new SaveSessionResult(SessionDto.FromEntity(session), liveActive);
 }
+
+private async Task<bool> CheckSiblingLiveAsync(Session session, CancellationToken ct)
+{
+    var link = await _db.GameNightSessions.FirstOrDefaultAsync(
+        l => l.SessionId == session.Id, ct);
+    if (link is null) return false;
+    return await _db.GameNightSessions.AnyAsync(s =>
+        s.GameNightEventId == link.GameNightEventId &&
+        s.Status == GameNightSessionStatus.InProgress &&
+        s.SessionId != session.Id, ct);
+}
 ```
 
+- [ ] **Step 4: Update endpoint to set X-Warning-Code header**
+
 ```csharp
-// SessionEndpoints.cs
 app.MapPut("/api/v1/sessions/{id:guid}/save", async (
     Guid id, SaveSessionRequest req, IMediator m, HttpResponse response) =>
 {
-    var result = await m.Send(new SaveSessionCommand(id, req.ScoringType, req.ScoreData));
+    var result = await m.Send(new SaveSessionCommand(id, /* fields */));
     if (result.LiveActiveWarning)
         response.Headers.Append("X-Warning-Code", "SAVED_WHILE_LIVE_ACTIVE");
     return Results.Ok(result.Session);
 });
 ```
 
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(session-tracking): #1896 SaveSession X-Warning-Code header on live coexistence (invariante #13)"
-```
-
----
-
-## WP3 — State machine GameNight #8/#15/#16/#17
-
-> **Spec reference**: Sezione 4 Asse A — "State machine GameNight" + Tagging vs RSVP a 5 fasi.
-> **Critical path**: blocca WP6 notification flow (SendInvitations comand triggers notification).
-
-### Task 10: GameNight state machine + SessionCreatedDomainEvent handler (invariante #15)
-
-**Mix-model**: sonnet · **Effort**: L (~8h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightStatus.cs`
-- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedDomainEvent.cs`
-- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNight.cs`
-- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightStateMachineTests.cs`
-
-- [ ] **Step 1: Write failing unit tests**
-
-```csharp
-public class GameNightStateMachineTests
-{
-    [Fact]
-    public void NewGameNight_HasStatusPlanned()
-    {
-        var gn = GameNight.Create(ownerId: Guid.NewGuid(), date: DateTimeOffset.UtcNow.AddDays(7));
-        gn.Status.Should().Be(GameNightStatus.Planned);
-    }
-
-    [Fact]
-    public void FirstSessionCreated_TransitionsToInProgress_InvariantE15()
-    {
-        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow.AddDays(1));
-        var draftEvent = new SessionCreatedDomainEvent(gn.Id, sessionId: Guid.NewGuid(), isLive: false);
-
-        gn.HandleSessionCreated(draftEvent);
-
-        gn.Status.Should().Be(GameNightStatus.InProgress);
-    }
-
-    [Fact]
-    public void FirstSessionLiveCreated_TransitionsToInProgress_InvariantE15()
-    {
-        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-        var liveEvent = new SessionCreatedDomainEvent(gn.Id, sessionId: Guid.NewGuid(), isLive: true);
-
-        gn.HandleSessionCreated(liveEvent);
-
-        gn.Status.Should().Be(GameNightStatus.InProgress);
-    }
-
-    [Fact]
-    public void SubsequentSessionCreated_StaysInProgress()
-    {
-        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
-        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
-        gn.Status.Should().Be(GameNightStatus.InProgress);
-    }
-
-    [Fact]
-    public void MarkAsCompleted_FromInProgress_TransitionsToCompleted()
-    {
-        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
-
-        gn.MarkAsCompleted();
-
-        gn.Status.Should().Be(GameNightStatus.Completed);
-    }
-
-    [Fact]
-    public void MarkAsCompleted_FromPlanned_Throws()
-    {
-        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-        var act = () => gn.MarkAsCompleted();
-        act.Should().Throw<InvalidOperationException>().WithMessage("*Planned*");
-    }
-
-    [Fact]
-    public void NoBackwardTransition_CompletedCantGoBackToInProgress()
-    {
-        var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-        gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
-        gn.MarkAsCompleted();
-
-        var act = () => gn.HandleSessionCreated(new SessionCreatedDomainEvent(gn.Id, Guid.NewGuid(), false));
-        act.Should().Throw<InvalidOperationException>();
-    }
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Implement enum + event + aggregate logic**
-
-```csharp
-// GameNightStatus.cs
-public enum GameNightStatus { Planned, InProgress, Completed }
-
-// SessionCreatedDomainEvent.cs
-public record SessionCreatedDomainEvent(Guid GameNightId, Guid SessionId, bool IsLive);
-
-// GameNight.cs (partial)
-public GameNightStatus Status { get; private set; } = GameNightStatus.Planned;
-
-public void HandleSessionCreated(SessionCreatedDomainEvent evt)
-{
-    if (evt.GameNightId != Id)
-        throw new InvalidOperationException("Event for different GameNight");
-    if (Status == GameNightStatus.Completed)
-        throw new InvalidOperationException(
-            $"GameNight {Id} is Completed, cannot accept new sessions.");
-    if (Status == GameNightStatus.Planned)
-        Status = GameNightStatus.InProgress; // invariante #15
-    // If already InProgress: no-op (subsequent sessions don't change state)
-}
-
-public void MarkAsCompleted()
-{
-    if (Status != GameNightStatus.InProgress)
-        throw new InvalidOperationException(
-            $"Cannot mark Planned GameNight {Id} as Completed. Status={Status}.");
-    Status = GameNightStatus.Completed;
-}
-```
-
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Wire SessionCreatedDomainEvent into Session.CreateDraft + Session.OpenLiveMode**
-
-```csharp
-// Session.cs
-public IReadOnlyList<object> DomainEvents => _events;
-private readonly List<object> _events = new();
-
-public static Session CreateDraft(Guid gameNightId, Guid gameId)
-{
-    var s = new Session { /* ... */ };
-    s._events.Add(new SessionCreatedDomainEvent(gameNightId, s.Id, isLive: false));
-    return s;
-}
-
-public Session OpenLiveMode()
-{
-    if (StartedAt is not null) throw new InvalidOperationException(/* ... */);
-    StartedAt = DateTimeOffset.UtcNow;
-    // If created via OpenLiveMode directly (not draft → live), emit IsLive=true
-    if (CreatedAt >= StartedAt.Value.AddSeconds(-1))
-        _events.Add(new SessionCreatedDomainEvent(GameNightId, Id, isLive: true));
-    return this;
-}
-```
-
-- [ ] **Step 6: Add MediatR INotification handler dispatching event to GameNight aggregate**
-
-```csharp
-// In SessionTracking/Application/EventHandlers/SessionCreatedHandler.cs
-public class SessionCreatedHandler : INotificationHandler<SessionCreatedDomainEvent>
-{
-    private readonly IGameNightRepository _repo;
-    public SessionCreatedHandler(IGameNightRepository repo) => _repo = repo;
-
-    public async Task Handle(SessionCreatedDomainEvent evt, CancellationToken ct)
-    {
-        var gn = await _repo.GetByIdAsync(evt.GameNightId, ct)
-            ?? throw new NotFoundException($"GameNight {evt.GameNightId} not found");
-        gn.HandleSessionCreated(evt);
-        await _repo.SaveAsync(gn, ct);
-    }
-}
-```
-
-- [ ] **Step 7: Run all unit + integration tests**
-
-```bash
-dotnet test --filter "BoundedContext=GameManagement|BoundedContext=SessionTracking"
-```
-Expected: PASS
-
-- [ ] **Step 8: Commit**
-
-```bash
-git commit -m "feat(game-management): #1896 GameNight state machine + SessionCreatedDomainEvent (invariante #15)"
-```
-
-**Self-review**:
-- [ ] Invariante #15 esplicita: trigger ON FIRST Session creation (draft OR live)
-- [ ] No backward transition Completed → InProgress
-- [ ] MediatR INotification dispatch via DomainEvents collection
-- [ ] Aggregate repository pattern preserved
-
----
-
-### Task 11: GameNightPlayer.IsTagged/IsInvited/RsvpStatus + invariante #16 separation
-
-**Mix-model**: sonnet · **Effort**: M (~5h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/RsvpStatus.cs`
-- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNightPlayer.cs`
-- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightPlayerRsvpTests.cs`
-
-- [ ] **Step 1: Write failing tests**
-
-```csharp
-public class GameNightPlayerRsvpTests
-{
-    [Fact]
-    public void TagPlayer_SetsIsTaggedTrue_IsInvitedFalse_RsvpPending()
-    {
-        var player = GameNightPlayer.Tag(playerId: Guid.NewGuid());
-        player.IsTagged.Should().BeTrue();
-        player.IsInvited.Should().BeFalse();
-        player.RsvpStatus.Should().Be(RsvpStatus.Pending);
-    }
-
-    [Fact]
-    public void Invite_OnTaggedPlayer_SetsIsInvitedTrue_StaysRsvpPending()
-    {
-        var player = GameNightPlayer.Tag(Guid.NewGuid());
-        player.Invite();
-        player.IsTagged.Should().BeTrue();
-        player.IsInvited.Should().BeTrue();
-        player.RsvpStatus.Should().Be(RsvpStatus.Pending);
-    }
-
-    [Fact]
-    public void ConfirmRsvp_OnInvited_SetsConfirmed()
-    {
-        var player = GameNightPlayer.Tag(Guid.NewGuid());
-        player.Invite();
-        player.ConfirmRsvp();
-        player.RsvpStatus.Should().Be(RsvpStatus.Confirmed);
-    }
-
-    [Fact]
-    public void DeclineRsvp_OnInvited_SetsDeclined()
-    {
-        var player = GameNightPlayer.Tag(Guid.NewGuid());
-        player.Invite();
-        player.DeclineRsvp();
-        player.RsvpStatus.Should().Be(RsvpStatus.Declined);
-    }
-
-    [Fact]
-    public void ConfirmRsvp_OnNotInvited_Throws()
-    {
-        var player = GameNightPlayer.Tag(Guid.NewGuid());
-        var act = () => player.ConfirmRsvp();
-        act.Should().Throw<InvalidOperationException>().WithMessage("*not yet invited*");
-    }
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Implement**
-
-```csharp
-public enum RsvpStatus { Pending, Confirmed, Declined }
-
-public sealed class GameNightPlayer
-{
-    public Guid Id { get; private set; }
-    public Guid PlayerId { get; private set; }
-    public bool IsTagged { get; private set; }
-    public bool IsInvited { get; private set; }
-    public RsvpStatus RsvpStatus { get; private set; }
-
-    private GameNightPlayer() { }
-
-    public static GameNightPlayer Tag(Guid playerId) => new()
-    {
-        Id = Guid.NewGuid(),
-        PlayerId = playerId,
-        IsTagged = true,
-        IsInvited = false,
-        RsvpStatus = RsvpStatus.Pending,
-    };
-
-    public void Invite()
-    {
-        if (!IsTagged) throw new InvalidOperationException("Player not tagged");
-        IsInvited = true;
-    }
-
-    public void ConfirmRsvp()
-    {
-        if (!IsInvited) throw new InvalidOperationException("Player not yet invited");
-        RsvpStatus = RsvpStatus.Confirmed;
-    }
-
-    public void DeclineRsvp()
-    {
-        if (!IsInvited) throw new InvalidOperationException("Player not yet invited");
-        RsvpStatus = RsvpStatus.Declined;
-    }
-}
-```
-
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(game-management): #1896 GameNightPlayer IsTagged/IsInvited/RsvpStatus separation (invariante #16)"
-```
-
----
-
-### Task 12: SendGameNightInvitationsCommand + 5-fase flow
-
-**Mix-model**: sonnet · **Effort**: M (~6h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/SendInvitations/SendGameNightInvitationsCommand.cs`
-- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/SendInvitations/SendGameNightInvitationsCommandHandler.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/SendGameNightInvitationsTests.cs`
-
-- [ ] **Step 1: Write failing integration test**
-
-```csharp
-[Fact]
-public async Task SendInvitations_TransitionsAllTaggedToInvited_DoesNotChangeRsvp()
-{
-    using var app = await TestApp.CreateAsync();
-    var gnId = await app.SeedGameNightAsync(taggedPlayers: 3);
-
-    await app.Client.PostAsync($"/api/v1/game-nights/{gnId}/send-invitations", null);
-
-    var players = await app.GetGameNightPlayersAsync(gnId);
-    players.Should().HaveCount(3);
-    players.All(p => p.IsTagged).Should().BeTrue();
-    players.All(p => p.IsInvited).Should().BeTrue();
-    players.All(p => p.RsvpStatus == "Pending").Should().BeTrue();
-}
-
-[Fact]
-public async Task SendInvitations_IsIdempotent_DoesntCreateDuplicateNotifications()
-{
-    using var app = await TestApp.CreateAsync();
-    var gnId = await app.SeedGameNightAsync(taggedPlayers: 2);
-
-    await app.Client.PostAsync($"/api/v1/game-nights/{gnId}/send-invitations", null);
-    await app.Client.PostAsync($"/api/v1/game-nights/{gnId}/send-invitations", null);
-
-    var notifs = await app.GetNotificationsForGameNightAsync(gnId);
-    notifs.Should().HaveCount(2); // not 4
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Implement command + handler**
-
-```csharp
-public record SendGameNightInvitationsCommand(Guid GameNightId) : IRequest<int>;
-
-public class SendGameNightInvitationsCommandHandler : IRequestHandler<SendGameNightInvitationsCommand, int>
-{
-    private readonly IGameNightRepository _gnRepo;
-    private readonly IMediator _mediator;
-
-    public SendGameNightInvitationsCommandHandler(IGameNightRepository repo, IMediator m)
-    {
-        _gnRepo = repo;
-        _mediator = m;
-    }
-
-    public async Task<int> Handle(SendGameNightInvitationsCommand cmd, CancellationToken ct)
-    {
-        var gn = await _gnRepo.GetByIdAsync(cmd.GameNightId, ct)
-            ?? throw new NotFoundException($"GameNight {cmd.GameNightId}");
-
-        var toInvite = gn.Players.Where(p => p.IsTagged && !p.IsInvited).ToList();
-        foreach (var player in toInvite)
-        {
-            player.Invite();
-            // dispatch notification command (will be implemented in WP6)
-            await _mediator.Send(new SendInvitationNotificationCommand(
-                gameNightId: gn.Id,
-                recipientPlayerId: player.PlayerId
-            ), ct);
-        }
-
-        await _gnRepo.SaveAsync(gn, ct);
-        return toInvite.Count;
-    }
-}
-```
-
-- [ ] **Step 4: Add endpoint via Routing**
-
-```csharp
-// GameNightEndpoints.cs
-app.MapPost("/api/v1/game-nights/{id:guid}/send-invitations",
-    async (Guid id, IMediator m) =>
-        Results.Ok(new { invitedCount = await m.Send(new SendGameNightInvitationsCommand(id)) }));
-```
-
-- [ ] **Step 5: Run → PASS** (notification handler stub in WP6 may not be ready — use temporary mock)
+- [ ] **Step 5: Run → PASS**
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git commit -m "feat(game-management): #1896 SendGameNightInvitations command + idempotent flow (invariante #17)"
+git commit -m "feat(session-tracking): #1896 SaveSession X-Warning-Code header (invariante #13)"
 ```
 
 ---
 
-## WP4 — Invariante #10 max 1 live
+### Task 5: Semantic mapping doc — backend term ↔ demo term
 
-> **Spec reference**: Sezione 4 Asse A — "Invariante max 1 live".
+**Mix-model**: haiku · **Effort**: S (~3h)
 
-### Task 13: MaxLiveSessionsExceededException + aggregate guard
+**Files:**
+- Modify: `docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md` (add Section "Backend Mapping")
+- Modify: `CLAUDE.md` (Domain Model section update)
+
+- [ ] **Step 1**: Add mapping table to domain model spec
+
+| Demo term | Backend term | Note |
+|-----------|--------------|------|
+| GameNight (Planned) | GameNightEvent (Published) | After Publish() call sends invitations |
+| GameNight (Planned, ad-hoc) | GameNightEvent (CreateAdHoc factory) | Skip RSVP, direct InProgress |
+| GameNight (InProgress) | GameNightEvent.Status = InProgress | Via HandleFirstSessionStarted or CreateAdHoc |
+| GameNight (Completed) | GameNightEvent.Status = Completed | Via Complete() or CompleteAdHoc() |
+| Session (created) | Session aggregate (CreatedAt valorized, StartedAt null) | Draft mode equivalent |
+| Session (live) | Session.IsLive (StartedAt != null && FinalizedAt == null) | Via OpenLiveMode() |
+| Session (completed) | Session (FinalizedAt valorized) | Via Finalize() |
+| Player tagged (no notification) | GameNightEvent.PreInvite() | Status=Draft, no events |
+| Player invited (notification sent) | GameNightEvent.Publish() | Status=Draft→Published, raises GameNightPublishedEvent → triggers email |
+| GameNightPlayer.RsvpStatus.Pending | GameNightRsvp.Status = Pending | Default after Publish |
+| GameNightPlayer.RsvpStatus.Confirmed | GameNightRsvp.Accept() → Status = Accepted | |
+
+- [ ] **Step 2**: Update CLAUDE.md Domain Model section linking to mapping
+
+- [ ] **Step 3**: Commit
+
+```bash
+git commit -m "docs(domain-model): #1896 backend ↔ demo semantic mapping doc (asse A WP2 T5)"
+```
+
+---
+
+## WP3 — Polymorphic ScoreType (DEC-1)
+
+> **Spec reference**: Sezione 4 Asse A — "DEC-1 Polymorphic ScoreType".
+> Backend reference: `ScoreEntry` esiste ma è single-shape (decimal value + round + category). Per polymorphic gaming (cooperativo BinaryWin, Objectives, Ranking) serve nuova astrazione.
+
+### Task 6: ScoreType enum + IScoringStrategy interface + factory
 
 **Mix-model**: sonnet · **Effort**: M (~5h)
 
 **Files:**
-- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs`
-- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/GameNight.cs`
-- Test: `apps/api/tests/Api.Tests/Unit/GameManagement/Domain/GameNightMaxLiveTests.cs`
-
-- [ ] **Step 1: Write failing test**
-
-```csharp
-[Fact]
-public void OpenLiveSession_WhenAnotherLiveActive_Throws_MaxLiveSessionsExceededException()
-{
-    var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-    var firstLive = Session.CreateDraft(gn.Id, Guid.NewGuid()).OpenLiveMode();
-    var secondDraft = Session.CreateDraft(gn.Id, Guid.NewGuid());
-
-    var act = () => gn.OpenLiveSession(secondDraft, currentlyLive: new[] { firstLive });
-
-    act.Should().Throw<MaxLiveSessionsExceededException>()
-        .Where(ex => ex.ErrorCode == "MAX_LIVE_SESSIONS_EXCEEDED")
-        .Where(ex => ex.GameNightId == gn.Id);
-}
-
-[Fact]
-public void OpenLiveSession_WithNoActiveLive_Succeeds()
-{
-    var gn = GameNight.Create(Guid.NewGuid(), DateTimeOffset.UtcNow);
-    var draft = Session.CreateDraft(gn.Id, Guid.NewGuid());
-
-    var act = () => gn.OpenLiveSession(draft, currentlyLive: Array.Empty<Session>());
-
-    act.Should().NotThrow();
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Implement exception + guard**
-
-```csharp
-public class MaxLiveSessionsExceededException : DomainException
-{
-    public Guid GameNightId { get; }
-    public override string ErrorCode => "MAX_LIVE_SESSIONS_EXCEEDED";
-
-    public MaxLiveSessionsExceededException(Guid gameNightId)
-        : base($"GameNight {gameNightId} already has an active live session.")
-    {
-        GameNightId = gameNightId;
-    }
-}
-
-// GameNight.cs
-public Session OpenLiveSession(Session draft, IEnumerable<Session> currentlyLive)
-{
-    if (currentlyLive.Any(s => s.StartedAt != null && s.CompletedAt == null))
-        throw new MaxLiveSessionsExceededException(Id);
-    return draft.OpenLiveMode();
-}
-```
-
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(game-management): #1896 MaxLiveSessionsExceededException + aggregate guard (invariante #10)"
-```
-
----
-
-### Task 14: API endpoint POST /game-nights/{id}/sessions/{sessionId}/live → 409
-
-**Mix-model**: sonnet · **Effort**: S (~3h)
-
-**Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Routing/GameNightEndpoints.cs`
-- Modify: `apps/api/src/Api/Infrastructure/ExceptionHandling/DomainExceptionMiddleware.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/OpenLiveSessionEndpointTests.cs`
-
-- [ ] **Step 1: Write failing integration test**
-
-```csharp
-[Fact]
-public async Task POST_OpenLiveSession_With_ExistingLive_Returns409_WithErrorCode()
-{
-    using var app = await TestApp.CreateAsync();
-    var gn = await app.SeedGameNightAsync();
-    await app.OpenLiveSessionAsync(gn.Id, gameId: Guid.NewGuid());
-    var secondDraft = await app.CreateDraftSessionAsync(gn.Id, gameId: Guid.NewGuid());
-
-    var response = await app.Client.PostAsync(
-        $"/api/v1/game-nights/{gn.Id}/sessions/{secondDraft.Id}/live", null);
-
-    response.StatusCode.Should().Be(HttpStatusCode.Conflict);
-    var body = await response.Content.ReadFromJsonAsync<ErrorDto>();
-    body!.Code.Should().Be("MAX_LIVE_SESSIONS_EXCEEDED");
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Add endpoint + middleware mapping**
-
-```csharp
-// GameNightEndpoints.cs
-app.MapPost("/api/v1/game-nights/{gnId:guid}/sessions/{sId:guid}/live",
-    async (Guid gnId, Guid sId, IMediator m) =>
-        Results.Ok(await m.Send(new OpenLiveSessionCommand(gnId, sId))));
-```
-
-```csharp
-// DomainExceptionMiddleware.cs
-catch (MaxLiveSessionsExceededException ex)
-{
-    context.Response.StatusCode = StatusCodes.Status409Conflict;
-    await context.Response.WriteAsJsonAsync(new ErrorDto(ex.ErrorCode, ex.Message));
-}
-```
-
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(game-management): #1896 POST live session returns 409 MAX_LIVE_SESSIONS_EXCEEDED"
-```
-
----
-
-## WP5 — Polymorphic ScoreType (DEC-1)
-
-> **Spec reference**: Sezione 4 Asse A — "DEC-1 — Polymorphic ScoreType".
-
-### Task 15: ScoreType enum + IScoringStrategy + factory skeleton
-
-**Mix-model**: sonnet · **Effort**: M (~5h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/ScoreType.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ScoreType.cs`
 - Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/IScoringStrategy.cs`
 - Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/ScoringStrategyFactory.cs`
 - Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Scoring/ScoringStrategyFactoryTests.cs`
@@ -1474,6 +674,7 @@ public void GetStrategy_OnUnknownType_Throws()
 - [ ] **Step 3: Create types**
 
 ```csharp
+// ScoreType.cs
 public enum ScoreType
 {
     [Description("Punti numerici per player")]
@@ -1486,6 +687,7 @@ public enum ScoreType
     Ranking = 3,
 }
 
+// IScoringStrategy.cs
 public interface IScoringStrategy
 {
     ScoreType Type { get; }
@@ -1495,7 +697,7 @@ public interface IScoringStrategy
     Guid? ComputeWinnerPlayerId(string scoreDataJson);
 }
 
-// Placeholder skeletons for 4 strategies (filled in T16+T17)
+// Stub placeholders for 4 strategies (filled in T7-T8)
 public class PointsScoringStrategy : IScoringStrategy
 {
     public ScoreType Type => ScoreType.Points;
@@ -1504,8 +706,9 @@ public class PointsScoringStrategy : IScoringStrategy
     public object Deserialize(string s) => throw new NotImplementedException();
     public Guid? ComputeWinnerPlayerId(string s) => throw new NotImplementedException();
 }
-// Same for Binary/Objectives/Ranking
+// Same stubs for BinaryWin/Objectives/Ranking
 
+// ScoringStrategyFactory.cs
 public class ScoringStrategyFactory
 {
     public IScoringStrategy GetStrategy(ScoreType type) => type switch
@@ -1529,7 +732,7 @@ git commit -m "feat(session-tracking): #1896 ScoreType enum + IScoringStrategy +
 
 ---
 
-### Task 16: PointsScoringStrategy + BinaryWinScoringStrategy
+### Task 7: PointsScoringStrategy + BinaryWinScoringStrategy
 
 **Mix-model**: sonnet · **Effort**: M (~6h)
 
@@ -1564,63 +767,21 @@ public class PointsScoringStrategyTests
     }
 
     [Fact]
-    public void Validate_DuplicatePlayer_ReturnsInvalid()
-    {
-        var json = """{"scores":[{"playerId":"a1","points":10},{"playerId":"a1","points":20}]}""";
-        var result = _sut.Validate(json);
-        result.IsValid.Should().BeFalse();
-    }
+    public void Validate_DuplicatePlayer_ReturnsInvalid() { /* ... */ }
 
     [Fact]
-    public void ComputeWinnerPlayerId_ReturnsHighestScorePlayer()
-    {
-        var json = """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":10},{"playerId":"00000000-0000-0000-0000-000000000002","points":50}]}""";
-        var winner = _sut.ComputeWinnerPlayerId(json);
-        winner.Should().Be(Guid.Parse("00000000-0000-0000-0000-000000000002"));
-    }
+    public void ComputeWinnerPlayerId_ReturnsHighestScorePlayer() { /* ... */ }
 
     [Fact]
-    public void Serialize_Deserialize_RoundTrip()
-    {
-        var data = new PointsScoreData
-        {
-            Scores = new[] { new PlayerScore(Guid.NewGuid(), 42) }
-        };
-        var json = _sut.Serialize(data);
-        var back = (PointsScoreData)_sut.Deserialize(json);
-        back.Scores.Should().HaveCount(1);
-        back.Scores[0].Points.Should().Be(42);
-    }
+    public void Serialize_Deserialize_RoundTrip() { /* ... */ }
 }
 ```
 
-- [ ] **Step 2: Write failing tests for BinaryWin (5 cases)**
-
-```csharp
-public class BinaryWinScoringStrategyTests
-{
-    private readonly BinaryWinScoringStrategy _sut = new();
-
-    [Fact]
-    public void Validate_AllWin_ReturnsValid() { /* cooperativo, all win */ }
-
-    [Fact]
-    public void Validate_AllLose_ReturnsValid() { /* cooperativo, all lose */ }
-
-    [Fact]
-    public void Validate_MixedWinLose_ReturnsValid() { /* competitivo binary */ }
-
-    [Fact]
-    public void Validate_EmptyPlayerList_ReturnsInvalid() { /* edge */ }
-
-    [Fact]
-    public void ComputeWinnerPlayerId_ReturnsNull_WhenCooperativeAllWin() { /* no single winner */ }
-}
-```
+- [ ] **Step 2: Write failing tests for BinaryWin (5 cases similar pattern)**
 
 - [ ] **Step 3: Run → FAIL**
 
-- [ ] **Step 4: Implement both strategies**
+- [ ] **Step 4: Implement Points strategy**
 
 ```csharp
 public record PointsScoreData(PlayerScore[] Scores);
@@ -1655,30 +816,13 @@ public class PointsScoringStrategy : IScoringStrategy
         return data.Scores.OrderByDescending(s => s.Points).FirstOrDefault()?.PlayerId;
     }
 }
-
-// BinaryWin
-public record BinaryWinScoreData(BinaryPlayerResult[] Results);
-public record BinaryPlayerResult(Guid PlayerId, bool IsWinner);
-
-public class BinaryWinScoringStrategy : IScoringStrategy
-{
-    public ScoreType Type => ScoreType.BinaryWin;
-    public ValidationResult Validate(string json) { /* similar */ }
-    public string Serialize(object d) => JsonSerializer.Serialize((BinaryWinScoreData)d);
-    public object Deserialize(string j) => JsonSerializer.Deserialize<BinaryWinScoreData>(j)!;
-    public Guid? ComputeWinnerPlayerId(string json)
-    {
-        var data = (BinaryWinScoreData)Deserialize(json);
-        var winners = data.Results.Where(r => r.IsWinner).ToList();
-        // If single winner: return; if all-win (cooperative) or all-lose: return null
-        return winners.Count == 1 ? winners.Single().PlayerId : null;
-    }
-}
 ```
 
-- [ ] **Step 5: Run → PASS**
+- [ ] **Step 5: Implement BinaryWin strategy** (similar pattern, records `BinaryWinScoreData(BinaryPlayerResult[] Results)`, `BinaryPlayerResult(Guid PlayerId, bool IsWinner)`)
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Run → PASS**
+
+- [ ] **Step 7: Commit**
 
 ```bash
 git commit -m "feat(session-tracking): #1896 Points + BinaryWin scoring strategies (DEC-1)"
@@ -1686,7 +830,7 @@ git commit -m "feat(session-tracking): #1896 Points + BinaryWin scoring strategi
 
 ---
 
-### Task 17: ObjectivesScoringStrategy + RankingScoringStrategy
+### Task 8: ObjectivesScoringStrategy + RankingScoringStrategy
 
 **Mix-model**: sonnet · **Effort**: M (~6h)
 
@@ -1695,13 +839,13 @@ git commit -m "feat(session-tracking): #1896 Points + BinaryWin scoring strategi
 - Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Scoring/RankingScoringStrategy.cs`
 - Test: corresponding test classes
 
-- [ ] **Step 1-6**: Same pattern as Task 16, 5 test cases per strategy.
+- [ ] **Same pattern as Task 7**: 5 test cases per strategy.
 
-**Objectives logic**: each player has list of completed objectives (string names). Winner = player with most objectives completed. Ties = null winner.
+**Objectives logic**: each player has list of completed objectives (string names). Winner = player with most objectives. Ties = null winner.
 
 **Ranking logic**: each player has integer position (1..N). Winner = position 1. Validate distinct positions, sequential 1..N.
 
-- [ ] **Step 7: Commit**
+- [ ] **Commit**
 
 ```bash
 git commit -m "feat(session-tracking): #1896 Objectives + Ranking scoring strategies (DEC-1)"
@@ -1709,59 +853,112 @@ git commit -m "feat(session-tracking): #1896 Objectives + Ranking scoring strate
 
 ---
 
-### Task 18: SaveSessionCommand polymorphic scoreData + FluentValidation rule
+### Task 9: Session.ScoringType + score_data JSONB migration + SetScores domain method
 
-**Mix-model**: sonnet · **Effort**: M (~5h)
+**Mix-model**: sonnet · **Effort**: M (~6h)
 
 **Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommand.cs`
-- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandValidator.cs`
-- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/SaveSessionCommandValidatorTests.cs`
+- Create: `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDD_AddSessionScoringType.cs`
+- Modify: `Session.cs` (add ScoringType + ScoreData fields + SetScores method)
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdatedEvent.cs`
+- Test: `apps/api/tests/Api.Tests/Unit/SessionTracking/Domain/SessionSetScoresTests.cs`
 
-- [ ] **Step 1: Write failing tests**
+- [ ] **Step 1: Add migration**
 
 ```csharp
-public class SaveSessionCommandValidatorTests
+public partial class AddSessionScoringType : Migration
 {
-    private readonly SaveSessionCommandValidator _sut = new(new ScoringStrategyFactory());
-
-    [Fact]
-    public void Validate_PointsScoreData_Valid_ReturnsValid()
+    protected override void Up(MigrationBuilder b)
     {
-        var cmd = new SaveSessionCommand(
-            SessionId: Guid.NewGuid(),
-            ScoringType: ScoreType.Points,
-            ScoreData: """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":50}]}"""
-        );
-        var result = _sut.Validate(cmd);
-        result.IsValid.Should().BeTrue();
+        b.AddColumn<string>("scoring_type", "sessions",
+            maxLength: 20, nullable: false, defaultValue: "Points");
+        b.AddColumn<string>("score_data", "sessions",
+            type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb");
     }
 
-    [Fact]
-    public void Validate_BinaryWinScoreData_AppliedAsPoints_ReturnsInvalid()
+    protected override void Down(MigrationBuilder b)
     {
-        var cmd = new SaveSessionCommand(
-            SessionId: Guid.NewGuid(),
-            ScoringType: ScoreType.Points,
-            ScoreData: """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true}]}"""
-        );
-        var result = _sut.Validate(cmd);
-        result.IsValid.Should().BeFalse();
+        b.DropColumn("score_data", "sessions");
+        b.DropColumn("scoring_type", "sessions");
     }
+}
+```
+
+- [ ] **Step 2: Update Session entity**
+
+```csharp
+public ScoreType ScoringType { get; private set; } = ScoreType.Points;
+public string ScoreData { get; private set; } = "{}";
+
+public void SetScores(ScoreType scoringType, string scoreData)
+{
+    ScoringType = scoringType;
+    ScoreData = scoreData;
+    AddDomainEvent(new SessionScoresUpdatedEvent(Id, scoringType, scoreData));
+}
+```
+
+- [ ] **Step 3: Update DbContext mapping**
+
+```csharp
+b.Property(e => e.ScoringType)
+    .HasColumnName("scoring_type")
+    .HasMaxLength(20)
+    .HasConversion<string>();
+b.Property(e => e.ScoreData)
+    .HasColumnName("score_data")
+    .HasColumnType("jsonb");
+```
+
+- [ ] **Step 4: Write + run unit tests → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session-tracking): #1896 Session.ScoringType + score_data JSONB + SetScores (DEC-1)"
+```
+
+---
+
+### Task 10: SaveSessionCommand polymorphic + FluentValidation + integration round-trip
+
+**Mix-model**: sonnet · **Effort**: L (~8h)
+
+**Files:**
+- Modify: SaveSessionCommand DTO (add ScoringType + ScoreData fields)
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/SaveSession/SaveSessionCommandValidator.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/PolymorphicScoringRoundTripTests.cs`
+
+- [ ] **Step 1: Write failing integration test (4 ScoreType round-trip via API)**
+
+```csharp
+[Theory]
+[InlineData("Points", """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":50}]}""")]
+[InlineData("BinaryWin", """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true}]}""")]
+[InlineData("Objectives", """{"completedByPlayer":[{"playerId":"00000000-0000-0000-0000-000000000001","objectives":["A","B"]}]}""")]
+[InlineData("Ranking", """{"positions":[{"playerId":"00000000-0000-0000-0000-000000000001","position":1}]}""")]
+public async Task SaveSession_WithPolymorphicScoring_RoundTripViaAPI(string scoringType, string scoreData)
+{
+    using var app = await TestApp.CreateAsync();
+    var draft = await app.CreateDraftSessionAsync();
+
+    var response = await app.Client.PutAsJsonAsync(
+        $"/api/v1/sessions/{draft.Id}/save",
+        new { scoringType, scoreData });
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    var fetched = await app.Client.GetFromJsonAsync<SessionDto>($"/api/v1/sessions/{draft.Id}");
+    fetched!.ScoringType.Should().Be(scoringType);
+    fetched.ScoreData.Should().Be(scoreData);
 }
 ```
 
 - [ ] **Step 2: Run → FAIL**
 
-- [ ] **Step 3: Implement command + validator**
+- [ ] **Step 3: Implement FluentValidation custom rule**
 
 ```csharp
-public record SaveSessionCommand(
-    Guid SessionId,
-    ScoreType ScoringType,
-    string ScoreData
-) : IRequest<SaveSessionResult>;
-
 public class SaveSessionCommandValidator : AbstractValidator<SaveSessionCommand>
 {
     public SaveSessionCommandValidator(ScoringStrategyFactory factory)
@@ -1782,487 +979,201 @@ public class SaveSessionCommandValidator : AbstractValidator<SaveSessionCommand>
 }
 ```
 
-- [ ] **Step 4: Run → PASS**
+- [ ] **Step 4: Update handler to call Session.SetScores**
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Run → PASS**
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git commit -m "feat(session-tracking): #1896 SaveSessionCommand polymorphic ScoreData + FluentValidation (DEC-1)"
+git commit -m "feat(session-tracking): #1896 SaveSession polymorphic + 4 ScoreType round-trip (DEC-1)"
 ```
 
 ---
 
-### Task 19: Session.SetScores + SessionScoresUpdated + integration round-trip
+## WP4 — Notification system extension (DEC-5)
 
-**Mix-model**: sonnet · **Effort**: L (~8h)
+> Backend reference: `Notification` aggregate ESISTE in UserNotifications. `IGameNightEmailService.SendGameNightInvitationEmailAsync` ESISTE via `IEmailService` wrapper. Da verificare: (a) /notifications REST endpoints; (b) IEmailService concrete impl (= Resend?).
 
-**Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Session.cs`
-- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionScoresUpdated.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/SessionTracking/PolymorphicScoringRoundTripTests.cs`
-
-- [ ] **Step 1: Write failing integration test (4 scoring types round-trip via API)**
-
-```csharp
-[Theory]
-[InlineData("Points", """{"scores":[{"playerId":"00000000-0000-0000-0000-000000000001","points":50}]}""")]
-[InlineData("BinaryWin", """{"results":[{"playerId":"00000000-0000-0000-0000-000000000001","isWinner":true}]}""")]
-[InlineData("Objectives", """{"completedByPlayer":[{"playerId":"00000000-0000-0000-0000-000000000001","objectives":["A","B"]}]}""")]
-[InlineData("Ranking", """{"positions":[{"playerId":"00000000-0000-0000-0000-000000000001","position":1}]}""")]
-public async Task SaveSession_WithPolymorphicScoring_RoundTripViaAPI(string scoringType, string scoreData)
-{
-    using var app = await TestApp.CreateAsync();
-    var gnId = await app.SeedGameNightAsync();
-    var draft = await app.CreateDraftSessionAsync(gnId, gameId: Guid.NewGuid());
-
-    var response = await app.Client.PutAsJsonAsync(
-        $"/api/v1/sessions/{draft.Id}/save",
-        new { scoringType, scoreData });
-
-    response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-    var fetched = await app.Client.GetFromJsonAsync<SessionDto>(
-        $"/api/v1/sessions/{draft.Id}");
-    fetched!.ScoringType.Should().Be(scoringType);
-    fetched.ScoreData.Should().Be(scoreData);
-}
-```
-
-- [ ] **Step 2: Add Session.SetScores domain method**
-
-```csharp
-public void SetScores(ScoreType scoringType, string scoreData)
-{
-    ScoringType = scoringType;
-    ScoreData = scoreData;
-    _events.Add(new SessionScoresUpdated(Id, scoringType, scoreData));
-}
-```
-
-- [ ] **Step 3: Update SaveSessionCommandHandler to call SetScores**
-
-- [ ] **Step 4: Run → PASS** (all 4 scoring types round-trip)
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(session-tracking): #1896 Session.SetScores + round-trip 4 ScoreType (DEC-1)"
-```
-
----
-
-## WP6 — Notification system (DEC-5)
-
-> **Spec reference**: Sezione 4 Asse A — "DEC-5 — Notification system".
-
-### Task 20: Notification repository + UserNotifications bounded context wiring
-
-**Mix-model**: sonnet · **Effort**: M (~5h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/Repositories/INotificationRepository.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Repositories/NotificationRepository.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationRepositoryTests.cs`
-
-- [ ] Standard repository pattern + CRUD operations + integration test against Testcontainers postgres.
-
-```bash
-git commit -m "feat(user-notifications): #1896 Notification repository (DEC-5)"
-```
-
----
-
-### Task 21: GET /notifications + PATCH read endpoints
-
-**Mix-model**: sonnet · **Effort**: M (~5h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/GetNotifications/GetNotificationsQuery.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/MarkAsRead/MarkAsReadCommand.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/NotificationEndpoints.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationEndpointsTests.cs`
-
-- [ ] Endpoint contract:
-  - `GET /api/v1/notifications?page=N&size=M` → `PagedResult<NotificationDto>`
-  - `PATCH /api/v1/notifications/{id}/read` → `204 No Content`
-  - `POST /api/v1/notifications/mark-all-read` → `{ markedCount }`
-
-```bash
-git commit -m "feat(user-notifications): #1896 inbox endpoints GET + PATCH read (DEC-5)"
-```
-
----
-
-### Task 22: IEmailSender + ResendEmailSender + GameNightInvitation template
-
-**Mix-model**: sonnet · **Effort**: L (~8h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/IEmailSender.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/ResendEmailSender.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/Templates/GameNightInvitationTemplate.cs`
-- Create: `infra/secrets/email.secret.example`
-- Test: `apps/api/tests/Api.Tests/Unit/UserNotifications/Email/ResendEmailSenderTests.cs`
-
-- [ ] **Step 1: Write failing test**
-
-```csharp
-[Fact]
-public async Task ResendEmailSender_SendAsync_PostsToResendAPI_WithApiKey()
-{
-    var mockHttp = new MockHttpMessageHandler();
-    mockHttp.When("https://api.resend.com/emails")
-        .Respond(HttpStatusCode.OK, JsonContent.Create(new { id = "test-msg-id" }));
-    var sender = new ResendEmailSender(
-        new HttpClient(mockHttp),
-        new ResendOptions { ApiKey = "re_test" });
-
-    var template = GameNightInvitationTemplate.Render(
-        recipientName: "Anna",
-        hostName: "Marco",
-        gameNightName: "Sabato a casa Marco",
-        date: new DateTimeOffset(2026, 6, 14, 20, 0, 0, TimeSpan.Zero),
-        location: "Roma");
-
-    await sender.SendAsync(
-        toEmail: "anna@example.com",
-        subject: "Marco ti ha invitato",
-        htmlBody: template.Html,
-        plainTextBody: template.PlainText);
-
-    mockHttp.GetMatchCount(/* request */).Should().Be(1);
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Implement**
-
-```csharp
-public interface IEmailSender
-{
-    Task<string> SendAsync(string toEmail, string subject, string htmlBody, string plainTextBody, CancellationToken ct = default);
-}
-
-public class ResendOptions { public string ApiKey { get; set; } = default!; public string FromEmail { get; set; } = "noreply@meepleai.app"; }
-
-public class ResendEmailSender : IEmailSender
-{
-    private readonly HttpClient _http;
-    private readonly ResendOptions _options;
-
-    public ResendEmailSender(HttpClient http, ResendOptions options)
-    {
-        _http = http;
-        _options = options;
-        _http.DefaultRequestHeaders.Authorization = new("Bearer", options.ApiKey);
-    }
-
-    public async Task<string> SendAsync(string to, string subject, string html, string text, CancellationToken ct = default)
-    {
-        var payload = new
-        {
-            from = _options.FromEmail,
-            to = new[] { to },
-            subject,
-            html,
-            text,
-        };
-        var response = await _http.PostAsJsonAsync("https://api.resend.com/emails", payload, ct);
-        response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<ResendResponse>(cancellationToken: ct);
-        return result!.Id;
-    }
-    private record ResendResponse(string Id);
-}
-
-public static class GameNightInvitationTemplate
-{
-    public record Rendered(string Html, string PlainText);
-
-    public static Rendered Render(
-        string recipientName, string hostName, string gameNightName,
-        DateTimeOffset date, string location)
-    {
-        var formattedDate = date.ToString("dddd d MMMM yyyy 'alle' HH:mm",
-            CultureInfo.GetCultureInfo("it-IT"));
-
-        var html = $"""
-            <h1>Ciao {recipientName}!</h1>
-            <p><strong>{hostName}</strong> ti ha invitato a una serata:</p>
-            <p><strong>{gameNightName}</strong> · {formattedDate} · {location}</p>
-            <p><a href="https://meepleai.app/game-nights">Conferma RSVP</a></p>
-            """;
-        var text = $"""
-            Ciao {recipientName}!
-            {hostName} ti ha invitato a {gameNightName} ({formattedDate}, {location}).
-            Conferma RSVP: https://meepleai.app/game-nights
-            """;
-        return new Rendered(html, text);
-    }
-}
-```
-
-- [ ] **Step 4: Update infra/secrets/email.secret.example**
-
-```bash
-# Email transactional provider (Resend)
-RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-RESEND_FROM_EMAIL=noreply@meepleai.app
-```
-
-- [ ] **Step 5: Register DI in Program.cs**
-
-```csharp
-builder.Services.Configure<ResendOptions>(builder.Configuration.GetSection("Resend"));
-builder.Services.AddHttpClient<IEmailSender, ResendEmailSender>();
-```
-
-- [ ] **Step 6: Run → PASS**
-
-- [ ] **Step 7: Commit**
-
-```bash
-git commit -m "feat(user-notifications): #1896 IEmailSender + ResendEmailSender + invitation template (DEC-5)"
-```
-
-**Self-review**:
-- [ ] HttpClient with Resend bearer auth
-- [ ] Idempotent (Resend SDK provides message-id, no double-send on retry)
-- [ ] Email template Italian-localized
-- [ ] HTML + plain text both provided
-
----
-
-### Task 23: SendInvitationNotificationCommand handler in-app+email
-
-**Mix-model**: sonnet · **Effort**: L (~8h)
-
-**Files:**
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/SendInvitationNotification/SendInvitationNotificationCommand.cs`
-- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/SendInvitationNotification/SendInvitationNotificationCommandHandler.cs`
-- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/SendInvitationFlowTests.cs`
-
-- [ ] **Step 1: Write failing integration test**
-
-```csharp
-[Fact]
-public async Task SendInvitationCommand_CreatesInAppNotification_AndCallsEmailSender()
-{
-    using var app = await TestApp.CreateAsync(services =>
-    {
-        services.AddSingleton<IEmailSender>(Substitute.For<IEmailSender>());
-    });
-    var emailSender = app.Resolve<IEmailSender>();
-    var (gnId, recipientPlayerId) = await app.SeedGameNightWithInvitedPlayerAsync();
-
-    await app.Mediator.Send(new SendInvitationNotificationCommand(gnId, recipientPlayerId));
-
-    var notifs = await app.Db.Notifications.Where(n => n.Type == "GameNightInvitation").ToListAsync();
-    notifs.Should().ContainSingle();
-    notifs[0].Payload.Should().Contain(gnId.ToString());
-
-    await emailSender.Received(1).SendAsync(
-        Arg.Any<string>(), Arg.Is<string>(s => s.Contains("invitato")),
-        Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-}
-
-[Fact]
-public async Task SendInvitationCommand_EmailFails_StillCommitsInAppNotification()
-{
-    using var app = await TestApp.CreateAsync(services =>
-    {
-        var failingEmail = Substitute.For<IEmailSender>();
-        failingEmail.SendAsync(default!, default!, default!, default!, default)
-            .ReturnsForAnyArgs(Task.FromException<string>(new HttpRequestException("Resend down")));
-        services.AddSingleton(failingEmail);
-    });
-    var (gnId, recipientPlayerId) = await app.SeedGameNightWithInvitedPlayerAsync();
-
-    await app.Mediator.Send(new SendInvitationNotificationCommand(gnId, recipientPlayerId));
-
-    var notifs = await app.Db.Notifications.ToListAsync();
-    notifs.Should().ContainSingle(); // in-app saved despite email failure
-}
-```
-
-- [ ] **Step 2: Run → FAIL**
-
-- [ ] **Step 3: Implement handler**
-
-```csharp
-public record SendInvitationNotificationCommand(Guid GameNightId, Guid RecipientPlayerId) : IRequest;
-
-public class SendInvitationNotificationCommandHandler : IRequestHandler<SendInvitationNotificationCommand>
-{
-    private readonly ApplicationDbContext _db;
-    private readonly IEmailSender _email;
-    private readonly ILogger<SendInvitationNotificationCommandHandler> _logger;
-
-    public SendInvitationNotificationCommandHandler(
-        ApplicationDbContext db, IEmailSender email, ILogger<SendInvitationNotificationCommandHandler> logger)
-    {
-        _db = db; _email = email; _logger = logger;
-    }
-
-    public async Task Handle(SendInvitationNotificationCommand cmd, CancellationToken ct)
-    {
-        var gn = await _db.GameNights.FindAsync(new object?[] { cmd.GameNightId }, ct)
-            ?? throw new NotFoundException($"GameNight {cmd.GameNightId}");
-        var player = await _db.Players.FindAsync(new object?[] { cmd.RecipientPlayerId }, ct)
-            ?? throw new NotFoundException($"Player {cmd.RecipientPlayerId}");
-        if (player.UserId is null) return; // guest, no notification
-
-        // 1. In-app notification (transactional)
-        var payload = JsonSerializer.Serialize(new
-        {
-            gameNightId = gn.Id,
-            gameNightName = gn.Name,
-            hostName = (await _db.Users.FindAsync(new object?[] { gn.OwnerId }, ct))?.DisplayName,
-            date = gn.Date,
-            location = gn.Location,
-        });
-        var notif = Notification.Create(
-            recipientUserId: player.UserId.Value,
-            type: "GameNightInvitation",
-            payloadJson: payload);
-        _db.Notifications.Add(notif);
-        await _db.SaveChangesAsync(ct);
-
-        // 2. Email (best-effort, doesn't block in-app)
-        try
-        {
-            var rendered = GameNightInvitationTemplate.Render(
-                recipientName: player.Name,
-                hostName: (await _db.Users.FindAsync(new object?[] { gn.OwnerId }, ct))!.DisplayName,
-                gameNightName: gn.Name,
-                date: gn.Date,
-                location: gn.Location);
-
-            var user = await _db.Users.FindAsync(new object?[] { player.UserId.Value }, ct);
-            await _email.SendAsync(
-                toEmail: user!.Email,
-                subject: $"Marco ti ha invitato a {gn.Name}",
-                htmlBody: rendered.Html,
-                plainTextBody: rendered.PlainText,
-                ct: ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Email send failed for notification {NotifId}, in-app committed", notif.Id);
-            // Swallow — in-app is the source of truth
-        }
-    }
-}
-```
-
-- [ ] **Step 4: Run → PASS**
-
-- [ ] **Step 5: Commit**
-
-```bash
-git commit -m "feat(user-notifications): #1896 SendInvitationNotificationCommand in-app+email (DEC-5)"
-```
-
----
-
-## WP7 — OpenAPI + final acceptance
-
-### Task 24: OpenAPI yaml updates + new error codes
+### Task 11: Verify Notification entity + repository + endpoint audit
 
 **Mix-model**: haiku · **Effort**: S (~3h)
 
 **Files:**
-- Modify: `apps/api/src/Api/openapi.yaml` (or wherever OpenAPI lives)
-- Test: `apps/api/tests/Api.Tests/Integration/OpenApiContractTests.cs`
+- Read existing: `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs`
+- Read existing: `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs`
+- Audit: `apps/api/src/Api/BoundedContexts/UserNotifications/` for routing/application layers
 
-- [ ] Add new error code definitions, polymorphic ScoreData schema, Notification DTOs, X-Warning-Code header.
+- [ ] **Step 1**: Open both Domain files + understand existing schema (fields, constructors, methods)
+- [ ] **Step 2**: Grep `/notifications` in `apps/api/src/Api/Routing/` and `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/` to check if endpoint registered
+- [ ] **Step 3**: Document audit findings:
+  - **Branch A**: Endpoints exist → SKIP T12, jump to T13
+  - **Branch B**: Endpoints missing → proceed to T12
+- [ ] **Step 4**: Commit audit summary as docs commit
 
 ```bash
-git commit -m "docs(api): #1896 OpenAPI updates + new error codes + polymorphic DTOs"
+git commit -m "docs(user-notifications): #1896 audit existing Notification entity + endpoint status (asse A WP4 T11)"
 ```
 
 ---
 
-### Task 25: Final spec compliance review + CLAUDE.md update
+### Task 12: /notifications endpoints (GET inbox + PATCH read + mark-all-read)
 
-**Mix-model**: haiku · **Effort**: M (~4h)
+**Mix-model**: sonnet · **Effort**: M (~5h)
+
+**Files** (if needed based on T11 audit):
+- Create or extend: `apps/api/src/Api/BoundedContexts/UserNotifications/Routing/NotificationEndpoints.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/GetNotifications/GetNotificationsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/MarkAsRead/MarkAsReadCommand.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationEndpointsTests.cs`
+
+> Endpoint contract:
+> - `GET /api/v1/notifications?page=N&size=M` → `PagedResult<NotificationDto>`
+> - `PATCH /api/v1/notifications/{id}/read` → `204 No Content`
+> - `POST /api/v1/notifications/mark-all-read` → `{ markedCount }`
+
+- [ ] **Step 1: Write failing integration tests for the 3 endpoints**
+- [ ] **Step 2: Run → FAIL** (or skip se already exist per T11)
+- [ ] **Step 3: Implement CQRS handlers + endpoints**
+  - Standard CQRS pattern via MediatR + EF Core query
+  - Auth filter: user can only see/modify own notifications
+  - Pagination: `Skip(page * size).Take(size)` con `[Required] [Range(1, 100)] int size`
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(user-notifications): #1896 /notifications endpoints — GET inbox + PATCH read (DEC-5)"
+```
+
+---
+
+### Task 13: Email provider audit — verify Resend swap necessity
+
+**Mix-model**: haiku · **Effort**: S (~4h)
+
+> Backend reference: `GameNightEmailService` chiama `IEmailService.SendRawEmailAsync` (esistente wrapper). Da capire: concrete impl = Resend, SendGrid, SMTP, MailKit, altro? Spec DEC-5 dice Resend.
 
 **Files:**
-- Modify: `CLAUDE.md` (Domain Model — GameNight / Session section)
-- Modify: `docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md` (changelog inline)
+- Audit: `apps/api/src/Api/Services/` for `IEmailService` concrete implementation
+- Audit: `infra/secrets/` for `EMAIL_*`, `RESEND_*`, `SENDGRID_*` env vars
+- Audit: `apps/api/src/Api/Program.cs` for `IEmailService` DI registration
 
-- [ ] **Step 1**: Run full test suite
+- [ ] **Step 1**: `grep -r "class.*: IEmailService"` per concrete implementation
+- [ ] **Step 2**: Verify env vars used (check `appsettings.json` + secret examples)
+- [ ] **Step 3**: **Decision branches**:
+  - **Branch A**: Provider is Resend → SKIP swap. Document in spec.
+  - **Branch B**: Provider is SendGrid/SMTP/MailKit/other → implement swap:
+    - Create `ResendEmailSender : IEmailService`
+    - Add secret `RESEND_API_KEY` to `infra/secrets/email.secret`
+    - Update Program.cs DI: `services.AddSingleton<IEmailService, ResendEmailSender>()`
+    - Run integration test with mock HTTP for Resend API
+- [ ] **Step 4**: Commit (audit summary OR swap implementation)
+
 ```bash
-dotnet test
-```
-Expected: PASS
-
-- [ ] **Step 2**: Update CLAUDE.md section "Domain Model — GameNight / Session" con stato post-impl: tutte 20 invarianti coperte + ScoreType polimorfico + Notification.
-
-- [ ] **Step 3**: Update spec consolidato changelog
-```markdown
-- 2026-06-XX: asse A implementation complete — 25 task TDD shipped via PR #YYYY
-```
-
-- [ ] **Step 4**: Verify Definition of Done umbrella:
-  - 20 invarianti implementate e testate
-  - DEC-1 ScoreType 4 strategies + 4 unit class + 1 integration test
-  - DEC-5 Notification + `/notifications` + email Resend operativo
-
-- [ ] **Step 5**: Final commit
-```bash
-git commit -m "docs(claude-design-alignment): #1896 asse A complete — 25 task shipped, spec updated"
+git commit -m "feat(infrastructure): #1896 email provider Resend swap (DEC-5)"
+# OR (audit-only)
+git commit -m "docs(infrastructure): #1896 email provider audit — already correct (DEC-5)"
 ```
 
 ---
 
-## Self-Review Checklist (post-plan)
+## WP5 — OpenAPI + final acceptance
 
-**Spec coverage**:
-- [x] WP1 covers Migration EF Core 3-step (MAJ-1 fix)
-- [x] WP2 covers invarianti #11/#12/#13/#14
-- [x] WP3 covers state machine #8/#15/#16/#17
-- [x] WP4 covers invariante #10 + MIN-1 rename
-- [x] WP5 covers DEC-1 polymorphic ScoreType (4 strategies)
-- [x] WP6 covers DEC-5 Notification (in-app + email Resend)
-- [x] WP7 covers OpenAPI updates + final acceptance
-- [x] MAJ-2 backwards-compat documented in T3
-- [x] MIN-6 factory method clarified in T6
+### Task 14: OpenAPI updates + CLAUDE.md update + acceptance verify
 
-**Placeholder scan**: no TBD, no "implement later", no "similar to Task N", no untyped methods.
+**Mix-model**: haiku · **Effort**: S (~4h)
+
+**Files:**
+- Modify: OpenAPI YAML/JSON (paths location depends on project setup)
+- Modify: `CLAUDE.md` (Domain Model section: add post-asse-A state)
+- Modify: spec consolidato changelog inline
+
+- [ ] **Step 1**: Add new error codes (`MAX_LIVE_SESSIONS_EXCEEDED`, `INVALID_SCORE_DATA`)
+- [ ] **Step 2**: Add polymorphic `scoreData` schema + `scoringType` enum reference
+- [ ] **Step 3**: Add `X-Warning-Code: SAVED_WHILE_LIVE_ACTIVE` response header
+- [ ] **Step 4**: Add `/notifications` endpoints + DTOs (paginated inbox) if added in T12
+- [ ] **Step 5**: Verify umbrella acceptance criteria:
+  - 20 invarianti implementate e testate (via WP1-WP2 + already-existing)
+  - DEC-1 ScoreType 4 strategies + 4 unit class + 1 integration test (WP3)
+  - DEC-5 Notification + /notifications + email Resend operativo (WP4)
+- [ ] **Step 6**: Run full test suite
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "BoundedContext=SessionTracking|BoundedContext=GameManagement|BoundedContext=UserNotifications"
+```
+
+- [ ] **Step 7**: Update spec consolidato changelog
+
+```markdown
+- 2026-06-XX: asse A v2 implementation complete — 14 task TDD shipped via PR #YYYY (effort 12 gg vs v1 estimate 18 gg — 33% reduction post-discovery)
+```
+
+- [ ] **Step 8**: Final commit
+
+```bash
+git commit -m "docs(api,claude-design-alignment): #1896 asse A complete — OpenAPI + acceptance verify"
+```
+
+---
+
+## Self-Review Checklist (post-plan v2)
+
+**Spec coverage post-discovery**:
+- [x] Invariante #10 max 1 live → WP1 T1
+- [x] Invariante #11 Session.StartedAt → WP2 T2
+- [x] Invariante #12 sort createdAt → trivial, included WP2 T2 if needed (verify existing query handler)
+- [x] Invariante #13 X-Warning-Code → WP2 T4
+- [x] Invariante #14 startedAt derived → WP2 T2 (no user input)
+- [x] Invariante #15 first-session triggers InProgress → WP2 T3
+- [x] Invariante #16/#17 tagged vs invited → WP2 T5 (semantic mapping doc, no new entity)
+- [x] DEC-1 Polymorphic ScoreType → WP3 T6-T10
+- [x] DEC-5 Notification + email → WP4 T11-T13 (existing entity, extend endpoints + audit provider)
+- [x] OpenAPI updates → WP5 T14
+
+**Placeholder scan**: WP4 T11-T13 have branch decisions (Resend audit). NO TBD.
 
 **Type consistency**:
-- `IScoringStrategy.ComputeWinnerPlayerId` returns `Guid?` consistently across T15/T16/T17/T19
-- `RsvpStatus` enum values consistent across T3/T11/T12
-- `GameNightStatus` consistent across T2/T10
-- `SaveSessionResult` record consistent across T9/T19
-
-**Critical path identification**:
-- WP1 → WP2 → WP4 (max 1 live needs Session.OpenLiveMode)
-- WP1 → WP3 → WP6 (SendGameNightInvitations triggers notification)
-- WP5 parallelizable with WP3+WP4 (no shared aggregate)
-- WP6 parallelizable with WP5 (different bounded context)
-- WP7 closes WP
+- `MaxLiveSessionsExceededException.ErrorCode = "MAX_LIVE_SESSIONS_EXCEEDED"` consistent WP1 T1 + WP5 T14
+- `SessionStartedDomainEvent` defined T2, used T3
+- `IScoringStrategy` consistent across T6/T7/T8
+- `ScoreType` enum consistent T6 → T9 → T10
 
 **Effort verification**:
-- WP1: 3+2+3+2+4 = 14h ≈ 2gg
-- WP2: 6+3+2+5 = 16h ≈ 2gg
-- WP3: 8+5+6 = 19h ≈ 2.5gg
-- WP4: 5+3 = 8h ≈ 1gg
-- WP5: 5+6+6+5+8 = 30h ≈ 4gg
-- WP6: 5+5+8+8 = 26h ≈ 3.5gg
-- WP7: 3+4 = 7h ≈ 1gg
-- **Total**: ~16gg dev + ~3gg buffer review/CI fix = ~19gg, in linea con stima 15+3=18gg ✓
+- WP1: 6h ≈ 1gg
+- WP2: 6+5+5+3 = 19h ≈ 2.5gg
+- WP3: 5+6+6+6+8 = 31h ≈ 4gg
+- WP4: 3+5+4 = 12h ≈ 1.5gg
+- WP5: 4h ≈ 0.5gg
+- **Total**: ~67h ≈ 8.5gg + ~3gg buffer review/CI = **~12gg**, in linea con target 10+2=12 gg ✓
+- Effort reduction vs v1: **33% riduzione** (18gg → 12gg)
 
 ---
 
 ## Execution Handoff
 
-**Plan complete and saved to `docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`. Two execution options:**
+**Plan v2 complete and saved to `docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`.**
 
-**1. Subagent-Driven (recommended)** — Dispatch fresh subagent per task with mix-model (haiku/sonnet), review between tasks, ~3-4 settimane elapsed time per asse A.
+**Critical path** (post-discovery):
+1. WP1 (max 1 live) — foundation, parallelizable with WP3
+2. WP2 (Session.StartedAt + invariante #15 + warning header + mapping doc) — sequential
+3. WP3 (polymorphic ScoreType) — parallel WP4
+4. WP4 (notification expand) — parallel WP3
+5. WP5 (OpenAPI close)
 
-**2. Inline Execution** — Execute tasks in current session sequentially, batch checkpoints. Non praticabile per asse A (XL).
+**Recommended sequence (2 dev parallel)**:
+- Dev1: WP1 → WP2 → WP5
+- Dev2: WP3 → WP4
 
-**Recommended sequence**: WP1 (must be first) → WP2 + WP5 parallel (con 2 dev) → WP3 + WP4 + WP6 parallel → WP7 final.
+Both finish ~2 weeks elapsed time vs solo dev ~3 weeks.
+
+**Two execution options**:
+1. **Subagent-Driven (recommended)** — Dispatch fresh subagent per task con mix-model (5 haiku + 9 sonnet)
+2. **Inline Execution** — Single session troppo grande per WP3 + WP4 combinati
+
+---
+
+## Changelog
+
+- **2026-06-04 v2**: rewrite post-discovery. Gap analysis backend reale → effort -33%. 14 task vs 25 task v1.
+- **2026-06-04 v1**: initial plan (now archived in git history). Assumed scratch backend, ~50% over-scoped.

--- a/docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md
+++ b/docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md
@@ -993,7 +993,15 @@ git commit -m "feat(session-tracking): #1896 SaveSession polymorphic + 4 ScoreTy
 
 ## WP4 — Notification system extension (DEC-5)
 
-> Backend reference: `Notification` aggregate ESISTE in UserNotifications. `IGameNightEmailService.SendGameNightInvitationEmailAsync` ESISTE via `IEmailService` wrapper. Da verificare: (a) /notifications REST endpoints; (b) IEmailService concrete impl (= Resend?).
+> **🚨 AUDIT 2026-06-04**: WP4 (T11+T12+T13) è **GIÀ INTERAMENTE IMPLEMENTATO upstream**. Plan v2 ipotizzava endpoint mancanti — discovery rivela altro.
+>
+> **Stato reale**:
+> - **T11/T12**: Issue #2053 ha shipped `NotificationEndpoints.cs` con TUTTI gli endpoint richiesti (GET /notifications + GET /unread-count + POST /{id}/mark-read + POST /mark-all-read + GET /stream SSE Issue #5005). Notification entity completa (MarkAsRead idempotente + RestoreReadStatus per persistence). INotificationRepository con GetByUserIdAsync (filtering unread+limit) + GetUnreadCountAsync + MarkAllAsReadAsync. CQRS handlers tutti esistenti: GetNotificationsQuery, GetUnreadCountQuery, MarkNotificationReadCommand, MarkAllNotificationsReadCommand. Rate limiting su mark-all-read (Issue #2155). Auth user-scoped (no IDOR). Registrato in Program.cs:887.
+> - **T13**: Issue #1629 ha shipped `ResendEmailSender : IEmailSender` in `apps/api/src/Api/Services/Email/`. `EmailService` centralizza la scelta SMTP vs Resend via `IEmailSender` DI dependency. Config supporta `RESEND_FROM_EMAIL` fallback. SMTP path mantenuto per legacy/unit-test fallback.
+>
+> **Azione plan v2 → v2.1**: WP4 T11+T12+T13 → **NO IMPLEMENTATION needed**. Solo audit commit + skip-to-T14.
+>
+> **Effort recovered**: 12h (3+5+4) → ~0h. Asse A v2 totale ricalcolato: 12gg → **~10.5gg** (-12.5%).
 
 ### Task 11: Verify Notification entity + repository + endpoint audit
 
@@ -1175,5 +1183,6 @@ Both finish ~2 weeks elapsed time vs solo dev ~3 weeks.
 
 ## Changelog
 
+- **2026-06-05 v2.1**: WP4 audit-only post-discovery (T11+T12+T13 già shipped upstream issue #2053+#1629+#5005). 12h recovered, effort 12gg → ~10.5gg (-12.5% additional). Plan task count: 14 → 11 effective tasks (3 WP4 collassati ad audit doc).
 - **2026-06-04 v2**: rewrite post-discovery. Gap analysis backend reale → effort -33%. 14 task vs 25 task v1.
 - **2026-06-04 v1**: initial plan (now archived in git history). Assumed scratch backend, ~50% over-scoped.

--- a/docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md
+++ b/docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md
@@ -404,6 +404,7 @@ Popolare on-going durante implementazione asse D.
 
 **Changelog spec consolidato**:
 - 2026-06-04: initial spec-panel review (DEC-1..DEC-6 + 32 findings)
+- 2026-06-05: asse A v2.1 implementation COMPLETE via subagent-driven sessione 32 — branch `feature/issue-1896-semantic-alignment`, ~15 commit (12 feat + 2 fix + 3 docs). 80+ unit test added. WP4 audit-only (T11+T12+T13 già shipped upstream #2053+#1629+#5005). Effort reale ~10.5gg (vs v2 stima 12gg, v1 stima 18gg → -42% rispetto plan iniziale post-discovery). Security: 1 HIGH IDOR finding catched + fixato in `c1efb4fb6`. 0 regression su SessionTracking 472/472 + Scoring 113/113 suites.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md
+++ b/docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md
@@ -1,0 +1,417 @@
+# Claude Design Alignment — Spec-Panel Review
+
+**Data**: 2026-06-04
+**Issue umbrella**: [#1895](https://github.com/meepleAi-app/meepleai-monorepo/issues/1895)
+**Sub-issue**: [#1896 (A)](https://github.com/meepleAi-app/meepleai-monorepo/issues/1896) · [#1897 (B)](https://github.com/meepleAi-app/meepleai-monorepo/issues/1897) · [#1898 (C)](https://github.com/meepleAi-app/meepleai-monorepo/issues/1898) · [#1899 (D)](https://github.com/meepleAi-app/meepleai-monorepo/issues/1899)
+**Origine**: `/sc:spec-panel` mode critique — 6 esperti (Wiegers · Cockburn · Adzic · Fowler · Nygard · Crispin)
+**Baseline review**: gap report [38 gap](../../for-developers/audits/2026-06-04-claude-design-gap-report.md) · domain model [20 invarianti](../../for-developers/specs/2026-06-04-gamenight-session-domain-model.md) · prototipo `claude-design-handoff/2026-06-04/`
+
+> Questo documento è il **source of truth post-panel** delle decisioni di scope/architettura/effort assunte sull'umbrella #1895. Va letto prima di iniziare qualsiasi PR su #1896/#1897/#1898/#1899. Le sezioni "Update richiesti" mappano 1:1 sui body delle issue come addendum applicato il 2026-06-04.
+
+---
+
+## Sezione 1 — Quality Assessment baseline
+
+| Asse | Clarity | Completeness | Testability | Consistency | Overall |
+|------|---------|--------------|-------------|-------------|---------|
+| Umbrella #1895 | 7.5/10 | 6.5/10 | 5.0/10 | 7.0/10 | **6.5** |
+| Asse A #1896 (BE) | 8.0/10 | 6.0/10 | 7.0/10 | 7.5/10 | **7.1** |
+| Asse B #1897 (UI shell) | 7.5/10 | 6.5/10 | 6.5/10 | 7.0/10 | **6.9** |
+| Asse C #1898 (Dashboard) | 8.0/10 | 6.0/10 | 6.5/10 | 7.5/10 | **7.0** |
+| Asse D #1899 (Routes) | 7.0/10 | 5.5/10 | 4.5/10 | 6.5/10 | **5.9** |
+
+**Verdetto**: umbrella strutturalmente solida (4 assi A/B/C/D logici) ma 3 blind spot strutturali + 1 sottostima effort ~40% + 1 lacuna operativa critica (no rollback strategy).
+
+---
+
+## Sezione 2 — Decisioni lockate (6)
+
+### DEC-1 · Scoring polimorfico estende asse A
+
+**Driver**: CRIT-1 / CRIT-7 (Fowler + Wiegers).
+**Decisione**: aggiungere `ScoreType {Points, BinaryWin, Objectives, Ranking}` + pattern `IScoringStrategy` + migration `sessions.scoring_type` + DTO polymorphic dentro #1896.
+**Motivazione**: gap report TOP 10 #4 "flow salva session rotto per ~50% catalog board game" è blocker semantico. Senza ScoreType backend, drawer FE è solo placeholder. Mettere in asse A separato dal D pulisce dependency graph (D drawer editor gated su A complete).
+**Impatto**: effort A da L (~5 gg) a XL (~10-14 gg, vedi DEC-6).
+
+### DEC-2 · 3 stub critiche costruite in asse D, 2 deferred
+
+**Driver**: CRIT-2 (Cockburn).
+**Decisione**:
+- **Costruire dentro #1899**: `/sessions/[id]` (session detail) · `/game-nights/[id]/summary` (GN summary post-completed) · `/games` tab Discover (esplicito).
+- **Defer "Coming soon" toast**: `/knowledge-base` · `/toolkit/[id]`.
+
+**Motivazione**: CTA primarie "Vai al riepilogo" e click toolkit/session card sono user-facing path principali. KB hub e toolkit detail sono CTA secondarie, accettabile defer con feedback (toast non-bloccante 4s). Mappa gap TOP 10 #8 (session detail) + gap #13 (summary) + gap #6 (chat agent → out of scope umbrella).
+**Impatto**: asse D effort +3-5 giorni.
+
+### DEC-3 · Designer-led review checklist per route
+
+**Driver**: CRIT-3 (Wiegers + Crispin).
+**Decisione**: ogni PR asse D include nel body una **Design Review Checklist** ~8-12 item semantici firmata da designer. Tracking matrix nell'umbrella aggregato.
+**Motivazione**: criterio "riconoscibile al prototipo" non testabile programmaticamente (visual regression rimossa 2026-05-20). Designer è l'autority finale. Checklist evita bikeshedding.
+**Esempio template per route**:
+```markdown
+## Design Review Checklist — /game-nights/[id]
+- [ ] Sidebar 2 voci game-related (Library + Games) ✓
+- [ ] Drawer stack pattern usato (no full-page navigate per Player peek)
+- [ ] Entity color GameNight (rosa) su CTA primaria
+- [ ] Sezione Player & RSVP con stati badge ✓ User / Guest
+- [ ] Sezione Sessions self-contained con paginazione
+- [ ] 5 stati (default/empty/loading/error/offline) toggleabili in dev
+- [ ] CTA contestuali per status (Planned: Modifica RSVP, InProgress: Aggiungi session, Completed: Aggiungi note)
+- [ ] Token discipline (no hex hardcoded, var(--c-*) only)
+- [ ] Hero matches prototipo screenshot `gn-detail.png` (semantic match, no pixel-perfect)
+- [ ] Designer approved-by: @<designer-handle>
+- [ ] Designer approved-on: YYYY-MM-DD
+```
+**Impatto**: umbrella tracking matrix new section.
+
+### DEC-4 · Accept + documented escalation path (no feature flag)
+
+**Driver**: CRIT-5 (Nygard).
+**Decisione**: zero infrastructure feature flag. Documentato **rollback playbook** in umbrella.
+**Playbook**:
+1. **Trigger**: production incident detected (user report / monitoring alert / failed deploy)
+2. **SLA**: rollback decision <30 min, execution <2h
+3. **Mechanism**: `git revert <PR-merge-commit>` + emergency hotfix PR + merge --admin
+4. **On-call**: dev autore del PR + reviewer (rotating)
+5. **Escalation**: se >3 rollback in 24h finestra, banner emergency in landing `<EmergencyBanner severity="degraded" />` + freeze merge umbrella
+6. **Post-mortem**: required per ogni rollback, output in `docs/for-developers/audits/incident-postmortems/`
+
+**Motivazione**: feature flag avrebbe aggiunto ~30% complessità FE code per 2-4 settimane; team MVP-stage non ha capacity sostenere overhead. Trade-off accettato.
+**Impatto**: umbrella aggiunge sezione "Rollback playbook".
+
+### DEC-5 · Notification system: in-app inbox + email transactional
+
+**Driver**: CRIT-6 (Cockburn + Wiegers).
+**Decisione**: invariante #17 (RSVP pending in dashboard invitato) richiede notification reale. Scope MVP:
+- **In-app inbox**: entity `Notification` + `/notifications` route + bell badge counter sidebar
+- **Email transactional**: invio sincrono su `SendInvitationCommand` via **Resend** (o SendGrid se config esistente)
+- **OUT of MVP**: push (mobile), webhook external, SMS, digest emails
+
+**Motivazione**: in-app only è troppo passivo (Anna deve aprire app per vedere invito → friction RSVP). Email transactional copre il caso "Anna non aperta app oggi". Push richiede mobile infrastructure → SP8.
+**Impatto**: asse A effort +5 giorni (provider integration + template + test). Nuovo secret `RESEND_API_KEY` in `infra/secrets/email.secret`.
+
+### DEC-6 · Effort rebaseline + buffer 20% asse A
+
+**Driver**: CRIT-4 (Nygard).
+**Decisione**:
+
+| Asse | Stima originale | Stima rebaseline | Note |
+|------|----------------|------------------|------|
+| A #1896 (BE semantic) | L (~3-5 gg) | **XL (~15 gg)** | +scoring (DEC-1) +notification (DEC-5) +20% buffer su uncertainty |
+| B #1897 (UI shell) | M (~2-3 gg) | **M+ (~8 gg)** | +token additions (MAJ-9) +sidebar 8 voci (CRIT-8) +Storybook |
+| C #1898 (Dashboard) | M (~2-3 gg) | **M (~4 gg)** | +empty-state matrix (MAJ-6) +Friends scope (MAJ-5) |
+| D #1899 (Routes) | L+ (~5-10 gg) | **XL (~25 gg)** | +3 stub (DEC-2) +designer checklist (DEC-3) +v2-shipped audit (MAJ-10) +cross-asse E2E (MAJ-11) |
+| **Totale** | ~3-5 settimane | **~7-8 settimane single-dev / 4-5 settimane parallel** | |
+
+**Critical path**: asse A è il bottleneck (15 gg + blocca D drawer editor e C dashboard live state). Parallelizzare D.1 (library + games detail FE-only) con A late stage.
+
+---
+
+## Sezione 3 — Findings (32 totali)
+
+### 🔴 CRITICAL (8)
+
+| # | Finding | Asse | Expert | Status |
+|---|---------|------|--------|--------|
+| CRIT-1 | Scoring polimorfico orfano (nessun asse possedeva) | A | Fowler, Wiegers | **Risolto** via DEC-1 |
+| CRIT-2 | 5 stub route non assegnate | Umbrella | Cockburn | **Risolto** via DEC-2 |
+| CRIT-3 | DoD "riconoscibile" non testabile | Umbrella, D | Wiegers, Crispin | **Risolto** via DEC-3 |
+| CRIT-4 | Effort sottostimato ~40% | Tutti | Nygard | **Risolto** via DEC-6 |
+| CRIT-5 | No rollback strategy ("UI mista 2-4 weeks" blind spot) | Umbrella | Nygard | **Risolto** via DEC-4 |
+| CRIT-6 | Asse A manca invariante #15 esplicita + scope notification ambiguous | A | Cockburn, Wiegers | **Risolto** via DEC-5 + scope additions sezione 4 |
+| CRIT-7 | Asse D session editor bloccato da CRIT-1 | D | Fowler | **Risolto** via DEC-1 (asse D drawer gated) |
+| CRIT-8 | Sidebar conta 7 voci, claim 8 | B | Doumont | **Aperto** — vedi scope addition asse B |
+
+### 🟡 MAJOR (12)
+
+| # | Finding | Asse | Expert | Action |
+|---|---------|------|--------|--------|
+| MAJ-1 | Migration SQL circolare (DEFAULT now() + UPDATE updated_at) | A | Hohpe | Riscrivere come 3-step ALTER NULL → UPDATE → ALTER NOT NULL |
+| MAJ-2 | Backfill IsInvited=true è product decision silente | A | Wiegers | Documentare backwards-compat decision |
+| MAJ-3 | StatePreviewProvider implementation undefined | B | Fowler | Pattern NODE_ENV gate + dynamic import; acceptance "0 prod bytes" |
+| MAJ-4 | WizardModal.validate signature undefined | B | Crispin, Fowler | TypeScript signature `validate: () => Promise<{valid: boolean, errors?: ValidationError[]}>` |
+| MAJ-5 | Friends feed entity undefined | C | Cockburn | Definire "friend = User-linked player with ≥1 shared GN last 90gg" |
+| MAJ-6 | Empty state inconsistent (4 sezioni × 5 stati) | C | Crispin | Matrice 4×5 cell-by-cell |
+| MAJ-7 | Paginazione "Recenti" assente | C | Cockburn | Link "Vedi tutti" → `/game-nights?status=completed` |
+| MAJ-8 | 5 stati toggleabili — chi testa? | D | Crispin | Manual QA checklist per route in `docs/for-developers/qa/` |
+| MAJ-9 | Token tokenization gap #37/#38 non scopato | D, B | Fowler | `--c-warning-ink` + overlay tokens in B; D references |
+| MAJ-10 | v2-shipped coordination audit pre-PR missing | D | Crispin, Fowler | Audit `v2-migration-matrix.md` pre-asse-D |
+| MAJ-11 | Cross-asse integration testing assente | Umbrella | Crispin, Newman | 3-5 E2E user journey cross-asse |
+| MAJ-12 | Sequencing rigid A→B→C→D ignora critical path slack | Umbrella | Nygard | Buffer 20% asse A; parallelizzare D.1 |
+
+### 🟢 MINOR (12)
+
+| # | Finding | Asse | Fix |
+|---|---------|------|-----|
+| MIN-1 | `MULTIPLE_LIVE_NOT_ALLOWED` → `MaxLiveSessionsExceededException` | A | Rename .NET convention |
+| MIN-2 | Suggested algorithm "fixture o naive" senza roadmap | C | Bullet "MVP fixture → V2 algorithm deferred" |
+| MIN-3 | Drawer animation no `prefers-reduced-motion` | B | Add a11y clause |
+| MIN-4 | PR D.5 mixe auth + onboarding + catalog | D | Split D.5a (catalog) + D.5b (auth/onboarding) |
+| MIN-5 | "MVP della serata" KPI undefined | C | "Player con highest score in session più recente" |
+| MIN-6 | `Session.OpenLiveMode()` lifecycle unclear | A | Clarify factory vs constructor |
+| MIN-7 | sonner library reference verify | B | Check `package.json` |
+| MIN-8 | Spec governance amendment process | Umbrella | "PR a spec doc + lock-in pre-merge sub-issue" |
+
+---
+
+## Sezione 4 — Update richiesti per issue
+
+### Umbrella #1895
+
+Aggiungere sezioni:
+1. **Rollback playbook** (DEC-4 sopra)
+2. **Timeline rebaseline** (DEC-6 tabella sopra)
+3. **Designer review tracking matrix** (DEC-3, popolare on-going)
+4. **Critical path identification** (asse A bottleneck, parallel D.1)
+5. **Spec governance** (MIN-8)
+
+Update Definition of Done:
+- Aggiungi: "Spec consolidato spec-panel review aggiornato in `docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md`"
+- Aggiungi: "Designer review tracking matrix completata per 13 route"
+- Aggiungi: "Rollback playbook validato (almeno 1 dry-run su staging)"
+
+### Asse A #1896
+
+**Scope additions**:
+- [ ] **Invariante #15 esplicita** etichettata: state machine triggered by first Session creation of any type via `SessionCreatedDomainEvent`
+- [ ] **DEC-1 ScoreType polimorfico**:
+  - Enum `ScoreType { Points, BinaryWin, Objectives, Ranking }` con `Description` attribute per UI
+  - Interface `IScoringStrategy` con metodi `Validate(scoreData)`, `Serialize(scoreData)`, `ComputeWinner()`
+  - 4 strategy implementations + factory `ScoringStrategyFactory.GetStrategy(scoring_type)`
+  - Migration: `sessions.scoring_type VARCHAR(20) NOT NULL DEFAULT 'Points'` (backfill all existing)
+  - DTO: `SaveSessionCommand` accept polymorphic `scoreData: object` (JSON) validated per `scoring_type` via FluentValidation custom rule
+  - Domain method `Session.SetScores(scoring_type, data)` con validation per-strategy + domain event `SessionScoresUpdated`
+  - 4 unit test class (1 per strategy) + 1 integration test (round-trip via API)
+- [ ] **DEC-5 Notification system**:
+  - Entity `Notification` con campi (Id, RecipientUserId, Type, Payload JSON, ReadAt nullable, CreatedAt)
+  - Bounded context: `UserNotifications` (esistente, vedi CLAUDE.md)
+  - REST endpoint: `GET /api/v1/notifications?page=N&size=M` (paginated inbox) + `PATCH /api/v1/notifications/{id}/read`
+  - Command: `SendInvitationNotificationCommand` handler emette in-app `Notification` + email via `IEmailSender`
+  - Email template `GameNightInvitation` (HTML + plain text)
+  - Provider: Resend (preferito, simple API) — concrete `ResendEmailSender : IEmailSender`
+  - Secret: `RESEND_API_KEY` in `infra/secrets/email.secret` (nuovo)
+  - Integration test: `SendGameNightInvitations_QueuesInAppAndSendsEmail` con mock `IEmailSender`
+- [ ] **MAJ-1 fix migration SQL**: pattern 3-step (ALTER NULL → UPDATE → ALTER NOT NULL)
+- [ ] **MAJ-2 backwards-compat**: documentare "IsInvited=true backfill = existing player sono già 'invited' (auto-shared pattern legacy)"
+- [ ] **MIN-1 rename**: `MaxLiveSessionsExceededException` + error code `MAX_LIVE_SESSIONS_EXCEEDED` (HTTP 409)
+- [ ] **MIN-6 Session.OpenLiveMode lifecycle**: chiarire come factory method (preferred) — Session instance già esiste, OpenLiveMode è state transition
+- [ ] **Effort updated**: L → **XL (~15 gg dev + 3 gg test/review)**
+
+### Asse B #1897
+
+**Scope additions**:
+- [ ] **CRIT-8 sidebar enumeration**: ricontare voci. Aggiungere voce `/notifications` (bell icon sidebar bottom) → 8 voci totali = Dashboard · Library · Games · Sessions · Agents · Game Nights · Notifications · Profile
+- [ ] **MAJ-3 StatePreviewProvider** implementation pattern:
+  - Dynamic import gated `NODE_ENV !== 'production'`
+  - Tree-shaking verify via `next build` + grep output bundle
+  - Acceptance: `pnpm build && grep -r 'StatePreviewProvider' .next/static/chunks/` returns 0 matches
+- [ ] **MAJ-4 WizardModal API**:
+  ```typescript
+  interface WizardStep {
+    title: string;
+    content: ReactNode;
+    validate?: () => Promise<{ valid: boolean; errors?: ValidationError[] }>;
+    optional?: boolean;
+  }
+  interface ValidationError {
+    field?: string;
+    message: string;
+  }
+  ```
+- [ ] **MAJ-9 token additions** in `apps/web/src/styles/design-tokens-canonical.css`:
+  - `--c-warning-ink: hsl(38 92% 32%)` (gap #37)
+  - `--c-overlay-scrim: hsla(0 0% 0% / 0.6)` (gap #38)
+  - `--c-overlay-gradient-end: hsl(25 95% 38%)` (gap #38)
+- [ ] **MIN-3 a11y**: drawer animation respects `@media (prefers-reduced-motion: reduce)` → animation duration 0ms
+- [ ] **MIN-7 sonner verify**: check `apps/web/package.json` → add `sonner@latest` if missing
+- [ ] **Effort updated**: M → **M+ (~7 gg dev + 2 gg Storybook/test)**
+
+### Asse C #1898
+
+**Scope additions**:
+- [ ] **MAJ-5 Friends qualification**:
+  - Definizione MVP: "friend = User-linked player con almeno 1 shared GameNight negli ultimi 90gg"
+  - Query `GetUserFriendsActivityQuery` returns `FriendActivity[]` con campi (FriendUserId, Avatar, Name, Verb, GameOrEventRef, Timestamp)
+  - Backend endpoint: `GET /api/v1/dashboard/friends-activity?limit=10`
+  - Fallback: empty state "Nessuna attività recente dai tuoi amici"
+- [ ] **MAJ-6 empty-state matrix 4×5**:
+
+  | Sezione \ Stato | default | empty | loading | error | offline |
+  |---|---|---|---|---|---|
+  | Prossimi | 2-3 card | CTA "Crea prima GN" | skeleton 2 card | banner rosso + retry | cache + banner ambra |
+  | Recenti | 2-3 card | hidden | skeleton 2 card | banner rosso + retry | cache + banner ambra |
+  | Suggested | 4-6 card horizontal | hidden | skeleton 4 card | hidden (error → fallback hidden) | cache |
+  | Friends | 2-3 entry | hidden | skeleton 3 entry | hidden | cache |
+
+- [ ] **MAJ-7 paginazione Recenti**: link "Vedi tutti i completati →" footer sezione → `/game-nights?status=completed`
+- [ ] **MIN-2 suggested roadmap**: nota "MVP fixture → V2 algorithm spec deferred a sub-issue futura post-MVP"
+- [ ] **MIN-5 MVP della serata**: "Player con highest score nella session più recente della GN. Per BinaryWin/Objectives: winner per default. Per Ranking: position 1."
+- [ ] **Effort**: M (~3-4 gg dev + 1 gg test) [stima invariata]
+
+### Asse D #1899
+
+**Scope additions**:
+- [ ] **DEC-2 build 3 stub critici** (gating su PR sequence):
+  - `/sessions/[id]` (session detail live+summary) — in PR D.4 con `/sessions`
+  - `/game-nights/[id]/summary` (GN summary post-completed) — in PR D.3 con `/game-nights/[id]`
+  - `/games` con tab Discover (esplicito) — in PR D.5a
+- [ ] **DEC-2 toast "Coming soon"** per `/knowledge-base` (in `/games/[id]` tab KB) e `/toolkit/[id]` (in `/discover` toolkit card)
+- [ ] **DEC-3 Design Review Checklist** per ogni route (template sopra). Tracking aggregato in umbrella.
+- [ ] **MAJ-8 5-state test plan**: manual QA checklist per route in `docs/for-developers/qa/2026-06-04-route-state-manual-qa.md` (creato pre-PR D.1)
+- [ ] **MAJ-10 v2-shipped audit**: pre-asse-D, audit `docs/for-developers/frontend/v2-migration-matrix.md` — output lista esplicita routes v2-shipped affected (commit in PR D.0 audit, prima di D.1)
+- [ ] **MAJ-11 cross-asse E2E**: 3-5 user journey Playwright in `apps/web/e2e/cross-asse-flows.spec.ts`:
+  1. Dashboard → drawer GameNight → drawer Player swap → ESC back → backdrop close
+  2. Dashboard empty → CTA "Crea prima GN" → wizard 3-step → Live mode opt-in
+  3. Game Detail tab Partite → paginazione inline (NO navigate /sessions)
+  4. Invitation flow: Anna login → /notifications → click invito → /game-nights/[id] pending → RSVP confirm → dashboard normale
+  5. Session live mode → toast warning "salva draft con live attiva" → click toast link → switch a live session
+- [ ] **MIN-4 PR sequence aggiornato** (6 PR invece di 5):
+  1. **PR D.0** — v2-migration-matrix audit + state QA checklist (`docs/` only)
+  2. **PR D.1** — `/library` + `/games/[id]` (collection + detail)
+  3. **PR D.2** — `/game-nights` + `/game-nights/new` (index + wizard)
+  4. **PR D.3** — `/game-nights/[id]` + `/game-nights/[id]/live` + **`/game-nights/[id]/summary`** (detail + live + summary)
+  5. **PR D.4** — `/sessions` + **`/sessions/[id]`** + `/agents` + `/agents/[id]` (archive + agent stack + session detail)
+  6. **PR D.5a** — `/games` con tab Discover + tab Discover content (catalog)
+  7. **PR D.5b** — `/login` + `/register` + `/onboarding` (auth)
+- [ ] **Effort updated**: L+ → **XL (~25 gg distribuiti)**
+
+---
+
+## Sezione 5 — Sequence rebaseline + critical path
+
+```
+Settimana 1: Asse A start (semantic foundations + Migration #11/#15 + Notification entity skeleton)
+                              |
+Settimana 2: Asse B start (PR per primitives) — parallel ad A
+             Asse A continue (ScoreType + IScoringStrategy)
+                              |
+Settimana 3: Asse A continue (Notification email integration + tagging/RSVP)
+             Asse B PR merged
+             Asse D PR D.0 (audit doc only)
+                              |
+Settimana 4: Asse A complete + merged
+             Asse C start (depends su A status + B drawer)
+             Asse D PR D.1 (library + game detail FE-only, no live state) — parallel
+                              |
+Settimana 5: Asse C complete + merged
+             Asse D PR D.2 (GN index + wizard)
+                              |
+Settimana 6: Asse D PR D.3 (GN detail + live + summary)
+                              |
+Settimana 7: Asse D PR D.4 (sessions + agents)
+                              |
+Settimana 8: Asse D PR D.5a + D.5b (catalog + auth/onboarding)
+             Final designer review tracking matrix complete
+             Umbrella close
+```
+
+**Bottleneck**: asse A in settimane 1-3. Slip qui cascata su C (Dashboard live state) + D.3 (Live mode) + D.4 (session detail polymorphic scoring).
+
+**Parallelization opportunity**: D.1 (library + games detail) FE-only può start settimana 4 senza dipendere da A complete (game detail tab "Partite" mostra cards Session ma il polymorphic scoring solo nella drawer editor di D.3).
+
+---
+
+## Sezione 6 — Rollback playbook (DEC-4)
+
+### Trigger condizioni
+- **Production incident detected**:
+  - User report via support channel (Discord, email)
+  - Monitoring alert (error rate >5% in 5 min finestra)
+  - Failed deploy / smoke test fail
+- **UX confusion riportata**:
+  - >5 support tickets riferiti alla nuova UI in 24h
+  - Designer feedback "regressione vs prototipo"
+
+### SLA
+- **Decision time**: <30 minuti dal trigger
+- **Execution time**: <2 ore (incluso CI verde post-revert)
+- **Communication**: aggiornamento status page entro 15 minuti
+
+### Mechanism
+```bash
+# 1. Identify offending PR merge commit
+git log --oneline --merges main-dev | head -5
+
+# 2. Revert (creates new commit, preserves history)
+git checkout -b hotfix/revert-pr-XXXX
+git revert -m 1 <merge-commit-sha>
+git push -u origin hotfix/revert-pr-XXXX
+
+# 3. Emergency PR with admin override
+gh pr create --title "hotfix: revert PR #XXXX (incident YYYY-MM-DD)" \
+  --body "Rollback per incident <description>. Postmortem TBD." \
+  --base main-dev
+gh pr merge <pr-number> --squash --admin --delete-branch
+
+# 4. Verify
+gh run watch # CI smoke test
+# 5. Post-mortem (required)
+# Create docs/for-developers/audits/incident-postmortems/YYYY-MM-DD-incident.md
+```
+
+### On-call
+- **Primary**: dev autore del PR mergeato
+- **Secondary**: dev reviewer del PR
+- **Rotation**: settimanale, documentata in `docs/for-developers/on-call-schedule.md`
+
+### Escalation
+- **>3 rollback in 24h**: deploy `<EmergencyBanner severity="degraded" />` in landing + **freeze merge umbrella** finché root cause identificata
+- **>1 rollback per route specifica**: opzione re-introdurre feature flag NEXT_PUBLIC_DEMO_ALIGNMENT_<ROUTE>=false per quella route
+- **Critical infra failure (DB migration corrupted, OAuth broken)**: page CTO + product owner
+
+### Post-mortem template
+Mandatory entro 5 giorni dal rollback:
+- Cosa è successo (timeline)
+- Cosa abbiamo imparato
+- Cosa cambiamo (action items con owner + deadline)
+- Output in `docs/for-developers/audits/incident-postmortems/`
+
+---
+
+## Sezione 7 — Designer Review Tracking Matrix
+
+Popolare on-going durante implementazione asse D.
+
+| Route | PR | Designer approved-by | Date | Status |
+|-------|-----|-------|------|--------|
+| `/library` | D.1 | TBD | — | pending |
+| `/games/[id]` | D.1 | TBD | — | pending |
+| `/game-nights` | D.2 | TBD | — | pending |
+| `/game-nights/new` | D.2 | TBD | — | pending |
+| `/game-nights/[id]` | D.3 | TBD | — | pending |
+| `/game-nights/[id]/live` | D.3 | TBD | — | pending |
+| `/game-nights/[id]/summary` | D.3 | TBD | — | pending |
+| `/sessions` | D.4 | TBD | — | pending |
+| `/sessions/[id]` | D.4 | TBD | — | pending |
+| `/agents` | D.4 | TBD | — | pending |
+| `/agents/[id]` | D.4 | TBD | — | pending |
+| `/games` (tab Discover) | D.5a | TBD | — | pending |
+| `/login` + `/register` | D.5b | TBD | — | pending |
+| `/onboarding` | D.5b | TBD | — | pending |
+| `/dashboard` | C (asse separato) | TBD | — | pending |
+
+---
+
+## Sezione 8 — Spec governance (MIN-8)
+
+**Process amendments**:
+1. Modifica delle 20 invarianti dominio → PR a `docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md`
+2. Lock-in pre-merge della sub-issue affetta (es. modifica invariante #15 lock-a #1896)
+3. Nuove invarianti emerse durante implementazione → PR umbrella con sezione "Nuova invariante #N proposta"
+4. Approver: product owner + dev autore PR + 1 reviewer asse interessato
+5. Update `docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md` con changelog inline
+
+**Changelog spec consolidato**:
+- 2026-06-04: initial spec-panel review (DEC-1..DEC-6 + 32 findings)
+
+---
+
+## Riferimenti
+
+- Gap report 38 gap: [`2026-06-04-claude-design-gap-report.md`](../../for-developers/audits/2026-06-04-claude-design-gap-report.md)
+- Domain model 20 invarianti: [`2026-06-04-gamenight-session-domain-model.md`](../../for-developers/specs/2026-06-04-gamenight-session-domain-model.md)
+- Prototipo runnable: `claude-design-handoff/2026-06-04/` (gitignored)
+- CLAUDE.md § Domain Model — GameNight / Session
+- v2 migration matrix: [`v2-migration-matrix.md`](../../for-developers/frontend/v2-migration-matrix.md)
+- ADR-054 DevOps Multi-Branch Strategy: [`adr-054-devops-multi-branch-strategy.md`](../../for-developers/architecture/adr/adr-054-devops-multi-branch-strategy.md)


### PR DESCRIPTION
## Summary

Implementa **asse A v2.1** dell'umbrella [#1895](https://github.com/meepleAi-app/meepleai-monorepo/issues/1895) (Claude Design alignment): invarianti #10/#11/#13/#14/#15 + DEC-1 polymorphic ScoreType + DEC-5 audit-only.

**Closes #1896**

## Scope shipped

### WP1 — Max 1 live invariant (#10)
- `MaxLiveSessionsExceededException` (Code `MAX_LIVE_SESSIONS_EXCEEDED`)
- Guard in `GameNightEvent.StartCurrentSession()` (HTTP 409 via ConflictException base)

### WP2 — Session timestamps + state machine wire
- `Session.StartedAt` + `OpenLiveMode()` factory + `IsLive` computed (#11+#14)
- `SessionStartedDomainEvent` raised on live transition
- `SessionStartedHandler` → `GameNightEvent.HandleFirstSessionStarted` (#15)
- `FinalizeSession` X-Warning-Code header for live coexistence (#13)
- Backend mapping doc (T5)

### WP3 — Polymorphic ScoreType (DEC-1)
- `ScoreType` enum + `IScoringStrategy` interface + `ScoringStrategyFactory` (DI Singleton)
- 4 strategies: Points · BinaryWin · Objectives · Ranking (~55 unit test)
- `Session.ScoringType` + `score_data` JSONB column + `SetScores()` domain method
- `UpdateSessionScoresCommand` + `UpdateSessionScoresCommandValidator` (FluentValidation custom rule dispatch to strategy)
- New endpoint `PUT /api/v1/game-sessions/{id}/scores-polymorphic`

### WP4 — Notification audit-only (DEC-5)
- T11+T12+T13 **già shipped upstream**: `NotificationEndpoints.cs` (Issue #2053+#5005), `ResendEmailSender` (Issue #1629)
- Plan v2.1 collapsed WP4 to audit doc commit (12h effort recovered)

### WP5 — Acceptance close
- OpenAPI: .NET 9 native usa XML doc auto-generated (no manual yaml)
- CLAUDE.md Domain Model section update + spec consolidato changelog

## Security fix

🔒 **HIGH IDOR finding** catched by automated security review post-T10 merge + fixed in `c1efb4fb6`:
- `UpdateSessionScoresCommand` ora richiede `RequestedBy` (Guid from claims)
- Handler verifica `session.UserId == RequestedBy || any(participant.UserId == RequestedBy)` else `ForbiddenException` (HTTP 403)
- Pattern mirrors `ExportSessionHandlers` + `AdvanceTurnCommandHandler`
- 3 new IDOR tests + 1 validator test (22 tests totali su UpdateSessionScores)

## Final review fixes (post-WP5 close)

Final code reviewer ha trovato 2 finding bloccanti, fixati in `28fd2e433`:
- **CRITICAL**: `SessionStartedHandler` (T3) staged GameNightEvent.Status update ma non committava → `IUnitOfWork.SaveChangesAsync` aggiunto post-`UpdateAsync`
- **IMPORTANT**: `MaxLiveSessionsExceededException` estendeva `DomainException` (→ HTTP 400) invece di `ConflictException` (→ HTTP 409) → base class switch + `[SetsRequiredMembers]`

## Stats finali

- **18 commit** shipped (12 feat + 3 fix + 3 docs/audit)
- **~80+ unit + integration test** creati
- **2270/2270 test pass** (1 skipped intenzionale), 0 regression
- **Effort actual**: ~10.5gg (vs plan v1 stima 18gg → **-42% post-discovery**)
- **Build**: 0 errors, 0 warnings

## Test plan

- [x] Unit tests passing per ogni invariante (#10/#11/#13/#14/#15)
- [x] Polymorphic ScoreType: 4 strategy + factory + round-trip (~55 tests)
- [x] Session.SetScores + SessionScoresUpdatedEvent (7 tests)
- [x] IDOR guard (3 owner/participant/forbidden tests)
- [x] Full SessionTracking + GameManagement regression suite (2270/2270)
- [ ] Manual smoke: invoke `POST /game-nights/{id}/sessions/{sid}/live` con altra live → expect 409 + `MAX_LIVE_SESSIONS_EXCEEDED` (post-merge, dopo migration apply su staging)
- [ ] Manual smoke: invoke `PUT /game-sessions/{id}/scores-polymorphic` come non-owner → expect 403 (post-merge)

## Plan reference

- Spec consolidato: `docs/superpowers/specs/2026-06-04-claude-design-alignment-spec-panel-review.md`
- Plan v2.1: `docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`
- Domain model 20 invarianti: `docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md` (con backend mapping section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)