### PR TITLE
fix(players): hero copy disambiguates /players from /play-records (#1974 F28)

### DIFF
--- a/apps/web/src/app/(authenticated)/players/_components/__tests__/PlayersLibraryView.test.tsx
+++ b/apps/web/src/app/(authenticated)/players/_components/__tests__/PlayersLibraryView.test.tsx
@@ -70,8 +70,11 @@ vi.mock('@/lib/players/players-visual-test-fixture', async () => {
 
 const MESSAGES: Record<string, string> = {
   'pages.players.metadata.title': 'Giocatori — MeepleAI',
-  'pages.players.hero.title': 'Le tue partite',
-  'pages.players.hero.subtitle': 'Riepilogo dei giochi che hai giocato, con sessioni e vittorie.',
+  // F28 #1974: hero copy rewritten to disambiguate /players (gaming partners)
+  // from /play-records (your sessions). See it.json `pages.players.hero.*`.
+  'pages.players.hero.title': 'I tuoi compagni di gioco',
+  'pages.players.hero.subtitle':
+    'Vedi con chi hai giocato di più, le sessioni condivise e i risultati al tavolo.',
   'pages.players.hero.totalPlays': 'Sessioni totali',
   'pages.players.hero.distinctGames': 'Giochi distinti',
   'pages.players.filters.searchPlaceholder': 'Cerca per nome del gioco…',

--- a/apps/web/src/components/features/players/__tests__/PlayersHero.test.tsx
+++ b/apps/web/src/components/features/players/__tests__/PlayersHero.test.tsx
@@ -18,8 +18,9 @@ import { PlayersHero } from '../PlayersHero';
 import type { PlayersHeroProps } from '../PlayersHero';
 
 const LABELS: PlayersHeroProps['labels'] = {
-  title: 'Le tue partite',
-  subtitle: 'Riepilogo dei giochi che hai giocato.',
+  // F28 #1974: copy disambiguates /players (gaming partners) from /play-records.
+  title: 'I tuoi compagni di gioco',
+  subtitle: 'Vedi con chi hai giocato di più.',
   totalPlays: 'Sessioni totali',
   distinctGames: 'Giochi distinti',
 };
@@ -38,8 +39,8 @@ describe('PlayersHero', () => {
 
   it('renders title and subtitle from labels', () => {
     render(<PlayersHero {...DEFAULT_PROPS} />);
-    expect(screen.getByText('Le tue partite')).toBeTruthy();
-    expect(screen.getByText('Riepilogo dei giochi che hai giocato.')).toBeTruthy();
+    expect(screen.getByText('I tuoi compagni di gioco')).toBeTruthy();
+    expect(screen.getByText('Vedi con chi hai giocato di più.')).toBeTruthy();
   });
 
   it('renders totalSessions KPI tile with count', () => {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2475,11 +2475,11 @@
     "players": {
       "metadata": {
         "title": "Players — MeepleAI",
-        "description": "Summary of your play history: games played, sessions and wins."
+        "description": "The gaming partners you've played with — shared sessions, results and head-to-head stats."
       },
       "hero": {
-        "title": "Your play history",
-        "subtitle": "Summary of the games you have played, with sessions and wins.",
+        "title": "Your gaming partners",
+        "subtitle": "See who you've played with the most, shared sessions and table results.",
         "totalPlays": "Total sessions",
         "distinctGames": "Distinct games"
       },

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2525,11 +2525,11 @@
     "players": {
       "metadata": {
         "title": "Giocatori — MeepleAI",
-        "description": "Riepilogo delle tue partite: giochi giocati, sessioni e vittorie."
+        "description": "I compagni di gioco con cui hai giocato, con sessioni e vittorie."
       },
       "hero": {
-        "title": "Le tue partite",
-        "subtitle": "Riepilogo dei giochi che hai giocato, con sessioni e vittorie.",
+        "title": "I tuoi compagni di gioco",
+        "subtitle": "Vedi con chi hai giocato di più, le sessioni condivise e i risultati al tavolo.",
         "totalPlays": "Sessioni totali",
         "distinctGames": "Giochi distinti"
       },


### PR DESCRIPTION
## Summary

F28 audit finding (#1974): `/players` hero shipped with title "Le tue partite", which is the same copy `/play-records` uses. Reaching `/players` from the `Players` sidebar voice felt like landing on the play-records UI — pure routing/copy confusion.

Both pages share an upstream data layer (`usePlayersFromRecords` derives partners from play records), so the conflation is understandable in implementation but UX-wrong.

## Changes

- **IT `/players` hero**: "I tuoi compagni di gioco" + subtitle reworded.
- **EN `/players` hero**: "Your gaming partners" + subtitle reworded.
- Metadata description aligned.
- Tests updated: `PlayersLibraryView.test.tsx` fixture + `PlayersHero.test.tsx` literals.

`/sessions` and `/play-records` keep "Le tue partite" — those are the right targets for that copy.

## Verification

- 112/112 players tests green (16 files)
- `pnpm typecheck` clean

## Notes

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)