### PR TITLE
fix(kb-hub): hide sparkline when costHistory is all zeros (#1974 F9)

### DIFF
--- a/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
+++ b/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
@@ -140,8 +140,14 @@ export function KbStatsCard(props: KbStatsCardProps): ReactElement {
       : []),
   ];
 
-  const maxSparklineVal = costHistory && costHistory.length > 0 ? Math.max(...costHistory) : 1;
-  const showSparkline = !compact && costHistory && costHistory.length > 0;
+  // F9 #1974 (audit 2026-06-07): hide the sparkline when costHistory contains
+  // only zeros (BE seeds an empty 7-day window for KBs that have never been
+  // used). Pre-fix the empty bars rendered as a low strip of grey rectangles
+  // — pure UI noise. We require at least one non-zero datapoint so the chart
+  // only appears once there is real signal.
+  const hasSparklineSignal = !!costHistory && costHistory.some(v => v > 0);
+  const maxSparklineVal = hasSparklineSignal ? Math.max(...costHistory!) : 1;
+  const showSparkline = !compact && hasSparklineSignal;
   const showLifetimeCost = !compact && lifetimeCost !== undefined;
   const gridCols =
     metrics.length >= 4 ? 'grid-cols-4' : metrics.length === 3 ? 'grid-cols-3' : 'grid-cols-2';

--- a/apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx
@@ -193,4 +193,40 @@ describe('KbStatsCard (Issue #1481)', () => {
     ).not.toBeInTheDocument();
     expect(container.querySelector('[data-slot="kb-hub-stats-sparkline"]')).not.toBeInTheDocument();
   });
+
+  it('hides the sparkline when costHistory contains only zeros (F9 #1974)', () => {
+    // F9 regression guard: the BE seeds an empty 7-day cost window for KBs
+    // that have never been used. Pre-fix the sparkline rendered 7 flat
+    // zero-height bars — pure UI noise. Now the chart is hidden unless at
+    // least one datapoint is non-zero.
+    const { container } = render(
+      <KbStatsCard
+        documentCount={12}
+        coverageLevel="Standard"
+        coverageScore={73}
+        lifetimeCost="$0.00"
+        costHistory={[0, 0, 0, 0, 0, 0, 0]}
+        labels={baseLabels}
+      />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-stats-sparkline"]')).not.toBeInTheDocument();
+    // Lifetime cost row is independent of sparkline signal — it still renders
+    // (the card still wants to surface the explicit "$0.00 lifetime" state).
+    expect(container.querySelector('[data-slot="kb-hub-stats-lifetime-cost"]')).toBeInTheDocument();
+  });
+
+  it('renders the sparkline when at least one datapoint is non-zero (F9 #1974)', () => {
+    const { container } = render(
+      <KbStatsCard
+        documentCount={12}
+        coverageLevel="Standard"
+        coverageScore={73}
+        lifetimeCost="$0.04"
+        // 6 zeros + 1 spike — first real activity within the window.
+        costHistory={[0, 0, 0, 0, 0, 0, 0.04]}
+        labels={baseLabels}
+      />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-stats-sparkline"]')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

F9 audit finding (#1974): the "Consumo token · ultimi 7 gg" sparkline rendered 7 flat zero-height bars for KBs that had never been used. The BE seeds an empty 7-day window with all zeros, and the existing guard (`costHistory.length > 0`) let it through.

## Fix

Tighten to `costHistory.some(v => v > 0)`. Sparkline appears only once at least one datapoint is non-zero. Lifetime-cost row is independent and still renders the explicit "$0.00 lifetime" state.

## Tests

- 2 new regression guards (all-zeros hides, single-spike shows)

## Verification

- 10/10 KbStatsCard.test.tsx green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)