### PR TITLE
feat(notifications): #1937 CF-1 — NotificationDispatcher idempotency via SourceEventId

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AutoAgentCreationFailedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AutoAgentCreationFailedEvent.cs
@@ -1,4 +1,4 @@
-using MediatR;
+using Api.SharedKernel.Domain.Interfaces;
 
 namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
 
@@ -12,6 +12,10 @@ namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
 /// user explicitly via in-app notification or email — instead of leaving them confused
 /// about why no agent appeared after PDF processing completed.
 ///
+/// Issue #1937 / CF-1: Implements <see cref="IDomainEvent"/> so the notification dispatcher
+/// can dedup on <c>EventId</c> when the publishing transaction rolls back after publish
+/// (or MediatR retries transiently).
+///
 /// Carry-forward: actual user-visible notification delivery (in-app + email channel)
 /// is a follow-up enhancement; this event ensures the failure is now observable
 /// (logs + integration tests + future notification handlers).
@@ -22,4 +26,8 @@ internal sealed record AutoAgentCreationFailedEvent(
     Guid UserId,
     string ErrorCode,
     string Reason
-) : INotification;
+) : IDomainEvent
+{
+    public Guid EventId { get; init; } = Guid.NewGuid();
+    public DateTime OccurredAt { get; init; } = DateTime.UtcNow;
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/AgentLinkedNotificationEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/AgentLinkedNotificationEventHandler.cs
@@ -68,7 +68,9 @@ internal sealed class AgentLinkedNotificationEventHandler : INotificationHandler
                     Payload = new GenericPayload(
                         "Agent Linked",
                         $"Agent linked to '{gameTitle}'. Game is ready for AI chat."),
-                    DeepLinkPath = $"/admin/shared-games/{notification.GameId}"
+                    DeepLinkPath = $"/admin/shared-games/{notification.GameId}",
+                    // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                    SourceEventId = notification.EventId
                 }, cancellationToken).ConfigureAwait(false);
             }
 

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/BadgeEarnedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/BadgeEarnedNotificationHandler.cs
@@ -73,7 +73,9 @@ internal sealed class BadgeEarnedNotificationHandler : INotificationHandler<Badg
                     notification.BadgeId,
                     badge.Name,
                     badge.Description),
-                DeepLinkPath = "/users/me/badges"
+                DeepLinkPath = "/users/me/badges",
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightCancelledNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightCancelledNotificationHandler.cs
@@ -56,7 +56,9 @@ internal sealed class GameNightCancelledNotificationHandler : INotificationHandl
                             notification.Title,
                             scheduledAt.UtcDateTime,
                             organizerName),
-                        DeepLinkPath = $"/game-nights/{notification.GameNightEventId}"
+                        DeepLinkPath = $"/game-nights/{notification.GameNightEventId}",
+                        // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                        SourceEventId = notification.EventId
                     }, cancellationToken).ConfigureAwait(false);
                 }
 #pragma warning disable CA1031

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightPublishedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightPublishedNotificationHandler.cs
@@ -48,7 +48,9 @@ internal sealed class GameNightPublishedNotificationHandler : INotificationHandl
                             notification.Title,
                             notification.ScheduledAt.UtcDateTime,
                             organizerName),
-                        DeepLinkPath = $"/game-nights/{notification.GameNightEventId}"
+                        DeepLinkPath = $"/game-nights/{notification.GameNightEventId}",
+                        // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                        SourceEventId = notification.EventId
                     }, cancellationToken).ConfigureAwait(false);
                 }
 #pragma warning disable CA1031

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder1hNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder1hNotificationHandler.cs
@@ -61,7 +61,9 @@ internal sealed class GameNightReminder1hNotificationHandler : INotificationHand
                             notification.ScheduledAt.UtcDateTime,
                             string.Empty),
                         DeepLinkPath = $"/game-nights/{notification.GameNightEventId}",
-                        Metadata = new { hours_before = 1 }
+                        Metadata = new { hours_before = 1 },
+                        // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                        SourceEventId = notification.EventId
                     }, cancellationToken).ConfigureAwait(false);
                     notifiedCount++;
                 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder24hNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder24hNotificationHandler.cs
@@ -60,7 +60,9 @@ internal sealed class GameNightReminder24hNotificationHandler : INotificationHan
                             notification.ScheduledAt.UtcDateTime,
                             string.Empty),
                         DeepLinkPath = $"/game-nights/{notification.GameNightEventId}",
-                        Metadata = new { hours_before = 24 }
+                        Metadata = new { hours_before = 24 },
+                        // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                        SourceEventId = notification.EventId
                     }, cancellationToken).ConfigureAwait(false);
                 }
 #pragma warning disable CA1031

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightRsvpReceivedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightRsvpReceivedNotificationHandler.cs
@@ -50,7 +50,9 @@ internal sealed class GameNightRsvpReceivedNotificationHandler : INotificationHa
                 Payload = new GenericPayload(
                     "RSVP Received",
                     $"{respondingUserName} {statusText} your game night invitation"),
-                DeepLinkPath = $"/game-nights/{notification.GameNightEventId}"
+                DeepLinkPath = $"/game-nights/{notification.GameNightEventId}",
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicAnalysisStatusChangedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicAnalysisStatusChangedNotificationHandler.cs
@@ -89,7 +89,9 @@ internal sealed class MechanicAnalysisStatusChangedNotificationHandler
             Type = notificationType,
             RecipientUserId = analysis.CreatedBy,
             Payload = new GenericPayload(title, body),
-            DeepLinkPath = $"/admin/mechanic-analyses/{domainEvent.AnalysisId}/review"
+            DeepLinkPath = $"/admin/mechanic-analyses/{domainEvent.AnalysisId}/review",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = domainEvent.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MilestoneBadgeNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MilestoneBadgeNotificationHandler.cs
@@ -91,7 +91,9 @@ internal sealed class MilestoneBadgeNotificationHandler : INotificationHandler<B
                     notification.BadgeId,
                     badge.Name,
                     $"{badge.Description} {milestoneMessage}"),
-                DeepLinkPath = "/users/me/badges"
+                DeepLinkPath = "/users/me/badges",
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NewShareRequestAdminAlertHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NewShareRequestAdminAlertHandler.cs
@@ -60,7 +60,9 @@ internal sealed class NewShareRequestAdminAlertHandler : INotificationHandler<Sh
                     Payload = new GenericPayload(
                         "New Share Request",
                         "A new share request is waiting for review."),
-                    DeepLinkPath = $"/admin/share-requests/{notification.ShareRequestId}"
+                    DeepLinkPath = $"/admin/share-requests/{notification.ShareRequestId}",
+                    // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                    SourceEventId = notification.EventId
                 }, cancellationToken).ConfigureAwait(false);
             }
 

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentCreationFailedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentCreationFailedHandler.cs
@@ -45,7 +45,9 @@ internal sealed class NotifyAgentCreationFailedHandler : INotificationHandler<Au
                 Type = NotificationType.AgentCreationFailed,
                 RecipientUserId = notification.UserId,
                 Payload = new GenericPayload(title, body),
-                DeepLinkPath = deepLink
+                DeepLinkPath = deepLink,
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs
@@ -43,7 +43,10 @@ internal sealed class NotifyAgentReadyHandler : INotificationHandler<AgentAutoCr
                 Payload = new GenericPayload(
                     $"Agente per {gameName} pronto!",
                     $"L'agente AI per {gameName} è stato creato automaticamente."),
-                DeepLinkPath = deepLink
+                DeepLinkPath = deepLink,
+                // Issue #1937 / CF-1: propagate the domain event id so the dispatcher
+                // dedupes on re-fire (rollback-after-publish in #1535, MediatR transient retry).
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/PdfNotificationEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/PdfNotificationEventHandler.cs
@@ -49,7 +49,9 @@ internal class PdfNotificationEventHandler :
                 evt.PdfDocumentId,
                 pdfDoc.FileName.Value,
                 "Ready"),
-            DeepLinkPath = $"/documents/{evt.PdfDocumentId}"
+            DeepLinkPath = $"/documents/{evt.PdfDocumentId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Dispatched PDF ready notification for user {UserId}", evt.UploadedByUserId);
@@ -72,7 +74,9 @@ internal class PdfNotificationEventHandler :
                 evt.PdfDocumentId,
                 pdfDoc.FileName.Value,
                 $"Failed: {evt.ErrorMessage}"),
-            DeepLinkPath = $"/documents/{evt.PdfDocumentId}"
+            DeepLinkPath = $"/documents/{evt.PdfDocumentId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogWarning("Dispatched PDF failure notification for user {UserId}", evt.UploadedByUserId);
@@ -95,7 +99,9 @@ internal class PdfNotificationEventHandler :
                 evt.PdfDocumentId,
                 pdfDoc.FileName.Value,
                 $"Retry #{evt.RetryCount}"),
-            DeepLinkPath = $"/documents/{evt.PdfDocumentId}"
+            DeepLinkPath = $"/documents/{evt.PdfDocumentId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Dispatched PDF retry notification for user {UserId}", evt.UploadedByUserId);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ProcessingJobNotificationEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ProcessingJobNotificationEventHandler.cs
@@ -53,7 +53,9 @@ internal class ProcessingJobNotificationEventHandler :
                 evt.PdfDocumentId,
                 fileName,
                 $"Completed in {durationText}"),
-            DeepLinkPath = "/admin/knowledge-base/queue"
+            DeepLinkPath = "/admin/knowledge-base/queue",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Dispatched job completed notification for user {UserId}, job {JobId}", evt.UserId, evt.JobId);
@@ -80,13 +82,15 @@ internal class ProcessingJobNotificationEventHandler :
                 evt.PdfDocumentId,
                 fileName,
                 $"Failed{stepText}: {evt.ErrorMessage}"),
-            DeepLinkPath = "/admin/knowledge-base/queue"
+            DeepLinkPath = "/admin/knowledge-base/queue",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogWarning("Dispatched job failed notification for user {UserId}, job {JobId}", evt.UserId, evt.JobId);
 
         // Admin in-app notifications for failure visibility
-        await NotifyAdminsOnFailureAsync(evt.UserId, fileName, stepText, evt.ErrorMessage, cancellationToken).ConfigureAwait(false);
+        await NotifyAdminsOnFailureAsync(evt.UserId, fileName, stepText, evt.ErrorMessage, evt.EventId, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task NotifyAdminsOnFailureAsync(
@@ -94,6 +98,7 @@ internal class ProcessingJobNotificationEventHandler :
         string fileName,
         string stepText,
         string? errorMessage,
+        Guid sourceEventId,
         CancellationToken cancellationToken)
     {
         try
@@ -113,7 +118,9 @@ internal class ProcessingJobNotificationEventHandler :
                         Guid.Empty,
                         fileName,
                         $"Failed{stepText}: {errorMessage}"),
-                    DeepLinkPath = "/admin/knowledge-base/queue"
+                    DeepLinkPath = "/admin/knowledge-base/queue",
+                    // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                    SourceEventId = sourceEventId
                 }, cancellationToken).ConfigureAwait(false);
             }
 

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/RateLimitApproachingHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/RateLimitApproachingHandler.cs
@@ -55,7 +55,9 @@ internal sealed class RateLimitApproachingHandler : INotificationHandler<ShareRe
                         "Approaching Monthly Limit",
                         $"You've used {status.CurrentMonthlyCount} of your {status.EffectiveMaxPerMonth} monthly share requests. " +
                         $"Your limit resets on {status.MonthResetAt:MMMM d}."),
-                    DeepLinkPath = "/contributions"
+                    DeepLinkPath = "/contributions",
+                    // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                    SourceEventId = notification.EventId
                 }, cancellationToken).ConfigureAwait(false);
 
                 _logger.LogInformation(
@@ -77,7 +79,9 @@ internal sealed class RateLimitApproachingHandler : INotificationHandler<ShareRe
                         "Approaching Pending Limit",
                         $"You have {status.CurrentPendingCount} pending requests. " +
                         $"You can have up to {status.EffectiveMaxPending} pending at once."),
-                    DeepLinkPath = "/contributions/requests?status=pending"
+                    DeepLinkPath = "/contributions/requests?status=pending",
+                    // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                    SourceEventId = notification.EventId
                 }, cancellationToken).ConfigureAwait(false);
 
                 _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestApprovedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestApprovedNotificationHandler.cs
@@ -109,7 +109,9 @@ internal sealed class ShareRequestApprovedNotificationHandler
                 user.DisplayName,
                 gameTitle,
                 sourceGame.ImageUrl),
-            DeepLinkPath = $"/shared-games/{targetSharedGameId}"
+            DeepLinkPath = $"/shared-games/{targetSharedGameId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = domainEvent.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestChangesRequestedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestChangesRequestedNotificationHandler.cs
@@ -82,7 +82,9 @@ internal sealed class ShareRequestChangesRequestedNotificationHandler
                 user.DisplayName,
                 gameTitle,
                 sourceGame.ImageUrl),
-            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}"
+            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = domainEvent.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestCreatedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestCreatedNotificationHandler.cs
@@ -82,7 +82,9 @@ internal sealed class ShareRequestCreatedNotificationHandler
                 user.DisplayName,
                 gameTitle,
                 sourceGame.ImageUrl),
-            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}"
+            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = domainEvent.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestRejectedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestRejectedNotificationHandler.cs
@@ -82,7 +82,9 @@ internal sealed class ShareRequestRejectedNotificationHandler
                 user.DisplayName,
                 gameTitle,
                 sourceGame.ImageUrl),
-            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}"
+            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = domainEvent.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestReviewStartedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/ShareRequestReviewStartedNotificationHandler.cs
@@ -84,7 +84,9 @@ internal sealed class ShareRequestReviewStartedNotificationHandler
                 user.DisplayName,
                 gameTitle,
                 sourceGame.ImageUrl),
-            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}"
+            DeepLinkPath = $"/contributions/requests/{domainEvent.ShareRequestId}",
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = domainEvent.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/SharedGameIndexingAdminNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/SharedGameIndexingAdminNotificationHandler.cs
@@ -66,7 +66,9 @@ internal sealed class SharedGameIndexingAdminNotificationHandler
                 chunkCount = evt.ChunkCount,
                 pdfDocumentId = evt.PdfDocumentId,
                 isSharedGame = true
-            }
+            },
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/SharedGameSubmittedForApprovalNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/SharedGameSubmittedForApprovalNotificationHandler.cs
@@ -85,7 +85,9 @@ internal sealed class SharedGameSubmittedForApprovalNotificationHandler
                 Payload = new GenericPayload(
                     "New Game Submitted for Approval",
                     $"{submitter.DisplayName} submitted \"{game.Title}\" for approval."),
-                DeepLinkPath = $"/admin/approval-queue?gameId={domainEvent.GameId}"
+                DeepLinkPath = $"/admin/approval-queue?gameId={domainEvent.GameId}",
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = domainEvent.EventId
             }, cancellationToken).ConfigureAwait(false);
         }
 

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/UserSuspendedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/UserSuspendedEventHandler.cs
@@ -55,7 +55,9 @@ internal sealed class UserSuspendedEventHandler : INotificationHandler<UserSuspe
                 Payload = new GenericPayload(
                     "Account Suspended",
                     $"Your account has been suspended. Reason: {notification.Reason}"),
-                DeepLinkPath = "/account/suspended"
+                DeepLinkPath = "/account/suspended",
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/UserUnsuspendedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/UserUnsuspendedEventHandler.cs
@@ -55,7 +55,9 @@ internal sealed class UserUnsuspendedEventHandler : INotificationHandler<UserUns
                 Payload = new GenericPayload(
                     "Account Reactivated",
                     "Your account has been reactivated. Welcome back!"),
-                DeepLinkPath = "/dashboard"
+                DeepLinkPath = "/dashboard",
+                // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+                SourceEventId = notification.EventId
             }, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/VectorDocumentReadyNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/VectorDocumentReadyNotificationHandler.cs
@@ -41,7 +41,9 @@ internal sealed class VectorDocumentReadyNotificationHandler
                 Guid.Empty,
                 fileName,
                 $"Indexed ({chunkCount} chunks)"),
-            DeepLinkPath = agentLink
+            DeepLinkPath = agentLink,
+            // Issue #1937 / CF-1: propagate event id for dispatcher dedup
+            SourceEventId = evt.EventId
         }, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/INotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/INotificationDispatcher.cs
@@ -13,6 +13,16 @@ internal record NotificationMessage
     /// Used to carry subtype context (e.g. hours_before for game_night_reminder).
     /// </summary>
     public object? Metadata { get; init; }
+    /// <summary>
+    /// Optional source domain event id used to dedupe at the dispatcher level (issue #1937 / CF-1).
+    /// When set, the dispatcher short-circuits if a Notification with the same SourceEventId already
+    /// exists for the recipient. Callers that fan out from a domain event handler MUST set this to
+    /// <c>notification.EventId</c> so that re-dispatch (rollback-after-publish in #1535, retry on
+    /// transient MediatR errors, browser refresh during command) does not produce duplicate notifications,
+    /// emails, or Slack pings. When <c>null</c>, dispatcher falls back to legacy behavior (one row per
+    /// call, no dedup) — used by hand-triggered admin notifications without an originating event.
+    /// </summary>
+    public Guid? SourceEventId { get; init; }
 }
 
 internal interface INotificationDispatcher

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs
@@ -21,6 +21,14 @@ internal sealed class Notification : AggregateRoot<Guid>
     public DateTime? ReadAt { get; private set; }
     public Guid? CorrelationId { get; private set; }
 
+    /// <summary>
+    /// Optional source domain event id used to dedupe at the dispatcher level (issue #1937 / CF-1).
+    /// When set, the dispatcher / repository can short-circuit if a Notification with the same
+    /// SourceEventId already exists. See <c>NotificationMessage.SourceEventId</c> for the full
+    /// rationale and propagation contract.
+    /// </summary>
+    public Guid? SourceEventId { get; private set; }
+
 #pragma warning disable CS8618
     private Notification() : base() { }
 #pragma warning restore CS8618
@@ -37,6 +45,7 @@ internal sealed class Notification : AggregateRoot<Guid>
     /// <param name="link">Optional deep-link target (e.g., /chat/thread-id)</param>
     /// <param name="metadata">Optional JSON metadata for additional context</param>
     /// <param name="correlationId">Optional correlation ID for cross-channel tracking</param>
+    /// <param name="sourceEventId">Optional source domain event id for dispatcher-level dedup (#1937 / CF-1)</param>
     public Notification(
         Guid id,
         Guid userId,
@@ -46,7 +55,8 @@ internal sealed class Notification : AggregateRoot<Guid>
         string message,
         string? link = null,
         string? metadata = null,
-        Guid? correlationId = null)
+        Guid? correlationId = null,
+        Guid? sourceEventId = null)
         : base(id)
     {
         UserId = userId;
@@ -59,6 +69,7 @@ internal sealed class Notification : AggregateRoot<Guid>
         Link = link;
         Metadata = metadata;
         CorrelationId = correlationId;
+        SourceEventId = sourceEventId;
         IsRead = false;
         CreatedAt = DateTime.UtcNow;
         ReadAt = null;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationQueueItem.cs
@@ -33,6 +33,14 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
     public Guid CorrelationId { get; private set; }
     public string? DeepLinkPath { get; private set; }
 
+    /// <summary>
+    /// Optional source domain event id used to dedupe at the dispatcher level (issue #1937 / CF-1).
+    /// When set together with <see cref="ChannelType"/> + <see cref="RecipientUserId"/>, the repository
+    /// can short-circuit if an existing queue item is already enqueued for the same channel/recipient/event.
+    /// See <c>NotificationMessage.SourceEventId</c> for the full rationale and propagation contract.
+    /// </summary>
+    public Guid? SourceEventId { get; private set; }
+
 #pragma warning disable CS8618
     private NotificationQueueItem() : base() { }
 #pragma warning restore CS8618
@@ -47,7 +55,8 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         string? slackTeamId,
         Guid correlationId,
         DateTime? createdAt = null,
-        string? deepLinkPath = null)
+        string? deepLinkPath = null,
+        Guid? sourceEventId = null)
         : base(id)
     {
         ChannelType = channelType ?? throw new ArgumentNullException(nameof(channelType));
@@ -65,6 +74,7 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         ProcessedAt = null;
         CorrelationId = correlationId;
         DeepLinkPath = deepLinkPath;
+        SourceEventId = sourceEventId;
     }
 
     /// <summary>
@@ -79,7 +89,8 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         string? slackTeamId = null,
         Guid? correlationId = null,
         DateTime? createdAt = null,
-        string? deepLinkPath = null)
+        string? deepLinkPath = null,
+        Guid? sourceEventId = null)
     {
         return new NotificationQueueItem(
             Guid.NewGuid(),
@@ -91,7 +102,8 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
             slackTeamId,
             correlationId ?? Guid.NewGuid(),
             createdAt,
-            deepLinkPath);
+            deepLinkPath,
+            sourceEventId);
     }
 
     /// <summary>
@@ -199,13 +211,15 @@ internal sealed class NotificationQueueItem : AggregateRoot<Guid>
         DateTime createdAt,
         DateTime? processedAt,
         Guid correlationId,
-        string? deepLinkPath = null)
+        string? deepLinkPath = null,
+        Guid? sourceEventId = null)
     {
         var item = new NotificationQueueItem(
             id, channelType, recipientUserId, notificationType,
             payload, slackChannelTarget, slackTeamId, correlationId,
             createdAt: createdAt,
-            deepLinkPath: deepLinkPath);
+            deepLinkPath: deepLinkPath,
+            sourceEventId: sourceEventId);
         item.Status = status;
         item.RetryCount = retryCount;
         item.MaxRetries = maxRetries;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
@@ -35,9 +35,11 @@ internal interface INotificationRepository : IRepository<Notification, Guid>
     Task<int> MarkAllAsReadAsync(Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns <c>true</c> when a Notification already exists for the given source domain event id
-    /// (issue #1937 / CF-1). Used by <c>NotificationDispatcher</c> to short-circuit re-dispatch
-    /// from a retried/rolled-back event handler — see <c>NotificationMessage.SourceEventId</c>.
+    /// Returns <c>true</c> when a Notification already exists for the given (user, source domain event id)
+    /// pair (issue #1937 / CF-1). Scoped per-user so a fan-out event (e.g. notify-all-admins) can
+    /// legitimately produce N Notifications — one per recipient — while still blocking same-user
+    /// re-dispatch on retry. Used by <c>NotificationDispatcher</c> to short-circuit duplicate dispatch
+    /// — see <c>NotificationMessage.SourceEventId</c>.
     /// </summary>
-    Task<bool> ExistsBySourceEventIdAsync(Guid sourceEventId, CancellationToken cancellationToken = default);
+    Task<bool> ExistsBySourceEventIdAsync(Guid userId, Guid sourceEventId, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
@@ -33,4 +33,11 @@ internal interface INotificationRepository : IRepository<Notification, Guid>
     /// Bulk update operation for "clear all" functionality.
     /// </summary>
     Task<int> MarkAllAsReadAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns <c>true</c> when a Notification already exists for the given source domain event id
+    /// (issue #1937 / CF-1). Used by <c>NotificationDispatcher</c> to short-circuit re-dispatch
+    /// from a retried/rolled-back event handler — see <c>NotificationMessage.SourceEventId</c>.
+    /// </summary>
+    Task<bool> ExistsBySourceEventIdAsync(Guid sourceEventId, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
@@ -131,7 +131,8 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             CreatedAt = item.CreatedAt,
             ProcessedAt = item.ProcessedAt,
             CorrelationId = item.CorrelationId,
-            DeepLinkPath = item.DeepLinkPath
+            DeepLinkPath = item.DeepLinkPath,
+            SourceEventId = item.SourceEventId
         };
     }
 
@@ -153,6 +154,7 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             createdAt: entity.CreatedAt,
             processedAt: entity.ProcessedAt,
             correlationId: entity.CorrelationId,
-            deepLinkPath: entity.DeepLinkPath);
+            deepLinkPath: entity.DeepLinkPath,
+            sourceEventId: entity.SourceEventId);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
@@ -132,6 +132,14 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
             .AnyAsync(n => n.Id == id, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
+    public async Task<bool> ExistsBySourceEventIdAsync(Guid sourceEventId, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<NotificationEntity>()
+            .AsNoTracking()
+            .AnyAsync(n => n.SourceEventId == sourceEventId, cancellationToken).ConfigureAwait(false);
+    }
+
     // Domain → Persistence mapping
     private static NotificationEntity MapToPersistence(Notification notification)
     {
@@ -148,7 +156,8 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
             IsRead = notification.IsRead,
             CreatedAt = notification.CreatedAt,
             ReadAt = notification.ReadAt,
-            CorrelationId = notification.CorrelationId
+            CorrelationId = notification.CorrelationId,
+            SourceEventId = notification.SourceEventId
         };
     }
 
@@ -181,7 +190,8 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
             message: entity.Message,
             link: entity.Link,
             metadata: entity.Metadata,
-            correlationId: entity.CorrelationId
+            correlationId: entity.CorrelationId,
+            sourceEventId: entity.SourceEventId
         );
 
         // Restore read status with original timestamp (not MarkAsRead which overwrites)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
@@ -133,11 +133,11 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
     }
 
     /// <inheritdoc />
-    public async Task<bool> ExistsBySourceEventIdAsync(Guid sourceEventId, CancellationToken cancellationToken = default)
+    public async Task<bool> ExistsBySourceEventIdAsync(Guid userId, Guid sourceEventId, CancellationToken cancellationToken = default)
     {
         return await DbContext.Set<NotificationEntity>()
             .AsNoTracking()
-            .AnyAsync(n => n.SourceEventId == sourceEventId, cancellationToken).ConfigureAwait(false);
+            .AnyAsync(n => n.UserId == userId && n.SourceEventId == sourceEventId, cancellationToken).ConfigureAwait(false);
     }
 
     // Domain → Persistence mapping

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -40,14 +40,17 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
 
     public async Task DispatchAsync(NotificationMessage message, CancellationToken ct = default)
     {
-        // Issue #1937 / CF-1: short-circuit if a Notification already exists for the same domain event.
-        // Guards against duplicate notifications when the calling event handler is re-dispatched
-        // (rolled-back outer tx in #1535, MediatR transient retry, hand-replay). When SourceEventId
+        // Issue #1937 / CF-1: short-circuit if a Notification already exists for the same
+        // (recipient, source domain event) pair. Guards against duplicate notifications when the
+        // calling event handler is re-dispatched (rolled-back outer tx in #1535, MediatR transient
+        // retry, hand-replay). Per-user scoping preserves legitimate fan-out from a single event
+        // (e.g. notify-all-admins): each admin gets their own Notification row, all sharing the
+        // same SourceEventId but distinct (user_id, source_event_id) UNIQUE pairs. When SourceEventId
         // is null the dispatcher falls back to legacy behavior (no dedup) — used by hand-triggered
         // admin notifications without an originating domain event.
         if (message.SourceEventId is Guid sourceEventId)
         {
-            if (await _notificationRepository.ExistsBySourceEventIdAsync(sourceEventId, ct).ConfigureAwait(false))
+            if (await _notificationRepository.ExistsBySourceEventIdAsync(message.RecipientUserId, sourceEventId, ct).ConfigureAwait(false))
             {
                 _logger.LogInformation(
                     "Skipping duplicate notification dispatch: user={UserId}, type={Type}, sourceEventId={SourceEventId} (already dispatched)",

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -40,6 +40,22 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
 
     public async Task DispatchAsync(NotificationMessage message, CancellationToken ct = default)
     {
+        // Issue #1937 / CF-1: short-circuit if a Notification already exists for the same domain event.
+        // Guards against duplicate notifications when the calling event handler is re-dispatched
+        // (rolled-back outer tx in #1535, MediatR transient retry, hand-replay). When SourceEventId
+        // is null the dispatcher falls back to legacy behavior (no dedup) — used by hand-triggered
+        // admin notifications without an originating domain event.
+        if (message.SourceEventId is Guid sourceEventId)
+        {
+            if (await _notificationRepository.ExistsBySourceEventIdAsync(sourceEventId, ct).ConfigureAwait(false))
+            {
+                _logger.LogInformation(
+                    "Skipping duplicate notification dispatch: user={UserId}, type={Type}, sourceEventId={SourceEventId} (already dispatched)",
+                    message.RecipientUserId, message.Type, sourceEventId);
+                return;
+            }
+        }
+
         var correlationId = Guid.NewGuid();
 
         // 1. Always create in-app notification
@@ -56,7 +72,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             message: message.Payload.ToString() ?? string.Empty,
             link: message.DeepLinkPath,
             metadata: metadataJson,
-            correlationId: correlationId);
+            correlationId: correlationId,
+            sourceEventId: message.SourceEventId);
 
         await _notificationRepository.AddAsync(notification, ct).ConfigureAwait(false);
 
@@ -90,7 +107,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
                     notificationType: message.Type,
                     payload: message.Payload,
                     correlationId: correlationId,
-                    deepLinkPath: message.DeepLinkPath);
+                    deepLinkPath: message.DeepLinkPath,
+                    sourceEventId: message.SourceEventId);
 
                 queueItems.Add(emailItem);
 
@@ -120,7 +138,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
                         slackChannelTarget: slackConnection.DmChannelId,
                         slackTeamId: slackConnection.SlackTeamId,
                         correlationId: correlationId,
-                        deepLinkPath: message.DeepLinkPath);
+                        deepLinkPath: message.DeepLinkPath,
+                        sourceEventId: message.SourceEventId);
 
                     queueItems.Add(slackItem);
 
@@ -153,7 +172,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
                         slackChannelTarget: settings.WebhookUrl,
                         slackTeamId: teamId,
                         correlationId: correlationId,
-                        deepLinkPath: message.DeepLinkPath);
+                        deepLinkPath: message.DeepLinkPath,
+                        sourceEventId: message.SourceEventId);
 
                     queueItems.Add(teamItem);
 

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationEntity.cs
@@ -93,4 +93,12 @@ public class NotificationEntity
     /// </summary>
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Optional source domain event id used to dedupe at the dispatcher level (issue #1937 / CF-1).
+    /// UNIQUE (partial — only when not null) so that re-dispatch from a retried/rolled-back event
+    /// handler does not insert duplicate notification rows.
+    /// </summary>
+    [Column("source_event_id")]
+    public Guid? SourceEventId { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationQueueEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationQueueEntity.cs
@@ -78,4 +78,13 @@ public class NotificationQueueEntity
     [MaxLength(500)]
     [Column("deep_link_path")]
     public string? DeepLinkPath { get; set; }
+
+    /// <summary>
+    /// Optional source domain event id used to dedupe at the dispatcher level (issue #1937 / CF-1).
+    /// Composite UNIQUE (channel_type, recipient_user_id, source_event_id) (partial — only when not null)
+    /// so that re-dispatch from a retried/rolled-back event handler does not enqueue duplicate
+    /// per-channel deliveries (email, Slack DM, Slack team).
+    /// </summary>
+    [Column("source_event_id")]
+    public Guid? SourceEventId { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs
@@ -35,12 +35,16 @@ internal class NotificationEntityConfiguration : IEntityTypeConfiguration<Notifi
             .HasDatabaseName("IX_notifications_correlation_id")
             .HasFilter("correlation_id IS NOT NULL");
 
-        // Issue #1937 / CF-1: SourceEventId UNIQUE (partial — only when not null).
+        // Issue #1937 / CF-1: composite UNIQUE (user_id, source_event_id) — partial (only when not null).
         // Guards against duplicate notifications when an event handler is re-dispatched
         // (rolled-back outer tx in #1535, MediatR transient retry, hand-replay).
-        builder.HasIndex(e => e.SourceEventId)
+        // Composite scope (vs single-column UNIQUE on source_event_id) because a single domain event
+        // can legitimately fan out to multiple users — e.g. SharedGameSubmittedForApprovalEvent →
+        // 1 Notification per admin. The (user_id, source_event_id) pair preserves cross-user fan-out
+        // while still blocking same-user re-dispatch from a retried/rolled-back handler.
+        builder.HasIndex(e => new { e.UserId, e.SourceEventId })
             .IsUnique()
-            .HasDatabaseName("UX_notifications_source_event_id")
+            .HasDatabaseName("UX_notifications_user_source_event_id")
             .HasFilter("source_event_id IS NOT NULL");
 
         // Critical indexes for notification queries (Issue #2053 code review)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs
@@ -28,11 +28,20 @@ internal class NotificationEntityConfiguration : IEntityTypeConfiguration<Notifi
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.ReadAt).HasColumnName("read_at");
         builder.Property(e => e.CorrelationId).HasColumnName("correlation_id");
+        builder.Property(e => e.SourceEventId).HasColumnName("source_event_id");
 
         // CorrelationId index for cross-channel tracking
         builder.HasIndex(e => e.CorrelationId)
             .HasDatabaseName("IX_notifications_correlation_id")
             .HasFilter("correlation_id IS NOT NULL");
+
+        // Issue #1937 / CF-1: SourceEventId UNIQUE (partial — only when not null).
+        // Guards against duplicate notifications when an event handler is re-dispatched
+        // (rolled-back outer tx in #1535, MediatR transient retry, hand-replay).
+        builder.HasIndex(e => e.SourceEventId)
+            .IsUnique()
+            .HasDatabaseName("UX_notifications_source_event_id")
+            .HasFilter("source_event_id IS NOT NULL");
 
         // Critical indexes for notification queries (Issue #2053 code review)
         // Primary query: get user notifications ordered by creation date

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationQueueEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationQueueEntityConfiguration.cs
@@ -47,5 +47,16 @@ internal class NotificationQueueEntityConfiguration : IEntityTypeConfiguration<N
         builder.HasIndex(e => new { e.RecipientUserId, e.CreatedAt })
             .HasDatabaseName("IX_notification_queue_items_recipient_user_id_created_at")
             .IsDescending(false, true);
+
+        builder.Property(e => e.SourceEventId).HasColumnName("source_event_id");
+
+        // Issue #1937 / CF-1: composite UNIQUE (channel_type, recipient_user_id, source_event_id) — partial.
+        // Guards against duplicate per-channel queue items when an event handler is re-dispatched.
+        // Composite (vs single-column UNIQUE on source_event_id) because a single domain event can
+        // legitimately fan out to multiple channels (Email + Slack DM + Slack team) for the same recipient.
+        builder.HasIndex(e => new { e.ChannelType, e.RecipientUserId, e.SourceEventId })
+            .IsUnique()
+            .HasDatabaseName("UX_notification_queue_items_channel_recipient_source_event")
+            .HasFilter("source_event_id IS NOT NULL");
     }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606060656_AddSourceEventIdToNotifications_CF1.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606060656_AddSourceEventIdToNotifications_CF1.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606060656_AddSourceEventIdToNotifications_CF1")]
+    partial class AddSourceEventIdToNotifications_CF1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606060656_AddSourceEventIdToNotifications_CF1.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606060656_AddSourceEventIdToNotifications_CF1.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSourceEventIdToNotifications_CF1 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "source_event_id",
+                table: "notifications",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "source_event_id",
+                table: "notification_queue_items",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_notifications_source_event_id",
+                table: "notifications",
+                column: "source_event_id",
+                unique: true,
+                filter: "source_event_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_notification_queue_items_channel_recipient_source_event",
+                table: "notification_queue_items",
+                columns: new[] { "channel_type", "recipient_user_id", "source_event_id" },
+                unique: true,
+                filter: "source_event_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_notifications_source_event_id",
+                table: "notifications");
+
+            migrationBuilder.DropIndex(
+                name: "UX_notification_queue_items_channel_recipient_source_event",
+                table: "notification_queue_items");
+
+            migrationBuilder.DropColumn(
+                name: "source_event_id",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "source_event_id",
+                table: "notification_queue_items");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606065305_RefineNotificationSourceEventIdUniqueScope_CF1.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606065305_RefineNotificationSourceEventIdUniqueScope_CF1.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606065305_RefineNotificationSourceEventIdUniqueScope_CF1")]
+    partial class RefineNotificationSourceEventIdUniqueScope_CF1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606065305_RefineNotificationSourceEventIdUniqueScope_CF1.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606065305_RefineNotificationSourceEventIdUniqueScope_CF1.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefineNotificationSourceEventIdUniqueScope_CF1 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_notifications_source_event_id",
+                table: "notifications");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_notifications_user_source_event_id",
+                table: "notifications",
+                columns: new[] { "user_id", "source_event_id" },
+                unique: true,
+                filter: "source_event_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_notifications_user_source_event_id",
+                table: "notifications");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_notifications_source_event_id",
+                table: "notifications",
+                column: "source_event_id",
+                unique: true,
+                filter: "source_event_id IS NOT NULL");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
@@ -388,4 +388,111 @@ public class NotificationDispatcherTests
         capturedItems?.Any(i => i.ChannelType == NotificationChannelType.SlackUser)
             .Should().BeFalse($"admin type '{typeValue}' should not be delivered via Slack DM");
     }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Issue #1937 / CF-1 — SourceEventId idempotency
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DispatchAsync_WithSourceEventId_ShortCircuits_WhenAlreadyDispatched()
+    {
+        // Arrange — repo reports an existing notification for this source event id
+        var sourceEventId = Guid.NewGuid();
+        var message = CreateMessage() with { SourceEventId = sourceEventId };
+
+        _notificationRepoMock
+            .Setup(r => r.ExistsBySourceEventIdAsync(sourceEventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — no AddAsync, no AddRangeAsync (dispatcher short-circuited)
+        _notificationRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _queueRepoMock.Verify(
+            r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithSourceEventId_PropagatesIdToNotification_WhenNotYetDispatched()
+    {
+        // Arrange — repo reports no prior notification for this source event id
+        var sourceEventId = Guid.NewGuid();
+        var message = CreateMessage() with { SourceEventId = sourceEventId };
+
+        _notificationRepoMock
+            .Setup(r => r.ExistsBySourceEventIdAsync(sourceEventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — Notification persisted with SourceEventId = the one from the message
+        _notificationRepoMock.Verify(
+            r => r.AddAsync(
+                It.Is<Notification>(n => n.SourceEventId == sourceEventId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithSourceEventId_PropagatesIdToQueueItems_WhenNotYetDispatched()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+        var message = CreateMessage(recipientUserId: userId) with { SourceEventId = sourceEventId };
+
+        _notificationRepoMock
+            .Setup(r => r.ExistsBySourceEventIdAsync(sourceEventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _prefsRepoMock
+            .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotificationPreferences(userId));
+
+        IEnumerable<NotificationQueueItem>? capturedItems = null;
+        _queueRepoMock
+            .Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<NotificationQueueItem>, CancellationToken>((items, _) => capturedItems = items)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — every persisted queue item carries the SourceEventId from the message
+        capturedItems.Should().NotBeNull();
+        capturedItems!.Should().NotBeEmpty();
+        capturedItems!.All(i => i.SourceEventId == sourceEventId).Should().BeTrue(
+            "every queue item must carry the source event id so the composite UNIQUE constraint can dedupe at the DB level");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithoutSourceEventId_FallsBackToLegacyBehavior_NoDedupLookup()
+    {
+        // Arrange — message has no SourceEventId; repo should NOT be queried for ExistsBy
+        var message = CreateMessage();
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — ExistsBySourceEventIdAsync never invoked; AddAsync fires once
+        _notificationRepoMock.Verify(
+            r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _notificationRepoMock.Verify(
+            r => r.AddAsync(
+                It.Is<Notification>(n => n.SourceEventId == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
@@ -401,7 +401,7 @@ public class NotificationDispatcherTests
         var message = CreateMessage() with { SourceEventId = sourceEventId };
 
         _notificationRepoMock
-            .Setup(r => r.ExistsBySourceEventIdAsync(sourceEventId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), sourceEventId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var sut = CreateSut();
@@ -426,7 +426,7 @@ public class NotificationDispatcherTests
         var message = CreateMessage() with { SourceEventId = sourceEventId };
 
         _notificationRepoMock
-            .Setup(r => r.ExistsBySourceEventIdAsync(sourceEventId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), sourceEventId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         var sut = CreateSut();
@@ -451,7 +451,7 @@ public class NotificationDispatcherTests
         var message = CreateMessage(recipientUserId: userId) with { SourceEventId = sourceEventId };
 
         _notificationRepoMock
-            .Setup(r => r.ExistsBySourceEventIdAsync(sourceEventId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), sourceEventId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _prefsRepoMock
             .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
@@ -487,7 +487,7 @@ public class NotificationDispatcherTests
 
         // Assert — ExistsBySourceEventIdAsync never invoked; AddAsync fires once
         _notificationRepoMock.Verify(
-            r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _notificationRepoMock.Verify(
             r => r.AddAsync(


### PR DESCRIPTION
## Summary

Implementa **CF-1** dei 3 cross-cutting fix individuati nell'audit del Task 0 di #1535 (vedi [`audits/2026-06-06-issue-1535-consumer-idempotency-audit.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/issue-1535-event-outbox-dispatch/audits/2026-06-06-issue-1535-consumer-idempotency-audit.md)). Chiude **22 BLOCKER** nel BC UserNotifications + 5 inline notification creators con una singola modifica al dispatcher.

Risolve issue **#1937**.

## Problem

`NotificationDispatcher.DispatchAsync:50` genera `Guid.NewGuid()` ad ogni call senza dedup by `EventId`. Quando il domain event collector flush avviene 2 volte (rollback after publish + retry, oppure cutover in #1535 Phase B), il dispatcher crea **2 Notification rows + 2 NotificationQueueItem per canale** (Email, Slack DM, Slack team). User-visible: notifica doppia + email doppia + Slack ping doppio.

## Solution

- `NotificationMessage` ottiene optional `Guid? SourceEventId` (init-only).
- `Notification` aggregate + `NotificationQueueItem` aggregate ottengono `Guid? SourceEventId` private setter.
- Migration `AddSourceEventIdToNotifications_CF1`:
  - `source_event_id UUID NULL` su `notifications` + `notification_queue_items`
  - UNIQUE partial index su `notifications.source_event_id`
  - UNIQUE composite `(channel_type, recipient_user_id, source_event_id)` su queue (partial)
- `INotificationRepository.ExistsBySourceEventIdAsync` + impl
- `NotificationDispatcher.DispatchAsync`:
  - Short-circuit early-exit se `SourceEventId.HasValue && _notificationRepository.ExistsBySourceEventIdAsync(eventId)`
  - Propaga `SourceEventId` a Notification + tutti i NotificationQueueItem (Email + Slack DM + Slack team)
- `NotifyAgentReadyHandler`: primo caller updated come pattern example (propaga `notification.EventId → message.SourceEventId`)

## Test plan

- [x] Backend build clean (0 errori, 185 warning preesistenti)
- [x] Frontend build verified (pre-push gate)
- [x] **29/29 NotificationDispatcherTests verdi** (4 nuovi + 25 esistenti)
  - `DispatchAsync_WithSourceEventId_ShortCircuits_WhenAlreadyDispatched`
  - `DispatchAsync_WithSourceEventId_PropagatesIdToNotification_WhenNotYetDispatched`
  - `DispatchAsync_WithSourceEventId_PropagatesIdToQueueItems_WhenNotYetDispatched`
  - `DispatchAsync_WithoutSourceEventId_FallsBackToLegacyBehavior_NoDedupLookup`
- [ ] Integration test (Testcontainers): UNIQUE violation handled gracefully — TODO sub-task
- [ ] 21 caller updates restanti + 5 inline creators (CircuitBreakerStateChangedEventHandler, ModelDeprecatedNotificationHandler×2, GameSessionTerminatedEventHandler, etc.) — TODO sub-task in this PR
- [ ] Code review

## Backward compat

`SourceEventId` è nullable. I caller esistenti che NON propagano `EventId` continuano a funzionare nella legacy behavior (no dedup lookup, dispatch once per call). Identificato e documentato nei doc-comment di `NotificationMessage.SourceEventId`.

## Why standalone (no dependency on #1535)

Migliora idempotency **anche pre-#1535**. Oggi il dispatcher può duplicare notifiche su:
- Retry MediatR transient errors
- Browser refresh during command (idempotent commands)
- Rollback-after-publish bug (the original #1535 motivation)

Fix indipendente, ship ASAP. Phase B cutover di #1535 è gated su questo + CF-2 + CF-3 + 3 isolated + n8n contract.

## Follow-up

Open: 21 caller updates restanti per propagation completa. Posso aggiungerli a questo PR in commit successivi o spliterli in PR follow-up — preferenza?

🤖 Generated with [Claude Code](https://claude.com/claude-code)