### PR TITLE
feat(integrations): #1942 iso-3 — n8n domain-event idempotency contract (BE side)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/EventHandlers/GameNightN8nEventHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/EventHandlers/GameNightN8nEventHandlers.cs
@@ -26,6 +26,10 @@ internal sealed class GameNightPublishedN8nHandler : INotificationHandler<GameNi
 
         await _n8nClient.TriggerWorkflowAsync("game-night-published", new
         {
+            // Issue #1942 / iso-3: domainEventId is the dedup key for n8n side workflows.
+            // Receiving workflows MUST dedup on this field to avoid re-running on rolled-back/retried
+            // domain events. See docs/for-developers/integrations/n8n-idempotency-contract.md.
+            domainEventId = notification.EventId,
             eventId = notification.GameNightEventId,
             organizerId = notification.OrganizerId,
             title = notification.Title,
@@ -52,6 +56,8 @@ internal sealed class GameNightCancelledN8nHandler : INotificationHandler<GameNi
 
         await _n8nClient.TriggerWorkflowAsync("game-night-cancelled", new
         {
+            // Issue #1942 / iso-3: domainEventId is the dedup key for n8n side workflows.
+            domainEventId = notification.EventId,
             eventId = notification.GameNightEventId,
             organizerId = notification.OrganizerId,
             title = notification.Title,
@@ -77,6 +83,8 @@ internal sealed class GameNightRsvpN8nHandler : INotificationHandler<GameNightRs
 
         await _n8nClient.TriggerWorkflowAsync("game-night-rsvp-changed", new
         {
+            // Issue #1942 / iso-3: domainEventId is the dedup key for n8n side workflows.
+            domainEventId = notification.EventId,
             eventId = notification.GameNightEventId,
             userId = notification.UserId,
             rsvpStatus = notification.RsvpStatus.ToString(),

--- a/apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/Services/IN8nWebhookClient.cs
+++ b/apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/Services/IN8nWebhookClient.cs
@@ -14,6 +14,20 @@ public interface IN8nWebhookClient
 {
     /// <summary>
     /// Trigger an n8n workflow via webhook. Fire-and-forget with circuit breaker.
+    ///
+    /// <para><b>Issue #1942 / iso-3 — Idempotency contract for domain-event-driven callers:</b>
+    /// when invoked from an <see cref="Api.SharedKernel.Domain.Interfaces.IDomainEvent"/>
+    /// handler, the <paramref name="payload"/> object MUST carry a top-level
+    /// <c>domainEventId</c> property equal to the originating event's
+    /// <see cref="Api.SharedKernel.Domain.Interfaces.IDomainEvent.EventId"/>. The
+    /// receiving n8n workflow MUST dedup on this field (typically via a "Set" + "IF" node,
+    /// or a Postgres lookup) to avoid re-running on rolled-back / retried domain events.
+    /// See <c>docs/for-developers/integrations/n8n-idempotency-contract.md</c> for the
+    /// full contract + reference workflow snippet.</para>
+    ///
+    /// <para>This rule is documented, not enforced at compile time — admins owning n8n
+    /// workflows are responsible for wiring the dedup node. The BE side validates that
+    /// every domain-event-driven caller propagates the field via code review.</para>
     /// </summary>
     Task TriggerWorkflowAsync(string webhookPath, object payload, CancellationToken ct = default);
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/WorkflowIntegration/Application/EventHandlers/GameNightN8nEventHandlersTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/WorkflowIntegration/Application/EventHandlers/GameNightN8nEventHandlersTests.cs
@@ -28,52 +28,65 @@ public sealed class GameNightN8nEventHandlersTests
     public async Task GameNightPublishedN8nHandler_ForwardsDomainEventIdInPayload()
     {
         // Arrange
+        var evt = new GameNightPublishedEvent(
+            gameNightEventId: Guid.NewGuid(),
+            organizerId: Guid.NewGuid(),
+            title: "Friday Catan",
+            scheduledAt: DateTimeOffset.UtcNow.AddDays(2),
+            invitedUserIds: new List<Guid> { Guid.NewGuid() });
+
         var capturedPayload = await CapturePayloadAsync<GameNightPublishedEvent, GameNightPublishedN8nHandler>(
-            evt => new GameNightPublishedN8nHandler(_clientMock.Object, NullLogger<GameNightPublishedN8nHandler>.Instance),
-            new GameNightPublishedEvent(
-                gameNightEventId: Guid.NewGuid(),
-                organizerId: Guid.NewGuid(),
-                title: "Friday Catan",
-                scheduledAt: DateTimeOffset.UtcNow.AddDays(2),
-                invitedUserIds: new List<Guid> { Guid.NewGuid() }),
+            _ => new GameNightPublishedN8nHandler(_clientMock.Object, NullLogger<GameNightPublishedN8nHandler>.Instance),
+            evt,
             expectedPath: "game-night-published");
 
-        // Assert — payload carries domainEventId equal to the event's EventId.
-        var json = JsonSerializer.SerializeToElement(capturedPayload);
-        json.TryGetProperty("domainEventId", out var domainEventIdProp).Should().BeTrue(
-            "iso-3 BE-side contract requires domainEventId on every domain-event-driven n8n call");
+        // Assert — payload carries domainEventId equal to the originating IDomainEvent.EventId.
+        // Presence alone is insufficient: a refactor that forwarded Guid.Empty (or a fresh Guid
+        // unrelated to the event) would defeat n8n-side dedup. iso-3 contract requires identity.
+        AssertDomainEventIdMatches(capturedPayload, evt.EventId);
     }
 
     [Fact]
     public async Task GameNightCancelledN8nHandler_ForwardsDomainEventIdInPayload()
     {
+        var evt = new GameNightCancelledEvent(
+            gameNightEventId: Guid.NewGuid(),
+            organizerId: Guid.NewGuid(),
+            title: "Friday Catan",
+            invitedUserIds: new List<Guid> { Guid.NewGuid() });
+
         var capturedPayload = await CapturePayloadAsync<GameNightCancelledEvent, GameNightCancelledN8nHandler>(
-            evt => new GameNightCancelledN8nHandler(_clientMock.Object, NullLogger<GameNightCancelledN8nHandler>.Instance),
-            new GameNightCancelledEvent(
-                gameNightEventId: Guid.NewGuid(),
-                organizerId: Guid.NewGuid(),
-                title: "Friday Catan",
-                invitedUserIds: new List<Guid> { Guid.NewGuid() }),
+            _ => new GameNightCancelledN8nHandler(_clientMock.Object, NullLogger<GameNightCancelledN8nHandler>.Instance),
+            evt,
             expectedPath: "game-night-cancelled");
 
-        var json = JsonSerializer.SerializeToElement(capturedPayload);
-        json.TryGetProperty("domainEventId", out _).Should().BeTrue();
+        AssertDomainEventIdMatches(capturedPayload, evt.EventId);
     }
 
     [Fact]
     public async Task GameNightRsvpN8nHandler_ForwardsDomainEventIdInPayload()
     {
+        var evt = new GameNightRsvpReceivedEvent(
+            gameNightEventId: Guid.NewGuid(),
+            userId: Guid.NewGuid(),
+            rsvpStatus: RsvpStatus.Accepted,
+            organizerId: Guid.NewGuid());
+
         var capturedPayload = await CapturePayloadAsync<GameNightRsvpReceivedEvent, GameNightRsvpN8nHandler>(
-            evt => new GameNightRsvpN8nHandler(_clientMock.Object, NullLogger<GameNightRsvpN8nHandler>.Instance),
-            new GameNightRsvpReceivedEvent(
-                gameNightEventId: Guid.NewGuid(),
-                userId: Guid.NewGuid(),
-                rsvpStatus: RsvpStatus.Accepted,
-                organizerId: Guid.NewGuid()),
+            _ => new GameNightRsvpN8nHandler(_clientMock.Object, NullLogger<GameNightRsvpN8nHandler>.Instance),
+            evt,
             expectedPath: "game-night-rsvp-changed");
 
-        var json = JsonSerializer.SerializeToElement(capturedPayload);
-        json.TryGetProperty("domainEventId", out _).Should().BeTrue();
+        AssertDomainEventIdMatches(capturedPayload, evt.EventId);
+    }
+
+    private static void AssertDomainEventIdMatches(object payload, Guid expectedEventId)
+    {
+        var json = JsonSerializer.SerializeToElement(payload);
+        json.TryGetProperty("domainEventId", out var prop).Should().BeTrue(
+            "iso-3 BE-side contract requires domainEventId on every domain-event-driven n8n call");
+        prop.GetGuid().Should().Be(expectedEventId,
+            "domainEventId MUST equal the originating IDomainEvent.EventId so n8n can dedup on it");
     }
 
     private async Task<object> CapturePayloadAsync<TEvent, THandler>(

--- a/apps/api/tests/Api.Tests/BoundedContexts/WorkflowIntegration/Application/EventHandlers/GameNightN8nEventHandlersTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/WorkflowIntegration/Application/EventHandlers/GameNightN8nEventHandlersTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.WorkflowIntegration.Application.EventHandlers;
+using Api.BoundedContexts.WorkflowIntegration.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.WorkflowIntegration.Application.EventHandlers;
+
+/// <summary>
+/// Issue #1942 / iso-3 — verifies that the 3 n8n handlers propagate the originating
+/// IDomainEvent.EventId as a top-level <c>domainEventId</c> field on the n8n webhook
+/// payload. This is the BE-side of the n8n idempotency contract documented in
+/// <c>docs/for-developers/integrations/n8n-idempotency-contract.md</c>; n8n workflows
+/// dedup on the field to avoid duplicate side-effects on re-dispatched events.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "WorkflowIntegration")]
+public sealed class GameNightN8nEventHandlersTests
+{
+    private readonly Mock<IN8nWebhookClient> _clientMock = new();
+
+    [Fact]
+    public async Task GameNightPublishedN8nHandler_ForwardsDomainEventIdInPayload()
+    {
+        // Arrange
+        var capturedPayload = await CapturePayloadAsync<GameNightPublishedEvent, GameNightPublishedN8nHandler>(
+            evt => new GameNightPublishedN8nHandler(_clientMock.Object, NullLogger<GameNightPublishedN8nHandler>.Instance),
+            new GameNightPublishedEvent(
+                gameNightEventId: Guid.NewGuid(),
+                organizerId: Guid.NewGuid(),
+                title: "Friday Catan",
+                scheduledAt: DateTimeOffset.UtcNow.AddDays(2),
+                invitedUserIds: new List<Guid> { Guid.NewGuid() }),
+            expectedPath: "game-night-published");
+
+        // Assert — payload carries domainEventId equal to the event's EventId.
+        var json = JsonSerializer.SerializeToElement(capturedPayload);
+        json.TryGetProperty("domainEventId", out var domainEventIdProp).Should().BeTrue(
+            "iso-3 BE-side contract requires domainEventId on every domain-event-driven n8n call");
+    }
+
+    [Fact]
+    public async Task GameNightCancelledN8nHandler_ForwardsDomainEventIdInPayload()
+    {
+        var capturedPayload = await CapturePayloadAsync<GameNightCancelledEvent, GameNightCancelledN8nHandler>(
+            evt => new GameNightCancelledN8nHandler(_clientMock.Object, NullLogger<GameNightCancelledN8nHandler>.Instance),
+            new GameNightCancelledEvent(
+                gameNightEventId: Guid.NewGuid(),
+                organizerId: Guid.NewGuid(),
+                title: "Friday Catan",
+                invitedUserIds: new List<Guid> { Guid.NewGuid() }),
+            expectedPath: "game-night-cancelled");
+
+        var json = JsonSerializer.SerializeToElement(capturedPayload);
+        json.TryGetProperty("domainEventId", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GameNightRsvpN8nHandler_ForwardsDomainEventIdInPayload()
+    {
+        var capturedPayload = await CapturePayloadAsync<GameNightRsvpReceivedEvent, GameNightRsvpN8nHandler>(
+            evt => new GameNightRsvpN8nHandler(_clientMock.Object, NullLogger<GameNightRsvpN8nHandler>.Instance),
+            new GameNightRsvpReceivedEvent(
+                gameNightEventId: Guid.NewGuid(),
+                userId: Guid.NewGuid(),
+                rsvpStatus: RsvpStatus.Accepted,
+                organizerId: Guid.NewGuid()),
+            expectedPath: "game-night-rsvp-changed");
+
+        var json = JsonSerializer.SerializeToElement(capturedPayload);
+        json.TryGetProperty("domainEventId", out _).Should().BeTrue();
+    }
+
+    private async Task<object> CapturePayloadAsync<TEvent, THandler>(
+        Func<TEvent, THandler> handlerFactory,
+        TEvent notification,
+        string expectedPath)
+        where THandler : MediatR.INotificationHandler<TEvent>
+        where TEvent : MediatR.INotification
+    {
+        object? captured = null;
+        _clientMock
+            .Setup(c => c.TriggerWorkflowAsync(expectedPath, It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object, CancellationToken>((_, payload, _) => captured = payload)
+            .Returns(Task.CompletedTask);
+
+        var handler = handlerFactory(notification);
+        await handler.Handle(notification, CancellationToken.None);
+
+        captured.Should().NotBeNull($"the handler must call TriggerWorkflowAsync(\"{expectedPath}\", …)");
+        return captured!;
+    }
+}

--- a/docs/for-developers/integrations/n8n-idempotency-contract.md
+++ b/docs/for-developers/integrations/n8n-idempotency-contract.md
@@ -1,0 +1,101 @@
+# n8n Idempotency Contract for Domain-Event-Driven Webhooks
+
+**Status:** active
+**Owner:** WorkflowIntegration BC + DevOps (n8n workflows)
+**Issue:** [#1942](https://github.com/meepleAi-app/meepleai-monorepo/issues/1942) (iso-3) — follow-up of [#1535](https://github.com/meepleAi-app/meepleai-monorepo/issues/1535) consumer idempotency audit
+
+## Why this contract exists
+
+The MeepleAI backend dispatches `IDomainEvent` instances via MediatR. The dispatch is currently inline-in-transaction and will move post-commit in #1535. In both modes a handler can be re-invoked for the same logical event:
+
+- **Pre-#1535**: MediatR transient retry; double-dispatch on a request-replay race.
+- **Post-#1535** (outbox): crash between `MediatR.Publish` and `MarkSent` re-fires the handler on the next processor tick.
+
+Handlers that call `IN8nWebhookClient.TriggerWorkflowAsync(...)` forward the event to an n8n workflow. n8n workflows often have observable side effects (send email, create calendar entry, post Slack message, ping external systems). **A duplicate workflow run produces a duplicate side effect**, since n8n has no built-in dedup against MeepleAI's dispatch lifecycle.
+
+To close that gap without changing n8n's transport semantics, both sides cooperate on a single contract:
+
+> **The BE-side caller writes `domainEventId` into the payload. The n8n-side workflow dedups on it.**
+
+## The contract
+
+### BE side — every domain-event-driven `TriggerWorkflowAsync` call
+
+The first-level payload object passed to `IN8nWebhookClient.TriggerWorkflowAsync` MUST contain a top-level property named `domainEventId` whose value is the originating `IDomainEvent.EventId` (a UUID).
+
+```csharp
+await _n8nClient.TriggerWorkflowAsync("game-night-published", new
+{
+    // Issue #1942 / iso-3: dedup key for n8n side workflows.
+    domainEventId = notification.EventId,
+    eventId = notification.GameNightEventId,
+    organizerId = notification.OrganizerId,
+    // ... other domain-specific fields ...
+}, cancellationToken).ConfigureAwait(false);
+```
+
+Hand-triggered admin webhooks (e.g. a manual "Test webhook" button) that do NOT originate from an `IDomainEvent` are exempt — they MAY omit `domainEventId`, and the n8n workflow MUST treat its absence as "no dedup possible, process normally".
+
+Verification is by code review. There is no compile-time enforcement (the `IN8nWebhookClient.TriggerWorkflowAsync` signature accepts `object`); the doc-comment carries the formal requirement and the audit checklist in `audits/2026-06-06-issue-1535-consumer-idempotency-audit.md` enumerates every caller that must comply.
+
+### n8n side — every workflow consuming a MeepleAI domain event
+
+The first node after the Webhook trigger MUST inspect the incoming payload's `domainEventId` and short-circuit when the same value has already been processed.
+
+Reference dedup pattern (n8n 1.x):
+
+```
+Webhook (path: /game-night-published)
+  ↓
+Set node                   // extract { domainEventId } as a fixed variable
+  ↓
+IF node                    // condition: domainEventId is empty → bypass dedup, continue
+  ├─ true  → Postgres SELECT 1 FROM n8n_processed_events WHERE event_id = $domainEventId
+  │           ├─ found → Respond 200 OK (no-op) and stop the workflow
+  │           └─ not found → Postgres INSERT INTO n8n_processed_events (event_id, workflow, received_at)
+  │                            then continue to the real workflow body
+  └─ false (no domainEventId) → continue to the real workflow body (legacy / hand-triggered)
+```
+
+The `n8n_processed_events` table is owned by n8n's own Postgres (NOT the MeepleAI app DB):
+
+```sql
+CREATE TABLE n8n_processed_events (
+  event_id UUID PRIMARY KEY,
+  workflow VARCHAR(128) NOT NULL,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Optional cleanup: retain 30 days for audit, then drop.
+CREATE INDEX idx_n8n_processed_events_received_at ON n8n_processed_events(received_at);
+```
+
+The `PRIMARY KEY` on `event_id` provides race-free dedup: two simultaneous workflow runs racing on the same `domainEventId` will see one `INSERT` succeed and the sibling fail with a unique-violation, which the workflow MUST translate into the "found → no-op" branch.
+
+## Workflows currently in scope
+
+As of 2026-06-07 the following 3 workflows MUST be wired with the dedup node:
+
+| Webhook path | Payload field carrying domainEventId | Owning caller |
+|---|---|---|
+| `game-night-published` | `domainEventId` | `GameNightPublishedN8nHandler` |
+| `game-night-cancelled` | `domainEventId` | `GameNightCancelledN8nHandler` |
+| `game-night-rsvp-changed` | `domainEventId` | `GameNightRsvpN8nHandler` |
+
+When new domain-event-driven webhooks are added, this table MUST be updated in the same PR that adds the BE caller. The PR description MUST also reference the n8n workflow change (or a follow-up DevOps issue) so the cross-system pair is tracked.
+
+## Backward compatibility
+
+n8n ignores unknown JSON fields by default. Workflows that have NOT yet been updated will continue to receive `domainEventId` and process the payload normally — they just won't dedup. The BE-side change is therefore **always safe to ship before** the n8n-side change. The reverse (n8n updated first, BE not propagating yet) is also safe because the IF node bypasses dedup when `domainEventId` is absent.
+
+## Rollout plan
+
+1. **BE ship** (this PR): caller-side `domainEventId` propagation merges to `main-dev`. Three workflows above start receiving the field.
+2. **n8n staging audit** (DevOps): for each of the 3 workflows on the n8n staging instance, add the dedup nodes per the reference pattern. Test by replaying a recent webhook invocation twice — verify the second run short-circuits.
+3. **n8n prod cutover** (DevOps): copy the staged workflows to prod. Verify by tailing `n8n_processed_events.received_at` for a known game-night-published event during a deploy window.
+
+## References
+
+- Audit doc: [`audits/2026-06-06-issue-1535-consumer-idempotency-audit.md`](../../../audits/2026-06-06-issue-1535-consumer-idempotency-audit.md) § "n8n webhook handlers"
+- Source: `IN8nWebhookClient` doc-comment in `apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/Services/IN8nWebhookClient.cs`
+- Caller examples: `GameNightN8nEventHandlers.cs` in `apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/EventHandlers/`

--- a/docs/for-developers/integrations/n8n-idempotency-contract.md
+++ b/docs/for-developers/integrations/n8n-idempotency-contract.md
@@ -96,6 +96,6 @@ n8n ignores unknown JSON fields by default. Workflows that have NOT yet been upd
 
 ## References
 
-- Audit doc: [`audits/2026-06-06-issue-1535-consumer-idempotency-audit.md`](../../../audits/2026-06-06-issue-1535-consumer-idempotency-audit.md) § "n8n webhook handlers"
+- Audit doc: `audits/2026-06-06-issue-1535-consumer-idempotency-audit.md` § "n8n webhook handlers" (staged in #1535 umbrella PR)
 - Source: `IN8nWebhookClient` doc-comment in `apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/Services/IN8nWebhookClient.cs`
 - Caller examples: `GameNightN8nEventHandlers.cs` in `apps/api/src/Api/BoundedContexts/WorkflowIntegration/Application/EventHandlers/`


### PR DESCRIPTION
## Summary

Implementa **iso-3** (#1942), il **6° e ULTIMO follow-up** dei BLOCKER P0 individuati nell'audit del Task 0 di #1535. **Sblocca Phase B cutover di #1535** una volta mergiati tutti i 6 PR (#1943 / #1946 / #1947 / #1949 / #1950 / questo).

Risolve issue **#1942**.

## Problema

I 3 handler in `GameNightN8nEventHandlers.cs` invocano `IN8nWebhookClient.TriggerWorkflowAsync` con payload che include solo aggregate IDs (es. `GameNightEventId`), **NON l'`IDomainEvent.EventId`**. n8n riceve quindi 2 chiamate su retry/rollback e non può dedupare → duplicate calendar event / email / Slack ping.

## BE side (questo PR)

- **3 handler aggiornati** con `domainEventId = notification.EventId` come field top-level del payload (`GameNightPublishedN8nHandler` / `GameNightCancelledN8nHandler` / `GameNightRsvpN8nHandler`).
- **`IN8nWebhookClient.TriggerWorkflowAsync` doc-comment esteso** con il contract: every domain-event-driven caller MUST include `domainEventId`; n8n side MUST dedup on it.
- **3 nuovi unit test (smoke)** che asseriscono la presenza di `domainEventId` nel payload serializzato. 3/3 verdi.
- **Nuova contract doc**: [`docs/for-developers/integrations/n8n-idempotency-contract.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/issue-1942-iso-3-n8n-contract/docs/for-developers/integrations/n8n-idempotency-contract.md) con:
  - Rationale + BE+n8n contract
  - Reference dedup pattern (Set + IF + Postgres SELECT/INSERT)
  - `n8n_processed_events` table schema
  - Scope table (3 workflow attuali)
  - Backward compat note
  - Rollout plan

## n8n side (out of scope di questo PR — DevOps follow-up)

1. **Staging audit**: audit dei 3 workflow su n8n staging
2. **Wire dedup**: aggiungere il nodo pattern documentato (Set → IF → Postgres SELECT/INSERT)
3. **Verify**: replay di un webhook noto, confirm dedup
4. **Promote**: copia su prod

## Test plan

- [x] Backend build clean (0 errori, 0 warning su `src/Api`)
- [x] **3/3 unit test verdi** (nuovi smoke per i 3 handler)
- [x] Doc reachable via Lychee link-check (CI verifica)
- [ ] Code review
- [ ] DevOps audit n8n workflow staging — TODO follow-up

## Backward compat

n8n ignora field unknown. Workflow non-aggiornati ricevono `domainEventId` ma non lo usano → continuano a processare normalmente (no dedup, comportamento attuale preservato). Questo PR è **always-safe to ship prima del n8n update**.

## Why standalone

Migliora idempotency **anche pre-#1535**: retry MediatR transient errors oggi produrrebbe duplicate calendar event / email / notification cross-system. Bug latente già reale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)