### PR TITLE
fix(wizard-modal): cap modal height + flow footer in flex column (#1974 F26)

### DIFF
--- a/apps/web/src/components/ui/wizard-modal/wizard-modal.tsx
+++ b/apps/web/src/components/ui/wizard-modal/wizard-modal.tsx
@@ -64,11 +64,22 @@ export function WizardModal({
             data-testid="wizard-modal-overlay"
           />
           <RadixDialog.Content
-            className="fixed left-1/2 top-1/2 z-[61] flex w-full max-w-[720px] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg bg-background shadow-2xl"
+            className="fixed left-1/2 top-1/2 z-[61] flex max-h-[85vh] w-full max-w-[720px] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg bg-background shadow-2xl"
             data-slot="wizard-modal"
             aria-labelledby="wizard-title"
           >
-            <header className="sticky top-0 border-b border-border p-4">
+            {/*
+              F26 #1974 (audit 2026-06-07): rewrote the 3-region layout from
+              header/content/footer with sticky positioning to a single
+              flex column where the content area `flex-1 overflow-y-auto`.
+              The previous sticky bottom-0 footer overlapped the last
+              option card (e.g. Miniatures in onboarding) on viewports
+              taller than the natural Content height, because Radix Dialog
+              Content has no fixed height and sticky needs a constrained
+              ancestor with overflow. Now the modal caps at 85vh and the
+              footer participates in flex flow — no overlap.
+            */}
+            <header className="shrink-0 border-b border-border p-4">
               <RadixDialog.Title id="wizard-title" className="text-lg font-semibold">
                 {wizard.currentStep.title}
               </RadixDialog.Title>
@@ -77,7 +88,7 @@ export function WizardModal({
               </div>
             </header>
 
-            <div className="max-h-[60vh] overflow-y-auto p-6" data-testid="wizard-step-content">
+            <div className="min-h-0 flex-1 overflow-y-auto p-6" data-testid="wizard-step-content">
               {wizard.currentStep.content}
               {wizard.errors.length > 0 && (
                 <ul
@@ -92,7 +103,7 @@ export function WizardModal({
               )}
             </div>
 
-            <footer className="sticky bottom-0 flex justify-between border-t border-border p-4">
+            <footer className="flex shrink-0 justify-between border-t border-border bg-background p-4">
               {!wizard.isFirst ? (
                 <button
                   onClick={wizard.goBack}


### PR DESCRIPTION
## Summary

F26 audit finding (#1974): the WizardModal footer (Cancel / Skip / Next) overlapped the last option card in the onboarding interests step on tall viewports — most visible with the Miniatures card on a 14" laptop screen.

Root cause: `RadixDialog.Content` had no explicit max-height; the 3-region layout relied on `header.sticky top-0` + `footer.sticky bottom-0` to anchor, but `sticky` needs a constrained ancestor with `overflow`. The Content element provided neither, so the footer collapsed onto the last child of the content area at certain widths/heights.

## Fix

- `RadixDialog.Content`: `max-h-[85vh] overflow-hidden` — establishes the scroll container for the flex layout.
- Header + footer: drop `sticky`, add `shrink-0`.
- Content area: `min-h-0 flex-1 overflow-y-auto`.
- Footer: explicit `bg-background` (no longer inherited via the chain).

Pure layout fix — no prop changes, no test changes.

## Verification

- 38/38 wizard-modal tests green (3 files: wizard-modal, use-wizard-step, normalize-validate)
- `pnpm typecheck` clean

## Notes

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)