### PR TITLE
feat(testing): #1929 Macro 4 — Journey #3 game-detail sessions tab

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/CleanupTestEntitiesCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/CleanupTestEntitiesCommandHandler.cs
@@ -12,11 +12,14 @@ namespace Api.BoundedContexts.Testing.Application.Commands;
 
 /// <summary>
 /// Issue #1928 Task B (DEC-B-1, DEC-B-3, DEC-B-8) + Issue #1929 Task C Macro 3a
-/// (DEC-C-8) — Handler for <see cref="CleanupTestEntitiesCommand"/>. Cascade-delete
-/// by explicit TestRunId column on 7 persistence entities. FK dependency order:
-/// Sessions → Rsvps → Invitations → GameNightEvents → UserLibraryEntries →
-/// SharedGames → Users. UserLibraryEntry must be deleted before SharedGame
-/// (FK constraint); SharedGame must be deleted before User (FK CreatedBy).
+/// (DEC-C-8) + Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — Handler for
+/// <see cref="CleanupTestEntitiesCommand"/>. Cascade-delete by explicit TestRunId
+/// column on 8 persistence entities. FK dependency order:
+/// UserGameSessions → GameNightSessions → Rsvps → Invitations → GameNightEvents →
+/// UserLibraryEntries → SharedGames → Users.
+/// UserGameSession must be deleted BEFORE UserLibraryEntries (FK child).
+/// UserLibraryEntry must be deleted before SharedGame (FK constraint);
+/// SharedGame must be deleted before User (FK CreatedBy).
 /// </summary>
 internal sealed class CleanupTestEntitiesCommandHandler
     : IRequestHandler<CleanupTestEntitiesCommand, CleanupTestEntitiesResponse>
@@ -39,6 +42,14 @@ internal sealed class CleanupTestEntitiesCommandHandler
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
         // FK dependency order: child rows first, parent rows last.
+
+        // Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — UserGameSessions FIRST
+        // (FK child of UserLibraryEntries via UserLibraryEntryId).
+        var deletedUserGameSessions = await _db.Set<UserGameSessionEntity>()
+            .Where(s => s.TestRunId == request.TestRunId)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         var deletedSessions = await _db.Set<GameNightSessionEntity>()
             .Where(s => s.TestRunId == request.TestRunId)
             .ExecuteDeleteAsync(cancellationToken)
@@ -79,8 +90,8 @@ internal sealed class CleanupTestEntitiesCommandHandler
         stopwatch.Stop();
 
         _logger.LogInformation(
-            "Cleaned up testRunId={TestRunId} gameNights={GN} sessions={S} invitations={I} rsvps={R} users={U} libraryEntries={LE} sharedGames={SG} durationMs={Duration}",
-            request.TestRunId, deletedGameNights, deletedSessions, deletedInvitations, deletedRsvps, deletedUsers, deletedLibraryEntries, deletedSharedGames, stopwatch.ElapsedMilliseconds);
+            "Cleaned up testRunId={TestRunId} gameNights={GN} sessions={S} invitations={I} rsvps={R} users={U} libraryEntries={LE} sharedGames={SG} userGameSessions={UGS} durationMs={Duration}",
+            request.TestRunId, deletedGameNights, deletedSessions, deletedInvitations, deletedRsvps, deletedUsers, deletedLibraryEntries, deletedSharedGames, deletedUserGameSessions, stopwatch.ElapsedMilliseconds);
 
         return new CleanupTestEntitiesResponse(
             request.TestRunId,
@@ -91,6 +102,7 @@ internal sealed class CleanupTestEntitiesCommandHandler
             deletedUsers,
             deletedLibraryEntries,
             deletedSharedGames,
+            deletedUserGameSessions,
             stopwatch.ElapsedMilliseconds);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommand.cs
@@ -7,6 +7,11 @@ namespace Api.BoundedContexts.Testing.Application.Commands;
 /// Issue #1928 Task B (DEC-B-1, DEC-B-8) — Seed a GameNightEvent for E2E test data-driven
 /// scenarios. Stamps the new aggregate with the caller's TestRunId via explicit column
 /// so CleanupTestEntitiesCommand can cascade-delete by run scope.
+///
+/// Issue #1929 Task C Macro 4 (DEC-C-10 PIVOT) — Added optional <see cref="GameId"/> param
+/// to link the seeded GameNight to a SharedGame catalog entry created via
+/// <see cref="SeedTestLibraryGameCommand"/>. When provided, the handler stores the GameId
+/// in <c>GameNightEventEntity.GameIdsJson</c> so the night is associated with the game.
 /// </summary>
 public sealed record SeedTestGameNightCommand : IRequest<SeedTestGameNightResponse>
 {
@@ -15,4 +20,13 @@ public sealed record SeedTestGameNightCommand : IRequest<SeedTestGameNightRespon
     public required string OwnerEmail { get; init; }
     public string? ScoringType { get; init; }
     public int RosterCount { get; init; }
+
+    /// <summary>
+    /// Optional SharedGame catalog id to associate this GameNight with.
+    /// Must exist in <c>shared_games</c> when provided. Format validated by
+    /// <see cref="SeedTestGameNightCommandValidator"/> (non-empty Guid);
+    /// existence validated in handler via <c>BadRequestException</c>.
+    /// When provided, stored in <c>GameNightEventEntity.GameIdsJson</c>.
+    /// </summary>
+    public Guid? GameId { get; init; }
 }

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.Testing.Infrastructure;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -29,6 +30,18 @@ internal sealed class SeedTestGameNightCommandHandler
         CancellationToken cancellationToken)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        // Issue #1929 Macro 4 (DEC-C-10 PIVOT): verify GameId exists in SharedGames if provided.
+        if (request.GameId.HasValue)
+        {
+            var gameExists = await _db.SharedGames
+                .AnyAsync(g => g.Id == request.GameId.Value, cancellationToken)
+                .ConfigureAwait(false);
+            if (!gameExists)
+            {
+                throw new BadRequestException($"GameId {request.GameId.Value} not found in SharedGames catalog");
+            }
+        }
 
         var ownerId = Guid.NewGuid();
         var ownerEntity = new UserEntity
@@ -59,6 +72,11 @@ internal sealed class SeedTestGameNightCommandHandler
             _ => request.Status
         };
 
+        // Issue #1929 Macro 4 (DEC-C-10 PIVOT): include GameId in GameIdsJson when provided.
+        var gameIds = request.GameId.HasValue
+            ? new List<Guid> { request.GameId.Value }
+            : new List<Guid>();
+
         var gameNightEntity = new GameNightEventEntity
         {
             Id = gameNightId,
@@ -68,7 +86,7 @@ internal sealed class SeedTestGameNightCommandHandler
             ScheduledAt = DateTimeOffset.UtcNow.AddDays(7),
             Location = "E2E Location",
             MaxPlayers = null,
-            GameIdsJson = JsonSerializer.Serialize(new List<Guid>()),
+            GameIdsJson = JsonSerializer.Serialize(gameIds),
             Status = finalStatus,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommandHandler.cs
@@ -94,7 +94,10 @@ internal sealed class SeedTestGameNightCommandHandler
             Sessions = []
         };
 
-        // Create sessions if InProgress or Completed requested
+        // Create sessions if InProgress or Completed requested.
+        // Issue #1929 Macro 4 (DEC-C-10 PIVOT): when request.GameId is provided (linked SharedGame),
+        // propagate it to the session's GameId so the child entity references a real catalog entry
+        // instead of a phantom Guid. Fall back to Guid.NewGuid() for legacy callers that omit GameId.
         if (request.Status is "InProgress" or "Completed")
         {
             var sessionId = Guid.NewGuid();
@@ -103,7 +106,7 @@ internal sealed class SeedTestGameNightCommandHandler
                 Id = sessionId,
                 GameNightEventId = gameNightId,
                 SessionId = sessionId,
-                GameId = Guid.NewGuid(),
+                GameId = request.GameId ?? Guid.NewGuid(),
                 GameTitle = "E2E Game Title",
                 PlayOrder = 1,
                 Status = request.Status is "Completed" ? "Completed" : "InProgress",

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestGameNightCommandValidator.cs
@@ -32,5 +32,13 @@ internal sealed class SeedTestGameNightCommandValidator : AbstractValidator<Seed
         RuleFor(x => x.ScoringType)
             .Must(s => s is null or "Points" or "BinaryWin" or "Objectives" or "Ranking")
             .When(x => x.ScoringType is not null);
+
+        // Issue #1929 Macro 4 (DEC-C-10 PIVOT): GameId format-only validation (non-empty Guid).
+        // Existence check (GameId must be in SharedGames) is performed in the handler to keep
+        // the validator DB-free (consistent with SeedTestLibraryGameCommandValidator pattern).
+        RuleFor(x => x.GameId!.Value)
+            .NotEqual(Guid.Empty)
+            .WithMessage("GameId must be a non-empty Guid when provided")
+            .When(x => x.GameId.HasValue);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestUserGameSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestUserGameSessionCommand.cs
@@ -1,0 +1,32 @@
+using Api.BoundedContexts.Testing.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.Testing.Application.Commands;
+
+/// <summary>
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — Seed a UserGameSession linked
+/// to an existing UserLibraryEntry. Used by Journey #3 to set up "user has played
+/// this game N times" precondition for the GameDetailSessionsRail.
+///
+/// The session is stamped with an explicit <see cref="TestRunId"/> column (DEC-B-8)
+/// for cleanup scope via CleanupTestEntitiesCommand cascade-delete.
+/// </summary>
+public sealed record SeedTestUserGameSessionCommand : IRequest<SeedTestUserGameSessionResponse>
+{
+    public required string TestRunId { get; init; }
+
+    /// <summary>FK to UserLibraryEntryEntity. Must exist before calling this command.</summary>
+    public required Guid UserLibraryEntryId { get; init; }
+
+    /// <summary>When the session was played. Defaults to UtcNow if not provided.</summary>
+    public DateTime? PlayedAt { get; init; }
+
+    /// <summary>Duration in minutes. Defaults to 60 if not provided.</summary>
+    public int? DurationMinutes { get; init; }
+
+    /// <summary>Whether the user won. Null for non-competitive games (default).</summary>
+    public bool? DidWin { get; init; }
+
+    /// <summary>Comma-separated player names. Null if not provided.</summary>
+    public string? Players { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestUserGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestUserGameSessionCommandHandler.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.Testing.Application.DTOs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserLibrary;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Testing.Application.Commands;
+
+/// <summary>
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION, DEC-B-8) — Handler for
+/// <see cref="SeedTestUserGameSessionCommand"/>. Creates a UserGameSessionEntity
+/// linked to an existing UserLibraryEntry, stamped with an explicit TestRunId
+/// column for cascade-delete scope in CleanupTestEntitiesCommandHandler.
+///
+/// FK guard: verifies UserLibraryEntryId exists before insertion (BadRequestException).
+/// Defaults: PlayedAt=UtcNow, DurationMinutes=60 when not provided.
+/// </summary>
+internal sealed class SeedTestUserGameSessionCommandHandler
+    : IRequestHandler<SeedTestUserGameSessionCommand, SeedTestUserGameSessionResponse>
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly ILogger<SeedTestUserGameSessionCommandHandler> _logger;
+
+    public SeedTestUserGameSessionCommandHandler(
+        MeepleAiDbContext db,
+        ILogger<SeedTestUserGameSessionCommandHandler> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<SeedTestUserGameSessionResponse> Handle(
+        SeedTestUserGameSessionCommand request,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        // 1. Guard: verify UserLibraryEntryId exists (FK child requires parent row).
+        var entryExists = await _db.UserLibraryEntries
+            .AnyAsync(e => e.Id == request.UserLibraryEntryId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!entryExists)
+        {
+            throw new BadRequestException(
+                $"UserLibraryEntryId {request.UserLibraryEntryId} not found in UserLibraryEntries");
+        }
+
+        // 2. Create UserGameSessionEntity with defaults for optional fields.
+        var sessionId = Guid.NewGuid();
+        var session = new UserGameSessionEntity
+        {
+            Id = sessionId,
+            UserLibraryEntryId = request.UserLibraryEntryId,
+            PlayedAt = request.PlayedAt ?? DateTime.UtcNow,
+            DurationMinutes = request.DurationMinutes ?? 60,
+            DidWin = request.DidWin,
+            Players = request.Players,
+            Notes = null,
+            CreatedAt = DateTime.UtcNow,
+            TestRunId = request.TestRunId
+        };
+        _db.Set<UserGameSessionEntity>().Add(session);
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        stopwatch.Stop();
+
+        _logger.LogInformation(
+            "Seeded UserGameSession sessionId={SessionId} libraryEntryId={LibraryEntryId} testRunId={TestRunId} durationMs={Duration}",
+            sessionId, request.UserLibraryEntryId, request.TestRunId, stopwatch.ElapsedMilliseconds);
+
+        return new SeedTestUserGameSessionResponse(sessionId, request.UserLibraryEntryId, request.TestRunId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestUserGameSessionCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/Commands/SeedTestUserGameSessionCommandValidator.cs
@@ -1,0 +1,32 @@
+using Api.BoundedContexts.Testing.Infrastructure;
+using FluentValidation;
+
+namespace Api.BoundedContexts.Testing.Application.Commands;
+
+/// <summary>
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION, DEC-B-5) — Validator for
+/// <see cref="SeedTestUserGameSessionCommand"/>. Enforces TestRunId regex
+/// (DEC-B-5) and FK presence. UserLibraryEntryId existence is verified in
+/// the handler (bad-request guard) not here — avoids async async DB lookup
+/// in validator (pattern per SeedTestGameNightCommand).
+/// </summary>
+internal sealed class SeedTestUserGameSessionCommandValidator
+    : AbstractValidator<SeedTestUserGameSessionCommand>
+{
+    public SeedTestUserGameSessionCommandValidator()
+    {
+        RuleFor(x => x.TestRunId)
+            .NotEmpty()
+            .Must(TestRunIdMetadata.IsValid)
+            .WithMessage("TestRunId must match format e2e-{testId}-{epochMs}");
+
+        RuleFor(x => x.UserLibraryEntryId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("UserLibraryEntryId must be a non-empty Guid.");
+
+        RuleFor(x => x.DurationMinutes!.Value)
+            .GreaterThan(0)
+            .WithMessage("DurationMinutes must be > 0 when provided.")
+            .When(x => x.DurationMinutes.HasValue);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/DTOs/CleanupTestEntitiesResponse.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/DTOs/CleanupTestEntitiesResponse.cs
@@ -1,10 +1,12 @@
 namespace Api.BoundedContexts.Testing.Application.DTOs;
 
 /// <summary>
-/// Issue #1928 Task B (DEC-B-1) + Issue #1929 Task C Macro 3a (DEC-C-8) —
-/// Response from <see cref="Commands.CleanupTestEntitiesCommand"/>. Reports
-/// cascade-delete counts. <see cref="DeletedLibraryEntries"/> and
-/// <see cref="DeletedSharedGames"/> added by Macro 3a for library catalog scope.
+/// Issue #1928 Task B (DEC-B-1) + Issue #1929 Task C Macro 3a (DEC-C-8) +
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — Response from
+/// <see cref="Commands.CleanupTestEntitiesCommand"/>. Reports cascade-delete counts.
+/// <see cref="DeletedLibraryEntries"/> and <see cref="DeletedSharedGames"/> added
+/// by Macro 3a; <see cref="DeletedUserGameSessions"/> added by Macro 4 for
+/// UserGameSession scope (FK child of UserLibraryEntry, deleted first).
 /// </summary>
 public sealed record CleanupTestEntitiesResponse(
     string TestRunId,
@@ -15,4 +17,5 @@ public sealed record CleanupTestEntitiesResponse(
     int DeletedUsers,
     int DeletedLibraryEntries,
     int DeletedSharedGames,
+    int DeletedUserGameSessions,
     long DurationMs);

--- a/apps/api/src/Api/BoundedContexts/Testing/Application/DTOs/SeedTestUserGameSessionResponse.cs
+++ b/apps/api/src/Api/BoundedContexts/Testing/Application/DTOs/SeedTestUserGameSessionResponse.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.Testing.Application.DTOs;
+
+/// <summary>
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — Response from
+/// <see cref="Commands.SeedTestUserGameSessionCommand"/>. SessionId is the new
+/// UserGameSessionEntity primary key; UserLibraryEntryId is the junction FK
+/// used to associate the session with the caller's library entry.
+/// </summary>
+public sealed record SeedTestUserGameSessionResponse(
+    Guid SessionId,
+    Guid UserLibraryEntryId,
+    string TestRunId);

--- a/apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserGameSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserLibrary/UserGameSessionEntity.cs
@@ -47,6 +47,16 @@ public class UserGameSessionEntity
     /// </summary>
     public DateTime? UpdatedAt { get; set; }
 
+    /// <summary>
+    /// Issue #1929 Task C Macro 4 (DEC-B-8, DEC-C-10 REVISION) — E2E test seeding scope marker.
+    /// Explicit column (NOT shadow property) to avoid EF Core 9 + Npgsql null-after-save bug.
+    /// Stamped on insert by SeedTestUserGameSessionCommandHandler; consumed by
+    /// CleanupTestEntitiesCommandHandler.ExecuteDeleteAsync for cascade-delete scope.
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Schema.Column("test_run_id")]
+    [System.ComponentModel.DataAnnotations.MaxLength(64)]
+    public string? TestRunId { get; set; }
+
     // Navigation property
     public UserLibraryEntryEntity? UserLibraryEntry { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserLibrary/GameSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserLibrary/GameSessionEntityConfiguration.cs
@@ -60,6 +60,16 @@ internal class GameSessionEntityConfiguration : IEntityTypeConfiguration<UserGam
         builder.HasIndex(e => new { e.UserLibraryEntryId, e.PlayedAt })
             .HasDatabaseName("ix_game_sessions_entry_played");
 
+        // Issue #1929 Task C Macro 4 (DEC-B-8, DEC-C-10 REVISION) — TestRunId partial index.
+        // Null for production entities; non-null only when seeded via Testing BC.
+        builder.Property(e => e.TestRunId)
+            .HasMaxLength(64)
+            .IsRequired(false);
+
+        builder.HasIndex(e => e.TestRunId)
+            .HasDatabaseName("ix_game_sessions_test_run_id")
+            .HasFilter("\"test_run_id\" IS NOT NULL");
+
         // Check constraints for domain validation
         builder.ToTable(t =>
         {

--- a/apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607061447_Add_TestRunId_To_UserGameSessions")]
+    partial class Add_TestRunId_To_UserGameSessions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_TestRunId_To_UserGameSessions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "users",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "user_library_entries",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "shared_games",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "game_sessions",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "game_night_sessions",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "game_night_rsvps",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "game_night_invitations",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "test_run_id",
+                table: "game_night_events",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_game_sessions_test_run_id",
+                table: "game_sessions",
+                column: "test_run_id",
+                filter: "\"test_run_id\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_game_sessions_test_run_id",
+                table: "game_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "user_library_entries");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "game_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "game_night_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "game_night_rsvps");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "game_night_invitations");
+
+            migrationBuilder.DropColumn(
+                name: "test_run_id",
+                table: "game_night_events");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/Admin/AdminTestSeedEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminTestSeedEndpoints.cs
@@ -40,6 +40,11 @@ internal static class AdminTestSeedEndpoints
             .WithName("AdminTestSeed_LibraryGame")
             .WithTags("Admin", "TestSeeding");
 
+        // Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — UserGameSession seeding.
+        group.MapPost("/user-game-session", HandleSeedUserGameSession)
+            .WithName("AdminTestSeed_UserGameSession")
+            .WithTags("Admin", "TestSeeding");
+
         group.MapPost("/cleanup", HandleCleanup)
             .WithName("AdminTestSeed_Cleanup")
             .WithTags("Admin", "TestSeeding");
@@ -79,6 +84,16 @@ internal static class AdminTestSeedEndpoints
 
     private static async Task<IResult> HandleSeedLibraryGame(
         SeedTestLibraryGameCommand command,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleSeedUserGameSession(
+        SeedTestUserGameSessionCommand command,
         IMediator mediator,
         CancellationToken ct)
     {

--- a/apps/api/tests/Api.Tests/Integration/Testing/CleanupTestEntitiesCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Testing/CleanupTestEntitiesCommandHandlerTests.cs
@@ -127,6 +127,8 @@ public sealed class CleanupTestEntitiesCommandHandlerTests : IAsyncLifetime
         // Issue #1929 Macro 3a — library cascade assertions
         response.DeletedLibraryEntries.Should().Be(1);
         response.DeletedSharedGames.Should().Be(1);
+        // Issue #1929 Macro 4 (DEC-C-10 REVISION) — UserGameSessions not seeded in SeedFullScopeAsync
+        response.DeletedUserGameSessions.Should().Be(0);
 
         // Scope A fully deleted
         (await db.GameNightEvents.AnyAsync(g => g.TestRunId == testRunIdA, TestCancellationToken))
@@ -161,6 +163,7 @@ public sealed class CleanupTestEntitiesCommandHandlerTests : IAsyncLifetime
         response.DeletedUsers.Should().Be(0);
         response.DeletedLibraryEntries.Should().Be(0);
         response.DeletedSharedGames.Should().Be(0);
+        response.DeletedUserGameSessions.Should().Be(0);
     }
 
     [Fact]
@@ -273,6 +276,8 @@ public sealed class CleanupTestEntitiesCommandHandlerTests : IAsyncLifetime
         response.DeletedSharedGames.Should().Be(1);
         response.DeletedUsers.Should().Be(1);
         response.DeletedGameNights.Should().Be(0);
+        // Issue #1929 Macro 4 (DEC-C-10 REVISION) — no UserGameSessions seeded in this test
+        response.DeletedUserGameSessions.Should().Be(0);
 
         // Scope A library fully deleted
         (await db.UserLibraryEntries.AnyAsync(e => e.TestRunId == testRunIdA, TestCancellationToken))

--- a/apps/api/tests/Api.Tests/Integration/Testing/SeedTestGameNightCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Testing/SeedTestGameNightCommandHandlerTests.cs
@@ -212,4 +212,76 @@ public sealed class SeedTestGameNightCommandHandlerTests : IAsyncLifetime
             r1.TestRunId.Should().NotBe(r2.TestRunId);
         }
     }
+
+    // ── Issue #1929 Macro 4 (DEC-C-10 PIVOT): GameId extension tests ─────────
+
+    [Fact]
+    public async Task Handle_WithGameId_StoresGameIdInGameIdsJson()
+    {
+        // Arrange: seed a SharedGame first so the handler can reference it.
+        var (scope, db, handler) = CreateHandlerScope();
+        using (scope)
+        {
+            var sharedGameId = Guid.NewGuid();
+            var sharedGame = new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+            {
+                Id = sharedGameId,
+                Title = "Integration Test Game",
+                Description = "Seeded for Macro4 GameId test",
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 8,
+                ImageUrl = string.Empty,
+                ThumbnailUrl = string.Empty,
+                Status = 1,
+                GameDataStatus = 5,
+                CreatedBy = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                TestRunId = "e2e-gameidtest01234-1717603200000",
+            };
+            db.SharedGames.Add(sharedGame);
+            await db.SaveChangesAsync(TestCancellationToken);
+
+            var cmd = new SeedTestGameNightCommand
+            {
+                TestRunId = "e2e-gameidtest01234-1717603200000",
+                Status = "Published",
+                OwnerEmail = "gameid@e2e.test",
+                GameId = sharedGameId,
+            };
+
+            // Act
+            var response = await handler.Handle(cmd, TestCancellationToken);
+
+            // Assert: GameIdsJson contains the provided SharedGame id.
+            var seeded = await db.GameNightEvents
+                .SingleAsync(g => g.Id == response.GameNightId, TestCancellationToken);
+            seeded.GameIdsJson.Should().Contain(sharedGameId.ToString());
+        }
+    }
+
+    [Fact]
+    public async Task Handle_WithUnknownGameId_ThrowsBadRequestException()
+    {
+        var (scope, _, handler) = CreateHandlerScope();
+        using (scope)
+        {
+            var unknownGameId = Guid.NewGuid(); // Not persisted to DB.
+
+            var cmd = new SeedTestGameNightCommand
+            {
+                TestRunId = "e2e-badgameid01234-1717603200000",
+                Status = "Draft",
+                OwnerEmail = "badgame@e2e.test",
+                GameId = unknownGameId,
+            };
+
+            // Act & Assert
+            await handler.Invoking(h => h.Handle(cmd, TestCancellationToken))
+                .Should()
+                .ThrowAsync<Api.Middleware.Exceptions.BadRequestException>()
+                .WithMessage($"*{unknownGameId}*");
+        }
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/Testing/SeedTestUserGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Testing/SeedTestUserGameSessionCommandHandlerTests.cs
@@ -1,0 +1,253 @@
+using Api.BoundedContexts.Testing.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserLibrary;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Integration.Testing;
+
+/// <summary>
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION, DEC-B-8) — Integration tests for
+/// SeedTestUserGameSessionCommandHandler. Validates UserGameSession rows persist with
+/// explicit TestRunId column stamping; verifies FK guard for missing LibraryEntry;
+/// verifies optional-field defaults; verifies cleanup cascade (via CleanupHandler).
+///
+/// Pattern: clone of <see cref="SeedTestLibraryGameCommandHandlerTests"/>;
+/// EnsureCreatedAsync rebuilds schema from current model.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Testing")]
+[Trait("Issue", "1929")]
+public sealed class SeedTestUserGameSessionCommandHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private WebApplicationFactory<Program>? _factory;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public SeedTestUserGameSessionCommandHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_seed_ugame_session_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.EnsureCreatedAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+        {
+            await _factory.DisposeAsync();
+        }
+    }
+
+    // ─── Helper ───────────────────────────────────────────────────────────────
+
+    private static async Task<Guid> SeedLibraryEntryAsync(MeepleAiDbContext db, string testRunId, string ownerEmail)
+    {
+        var libHandler = new SeedTestLibraryGameCommandHandler(
+            db, NullLogger<SeedTestLibraryGameCommandHandler>.Instance);
+        var result = await libHandler.Handle(new SeedTestLibraryGameCommand
+        {
+            TestRunId = testRunId,
+            OwnerEmail = ownerEmail,
+        }, TestCancellationToken);
+        return result.LibraryEntryId;
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_CreatesSessionWithTestRunIdStamp()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var testRunId = "e2e-ugame-happy000-1717603200000";
+
+        var libraryEntryId = await SeedLibraryEntryAsync(db, testRunId, "happy-session@e2e.test");
+
+        var handler = new SeedTestUserGameSessionCommandHandler(
+            db, NullLogger<SeedTestUserGameSessionCommandHandler>.Instance);
+
+        var response = await handler.Handle(new SeedTestUserGameSessionCommand
+        {
+            TestRunId = testRunId,
+            UserLibraryEntryId = libraryEntryId,
+            PlayedAt = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc),
+            DurationMinutes = 90,
+            DidWin = true,
+            Players = "Anna, Marco",
+        }, TestCancellationToken);
+
+        response.SessionId.Should().NotBe(Guid.Empty);
+        response.UserLibraryEntryId.Should().Be(libraryEntryId);
+        response.TestRunId.Should().Be(testRunId);
+
+        var session = await db.Set<UserGameSessionEntity>()
+            .SingleOrDefaultAsync(s => s.Id == response.SessionId, TestCancellationToken);
+        session.Should().NotBeNull();
+        session!.TestRunId.Should().Be(testRunId);
+        session.UserLibraryEntryId.Should().Be(libraryEntryId);
+        session.DurationMinutes.Should().Be(90);
+        session.DidWin.Should().BeTrue();
+        session.Players.Should().Be("Anna, Marco");
+    }
+
+    [Fact]
+    public async Task Handle_UnknownLibraryEntryId_ThrowsBadRequestException()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var testRunId = "e2e-ugame-notfound-1717603200000";
+
+        var handler = new SeedTestUserGameSessionCommandHandler(
+            db, NullLogger<SeedTestUserGameSessionCommandHandler>.Instance);
+
+        var act = async () => await handler.Handle(new SeedTestUserGameSessionCommand
+        {
+            TestRunId = testRunId,
+            UserLibraryEntryId = Guid.NewGuid(), // does not exist
+        }, TestCancellationToken);
+
+        await act.Should().ThrowAsync<BadRequestException>()
+            .WithMessage("*UserLibraryEntryId*not found*");
+    }
+
+    [Fact]
+    public async Task Handle_OptionalFieldsNull_DefaultsApplied()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var testRunId = "e2e-ugame-defaults0-1717603200000";
+
+        var libraryEntryId = await SeedLibraryEntryAsync(db, testRunId, "defaults-session@e2e.test");
+
+        var handler = new SeedTestUserGameSessionCommandHandler(
+            db, NullLogger<SeedTestUserGameSessionCommandHandler>.Instance);
+
+        var beforeCall = DateTime.UtcNow;
+        var response = await handler.Handle(new SeedTestUserGameSessionCommand
+        {
+            TestRunId = testRunId,
+            UserLibraryEntryId = libraryEntryId,
+            // PlayedAt, DurationMinutes, DidWin, Players all omitted → defaults
+        }, TestCancellationToken);
+
+        var session = await db.Set<UserGameSessionEntity>()
+            .SingleAsync(s => s.Id == response.SessionId, TestCancellationToken);
+
+        session.DurationMinutes.Should().Be(60);
+        session.PlayedAt.Should().BeOnOrAfter(beforeCall);
+        session.DidWin.Should().BeNull();
+        session.Players.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_MultipleSessionsSameEntry_AllCreatedWithSameLibraryEntryId()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var testRunId = "e2e-ugame-multisess-1717603200000";
+
+        var libraryEntryId = await SeedLibraryEntryAsync(db, testRunId, "multi-session@e2e.test");
+
+        var handler = new SeedTestUserGameSessionCommandHandler(
+            db, NullLogger<SeedTestUserGameSessionCommandHandler>.Instance);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await handler.Handle(new SeedTestUserGameSessionCommand
+            {
+                TestRunId = testRunId,
+                UserLibraryEntryId = libraryEntryId,
+                PlayedAt = new DateTime(2026, 5, i + 1, 10, 0, 0, DateTimeKind.Utc),
+            }, TestCancellationToken);
+        }
+
+        var count = await db.Set<UserGameSessionEntity>()
+            .CountAsync(s => s.UserLibraryEntryId == libraryEntryId && s.TestRunId == testRunId, TestCancellationToken);
+        count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_TestRunIdScope_CleanupCascadesUserGameSessions()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var testRunId = "e2e-ugame-cascade00-1717603200000";
+
+        var libraryEntryId = await SeedLibraryEntryAsync(db, testRunId, "cascade-session@e2e.test");
+
+        var handler = new SeedTestUserGameSessionCommandHandler(
+            db, NullLogger<SeedTestUserGameSessionCommandHandler>.Instance);
+
+        await handler.Handle(new SeedTestUserGameSessionCommand
+        {
+            TestRunId = testRunId,
+            UserLibraryEntryId = libraryEntryId,
+        }, TestCancellationToken);
+
+        // Verify session exists before cleanup
+        var beforeCleanup = await db.Set<UserGameSessionEntity>()
+            .AnyAsync(s => s.TestRunId == testRunId, TestCancellationToken);
+        beforeCleanup.Should().BeTrue();
+
+        // Execute cleanup
+        var cleanupHandler = new CleanupTestEntitiesCommandHandler(
+            db, NullLogger<CleanupTestEntitiesCommandHandler>.Instance);
+        var cleanupResponse = await cleanupHandler.Handle(
+            new CleanupTestEntitiesCommand { TestRunId = testRunId },
+            TestCancellationToken);
+
+        // Session deleted before library entry (FK cascade order)
+        cleanupResponse.DeletedUserGameSessions.Should().Be(1);
+        cleanupResponse.DeletedLibraryEntries.Should().Be(1);
+
+        var afterCleanup = await db.Set<UserGameSessionEntity>()
+            .AnyAsync(s => s.TestRunId == testRunId, TestCancellationToken);
+        afterCleanup.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ResponseShape_SessionIdMatchesDbRow()
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var testRunId = "e2e-ugame-shape0000-1717603200000";
+
+        var libraryEntryId = await SeedLibraryEntryAsync(db, testRunId, "shape-session@e2e.test");
+
+        var handler = new SeedTestUserGameSessionCommandHandler(
+            db, NullLogger<SeedTestUserGameSessionCommandHandler>.Instance);
+
+        var response = await handler.Handle(new SeedTestUserGameSessionCommand
+        {
+            TestRunId = testRunId,
+            UserLibraryEntryId = libraryEntryId,
+        }, TestCancellationToken);
+
+        var session = await db.Set<UserGameSessionEntity>()
+            .SingleOrDefaultAsync(s => s.Id == response.SessionId, TestCancellationToken);
+        session.Should().NotBeNull();
+        session!.UserLibraryEntryId.Should().Be(response.UserLibraryEntryId);
+        session.TestRunId.Should().Be(response.TestRunId);
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/Testing/Validators/SeedTestGameNightCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Testing/Validators/SeedTestGameNightCommandValidatorTests.cs
@@ -65,4 +65,43 @@ public class SeedTestGameNightCommandValidatorTests
         };
         _sut.TestValidate(cmd).ShouldHaveValidationErrorFor(x => x.OwnerEmail);
     }
+
+    [Fact]
+    public void Validate_GameIdEmpty_FailsValidation()
+    {
+        var cmd = new SeedTestGameNightCommand
+        {
+            TestRunId = "e2e-validcase01234-1717603200000",
+            Status = "Draft",
+            OwnerEmail = "ok@e2e.test",
+            GameId = Guid.Empty,
+        };
+        _sut.TestValidate(cmd).ShouldHaveValidationErrorFor(x => x.GameId!.Value);
+    }
+
+    [Fact]
+    public void Validate_GameIdValidGuid_PassesAll()
+    {
+        var cmd = new SeedTestGameNightCommand
+        {
+            TestRunId = "e2e-validcase01234-1717603200000",
+            Status = "Draft",
+            OwnerEmail = "ok@e2e.test",
+            GameId = Guid.NewGuid(),
+        };
+        _sut.TestValidate(cmd).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_GameIdNull_PassesAll()
+    {
+        var cmd = new SeedTestGameNightCommand
+        {
+            TestRunId = "e2e-validcase01234-1717603200000",
+            Status = "Draft",
+            OwnerEmail = "ok@e2e.test",
+            GameId = null,
+        };
+        _sut.TestValidate(cmd).ShouldNotHaveAnyValidationErrors();
+    }
 }

--- a/apps/api/tests/Api.Tests/Unit/Testing/Validators/SeedTestUserGameSessionCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Testing/Validators/SeedTestUserGameSessionCommandValidatorTests.cs
@@ -1,0 +1,114 @@
+using Api.BoundedContexts.Testing.Application.Commands;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.Unit.Testing.Validators;
+
+/// <summary>
+/// Issue #1929 Task C Macro 4 (DEC-C-10 REVISION, DEC-B-5) — Unit validator coverage
+/// for <see cref="SeedTestUserGameSessionCommandValidator"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Testing")]
+[Trait("Issue", "1929")]
+public class SeedTestUserGameSessionCommandValidatorTests
+{
+    private readonly SeedTestUserGameSessionCommandValidator _sut = new();
+
+    private static readonly Guid ValidLibraryEntryId = Guid.NewGuid();
+    private const string ValidTestRunId = "e2e-usergamesess01-1717603200000";
+
+    [Fact]
+    public void Validate_ValidCommand_PassesAll()
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = ValidTestRunId,
+            UserLibraryEntryId = ValidLibraryEntryId,
+        };
+        _sut.TestValidate(cmd).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ValidCommandWithAllOptionals_PassesAll()
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = ValidTestRunId,
+            UserLibraryEntryId = ValidLibraryEntryId,
+            PlayedAt = new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc),
+            DurationMinutes = 90,
+            DidWin = true,
+            Players = "Anna, Marco",
+        };
+        _sut.TestValidate(cmd).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("")]
+    [InlineData("e2e-no-epoch-")]
+    [InlineData("noe2e-prefix-1717603200000")]
+    public void Validate_InvalidTestRunId_FailsValidation(string testRunId)
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = testRunId,
+            UserLibraryEntryId = ValidLibraryEntryId,
+        };
+        _sut.TestValidate(cmd).ShouldHaveValidationErrorFor(x => x.TestRunId);
+    }
+
+    [Fact]
+    public void Validate_EmptyUserLibraryEntryId_FailsValidation()
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = ValidTestRunId,
+            UserLibraryEntryId = Guid.Empty,
+        };
+        _sut.TestValidate(cmd).ShouldHaveValidationErrorFor(x => x.UserLibraryEntryId);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_DurationMinutesZeroOrNegative_FailsValidation(int duration)
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = ValidTestRunId,
+            UserLibraryEntryId = ValidLibraryEntryId,
+            DurationMinutes = duration,
+        };
+        _sut.TestValidate(cmd).ShouldHaveValidationErrorFor(x => x.DurationMinutes!.Value);
+    }
+
+    [Fact]
+    public void Validate_DurationMinutesNull_PassesAll()
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = ValidTestRunId,
+            UserLibraryEntryId = ValidLibraryEntryId,
+            DurationMinutes = null,
+        };
+        _sut.TestValidate(cmd).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_AllOptionalFieldsNull_PassesAll()
+    {
+        var cmd = new SeedTestUserGameSessionCommand
+        {
+            TestRunId = ValidTestRunId,
+            UserLibraryEntryId = ValidLibraryEntryId,
+            PlayedAt = null,
+            DurationMinutes = null,
+            DidWin = null,
+            Players = null,
+        };
+        _sut.TestValidate(cmd).ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/apps/web/e2e/_helpers/seedEntities.ts
+++ b/apps/web/e2e/_helpers/seedEntities.ts
@@ -50,6 +50,12 @@ export interface SeedLibraryGameResponse {
   testRunId: string;
 }
 
+export interface SeedUserGameSessionResponse {
+  sessionId: string;
+  userLibraryEntryId: string;
+  testRunId: string;
+}
+
 export interface CleanupResponse {
   testRunId: string;
   deletedGameNights: number;
@@ -59,6 +65,8 @@ export interface CleanupResponse {
   deletedUsers: number;
   deletedLibraryEntries: number;
   deletedSharedGames: number;
+  /** Issue #1929 Macro 4 (DEC-C-10 REVISION) — UserGameSessions deleted BEFORE UserLibraryEntries. */
+  deletedUserGameSessions: number;
   durationMs: number;
 }
 
@@ -160,6 +168,36 @@ export async function seedLibraryGame(
     throw new Error(`seedLibraryGame failed (${response.status()}): ${body}`);
   }
   return (await response.json()) as SeedLibraryGameResponse;
+}
+
+/**
+ * Issue #1929 Task C Macro 4 (DEC-C-10 REVISION) — Seeds a UserGameSession linked
+ * to an existing UserLibraryEntry. Used by Journey #3 to set up "user has played
+ * N times" precondition for the GameDetailSessionsRail.
+ *
+ * Requires `libraryEntryId` from `seedLibraryGame` response.
+ * Cascade-cleaned by `cleanupTestEntities` via DEC-B-8 TestRunId scope
+ * (UserGameSessions deleted BEFORE UserLibraryEntries — FK child order).
+ */
+export async function seedUserGameSession(
+  page: Page,
+  opts: {
+    testRunId: string;
+    userLibraryEntryId: string;
+    playedAt?: string;
+    durationMinutes?: number;
+    didWin?: boolean | null;
+    players?: string;
+  }
+): Promise<SeedUserGameSessionResponse> {
+  const response = await page.request.post(`${SEED_BASE}/user-game-session`, {
+    data: opts,
+  });
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`seedUserGameSession failed (${response.status()}): ${body}`);
+  }
+  return (await response.json()) as SeedUserGameSessionResponse;
 }
 
 export async function cleanupTestEntities(

--- a/apps/web/e2e/_helpers/seedEntities.ts
+++ b/apps/web/e2e/_helpers/seedEntities.ts
@@ -82,6 +82,8 @@ export async function seedGameNight(
     ownerEmail: string;
     scoringType?: ScoringType;
     rosterCount?: number;
+    /** Issue #1929 Macro 4 (DEC-C-10 PIVOT): optional SharedGame catalog id to associate this GameNight with. */
+    gameId?: string;
   }
 ): Promise<SeedGameNightResponse> {
   const response = await page.request.post(`${SEED_BASE}/game-night`, {

--- a/apps/web/e2e/cross-asse-journey-3-game-detail-tab-partite.spec.ts
+++ b/apps/web/e2e/cross-asse-journey-3-game-detail-tab-partite.spec.ts
@@ -3,34 +3,28 @@
  *
  * Anna (user) navigates to `/games/${gameId}` → clicks the **Sessioni** tab →
  * verifies the `GameDetailSessionsRail` renders correctly with:
- *   - T4.1: happy path 5-cap (BE Take(5)) — rail shows up to 5 cards + viewAll visible
+ *   - T4.1: happy path 15-seed → 5-cap (BE Take(5)) — rail shows 5 cards + viewAll visible
  *   - T4.2: boundary 0 sessions — rail empty-state (`data-empty=true`), no viewAll
  *   - T4.3: boundary 3 sessions — 3 cards + viewAll IS visible (no threshold guard)
- *   - T4.4: filter persistence — URL query params preserved after viewAll navigation
+ *   - T4.4: viewAll navigation — URL changes to `/games/${id}/sessions`
  *
  * **Initial state** (DEC-C-1 journey3):
  *   - 0 GameNight
  *   - 1 library game (seeded via Real BE `seedLibraryGame` factory, DEC-C-8)
- *   - 15 sessionCount (informational only — NOT seeded as UserGameSessionEntity)
+ *   - N UserGameSession rows seeded per-test via `seedUserGameSession` factory (DEC-C-10 REVISION)
  *
- * **PIVOT-3**: Mission brief assumed `seedSession` → `UserGameSessionEntity`.
- *   Reality: `seedSession` creates `GameNightSessionEntity` (different table/entity).
- *   `UserGameSessionEntity` has no TestRunId column and no seeding factory.
- *   Fix: mock `GET /api/v1/library/games/${gameId}` to return synthetic
- *   `recentSessions[]` payload. `seedLibraryGame` provides the valid `gameId`
- *   consumed by the mock URL pattern. (P193 architectural-pivot-documented-inline)
+ * **DEC-C-10 REVISION** (user-locked sessione 43): supersedes PIVOT-3 (mock endpoint) and
+ * PIVOT-4 (userId mismatch). Real BE wire via:
+ *   - `seedLibraryGame` for the library entry (DEC-C-8, Macro 3a)
+ *   - `seedUserGameSession` for per-test session counts (Macro 4 Phase B-E)
+ *   - PIVOT-4 fix: `mockAuthEndpoints({ userId: libGame.ownerId })` → matches seeded user
  *
- * **PIVOT-4**: `GET /api/v1/library/games/${gameId}` endpoint extracts userId from
- *   the real JWT session. The `mockAuthEndpoints` helper returns the static
- *   `ANNA_PERSONA.userId` while `seedLibraryGame` creates a different seeded user.
- *   Fix: mock the library detail endpoint entirely; no real BE call needed.
+ * **PIVOT-1** (preserved): `GameDetailSessionsRail` shows the viewAll link whenever
+ *   `sessions.length > 0` — there is no configurable threshold.
+ *   T4.3 asserts viewAll IS visible (not absent) when N=3.
  *
- * **PIVOT-1** (mission brief correction): `GameDetailSessionsRail` shows the viewAll
- *   link whenever `sessions.length > 0` — there is no configurable threshold.
- *   T4.3 must assert viewAll IS visible (not absent) when N=3.
- *
- * **PIVOT-2** (mission brief correction): BE `GetGameDetailQueryHandler.cs:81` uses
- *   `Take(5)`. T4.1 assertions use `≤5` (capped) not `15`.
+ * **PIVOT-2** (preserved): BE `GetGameDetailQueryHandler.cs:81` uses `Take(5)`.
+ *   T4.1 seeds 15 sessions but asserts exactly 5 cards (capped by BE).
  *
  * **testid contract**:
  *   - Sessions tab button: `id="game-detail-tab-sessions"` (tabIdFor('sessions'))
@@ -42,125 +36,25 @@
  *
  * **Spec ref**: DEC-C-1 + DEC-C-3 (verify-only, no rail refactor) + DEC-C-4 (non-blocking CI)
  *               + DEC-C-8 Real BE seedLibraryGame (Macro 3a `789b3a301`)
- *               + DEC-C-10 PIVOT seedLibraryGame as game-id anchor
+ *               + DEC-C-10 REVISION Real BE seedUserGameSession (Macro 4 Phase B-E)
  *
  * **CI gate**: non-blocking on main-dev (DEC-C-4). Blocking on main-staging.
  *
  * Issue #1929 Task C Macro 4 — Asse D P4 follow-up.
  */
-import { test, expect, type Page, type Route } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 import { ANNA_PERSONA, buildAnnaInitialState } from './_helpers/annaPersona';
 import { assertExactUrl } from './_helpers/dataAssertionUtils';
 import { withRetry } from './_helpers/resilienceWrappers';
 import { mockAuthEndpoints, seedAuthSession } from './_helpers/seedAuthSession';
 import { seedCookieConsent } from './_helpers/seedCookieConsent';
-import { cleanupTestEntities, newTestRunId, seedLibraryGame } from './_helpers/seedEntities';
-
-// ─── Fixtures ─────────────────────────────────────────────────────────────────
-
-/** Minimal valid GameDetailDto for the mock — only required fields + recentSessions. */
-function makeGameDetailDto(gameId: string, userId: string, sessions: unknown[]) {
-  return {
-    id: '00000000-0000-4000-8000-000000000010',
-    userId,
-    gameId,
-    gameTitle: 'Catan E2E Test',
-    gamePublisher: 'KOSMOS E2E',
-    gameYearPublished: 1995,
-    gameDescription: 'Catan seeded for Journey #3 test',
-    gameIconUrl: null,
-    gameImageUrl: null,
-    minPlayers: 3,
-    maxPlayers: 4,
-    playTimeMinutes: 90,
-    complexityRating: null,
-    averageRating: null,
-    addedAt: '2026-01-01T00:00:00+00:00',
-    notes: null,
-    isFavorite: false,
-    currentState: 'Nuovo',
-    stateChangedAt: null,
-    stateNotes: null,
-    isAvailableForPlay: true,
-    timesPlayed: sessions.length,
-    lastPlayed: sessions.length > 0 ? '2026-06-01T10:00:00+00:00' : null,
-    winRate: null,
-    avgDuration: null,
-    hasRagAccess: false,
-    recentSessions: sessions,
-    checklist: null,
-    customAgentConfig: null,
-    customPdf: null,
-    customCoverR2Key: null,
-  };
-}
-
-/** Build N synthetic LibraryGameSession DTOs. */
-function makeSessionDtos(count: number) {
-  return Array.from({ length: count }, (_, i) => ({
-    id: `00000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
-    playedAt: `2026-05-${String(i + 1).padStart(2, '0')}T18:00:00+00:00`,
-    durationMinutes: 60 + i * 5,
-    durationFormatted: `${60 + i * 5} min`,
-    didWin: i % 2 === 0,
-    players: 'Anna, Marco',
-    notes: null,
-  }));
-}
-
-/**
- * Mocks the library game detail endpoint with synthetic `recentSessions`.
- * Called once per test with the desired session count.
- */
-async function mockLibraryGameDetail(page: Page, gameId: string, sessionCount: number) {
-  const dto = makeGameDetailDto(gameId, ANNA_PERSONA.userId, makeSessionDtos(sessionCount));
-
-  // Primary endpoint: GET /api/v1/library/games/{gameId}
-  await page.route(
-    new RegExp(`/api/v1/library/games/${gameId}(?:\\?.*)?$`),
-    async (route: Route) => {
-      if (route.request().method() === 'GET') {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(dto),
-        });
-        return;
-      }
-      await route.continue();
-    }
-  );
-
-  // Prevent sharedGames fallback from overriding: return 404 so useLibraryGameDetail
-  // falls through to the mocked gameDetail (which wins since it's non-null).
-  await page.route(
-    new RegExp(`/api/v1/shared-games/${gameId}(?:\\?.*)?$`),
-    async (route: Route) => {
-      if (route.request().method() === 'GET') {
-        await route.fulfill({ status: 404, body: '' });
-        return;
-      }
-      await route.continue();
-    }
-  );
-
-  // Also mock library/games/{gameId}/status so hero variant stays 'own'.
-  await page.route(
-    new RegExp(`/api/v1/library/games/${gameId}/status(?:\\?.*)?$`),
-    async (route: Route) => {
-      if (route.request().method() === 'GET') {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ inLibrary: true, isFavorite: false }),
-        });
-        return;
-      }
-      await route.continue();
-    }
-  );
-}
+import {
+  cleanupTestEntities,
+  newTestRunId,
+  seedLibraryGame,
+  seedUserGameSession,
+} from './_helpers/seedEntities';
 
 // ─── Suite ────────────────────────────────────────────────────────────────────
 
@@ -169,21 +63,15 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
 
   let testRunId: string;
   let libraryGameId: string;
+  let libraryEntryId: string;
+  let ownerUserId: string;
 
   test.beforeEach(async ({ page }, testInfo) => {
     testRunId = newTestRunId(testInfo.testId);
 
-    // ① FE auth seeding — Anna as authenticated user
     await seedCookieConsent(page);
-    await seedAuthSession(page, { role: ANNA_PERSONA.role });
-    await mockAuthEndpoints(page, {
-      role: ANNA_PERSONA.role,
-      userId: ANNA_PERSONA.userId,
-      email: ANNA_PERSONA.email,
-      onboardingCompleted: ANNA_PERSONA.onboardingCompleted,
-    });
 
-    // ② BE entity seeding — journey3 initial state: 1 library game as gameId anchor
+    // ① BE entity seeding — journey3 initial state: 1 library game (Real BE DEC-C-8)
     const initial = buildAnnaInitialState('journey3');
     expect(initial.libraryGameCount).toBe(1);
 
@@ -192,7 +80,7 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
         seedLibraryGame(page, {
           testRunId,
           ownerEmail: ANNA_PERSONA.email,
-          title: 'Catan E2E Test',
+          title: 'Catan E2E Journey3',
           publisher: 'KOSMOS E2E',
           minPlayers: 3,
           maxPlayers: 4,
@@ -200,6 +88,17 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
       { reason: 'seedLibraryGame journey3 beforeEach' }
     );
     libraryGameId = libGame.gameId;
+    libraryEntryId = libGame.libraryEntryId;
+    ownerUserId = libGame.ownerId;
+
+    // ② FE auth seeding — DEC-C-10 PIVOT-4 fix: use libGame.ownerId (matches seeded user)
+    await seedAuthSession(page, { role: ANNA_PERSONA.role });
+    await mockAuthEndpoints(page, {
+      role: ANNA_PERSONA.role,
+      userId: ownerUserId, // ← PIVOT-4 fix: seeded user, not static ANNA_PERSONA.userId
+      email: ANNA_PERSONA.email,
+      onboardingCompleted: ANNA_PERSONA.onboardingCompleted,
+    });
   });
 
   test.afterEach(async ({ page }) => {
@@ -208,18 +107,34 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
     }
   });
 
-  // ── T4.1: happy path — 5 sessions (BE Take(5) cap) → rail cards + viewAll ─
+  // ── T4.1: happy path — 15 seeded → 5 BE-capped → rail cards + viewAll ─────
 
   /**
-   * T4.1 — Anna navigates to game detail, clicks Sessioni tab.
-   * Mock returns 5 sessions (BE slice cap).
-   * Asserts: rail renders 5 cards, viewAll link visible, empty-state absent.
+   * T4.1 — Anna navigates to game detail; 15 UserGameSessions seeded Real BE.
+   * BE GetGameDetailQueryHandler.cs:81 caps at Take(5).
+   * Asserts: rail renders exactly 5 cards (cap), viewAll link visible, empty-state absent.
    *
-   * PIVOT-2: BE Take(5) cap; original mission expected 15 visible — corrected.
+   * PIVOT-2 preserved: BE Take(5) cap; 15 seeded → 5 visible.
+   * DEC-C-10 REVISION: Real BE seedUserGameSession (no mock routes).
    */
-  test('sessions tab renders N=5 cards + viewAll visible', async ({ page }) => {
-    // Arrange: mock library detail with 5 sessions (= BE slice cap)
-    await mockLibraryGameDetail(page, libraryGameId, 5);
+  test('sessions tab renders N=5 cards + viewAll visible (BE Take(5) cap from 15 seeded)', async ({
+    page,
+  }) => {
+    // Arrange: seed 15 sessions (BE cap = Take(5) → only 5 returned in recentSessions)
+    for (let i = 0; i < 15; i++) {
+      await withRetry(
+        () =>
+          seedUserGameSession(page, {
+            testRunId,
+            userLibraryEntryId: libraryEntryId,
+            playedAt: new Date(2026, 4, i + 1).toISOString(),
+            durationMinutes: 60 + i,
+            didWin: i % 2 === 0,
+            players: 'Anna, Marco',
+          }),
+        { reason: `seedUserGameSession journey3 T4.1 #${i + 1}/15` }
+      );
+    }
 
     // Act: navigate to game detail
     await page.goto(`/games/${libraryGameId}`);
@@ -230,7 +145,7 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
     await expect(sessionsTab).toBeVisible({ timeout: 5_000 });
     await sessionsTab.click();
 
-    // Wait for panel to become visible (tab switch is synchronous but ARIA hidden toggle)
+    // Wait for panel to become visible
     const sessionsPanel = page.locator('[data-slot="game-detail-panel-sessions"]');
     await expect(sessionsPanel).not.toHaveAttribute('hidden', { timeout: 5_000 });
 
@@ -239,7 +154,7 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
     await expect(rail).toBeVisible({ timeout: 5_000 });
     await expect(rail).toHaveAttribute('data-empty', 'false');
 
-    // 5 session cards
+    // Exactly 5 cards (BE Take(5) cap)
     const cards = rail.locator('[data-slot="game-detail-session-card"]');
     await expect(cards).toHaveCount(5, { timeout: 5_000 });
 
@@ -255,13 +170,15 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
   // ── T4.2: boundary 0 sessions — empty-state, no viewAll ──────────────────
 
   /**
-   * T4.2 — Mock returns 0 sessions.
+   * T4.2 — No UserGameSessions seeded (0). Library game exists but no sessions.
    * Asserts: rail `data-empty=true`, empty-state visible, viewAll absent.
+   *
+   * DEC-C-10 REVISION: No seed calls needed — beforeEach seeds only the library entry.
    */
   test('sessions tab empty-state when N=0 (no viewAll link)', async ({ page }) => {
-    // Arrange: mock library detail with 0 sessions
-    await mockLibraryGameDetail(page, libraryGameId, 0);
+    // Arrange: no seedUserGameSession calls — 0 sessions
 
+    // Act: navigate to game detail
     await page.goto(`/games/${libraryGameId}`);
     await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
 
@@ -292,18 +209,31 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
   // ── T4.3: boundary 3 sessions — 3 cards + viewAll IS visible ──────────────
 
   /**
-   * T4.3 — Mock returns 3 sessions.
+   * T4.3 — 3 UserGameSessions seeded Real BE.
    * Asserts: 3 cards rendered, viewAll IS visible (no threshold — any N>0 shows it).
    *
-   * PIVOT-1: mission brief incorrectly stated "no viewAll when N=3 (threshold non superato)".
-   * Reality: GameDetailSessionsRail shows viewAll whenever sessions.length > 0.
+   * PIVOT-1 preserved: GameDetailSessionsRail shows viewAll whenever sessions.length > 0.
+   * DEC-C-10 REVISION: Real BE seedUserGameSession.
    */
   test('sessions tab renders N=3 cards + viewAll visible (no threshold guard)', async ({
     page,
   }) => {
-    // Arrange: mock library detail with 3 sessions
-    await mockLibraryGameDetail(page, libraryGameId, 3);
+    // Arrange: seed exactly 3 sessions
+    for (let i = 0; i < 3; i++) {
+      await withRetry(
+        () =>
+          seedUserGameSession(page, {
+            testRunId,
+            userLibraryEntryId: libraryEntryId,
+            playedAt: new Date(2026, 4, i + 1).toISOString(),
+            durationMinutes: 90,
+            didWin: i % 2 === 0,
+          }),
+        { reason: `seedUserGameSession journey3 T4.3 #${i + 1}/3` }
+      );
+    }
 
+    // Act
     await page.goto(`/games/${libraryGameId}`);
     await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
 
@@ -336,14 +266,24 @@ test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () 
    * T4.4 — Click viewAll from sessions tab.
    * Asserts: browser navigates to `/games/${gameId}/sessions`.
    *
-   * Filter-persistence scope note: the viewAll link href is a static
-   * `/games/{gameId}/sessions` (no query param forwarding in GameDetailView).
-   * This test verifies navigation completes to the correct subroute.
+   * DEC-C-10 REVISION: 2 sessions seeded Real BE so viewAll renders.
    */
   test('viewAll link navigates to /games/{gameId}/sessions subroute', async ({ page }) => {
-    // Arrange: mock library detail with 2 sessions so viewAll renders
-    await mockLibraryGameDetail(page, libraryGameId, 2);
+    // Arrange: seed 2 sessions so viewAll renders
+    for (let i = 0; i < 2; i++) {
+      await withRetry(
+        () =>
+          seedUserGameSession(page, {
+            testRunId,
+            userLibraryEntryId: libraryEntryId,
+            playedAt: new Date(2026, 4, i + 1).toISOString(),
+            durationMinutes: 60,
+          }),
+        { reason: `seedUserGameSession journey3 T4.4 #${i + 1}/2` }
+      );
+    }
 
+    // Act
     await page.goto(`/games/${libraryGameId}`);
     await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
 

--- a/apps/web/e2e/cross-asse-journey-3-game-detail-tab-partite.spec.ts
+++ b/apps/web/e2e/cross-asse-journey-3-game-detail-tab-partite.spec.ts
@@ -1,0 +1,367 @@
+/**
+ * Cross-Asse Journey #3 — Game Detail "Storico partite" rail (sessions tab).
+ *
+ * Anna (user) navigates to `/games/${gameId}` → clicks the **Sessioni** tab →
+ * verifies the `GameDetailSessionsRail` renders correctly with:
+ *   - T4.1: happy path 5-cap (BE Take(5)) — rail shows up to 5 cards + viewAll visible
+ *   - T4.2: boundary 0 sessions — rail empty-state (`data-empty=true`), no viewAll
+ *   - T4.3: boundary 3 sessions — 3 cards + viewAll IS visible (no threshold guard)
+ *   - T4.4: filter persistence — URL query params preserved after viewAll navigation
+ *
+ * **Initial state** (DEC-C-1 journey3):
+ *   - 0 GameNight
+ *   - 1 library game (seeded via Real BE `seedLibraryGame` factory, DEC-C-8)
+ *   - 15 sessionCount (informational only — NOT seeded as UserGameSessionEntity)
+ *
+ * **PIVOT-3**: Mission brief assumed `seedSession` → `UserGameSessionEntity`.
+ *   Reality: `seedSession` creates `GameNightSessionEntity` (different table/entity).
+ *   `UserGameSessionEntity` has no TestRunId column and no seeding factory.
+ *   Fix: mock `GET /api/v1/library/games/${gameId}` to return synthetic
+ *   `recentSessions[]` payload. `seedLibraryGame` provides the valid `gameId`
+ *   consumed by the mock URL pattern. (P193 architectural-pivot-documented-inline)
+ *
+ * **PIVOT-4**: `GET /api/v1/library/games/${gameId}` endpoint extracts userId from
+ *   the real JWT session. The `mockAuthEndpoints` helper returns the static
+ *   `ANNA_PERSONA.userId` while `seedLibraryGame` creates a different seeded user.
+ *   Fix: mock the library detail endpoint entirely; no real BE call needed.
+ *
+ * **PIVOT-1** (mission brief correction): `GameDetailSessionsRail` shows the viewAll
+ *   link whenever `sessions.length > 0` — there is no configurable threshold.
+ *   T4.3 must assert viewAll IS visible (not absent) when N=3.
+ *
+ * **PIVOT-2** (mission brief correction): BE `GetGameDetailQueryHandler.cs:81` uses
+ *   `Take(5)`. T4.1 assertions use `≤5` (capped) not `15`.
+ *
+ * **testid contract**:
+ *   - Sessions tab button: `id="game-detail-tab-sessions"` (tabIdFor('sessions'))
+ *   - Sessions panel: `data-slot="game-detail-panel-sessions"`
+ *   - Sessions rail: `data-slot="game-detail-sessions-rail"` + `data-empty={isEmpty}`
+ *   - Session cards: `data-slot="game-detail-session-card"`
+ *   - View-all link: `data-slot="game-detail-sessions-view-all"` (href=`/games/${id}/sessions`)
+ *   - Empty state: `data-slot="game-detail-sessions-empty"`
+ *
+ * **Spec ref**: DEC-C-1 + DEC-C-3 (verify-only, no rail refactor) + DEC-C-4 (non-blocking CI)
+ *               + DEC-C-8 Real BE seedLibraryGame (Macro 3a `789b3a301`)
+ *               + DEC-C-10 PIVOT seedLibraryGame as game-id anchor
+ *
+ * **CI gate**: non-blocking on main-dev (DEC-C-4). Blocking on main-staging.
+ *
+ * Issue #1929 Task C Macro 4 — Asse D P4 follow-up.
+ */
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+import { ANNA_PERSONA, buildAnnaInitialState } from './_helpers/annaPersona';
+import { assertExactUrl } from './_helpers/dataAssertionUtils';
+import { withRetry } from './_helpers/resilienceWrappers';
+import { mockAuthEndpoints, seedAuthSession } from './_helpers/seedAuthSession';
+import { seedCookieConsent } from './_helpers/seedCookieConsent';
+import { cleanupTestEntities, newTestRunId, seedLibraryGame } from './_helpers/seedEntities';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Minimal valid GameDetailDto for the mock — only required fields + recentSessions. */
+function makeGameDetailDto(gameId: string, userId: string, sessions: unknown[]) {
+  return {
+    id: '00000000-0000-4000-8000-000000000010',
+    userId,
+    gameId,
+    gameTitle: 'Catan E2E Test',
+    gamePublisher: 'KOSMOS E2E',
+    gameYearPublished: 1995,
+    gameDescription: 'Catan seeded for Journey #3 test',
+    gameIconUrl: null,
+    gameImageUrl: null,
+    minPlayers: 3,
+    maxPlayers: 4,
+    playTimeMinutes: 90,
+    complexityRating: null,
+    averageRating: null,
+    addedAt: '2026-01-01T00:00:00+00:00',
+    notes: null,
+    isFavorite: false,
+    currentState: 'Nuovo',
+    stateChangedAt: null,
+    stateNotes: null,
+    isAvailableForPlay: true,
+    timesPlayed: sessions.length,
+    lastPlayed: sessions.length > 0 ? '2026-06-01T10:00:00+00:00' : null,
+    winRate: null,
+    avgDuration: null,
+    hasRagAccess: false,
+    recentSessions: sessions,
+    checklist: null,
+    customAgentConfig: null,
+    customPdf: null,
+    customCoverR2Key: null,
+  };
+}
+
+/** Build N synthetic LibraryGameSession DTOs. */
+function makeSessionDtos(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `00000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
+    playedAt: `2026-05-${String(i + 1).padStart(2, '0')}T18:00:00+00:00`,
+    durationMinutes: 60 + i * 5,
+    durationFormatted: `${60 + i * 5} min`,
+    didWin: i % 2 === 0,
+    players: 'Anna, Marco',
+    notes: null,
+  }));
+}
+
+/**
+ * Mocks the library game detail endpoint with synthetic `recentSessions`.
+ * Called once per test with the desired session count.
+ */
+async function mockLibraryGameDetail(page: Page, gameId: string, sessionCount: number) {
+  const dto = makeGameDetailDto(gameId, ANNA_PERSONA.userId, makeSessionDtos(sessionCount));
+
+  // Primary endpoint: GET /api/v1/library/games/{gameId}
+  await page.route(
+    new RegExp(`/api/v1/library/games/${gameId}(?:\\?.*)?$`),
+    async (route: Route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(dto),
+        });
+        return;
+      }
+      await route.continue();
+    }
+  );
+
+  // Prevent sharedGames fallback from overriding: return 404 so useLibraryGameDetail
+  // falls through to the mocked gameDetail (which wins since it's non-null).
+  await page.route(
+    new RegExp(`/api/v1/shared-games/${gameId}(?:\\?.*)?$`),
+    async (route: Route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 404, body: '' });
+        return;
+      }
+      await route.continue();
+    }
+  );
+
+  // Also mock library/games/{gameId}/status so hero variant stays 'own'.
+  await page.route(
+    new RegExp(`/api/v1/library/games/${gameId}/status(?:\\?.*)?$`),
+    async (route: Route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ inLibrary: true, isFavorite: false }),
+        });
+        return;
+      }
+      await route.continue();
+    }
+  );
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+test.describe('Cross-Asse Journey #3 — Game Detail "Storico partite" tab', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium', 'Chromium-only for speed');
+
+  let testRunId: string;
+  let libraryGameId: string;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    testRunId = newTestRunId(testInfo.testId);
+
+    // ① FE auth seeding — Anna as authenticated user
+    await seedCookieConsent(page);
+    await seedAuthSession(page, { role: ANNA_PERSONA.role });
+    await mockAuthEndpoints(page, {
+      role: ANNA_PERSONA.role,
+      userId: ANNA_PERSONA.userId,
+      email: ANNA_PERSONA.email,
+      onboardingCompleted: ANNA_PERSONA.onboardingCompleted,
+    });
+
+    // ② BE entity seeding — journey3 initial state: 1 library game as gameId anchor
+    const initial = buildAnnaInitialState('journey3');
+    expect(initial.libraryGameCount).toBe(1);
+
+    const libGame = await withRetry(
+      () =>
+        seedLibraryGame(page, {
+          testRunId,
+          ownerEmail: ANNA_PERSONA.email,
+          title: 'Catan E2E Test',
+          publisher: 'KOSMOS E2E',
+          minPlayers: 3,
+          maxPlayers: 4,
+        }),
+      { reason: 'seedLibraryGame journey3 beforeEach' }
+    );
+    libraryGameId = libGame.gameId;
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (testRunId) {
+      await cleanupTestEntities(page, { testRunId });
+    }
+  });
+
+  // ── T4.1: happy path — 5 sessions (BE Take(5) cap) → rail cards + viewAll ─
+
+  /**
+   * T4.1 — Anna navigates to game detail, clicks Sessioni tab.
+   * Mock returns 5 sessions (BE slice cap).
+   * Asserts: rail renders 5 cards, viewAll link visible, empty-state absent.
+   *
+   * PIVOT-2: BE Take(5) cap; original mission expected 15 visible — corrected.
+   */
+  test('sessions tab renders N=5 cards + viewAll visible', async ({ page }) => {
+    // Arrange: mock library detail with 5 sessions (= BE slice cap)
+    await mockLibraryGameDetail(page, libraryGameId, 5);
+
+    // Act: navigate to game detail
+    await page.goto(`/games/${libraryGameId}`);
+    await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
+
+    // Click Sessioni tab
+    const sessionsTab = page.locator('#game-detail-tab-sessions');
+    await expect(sessionsTab).toBeVisible({ timeout: 5_000 });
+    await sessionsTab.click();
+
+    // Wait for panel to become visible (tab switch is synchronous but ARIA hidden toggle)
+    const sessionsPanel = page.locator('[data-slot="game-detail-panel-sessions"]');
+    await expect(sessionsPanel).not.toHaveAttribute('hidden', { timeout: 5_000 });
+
+    // Rail mounts with data-empty=false
+    const rail = sessionsPanel.locator('[data-slot="game-detail-sessions-rail"]');
+    await expect(rail).toBeVisible({ timeout: 5_000 });
+    await expect(rail).toHaveAttribute('data-empty', 'false');
+
+    // 5 session cards
+    const cards = rail.locator('[data-slot="game-detail-session-card"]');
+    await expect(cards).toHaveCount(5, { timeout: 5_000 });
+
+    // View-all link visible (href includes /sessions subroute)
+    const viewAll = rail.locator('[data-slot="game-detail-sessions-view-all"]');
+    await expect(viewAll).toBeVisible({ timeout: 3_000 });
+    await expect(viewAll).toHaveAttribute('href', new RegExp(`/games/${libraryGameId}/sessions`));
+
+    // Empty state MUST be absent
+    await expect(rail.locator('[data-slot="game-detail-sessions-empty"]')).toBeHidden();
+  });
+
+  // ── T4.2: boundary 0 sessions — empty-state, no viewAll ──────────────────
+
+  /**
+   * T4.2 — Mock returns 0 sessions.
+   * Asserts: rail `data-empty=true`, empty-state visible, viewAll absent.
+   */
+  test('sessions tab empty-state when N=0 (no viewAll link)', async ({ page }) => {
+    // Arrange: mock library detail with 0 sessions
+    await mockLibraryGameDetail(page, libraryGameId, 0);
+
+    await page.goto(`/games/${libraryGameId}`);
+    await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
+
+    const sessionsTab = page.locator('#game-detail-tab-sessions');
+    await expect(sessionsTab).toBeVisible({ timeout: 5_000 });
+    await sessionsTab.click();
+
+    const sessionsPanel = page.locator('[data-slot="game-detail-panel-sessions"]');
+    await expect(sessionsPanel).not.toHaveAttribute('hidden', { timeout: 5_000 });
+
+    const rail = sessionsPanel.locator('[data-slot="game-detail-sessions-rail"]');
+    await expect(rail).toBeVisible({ timeout: 5_000 });
+    await expect(rail).toHaveAttribute('data-empty', 'true');
+
+    // Empty state component visible
+    const emptyState = rail.locator('[data-slot="game-detail-sessions-empty"]');
+    await expect(emptyState).toBeVisible({ timeout: 3_000 });
+
+    // No session cards
+    const cards = rail.locator('[data-slot="game-detail-session-card"]');
+    await expect(cards).toHaveCount(0);
+
+    // View-all link MUST be absent (hidden branch in Rail: renders only when !isEmpty)
+    const viewAll = rail.locator('[data-slot="game-detail-sessions-view-all"]');
+    await expect(viewAll).toBeHidden();
+  });
+
+  // ── T4.3: boundary 3 sessions — 3 cards + viewAll IS visible ──────────────
+
+  /**
+   * T4.3 — Mock returns 3 sessions.
+   * Asserts: 3 cards rendered, viewAll IS visible (no threshold — any N>0 shows it).
+   *
+   * PIVOT-1: mission brief incorrectly stated "no viewAll when N=3 (threshold non superato)".
+   * Reality: GameDetailSessionsRail shows viewAll whenever sessions.length > 0.
+   */
+  test('sessions tab renders N=3 cards + viewAll visible (no threshold guard)', async ({
+    page,
+  }) => {
+    // Arrange: mock library detail with 3 sessions
+    await mockLibraryGameDetail(page, libraryGameId, 3);
+
+    await page.goto(`/games/${libraryGameId}`);
+    await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
+
+    const sessionsTab = page.locator('#game-detail-tab-sessions');
+    await expect(sessionsTab).toBeVisible({ timeout: 5_000 });
+    await sessionsTab.click();
+
+    const sessionsPanel = page.locator('[data-slot="game-detail-panel-sessions"]');
+    await expect(sessionsPanel).not.toHaveAttribute('hidden', { timeout: 5_000 });
+
+    const rail = sessionsPanel.locator('[data-slot="game-detail-sessions-rail"]');
+    await expect(rail).toBeVisible({ timeout: 5_000 });
+    await expect(rail).toHaveAttribute('data-empty', 'false');
+
+    // Exactly 3 cards
+    const cards = rail.locator('[data-slot="game-detail-session-card"]');
+    await expect(cards).toHaveCount(3, { timeout: 5_000 });
+
+    // View-all IS visible (no threshold on Rail — any sessions > 0)
+    const viewAll = rail.locator('[data-slot="game-detail-sessions-view-all"]');
+    await expect(viewAll).toBeVisible({ timeout: 3_000 });
+
+    // Empty state absent
+    await expect(rail.locator('[data-slot="game-detail-sessions-empty"]')).toBeHidden();
+  });
+
+  // ── T4.4: viewAll navigation → /games/{id}/sessions ──────────────────────
+
+  /**
+   * T4.4 — Click viewAll from sessions tab.
+   * Asserts: browser navigates to `/games/${gameId}/sessions`.
+   *
+   * Filter-persistence scope note: the viewAll link href is a static
+   * `/games/{gameId}/sessions` (no query param forwarding in GameDetailView).
+   * This test verifies navigation completes to the correct subroute.
+   */
+  test('viewAll link navigates to /games/{gameId}/sessions subroute', async ({ page }) => {
+    // Arrange: mock library detail with 2 sessions so viewAll renders
+    await mockLibraryGameDetail(page, libraryGameId, 2);
+
+    await page.goto(`/games/${libraryGameId}`);
+    await expect(page.locator('[data-slot="game-detail-view"]')).toBeVisible({ timeout: 15_000 });
+
+    const sessionsTab = page.locator('#game-detail-tab-sessions');
+    await expect(sessionsTab).toBeVisible({ timeout: 5_000 });
+    await sessionsTab.click();
+
+    const sessionsPanel = page.locator('[data-slot="game-detail-panel-sessions"]');
+    await expect(sessionsPanel).not.toHaveAttribute('hidden', { timeout: 5_000 });
+
+    const viewAll = sessionsPanel.locator('[data-slot="game-detail-sessions-view-all"]');
+    await expect(viewAll).toBeVisible({ timeout: 5_000 });
+
+    // Click viewAll → navigate to sessions subroute
+    await withRetry(() => viewAll.click(), { reason: 'viewAll click journey3' });
+
+    // Assert navigation to /games/{gameId}/sessions
+    await page.waitForURL(new RegExp(`/games/${libraryGameId}/sessions`), { timeout: 10_000 });
+    assertExactUrl(page.url(), new RegExp(`/games/${libraryGameId}/sessions(\\?.*)?$`));
+  });
+});


### PR DESCRIPTION
## Summary

### Sessione 43 BASELINE (original commit 8dd170779)
- **BE-1**: Extend `SeedTestGameNightCommand` with optional `Guid? GameId` param (DEC-C-10 PIVOT). Validator sync format-only; handler owns existence check via `BadRequestException`
- **TS-1**: Extend `seedGameNight` TS factory with `gameId?: string` opt in `seedEntities.ts`
- **FE-1**: Initial mock-based spec via `page.route()` (PIVOT-3/PIVOT-4 workarounds)

### Sessione 43 REVISION — Re-dispatch BE extension Real BE (Phases A-F)

User-locked decision: drop PIVOT-3 (mock endpoint) and PIVOT-4 (static userId mismatch) via Real BE wire.

**Phase A** — `UserGameSessionEntity.TestRunId` column (explicit, DEC-B-8 pattern)
- Migration `20260607061447_Add_TestRunId_To_UserGameSessions` — `test_run_id` column + partial index `WHERE test_run_id IS NOT NULL`

**Phase B** — `SeedTestUserGameSessionCommand` MediatR + Validator + Handler + DTO
- Validator: TestRunId format regex + `UserLibraryEntryId NotEqual(Empty)` + DurationMinutes > 0 (when provided)
- Handler: FK guard (BadRequestException if LibraryEntry not found), default PlayedAt=UtcNow/DurationMinutes=60
- 12 validator unit tests + 5 integration tests

**Phase C** — `POST /admin/test/seed/user-game-session` endpoint in `AdminTestSeedEndpoints.cs`

**Phase D** — Cleanup cascade: `UserGameSessions` deleted **BEFORE** `UserLibraryEntries` (FK child order)
- `CleanupTestEntitiesResponse` gains `DeletedUserGameSessions`
- `CleanupTestEntitiesCommandHandler` updated with cascade step at top of FK chain

**Phase E** — TS factory `seedUserGameSession` + `SeedUserGameSessionResponse` interface + `CleanupResponse.deletedUserGameSessions`

**Phase F** — Spec refactor mock→Real BE (DEC-C-10 REVISION)
- Drops all `page.route()` mock interceptors (`mockLibraryGameDetail` helper removed entirely)
- PIVOT-4 fix: `mockAuthEndpoints({ userId: libGame.ownerId })` → matches seeded user (not static `ANNA_PERSONA.userId`)
- Per-test `seedUserGameSession` calls: T4.1=15 sessions (→5 BE cap), T4.2=0, T4.3=3, T4.4=2

### Sessione 43 CODE QUALITY REVIEW FIXES (commit d2edde0ef)

Code quality reviewer subagent identified 3 Important findings + 2 Minor. Fixes applied inline:

**Finding 2 fix (Important)** — `SeedTestGameNightCommandValidatorTests`: added 3 test cases for the `GameId` rule that was introduced earlier in this PR but lacked unit coverage:
- `Validate_GameIdEmpty_FailsValidation` (Guid.Empty rejected)
- `Validate_GameIdValidGuid_PassesAll` (random Guid accepted)
- `Validate_GameIdNull_PassesAll` (null bypasses the `When()` guard)
- Total: **7 validator tests now (was 4)**. All pass (20 tests in the `SeedTestGameNight` filter).

**Finding 3 fix (Important)** — `SeedTestGameNightCommandHandler` phantom GameId: when `request.GameId.HasValue` AND `Status is InProgress/Completed`, propagate `request.GameId.Value` to the child `GameNightSessionEntity.GameId` instead of `Guid.NewGuid()`. Removes internal inconsistency where the GameNight aggregate's `GameIdsJson` referenced the real SharedGame but the embedded session reference was a phantom Guid.

**Finding 1 accepted as cosmetic** — Migration `20260607061447_Add_TestRunId_To_UserGameSessions` adds `test_run_id` to 8 tables (not just `user_game_sessions`). This is **logically correct**: the previous schema drift (TestRunId existed as property on 7 entity classes via DEC-B-8 sessione 40 but was never materialized in any migration, only in entity configuration + entity property declarations) is consolidated in this first migration. Renaming would require migration rescaffold + Designer.cs regeneration; deferred as low-value cosmetic change.

**Minor findings deferred**: (1) `UpdatedAt` not set on `SeedTestUserGameSessionCommandHandler` (null on insert is a valid pattern, sibling handlers are inconsistent); (2) Sequential per-test seeding loop in T4.1 (could use `Promise.all` for ~1s wall-clock savings; sequential is safer for debug log readability).

## Architectural PIVOTs (P193 documented inline)

| PIVOT | Discovery | Status |
|-------|-----------|--------|
| PIVOT-1 | `GameDetailSessionsRail` shows viewAll whenever `sessions.length > 0` — no threshold | Preserved: T4.3 asserts viewAll IS visible |
| PIVOT-2 | `GetGameDetailQueryHandler.cs:81` uses `Take(5)` | Preserved: T4.1 seeds 15 but asserts 5 cards |
| PIVOT-3 | `seedSession` → `GameNightSessionEntity`, not `UserGameSessionEntity`; no factory | **SUPERSEDED** by Phase A-E Real BE extension |
| PIVOT-4 | Library detail endpoint userId mismatch (`ANNA_PERSONA.userId` ≠ seeded user) | **SUPERSEDED** by `libGame.ownerId` fix (Phase F) |

## Test Results

- BE: **20/20 SeedTestGameNight tests pass** (post Finding 2 additions: 7 validator unit + 13 handler integration)
- BE: **17/17 SeedTestUserGameSession tests pass** (12 validator unit + 5 handler integration)
- BE: **CleanupTestEntitiesCommandHandler tests pass** with new `DeletedUserGameSessions` counter
- FE: `pnpm typecheck` → **0 errors**, `pnpm lint` → **0 errors**
- DEC-C-3 honored: `GameDetailSessionsRail.tsx` not modified

## Test plan

- [x] Phase A: `dotnet ef migrations add` consolidates TestRunId across Testing BC schema (8 tables)
- [x] Phase B: `SeedTestUserGameSessionCommand` MediatR command + validator + handler + 17 tests
- [x] Phase C: `POST /admin/test/seed/user-game-session` endpoint wired via MediatR
- [x] Phase D: Cleanup cascade order verified (UserGameSession deleted before UserLibraryEntry FK parent)
- [x] Phase E: TS factory `seedUserGameSession` + types extension, 0 typecheck errors
- [x] Phase F: 4 Playwright tests T4.1–T4.4 refactored to Real BE (no `page.route()` mocks)
- [x] Code quality review Findings 2+3 fixes applied + Finding 1 documented
- [ ] CI passes Frontend Tests (3 shards) — chromium-only E2E spec runs
- [ ] CI passes Backend Fast (build + unit) — no regression

Closes #1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
