### PR TITLE
fix(shell): remove duplicate MainSidebar mount from DesktopShell (#1977)

### DIFF
--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -9,7 +9,6 @@ import { AppTopBar } from '@/components/layout/AppNav/AppTopBar';
 import { isImmersiveRoute } from '@/components/layout/AppNav/immersive-routes';
 import { MobileBottomBar } from '@/components/layout/AppNav/MobileBottomBar';
 import { MobileTopBar } from '@/components/layout/AppNav/MobileTopBar';
-import { MainSidebar } from '@/components/layout/MainSidebar/MainSidebar';
 import { SideDrawer } from '@/components/layout/SideDrawer/SideDrawer';
 import { cn } from '@/lib/utils';
 
@@ -25,11 +24,14 @@ interface DesktopShellProps {
  * {@link MobileBottomBar}. The hamburger drawer holds the secondary destinations
  * ("tutto il resto"); the bottom bar holds the 5 primary tabs.
  *
- * Asse B (#1897) WP7 T7: {@link MainSidebar} is mounted side-by-side with the
- * main content area on `lg+` screens (`hidden lg:flex` inside the component).
- * It mirrors the AdminSidebar pattern (8 voci, see {@link MAIN_NAV_ITEMS}) and
- * coexists with the legacy AppTopBar/MobileBottomBar for now; consolidation is
- * tracked under asse C (dashboard integration).
+ * #1977 (audit follow-up of umbrella #1974, finding F18): MainSidebar mount on
+ * lg+ removed — Asse B (#1897) WP7 T7 had introduced a persistent left sidebar
+ * mirroring `AdminSidebar`, but it duplicated the AppTopBar nav items already
+ * present at the top of the page. Design owner directive: topbar is the single
+ * source-of-truth for primary navigation on desktop. The mobile hamburger
+ * drawer (`SideDrawer` below) continues to expose secondary destinations on
+ * `<lg` viewports; `MainNavList` + `MAIN_NAV_ITEMS` remain in place for that
+ * drawer and any future consumer.
  *
  * The bottom-bar clearance padding is dropped on immersive routes, where the
  * bottom bar hides itself (kept in sync via {@link isImmersiveRoute}).
@@ -46,20 +48,15 @@ export function DesktopShell({ children }: DesktopShellProps) {
 
       <SessionBanner />
 
-      <div className="flex flex-1 min-h-0">
-        {/* Asse B (#1897) MainSidebar — hidden on <lg, persistent on lg+. */}
-        <MainSidebar />
-
-        <main
-          id="main-content"
-          className={cn(
-            'flex-1 overflow-y-auto overflow-x-clip min-w-0',
-            !immersive && 'pb-16 md:pb-0'
-          )}
-        >
-          {children}
-        </main>
-      </div>
+      <main
+        id="main-content"
+        className={cn(
+          'flex-1 overflow-y-auto overflow-x-clip min-w-0',
+          !immersive && 'pb-16 md:pb-0'
+        )}
+      >
+        {children}
+      </main>
 
       <ChatSlideOverPanel />
       <MobileBottomBar />

--- a/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
@@ -21,13 +21,11 @@ vi.mock('@/components/layout/SideDrawer/SideDrawer', () => ({
   SideDrawer: () => null,
 }));
 
-// Asse B (#1897) WP7 T7: MainSidebar is mounted in DesktopShell. It pulls
-// `useCurrentUser` (TanStack Query) and `usePathname`; stub it here so the
-// shell test stays focused on layout structure (the sidebar has its own
-// suite under `MainSidebar/__tests__/`).
-vi.mock('@/components/layout/MainSidebar/MainSidebar', () => ({
-  MainSidebar: () => <div data-testid="main-sidebar" />,
-}));
+// #1977 (audit follow-up of umbrella #1974, finding F18): MainSidebar mount
+// was removed from DesktopShell to dedupe primary navigation with the
+// AppTopBar. The component is no longer imported by the shell, so no stub
+// is needed here. `MAIN_NAV_ITEMS` + `MainNavList` are still consumed by the
+// mobile drawer; their own test suites cover that path.
 
 vi.mock('@/components/layout/UserShell/SessionBanner', () => ({
   SessionBanner: () => null,


### PR DESCRIPTION
## Summary

- Rimuove il mount di `<MainSidebar />` da `DesktopShell.tsx` per chiudere la duplicazione di navigazione cross-page rilevata nell'audit 2026-06-07 (umbrella #1974, finding F18)
- Aggiornato comment block del componente per documentare la decisione (Asse B #1897 WP7 T7 → consolidato sulla topbar)
- `DesktopShell.test.tsx`: rimosso `vi.mock` stub per `MainSidebar`, sostituito con nota in commento sul retirement

## Context

Asse B (PR #1897) WP7 T7 aveva introdotto `MainSidebar` come pannello persistente lg+ mirrorando `AdminSidebar` (8 voci `MAIN_NAV_ITEMS`). Il commento originale riconosceva esplicitamente l'overlap con `AppTopBar`: *"coexists with the legacy AppTopBar/MobileBottomBar for now; consolidation is tracked under asse C (dashboard integration)"*.

Audit 2026-06-07 ha rilevato la duplicazione user-side (tracker `claudedocs/2026-06-07-reskin-verification.md` F18). Design owner directive: **topbar = single source-of-truth** per la navigazione primaria desktop.

## Change scope

- ✅ Desktop (≥lg): solo `AppTopBar` come nav primaria
- ✅ Mobile (<lg): `MobileTopBar` (☰) + `MobileBottomBar` (5 primary tabs) + `SideDrawer` (hamburger drawer per secondary destinations) — **unchanged**
- ✅ `MainNavList` + `MAIN_NAV_ITEMS` + `MainSidebar` component restano in repo (potranno tornare a essere consumati se la decisione cambia o per `SideDrawer` content)
- ✅ Admin shell (`AdminShell` + `AdminSidebar`) — unchanged, separato

## Test plan

- [x] `pnpm typecheck` clean
- [x] `DesktopShell.test.tsx` 4/4 PASS
- [x] Manual verify via Playwright MCP: `/dashboard`, `/library`, `/games`, `/library/[gameId]/kb`, `/game-nights`, `/onboarding`, `/agents`, `/toolkits` → solo topbar visibile, no sidebar dup
- [ ] CI Frontend Tests shards green
- [ ] CI A11y E2E (no regression heading-order / nav landmark)
- [ ] Smoke regression check: secondary destinations (Notifications · Profile · Settings) still reachable via topbar "Account/Altro" menu

## Audit ref

- Tracker: `claudedocs/2026-06-07-reskin-verification.md` F18
- Umbrella: #1974
- Screenshots: `claudedocs/screenshots-reskin/p{02,06-16}-*-live*.png` (pre-fix evidence of dup nav)

Closes #1977.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
