### PR TITLE
feat(events): #1940 iso-1 — Auth + GameNight invitation idempotency guards

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
@@ -30,6 +30,21 @@ internal sealed class AccessRequestApprovedEventHandler : DomainEventHandlerBase
     {
         try
         {
+            // Issue #1940 / iso-1 Fix 2: pre-flight idempotency check. If the AccessRequest
+            // already has an InvitationId, a prior dispatch already issued the SendInvitationCommand
+            // (DB row + invitation email). Re-dispatch on a rolled-back/retried event MUST skip to
+            // avoid duplicate InvitationToken row + duplicate invitation email.
+            var accessRequest = await _repository.GetByIdAsync(
+                domainEvent.AccessRequestId, cancellationToken).ConfigureAwait(false);
+
+            if (accessRequest?.InvitationId is not null)
+            {
+                Logger.LogDebug(
+                    "Skipping SendInvitationCommand for AccessRequest {AccessRequestId}: invitation {InvitationId} already issued (iso-1)",
+                    domainEvent.AccessRequestId, accessRequest.InvitationId.Value);
+                return;
+            }
+
             var invitationResult = await _mediator.Send(
                 new SendInvitationCommand(
                     domainEvent.Email,
@@ -38,8 +53,6 @@ internal sealed class AccessRequestApprovedEventHandler : DomainEventHandlerBase
                 cancellationToken).ConfigureAwait(false);
 
             // Set correlation ID linking access request to invitation
-            var accessRequest = await _repository.GetByIdAsync(
-                domainEvent.AccessRequestId, cancellationToken).ConfigureAwait(false);
             if (accessRequest is not null)
             {
                 accessRequest.SetInvitationId(invitationResult.Id);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
@@ -71,19 +71,28 @@ internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<
                     ["_slack_category"] = "access_request"
                 },
                 cancellationToken).ConfigureAwait(false);
-
-            // Mark notified + persist the guard so re-dispatch dedupes.
-            accessRequest.MarkNotified(domainEvent.EventId);
-            await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
-            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
-        // FAIL-OPEN PATTERN: Notification failure must not block access request creation
+        // FAIL-OPEN PATTERN: Notification failure must not block access request creation.
+        // Return WITHOUT persisting the guard so the next outbox retry can attempt the
+        // alert again — silently swallowing the guard write here would mark this event as
+        // "notified" even though no Slack message went out.
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Failed to send access request notification for {Email}", DataMasking.MaskEmail(domainEvent.Email));
+            return;
         }
 #pragma warning restore CA1031
+
+        // Persist the guard OUTSIDE the fail-open catch: only run when SendAlertAsync
+        // succeeded. If SaveChangesAsync now throws, the exception propagates to MediatR
+        // and the outbox dispatcher will retry the handler. Risk: at-least-once delivery
+        // may resend the Slack alert on the retry — accepted trade-off vs the alternative
+        // where a DB failure after a successful Slack send silently swallows the guard,
+        // which would have the same effect plus no operator signal.
+        accessRequest.MarkNotified(domainEvent.EventId);
+        await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     protected override Guid? GetUserId(AccessRequestCreatedEvent domainEvent)

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.Authentication.Domain.Events;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Security;
 using Api.Services;
 using Api.SharedKernel.Application.EventHandlers;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
@@ -10,14 +12,20 @@ namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
 internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<AccessRequestCreatedEvent>
 {
     private readonly IAlertingService _alertingService;
+    private readonly IAccessRequestRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
 
     public AccessRequestCreatedEventHandler(
         MeepleAiDbContext dbContext,
         IAlertingService alertingService,
+        IAccessRequestRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<AccessRequestCreatedEventHandler> logger)
         : base(dbContext, logger)
     {
         _alertingService = alertingService;
+        _repository = repository;
+        _unitOfWork = unitOfWork;
     }
 
     protected override async Task HandleEventAsync(
@@ -26,6 +34,29 @@ internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<
         Logger.LogInformation(
             "New access request {AccessRequestId} created for email {Email}",
             domainEvent.AccessRequestId, DataMasking.MaskEmail(domainEvent.Email));
+
+        // Issue #1940 / iso-1 Fix 1: pre-flight idempotency check. If the AccessRequest already
+        // carries this event's LastNotifiedEventId, a prior dispatch already fired the Slack
+        // alert. Re-dispatch on a rolled-back/retried event MUST skip to avoid double-pinging
+        // oncall — Slack has no remote dedup.
+        var accessRequest = await _repository.GetByIdAsync(
+            domainEvent.AccessRequestId, cancellationToken).ConfigureAwait(false);
+
+        if (accessRequest is null)
+        {
+            Logger.LogWarning(
+                "AccessRequest {AccessRequestId} disappeared between event raise and handler — skipping Slack alert",
+                domainEvent.AccessRequestId);
+            return;
+        }
+
+        if (accessRequest.LastNotifiedEventId == domainEvent.EventId)
+        {
+            Logger.LogDebug(
+                "Skipping Slack alert for AccessRequest {AccessRequestId}: event {EventId} already notified (iso-1)",
+                domainEvent.AccessRequestId, domainEvent.EventId);
+            return;
+        }
 
         try
         {
@@ -40,6 +71,11 @@ internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<
                     ["_slack_category"] = "access_request"
                 },
                 cancellationToken).ConfigureAwait(false);
+
+            // Mark notified + persist the guard so re-dispatch dedupes.
+            accessRequest.MarkNotified(domainEvent.EventId);
+            await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         // FAIL-OPEN PATTERN: Notification failure must not block access request creation

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccountLockedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccountLockedEventHandler.cs
@@ -74,6 +74,18 @@ internal sealed class AccountLockedEventHandler : INotificationHandler<AccountLo
                 return;
             }
 
+            // Issue #1940 / iso-1 Fix 3: pre-flight idempotency check. If the User row already
+            // carries this event's LastLockoutEventId, a prior dispatch already fired the lockout
+            // email and wrote the audit rows. Re-dispatch on a rolled-back/retried event MUST skip
+            // to avoid double-emailing the locked-out user.
+            if (user.LastLockoutEventId == notification.EventId)
+            {
+                _logger.LogDebug(
+                    "Skipping AccountLocked side-effects for user {UserId}: event {EventId} already processed (iso-1)",
+                    notification.UserId, notification.EventId);
+                return;
+            }
+
             // Send email notification first to know if it succeeded
             try
             {
@@ -107,6 +119,18 @@ internal sealed class AccountLockedEventHandler : INotificationHandler<AccountLo
                     ipAddress: notification.IpAddress,
                     cancellationToken: cancellationToken
                 ).ConfigureAwait(false);
+
+                // Issue #1940 / iso-1 Fix 3: mark the event as processed so a retried/rolled-back
+                // dispatch short-circuits at the pre-flight check above. Raw SQL is used to bypass
+                // the AuditingSaveChangesInterceptor — User is [Auditable] but this guard write is
+                // a metadata bookmark, not a user-facing mutation, so it must NOT produce an audit row.
+                // Skip on InMemory provider (unit tests) — relational-only.
+                if (_dbContext.Database.IsRelational())
+                {
+                    await _dbContext.Database.ExecuteSqlInterpolatedAsync(
+                        $"UPDATE users SET last_lockout_event_id = {notification.EventId} WHERE id = {notification.UserId}",
+                        cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (Exception emailEx)
             {

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs
@@ -18,6 +18,13 @@ internal sealed class AccessRequest : AggregateRoot<Guid>
     public string? RejectionReason { get; private set; }
     public Guid? InvitationId { get; private set; }
 
+    /// <summary>
+    /// Last <c>AccessRequestCreatedEvent</c> id for which the Slack alert has been sent
+    /// (issue #1940 / iso-1). Handler MUST early-exit when equal to the incoming event id
+    /// to avoid duplicate Slack alerts on a retried/rolled-back event.
+    /// </summary>
+    public Guid? LastNotifiedEventId { get; private set; }
+
     // EF Core constructor
     private AccessRequest() { }
     private AccessRequest(Guid id) : base(id) { }
@@ -92,6 +99,14 @@ internal sealed class AccessRequest : AggregateRoot<Guid>
         InvitationId = invitationId;
     }
 
+    /// <summary>
+    /// Records which AccessRequestCreatedEvent has already been notified (issue #1940 / iso-1).
+    /// </summary>
+    public void MarkNotified(Guid eventId)
+    {
+        LastNotifiedEventId = eventId;
+    }
+
     #region Persistence Hydration Methods (internal - S3011 fix)
 
     /// <summary>
@@ -106,7 +121,8 @@ internal sealed class AccessRequest : AggregateRoot<Guid>
         DateTime? reviewedAt,
         Guid? reviewedBy,
         string? rejectionReason,
-        Guid? invitationId)
+        Guid? invitationId,
+        Guid? lastNotifiedEventId = null)
     {
         Email = email;
         Status = status;
@@ -115,6 +131,7 @@ internal sealed class AccessRequest : AggregateRoot<Guid>
         ReviewedBy = reviewedBy;
         RejectionReason = rejectionReason;
         InvitationId = invitationId;
+        LastNotifiedEventId = lastNotifiedEventId;
     }
 
     #endregion

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs
@@ -59,6 +59,7 @@ internal sealed class AccessRequestRepository : RepositoryBase, IAccessRequestRe
         existing.ReviewedBy = entity.ReviewedBy;
         existing.RejectionReason = entity.RejectionReason;
         existing.InvitationId = entity.InvitationId;
+        existing.LastNotifiedEventId = entity.LastNotifiedEventId;
     }
 
     public async Task DeleteAsync(AccessRequest entity, CancellationToken cancellationToken = default)
@@ -139,7 +140,8 @@ internal sealed class AccessRequestRepository : RepositoryBase, IAccessRequestRe
             reviewedAt: entity.ReviewedAt,
             reviewedBy: entity.ReviewedBy,
             rejectionReason: entity.RejectionReason,
-            invitationId: entity.InvitationId);
+            invitationId: entity.InvitationId,
+            lastNotifiedEventId: entity.LastNotifiedEventId);
 
         return request;
     }
@@ -158,7 +160,8 @@ internal sealed class AccessRequestRepository : RepositoryBase, IAccessRequestRe
             ReviewedAt = domain.ReviewedAt,
             ReviewedBy = domain.ReviewedBy,
             RejectionReason = domain.RejectionReason,
-            InvitationId = domain.InvitationId
+            InvitationId = domain.InvitationId,
+            LastNotifiedEventId = domain.LastNotifiedEventId
         };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Caching.Hybrid;
 
@@ -38,6 +39,7 @@ internal sealed class GameNightInvitationRespondedHandler
     private readonly IGameNightEventRepository _gameNightRepository;
     private readonly IGameNightEmailService _emailService;
     private readonly HybridCache _cache;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<GameNightInvitationRespondedHandler> _logger;
 
     public GameNightInvitationRespondedHandler(
@@ -45,12 +47,14 @@ internal sealed class GameNightInvitationRespondedHandler
         IGameNightEventRepository gameNightRepository,
         IGameNightEmailService emailService,
         HybridCache cache,
+        IUnitOfWork unitOfWork,
         ILogger<GameNightInvitationRespondedHandler> logger)
     {
         _invitationRepository = invitationRepository ?? throw new ArgumentNullException(nameof(invitationRepository));
         _gameNightRepository = gameNightRepository ?? throw new ArgumentNullException(nameof(gameNightRepository));
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -89,6 +93,17 @@ internal sealed class GameNightInvitationRespondedHandler
             return;
         }
 
+        // Issue #1940 / iso-1 Fix 4: skip if the confirmation email was already sent for this
+        // invitation. Guards against duplicate confirmation emails on a retried/rolled-back event
+        // (SMTP has no remote dedup; the guest would otherwise receive the same confirmation twice).
+        if (invitation.RsvpConfirmationSentAt is not null)
+        {
+            _logger.LogDebug(
+                "Skipping RSVP confirmation email for invitation {InvitationId}: already sent at {SentAt} (iso-1)",
+                invitation.Id, invitation.RsvpConfirmationSentAt.Value);
+            return;
+        }
+
         var gameNight = await _gameNightRepository
             .GetByIdAsync(invitation.GameNightId, cancellationToken)
             .ConfigureAwait(false);
@@ -111,5 +126,10 @@ internal sealed class GameNightInvitationRespondedHandler
             location: gameNight.Location,
             unsubscribeUrl: unsubscribeUrl,
             ct: cancellationToken).ConfigureAwait(false);
+
+        // Mark and persist the confirmation-sent timestamp so a retried event short-circuits above.
+        invitation.MarkConfirmationSent(DateTimeOffset.UtcNow);
+        await _invitationRepository.UpdateAsync(invitation, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightInvitation.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightInvitation.cs
@@ -53,6 +53,14 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
     public DateTimeOffset CreatedAt { get; private set; }
     public Guid CreatedBy { get; private set; }
 
+    /// <summary>
+    /// Timestamp of the last RSVP confirmation email successfully sent for this invitation
+    /// (issue #1940 / iso-1). When non-null the
+    /// <c>GameNightInvitationRespondedHandler</c> MUST skip sending another confirmation
+    /// email — guards against duplicate confirmations on a retried/rolled-back event.
+    /// </summary>
+    public DateTimeOffset? RsvpConfirmationSentAt { get; private set; }
+
 #pragma warning disable CS8618
     private GameNightInvitation() : base() { } // EF Core
 #pragma warning restore CS8618
@@ -68,7 +76,8 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         Guid? respondedByUserId,
         string? respondedByName,
         DateTimeOffset createdAt,
-        Guid createdBy) : base(id)
+        Guid createdBy,
+        DateTimeOffset? rsvpConfirmationSentAt = null) : base(id)
     {
         Token = token;
         GameNightId = gameNightId;
@@ -80,6 +89,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         RespondedByName = respondedByName;
         CreatedAt = createdAt;
         CreatedBy = createdBy;
+        RsvpConfirmationSentAt = rsvpConfirmationSentAt;
     }
 
     /// <summary>
@@ -151,7 +161,8 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         Guid? respondedByUserId,
         DateTimeOffset createdAt,
         Guid createdBy,
-        string? respondedByName = null)
+        string? respondedByName = null,
+        DateTimeOffset? rsvpConfirmationSentAt = null)
     {
         return new GameNightInvitation(
             id: id,
@@ -164,7 +175,17 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
             respondedByUserId: respondedByUserId,
             respondedByName: respondedByName,
             createdAt: createdAt,
-            createdBy: createdBy);
+            createdBy: createdBy,
+            rsvpConfirmationSentAt: rsvpConfirmationSentAt);
+    }
+
+    /// <summary>
+    /// Records that the RSVP confirmation email has been sent for this invitation
+    /// (issue #1940 / iso-1 Fix 4).
+    /// </summary>
+    public void MarkConfirmationSent(DateTimeOffset utcNow)
+    {
+        RsvpConfirmationSentAt = utcNow;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightInvitationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightInvitationRepository.cs
@@ -182,7 +182,8 @@ internal class GameNightInvitationRepository : RepositoryBase, IGameNightInvitat
             RespondedByUserId = domain.RespondedByUserId,
             RespondedByName = domain.RespondedByName,
             CreatedAt = domain.CreatedAt,
-            CreatedBy = domain.CreatedBy
+            CreatedBy = domain.CreatedBy,
+            RsvpConfirmationSentAt = domain.RsvpConfirmationSentAt
         };
     }
 
@@ -205,7 +206,8 @@ internal class GameNightInvitationRepository : RepositoryBase, IGameNightInvitat
             respondedByUserId: entity.RespondedByUserId,
             createdAt: entity.CreatedAt,
             createdBy: entity.CreatedBy,
-            respondedByName: entity.RespondedByName);
+            respondedByName: entity.RespondedByName,
+            rsvpConfirmationSentAt: entity.RsvpConfirmationSentAt);
 
         // Reconstitute is a pure factory and does not raise events — defensive clear in case
         // base AggregateRoot ctor introduces any (matches GameNightEventRepository pattern).

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/AccessRequestEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/AccessRequestEntity.cs
@@ -41,6 +41,12 @@ public sealed class AccessRequestEntity
     [Column("invitation_id")]
     public Guid? InvitationId { get; set; }
 
+    /// <summary>
+    /// Issue #1940 / iso-1: dedup key for AccessRequestCreatedEvent Slack alert.
+    /// </summary>
+    [Column("last_notified_event_id")]
+    public Guid? LastNotifiedEventId { get; set; }
+
     // Navigation properties
     [ForeignKey(nameof(ReviewedBy))]
     public UserEntity? ReviewedByUser { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/UserEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/UserEntity.cs
@@ -62,6 +62,14 @@ public class UserEntity
     public int FailedLoginAttempts { get; set; }
     public DateTime? LockedUntil { get; set; }
 
+    /// <summary>
+    /// Issue #1940 / iso-1 Fix 3: dedup key for AccountLockedEvent email + audit-log emission.
+    /// Handler MUST early-exit when equal to the incoming AccountLockedEvent.EventId to avoid
+    /// double-firing the lockout email and writing duplicate audit rows on a retried event.
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Schema.Column("last_lockout_event_id")]
+    public Guid? LastLockoutEventId { get; set; }
+
     // D3: Contributor flag — contributors get premium tier access
     public bool IsContributor { get; set; }
 

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightInvitationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightInvitationEntity.cs
@@ -68,4 +68,11 @@ public class GameNightInvitationEntity
     [Column("test_run_id")]
     [MaxLength(64)]
     public string? TestRunId { get; set; }
+
+    /// <summary>
+    /// Issue #1940 / iso-1 Fix 4: timestamp of the last RSVP confirmation email sent.
+    /// Non-null = handler MUST skip resending on a retried event.
+    /// </summary>
+    [Column("rsvp_confirmation_sent_at")]
+    public DateTimeOffset? RsvpConfirmationSentAt { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/AccessRequestEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/AccessRequestEntityConfiguration.cs
@@ -18,6 +18,7 @@ internal class AccessRequestEntityConfiguration : IEntityTypeConfiguration<Acces
         builder.Property(e => e.ReviewedBy);
         builder.Property(e => e.RejectionReason).HasMaxLength(500);
         builder.Property(e => e.InvitationId);
+        builder.Property(e => e.LastNotifiedEventId);
 
         // Unique index: only one pending request per email
         builder.HasIndex(e => new { e.Email, e.Status })

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1")]
+    partial class AddIdempotencyGuardsToAuthAndInvitations_Iso1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdempotencyGuardsToAuthAndInvitations_Iso1 : Migration
+    {
+        // PR comment: 3 colonne nuove di iso-1 (access_requests.last_notified_event_id,
+        // users.last_lockout_event_id, game_night_invitations.rsvp_confirmation_sent_at).
+        // Le 5 colonne test_run_id rilevate come drift sono manualmente rimosse: sono già
+        // nelle migration di CF-2 (#1946) e CF-3 (#1947). Concurrent merge garantisce single
+        // application — la prima a essere applicata vince.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_lockout_event_id",
+                table: "users",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "rsvp_confirmation_sent_at",
+                table: "game_night_invitations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_notified_event_id",
+                table: "access_requests",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_lockout_event_id",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "rsvp_confirmation_sent_at",
+                table: "game_night_invitations");
+
+            migrationBuilder.DropColumn(
+                name: "last_notified_event_id",
+                table: "access_requests");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/GameNightInvitationRespondedHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Microsoft.Extensions.Caching.Distributed;
@@ -37,6 +38,7 @@ public sealed class GameNightInvitationRespondedHandlerTests
     private readonly Mock<IGameNightInvitationRepository> _invitationRepoMock = new();
     private readonly Mock<IGameNightEventRepository> _gameNightRepoMock = new();
     private readonly Mock<IGameNightEmailService> _emailServiceMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
     private readonly Mock<ILogger<GameNightInvitationRespondedHandler>> _loggerMock = new();
 
     private static HybridCache CreateHybridCache()
@@ -54,6 +56,7 @@ public sealed class GameNightInvitationRespondedHandlerTests
         _gameNightRepoMock.Object,
         _emailServiceMock.Object,
         cache,
+        _unitOfWorkMock.Object,
         _loggerMock.Object);
 
     private static GameNightInvitation Reconstitute(GameNightInvitationStatus status)


### PR DESCRIPTION
## Summary

Implementa **iso-1** dei 6 follow-up individuati nell'audit del Task 0 di #1535 (vedi [audit doc](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/issue-1535-event-outbox-dispatch/audits/2026-06-06-issue-1535-consumer-idempotency-audit.md) § "Isolated P0 BLOCKERs"). Chiude **4 BLOCKER P0** in Authentication + GameManagement BC.

Risolve issue **#1940**. Standalone: migliora idempotency anche pre-#1535.

## 4 fix dedicati

### Fix 1 — `AccessRequestCreatedEventHandler` (Slack alert dedup)
- AccessRequest aggregate: add `Guid? LastNotifiedEventId` + `MarkNotified(eventId)`
- Persistence: `last_notified_event_id` column on `access_requests`
- Handler: load AccessRequest, early-exit if `LastNotifiedEventId == EventId`, altrimenti SendAlert → MarkNotified → Update+SaveChanges
- Injected `IAccessRequestRepository` + `IUnitOfWork`

### Fix 2 — `AccessRequestApprovedEventHandler` (invitation+email dedup)
- **Riusa il field `InvitationId`** esistente come idempotency key
- Pre-flight: se `accessRequest.InvitationId != null` → skip `SendInvitationCommand`
- Nessuna migration richiesta

### Fix 3 — `AccountLockedEventHandler` (lockout email + audit dedup)
- UserEntity: add `Guid? LastLockoutEventId` with `[Column("last_lockout_event_id")]`
- Handler: pre-flight check `user.LastLockoutEventId == EventId → skip`
- Guard write via **raw SQL `ExecuteSqlInterpolatedAsync`** per bypassare `AuditingSaveChangesInterceptor` (User is `[Auditable]` ma il guard è metadata bookmark, non user-visible mutation → non deve produrre audit row)
- Provider check: `IsRelational()` — skip su InMemory test provider

### Fix 4 — `GameNightInvitationRespondedHandler` (RSVP confirmation email dedup)
- GameNightInvitation aggregate: add `DateTimeOffset? RsvpConfirmationSentAt` + `MarkConfirmationSent(utcNow)`
- `Reconstitute()` signature estesa con param optional (backward compat)
- Persistence: `rsvp_confirmation_sent_at` column on `game_night_invitations`
- Handler: pre-flight check, send email, MarkConfirmationSent, Update+SaveChanges
- Injected `IUnitOfWork`

## Migration `AddIdempotencyGuardsToAuthAndInvitations_Iso1`

- 3 colonne: `access_requests.last_notified_event_id`, `users.last_lockout_event_id`, `game_night_invitations.rsvp_confirmation_sent_at`
- **Drift cleanup**: rimosse manualmente le 5 colonne `test_run_id` (asse-d task B #1928), già presenti in CF-2 ([#1946](https://github.com/meepleAi-app/meepleai-monorepo/pull/1946)) e CF-3 ([#1947](https://github.com/meepleAi-app/meepleai-monorepo/pull/1947)). Concurrent merge garantisce single application.

## Test plan

- [x] Backend build clean (0 errori, 0 warning su `src/Api`)
- [x] **67/67 unit test verdi** sui filtri Authentication.EventHandlers + GameNightInvitationResponded + AccessRequest
- [x] 1 baseline regression risolta in-situ con `IsRelational()` check (test usa InMemory provider, ma raw SQL è Postgres-only)
- [ ] Code review
- [ ] Integration test: 2× fire stesso EventId → 1 Slack + 1 email + 1 audit row + 1 RSVP confirmation — TODO sub-task

## Why standalone

Migliora idempotency **anche pre-#1535**: retry MediatR transient errors oggi produrrebbe duplicate Slack alert / email / audit / RSVP confirmation. Bug latenti già reali.

🤖 Generated with [Claude Code](https://claude.com/claude-code)