### PR TITLE
feat(onboarding): translate interests step to Italian (#1976)

### DIFF
--- a/apps/web/src/components/onboarding/InterestsStep.tsx
+++ b/apps/web/src/components/onboarding/InterestsStep.tsx
@@ -6,6 +6,10 @@
  *
  * Checkbox grid with 9 board game category options.
  * Selections can be used for personalized recommendations.
+ *
+ * F25 #1976 (audit 2026-06-07): all hardcoded English copy moved to
+ * `pages.onboarding.interests.*` i18n keys (it.json + en.json) so the
+ * wizard renders in Italian for the IT-default user base.
  */
 
 import { FormEvent, useState } from 'react';
@@ -13,6 +17,7 @@ import { FormEvent, useState } from 'react';
 import { toast } from 'sonner';
 
 import { AccessibleButton } from '@/components/accessible';
+import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
@@ -21,19 +26,25 @@ export interface InterestsStepProps {
   onSkip: () => void;
 }
 
+/**
+ * Category ids are kept stable (backend contract) but the rendered label
+ * resolves through `pages.onboarding.interests.categories.{id}` at render
+ * time, so adding a new locale doesn't touch this component.
+ */
 const INTEREST_CATEGORIES = [
-  { id: 'strategy', label: 'Strategy', icon: '\u265F' },
-  { id: 'party', label: 'Party', icon: '\u{1F389}' },
-  { id: 'cooperative', label: 'Cooperative', icon: '\u{1F91D}' },
-  { id: 'family', label: 'Family', icon: '\u{1F3E0}' },
-  { id: 'thematic', label: 'Thematic', icon: '\u{1F3AD}' },
-  { id: 'abstract', label: 'Abstract', icon: '\u25B3' },
-  { id: 'card', label: 'Card', icon: '\u{1F0CF}' },
-  { id: 'dice', label: 'Dice', icon: '\u{1F3B2}' },
-  { id: 'miniatures', label: 'Miniatures', icon: '\u2694\uFE0F' },
+  { id: 'strategy', icon: '♟' },
+  { id: 'party', icon: '\u{1F389}' },
+  { id: 'cooperative', icon: '\u{1F91D}' },
+  { id: 'family', icon: '\u{1F3E0}' },
+  { id: 'thematic', icon: '\u{1F3AD}' },
+  { id: 'abstract', icon: '△' },
+  { id: 'card', icon: '\u{1F0CF}' },
+  { id: 'dice', icon: '\u{1F3B2}' },
+  { id: 'miniatures', icon: '⚔️' },
 ] as const;
 
 export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
+  const { t } = useTranslation();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(false);
 
@@ -61,7 +72,7 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
     try {
       // Issue #323: Save interests to backend
       await api.auth.saveInterests(Array.from(selected));
-      toast.success(`${selected.size} interests saved!`);
+      toast.success(t('pages.onboarding.interests.toast.saved', { count: selected.size }));
       onComplete();
     } catch {
       // Non-critical step, proceed anyway
@@ -74,16 +85,23 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="font-quicksand text-lg font-semibold text-foreground">What Do You Enjoy?</h2>
+        <h2 className="font-quicksand text-lg font-semibold text-foreground">
+          {t('pages.onboarding.interests.heading')}
+        </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Select categories that interest you. This helps us personalize your experience.
+          {t('pages.onboarding.interests.subtitle')}
         </p>
       </div>
 
       <form noValidate onSubmit={handleSubmit} className="space-y-6">
-        <div className="grid grid-cols-3 gap-3" role="group" aria-label="Game category interests">
+        <div
+          className="grid grid-cols-3 gap-3"
+          role="group"
+          aria-label={t('pages.onboarding.interests.groupLabel')}
+        >
           {INTEREST_CATEGORIES.map(cat => {
             const isSelected = selected.has(cat.id);
+            const label = t(`pages.onboarding.interests.categories.${cat.id}`);
             return (
               <button
                 key={cat.id}
@@ -103,14 +121,16 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
                 <span className="text-2xl" aria-hidden="true">
                   {cat.icon}
                 </span>
-                <span className="text-sm font-medium">{cat.label}</span>
+                <span className="text-sm font-medium">{label}</span>
               </button>
             );
           })}
         </div>
 
         {selected.size > 0 && (
-          <p className="text-center text-sm text-muted-foreground">{selected.size} selected</p>
+          <p className="text-center text-sm text-muted-foreground">
+            {t('pages.onboarding.interests.selectedCount', { count: selected.size })}
+          </p>
         )}
 
         <div className="flex items-center gap-3">
@@ -119,9 +139,11 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
             variant="primary"
             className="flex-1"
             isLoading={isLoading}
-            loadingText="Saving..."
+            loadingText={t('pages.onboarding.interests.loading')}
           >
-            {selected.size > 0 ? 'Continue' : 'Skip'}
+            {selected.size > 0
+              ? t('pages.onboarding.interests.cta.continue')
+              : t('pages.onboarding.interests.cta.skip')}
           </AccessibleButton>
           <button
             type="button"
@@ -129,7 +151,7 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
             className="text-sm text-muted-foreground hover:text-foreground"
             data-testid="interests-skip"
           >
-            Skip for now
+            {t('pages.onboarding.interests.cta.skipForNow')}
           </button>
         </div>
       </form>

--- a/apps/web/src/components/onboarding/__tests__/InterestsStep.test.tsx
+++ b/apps/web/src/components/onboarding/__tests__/InterestsStep.test.tsx
@@ -33,7 +33,9 @@ describe('InterestsStep', () => {
   it('renders all 9 category options', () => {
     renderWithQuery(<InterestsStep onComplete={onComplete} onSkip={onSkip} />);
 
-    expect(screen.getByText('What Do You Enjoy?')).toBeInTheDocument();
+    // F25 #1976: heading driven by `pages.onboarding.interests.heading`
+    // (renderWithQuery loads en.json messages — IT fallback exercised separately).
+    expect(screen.getByText(/what do you enjoy/i)).toBeInTheDocument();
     expect(screen.getByTestId('interest-strategy')).toBeInTheDocument();
     expect(screen.getByTestId('interest-party')).toBeInTheDocument();
     expect(screen.getByTestId('interest-cooperative')).toBeInTheDocument();

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2043,6 +2043,34 @@
         "pageNumber": "Page {n}"
       }
     },
+    "onboarding": {
+      "interests": {
+        "heading": "What do you enjoy?",
+        "subtitle": "Select categories that interest you. We'll use them to personalize recommendations.",
+        "groupLabel": "Game category interests",
+        "categories": {
+          "strategy": "Strategy",
+          "party": "Party",
+          "cooperative": "Cooperative",
+          "family": "Family",
+          "thematic": "Thematic",
+          "abstract": "Abstract",
+          "card": "Card",
+          "dice": "Dice",
+          "miniatures": "Miniatures"
+        },
+        "selectedCount": "{count} selected",
+        "cta": {
+          "continue": "Continue",
+          "skip": "Skip",
+          "skipForNow": "Skip for now"
+        },
+        "loading": "Saving…",
+        "toast": {
+          "saved": "{count} interests saved!"
+        }
+      }
+    },
     "discover": {
       "miniNav": {
         "breadcrumb": "Discover",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2093,6 +2093,34 @@
         "pageNumber": "Pagina {n}"
       }
     },
+    "onboarding": {
+      "interests": {
+        "heading": "Cosa ti piace giocare?",
+        "subtitle": "Seleziona le categorie che ti interessano. Useremo le tue scelte per personalizzare i suggerimenti.",
+        "groupLabel": "Categorie di giochi preferite",
+        "categories": {
+          "strategy": "Strategia",
+          "party": "Festa",
+          "cooperative": "Cooperativo",
+          "family": "Famiglia",
+          "thematic": "Tematico",
+          "abstract": "Astratto",
+          "card": "Carte",
+          "dice": "Dadi",
+          "miniatures": "Miniature"
+        },
+        "selectedCount": "{count} selezionate",
+        "cta": {
+          "continue": "Continua",
+          "skip": "Salta",
+          "skipForNow": "Salta per ora"
+        },
+        "loading": "Salvataggio in corso…",
+        "toast": {
+          "saved": "{count} interessi salvati!"
+        }
+      }
+    },
     "discover": {
       "miniNav": {
         "breadcrumb": "Scopri",


### PR DESCRIPTION
## Summary

F25 from the 2026-06-07 audit (#1974): the onboarding interests step shipped with hardcoded English ("What Do You Enjoy?", category names, "Skip"/"Continue") leaving the wizard untranslated for the IT-default user base.

- **i18n**: introduce `pages.onboarding.interests.{heading, subtitle, groupLabel, categories.*, selectedCount, cta.*, loading, toast.saved}` in `it.json` + `en.json`.
- **Component**: `InterestsStep.tsx` wired with `useTranslation`, all literals replaced. Category ids stay stable (backend contract); only the label resolves at render.
- **Test**: heading assertion swapped to a locale-agnostic regex (`/what do you enjoy/i`) so the EN fixture still passes.

## Verification

- 6/6 InterestsStep.test.tsx green
- `pnpm typecheck` clean

## Notes

Closes #1976
Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)