### PR TITLE
fix(events): CF-2 follow-up — restore lost helper + swallow 23505 on 4 handlers (#1938)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/EventHandlers/TokenUsageLedgerEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/EventHandlers/TokenUsageLedgerEventHandler.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.BusinessSimulations.Application.Interfaces;
 using Api.BoundedContexts.BusinessSimulations.Domain.Events;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.BusinessSimulations.Application.EventHandlers;
@@ -35,6 +37,18 @@ internal sealed class TokenUsageLedgerEventHandler : INotificationHandler<TokenU
                 endpoint: notification.Endpoint,
                 sourceEventId: notification.EventId,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox replay (#1535 at-least-once delivery) for an event
+            // already persisted. The partial UNIQUE index on ledger_entries.source_event_id
+            // blocked the duplicate insert at the DB. Log at Information — a noisy
+            // LogError on legitimate replays would crowd out real failures in operator
+            // dashboards.
+            _logger.LogInformation(
+                ex,
+                "Skipping duplicate ledger entry for token usage: User={UserId}, Model={ModelId}, SourceEventId={SourceEventId} (already recorded)",
+                notification.UserId, notification.ModelId, notification.EventId);
         }
         catch (Exception ex)
         {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingMetricsService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingMetricsService.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
@@ -63,7 +64,24 @@ internal sealed class ProcessingMetricsService : IProcessingMetricsService
         };
 
         _context.ProcessingMetrics.Add(metric);
-        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox re-dispatched a domain event whose metric we already
+            // recorded. The UNIQUE partial index on source_event_id won the race; detach
+            // so the tracker is clean for the next SaveChanges, and log at Information
+            // instead of Error — replays are an expected at-least-once behaviour, not a
+            // failure.
+            _context.Entry(metric).State = EntityState.Detached;
+            _logger.LogInformation(
+                ex,
+                "Skipping duplicate processing metric: PdfId={PdfId}, Step={Step}, SourceEventId={SourceEventId} (already recorded)",
+                pdfId, step, sourceEventId);
+            return;
+        }
 
         _logger.LogDebug(
             "Recorded metric: PdfId={PdfId}, Step={Step}, Duration={Duration}s, Size={Size}bytes, Pages={Pages}",

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionCompletedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionCompletedEventHandler.cs
@@ -4,6 +4,8 @@ using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.EventHandlers;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
@@ -82,6 +84,17 @@ internal sealed class LiveSessionCompletedEventHandler : DomainEventHandlerBase<
                 "Generated PlayRecord {PlayRecordId} from completed LiveSession {SessionId}",
                 playRecord.Id,
                 domainEvent.SessionId);
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox replay (#1535 at-least-once delivery) for a session
+            // already mapped to a PlayRecord. The partial UNIQUE index on
+            // play_records.source_event_id blocked the duplicate insert at the DB.
+            // Log at Information — legitimate replays are not failures.
+            Logger.LogInformation(
+                ex,
+                "Skipping duplicate PlayRecord for LiveSession {SessionId}: SourceEventId={SourceEventId} (already recorded)",
+                domainEvent.SessionId, domainEvent.EventId);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         // SERVICE BOUNDARY: EVENT HANDLER PATTERN - Background event processing

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionPausedAutoSnapshotHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionPausedAutoSnapshotHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
 
@@ -81,6 +82,17 @@ internal sealed class SessionPausedAutoSnapshotHandler
             _logger.LogInformation(
                 "Auto-snapshot created for session {SessionId} on pause at turn {Turn}",
                 notification.SessionId, turnNumber);
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox replay (#1535 at-least-once delivery) for a snapshot
+            // already persisted by an earlier dispatch. The partial UNIQUE index on
+            // session_snapshots.source_event_id blocked the duplicate insert at the DB.
+            // Log at Information — legitimate replays are not failures.
+            _logger.LogInformation(
+                ex,
+                "Skipping duplicate auto-snapshot for session {SessionId}: SourceEventId={SourceEventId} (already recorded)",
+                notification.SessionId, notification.EventId);
         }
 #pragma warning disable CA1031
         catch (Exception ex)

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/CreateProposalMigrationOnApprovalHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/CreateProposalMigrationOnApprovalHandler.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Entities;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.EventHandlers;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.UserLibrary.Application.EventHandlers;
@@ -104,7 +105,23 @@ internal sealed class CreateProposalMigrationOnApprovalHandler : DomainEventHand
             userId: shareRequest.UserId,
             sourceEventId: domainEvent.EventId);
 
-        await _migrationRepo.AddAsync(migration, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _migrationRepo.AddAsync(migration, cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox replay (#1535 at-least-once delivery) for a ShareRequest
+            // approval already processed. The partial UNIQUE index on
+            // proposal_migrations.source_event_id blocked the duplicate insert. Return
+            // without throwing so the base DomainEventHandlerBase doesn't log this as a
+            // failure — legitimate replays are not failures.
+            Logger.LogInformation(
+                ex,
+                "Skipping duplicate ProposalMigration for ShareRequest {ShareRequestId}: SourceEventId={SourceEventId} (already recorded)",
+                shareRequest.Id, domainEvent.EventId);
+            return;
+        }
 
         Logger.LogInformation(
             "Created ProposalMigration {MigrationId} for ShareRequest {ShareRequestId}: PrivateGame {PrivateGameId} → SharedGame {SharedGameId}",

--- a/apps/api/src/Api/SharedKernel/Infrastructure/Persistence/CounterTableIdempotency.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/Persistence/CounterTableIdempotency.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.SharedKernel.Infrastructure.Persistence;
+
+/// <summary>
+/// Helper for detecting PostgreSQL unique-constraint violations on counter / append
+/// tables guarded by the CF-2 (#1938) idempotency partial index. Centralises the
+/// SQL-state check so that any service inserting a row with <c>source_event_id</c>
+/// can wrap its <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)"/>
+/// call uniformly:
+///
+/// <code>
+/// try { await _db.SaveChangesAsync(ct); }
+/// catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+/// {
+///     _db.Entry(entity).State = EntityState.Detached;
+///     return; // idempotent skip
+/// }
+/// </code>
+///
+/// Mirrors the inline pattern already used in <c>EmailOutboxService.EnqueueAsync</c>
+/// (UserNotifications) and <c>NotificationRepository.AddAndCommitAsync</c> (CF-1).
+/// </summary>
+internal static class CounterTableIdempotency
+{
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="ex"/> wraps a PostgreSQL
+    /// <c>23505 unique_violation</c> error — the signal that a concurrent caller
+    /// (another pod, an outbox retry, a rolled-back-then-retried tx) already
+    /// persisted a row keyed by the same <c>source_event_id</c>.
+    /// </summary>
+    public static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        return ex.InnerException is Npgsql.PostgresException pgEx
+            && string.Equals(pgEx.SqlState, "23505", System.StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

Restores the CF-2 helper that was lost in the squash merge of #1946, then extends the same `23505 → LogInformation` pattern to the four remaining counter/append handlers identified in the consumer-idempotency audit. Together this closes the operator-dashboard-noise carry-forward documented in #1946's commit message.

### What got rescued

`apps/api/src/Api/SharedKernel/Infrastructure/Persistence/CounterTableIdempotency.cs` — the `IsUniqueViolation(DbUpdateException)` helper. Committed locally on the CF-2 branch (commit `1db73b55d`) but the squash merge of PR #1946 picked up only the original `0bc706090` commit, dropping the helper file and the inline-catch in `ProcessingMetricsService`. Restored verbatim plus the matching `ProcessingMetricsService.RecordStepDurationAsync` catch.

### Handlers covered

| Handler | Save path | Catch effectiveness |
|---|---|---|
| `ProcessingMetricsService.RecordStepDurationAsync` | inline `_context.SaveChangesAsync` | solid (rescued) |
| `LiveSessionCompletedEventHandler` | inline `_dbContext.SaveChangesAsync` | solid |
| `SessionPausedAutoSnapshotHandler` | via `_mediator.Send(CreateSnapshotCommand)` | picks up propagated 23505 |
| `TokenUsageLedgerEventHandler` | downstream (UoW pipeline), already had `catch (Exception)` | specialised 23505 before the generic catch |
| `CreateProposalMigrationOnApprovalHandler` | downstream (UoW pipeline) | defense-in-depth only — runtime save fires past this handler, full fix would require `AddAndCommitAsync` on the repo (deferred) |

All catches pass `ex` to `LogInformation` per Sonar S6667.

## Context

Closes the operator-dashboard noise on legitimate outbox replays (#1535 at-least-once delivery). The DB partial-UNIQUE indexes from #1946 already block duplicate rows at the constraint level; this PR demotes the resulting log line from `LogError` to `LogInformation` so real failures stay visible.

Tracks the audit findings in `audits/2026-06-06-issue-1535-consumer-idempotency-audit.md`.

## Test plan

- [x] `dotnet build` clean on `apps/api/src/Api` — 0 errors, 164 pre-existing warnings unchanged.
- [ ] Unit tests on the 5 modified handlers should pass unchanged — the new catch is additive and only intercepts an exception class previously logged at Error.
- [ ] Integration: follow-up to add Testcontainers tests that drive the inline-save path in `ProposalMigration` and `TokenUsage` to exercise the defense-in-depth catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)