### PR TITLE
feat(library): semantic h1 + page title from game name (#1816 P2-2)

### DIFF
--- a/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
+++ b/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
@@ -324,6 +324,18 @@ export const settingsLabels = {
 } as const;
 
 // =============================================================================
+// #1816 P2-2 — library game detail h1 + document.title 3-state machine
+// =============================================================================
+
+export const libraryGameDetailHeaderMessages = {
+  'pages.library.gameDetail.h1.loading': 'Loading game…',
+  'pages.library.gameDetail.h1.notFound': 'Game not found',
+  'pages.library.gameDetail.documentTitle.format': '{gameName} · MeepleAI',
+  'pages.library.gameDetail.documentTitle.loading': 'Loading game — MeepleAI',
+  'pages.library.gameDetail.documentTitle.notFound': 'Game not found — MeepleAI',
+} as const;
+
+// =============================================================================
 // All Test Messages (combined)
 // =============================================================================
 
@@ -337,6 +349,7 @@ export const allTestMessages: Record<string, string> = {
   ...validationMessages,
   ...settingsLabels,
   ...playRecordsIndexMessages,
+  ...libraryGameDetailHeaderMessages,
 };
 
 // =============================================================================

--- a/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/layout.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Library Game Detail Layout — #1816 P2-2 regression
+ *
+ * Asserts the 3-state h1 + `document.title` resolution introduced by P2-2:
+ *   - loading: "Loading game…" + document.title "Loading game — MeepleAI"
+ *   - loaded:  "Catan" + document.title "Catan · MeepleAI"
+ *   - 404:     "Game not found" + document.title "Game not found — MeepleAI"
+ *
+ * Pre-fix behavior was a hardcoded "Gioco" literal regardless of state, which
+ * broke a11y (screen reader heading) + SEO (`<title>`) + breadcrumb
+ * differentiation. Audit ref: 2026-06-02-mobile-golden-path-audit § P2 h1.
+ *
+ * Test scope: the inner `LibraryGameHeader` component (exported from the
+ * layout file for this purpose). The Suspense boundary in the default export
+ * is not exercised here to avoid a jsdom timeout under react-intl + Suspense.
+ */
+
+import { screen } from '@testing-library/react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+import { renderWithIntl } from '../../../../../__tests__/fixtures/common-fixtures';
+
+import { LibraryGameHeader } from '../layout';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(),
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+const mockUseLibraryGameDetail = vi.fn();
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibraryGameDetail: (...args: unknown[]) => mockUseLibraryGameDetail(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useParams as Mock).mockReturnValue({ gameId: 'cc1678e8-f460-4b53-81f6-6d6539f82b65' });
+  (useRouter as Mock).mockReturnValue({ push: vi.fn() });
+  (useSearchParams as Mock).mockReturnValue(new URLSearchParams(''));
+});
+
+describe('LibraryGameHeader — #1816 P2-2 h1 + document.title state machine', () => {
+  it('renders loading h1 + document.title while the query is pending', () => {
+    mockUseLibraryGameDetail.mockReturnValue({ data: undefined, isLoading: true });
+
+    renderWithIntl(<LibraryGameHeader />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Loading game…');
+    expect(document.title).toBe('Loading game — MeepleAI');
+  });
+
+  it('renders the game title as h1 + document.title once data resolves', () => {
+    mockUseLibraryGameDetail.mockReturnValue({
+      data: { gameTitle: 'Catan' },
+      isLoading: false,
+    });
+
+    renderWithIntl(<LibraryGameHeader />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Catan');
+    expect(document.title).toBe('Catan · MeepleAI');
+  });
+
+  it('renders 404 h1 + document.title when the query resolves to null', () => {
+    mockUseLibraryGameDetail.mockReturnValue({ data: null, isLoading: false });
+
+    renderWithIntl(<LibraryGameHeader />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Game not found');
+    expect(document.title).toBe('Game not found — MeepleAI');
+  });
+
+  it('does not render the legacy hardcoded "Gioco" literal as h1', () => {
+    mockUseLibraryGameDetail.mockReturnValue({
+      data: { gameTitle: 'Catan' },
+      isLoading: false,
+    });
+
+    renderWithIntl(<LibraryGameHeader />);
+
+    // Audit regression guard: the hardcoded "Gioco" generic must never appear
+    // as the page h1. Use heading-scoped queryByRole to avoid matching nav
+    // labels or other surrounding text.
+    expect(screen.queryByRole('heading', { level: 1, name: 'Gioco' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Catan' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/[gameId]/layout.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/layout.tsx
@@ -7,27 +7,69 @@
  *
  * Renders PageHeader with contextual tabs (Dettagli · Agente · Toolkit · FAQ)
  * and a primary action for chat. The gameId is dynamic — read from URL params.
+ *
+ * #1816 P2-2 — h1 + document.title resolve the game name from
+ * `useLibraryGameDetail`. Three semantic states surfaced to the header:
+ *   - loading: t('pages.library.gameDetail.h1.loading')
+ *   - loaded:  game.gameTitle
+ *   - 404:     t('pages.library.gameDetail.h1.notFound')
+ * The page itself also calls `useLibraryGameDetail` — React Query dedupes via
+ * the shared `libraryKeys.gameDetail(gameId)` key, so no duplicate fetch.
  */
 
 'use client';
 
-import { Suspense, type ReactNode } from 'react';
+import { Suspense, useEffect, type ReactNode } from 'react';
 
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 
 import { PageHeader } from '@/components/layout/PageHeader';
+import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
+import { useTranslation } from '@/hooks/useTranslation';
 
-function LibraryGameHeader() {
+// Exported for unit testing the 3-state h1/document.title resolution (#1816 P2-2)
+// without forcing tests through the Suspense boundary.
+export function LibraryGameHeader() {
   const { gameId } = useParams<{ gameId: string }>();
   const router = useRouter();
   const searchParams = useSearchParams();
   const tab = searchParams?.get('tab');
+  const { t } = useTranslation();
+
+  const { data: gameDetail, isLoading } = useLibraryGameDetail(gameId);
+
+  // 3-state resolution for header h1 + browser document.title.
+  // The PageHeader component renders `title` inside an h1 element.
+  let headerTitle: string;
+  let documentTitle: string;
+  if (isLoading) {
+    headerTitle = t('pages.library.gameDetail.h1.loading');
+    documentTitle = t('pages.library.gameDetail.documentTitle.loading');
+  } else if (gameDetail?.gameTitle) {
+    headerTitle = gameDetail.gameTitle;
+    documentTitle = t('pages.library.gameDetail.documentTitle.format', {
+      gameName: gameDetail.gameTitle,
+    });
+  } else {
+    headerTitle = t('pages.library.gameDetail.h1.notFound');
+    documentTitle = t('pages.library.gameDetail.documentTitle.notFound');
+  }
+
+  // Document title — restore prior value on unmount so the browser tab does
+  // not retain the game name when navigating to a non-library surface.
+  useEffect(() => {
+    const previous = document.title;
+    document.title = documentTitle;
+    return () => {
+      document.title = previous;
+    };
+  }, [documentTitle]);
 
   const activeTabId = tab ?? 'details';
 
   return (
     <PageHeader
-      title="Gioco"
+      title={headerTitle}
       parentHref="/library"
       parentLabel="Libreria"
       tabs={[

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1998,6 +1998,15 @@
             "raptorFailed": "RAPTOR rebuild failed.",
             "deleteFailed": "Unable to delete PDF."
           }
+        },
+        "h1": {
+          "loading": "Loading game…",
+          "notFound": "Game not found"
+        },
+        "documentTitle": {
+          "format": "{gameName} · MeepleAI",
+          "loading": "Loading game — MeepleAI",
+          "notFound": "Game not found — MeepleAI"
         }
       }
     },
@@ -4095,10 +4104,27 @@
           "cta": "Go to library"
         },
         "error": {
-          "connection": { "title": "Connection lost", "body": "Auto-retry in progress…", "action": "Retry now" },
-          "timeout": { "title": "Slow response", "body": "Continue waiting?", "action": "Continue waiting", "alt": "Cancel" },
-          "partial": { "title": "Incomplete response", "body": "Stream was interrupted.", "action": "Repeat query" },
-          "server": { "title": "Server error", "body": "Try again in a moment.", "action": "Retry" }
+          "connection": {
+            "title": "Connection lost",
+            "body": "Auto-retry in progress…",
+            "action": "Retry now"
+          },
+          "timeout": {
+            "title": "Slow response",
+            "body": "Continue waiting?",
+            "action": "Continue waiting",
+            "alt": "Cancel"
+          },
+          "partial": {
+            "title": "Incomplete response",
+            "body": "Stream was interrupted.",
+            "action": "Repeat query"
+          },
+          "server": {
+            "title": "Server error",
+            "body": "Try again in a moment.",
+            "action": "Retry"
+          }
         }
       }
     }

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2048,6 +2048,15 @@
             "raptorFailed": "Rebuild RAPTOR fallito.",
             "deleteFailed": "Impossibile eliminare il PDF."
           }
+        },
+        "h1": {
+          "loading": "Caricamento gioco…",
+          "notFound": "Gioco non trovato"
+        },
+        "documentTitle": {
+          "format": "{gameName} · MeepleAI",
+          "loading": "Caricamento gioco — MeepleAI",
+          "notFound": "Gioco non trovato — MeepleAI"
         }
       }
     },
@@ -4148,10 +4157,27 @@
           "cta": "Vai alla libreria"
         },
         "error": {
-          "connection": { "title": "Connessione persa", "body": "Retry automatico in corso…", "action": "Riprova ora" },
-          "timeout": { "title": "Risposta lenta", "body": "Vuoi continuare ad aspettare?", "action": "Continua attesa", "alt": "Cancella" },
-          "partial": { "title": "Risposta incompleta", "body": "Lo stream si è interrotto.", "action": "Ripeti query" },
-          "server": { "title": "Errore del server", "body": "Riprova tra qualche istante.", "action": "Riprova" }
+          "connection": {
+            "title": "Connessione persa",
+            "body": "Retry automatico in corso…",
+            "action": "Riprova ora"
+          },
+          "timeout": {
+            "title": "Risposta lenta",
+            "body": "Vuoi continuare ad aspettare?",
+            "action": "Continua attesa",
+            "alt": "Cancella"
+          },
+          "partial": {
+            "title": "Risposta incompleta",
+            "body": "Lo stream si è interrotto.",
+            "action": "Ripeti query"
+          },
+          "server": {
+            "title": "Errore del server",
+            "body": "Riprova tra qualche istante.",
+            "action": "Riprova"
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- `/library/[gameId]` layout hardcoded `<PageHeader title="Gioco">` regardless of game state → generic h1 + breadcrumb + static `<title>`. Audit-flagged a11y/SEO loss.
- `LibraryGameHeader` now resolves a **3-state header** from `useLibraryGameDetail(gameId)`:
  - **loading**: `t('pages.library.gameDetail.h1.loading')` → "Caricamento gioco…"
  - **loaded**: `game.gameTitle` (e.g. "Catan")
  - **404**: `t('pages.library.gameDetail.h1.notFound')` → "Gioco non trovato"
- `document.title` mirrored via `useEffect` (cleanup restores prior value on unmount so the browser tab does not retain the game name when leaving library).
- React Query dedupes via shared `libraryKeys.gameDetail(gameId)` — no duplicate fetch (page route also calls the hook).
- 5 new i18n keys IT+EN under `pages.library.gameDetail.{h1,documentTitle}.*` via atomic Python merge.

## Test plan

- [x] Local `pnpm typecheck` green
- [x] Local `eslint` clean on modified files
- [x] **4 new unit tests** (`__tests__/layout.test.tsx`) — loading / loaded / 404 / "no hardcoded Gioco" regression guard — all green
- [x] Existing **6 page tests** still green (no regression)
- [ ] CI `Frontend - Tests` shards green
- [ ] CI `Frontend - A11y E2E` — h1 descriptive check on `/library/[gameId]`
- [ ] Manual staging verify: navigate to a game → h1 shows game name + browser tab title includes game name; 404 path shows "Gioco non trovato" + tab title

## Scope of #1816 closed

- ✅ **P2-2** semantic h1 + page `<title>`
- ⏳ remaining: **P2-3** CSP per-env, **P3-7 Phase 2** KB Coverage 3-state FE

## Architecture note

The inner `LibraryGameHeader` function is now exported (alongside the default layout export) so the unit test exercises the 3-state resolution **without** going through the Suspense boundary in the layout — that boundary caused a jsdom timeout under react-intl when tested holistically. The component is otherwise private to the layout file in terms of import surface.

Closes part of [#1816](https://github.com/meepleAi-app/meepleai-monorepo/issues/1816).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
