### PR TITLE
feat(events): #1941 iso-2 — Alert dispatch dedup (ChannelDispatch + HealthStatus)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/ChannelDispatchHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/ChannelDispatchHandler.cs
@@ -97,6 +97,21 @@ internal sealed class ChannelDispatchHandler : INotificationHandler<AlertFiredEv
             return;
         }
 
+        // Issue #1941 / iso-2 Fix 1: pre-flight idempotency check. If this channel already
+        // dispatched the incoming AlertFiredEvent, skip to avoid double-pinging oncall
+        // (Slack webhook + Email SMTP have no remote dedup). Dry-run and test fires are
+        // exempt — those use IsDryRun/IsTest flags, not LastDispatchedEventId, and admins
+        // legitimately may want to test the same channel multiple times.
+        if (!notification.IsDryRun
+            && !notification.IsTest
+            && channel.LastDispatchedEventId == notification.EventId)
+        {
+            _logger.LogDebug(
+                "[ChannelDispatch] Skipping {Type} dispatch for rule {Rule}: event {EventId} already dispatched (iso-2)",
+                type, LogSanitizer.Sanitize(notification.RuleName), notification.EventId);
+            return;
+        }
+
         try
         {
             switch (type)
@@ -112,6 +127,15 @@ internal sealed class ChannelDispatchHandler : INotificationHandler<AlertFiredEv
                         "[ChannelDispatch] No dispatch implementation for channel type {Type}",
                         type);
                     break;
+            }
+
+            // Issue #1941 / iso-2 Fix 1: only mark dispatched on real (non-dry-run, non-test)
+            // alerts that completed without throwing. Concurrency: parallel sibling channels
+            // each upsert their own row, so RowVersion contention is bounded per-channel.
+            if (!notification.IsDryRun && !notification.IsTest)
+            {
+                channel.MarkDispatched(notification.EventId);
+                await _channelRepository.UpsertAsync(channel, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/HealthStatusChangedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/HealthStatusChangedEventHandler.cs
@@ -1,7 +1,10 @@
 using Api.BoundedContexts.Administration.Domain.Events;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.Administration;
 using Api.Infrastructure.Health.Models;
 using Api.Services;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.Administration.Application.EventHandlers;
 
@@ -28,6 +31,27 @@ internal sealed class HealthStatusChangedEventHandler
     {
         using var scope = _scopeFactory.CreateScope();
         var alertingService = scope.ServiceProvider.GetRequiredService<IAlertingService>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Issue #1941 / iso-2 Fix 2: per-service idempotency check. If we already dispatched
+        // an alert for this exact event id (rolled-back/retried domain event), skip the Slack
+        // send to avoid double-pinging oncall. Storage is a single row keyed by ServiceName —
+        // upserted after each successful dispatch. Skip on InMemory (unit tests) — relational only.
+        if (dbContext.Database.IsRelational())
+        {
+            var existing = await dbContext.HealthStatusAlertsSent
+                .AsNoTracking()
+                .FirstOrDefaultAsync(e => e.ServiceName == evt.ServiceName, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is not null && existing.LastEventId == evt.EventId)
+            {
+                _logger.LogDebug(
+                    "[HealthAlert] Skipping dispatch for service {ServiceName}: event {EventId} already sent at {SentAt} (iso-2)",
+                    evt.ServiceName, evt.EventId, existing.LastSentAt);
+                return;
+            }
+        }
 
         var category = MapCategory(evt.ServiceName, evt.Tags);
         var severity = MapSeverity(evt.CurrentStatus);
@@ -56,6 +80,19 @@ internal sealed class HealthStatusChangedEventHandler
             _logger.LogInformation(
                 "[HealthAlert] {AlertType} ({Severity}) → category={Category}",
                 alertType, severity, category);
+
+            // Issue #1941 / iso-2 Fix 2: upsert the dedup record so a retried event short-circuits
+            // at the pre-flight check above. Skip on InMemory (no relational provider in tests).
+            if (dbContext.Database.IsRelational())
+            {
+                await dbContext.Database.ExecuteSqlInterpolatedAsync(
+                    $@"INSERT INTO health_status_alerts_sent (service_name, last_event_id, last_sent_at)
+                       VALUES ({evt.ServiceName}, {evt.EventId}, {DateTime.UtcNow})
+                       ON CONFLICT (service_name) DO UPDATE
+                       SET last_event_id = EXCLUDED.last_event_id,
+                           last_sent_at = EXCLUDED.last_sent_at",
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (InvalidOperationException ex)
         {

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Aggregates/AlertChannel/AlertChannel.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Aggregates/AlertChannel/AlertChannel.cs
@@ -47,6 +47,16 @@ internal sealed class AlertChannel
     public string? CreatedBy { get; private set; }
     public string? UpdatedBy { get; private set; }
 
+    /// <summary>
+    /// Last <c>AlertFiredEvent</c> id dispatched through this channel (issue #1941 / iso-2 Fix 1).
+    /// When equal to the incoming event id, the ChannelDispatchHandler MUST skip the Slack
+    /// webhook / Email send for this channel to avoid double-alerting oncall on a retried
+    /// or rolled-back event. Per-channel scope: 1 fan-out event produces independent guards
+    /// for each channel (Slack and Email each have their own row, each tracks the last
+    /// successful dispatch separately).
+    /// </summary>
+    public Guid? LastDispatchedEventId { get; private set; }
+
     /// <summary>SQL Server / Postgres optimistic concurrency token.
     /// Repository populates this from <c>xmin</c> via EF's <c>[Timestamp]</c>
     /// equivalent (<see cref="Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder.IsRowVersion"/>).</summary>
@@ -100,7 +110,8 @@ internal sealed class AlertChannel
         DateTime updatedAt,
         string? createdBy,
         string? updatedBy,
-        byte[] rowVersion)
+        byte[] rowVersion,
+        Guid? lastDispatchedEventId = null)
     {
         return new AlertChannel(type, configJson, isEnabled, createdAt, updatedAt, createdBy, updatedBy)
         {
@@ -108,6 +119,7 @@ internal sealed class AlertChannel
             LastTestStatus = lastTestStatus,
             LastTestMessage = lastTestMessage,
             RowVersion = rowVersion ?? Array.Empty<byte>(),
+            LastDispatchedEventId = lastDispatchedEventId,
         };
     }
 
@@ -131,6 +143,16 @@ internal sealed class AlertChannel
         LastTestMessage = string.IsNullOrWhiteSpace(message)
             ? (success ? "Connection OK" : "Unknown error")
             : message;
+    }
+
+    /// <summary>
+    /// Records that an <c>AlertFiredEvent</c> has been dispatched through this channel
+    /// (issue #1941 / iso-2 Fix 1). Used by <c>ChannelDispatchHandler</c> to short-circuit
+    /// duplicate dispatches when the event is retried/rolled back.
+    /// </summary>
+    public void MarkDispatched(Guid eventId)
+    {
+        LastDispatchedEventId = eventId;
     }
 
     private static void ValidateConfigJson(string configJson)

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Events/HealthStatusChangedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Events/HealthStatusChangedEvent.cs
@@ -1,7 +1,14 @@
-using MediatR;
+using Api.SharedKernel.Domain.Interfaces;
 
 namespace Api.BoundedContexts.Administration.Domain.Events;
 
+/// <summary>
+/// Health status transition event. Issue #1941 / iso-2 promoted from <c>INotification</c>
+/// to <see cref="IDomainEvent"/> so the dispatcher dedup guard can short-circuit re-dispatched
+/// alerts (collateral pattern shared with CF-1 AutoAgentCreationFailedEvent + CF-2
+/// TokenUsageLedgerEvent). Backward compat: positional ctor unchanged; the <see cref="EventId"/>
+/// and <see cref="OccurredAt"/> properties auto-initialise so existing publishers compile.
+/// </summary>
 public record HealthStatusChangedEvent(
     string ServiceName,
     string PreviousStatus,
@@ -10,4 +17,11 @@ public record HealthStatusChangedEvent(
     string[] Tags,
     DateTime TransitionAt,
     bool IsReminder
-) : INotification;
+) : IDomainEvent
+{
+    /// <inheritdoc />
+    public Guid EventId { get; init; } = Guid.NewGuid();
+
+    /// <inheritdoc />
+    public DateTime OccurredAt { get; init; } = DateTime.UtcNow;
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Repositories/AlertChannelRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Repositories/AlertChannelRepository.cs
@@ -66,6 +66,7 @@ internal sealed class AlertChannelRepository : RepositoryBase, IAlertChannelRepo
                 UpdatedAt = channel.UpdatedAt,
                 CreatedBy = channel.CreatedBy,
                 UpdatedBy = channel.UpdatedBy,
+                LastDispatchedEventId = channel.LastDispatchedEventId,
             };
             await DbContext.AlertChannels.AddAsync(entity, cancellationToken).ConfigureAwait(false);
         }
@@ -83,6 +84,7 @@ internal sealed class AlertChannelRepository : RepositoryBase, IAlertChannelRepo
             tracked.LastTestMessage = channel.LastTestMessage;
             tracked.UpdatedAt = channel.UpdatedAt;
             tracked.UpdatedBy = channel.UpdatedBy;
+            tracked.LastDispatchedEventId = channel.LastDispatchedEventId;
         }
 
         await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -100,5 +102,6 @@ internal sealed class AlertChannelRepository : RepositoryBase, IAlertChannelRepo
             e.UpdatedAt,
             e.CreatedBy,
             e.UpdatedBy,
-            e.RowVersion);
+            e.RowVersion,
+            e.LastDispatchedEventId);
 }

--- a/apps/api/src/Api/Infrastructure/Entities/Administration/AlertChannelEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Administration/AlertChannelEntity.cs
@@ -32,4 +32,7 @@ public class AlertChannelEntity
 
     /// <summary>EF Core optimistic concurrency token (PostgreSQL <c>xmin</c>).</summary>
     public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+
+    /// <summary>Issue #1941 / iso-2 Fix 1: dedup key for AlertFiredEvent dispatch per channel.</summary>
+    public Guid? LastDispatchedEventId { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/Administration/HealthStatusAlertSentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Administration/HealthStatusAlertSentEntity.cs
@@ -1,0 +1,23 @@
+namespace Api.Infrastructure.Entities.Administration;
+
+/// <summary>
+/// Per-service dedup record for HealthStatusChangedEvent alert dispatch
+/// (issue #1941 / iso-2 Fix 2). The handler must short-circuit when the
+/// incoming event id matches <see cref="LastEventId"/>, avoiding duplicate
+/// Slack alerts on a rolled-back / retried health-status transition.
+///
+/// <para>Service name is the primary key — at most one row per service.
+/// On each successful alert send, the handler upserts this row with the
+/// latest event id and timestamp. Re-dispatch sees the match and skips.</para>
+/// </summary>
+public class HealthStatusAlertSentEntity
+{
+    /// <summary>Service name (e.g., "postgres", "ollama", "oauth"). Primary key.</summary>
+    public required string ServiceName { get; set; }
+
+    /// <summary>The <c>HealthStatusChangedEvent.EventId</c> of the last successfully dispatched alert.</summary>
+    public Guid LastEventId { get; set; }
+
+    /// <summary>When the last alert was successfully sent.</summary>
+    public DateTime LastSentAt { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/AlertChannelEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/AlertChannelEntityConfiguration.cs
@@ -71,6 +71,10 @@ internal class AlertChannelEntityConfiguration : IEntityTypeConfiguration<AlertC
             .IsRowVersion()
             .IsConcurrencyToken();
 
+        // Issue #1941 / iso-2 Fix 1: dedup key for AlertFiredEvent dispatch per channel.
+        builder.Property(e => e.LastDispatchedEventId)
+            .HasColumnName("last_dispatched_event_id");
+
         // Per-spec: enforce the type discriminator at the schema level — only
         // 'email' and 'slack' are valid in #1840 scope.
         builder.ToTable(t => t.HasCheckConstraint(

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/HealthStatusAlertSentEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/HealthStatusAlertSentEntityConfiguration.cs
@@ -1,0 +1,33 @@
+using Api.Infrastructure.Entities.Administration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.Administration;
+
+/// <summary>
+/// Entity configuration for <see cref="HealthStatusAlertSentEntity"/>
+/// (issue #1941 / iso-2 Fix 2). Single row per service name.
+/// </summary>
+internal class HealthStatusAlertSentEntityConfiguration
+    : IEntityTypeConfiguration<HealthStatusAlertSentEntity>
+{
+    public void Configure(EntityTypeBuilder<HealthStatusAlertSentEntity> builder)
+    {
+        builder.ToTable("health_status_alerts_sent");
+
+        builder.HasKey(e => e.ServiceName);
+
+        builder.Property(e => e.ServiceName)
+            .HasColumnName("service_name")
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(e => e.LastEventId)
+            .HasColumnName("last_event_id")
+            .IsRequired();
+
+        builder.Property(e => e.LastSentAt)
+            .HasColumnName("last_sent_at")
+            .IsRequired();
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -126,6 +126,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<StagingAllowlistEntity> StagingAllowlist => Set<StagingAllowlistEntity>(); // #845: DevOps Wave 1 staging email allowlist
     public DbSet<AlertConfigurationEntity> AlertConfigurations => Set<AlertConfigurationEntity>(); // ISSUE-921: Dynamic alert config
     public DbSet<AlertChannelEntity> AlertChannels => Set<AlertChannelEntity>(); // Issue #1840 SP5 F4-C7: Per-channel alert notification config
+    public DbSet<HealthStatusAlertSentEntity> HealthStatusAlertsSent => Set<HealthStatusAlertSentEntity>(); // Issue #1941 / iso-2 Fix 2: dedup for HealthStatusChangedEvent dispatch
     public DbSet<ServiceHealthStateEntity> ServiceHealthStates => Set<ServiceHealthStateEntity>(); // ISSUE-448: Service health monitoring
     public DbSet<DatabaseMetricsSnapshotEntity> DatabaseMetricsSnapshots => Set<DatabaseMetricsSnapshotEntity>(); // Database growth tracking
     public DbSet<UserBackupCodeEntity> UserBackupCodes => Set<UserBackupCodeEntity>(); // AUTH-07

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606210753_AddIdempotencyGuardsToAlertChannels_Iso2.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606210753_AddIdempotencyGuardsToAlertChannels_Iso2.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606210753_AddIdempotencyGuardsToAlertChannels_Iso2")]
+    partial class AddIdempotencyGuardsToAlertChannels_Iso2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260606210753_AddIdempotencyGuardsToAlertChannels_Iso2.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260606210753_AddIdempotencyGuardsToAlertChannels_Iso2.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdempotencyGuardsToAlertChannels_Iso2 : Migration
+    {
+        // PR comment: 2 modifiche di iso-2 (alert_channels.last_dispatched_event_id +
+        // nuova tabella health_status_alerts_sent). Le 5 colonne test_run_id rilevate
+        // come drift sono manualmente rimosse: sono già presenti nelle migration di
+        // CF-2 (#1946), CF-3 (#1947) e iso-1 (#1949). Concurrent merge garantisce
+        // single application.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_dispatched_event_id",
+                table: "alert_channels",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "health_status_alerts_sent",
+                columns: table => new
+                {
+                    service_name = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    last_event_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    last_sent_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_health_status_alerts_sent", x => x.service_name);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "health_status_alerts_sent");
+
+            migrationBuilder.DropColumn(
+                name: "last_dispatched_event_id",
+                table: "alert_channels");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implementa **iso-2** dei 6 follow-up individuati nell'audit del Task 0 di #1535 (vedi [audit doc](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/issue-1535-event-outbox-dispatch/audits/2026-06-06-issue-1535-consumer-idempotency-audit.md) § "iso-2"). Chiude **2 BLOCKER P0** in Administration BC.

Risolve issue **#1941**. Standalone: migliora idempotency anche pre-#1535.

## 2 fix dedicati

### Fix 1 — `ChannelDispatchHandler` (per-channel dedup AlertFiredEvent)
- AlertChannel aggregate: add `Guid? LastDispatchedEventId` + `MarkDispatched(eventId)`
- `Reconstitute()` signature estesa con param optional (backward compat)
- Persistence: `last_dispatched_event_id` column on `alert_channels`
- Repository `UpsertAsync`: propaga `LastDispatchedEventId` su insert+update path
- Handler `DispatchSingleAsync`:
  - Pre-flight: skip if `channel.LastDispatchedEventId == notification.EventId` (dry-run + test fires esenti)
  - Post-dispatch: `MarkDispatched` + `UpsertAsync` solo su real (non-dry-run, non-test) alerts
- Per-channel scope: 1 fan-out event → independent guards per Slack e Email (1 row each)

### Fix 2 — `HealthStatusChangedEventHandler` (per-service dedup)
- **New table** `health_status_alerts_sent` (service_name PK, last_event_id, last_sent_at)
- `HealthStatusAlertSentEntity` + EF config + DbSet `HealthStatusAlertsSent`
- Handler: pre-flight via `_dbContext.HealthStatusAlertsSent.AsNoTracking()`, early-exit if `LastEventId == evt.EventId`
- Post-dispatch: raw SQL `UPSERT ON CONFLICT DO UPDATE` per bypassare `AuditingSaveChangesInterceptor` (pattern analogo a iso-1 Fix 3 AccountLocked)
- Provider check: `IsRelational()` — skip su InMemory test provider

## Collateral fix

- **`HealthStatusChangedEvent`** promoted from `: INotification` to `: IDomainEvent` (auto `EventId` + `OccurredAt` init-only). Stesso pattern usato in CF-1 (`AutoAgentCreationFailedEvent`) e CF-2 (`TokenUsageLedgerEvent`). Positional ctor invariato → backward compat preservato.

## Migration `AddIdempotencyGuardsToAlertChannels_Iso2`

- `alert_channels.last_dispatched_event_id` (UUID NULL)
- `health_status_alerts_sent` table (3 col, PK=service_name)
- **Drift cleanup**: rimosse manualmente le 5 colonne `test_run_id` (asse-d task B #1928), già presenti in CF-2 ([#1946](https://github.com/meepleAi-app/meepleai-monorepo/pull/1946)) / CF-3 ([#1947](https://github.com/meepleAi-app/meepleai-monorepo/pull/1947)) / iso-1 ([#1949](https://github.com/meepleAi-app/meepleai-monorepo/pull/1949)). Concurrent merge garantisce single application.

## Test plan

- [x] Backend build clean (0 errori, 0 warning su `src/Api`)
- [x] **58/62 unit test verdi** sui filtri Administration AlertChannel + HealthStatus
- [x] 4 baseline failures su `AlertChannelRepository` integration test = preexistenti su main-dev (verified via stash + checkout, 4/5 fail anche su main pulito — Testcontainers Postgres setup issue, non causato da iso-2)
- [ ] Code review
- [ ] Integration test: 2× fire stesso EventId → 1 Slack message + 1 row health_status_alerts_sent — TODO sub-task

## Why standalone

Migliora idempotency **anche pre-#1535**: retry MediatR transient errors oggi produrrebbe duplicate Slack/Email/health-alert oncall ping. Bug latente già reale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)