### PR TITLE
feat(shell): mount MiniNavSlot so per-page useMiniNavConfig renders (#1974 F23a)

### DIFF
--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -12,6 +12,7 @@ import { MobileTopBar } from '@/components/layout/AppNav/MobileTopBar';
 import { SideDrawer } from '@/components/layout/SideDrawer/SideDrawer';
 import { cn } from '@/lib/utils';
 
+import { MiniNavSlot } from './MiniNavSlot';
 import { SessionBanner } from './SessionBanner';
 
 interface DesktopShellProps {
@@ -45,6 +46,15 @@ export function DesktopShell({ children }: DesktopShellProps) {
     <div className="min-h-dvh flex flex-col bg-[var(--bg)]">
       <AppTopBar />
       <MobileTopBar onHamburgerClick={() => setDrawerOpen(true)} />
+
+      {/*
+        F23a #1974 (audit 2026-06-07): mount MiniNavSlot so pages that call
+        `useMiniNavConfig(...)` (e.g. `/games`, `/library`, `/discover`) get
+        their tab strip rendered. The component is a no-op when no page has
+        registered a config — safe to keep mounted globally. Pre-fix, the
+        store was being updated but no consumer rendered it.
+      */}
+      <MiniNavSlot />
 
       <SessionBanner />
 

--- a/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
@@ -31,6 +31,10 @@ vi.mock('@/components/layout/UserShell/SessionBanner', () => ({
   SessionBanner: () => null,
 }));
 
+vi.mock('@/components/layout/UserShell/MiniNavSlot', () => ({
+  MiniNavSlot: () => <div data-testid="mini-nav-slot" />,
+}));
+
 vi.mock('next/navigation', () => ({
   usePathname: () => '/dashboard',
 }));
@@ -74,5 +78,19 @@ describe('DesktopShell', () => {
       </DesktopShell>
     );
     expect(screen.getByRole('main').className).toContain('pb-16');
+  });
+
+  it('mounts the MiniNavSlot so per-page useMiniNavConfig renders (F23a #1974)', () => {
+    // F23a regression guard: routes like /games + /library register a
+    // mini-nav config via `useMiniNavConfig`, but pre-fix the shell never
+    // mounted any consumer of that store, so the tab strip was silently
+    // dropped. MiniNavSlot is a no-op when no page has registered, so the
+    // shell can keep it mounted unconditionally.
+    render(
+      <DesktopShell>
+        <div>child</div>
+      </DesktopShell>
+    );
+    expect(screen.getByTestId('mini-nav-slot')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

F23a audit finding (#1974): pages like `/games`, `/library`, `/discover` call `useMiniNavConfig(...)` to register their tab strip, but the shell never mounted any consumer of `useMiniNavConfigStore`. The store was being updated, but the breadcrumb + tab strip + primary action just never rendered.

`MiniNavSlot` already implements the visual contract and returns `null` when no config is registered. Mounting it unconditionally in `DesktopShell` is safe (no flash) and finally surfaces the registered configs.

## Changes

- `DesktopShell.tsx`: import + mount `MiniNavSlot` between `MobileTopBar` and `SessionBanner`.
- `DesktopShell.test.tsx`: regression assertion that the slot is mounted (mocked).

## Verification

- 5/5 DesktopShell.test.tsx green
- 5/5 MiniNavSlot.test.tsx green (pre-existing)
- `pnpm typecheck` clean

## Notes

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)