### PR TITLE
feat(library): gate BGG import CTAs behind admin role (#1975)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -54,6 +54,7 @@ import {
 import { useHybridHubItems } from '@/hooks/queries/useHybridHubItems';
 import { useLibrary, useRemoveGameFromLibrary } from '@/hooks/queries/useLibrary';
 import { useActivityFeed } from '@/hooks/useActivityFeed';
+import { useAdminRole } from '@/hooks/useAdminRole';
 import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
@@ -113,6 +114,10 @@ export function LibraryHub(): ReactElement {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  // F2 (#1975): BGG import is admin-only (BGG ToS — see AddGameDrawer.tsx:18 note).
+  // Gate the CTA visibility behind admin role; non-admins get `undefined` callbacks
+  // which collapse the CTA buttons in LibraryHeroDesktop + EmptyLibrary.
+  const { isAdminOrAbove } = useAdminRole();
 
   const [tab, setTab] = useState<HybridHubTab>('all');
   const [selectionMode, setSelectionMode] = useState<LibrarySelectionMode>('browse');
@@ -228,6 +233,7 @@ export function LibraryHub(): ReactElement {
       subtitle: t('pages.library.hero.subtitle'),
       eyebrow: t('pages.library.hero.eyebrow'),
       ctaAdd: t('pages.library.hero.cta.add'),
+      // F2: label kept (i18n stable) — visibility gated by `onImportBgg` prop in hero.
       ctaImportBgg: t('pages.library.hero.cta.importBgg'),
       ctaExportAriaLabel: t('pages.library.hero.cta.exportAriaLabel'),
     }),
@@ -288,7 +294,8 @@ export function LibraryHub(): ReactElement {
         title: t('pages.library.emptyState.empty.title'),
         subtitle: t('pages.library.emptyState.empty.subtitle'),
         cta: t('pages.library.emptyState.empty.cta'),
-        ctaImportBgg: t('pages.library.emptyState.empty.ctaImportBgg'),
+        // F2 (#1975): only render the BGG secondary CTA for admin users.
+        ctaImportBgg: isAdminOrAbove ? t('pages.library.emptyState.empty.ctaImportBgg') : undefined,
         suggestions: {
           heading: t('pages.library.emptyState.empty.suggestions.heading'),
         },
@@ -304,7 +311,7 @@ export function LibraryHub(): ReactElement {
         cta: t('pages.library.emptyState.error.cta'),
       },
     }),
-    [t]
+    [t, isAdminOrAbove]
   );
 
   const bulkLabels = useMemo<BulkSelectionBarLabels>(() => {
@@ -487,7 +494,7 @@ export function LibraryHub(): ReactElement {
         labels={heroLabels}
         stats={heroStatRows}
         onAddGame={handleAddGame}
-        onImportBgg={handleImportBgg}
+        onImportBgg={isAdminOrAbove ? handleImportBgg : undefined}
       />
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
         <div className="flex flex-1 flex-col gap-4">
@@ -548,7 +555,7 @@ export function LibraryHub(): ReactElement {
                   kind={effectiveKind}
                   labels={emptyLabels}
                   onAddGame={handleAddGame}
-                  onImportBgg={handleImportBgg}
+                  onImportBgg={isAdminOrAbove ? handleImportBgg : undefined}
                   onClearFilters={handleClearFilters}
                   onRetry={handleRetry}
                 />

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -113,6 +113,23 @@ vi.mock('@/hooks/useMiniNavConfig', () => ({
   useMiniNavConfig: (cfg: unknown) => useMiniNavConfigMock(cfg),
 }));
 
+// ─── useAdminRole mock (F2 #1975: BGG admin-only gate) ────────────────────
+
+type MockAdminRoleReturn = {
+  user: null;
+  isSuperAdmin: boolean;
+  isAdminOrAbove: boolean;
+  isEditorOrAbove: boolean;
+  hasRole: (role: string) => boolean;
+  isLoading: boolean;
+};
+
+const useAdminRoleMock = vi.fn<[], MockAdminRoleReturn>();
+
+vi.mock('@/hooks/useAdminRole', () => ({
+  useAdminRole: () => useAdminRoleMock(),
+}));
+
 // ─── useActivityFeed mock (Phase 3b #1593) ────────────────────────────────
 
 type MockActivityFeedReturn = {
@@ -461,6 +478,15 @@ describe('LibraryHub (Phase 2a hybrid hub)', () => {
       isError: false,
       error: null,
     });
+    // F2 #1975 default: regular user (BGG CTAs hidden).
+    useAdminRoleMock.mockReturnValue({
+      user: null,
+      isSuperAdmin: false,
+      isAdminOrAbove: false,
+      isEditorOrAbove: false,
+      hasRole: () => false,
+      isLoading: false,
+    });
   });
 
   // ─── 6 hub tabs ──────────────────────────────────────────────────────────
@@ -565,6 +591,24 @@ describe('LibraryHub (Phase 2a hybrid hub)', () => {
     expect(
       within(empty).getByRole('button', { name: /Aggiungi il tuo primo gioco/i })
     ).toBeInTheDocument();
+    // F2 #1975: BGG secondary CTA is admin-only; default user → hidden.
+    expect(within(empty).queryByRole('button', { name: /Importa.*BGG/i })).toBeNull();
+  });
+
+  it('renders BGG secondary CTA in empty state only for admin users (F2 #1975)', () => {
+    useAdminRoleMock.mockReturnValue({
+      user: null,
+      isSuperAdmin: false,
+      isAdminOrAbove: true,
+      isEditorOrAbove: true,
+      hasRole: () => true,
+      isLoading: false,
+    });
+    const { container } = renderHub(
+      makeHub({ sources: emptySources, totalCounts: { ...zeroCounts } })
+    );
+    const empty = container.querySelector('[data-slot="library-empty-state"]') as HTMLElement;
+    expect(empty).toHaveAttribute('data-kind', 'empty');
     expect(within(empty).getByRole('button', { name: /Importa.*BGG/i })).toBeInTheDocument();
   });
 
@@ -839,6 +883,15 @@ describe('LibraryHub — games tab (#1566)', () => {
       isError: false,
       error: null,
     });
+    // F2 #1975 default: regular user (BGG CTAs hidden).
+    useAdminRoleMock.mockReturnValue({
+      user: null,
+      isSuperAdmin: false,
+      isAdminOrAbove: false,
+      isEditorOrAbove: false,
+      hasRole: () => false,
+      isLoading: false,
+    });
   });
 
   it('renders GamesFiltersInline + GamesResultsGrid when tab=games with entries', async () => {
@@ -951,6 +1004,15 @@ describe('LibraryHub — Phase 3b drawer + rail integration (#1593)', () => {
       isSuccess: true,
       isError: false,
       error: null,
+    });
+    // F2 #1975 default: regular user (BGG CTAs hidden).
+    useAdminRoleMock.mockReturnValue({
+      user: null,
+      isSuperAdmin: false,
+      isAdminOrAbove: false,
+      isEditorOrAbove: false,
+      hasRole: () => false,
+      isLoading: false,
     });
     // Force Radix Dialog (desktop) mode for drawer tests.
     installMatchMedia(true);
@@ -1081,6 +1143,15 @@ describe('LibraryHub — a11y axe (#1842)', () => {
       isSuccess: true,
       isError: false,
       error: null,
+    });
+    // F2 #1975 default: regular user (BGG CTAs hidden).
+    useAdminRoleMock.mockReturnValue({
+      user: null,
+      isSuperAdmin: false,
+      isAdminOrAbove: false,
+      isEditorOrAbove: false,
+      hasRole: () => false,
+      isLoading: false,
     });
     // LibraryHub renders a Drawer (AdvancedFiltersDrawer) which calls
     // window.matchMedia synchronously via useSyncExternalStore. Without this

--- a/apps/web/src/components/features/library/LibraryHeroDesktop.tsx
+++ b/apps/web/src/components/features/library/LibraryHeroDesktop.tsx
@@ -228,13 +228,15 @@ export function LibraryHeroDesktop({
             >
               {labels.ctaAdd}
             </button>
-            <button
-              type="button"
-              onClick={onImportBgg}
-              className="cursor-pointer rounded-md border border-border-strong bg-card px-[14px] py-[9px] font-quicksand text-[13px] font-bold text-foreground"
-            >
-              {labels.ctaImportBgg}
-            </button>
+            {onImportBgg ? (
+              <button
+                type="button"
+                onClick={onImportBgg}
+                className="cursor-pointer rounded-md border border-border-strong bg-card px-[14px] py-[9px] font-quicksand text-[13px] font-bold text-foreground"
+              >
+                {labels.ctaImportBgg}
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={onExport}

--- a/apps/web/src/components/features/library/__tests__/LibraryHeroDesktop.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/LibraryHeroDesktop.test.tsx
@@ -147,6 +147,18 @@ describe('LibraryHeroDesktop (Wave B.3)', () => {
     expect(screen.queryByRole('button', { name: 'Esporta' })).toBeNull();
   });
 
+  it('hides the "Importa BGG" button when onImportBgg is undefined (F2 #1975 admin-only gate)', () => {
+    // F2 #1975: BGG ToS restricts the import flow to admins. When the parent
+    // (LibraryHub) detects a non-admin user it omits the callback; the hero
+    // must collapse the CTA entirely (no disabled button — full removal).
+    render(
+      <LibraryHeroDesktop labels={baseLabels} stats={baseStats} onAddGame={() => undefined} />
+    );
+    expect(screen.queryByRole('button', { name: '↓ Importa BGG' })).toBeNull();
+    // Primary CTA is still rendered — only the BGG secondary CTA is gated.
+    expect(screen.getByRole('button', { name: '+ Aggiungi gioco' })).toBeInTheDocument();
+  });
+
   it('keeps subtitle visible when compact is true (mockup: subtitle is reduced, not removed)', () => {
     // Mockup contract (sp4-library-desktop.jsx:72-75): the subtitle <p> renders
     // unconditionally; only its font-size shrinks (14.5 → 13) in compact mode.


### PR DESCRIPTION
## Summary

F2 from the 2026-06-07 audit (#1974): two user-facing surfaces still expose a "Importa BGG" CTA even though the BGG ToS restricts third-party metadata import to admin-only flows. The drawer (`AddGameDrawer.tsx:18`) was already cleaned up — this PR closes the remaining gap in the hero + empty state.

- **LibraryHub**: `useAdminRole()`, gate `onImportBgg` callbacks + `emptyLabels.empty.ctaImportBgg` behind `isAdminOrAbove`.
- **LibraryHeroDesktop**: secondary BGG button renders conditionally on `onImportBgg !== undefined` (full removal — no disabled state, mirrors the empty-state pattern).
- **EmptyLibrary**: unchanged — already conditional on `copy.ctaImportBgg`.

## Tests

- `LibraryHeroDesktop.test.tsx` (14 tests): adds explicit "hides BGG button when `onImportBgg` is undefined" coverage, primary CTA stays visible.
- `LibraryHub.test.tsx` (38 tests): inverts the "BGG in empty state" assertion to match the new admin-only contract, adds explicit admin-mode regression test that flips `isAdminOrAbove: true` and asserts the BGG CTA reappears.
- `useAdminRole` mock added to all 4 `beforeEach` blocks (Phase 2a / games tab / Phase 3b / a11y axe).

## Verification

- `pnpm typecheck` — clean
- `pnpm exec vitest run` library + hero + empty — 52/52 verdi

## Notes

Closes #1975
Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)