### PR TITLE
fix(kb-hub): resolve game title from library detail (#1974 F4)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
@@ -27,6 +27,14 @@ vi.mock('@/hooks/queries/useKbHub', () => ({
   useDeletePdf: (gameId: string) => mockUseDeletePdf(gameId),
 }));
 
+// F4 #1974: KbHubContent now consults useLibraryGameDetail to resolve the
+// game title. Mock it as a simple identity hook returning `{ gameTitle }`
+// from a per-test fixture so the orchestrator doesn't need a QueryClient.
+const mockUseLibraryGameDetail = vi.fn();
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibraryGameDetail: (gameId: string) => mockUseLibraryGameDetail(gameId),
+}));
+
 // Mock useTranslation with a lightweight lookup in MESSAGES dict (defined below).
 // Avoids react-intl IntlProvider initialization that becomes pathological under the
 // scale of orchestrator label assembly (~90 t() calls per render).
@@ -180,6 +188,12 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
     mockUseReindexKb.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseRebuildRaptor.mockReturnValue({ mutateAsync: vi.fn() });
     mockUseDeletePdf.mockReturnValue({ mutateAsync: vi.fn() });
+    // F4 #1974 default: catalog game title resolved; tests override per case.
+    mockUseLibraryGameDetail.mockReturnValue({
+      data: { gameTitle: 'Catan' },
+      isLoading: false,
+      isError: false,
+    });
   });
 
   it('renders skeleton while either query is loading', () => {

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -48,6 +48,7 @@ import {
   useRebuildRaptor,
   useUserKbStatus,
 } from '@/hooks/queries/useKbHub';
+import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { GamePdfDto } from '@/lib/api/schemas/pdf.schemas';
 
@@ -99,6 +100,12 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
   const reindexMutation = useReindexKb(gameId);
   const _raptorMutation = useRebuildRaptor(gameId);
   const deleteMutation = useDeletePdf(gameId);
+  // F4 #1974 (audit 2026-06-07): pull the game title from the library detail
+  // hook (shared QueryKey with the layout — TanStack dedups) so the KB hub
+  // renders "Catan" instead of the cc1678e8… UUID when the BE status payload
+  // omits `gameTitle`. `useLibraryGameDetail` already falls back to the
+  // shared-catalog title for games not in the user's library.
+  const gameDetailQuery = useLibraryGameDetail(gameId);
 
   const [reindexOpen, setReindexOpen] = useState(false);
   const [reindexPhase, setReindexPhase] = useState<ReindexPhase>('confirm');
@@ -129,7 +136,13 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
 
   const status = statusQuery.data;
   const pdfs = pdfsQuery.data ?? [];
-  const gameTitle = status?.gameId ?? gameId; // BE schema has no title; consumer falls back to id MVP
+  // F4 #1974: title resolution order
+  //   1. library-detail (preferred — shared with the layout via TanStack dedup)
+  //   2. KB status.gameId (only ever the UUID — last resort, signals BE schema
+  //      gap rather than a real title; surfaced as the literal id when nothing
+  //      else is available so consumers see the bug instead of a silent blank).
+  //   3. route param (defensive — should never differ from gameId in BE)
+  const gameTitle = gameDetailQuery.data?.gameTitle ?? status?.gameId ?? gameId;
 
   // #1816 P3-7 Phase 2 — derived from the two independent BE endpoints:
   //   - useGamePdfs returns rows from `pdf_documents` (uploaded files)


### PR DESCRIPTION
## Summary

F4 audit finding (#1974): `/library/[gameId]/kb` rendered the raw UUID (`cc1678e8-…`) as the "game name" in HubDefault header, EmptyState illustration, and ActionsMenu rows. Root cause: `KbHubContent` fell back to `status?.gameId ?? gameId` because the `useUserKbStatus` payload has no `gameTitle` field — the BE schema only exposes coverage stats.

## Fix

Consult `useLibraryGameDetail(gameId)` for the title before falling back to id sentinels. The hook is already invoked by the parent layout (P2-2 #1816); React Query dedups on the shared `libraryKeys.gameDetail(gameId)` key — single fetch shared across layout + KB content.

Resolution order:
1. `useLibraryGameDetail.data.gameTitle` (catalog fallback included)
2. `status?.gameId` (UUID — last resort)
3. route param `gameId` (defensive)

## Verification

- 9/9 KbHubContent.test.tsx green
- `pnpm typecheck` clean

## Out of Scope

F5 (stats-strip tag-style), F7 (KbStatsCard dedup), F9 (sparkline 0-data), F10 (bottom drop-zone CTA) recommended as separate follow-up issues — each needs design input or HubDefault refactor.

## Notes

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)