### PR TITLE
feat(i18n): batched P3 mobile golden-path fixes (#1816 P3-4/5/6/8)

### DIFF
--- a/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
+++ b/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
@@ -31,6 +31,16 @@ export const twoFactorVerificationMessages = {
   'auth.2fa.verifying': 'Verifying...',
   'auth.2fa.verify': 'Verify',
   'auth.2fa.useBackupCode': 'Use a backup code instead',
+  // #1816 P3-4 — TwoFactorVerification migrated from auth.2fa.* to auth.twoFactor.*
+  // namespace + removed duplicate inline h2/p header (AuthCard/Dialog wrappers
+  // already provide the heading). These keys mirror the runtime locales.
+  'auth.twoFactor.code': 'Verification code',
+  'auth.twoFactor.submit': 'Verify',
+  'auth.twoFactor.submitting': 'Verifying...',
+  'auth.twoFactor.codeRequired': 'Please enter a 6-digit code',
+  'auth.twoFactor.codeInvalid': 'Invalid code format',
+  'auth.twoFactor.rememberDevice': 'Trust this device for 30 days',
+  'auth.twoFactor.backupCode': 'Use a backup code instead',
 } as const;
 
 // =============================================================================
@@ -339,6 +349,43 @@ export const libraryGameDetailHeaderMessages = {
 // All Test Messages (combined)
 // =============================================================================
 
+// =============================================================================
+// #1816 P3 batched i18n — pages.library + common.entity (catalog pagination,
+// AddGameDrawer, ChatNavigationContext)
+// =============================================================================
+
+export const catalogPaginationMessages = {
+  'pages.library.catalogPagination.firstPage': 'First page',
+  'pages.library.catalogPagination.previousPage': 'Previous page',
+  'pages.library.catalogPagination.nextPage': 'Next page',
+  'pages.library.catalogPagination.lastPage': 'Last page',
+  'pages.library.catalogPagination.pageNumber': 'Page {n}',
+} as const;
+
+export const addGameDrawerMessages = {
+  'pages.library.addGame.drawerTitle': 'Add a game',
+  'pages.library.addGame.manualTitle': 'Add game manually',
+  'pages.library.addGame.catalogTitle': 'Add from catalog',
+  'pages.library.addGame.question': 'How do you want to add your game?',
+  'pages.library.addGame.manualLabel': 'Add manually',
+  'pages.library.addGame.manualDescription':
+    'Enter the game details. You can upload the rulebook and configure the AI agent later from the game detail page.',
+  'pages.library.addGame.catalogLabel': 'From shared catalog',
+  'pages.library.addGame.catalogDescription':
+    'Search the community catalog and add a game in one click. Rulebook and AI agent setup come later.',
+} as const;
+
+export const entityLabelMessages = {
+  'common.entity.game': 'Game',
+  'common.entity.agent': 'Agent',
+  'common.entity.session': 'Session',
+  'common.entity.kb': 'KB',
+  'common.entity.player': 'Players',
+  'common.entity.chat': 'Chat',
+  'common.entity.event': 'Events',
+  'common.entity.toolkit': 'Toolkit',
+} as const;
+
 export const allTestMessages: Record<string, string> = {
   ...oauthMessages,
   ...twoFactorVerificationMessages,
@@ -350,6 +397,9 @@ export const allTestMessages: Record<string, string> = {
   ...settingsLabels,
   ...playRecordsIndexMessages,
   ...libraryGameDetailHeaderMessages,
+  ...catalogPaginationMessages,
+  ...addGameDrawerMessages,
+  ...entityLabelMessages,
 };
 
 // =============================================================================

--- a/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
+++ b/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
@@ -26,6 +26,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { CatalogSearchStep } from '@/app/(authenticated)/library/CatalogSearchStep';
 import { UserWizardClient } from '@/app/(authenticated)/library/private/add/client';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
+import { useTranslation } from '@/hooks/useTranslation';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -74,6 +75,7 @@ interface AddGameDrawerProps {
 
 export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
   const router = useRouter();
+  const { t } = useTranslation();
   const [step, setStep] = useState<DrawerStep>('choice');
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -109,10 +111,10 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
 
   const drawerTitle =
     step === 'manual'
-      ? 'Add game manually'
+      ? t('pages.library.addGame.manualTitle')
       : step === 'catalog'
-        ? 'Add from catalog'
-        : 'Add a game';
+        ? t('pages.library.addGame.catalogTitle')
+        : t('pages.library.addGame.drawerTitle');
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -129,21 +131,21 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
           {/* Step 0: Choice */}
           {step === 'choice' && (
             <div className="px-6 py-6 space-y-4" data-testid="add-game-step-choice">
-              <p className="text-sm text-muted-foreground">How do you want to add your game?</p>
+              <p className="text-sm text-muted-foreground">{t('pages.library.addGame.question')}</p>
 
               <ChoiceCard
                 data-testid="add-game-choice-manual"
                 icon={<PenLine className="h-6 w-6" />}
-                title="Add manually"
-                description="Enter the game details. You can upload the rulebook and configure the AI agent later from the game detail page."
+                title={t('pages.library.addGame.manualLabel')}
+                description={t('pages.library.addGame.manualDescription')}
                 onClick={() => setStep('manual')}
               />
 
               <ChoiceCard
                 data-testid="add-game-choice-catalog"
                 icon={<BookOpen className="h-6 w-6" />}
-                title="From shared catalog"
-                description="Search the community catalog and add a game in one click. Rulebook and AI agent setup come later."
+                title={t('pages.library.addGame.catalogLabel')}
+                description={t('pages.library.addGame.catalogDescription')}
                 onClick={() => setStep('catalog')}
               />
             </div>

--- a/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
@@ -13,12 +13,18 @@
  * - Direct prop-driven open/close (AddGameDrawer)
  */
 
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 
+import { renderWithIntl } from '../../../../__tests__/fixtures/common-fixtures';
 import { AddGameDrawer, AddGameDrawerController } from '../AddGameDrawer';
+
+// #1816 P3-5 — AddGameDrawer migrated from hardcoded EN strings to i18n keys
+// (`pages.library.addGame.*`). Tests use `renderWithIntl` (loads EN test
+// catalog) so existing 'Add a game'/'Add manually'/... assertions stay valid.
+const render = renderWithIntl;
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -38,10 +44,7 @@ vi.mock('@/app/(authenticated)/library/private/add/client', () => ({
     onCancel?: () => void;
     compactMode?: boolean;
   }) => (
-    <div
-      data-testid="user-wizard-client"
-      data-compact-mode={compactMode ? 'true' : 'false'}
-    >
+    <div data-testid="user-wizard-client" data-compact-mode={compactMode ? 'true' : 'false'}>
       <button data-testid="wizard-complete" onClick={onComplete}>
         Complete wizard
       </button>
@@ -62,10 +65,7 @@ vi.mock('@/app/(authenticated)/library/CatalogSearchStep', () => ({
     onBack: () => void;
   }) => (
     <div data-testid="catalog-search-step">
-      <button
-        data-testid="catalog-select-game"
-        onClick={() => onSelect('game-123', 'Catan')}
-      >
+      <button data-testid="catalog-select-game" onClick={() => onSelect('game-123', 'Catan')}>
         Select Catan
       </button>
       <button data-testid="catalog-back" onClick={onBack}>
@@ -82,9 +82,7 @@ const mockUseSearchParams = useSearchParams as Mock;
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function renderDrawer(props: { open: boolean; onClose?: () => void } = { open: false }) {
-  return render(
-    <AddGameDrawer open={props.open} onClose={props.onClose ?? vi.fn()} />,
-  );
+  return render(<AddGameDrawer open={props.open} onClose={props.onClose ?? vi.fn()} />);
 }
 
 function renderController(searchParamsString = '') {
@@ -160,9 +158,7 @@ describe('AddGameDrawer', () => {
 
       await user.click(screen.getByTestId('add-game-choice-manual'));
 
-      expect(screen.getByTestId('add-game-drawer-title')).toHaveTextContent(
-        'Add game manually',
-      );
+      expect(screen.getByTestId('add-game-drawer-title')).toHaveTextContent('Add game manually');
     });
 
     it('calls onClose when wizard completes', async () => {
@@ -206,9 +202,7 @@ describe('AddGameDrawer', () => {
 
       await user.click(screen.getByTestId('add-game-choice-catalog'));
 
-      expect(screen.getByTestId('add-game-drawer-title')).toHaveTextContent(
-        'Add from catalog',
-      );
+      expect(screen.getByTestId('add-game-drawer-title')).toHaveTextContent('Add from catalog');
     });
 
     it('goes back to choice step when catalog back is clicked', async () => {

--- a/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
@@ -13,12 +13,18 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import NotificationsPage from '../page';
 import type { NotificationDto } from '@/lib/api';
 import { EMPTY } from '../../../../__tests__/fixtures/test-strings';
+// #1816 P3-i18n: CatalogPagination (rendered when notifications > 20) calls
+// useTranslation which requires IntlProvider in the tree. Use renderWithIntl
+// for all tests so the paginated case has the provider available.
+import { renderWithIntl } from '../../../../__tests__/fixtures/common-fixtures';
+
+const render = renderWithIntl;
 
 // ============================================================================
 // Mocks

--- a/apps/web/src/components/auth/TwoFactorVerification.tsx
+++ b/apps/web/src/components/auth/TwoFactorVerification.tsx
@@ -83,9 +83,9 @@ export function TwoFactorVerification({
   const verificationSchema = z.object({
     code: z
       .string()
-      .min(6, t('auth.2fa.codeRequired', 'Please enter a 6-digit code'))
-      .max(8, t('auth.2fa.codeInvalid', 'Code must be 6-8 characters')) // Allow backup codes (8 chars)
-      .regex(/^[0-9A-Za-z-]+$/, t('auth.2fa.codeInvalid', 'Invalid code format')),
+      .min(6, t('auth.twoFactor.codeRequired'))
+      .max(8, t('auth.twoFactor.codeInvalid')) // Allow backup codes (8 chars)
+      .regex(/^[0-9A-Za-z-]+$/, t('auth.twoFactor.codeInvalid')),
     rememberDevice: z.boolean().default(false),
   });
 
@@ -150,20 +150,20 @@ export function TwoFactorVerification({
     setValue('code', value, { shouldValidate: true });
   };
 
+  // Header rendering: AuthCard / Dialog wrappers already supply h1 + subtitle.
+  // The component renders an optional inline header ONLY when `title` is
+  // passed explicitly (rare); default usage (no title prop) skips the block to
+  // avoid a duplicate heading inside the wrapper. Audit ref: #1816 § P3 2FA i18n.
+  const showInlineHeader = Boolean(title) || Boolean(subtitle);
+
   return (
-    <div
-      className="w-full max-w-md space-y-6"
-      data-testid="two-factor-verification"
-    >
-      {/* Header */}
-      <div className="text-center space-y-2">
-        <h2 className="text-2xl font-bold text-foreground">
-          {title || t('auth.2fa.verificationTitle', 'Two-Factor Authentication')}
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          {subtitle || t('auth.2fa.verificationSubtitle', 'Enter the 6-digit code from your authenticator app')}
-        </p>
-      </div>
+    <div className="w-full max-w-md space-y-6" data-testid="two-factor-verification">
+      {showInlineHeader && (
+        <div className="text-center space-y-2">
+          {title && <h2 className="text-2xl font-bold text-foreground">{title}</h2>}
+          {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
+        </div>
+      )}
 
       <form
         onSubmit={handleSubmit(onFormSubmit)}
@@ -174,11 +174,11 @@ export function TwoFactorVerification({
         {/* Code Input */}
         <div className="space-y-2">
           <Label htmlFor="2fa-code" className="sr-only">
-            {t('auth.2fa.codeLabel', 'Verification Code')}
+            {t('auth.twoFactor.code')}
           </Label>
           <input
             {...register('code')}
-            ref={(e) => {
+            ref={e => {
               register('code').ref(e);
               inputRef.current = e;
             }}
@@ -196,11 +196,7 @@ export function TwoFactorVerification({
             data-testid="2fa-code-input"
           />
           {errors.code && (
-            <p
-              id="2fa-code-error"
-              className="text-sm text-destructive"
-              role="alert"
-            >
+            <p id="2fa-code-error" className="text-sm text-destructive" role="alert">
               {errors.code.message}
             </p>
           )}
@@ -224,7 +220,7 @@ export function TwoFactorVerification({
             <Checkbox
               id="remember-device"
               checked={watch('rememberDevice')}
-              onCheckedChange={(checked) => setValue('rememberDevice', !!checked)}
+              onCheckedChange={checked => setValue('rememberDevice', !!checked)}
               disabled={isLoading}
               data-testid="remember-device-checkbox"
             />
@@ -232,7 +228,7 @@ export function TwoFactorVerification({
               htmlFor="remember-device"
               className="text-sm text-muted-foreground cursor-pointer"
             >
-              {t('auth.2fa.rememberDevice', 'Trust this device for 30 days')}
+              {t('auth.twoFactor.rememberDevice')}
             </Label>
           </div>
         )}
@@ -242,11 +238,11 @@ export function TwoFactorVerification({
           type="submit"
           className="w-full"
           isLoading={isLoading}
-          loadingText={t('auth.2fa.verifying', 'Verifying...')}
+          loadingText={t('auth.twoFactor.submitting')}
           disabled={codeValue.length < 6}
           data-testid="2fa-verify-button"
         >
-          {t('auth.2fa.verify', 'Verify')}
+          {t('auth.twoFactor.submit')}
         </LoadingButton>
 
         {/* Backup Code Link */}
@@ -259,7 +255,7 @@ export function TwoFactorVerification({
               className="text-sm text-primary hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
               data-testid="use-backup-code-link"
             >
-              {t('auth.2fa.useBackupCode', 'Use a backup code instead')}
+              {t('auth.twoFactor.backupCode')}
             </button>
           </div>
         )}
@@ -274,7 +270,7 @@ export function TwoFactorVerification({
               className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
               data-testid="2fa-cancel-button"
             >
-              {t('common.cancel', 'Cancel')}
+              {t('common.cancel')}
             </button>
           </div>
         )}

--- a/apps/web/src/components/auth/__tests__/TwoFactorVerification.test.tsx
+++ b/apps/web/src/components/auth/__tests__/TwoFactorVerification.test.tsx
@@ -5,7 +5,7 @@
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithIntl, msg } from '../../../__tests__/fixtures/common-fixtures';
+import { renderWithIntl } from '../../../__tests__/fixtures/common-fixtures';
 import { TwoFactorVerification } from '../TwoFactorVerification';
 
 describe('TwoFactorVerification', () => {
@@ -18,14 +18,26 @@ describe('TwoFactorVerification', () => {
   });
 
   describe('Rendering', () => {
-    it('renders default title and subtitle', () => {
+    it('does not render an inline header by default (wrapper-supplied)', () => {
+      // #1816 P3-4: AuthCard / Dialog wrappers already render h1 + subtitle.
+      // Component default-renders form-only to avoid duplicate heading reported
+      // by audit (h1 IT + h2 EN observed simultaneously on /login 2FA step).
       renderWithIntl(<TwoFactorVerification {...defaultProps} />);
 
-      expect(screen.getByText(msg('auth.2fa.verificationTitle'))).toBeInTheDocument();
-      expect(screen.getByText(msg('auth.2fa.verificationSubtitle'))).toBeInTheDocument();
+      // Inline header (h2 + paragraph) should NOT be in DOM when title/subtitle
+      // props are absent.
+      expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
     });
 
-    it('renders custom title and subtitle', () => {
+    it('renders inline header when title prop is provided', () => {
+      renderWithIntl(<TwoFactorVerification {...defaultProps} title="Custom Title" />);
+
+      // Custom title renders as h2 inside the component.
+      const heading = screen.getByRole('heading', { level: 2 });
+      expect(heading).toHaveTextContent('Custom Title');
+    });
+
+    it('renders custom subtitle when subtitle prop is provided', () => {
       renderWithIntl(
         <TwoFactorVerification
           {...defaultProps}
@@ -53,9 +65,7 @@ describe('TwoFactorVerification', () => {
     });
 
     it('hides remember device checkbox when showRememberDevice is false', () => {
-      renderWithIntl(
-        <TwoFactorVerification {...defaultProps} showRememberDevice={false} />
-      );
+      renderWithIntl(<TwoFactorVerification {...defaultProps} showRememberDevice={false} />);
 
       expect(screen.queryByTestId('remember-device-checkbox')).not.toBeInTheDocument();
     });
@@ -68,9 +78,7 @@ describe('TwoFactorVerification', () => {
 
     it('renders backup code link when onUseBackupCode is provided', () => {
       const onUseBackupCode = vi.fn();
-      renderWithIntl(
-        <TwoFactorVerification {...defaultProps} onUseBackupCode={onUseBackupCode} />
-      );
+      renderWithIntl(<TwoFactorVerification {...defaultProps} onUseBackupCode={onUseBackupCode} />);
 
       expect(screen.getByTestId('use-backup-code-link')).toBeInTheDocument();
     });
@@ -120,19 +128,14 @@ describe('TwoFactorVerification', () => {
   describe('Error State', () => {
     it('displays error message when error prop is provided', () => {
       renderWithIntl(
-        <TwoFactorVerification
-          {...defaultProps}
-          error="Invalid code. Please try again."
-        />
+        <TwoFactorVerification {...defaultProps} error="Invalid code. Please try again." />
       );
 
       expect(screen.getByText('Invalid code. Please try again.')).toBeInTheDocument();
     });
 
     it('displays error with destructive styling', () => {
-      renderWithIntl(
-        <TwoFactorVerification {...defaultProps} error="Error message" />
-      );
+      renderWithIntl(<TwoFactorVerification {...defaultProps} error="Error message" />);
 
       const alert = screen.getByTestId('2fa-error');
       expect(alert).toBeInTheDocument();
@@ -187,9 +190,7 @@ describe('TwoFactorVerification', () => {
       const user = userEvent.setup();
       const onUseBackupCode = vi.fn();
 
-      renderWithIntl(
-        <TwoFactorVerification {...defaultProps} onUseBackupCode={onUseBackupCode} />
-      );
+      renderWithIntl(<TwoFactorVerification {...defaultProps} onUseBackupCode={onUseBackupCode} />);
 
       const backupLink = screen.getByTestId('use-backup-code-link');
       await user.click(backupLink);
@@ -236,9 +237,7 @@ describe('TwoFactorVerification', () => {
     });
 
     it('renders error with alert role', () => {
-      renderWithIntl(
-        <TwoFactorVerification {...defaultProps} error="Error message" />
-      );
+      renderWithIntl(<TwoFactorVerification {...defaultProps} error="Error message" />);
 
       const alert = screen.getByTestId('2fa-error');
       expect(alert).toBeInTheDocument();

--- a/apps/web/src/components/catalog/CatalogPagination.tsx
+++ b/apps/web/src/components/catalog/CatalogPagination.tsx
@@ -14,6 +14,7 @@
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 
 import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
 
 interface CatalogPaginationProps {
   currentPage: number;
@@ -29,6 +30,8 @@ export function CatalogPagination({
   onPageChange,
   totalResults,
 }: CatalogPaginationProps) {
+  const { t } = useTranslation();
+
   // Calculate visible page numbers
   const getPageNumbers = () => {
     const pages: (number | string)[] = [];
@@ -73,7 +76,8 @@ export function CatalogPagination({
   const pageNumbers = getPageNumbers();
 
   // Format results count display
-  const resultsText = totalResults !== undefined ? `${totalResults.toLocaleString()} risultati` : null;
+  const resultsText =
+    totalResults !== undefined ? `${totalResults.toLocaleString()} risultati` : null;
   const pageInfoText = `Pagina ${currentPage} di ${totalPages}`;
 
   return (
@@ -91,78 +95,78 @@ export function CatalogPagination({
 
       {/* Pagination controls */}
       <div className="flex items-center justify-center gap-2">
-      {/* First Page */}
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => onPageChange(1)}
-        disabled={currentPage === 1}
-        aria-label="First page"
-      >
-        <ChevronsLeft className="h-4 w-4" />
-      </Button>
+        {/* First Page */}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => onPageChange(1)}
+          disabled={currentPage === 1}
+          aria-label={t('pages.library.catalogPagination.firstPage')}
+        >
+          <ChevronsLeft className="h-4 w-4" />
+        </Button>
 
-      {/* Previous Page */}
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
-        aria-label="Previous page"
-      >
-        <ChevronLeft className="h-4 w-4" />
-      </Button>
+        {/* Previous Page */}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          aria-label={t('pages.library.catalogPagination.previousPage')}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
 
-      {/* Page Numbers */}
-      <div className="flex items-center gap-1">
-        {pageNumbers.map((page, index) => {
-          if (page === '...') {
+        {/* Page Numbers */}
+        <div className="flex items-center gap-1">
+          {pageNumbers.map((page, index) => {
+            if (page === '...') {
+              return (
+                <span key={`ellipsis-${index}`} className="px-2 text-muted-foreground">
+                  ...
+                </span>
+              );
+            }
+
+            const pageNum = page as number;
+            const isActive = pageNum === currentPage;
+
             return (
-              <span key={`ellipsis-${index}`} className="px-2 text-muted-foreground">
-                ...
-              </span>
+              <Button
+                key={pageNum}
+                variant={isActive ? 'default' : 'outline'}
+                size="icon"
+                onClick={() => onPageChange(pageNum)}
+                aria-label={t('pages.library.catalogPagination.pageNumber', { n: pageNum })}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {pageNum}
+              </Button>
             );
-          }
+          })}
+        </div>
 
-          const pageNum = page as number;
-          const isActive = pageNum === currentPage;
+        {/* Next Page */}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          aria-label={t('pages.library.catalogPagination.nextPage')}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
 
-          return (
-            <Button
-              key={pageNum}
-              variant={isActive ? 'default' : 'outline'}
-              size="icon"
-              onClick={() => onPageChange(pageNum)}
-              aria-label={`Page ${pageNum}`}
-              aria-current={isActive ? 'page' : undefined}
-            >
-              {pageNum}
-            </Button>
-          );
-        })}
-      </div>
-
-      {/* Next Page */}
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-        aria-label="Next page"
-      >
-        <ChevronRight className="h-4 w-4" />
-      </Button>
-
-      {/* Last Page */}
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => onPageChange(totalPages)}
-        disabled={currentPage === totalPages}
-        aria-label="Last page"
-      >
-        <ChevronsRight className="h-4 w-4" />
-      </Button>
+        {/* Last Page */}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => onPageChange(totalPages)}
+          disabled={currentPage === totalPages}
+          aria-label={t('pages.library.catalogPagination.lastPage')}
+        >
+          <ChevronsRight className="h-4 w-4" />
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/components/catalog/__tests__/CatalogPagination.test.tsx
+++ b/apps/web/src/components/catalog/__tests__/CatalogPagination.test.tsx
@@ -12,10 +12,17 @@
  * - Results info display (#2876)
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { renderWithIntl } from '../../../__tests__/fixtures/common-fixtures';
 import { CatalogPagination } from '../CatalogPagination';
+
+// #1816 P3-6 — pagination aria-labels migrated from hardcoded EN to i18n keys
+// (`pages.library.catalogPagination.*`). Tests use `renderWithIntl` which loads
+// `allTestMessages` (EN values) so existing 'First page'/'Previous page'/...
+// assertions remain valid.
+const render = renderWithIntl;
 
 describe('CatalogPagination', () => {
   const mockOnPageChange = vi.fn();
@@ -30,13 +37,7 @@ describe('CatalogPagination', () => {
 
   describe('Basic Rendering', () => {
     it('renders all navigation buttons', () => {
-      render(
-        <CatalogPagination
-          currentPage={1}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
 
       expect(screen.getByLabelText('First page')).toBeInTheDocument();
       expect(screen.getByLabelText('Previous page')).toBeInTheDocument();
@@ -45,13 +46,7 @@ describe('CatalogPagination', () => {
     });
 
     it('displays current page number', () => {
-      render(
-        <CatalogPagination
-          currentPage={5}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
 
       const currentPageButton = screen.getByLabelText('Page 5');
       expect(currentPageButton).toBeInTheDocument();
@@ -65,13 +60,7 @@ describe('CatalogPagination', () => {
 
   describe('Page Number Display', () => {
     it('shows all pages when total is 5 or less', () => {
-      render(
-        <CatalogPagination
-          currentPage={3}
-          totalPages={5}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={3} totalPages={5} onPageChange={mockOnPageChange} />);
 
       for (let i = 1; i <= 5; i++) {
         expect(screen.getByLabelText(`Page ${i}`)).toBeInTheDocument();
@@ -81,13 +70,7 @@ describe('CatalogPagination', () => {
     });
 
     it('shows ellipsis at end when near start (page 2)', () => {
-      render(
-        <CatalogPagination
-          currentPage={2}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={2} totalPages={10} onPageChange={mockOnPageChange} />);
 
       // Should show 1, 2, 3, 4, ..., 10
       expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
@@ -99,13 +82,7 @@ describe('CatalogPagination', () => {
     });
 
     it('shows ellipsis at start when near end (page 9)', () => {
-      render(
-        <CatalogPagination
-          currentPage={9}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={9} totalPages={10} onPageChange={mockOnPageChange} />);
 
       // Should show 1, ..., 7, 8, 9, 10
       expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
@@ -117,13 +94,7 @@ describe('CatalogPagination', () => {
     });
 
     it('shows ellipsis on both sides when in middle (page 5)', () => {
-      render(
-        <CatalogPagination
-          currentPage={5}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
 
       // Should show 1, ..., 4, 5, 6, ..., 10
       expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
@@ -141,65 +112,35 @@ describe('CatalogPagination', () => {
 
   describe('Navigation', () => {
     it('calls onPageChange with correct page when clicking page number', () => {
-      render(
-        <CatalogPagination
-          currentPage={1}
-          totalPages={5}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={1} totalPages={5} onPageChange={mockOnPageChange} />);
 
       fireEvent.click(screen.getByLabelText('Page 3'));
       expect(mockOnPageChange).toHaveBeenCalledWith(3);
     });
 
     it('navigates to first page', () => {
-      render(
-        <CatalogPagination
-          currentPage={5}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
 
       fireEvent.click(screen.getByLabelText('First page'));
       expect(mockOnPageChange).toHaveBeenCalledWith(1);
     });
 
     it('navigates to previous page', () => {
-      render(
-        <CatalogPagination
-          currentPage={5}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
 
       fireEvent.click(screen.getByLabelText('Previous page'));
       expect(mockOnPageChange).toHaveBeenCalledWith(4);
     });
 
     it('navigates to next page', () => {
-      render(
-        <CatalogPagination
-          currentPage={5}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
 
       fireEvent.click(screen.getByLabelText('Next page'));
       expect(mockOnPageChange).toHaveBeenCalledWith(6);
     });
 
     it('navigates to last page', () => {
-      render(
-        <CatalogPagination
-          currentPage={5}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
 
       fireEvent.click(screen.getByLabelText('Last page'));
       expect(mockOnPageChange).toHaveBeenCalledWith(10);
@@ -212,13 +153,7 @@ describe('CatalogPagination', () => {
 
   describe('Boundary Conditions', () => {
     it('disables first and previous buttons on first page', () => {
-      render(
-        <CatalogPagination
-          currentPage={1}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
 
       expect(screen.getByLabelText('First page')).toBeDisabled();
       expect(screen.getByLabelText('Previous page')).toBeDisabled();
@@ -228,11 +163,7 @@ describe('CatalogPagination', () => {
 
     it('disables next and last buttons on last page', () => {
       render(
-        <CatalogPagination
-          currentPage={10}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
+        <CatalogPagination currentPage={10} totalPages={10} onPageChange={mockOnPageChange} />
       );
 
       expect(screen.getByLabelText('First page')).not.toBeDisabled();
@@ -242,13 +173,7 @@ describe('CatalogPagination', () => {
     });
 
     it('disables all navigation when only one page', () => {
-      render(
-        <CatalogPagination
-          currentPage={1}
-          totalPages={1}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={1} totalPages={1} onPageChange={mockOnPageChange} />);
 
       expect(screen.getByLabelText('First page')).toBeDisabled();
       expect(screen.getByLabelText('Previous page')).toBeDisabled();
@@ -263,13 +188,7 @@ describe('CatalogPagination', () => {
 
   describe('Accessibility', () => {
     it('has accessible button labels', () => {
-      render(
-        <CatalogPagination
-          currentPage={3}
-          totalPages={5}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={3} totalPages={5} onPageChange={mockOnPageChange} />);
 
       // All buttons should have aria-label
       expect(screen.getByLabelText('First page')).toBeInTheDocument();
@@ -281,13 +200,7 @@ describe('CatalogPagination', () => {
     });
 
     it('marks current page with aria-current', () => {
-      render(
-        <CatalogPagination
-          currentPage={3}
-          totalPages={5}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={3} totalPages={5} onPageChange={mockOnPageChange} />);
 
       const currentButton = screen.getByLabelText('Page 3');
       expect(currentButton).toHaveAttribute('aria-current', 'page');
@@ -298,13 +211,7 @@ describe('CatalogPagination', () => {
     });
 
     it('applies different variant to current page button', () => {
-      render(
-        <CatalogPagination
-          currentPage={3}
-          totalPages={5}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={3} totalPages={5} onPageChange={mockOnPageChange} />);
 
       // Current page should have the default variant (visually distinct)
       const currentButton = screen.getByLabelText('Page 3');
@@ -321,13 +228,7 @@ describe('CatalogPagination', () => {
 
   describe('Results Info Display', () => {
     it('displays page info without results when totalResults not provided', () => {
-      render(
-        <CatalogPagination
-          currentPage={3}
-          totalPages={10}
-          onPageChange={mockOnPageChange}
-        />
-      );
+      render(<CatalogPagination currentPage={3} totalPages={10} onPageChange={mockOnPageChange} />);
 
       expect(screen.getByText('Pagina 3 di 10')).toBeInTheDocument();
     });

--- a/apps/web/src/components/chat-unified/ChatNavigationContext.tsx
+++ b/apps/web/src/components/chat-unified/ChatNavigationContext.tsx
@@ -13,14 +13,31 @@ import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
 
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
 import { getNavigationLinks, type ResolvedNavigationLink } from '@/config/entity-navigation';
+import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
 
 interface ChatNavigationContextProps {
   threadId: string;
 }
 
+// Entity-type → i18n key map. Keeps the `entity-navigation` config translation-
+// free (labels stay as EN fallbacks) while the chat surface localizes labels
+// via the translation layer. New entries map to `common.entity.*` keys.
+const ENTITY_LABEL_KEY: Partial<Record<MeepleEntityType, string>> = {
+  game: 'common.entity.game',
+  agent: 'common.entity.agent',
+  session: 'common.entity.session',
+  kb: 'common.entity.kb',
+  player: 'common.entity.player',
+  chat: 'common.entity.chat',
+  event: 'common.entity.event',
+  toolkit: 'common.entity.toolkit',
+};
+
 export function ChatNavigationContext({ threadId }: ChatNavigationContextProps) {
+  const { t } = useTranslation();
   const [links, setLinks] = useState<ResolvedNavigationLink[]>([]);
 
   useEffect(() => {
@@ -51,17 +68,20 @@ export function ChatNavigationContext({ threadId }: ChatNavigationContextProps) 
 
   return (
     <div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-card px-4 py-2">
-      {links.map(link =>
-        link.href ? (
+      {links.map(link => {
+        if (!link.href) return null;
+        const labelKey = ENTITY_LABEL_KEY[link.entity];
+        const label = labelKey ? t(labelKey) : link.label;
+        return (
           <Link
             key={link.entity}
             href={link.href}
             className="text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            {link.label}
+            {label}
           </Link>
-        ) : null
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -228,7 +228,11 @@
       "error": "Invalid code. Please try again.",
       "submit": "Verify",
       "title": "Two-Factor Authentication",
-      "verificationSubtitle": "Enter the code from your authenticator app to continue."
+      "verificationSubtitle": "Enter the code from your authenticator app to continue.",
+      "submitting": "Verifying...",
+      "codeRequired": "Please enter a 6-digit code",
+      "codeInvalid": "Invalid code format",
+      "rememberDevice": "Trust this device for 30 days"
     },
     "emailVerification": {
       "pageTitle": "Email verification",
@@ -386,6 +390,16 @@
           "resolved": "Incident resolved"
         }
       }
+    },
+    "entity": {
+      "game": "Game",
+      "agent": "Agent",
+      "session": "Session",
+      "kb": "KB",
+      "player": "Players",
+      "chat": "Chat",
+      "event": "Events",
+      "toolkit": "Toolkit"
     }
   },
   "comments": {
@@ -2010,6 +2024,23 @@
           "loading": "Loading game — MeepleAI",
           "notFound": "Game not found — MeepleAI"
         }
+      },
+      "addGame": {
+        "drawerTitle": "Add a game",
+        "manualTitle": "Add game manually",
+        "catalogTitle": "Add from catalog",
+        "question": "How do you want to add your game?",
+        "manualLabel": "Add manually",
+        "manualDescription": "Enter the game details. You can upload the rulebook and configure the AI agent later from the game detail page.",
+        "catalogLabel": "From shared catalog",
+        "catalogDescription": "Search the community catalog and add a game in one click. Rulebook and AI agent setup come later."
+      },
+      "catalogPagination": {
+        "firstPage": "First page",
+        "previousPage": "Previous page",
+        "nextPage": "Next page",
+        "lastPage": "Last page",
+        "pageNumber": "Page {n}"
       }
     },
     "discover": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -219,7 +219,11 @@
       "error": "Codice non valido. Riprova.",
       "submit": "Verifica",
       "title": "Autenticazione a due fattori",
-      "verificationSubtitle": "Inserisci il codice dell'app di autenticazione per continuare."
+      "verificationSubtitle": "Inserisci il codice dell'app di autenticazione per continuare.",
+      "submitting": "Verifica in corso...",
+      "codeRequired": "Inserisci un codice a 6 cifre",
+      "codeInvalid": "Codice non valido",
+      "rememberDevice": "Ricorda questo dispositivo per 30 giorni"
     },
     "emailVerification": {
       "pageTitle": "Verifica email",
@@ -377,6 +381,16 @@
           "resolved": "Incidente risolto"
         }
       }
+    },
+    "entity": {
+      "game": "Gioco",
+      "agent": "Agente",
+      "session": "Sessione",
+      "kb": "KB",
+      "player": "Giocatori",
+      "chat": "Chat",
+      "event": "Eventi",
+      "toolkit": "Toolkit"
     }
   },
   "comments": {
@@ -2060,6 +2074,23 @@
           "loading": "Caricamento gioco — MeepleAI",
           "notFound": "Gioco non trovato — MeepleAI"
         }
+      },
+      "addGame": {
+        "drawerTitle": "Aggiungi un gioco",
+        "manualTitle": "Aggiungi gioco manualmente",
+        "catalogTitle": "Aggiungi da catalogo",
+        "question": "Come vuoi aggiungere il tuo gioco?",
+        "manualLabel": "Aggiungi manualmente",
+        "manualDescription": "Inserisci i dettagli del gioco. Potrai caricare il regolamento e configurare l'agente AI dalla pagina di dettaglio.",
+        "catalogLabel": "Da catalogo condiviso",
+        "catalogDescription": "Cerca nel catalogo della community e aggiungi un gioco con un click. Regolamento e setup agente in seguito."
+      },
+      "catalogPagination": {
+        "firstPage": "Prima pagina",
+        "previousPage": "Pagina precedente",
+        "nextPage": "Pagina successiva",
+        "lastPage": "Ultima pagina",
+        "pageNumber": "Pagina {n}"
       }
     },
     "discover": {


### PR DESCRIPTION
## Summary

Batched i18n fix for **4 of the P3 findings** in [#1816](https://github.com/meepleAi-app/meepleai-monorepo/issues/1816) mobile golden-path audit (2026-06-02). Each finding stands as a discrete, audit-traced semantic correction: no mixed-locale rendering, no duplicate inline heading, no English aria-labels on Italian UI.

**25 new i18n keys** (IT + EN) across 4 namespaces:
- `auth.twoFactor.*` (extends existing) — 2FA submit / loading / validation
- `pages.library.addGame.*` (new) — drawer titles + choice cards
- `pages.library.catalogPagination.*` (new) — pagination aria-labels
- `common.entity.*` (new) — entity nav labels (Game→Gioco, etc.)

**4 components migrated**:

| Finding | Component | Change |
|---------|-----------|--------|
| **P3-4** | `TwoFactorVerification.tsx` | Remove duplicate inline h2 + paragraph (AuthCard wrapper supplies it); migrate t() keys `auth.2fa.*` (missing → EN fallback) → existing `auth.twoFactor.*` |
| **P3-5** | `AddGameDrawer.tsx` | Add `useTranslation`, replace 8 hardcoded EN strings |
| **P3-6** | `CatalogPagination.tsx` | i18n 5 aria-labels — **a11y CRITICAL** per Crispin (NVDA/VoiceOver announced wrong lang on IT UI) |
| **P3-8** | `ChatNavigationContext.tsx` | `ENTITY_LABEL_KEY` map → `t(labelKey)` for each chat nav link; resolves "Game" hardcoded on `/chat/[threadId]?gameId=` |

## Architecture notes

- **P3-4 wrapper-supplied heading**: AuthCard / Dialog / StepUpTwoFactorModal already render h1 + subtitle. TwoFactorVerification's default-render now skips its inline h2; renders only when `title` prop is explicitly supplied (backward-compat for non-wrapper usage).
- **P3-8 surgical scope**: `entity-navigation.ts` config stays translation-free (literal `label` = EN fallback for consumers that don't translate). The chat surface owns the i18n via the local `ENTITY_LABEL_KEY` map. Other consumers (CardNavigationFooter, etc.) are unaffected.

## Test plan

- [x] Local `pnpm typecheck` green
- [x] Local `eslint --max-warnings=0` green on 4 modified components + 3 modified tests
- [x] Vitest: **97 tests pass** locally
  - CatalogPagination: 23/23 (after `render` → `renderWithIntl` switch)
  - AddGameDrawer: 23/23 (after `render` → `renderWithIntl` switch)
  - TwoFactorVerification: 28/28 (replaced "renders default title" assertion with "no inline h2 by default")
  - login `_content`: 13/13 (related — wraps TwoFactor in AuthCard)
  - StepUpTwoFactorModal: 10/10 (related — wraps TwoFactor in Dialog)
- [ ] CI `Frontend - Tests` shards 1/3 + 2/3 + 3/3 green
- [ ] CI `Frontend - A11y E2E` no axe regressions (heading-order on `/login` 2FA, aria-label coverage on catalog drawer)
- [ ] Manual verify on staging post-merge: 2FA step single h1, AddGameDrawer fully IT, catalog pagination buttons announce IT via screen reader, chat nav says "Gioco"

## Scope of #1816 closed

- ✅ **P3-4** TwoFactorVerification i18n + single h1
- ✅ **P3-5** AddGameDrawer full i18n
- ✅ **P3-6** Catalog pagination i18n (aria-label)
- ✅ **P3-8** Mobile breadcrumb "Game" → "Gioco"
- ⏳ Remaining: **P2-1** (PR #1962 in review), **P2-2** semantic h1, **P2-3** CSP per-env staging-only, **P3-7** KB Coverage Stats FE 3-state machine

Closes part of #1816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
