### PR TITLE
fix(onboarding): drop duplicate "Skip for now" link from interests step (#1974 F27)

### DIFF
--- a/apps/web/src/components/onboarding/InterestsStep.tsx
+++ b/apps/web/src/components/onboarding/InterestsStep.tsx
@@ -133,6 +133,19 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
           </p>
         )}
 
+        {/*
+          F27 #1974 (audit 2026-06-07): collapsed the duplicate skip surface.
+          Pre-fix there were two skip affordances on the same row — the
+          primary submit (relabeled "Skip" when nothing was selected) plus a
+          gray text link "Skip for now". The audit flagged this as decision
+          friction: both buttons did the exact same thing (`onSkip`) and the
+          gray link is the conventional secondary affordance, but the orange
+          primary already covers the "no selection → skip" path. We keep the
+          primary submit (it ramps to "Continue" once the user selects
+          anything) and drop the link. `interests-skip` testid is removed
+          along with it; tests should rely on the primary submit's "Skip"
+          label in the empty-selection path.
+        */}
         <div className="flex items-center gap-3">
           <AccessibleButton
             type="submit"
@@ -145,14 +158,6 @@ export function InterestsStep({ onComplete, onSkip }: InterestsStepProps) {
               ? t('pages.onboarding.interests.cta.continue')
               : t('pages.onboarding.interests.cta.skip')}
           </AccessibleButton>
-          <button
-            type="button"
-            onClick={onSkip}
-            className="text-sm text-muted-foreground hover:text-foreground"
-            data-testid="interests-skip"
-          >
-            {t('pages.onboarding.interests.cta.skipForNow')}
-          </button>
         </div>
       </form>
     </div>

--- a/apps/web/src/components/onboarding/__tests__/InterestsStep.test.tsx
+++ b/apps/web/src/components/onboarding/__tests__/InterestsStep.test.tsx
@@ -72,10 +72,15 @@ describe('InterestsStep', () => {
     expect(screen.getByText('3 selected')).toBeInTheDocument();
   });
 
-  it('calls onSkip when skip button clicked', async () => {
+  it('calls onSkip when the primary CTA shows "Skip" (no selection) and is clicked', async () => {
+    // F27 #1974: the legacy `interests-skip` text-link was removed because it
+    // duplicated the primary submit's no-selection skip action. Coverage
+    // moves to the primary submit; the no-selection submit path still
+    // delegates to `onSkip` so the wizard never traps the user.
     renderWithQuery(<InterestsStep onComplete={onComplete} onSkip={onSkip} />);
 
-    await user.click(screen.getByTestId('interests-skip'));
+    expect(screen.queryByTestId('interests-skip')).toBeNull();
+    await user.click(screen.getByRole('button', { name: /^skip$/i }));
 
     expect(onSkip).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

F27 audit finding (#1974): InterestsStep exposed two skip affordances on the same row — the primary submit (relabeled "Skip" when nothing was selected) and a gray text link "Skip for now". Both invoked the same `onSkip` callback — decision friction with zero behavioural difference.

## Fix

Remove the gray text link. The primary submit ramps "Skip" → "Continue" so a single button carries the right action label.

## Tests

- Replace the legacy `interests-skip` testid assertion with one that exercises the primary submit "Skip" label path and verifies the legacy testid is gone.

## Verification

- 6/6 InterestsStep.test.tsx green
- `pnpm typecheck` clean

## Notes

The `pages.onboarding.interests.cta.skipForNow` i18n key stays in locale files (backward compat — zero callers but cheap to keep).

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)