### PR TITLE
test(library): regression guard for catalog-fallback h1 (#1974 F4.1)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/layout.test.tsx
@@ -88,4 +88,32 @@ describe('LibraryGameHeader — #1816 P2-2 h1 + document.title state machine', (
     expect(screen.queryByRole('heading', { level: 1, name: 'Gioco' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: 'Catan' })).toBeInTheDocument();
   });
+
+  it('renders the catalog-fallback game title when the entry is not in user library (F4.1 #1974)', () => {
+    // F4.1 regression guard (2026-06-07 audit): when a user opens
+    // /library/[gameId] for a SharedGame that is NOT in their personal
+    // library, `useLibraryGameDetail` falls back to the shared-catalog
+    // payload (libraryEntryId === ''). The header must still surface the
+    // catalog game name — NOT the legacy "Gioco" generic OR "Gioco non
+    // trovato" — because the page renders a catalog-only view with an
+    // "Aggiungi alla libreria" CTA. See useLibrary.ts:929-981 for the
+    // fallback contract.
+    mockUseLibraryGameDetail.mockReturnValue({
+      data: {
+        libraryEntryId: '', // catalog fallback sentinel
+        gameId: 'shared-catan-uuid',
+        gameTitle: 'Catan',
+        userId: '',
+      },
+      isLoading: false,
+    });
+
+    renderWithIntl(<LibraryGameHeader />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Catan' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 1, name: /Gioco non trovato/i })
+    ).not.toBeInTheDocument();
+    expect(document.title).toBe('Catan · MeepleAI');
+  });
 });


### PR DESCRIPTION
## Summary

F4.1 audit finding (#1974) flagged the `/library/[gameId]` header as showing a generic "Gioco" literal when the user opens a game that's not in their personal library. Investigation found the existing 3-state header (loading / loaded / 404) already lands the catalog game name correctly via the `useLibraryGameDetail` fallback (`useLibrary.ts:929-981`), which returns a `LibraryGameDetail` with `libraryEntryId: ''` and `gameTitle` populated from `sharedGame.title`.

This PR adds an explicit regression test for that path so the catalog-fallback contract is locked in.

## Test

Mock: `{ libraryEntryId: '', gameTitle: 'Catan' }`
Assert: h1 + document.title = "Catan" (not "Gioco non trovato").

## Verification

- 5/5 layout.test.tsx green
- `pnpm typecheck` clean

## Notes

No behavior change — the existing #1816 P2-2 fix already handles the edge case. Test only.

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)