### PR TITLE
fix(chat): mobile chat input/send testid coverage + B1 spec (#1816 P2-1)

### DIFF
--- a/apps/web/e2e/mobile-golden-path.spec.ts
+++ b/apps/web/e2e/mobile-golden-path.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Mobile golden-path B1 — chat input testid contract (#1816 P2-1).
+ *
+ * Regression: at viewport <1024px (Tailwind `lg` breakpoint), the mobile chat
+ * surface (`ChatMobile`) renders a <textarea> + send button that must carry the
+ * same `data-testid` attributes as the desktop `ChatThreadView`/`ChatInputArea`
+ * so that E2E specs targeting `getByTestId('message-input')` resolve to the
+ * VISIBLE mobile element on the `mobile-chrome` / `mobile-safari` projects.
+ *
+ * Pre-fix DOM contained:
+ *   [0] visible mobile <textarea> (303×42 @ y=726), NO data-testid
+ *   [1] hidden desktop <textarea> with `data-testid="message-input"` (display:none)
+ *
+ * Audit: `docs/for-developers/audits/2026-06-02-mobile-golden-path-audit.md` § P2 testid.
+ *
+ * Runs only when the active project viewport is < lg (1024px). Auto-skips on
+ * desktop-chrome / desktop-firefox / desktop-safari / tablet-chrome.
+ */
+import { test, expect } from '@playwright/test';
+
+const MOCK_THREAD_ID = 'b1-thread-1816';
+const MOCK_USER_ID = 'b1-user-1816';
+
+test.describe('Mobile golden-path B1 — message-input testid', () => {
+  test.beforeEach(async ({ page }) => {
+    // Auth — FE still calls /auth/me even under PLAYWRIGHT_AUTH_BYPASS to
+    // populate the auth context store.
+    await page.context().route('**/api/v1/auth/me', async route => {
+      await route.fulfill({
+        json: {
+          id: MOCK_USER_ID,
+          email: 'b1@meepleai.app',
+          displayName: 'B1 Mobile Test',
+          role: 'User',
+          tier: 'free',
+        },
+      });
+    });
+
+    // Thread data — minimal stub: no messages, no agent, no game so neither
+    // SSE stream nor RAG QA pipeline kicks in.
+    await page.context().route(`**/api/v1/chat-threads/${MOCK_THREAD_ID}`, async route => {
+      await route.fulfill({
+        json: {
+          id: MOCK_THREAD_ID,
+          title: 'B1 mobile testid contract',
+          agentId: null,
+          gameId: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          messages: [],
+        },
+      });
+    });
+  });
+
+  test('mobile chat textarea exposes data-testid="message-input"', async ({ page, viewport }) => {
+    test.skip(
+      (viewport?.width ?? 0) >= 1024,
+      'mobile-only contract — desktop renders ChatThreadView with its own testid'
+    );
+
+    await page.goto(`/chat/${MOCK_THREAD_ID}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    // Both ChatMobile and ChatThreadView are mounted in DOM under responsive
+    // `lg:hidden` / `hidden lg:block` wrappers. At <lg only the mobile one is
+    // visible. Assert that exactly ONE visible element carries the testid.
+    const visibleInputs = page.locator('[data-testid="message-input"]:visible');
+    await expect(visibleInputs).toHaveCount(1);
+
+    // The visible element must be a <textarea> (mobile pattern).
+    const tagName = await visibleInputs.evaluate(el => el.tagName.toLowerCase());
+    expect(tagName).toBe('textarea');
+  });
+
+  test('mobile send button exposes data-testid="send-btn"', async ({ page, viewport }) => {
+    test.skip(
+      (viewport?.width ?? 0) >= 1024,
+      'mobile-only contract — desktop ChatInputArea also carries send-btn'
+    );
+
+    await page.goto(`/chat/${MOCK_THREAD_ID}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const visibleSendBtn = page.locator('[data-testid="send-btn"]:visible');
+    await expect(visibleSendBtn).toHaveCount(1);
+  });
+});

--- a/apps/web/src/components/chat-unified/ChatMobile.tsx
+++ b/apps/web/src/components/chat-unified/ChatMobile.tsx
@@ -628,6 +628,7 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
               'max-h-24'
             )}
             disabled={streamState.isStreaming}
+            data-testid="message-input"
           />
           <button
             onClick={() => handleSend()}
@@ -639,6 +640,7 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
                 : 'bg-[var(--glass-bg)] text-[var(--text-sec)]'
             )}
             aria-label="Invia messaggio"
+            data-testid="send-btn"
           >
             {streamState.isStreaming ? (
               <div className="h-5 w-5 border-2 border-border border-t-white rounded-full animate-spin" />


### PR DESCRIPTION
## Summary

- Add `data-testid="message-input"` + `data-testid="send-btn"` to `ChatMobile` textarea + send button so Playwright E2E specs targeting `getByTestId('message-input')` resolve to the VISIBLE element on `mobile-chrome` / `mobile-safari` projects (pre-fix: only the hidden desktop `ChatThreadView` carried the testid)
- New `e2e/mobile-golden-path.spec.ts` B1 contract spec: 2 mobile-only tests asserting visible testid + `<textarea>` tag for input + visible testid for send button. Auto-skips on desktop projects via `viewport.width >= 1024` check
- Audit ref: [`docs/for-developers/audits/2026-06-02-mobile-golden-path-audit.md`](../blob/main-dev/docs/for-developers/audits/2026-06-02-mobile-golden-path-audit.md) § P2 testid

## Test plan

- [x] Local typecheck (`pnpm typecheck`) green
- [x] Local lint (`eslint`) green on modified + new files
- [x] Pre-push hook: FE build verified
- [ ] CI `Frontend - Tests` shards 1/3 + 2/3 + 3/3 green
- [ ] CI `Frontend - A11y E2E` mobile-chrome project passes new B1 spec
- [ ] No regression on `mobile-shell-viewport.spec.ts` / `mobile-card-browser.spec.ts`

## Scope of #1816 closed

- ✅ **P2-1** `data-testid="message-input"` mobile coverage
- ⏳ remaining: P2-2 (h1 semantic) · P2-3 (CSP staging-only) · P3-4..8 (i18n batched + KB Coverage states)

Closes part of #1816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
