### PR TITLE
feat(events): #1939 CF-3 — reaction handlers no-counter via LastProcessedEventId

### DIFF
--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/EventHandlers/OnDisputeOverriddenAddHouseRuleHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/EventHandlers/OnDisputeOverriddenAddHouseRuleHandler.cs
@@ -64,11 +64,22 @@ internal sealed class OnDisputeOverriddenAddHouseRuleHandler : INotificationHand
         {
             gameMemory = GameMemory.Create(gameId, ownerId);
             gameMemory.AddHouseRule(notification.OverrideRule, HouseRuleSource.DisputeOverride);
+            gameMemory.MarkProcessed(notification.EventId);  // CF-3 / #1939
             await _gameMemoryRepo.AddAsync(gameMemory, cancellationToken).ConfigureAwait(false);
+        }
+        else if (gameMemory.LastProcessedEventId == notification.EventId)
+        {
+            // CF-3 / #1939: handler re-dispatched on a rolled-back / retried event —
+            // house rule already appended, skip to avoid duplicate entry.
+            _logger.LogDebug(
+                "Skipping AddHouseRule for game {GameId}, owner {OwnerId}: event {EventId} already processed",
+                gameId, ownerId, notification.EventId);
+            return;
         }
         else
         {
             gameMemory.AddHouseRule(notification.OverrideRule, HouseRuleSource.DisputeOverride);
+            gameMemory.MarkProcessed(notification.EventId);  // CF-3 / #1939
             await _gameMemoryRepo.UpdateAsync(gameMemory, cancellationToken).ConfigureAwait(false);
         }
 

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/EventHandlers/OnSessionCompletedUpdateStatsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/EventHandlers/OnSessionCompletedUpdateStatsHandler.cs
@@ -74,11 +74,21 @@ internal sealed class OnSessionCompletedUpdateStatsHandler : INotificationHandle
                 {
                     memory = PlayerMemory.CreateForUser(player.UserId.Value);
                     memory.UpdateGameStats(gameId, won, player.TotalScore);
+                    memory.MarkProcessed(notification.EventId);  // CF-3 / #1939
                     await _playerMemoryRepo.AddAsync(memory, cancellationToken).ConfigureAwait(false);
+                }
+                else if (memory.LastProcessedEventId == notification.EventId)
+                {
+                    // CF-3 / #1939: handler is re-dispatched on a rolled-back / retried event
+                    // — stats already updated for this player, skip to avoid double-increment.
+                    _logger.LogDebug(
+                        "Skipping stats update for player {UserId} on session {SessionId}: event {EventId} already processed",
+                        player.UserId.Value, notification.SessionId, notification.EventId);
                 }
                 else
                 {
                     memory.UpdateGameStats(gameId, won, player.TotalScore);
+                    memory.MarkProcessed(notification.EventId);  // CF-3 / #1939
                     await _playerMemoryRepo.UpdateAsync(memory, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -92,11 +102,19 @@ internal sealed class OnSessionCompletedUpdateStatsHandler : INotificationHandle
                 {
                     memory = PlayerMemory.CreateForGuest(player.DisplayName);
                     memory.UpdateGameStats(gameId, won, player.TotalScore);
+                    memory.MarkProcessed(notification.EventId);  // CF-3 / #1939
                     await _playerMemoryRepo.AddAsync(memory, cancellationToken).ConfigureAwait(false);
+                }
+                else if (memory.LastProcessedEventId == notification.EventId)
+                {
+                    _logger.LogDebug(
+                        "Skipping stats update for guest {GuestName} on session {SessionId}: event {EventId} already processed",
+                        player.DisplayName, notification.SessionId, notification.EventId);
                 }
                 else
                 {
                     memory.UpdateGameStats(gameId, won, player.TotalScore);
+                    memory.MarkProcessed(notification.EventId);  // CF-3 / #1939
                     await _playerMemoryRepo.UpdateAsync(memory, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -109,7 +127,14 @@ internal sealed class OnSessionCompletedUpdateStatsHandler : INotificationHandle
                 .GetByIdAsync(notification.GroupId.Value, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (group != null)
+            if (group != null && group.LastProcessedEventId == notification.EventId)
+            {
+                // CF-3 / #1939: re-dispatched event — group stats already updated.
+                _logger.LogDebug(
+                    "Skipping group stats update on session {SessionId}: event {EventId} already processed",
+                    notification.SessionId, notification.EventId);
+            }
+            else if (group != null)
             {
                 var stats = group.Stats ?? new GroupStats();
                 stats.TotalSessions++;
@@ -121,6 +146,7 @@ internal sealed class OnSessionCompletedUpdateStatsHandler : INotificationHandle
                 stats.LastPlayedAt = notification.CompletedAt;
 
                 group.UpdateStats(stats);
+                group.MarkProcessed(notification.EventId);  // CF-3 / #1939
                 await _groupMemoryRepo.UpdateAsync(group, cancellationToken).ConfigureAwait(false);
             }
             else

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GameMemory.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GameMemory.cs
@@ -26,6 +26,13 @@ internal sealed class GameMemory : AggregateRoot<Guid>
 
     public DateTime CreatedAt { get; private set; }
 
+    /// <summary>
+    /// Last domain event id processed against this aggregate (issue #1939 / CF-3).
+    /// Handlers MUST early-exit when this equals the incoming event id to avoid
+    /// appending the same HouseRule / GlossaryEntry / Note twice on a retried event.
+    /// </summary>
+    public Guid? LastProcessedEventId { get; private set; }
+
     /// <summary>EF Core constructor.</summary>
     private GameMemory() { }
 
@@ -96,5 +103,14 @@ internal sealed class GameMemory : AggregateRoot<Guid>
         }
 
         _glossaryEntries.Add(GlossaryEntry.Create(term, definition, language, source));
+    }
+
+    /// <summary>
+    /// Records which domain event has just been processed against this aggregate
+    /// (issue #1939 / CF-3). Used by handlers to short-circuit on re-dispatch.
+    /// </summary>
+    public void MarkProcessed(Guid eventId)
+    {
+        LastProcessedEventId = eventId;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GroupMemory.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GroupMemory.cs
@@ -18,6 +18,13 @@ internal sealed class GroupMemory : AggregateRoot<Guid>
     public GroupStats Stats { get; private set; } = new();
     public DateTime CreatedAt { get; private set; }
 
+    /// <summary>
+    /// Last domain event id processed against this aggregate (issue #1939 / CF-3).
+    /// Handlers MUST early-exit when this equals the incoming event id to avoid
+    /// double-incrementing GroupStats (TotalSessions, GamePlayCounts) on retry.
+    /// </summary>
+    public Guid? LastProcessedEventId { get; private set; }
+
     /// <summary>EF Core constructor.</summary>
     private GroupMemory() { }
 
@@ -67,5 +74,14 @@ internal sealed class GroupMemory : AggregateRoot<Guid>
     public void UpdateStats(GroupStats stats)
     {
         Stats = stats ?? throw new ArgumentNullException(nameof(stats));
+    }
+
+    /// <summary>
+    /// Records which domain event has just been processed against this aggregate
+    /// (issue #1939 / CF-3). Used by handlers to short-circuit on re-dispatch.
+    /// </summary>
+    public void MarkProcessed(Guid eventId)
+    {
+        LastProcessedEventId = eventId;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/PlayerMemory.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/PlayerMemory.cs
@@ -19,6 +19,13 @@ internal sealed class PlayerMemory : AggregateRoot<Guid>
     public DateTime? ClaimedAt { get; private set; }
     public DateTime CreatedAt { get; private set; }
 
+    /// <summary>
+    /// Last domain event id processed against this aggregate (issue #1939 / CF-3).
+    /// When set and equal to the incoming event id, handlers MUST early-exit to avoid
+    /// double-incrementing counters / stats on a retried/rolled-back event handler.
+    /// </summary>
+    public Guid? LastProcessedEventId { get; private set; }
+
     /// <summary>EF Core constructor.</summary>
     private PlayerMemory() { }
 
@@ -75,5 +82,14 @@ internal sealed class PlayerMemory : AggregateRoot<Guid>
         {
             _gameStats.Add(PlayerGameStats.Create(gameId, won, score));
         }
+    }
+
+    /// <summary>
+    /// Records which domain event has just been processed against this aggregate
+    /// (issue #1939 / CF-3). Used by handlers to short-circuit on re-dispatch.
+    /// </summary>
+    public void MarkProcessed(Guid eventId)
+    {
+        LastProcessedEventId = eventId;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/GameMemoryEntityConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/GameMemoryEntityConfiguration.cs
@@ -36,6 +36,10 @@ internal sealed class GameMemoryEntityConfiguration : IEntityTypeConfiguration<G
         builder.Property(e => e.UpdatedAt)
             .HasColumnName("updated_at");
 
+        // Issue #1939 / CF-3 — idempotency guard for OnDisputeOverriddenAddHouseRuleHandler
+        builder.Property(e => e.LastProcessedEventId)
+            .HasColumnName("last_processed_event_id");
+
         // --- JSON Columns ---
 
         builder.Property(e => e.HouseRulesJson)

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/GroupMemoryEntityConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/GroupMemoryEntityConfiguration.cs
@@ -37,6 +37,10 @@ internal sealed class GroupMemoryEntityConfiguration : IEntityTypeConfiguration<
         builder.Property(e => e.UpdatedAt)
             .HasColumnName("updated_at");
 
+        // Issue #1939 / CF-3 — idempotency guard for OnSessionCompletedUpdateStatsHandler
+        builder.Property(e => e.LastProcessedEventId)
+            .HasColumnName("last_processed_event_id");
+
         // --- JSON Columns ---
 
         builder.Property(e => e.MembersJson)

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/PlayerMemoryEntityConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Configurations/PlayerMemoryEntityConfiguration.cs
@@ -41,6 +41,10 @@ internal sealed class PlayerMemoryEntityConfiguration : IEntityTypeConfiguration
         builder.Property(e => e.UpdatedAt)
             .HasColumnName("updated_at");
 
+        // Issue #1939 / CF-3 — idempotency guard for OnSessionCompletedUpdateStatsHandler
+        builder.Property(e => e.LastProcessedEventId)
+            .HasColumnName("last_processed_event_id");
+
         // --- JSON Columns ---
 
         builder.Property(e => e.GameStatsJson)

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/GameMemoryEntity.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/GameMemoryEntity.cs
@@ -15,4 +15,9 @@ public class GameMemoryEntity
     public string? GlossaryEntriesJson { get; set; }  // JSONB
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Last domain event id processed against this aggregate (issue #1939 / CF-3).
+    /// </summary>
+    public Guid? LastProcessedEventId { get; set; }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/GroupMemoryEntity.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/GroupMemoryEntity.cs
@@ -14,4 +14,9 @@ public class GroupMemoryEntity
     public string? StatsJson { get; set; }  // JSONB
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Last domain event id processed against this aggregate (issue #1939 / CF-3).
+    /// </summary>
+    public Guid? LastProcessedEventId { get; set; }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/PlayerMemoryEntity.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Entities/PlayerMemoryEntity.cs
@@ -14,4 +14,9 @@ public class PlayerMemoryEntity
     public DateTime? ClaimedAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Last domain event id processed against this aggregate (issue #1939 / CF-3).
+    /// </summary>
+    public Guid? LastProcessedEventId { get; set; }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GameMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GameMemoryRepository.cs
@@ -73,6 +73,7 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
         // Restore Id and CreatedAt via reflection (factory generates new ones)
         SetPrivateProperty(memory, nameof(GameMemory.Id), entity.Id);
         SetPrivateProperty(memory, nameof(GameMemory.CreatedAt), entity.CreatedAt);
+        SetPrivateProperty(memory, nameof(GameMemory.LastProcessedEventId), entity.LastProcessedEventId);
 
         // Restore house rules from JSONB
         if (entity.HouseRulesJson != null)
@@ -155,6 +156,7 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
             GameId = memory.GameId,
             OwnerId = memory.OwnerId,
             CreatedAt = memory.CreatedAt,
+            LastProcessedEventId = memory.LastProcessedEventId,
         };
 
         // Serialize house rules to JSONB

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GroupMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GroupMemoryRepository.cs
@@ -104,6 +104,7 @@ internal sealed class GroupMemoryRepository : RepositoryBase, IGroupMemoryReposi
         // Restore Id and CreatedAt via reflection (factory generates new ones)
         SetPrivateProperty(memory, nameof(GroupMemory.Id), entity.Id);
         SetPrivateProperty(memory, nameof(GroupMemory.CreatedAt), entity.CreatedAt);
+        SetPrivateProperty(memory, nameof(GroupMemory.LastProcessedEventId), entity.LastProcessedEventId);
 
         // Restore members from JSONB
         if (entity.MembersJson != null)
@@ -173,6 +174,7 @@ internal sealed class GroupMemoryRepository : RepositoryBase, IGroupMemoryReposi
             Name = memory.Name,
             CreatorId = memory.CreatorId,
             CreatedAt = memory.CreatedAt,
+            LastProcessedEventId = memory.LastProcessedEventId,
         };
 
         // Serialize members to JSONB

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/PlayerMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/PlayerMemoryRepository.cs
@@ -126,6 +126,7 @@ internal sealed class PlayerMemoryRepository : RepositoryBase, IPlayerMemoryRepo
         SetPrivateProperty(memory, nameof(PlayerMemory.Id), entity.Id);
         SetPrivateProperty(memory, nameof(PlayerMemory.CreatedAt), entity.CreatedAt);
         SetPrivateProperty(memory, nameof(PlayerMemory.ClaimedAt), entity.ClaimedAt);
+        SetPrivateProperty(memory, nameof(PlayerMemory.LastProcessedEventId), entity.LastProcessedEventId);
 
         // For guest records that were later claimed, restore UserId
         // (CreateForGuest doesn't set UserId, but the entity might have it from a claim)
@@ -169,6 +170,7 @@ internal sealed class PlayerMemoryRepository : RepositoryBase, IPlayerMemoryRepo
             GroupId = memory.GroupId,
             ClaimedAt = memory.ClaimedAt,
             CreatedAt = memory.CreatedAt,
+            LastProcessedEventId = memory.LastProcessedEventId,
         };
 
         // Serialize game stats to JSONB

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Services;
@@ -22,17 +23,20 @@ internal sealed class GenerateAgentSummaryHandler : INotificationHandler<Session
     private const int MaxMessages = 50;
 
     private readonly IAgentDefinitionRepository _agentRepo;
+    private readonly IPauseSnapshotRepository _pauseSnapshotRepo;
     private readonly ILlmService _llmService;
     private readonly IPublisher _publisher;
     private readonly ILogger<GenerateAgentSummaryHandler> _logger;
 
     public GenerateAgentSummaryHandler(
         IAgentDefinitionRepository agentRepo,
+        IPauseSnapshotRepository pauseSnapshotRepo,
         ILlmService llmService,
         IPublisher publisher,
         ILogger<GenerateAgentSummaryHandler> logger)
     {
         _agentRepo = agentRepo ?? throw new ArgumentNullException(nameof(agentRepo));
+        _pauseSnapshotRepo = pauseSnapshotRepo ?? throw new ArgumentNullException(nameof(pauseSnapshotRepo));
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -44,6 +48,23 @@ internal sealed class GenerateAgentSummaryHandler : INotificationHandler<Session
 
         try
         {
+            // Issue #1939 / CF-3: pre-flight idempotency check — skip the (costly) LLM call
+            // if the PauseSnapshot already carries an agent summary. Guards against duplicate
+            // LLM cost when the event is re-dispatched on rollback-after-publish in #1535 or
+            // a MediatR transient retry. UpdateSnapshotSummaryHandler persists the summary in
+            // the same SaveChanges as the snapshot row, so this check is durable.
+            var snapshot = await _pauseSnapshotRepo
+                .GetByIdAsync(notification.PauseSnapshotId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (snapshot is { AgentConversationSummary: not null })
+            {
+                _logger.LogDebug(
+                    "GenerateAgentSummary: SnapshotId={SnapshotId} already has a summary; skipping LLM call (CF-3).",
+                    notification.PauseSnapshotId);
+                return;
+            }
+
             // 1. Load the agent definition (to get the agent's name/context for the prompt)
             var agentDefinition = await _agentRepo
                 .GetByIdAsync(notification.AgentDefinitionId, cancellationToken)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606082830_AddLastProcessedEventIdToMemoryTables_CF3.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606082830_AddLastProcessedEventIdToMemoryTables_CF3.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606082830_AddLastProcessedEventIdToMemoryTables_CF3")]
+    partial class AddLastProcessedEventIdToMemoryTables_CF3
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606082830_AddLastProcessedEventIdToMemoryTables_CF3.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606082830_AddLastProcessedEventIdToMemoryTables_CF3.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLastProcessedEventIdToMemoryTables_CF3 : Migration
+    {
+        // PR comment: questa migration è stata regenerata e poi RIPULITA manualmente per rimuovere
+        // le aggiunte `test_run_id` rilevate come drift di asse-d task B (#1928), shippato in
+        // main-dev SENZA migration corrispondente. Le colonne TestRunId sono incluse nella CF-2
+        // migration di PR #1946 (committed first); concorrente merge garantisce single application.
+        // Vedi PR comment per il tracker del drift.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_processed_event_id",
+                table: "player_memories",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_processed_event_id",
+                table: "group_memories",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_processed_event_id",
+                table: "game_memories",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_processed_event_id",
+                table: "player_memories");
+
+            migrationBuilder.DropColumn(
+                name: "last_processed_event_id",
+                table: "group_memories");
+
+            migrationBuilder.DropColumn(
+                name: "last_processed_event_id",
+                table: "game_memories");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandlerTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
@@ -30,6 +31,7 @@ public sealed class GenerateAgentSummaryHandlerTests
         "Quando avete messo in pausa la partita, il turno 5 era appena iniziato.";
 
     private readonly Mock<IAgentDefinitionRepository> _agentRepoMock;
+    private readonly Mock<IPauseSnapshotRepository> _pauseSnapshotRepoMock;
     private readonly Mock<ILlmService> _llmServiceMock;
     private readonly Mock<IPublisher> _publisherMock;
     private readonly GenerateAgentSummaryHandler _sut;
@@ -37,8 +39,14 @@ public sealed class GenerateAgentSummaryHandlerTests
     public GenerateAgentSummaryHandlerTests()
     {
         _agentRepoMock = new Mock<IAgentDefinitionRepository>();
+        _pauseSnapshotRepoMock = new Mock<IPauseSnapshotRepository>();
         _llmServiceMock = new Mock<ILlmService>();
         _publisherMock = new Mock<IPublisher>();
+
+        // CF-3 default: PauseSnapshot does NOT yet have a summary — handler runs the LLM call.
+        _pauseSnapshotRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot.PauseSnapshot?)null);
 
         // Default: agent definition returns null (not found is gracefully handled)
         _agentRepoMock
@@ -58,6 +66,7 @@ public sealed class GenerateAgentSummaryHandlerTests
 
         _sut = new GenerateAgentSummaryHandler(
             _agentRepoMock.Object,
+            _pauseSnapshotRepoMock.Object,
             _llmServiceMock.Object,
             _publisherMock.Object,
             NullLogger<GenerateAgentSummaryHandler>.Instance);


### PR DESCRIPTION
## Summary

Implementa **CF-3** dei 3 cross-cutting fix individuati nell'audit del Task 0 di #1535 (vedi [audit doc](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/issue-1535-event-outbox-dispatch/audits/2026-06-06-issue-1535-consumer-idempotency-audit.md) § "CF-3"). Chiude **3 BLOCKER P0**: stats inflation, LLM cost duplication, duplicate house rule append.

Risolve issue **#1939**. Standalone: migliora idempotency anche pre-#1535.

## 3 fix implementati + 1 SKIPPATO

### ⚠️ Fix 1 SKIPPATO — `AgentStateMapper.UpdateTurn` `+ 1` counter

Investigato: `GameManagement/Domain/Events/TurnAdvancedEvent` (handled da `AgentStateMapper.UpdateTurn`) NON ha publisher nel codebase. Solo l'omonimo `Application/Events/TurnAdvancedEvent` ha un raise (in `TurnOrderCommandHandlers:97`), ma ha signature diversa e non è consumed da AgentStateMapper.

→ **DEAD CODE**. Il bug del `currentTurn + 1` non riproducibile. Flag per cleanup separato.

### ✅ Fix 2 + 4 — Memory aggregates `LastProcessedEventId`

3 aggregate (PlayerMemory, GroupMemory, GameMemory) + 3 persistence entity + 3 EF config + 3 repository updated. Migration aggiunge `last_processed_event_id UUID NULL` su:
- `player_memories`
- `group_memories`
- `game_memories`

Handler updates:
- **`OnSessionCompletedUpdateStatsHandler`**: early-exit per-player + per-group quando `memory.LastProcessedEventId == notification.EventId`. Su path update: `MarkProcessed(eventId)` dopo `UpdateGameStats`.
- **`OnDisputeOverriddenAddHouseRuleHandler`**: early-exit + `MarkProcessed(eventId)` su create/update.

Chiude:
- `OnSessionCompletedUpdateStatsHandler` stats `++` (TotalSessions, GamePlayCounts, win/loss counters)
- `OnDisputeOverriddenAddHouseRuleHandler` `AddHouseRule(...)` duplicato

### ✅ Fix 3 — `GenerateAgentSummaryHandler` pre-check LLM cost

Aggiunto `IPauseSnapshotRepository` dependency. Pre-flight: se `snapshot.AgentConversationSummary is not null` → skip LLM call.

`UpdateSnapshotSummaryHandler` persiste il summary nella stessa `SaveChanges` della snapshot row, quindi il check è **durable** rispetto a un re-dispatch dopo crash. LLM cost ($) evitato su retry.

Test ctor updated con mock `IPauseSnapshotRepository`.

## Migration

`AddLastProcessedEventIdToMemoryTables_CF3` — 3 colonne nullable.

### Drift cleanup

EF Core ha rilevato anche le **5 colonne `test_run_id`** di asse-d task B (#1928) come drift di main-dev. **Manualmente rimosse** dalla migration: sono già nella CF-2 migration ([PR #1946](https://github.com/meepleAi-app/meepleai-monorepo/pull/1946)). Concurrent merge della prima vinta. Vedi commit message per il commento full.

## Test plan

- [x] Backend build clean (0 errori, 0 warning su `src/Api`)
- [x] Frontend build OK (pre-push gate)
- [x] **105/105 unit test verdi** (AgentMemory + GenerateAgentSummary handler filters)
- [ ] Code review
- [ ] Integration test: 2× fire stesso EventId → 1 update memory + 0 LLM call retry — TODO sub-task

## Backward compat

`LastProcessedEventId` è nullable, default null. Memory existing rows hanno `null` → primo handler fire applica update + MarkProcessed normally.

## Why standalone

Migliora idempotency **anche pre-#1535**. Bug latenti già reali oggi su retry MediatR transient errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)