### PR TITLE
feat(kb-hub): indexing-pending state for KB Coverage Stats (#1816 P3-7 Phase 2)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
@@ -80,6 +80,9 @@ const MESSAGES: Record<string, string> = {
   'pages.library.gameDetail.kb.stats.coverage.Complete': 'Completa',
   'pages.library.gameDetail.kb.stats.cardTitle': 'KB Coverage Stats',
   'pages.library.gameDetail.kb.stats.cardSubtitle': 'Metriche',
+  'pages.library.gameDetail.kb.stats.indexingBadge': '⏳ Indicizzazione in corso',
+  'pages.library.gameDetail.kb.stats.indexingDescription':
+    'Il documento è caricato ma non ancora ricercabile dalla chat.',
   'pages.library.gameDetail.kb.stats.lifetimeCostLabel': 'Costo lifetime',
   'pages.library.gameDetail.kb.stats.sparklineLabel': 'Consumo',
   'pages.library.gameDetail.kb.stats.sparklineStart': '-7gg',
@@ -214,6 +217,97 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
     mockUseGamePdfs.mockReturnValue({ isLoading: false, isError: false, data: [] });
     const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
     expect(container.querySelector('[data-slot="kb-hub-empty-state"]')).toBeInTheDocument();
+  });
+
+  // #1816 P3-7 Phase 2 — indexing-pending state surface.
+  describe('indexing-pending state (#1816 P3-7 Phase 2)', () => {
+    it('renders indexing badges on KbStatsCard + HubDefault when pdfs present and isIndexed=false', () => {
+      mockUseUserKbStatus.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          gameId: GAME_ID,
+          isIndexed: false, // BE has no chunks yet
+          documentCount: 0,
+          coverageScore: 0,
+          coverageLevel: 'None',
+          suggestedQuestions: [],
+        },
+      });
+      mockUseGamePdfs.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: [pdfFixture({ id: 'p1' })], // PDF row visible
+      });
+
+      const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+
+      expect(
+        container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('[data-slot="kb-hub-default-indexing-banner"]')
+      ).toBeInTheDocument();
+      // Audit-quoted IT copy renders end-to-end (orchestrator → child).
+      expect(screen.getAllByText('⏳ Indicizzazione in corso').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does NOT render indexing badges when pdfs present and isIndexed=true', () => {
+      mockUseUserKbStatus.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          gameId: GAME_ID,
+          isIndexed: true, // BE indexing complete
+          documentCount: 2,
+          coverageScore: 70,
+          coverageLevel: 'Standard',
+          suggestedQuestions: [],
+        },
+      });
+      mockUseGamePdfs.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: [pdfFixture({ id: 'p1' })],
+      });
+
+      const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+
+      expect(
+        container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('[data-slot="kb-hub-default-indexing-banner"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT render indexing badges when pdfs.length === 0 (empty state route)', () => {
+      // Empty state takes precedence — the HubDefault + KbStatsCard are not
+      // mounted at all, so neither badge slot exists in DOM.
+      mockUseUserKbStatus.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          gameId: GAME_ID,
+          isIndexed: false,
+          documentCount: 0,
+          coverageScore: 0,
+          coverageLevel: 'None',
+          suggestedQuestions: [],
+        },
+      });
+      mockUseGamePdfs.mockReturnValue({ isLoading: false, isError: false, data: [] });
+
+      const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+
+      expect(container.querySelector('[data-slot="kb-hub-empty-state"]')).toBeInTheDocument();
+      expect(
+        container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
+      ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('[data-slot="kb-hub-default-indexing-banner"]')
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('renders HubDefault + KbStatsCard + RaptorPanel when PDFs present', () => {

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -131,6 +131,14 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
   const pdfs = pdfsQuery.data ?? [];
   const gameTitle = status?.gameId ?? gameId; // BE schema has no title; consumer falls back to id MVP
 
+  // #1816 P3-7 Phase 2 — derived from the two independent BE endpoints:
+  //   - useGamePdfs returns rows from `pdf_documents` (uploaded files)
+  //   - useUserKbStatus.isIndexed reflects pgvector chunk presence (indexed)
+  // When at least one file exists but pgvector indexing has not produced any
+  // chunk yet, surface the audit-flagged "0 Documenti / Copertura: Nessuna"
+  // state as an explicit "Indicizzazione in corso" badge.
+  const indexingPending = pdfs.length > 0 && status?.isIndexed === false;
+
   // ─── Labels (caller-side i18n resolution) ─────────────
   const emptyLabels: EmptyStateLabels = {
     title: t('pages.library.gameDetail.kb.empty.title'),
@@ -143,6 +151,8 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
     headerSubtitle: t('pages.library.gameDetail.kb.header.titleSuffix'),
     uploadCta: t('pages.library.gameDetail.kb.header.uploadCta'),
     reindexAllCta: t('pages.library.gameDetail.kb.header.reindexAllCta'),
+    indexingBadge: t('pages.library.gameDetail.kb.stats.indexingBadge'),
+    indexingDescription: t('pages.library.gameDetail.kb.stats.indexingDescription'),
     statsStrip: {
       docs: t('pages.library.gameDetail.kb.stats.docs', { count: status?.documentCount ?? 0 }),
       chunks: t('pages.library.gameDetail.kb.stats.chunksTemplate'),
@@ -193,6 +203,8 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
     sparklineLabel: t('pages.library.gameDetail.kb.stats.sparklineLabel'),
     sparklineStart: t('pages.library.gameDetail.kb.stats.sparklineStart'),
     sparklineEnd: t('pages.library.gameDetail.kb.stats.sparklineEnd'),
+    indexingBadge: t('pages.library.gameDetail.kb.stats.indexingBadge'),
+    indexingDescription: t('pages.library.gameDetail.kb.stats.indexingDescription'),
   };
 
   const raptorLabels: RaptorPanelLabels = {
@@ -338,6 +350,7 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
               setReindexOpen(true);
             }}
             onPdfAction={handlePdfActionTrigger}
+            indexingPending={indexingPending}
           />
 
           <KbStatsCard
@@ -345,6 +358,7 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
             coverageLevel={status?.coverageLevel ?? 'None'}
             coverageScore={status?.coverageScore ?? 0}
             labels={statsCardLabels}
+            indexingPending={indexingPending}
           />
 
           <RaptorPanel tier="free" labels={raptorLabels} />

--- a/apps/web/src/components/features/kb-hub/HubDefault.tsx
+++ b/apps/web/src/components/features/kb-hub/HubDefault.tsx
@@ -53,6 +53,11 @@ export interface HubDefaultLabels {
   readonly coverage: HubDefaultCoverageLabels;
   readonly columnHeaders: HubDefaultColumnHeaders;
   readonly pdfRow: PdfRowLabels;
+  // #1816 P3-7 — indexing-pending badge shown when caller flags the state
+  // (`pdfs.length > 0 && !status.isIndexed`). Optional — when undefined the
+  // hub does not render the badge slot.
+  readonly indexingBadge?: string;
+  readonly indexingDescription?: string;
 }
 
 export interface HubDefaultProps {
@@ -69,6 +74,9 @@ export interface HubDefaultProps {
   readonly embeddings?: number;
   readonly lastReindexRelative?: string;
   readonly className?: string;
+  // #1816 P3-7 Phase 2 — surfaces a banner above the stats strip when a PDF
+  // is uploaded but BE indexing has not yet completed.
+  readonly indexingPending?: boolean;
 }
 
 export function HubDefault(props: HubDefaultProps): ReactElement {
@@ -85,6 +93,7 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
     embeddings,
     lastReindexRelative,
     className,
+    indexingPending = false,
   } = props;
 
   // Locale resolved at runtime (caller's IntlProvider); avoids hardcoded it-IT divergence.
@@ -179,6 +188,23 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
             </button>
           </div>
         </div>
+
+        {/* #1816 P3-7 Phase 2 — indexing-pending banner above the stats strip.
+            Rendered only when the caller flags the state AND provides at least
+            an `indexingBadge` label. Warning tint = transient state, not error. */}
+        {indexingPending && labels.indexingBadge && (
+          <div
+            data-slot="kb-hub-default-indexing-banner"
+            role="status"
+            aria-live="polite"
+            className="mb-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs"
+          >
+            <div className="font-display font-bold text-warning">{labels.indexingBadge}</div>
+            {labels.indexingDescription && (
+              <div className="mt-1 text-muted-foreground">{labels.indexingDescription}</div>
+            )}
+          </div>
+        )}
 
         {/* Stats strip */}
         <div

--- a/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
+++ b/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
@@ -30,6 +30,11 @@ export interface KbStatsCardLabels {
   readonly sparklineLabel: string; // "Consumo token · ultimi 7 gg"
   readonly sparklineStart: string; // "-7gg"
   readonly sparklineEnd: string; // "oggi"
+  // #1816 P3-7 — indexing-pending state surfaces a badge + short description
+  // when a PDF is uploaded but the BE has not yet completed indexing. Optional
+  // (component renders nothing for the badge slot when label is undefined).
+  readonly indexingBadge?: string; // "⏳ Indicizzazione in corso"
+  readonly indexingDescription?: string; // "Il documento è caricato ma non ancora ricercabile dalla chat."
 }
 
 export interface KbStatsCardProps {
@@ -46,6 +51,11 @@ export interface KbStatsCardProps {
   readonly raptorLastRebuildRelative?: string;
   readonly lifetimeCost?: string;
   readonly costHistory?: ReadonlyArray<number>;
+  // #1816 P3-7 Phase 2 — surfaces a badge when a PDF is uploaded but the BE
+  // has not yet completed indexing (PDF rows present + `status.isIndexed=false`).
+  // Disambiguates the audit-found "0 Documenti / Copertura: Nessuna" UX while
+  // the chunk count is still 0 because indexing has not run yet.
+  readonly indexingPending?: boolean;
 }
 
 export function KbStatsCard(props: KbStatsCardProps): ReactElement {
@@ -62,6 +72,7 @@ export function KbStatsCard(props: KbStatsCardProps): ReactElement {
     raptorLastRebuildRelative,
     lifetimeCost,
     costHistory,
+    indexingPending = false,
   } = props;
 
   // Locale resolved at runtime (caller decides via IntlProvider); avoids hardcoding it-IT
@@ -159,6 +170,27 @@ export function KbStatsCard(props: KbStatsCardProps): ReactElement {
             <p className="text-[11px] text-muted-foreground">{labels.cardSubtitle}</p>
           </div>
         </header>
+      )}
+
+      {/* #1816 P3-7 Phase 2 — indexing-pending badge. Rendered when caller
+          flags `indexingPending` AND provides at least an `indexingBadge`
+          label. Uses warning-tinted background so it reads as a transient
+          state, not an error. */}
+      {indexingPending && labels.indexingBadge && (
+        <div
+          data-slot="kb-hub-stats-indexing-badge"
+          role="status"
+          aria-live="polite"
+          className={clsx(
+            'mb-3 rounded-md border border-warning/30 bg-warning/10 px-3 py-2',
+            compact ? 'text-[11px]' : 'text-xs'
+          )}
+        >
+          <div className="font-display font-bold text-warning">{labels.indexingBadge}</div>
+          {labels.indexingDescription && (
+            <div className="mt-1 text-muted-foreground">{labels.indexingDescription}</div>
+          )}
+        </div>
       )}
 
       {/* Metric grid (adaptive cols) */}

--- a/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
@@ -47,6 +47,76 @@ const basePdfs: KbPdf[] = [
 const baseGame = { title: 'Gloomhaven', emoji: '⚔️' };
 
 describe('HubDefault (Issue #1481)', () => {
+  // #1816 P3-7 Phase 2 — indexing-pending banner.
+  describe('indexingPending banner (#1816 P3-7)', () => {
+    const labelsWithBadge = {
+      ...baseLabels,
+      indexingBadge: '⏳ Indexing in progress',
+      indexingDescription: 'The document is uploaded but not yet searchable from chat.',
+    };
+
+    it('does NOT render the indexing banner by default (prop omitted)', () => {
+      const { container } = render(
+        <HubDefault
+          game={baseGame}
+          documentCount={0}
+          coverageLevel="None"
+          pdfs={basePdfs}
+          labels={labelsWithBadge}
+          onUpload={() => {}}
+          onReindexAll={() => {}}
+          onPdfAction={() => {}}
+        />
+      );
+      expect(
+        container.querySelector('[data-slot="kb-hub-default-indexing-banner"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the indexing banner + description when indexingPending=true', () => {
+      const { container } = render(
+        <HubDefault
+          game={baseGame}
+          documentCount={0}
+          coverageLevel="None"
+          pdfs={basePdfs}
+          labels={labelsWithBadge}
+          onUpload={() => {}}
+          onReindexAll={() => {}}
+          onPdfAction={() => {}}
+          indexingPending={true}
+        />
+      );
+      const banner = container.querySelector('[data-slot="kb-hub-default-indexing-banner"]');
+      expect(banner).toBeInTheDocument();
+      expect(banner).toHaveAttribute('role', 'status');
+      expect(banner).toHaveAttribute('aria-live', 'polite');
+      expect(screen.getByText('⏳ Indexing in progress')).toBeInTheDocument();
+      expect(
+        screen.getByText('The document is uploaded but not yet searchable from chat.')
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT render the banner when indexingPending=true but labels.indexingBadge is missing', () => {
+      const { container } = render(
+        <HubDefault
+          game={baseGame}
+          documentCount={0}
+          coverageLevel="None"
+          pdfs={basePdfs}
+          labels={baseLabels}
+          onUpload={() => {}}
+          onReindexAll={() => {}}
+          onPdfAction={() => {}}
+          indexingPending={true}
+        />
+      );
+      expect(
+        container.querySelector('[data-slot="kb-hub-default-indexing-banner"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('renders game title with " · KB" suffix and header subtitle', () => {
     render(
       <HubDefault

--- a/apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx
@@ -25,6 +25,81 @@ const baseLabels = {
 };
 
 describe('KbStatsCard (Issue #1481)', () => {
+  // #1816 P3-7 Phase 2 — indexing-pending badge.
+  describe('indexingPending badge (#1816 P3-7)', () => {
+    const labelsWithBadge = {
+      ...baseLabels,
+      indexingBadge: '⏳ Indexing in progress',
+      indexingDescription: 'The document is uploaded but not yet searchable from chat.',
+    };
+
+    it('does NOT render the indexing badge by default (prop omitted)', () => {
+      const { container } = render(
+        <KbStatsCard
+          documentCount={0}
+          coverageLevel="None"
+          coverageScore={0}
+          labels={labelsWithBadge}
+        />
+      );
+      expect(
+        container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the indexing badge when indexingPending=false', () => {
+      const { container } = render(
+        <KbStatsCard
+          documentCount={3}
+          coverageLevel="Standard"
+          coverageScore={70}
+          labels={labelsWithBadge}
+          indexingPending={false}
+        />
+      );
+      expect(
+        container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the indexing badge + description when indexingPending=true and labels provided', () => {
+      const { container } = render(
+        <KbStatsCard
+          documentCount={0}
+          coverageLevel="None"
+          coverageScore={0}
+          labels={labelsWithBadge}
+          indexingPending={true}
+        />
+      );
+      const badge = container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute('role', 'status');
+      expect(badge).toHaveAttribute('aria-live', 'polite');
+      expect(screen.getByText('⏳ Indexing in progress')).toBeInTheDocument();
+      expect(
+        screen.getByText('The document is uploaded but not yet searchable from chat.')
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT render the badge when indexingPending=true but labels.indexingBadge is missing', () => {
+      const { container } = render(
+        <KbStatsCard
+          documentCount={0}
+          coverageLevel="None"
+          coverageScore={0}
+          labels={baseLabels}
+          indexingPending={true}
+        />
+      );
+      // The component guards on BOTH the flag AND the presence of the label —
+      // an i18n-key resolution miss must not render an empty badge slot.
+      expect(
+        container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('renders required fields: documentCount, coverageLevel, coverageScore', () => {
     render(
       <KbStatsCard

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1899,7 +1899,9 @@
               "document": "Document",
               "status": "Status",
               "uploaded": "Uploaded"
-            }
+            },
+            "indexingBadge": "⏳ Indexing in progress",
+            "indexingDescription": "The document is uploaded but not yet searchable from chat."
           },
           "empty": {
             "title": "No PDFs indexed yet",
@@ -4095,10 +4097,27 @@
           "cta": "Go to library"
         },
         "error": {
-          "connection": { "title": "Connection lost", "body": "Auto-retry in progress…", "action": "Retry now" },
-          "timeout": { "title": "Slow response", "body": "Continue waiting?", "action": "Continue waiting", "alt": "Cancel" },
-          "partial": { "title": "Incomplete response", "body": "Stream was interrupted.", "action": "Repeat query" },
-          "server": { "title": "Server error", "body": "Try again in a moment.", "action": "Retry" }
+          "connection": {
+            "title": "Connection lost",
+            "body": "Auto-retry in progress…",
+            "action": "Retry now"
+          },
+          "timeout": {
+            "title": "Slow response",
+            "body": "Continue waiting?",
+            "action": "Continue waiting",
+            "alt": "Cancel"
+          },
+          "partial": {
+            "title": "Incomplete response",
+            "body": "Stream was interrupted.",
+            "action": "Repeat query"
+          },
+          "server": {
+            "title": "Server error",
+            "body": "Try again in a moment.",
+            "action": "Retry"
+          }
         }
       }
     }

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1949,7 +1949,9 @@
               "document": "Documento",
               "status": "Stato",
               "uploaded": "Caricato"
-            }
+            },
+            "indexingBadge": "⏳ Indicizzazione in corso",
+            "indexingDescription": "Il documento è caricato ma non ancora ricercabile dalla chat."
           },
           "empty": {
             "title": "Nessun PDF indicizzato",
@@ -4148,10 +4150,27 @@
           "cta": "Vai alla libreria"
         },
         "error": {
-          "connection": { "title": "Connessione persa", "body": "Retry automatico in corso…", "action": "Riprova ora" },
-          "timeout": { "title": "Risposta lenta", "body": "Vuoi continuare ad aspettare?", "action": "Continua attesa", "alt": "Cancella" },
-          "partial": { "title": "Risposta incompleta", "body": "Lo stream si è interrotto.", "action": "Ripeti query" },
-          "server": { "title": "Errore del server", "body": "Riprova tra qualche istante.", "action": "Riprova" }
+          "connection": {
+            "title": "Connessione persa",
+            "body": "Retry automatico in corso…",
+            "action": "Riprova ora"
+          },
+          "timeout": {
+            "title": "Risposta lenta",
+            "body": "Vuoi continuare ad aspettare?",
+            "action": "Continua attesa",
+            "alt": "Cancella"
+          },
+          "partial": {
+            "title": "Risposta incompleta",
+            "body": "Lo stream si è interrotto.",
+            "action": "Ripeti query"
+          },
+          "server": {
+            "title": "Errore del server",
+            "body": "Riprova tra qualche istante.",
+            "action": "Riprova"
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes **P3-7 Phase 2**. Phase 1 investigation (#1816 [comment 4642657379](https://github.com/meepleAi-app/meepleai-monorepo/issues/1816#issuecomment-4642657379)) confirmed the audit-flagged inconsistency on `/library/<id>/kb` (PDF row visible AND "0 Documenti / Copertura: Nessuna · 0%") is a **semantic field mismatch**, not a BE bug:

| Endpoint | Source | Returns |
|---|---|---|
| `useGamePdfs` | `pdf_documents` table | uploaded files |
| `useUserKbStatus` (`GetUserGameKbStatusQueryHandler.cs:38`) | `_vectorRepo.GetByGameIdAsync().Count` | indexed chunks (pgvector) |

When a PDF is uploaded but pgvector indexing has not produced chunks yet, `pdfs.length > 0` AND `status.isIndexed === false` simultaneously — a legitimate "indexing pending" state the UI failed to surface.

## Phase 2 fix (FE-only)

- `KbHubContent` orchestrator computes `indexingPending = pdfs.length > 0 && status?.isIndexed === false` and passes it to both `HubDefault` + `KbStatsCard`.
- `KbStatsCard` (sidebar): warning-tinted badge above the metric grid — "⏳ Indicizzazione in corso" + description.
- `HubDefault` (hero header): same badge as a banner above the stats strip so the pending state is visible without scrolling.
- Both use `role="status"` + `aria-live="polite"` so screen readers announce the transient state.
- Guard pattern: badge renders ONLY when BOTH `indexingPending=true` AND `indexingBadge` label is present. A missing i18n resolution does NOT produce an empty badge slot.
- 2 new i18n keys IT+EN under `pages.library.gameDetail.kb.stats.{indexingBadge, indexingDescription}`.

## State matrix

| Condition | UI |
|---|---|
| `pdfs.length === 0` | Existing empty state (badges NOT mounted at all) |
| `pdfs.length > 0 && !status.isIndexed` | **NEW**: "⏳ Indicizzazione in corso" badge on both surfaces + existing counts |
| `pdfs.length > 0 && status.isIndexed` | Existing full counts, no badge |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `eslint` clean on modified components (2 pre-existing warnings in KbStatsCard:244,250 unrelated to this PR)
- [x] **25 tests pass** locally:
  - KbStatsCard: 8/8 (4 new + 4 pre-existing)
  - HubDefault: 8/8 (3 new + 5 pre-existing)
  - KbHubContent: 9/9 (3 new orchestrator wire-up + 6 pre-existing)
- [ ] CI `Frontend - Tests` shards green
- [ ] CI `Frontend - A11y E2E` — no axe regressions (warning tint contrast + role="status" announcement)
- [ ] Manual staging verify: upload a PDF → KB hub shows "⏳ Indicizzazione in corso" badge until BE indexing completes → badge disappears + counts populate

## Scope of #1816 closed

- ✅ **P3-7 Phase 2** KB Coverage 3-state FE machine

After this PR all the actionable audit findings tracked under #1816 have shipped PRs. Remaining scope:
- Open: deferred items (Library 6-tab @ 390px → SP8; Chat Enter UX decision)
- Open: post-merge audit re-run @ 390×844 (AC matrix in umbrella body)

Closes #1816 P3-7 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
