### PR TITLE
fix(library): cherry-pick hotfix CS8604 from main-staging (PR #1958)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/CustomCover/UploadCustomCoverCommandHandler.cs
@@ -56,7 +56,7 @@ internal sealed class UploadCustomCoverCommandHandler : ICommandHandler<UploadCu
             try
             {
                 await _blobStorage.DeleteAsync(
-                    ToObjectKey(entry.CustomCoverR2Key),
+                    ToObjectKey(entry.CustomCoverR2Key!),
                     BlobCategory.GameImage,
                     entry.CustomCoverR2Key!,
                     cancellationToken


### PR DESCRIPTION
## Context

Hotfix PR #1958 landed directly on `main-staging` to unblock today's deploy (PR #1957). Cherry-picks the 1-char fix into `main-dev` so:

1. **Local builds work**: `dotnet publish -c Release` no longer fails on `main-dev`.
2. **Future promotions clean**: next `main-dev → main-staging` PR doesn't re-introduce the bug from main-dev's pre-hotfix state.

## Change

Cherry-pick of [`e144b0b0f`](https://github.com/meepleAi-app/meepleai-monorepo/commit/e144b0b0f).

```diff
- ToObjectKey(entry.CustomCoverR2Key),
+ ToObjectKey(entry.CustomCoverR2Key!),
```

## Verification

`dotnet build` locally: 0 errors, 0 warnings.

🤖 Generated with Claude Code