### PR TITLE
hotfix(library): CS8604 in UploadCustomCoverCommandHandler:59 blocking staging deploy

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
@@ -56,7 +56,7 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             try
             {
                 await _blobStorage.DeleteAsync(
-                    ToObjectKey(entry.CustomCoverR2Key),
+                    ToObjectKey(entry.CustomCoverR2Key!),
                     BlobCategory.GameImage,
                     entry.CustomCoverR2Key!,
                     cancellationToken


### PR DESCRIPTION
## Context

Deploy run [27089623661](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27089623661) (triggered by promotion PR #1957) failed at **Build and Push API Image** step.

## Root cause

`UploadCustomCoverCommandHandler.cs:59` passes a **nullable** `entry.CustomCoverR2Key` to `ToObjectKey(string resourceKey)` which requires non-nullable.

`Api.csproj` has `<Nullable>enable</Nullable>` + `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` so `dotnet publish -c Release` rejects the build with **CS8604**. Regular CI uses `dotnet build` which is more lenient → bug shipped via PR #1892 (2026-06-04, #1824 L3 user-uploaded cover) and survived 4 days. Last staging deploy (2026-06-02, PR #1844) predated PR #1892, so the regression went unnoticed until today's promotion.

## Fix

1-char addition of null-forgiving (`!`) on line 59, matching the pattern already used on line 61 of the same method. Semantically safe: code path is inside `if (entry.HasCustomCover)` guard, so the key cannot actually be null at runtime.

```diff
- ToObjectKey(entry.CustomCoverR2Key),
+ ToObjectKey(entry.CustomCoverR2Key!),
```

## Follow-up

Align CI to also run `dotnet publish -c Release` (or add `-p:WarningLevel=…` matching production) so this class of nullable errors is caught **pre-merge**, not at deploy time. Not in scope for this hotfix.

🤖 Generated with Claude Code