### PR TITLE
feat(web): per-env CSP manifest-src opt-in for CF Access (#1816 P2-3)

### DIFF
--- a/apps/web/lib/security/__tests__/csp.test.ts
+++ b/apps/web/lib/security/__tests__/csp.test.ts
@@ -1,0 +1,101 @@
+/**
+ * CSP header builder — #1816 P2-3 per-env staging-only opt-in.
+ *
+ * Asserts:
+ *   1. Prod default: `manifest-src 'self'` (no CF Access subdomain)
+ *   2. Staging opt-in: `manifest-src 'self' https://*.cloudflareaccess.com`
+ *   3. `apiBaseUrl` is reflected verbatim in `connect-src`
+ *   4. `isCfAccessAllowed` only enables on literal "true" (defensive)
+ *
+ * Audit ref: docs/for-developers/audits/2026-06-02-mobile-golden-path-audit.md
+ * § P2 CSP manifest. Security note (Nygard): prod CSP must NEVER include
+ * `cloudflareaccess.com`. The regression guards below enforce that contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// CommonJS import — csp.js is consumed by next.config.js which is CJS.
+import { buildCspHeader, isCfAccessAllowed } from '../csp';
+
+const PROD_API = 'https://api.meepleai.app';
+const STAGING_API = 'https://api.meepleai-staging.cloudflareaccess.com';
+
+describe('buildCspHeader — #1816 P2-3 per-env CSP manifest-src', () => {
+  describe('prod default (allowCfAccess=false)', () => {
+    it("emits `manifest-src 'self'` without cloudflareaccess.com", () => {
+      const csp = buildCspHeader({ apiBaseUrl: PROD_API, allowCfAccess: false });
+
+      expect(csp).toContain("manifest-src 'self'");
+      // 🔴 Security regression guard — prod CSP must NOT widen to CF Access.
+      expect(csp).not.toContain('cloudflareaccess.com');
+    });
+
+    it('reflects the prod apiBaseUrl in connect-src', () => {
+      const csp = buildCspHeader({ apiBaseUrl: PROD_API, allowCfAccess: false });
+      expect(csp).toContain(`connect-src 'self' ${PROD_API}`);
+    });
+
+    it('treats `allowCfAccess` undefined as false (prod-safe default)', () => {
+      const csp = buildCspHeader({ apiBaseUrl: PROD_API });
+
+      expect(csp).toContain("manifest-src 'self'");
+      expect(csp).not.toContain('cloudflareaccess.com');
+    });
+  });
+
+  describe('staging opt-in (allowCfAccess=true)', () => {
+    it('widens `manifest-src` to include `https://*.cloudflareaccess.com`', () => {
+      const csp = buildCspHeader({ apiBaseUrl: STAGING_API, allowCfAccess: true });
+
+      expect(csp).toContain("manifest-src 'self' https://*.cloudflareaccess.com");
+    });
+
+    it('keeps the rest of the directive set unchanged', () => {
+      const csp = buildCspHeader({ apiBaseUrl: STAGING_API, allowCfAccess: true });
+
+      // Stable invariants that prod + staging share.
+      expect(csp).toContain("default-src 'self'");
+      expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).toContain("base-uri 'self'");
+      expect(csp).toContain("form-action 'self'");
+    });
+  });
+
+  describe('directive ordering & format', () => {
+    it('emits semicolon-separated directives (one per line equivalent)', () => {
+      const csp = buildCspHeader({ apiBaseUrl: PROD_API, allowCfAccess: false });
+
+      // Each top-level directive must be present.
+      const directives = csp.split('; ');
+      expect(directives).toEqual(
+        expect.arrayContaining([
+          "default-src 'self'",
+          "script-src 'self' 'unsafe-inline'",
+          "style-src 'self' 'unsafe-inline'",
+          "img-src 'self' data: https:",
+          "font-src 'self' data:",
+          "manifest-src 'self'",
+          `connect-src 'self' ${PROD_API}`,
+          "frame-ancestors 'none'",
+          "base-uri 'self'",
+          "form-action 'self'",
+        ])
+      );
+    });
+  });
+});
+
+describe('isCfAccessAllowed — defensive env var parsing', () => {
+  it.each([
+    ['true', true],
+    ['false', false],
+    ['1', false],
+    ['yes', false],
+    ['TRUE', false], // case-sensitive on purpose — opt-in must be explicit "true"
+    ['', false],
+    [undefined, false],
+  ])('isCfAccessAllowed(%j) === %s', (input, expected) => {
+    expect(isCfAccessAllowed(input as string | undefined)).toBe(expected);
+  });
+});

--- a/apps/web/lib/security/csp.js
+++ b/apps/web/lib/security/csp.js
@@ -1,0 +1,72 @@
+/**
+ * CSP header builder — used by `next.config.js` `headers()` callback.
+ *
+ * Lives in a separate CommonJS module (not under `src/`) so that:
+ *   1. `next.config.js` can `require()` it without TS tooling, and
+ *   2. Vitest can import it from a `.test.ts` to assert the per-env contract.
+ *
+ * #1816 P2-3 — staging deploys hide `/manifest.json` behind a Cloudflare Access
+ * gateway. When the user's CF Access cookie expires the browser is redirected
+ * to `https://meepleai-staging.cloudflareaccess.com/...`, which the default
+ * `manifest-src 'self'` directive blocks (audit § P2 CSP manifest). The fix
+ * is to opt-in `https://*.cloudflareaccess.com` to `manifest-src` **only**
+ * on the staging build — prod CSP must NOT widen to the CF Access subdomain.
+ *
+ * Opt-in flag: build-time env var `NEXT_PUBLIC_CSP_ALLOW_CF_ACCESS=true`.
+ * Default (unset / any other value) keeps the prod-safe `manifest-src 'self'`.
+ */
+
+'use strict';
+
+/**
+ * Build the `Content-Security-Policy` header value.
+ *
+ * @param {object} opts
+ * @param {string} opts.apiBaseUrl - URL allowed by `connect-src` (XHR/fetch target)
+ * @param {boolean} [opts.allowCfAccess=false] - When true, widen `manifest-src`
+ *   to include `https://*.cloudflareaccess.com` (staging-only opt-in for the
+ *   PWA manifest behind Cloudflare Access gateway).
+ * @returns {string} The full CSP header value (semicolon-separated directives).
+ */
+function buildCspHeader(opts) {
+  const apiBaseUrl = opts.apiBaseUrl;
+  const allowCfAccess = opts.allowCfAccess === true;
+
+  const manifestSources = ["'self'"];
+  if (allowCfAccess) {
+    // `https://*.cloudflareaccess.com` covers any tenant subdomain CF Access
+    // assigns (e.g. `meepleai-staging.cloudflareaccess.com`). Wildcard is the
+    // minimum the CF Access redirect flow requires.
+    manifestSources.push('https://*.cloudflareaccess.com');
+  }
+
+  return [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self' data:",
+    `manifest-src ${manifestSources.join(' ')}`,
+    `connect-src 'self' ${apiBaseUrl}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+}
+
+/**
+ * Resolve the opt-in flag from a build-time env var. Parses defensively — only
+ * the string literal "true" enables the wider manifest-src; anything else
+ * (missing, "false", "1", "yes", typos) stays on the prod-safe default.
+ *
+ * @param {string | undefined} envValue
+ * @returns {boolean}
+ */
+function isCfAccessAllowed(envValue) {
+  return envValue === 'true';
+}
+
+module.exports = {
+  buildCspHeader,
+  isCfAccessAllowed,
+};

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -583,8 +583,13 @@ const nextConfig = {
   },
 
   // SEC-09: Security headers for Next.js responses (static assets bypass API middleware)
+  // #1816 P2-3 — CSP `manifest-src` widened to include CF Access subdomain ONLY
+  // on staging (where `/manifest.json` is gated by Cloudflare Access). Prod
+  // builds keep `manifest-src 'self'`. Flag: `NEXT_PUBLIC_CSP_ALLOW_CF_ACCESS=true`.
   async headers() {
+    const { buildCspHeader, isCfAccessAllowed } = require('./lib/security/csp');
     const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+    const allowCfAccess = isCfAccessAllowed(process.env.NEXT_PUBLIC_CSP_ALLOW_CF_ACCESS);
     return [
       {
         source: '/(.*)',
@@ -598,23 +603,7 @@ const nextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: https:",
-              "font-src 'self' data:",
-              // PWA manifest declared in app/layout.tsx (rel="manifest" -> /manifest.json).
-              // Explicit manifest-src avoids falling back to default-src and reduces console
-              // noise when an upstream gateway (e.g. Cloudflare Access) intercepts the static
-              // /manifest.json request and serves a cross-origin login page. Root cause of the
-              // gateway-intercept must be fixed via infra (allowlist /manifest.json + /sw.js).
-              "manifest-src 'self'",
-              `connect-src 'self' ${apiBaseUrl}`,
-              "frame-ancestors 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
+            value: buildCspHeader({ apiBaseUrl, allowCfAccess }),
           },
         ],
       },


### PR DESCRIPTION
## Summary

- `/manifest.json` is gated by Cloudflare Access on staging. When the CF Access cookie expires the browser is redirected to `https://meepleai-staging.cloudflareaccess.com/...`, which the default `manifest-src 'self'` directive blocks → broken PWA "Add to Home Screen" + console noise on every authenticated page (audit § P2 CSP manifest).
- New opt-in build-time flag **`NEXT_PUBLIC_CSP_ALLOW_CF_ACCESS=true`** widens `manifest-src` to include `https://*.cloudflareaccess.com` **only** on staging. Default (unset / any other value) keeps `manifest-src 'self'`.

## Architecture

- New CJS module `apps/web/lib/security/csp.js` (`next.config.js` is CommonJS) exposing:
  - `buildCspHeader({ apiBaseUrl, allowCfAccess })` → returns the full `Content-Security-Policy` value
  - `isCfAccessAllowed(envValue)` → defensive parser, case-sensitive on literal `"true"`
- `next.config.js` `headers()` callback delegates to the helper. Directive set otherwise unchanged.

## 🔴 Security note (Nygard CRITICAL on audit)

Prod CSP MUST NOT include `cloudflareaccess.com`. Regression guards in `csp.test.ts`:
- `allowCfAccess: false` → no `cloudflareaccess.com` in header
- `allowCfAccess` undefined → no `cloudflareaccess.com` in header (prod-safe default)
- Only literal `"true"` enables the opt-in — `"1"` / `"yes"` / `"TRUE"` / `""` all stay on the prod default

## Operations — enable on staging

1. Set `NEXT_PUBLIC_CSP_ALLOW_CF_ACCESS=true` in the staging build env (e.g. `infra/secrets/web.staging.secret` or the GitHub Actions environment for the staging release pipeline).
2. Rebuild the web container (the var is baked at `next build` time).
3. Verify: Lighthouse mobile PWA badge present + no CSP violation in DevTools.

To verify prod safety:
- Inspect prod CSP header after deploy — `cloudflareaccess.com` MUST NOT appear.

## Test plan

- [x] Local `pnpm typecheck` clean
- [x] Local `eslint` clean
- [x] **13 unit tests** in `lib/security/__tests__/csp.test.ts` — all green
- [ ] CI `Frontend - Tests` shards green
- [ ] Staging deploy (post-merge): set flag → rebuild → verify PWA badge in Lighthouse + no CSP violation in DevTools
- [ ] Prod regression check (post-staging verify): prod CSP header MUST NOT include `cloudflareaccess.com`

## Scope of #1816 closed

- ✅ **P2-3** CSP `manifest-src` Cloudflare Access (staging-only scope)
- ⏳ remaining: **P3-7 Phase 2** KB Coverage 3-state FE machine

Closes part of [#1816](https://github.com/meepleAi-app/meepleai-monorepo/issues/1816).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
