### PR TITLE
fix(persistence): CF-2 complete coverage via AddAndCommitAsync on ProposalMigration + LedgerEntry repos (#1993)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/EventHandlers/TokenUsageLedgerEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/EventHandlers/TokenUsageLedgerEventHandler.cs
@@ -1,8 +1,6 @@
 using Api.BoundedContexts.BusinessSimulations.Application.Interfaces;
 using Api.BoundedContexts.BusinessSimulations.Domain.Events;
-using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.BusinessSimulations.Application.EventHandlers;
@@ -29,6 +27,10 @@ internal sealed class TokenUsageLedgerEventHandler : INotificationHandler<TokenU
     {
         try
         {
+            // 23505 dedup is now handled inside the service (AddAndCommitAsync). The
+            // catch (Exception) below stays as a safety net for any other failure
+            // (network glitch, EF model misconfiguration, …) that must not block the
+            // main token-tracking flow.
             await _ledgerTrackingService.TrackTokenUsageAsync(
                 userId: notification.UserId,
                 modelId: notification.ModelId,
@@ -37,18 +39,6 @@ internal sealed class TokenUsageLedgerEventHandler : INotificationHandler<TokenU
                 endpoint: notification.Endpoint,
                 sourceEventId: notification.EventId,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
-        {
-            // CF-2 / #1938: outbox replay (#1535 at-least-once delivery) for an event
-            // already persisted. The partial UNIQUE index on ledger_entries.source_event_id
-            // blocked the duplicate insert at the DB. Log at Information — a noisy
-            // LogError on legitimate replays would crowd out real failures in operator
-            // dashboards.
-            _logger.LogInformation(
-                ex,
-                "Skipping duplicate ledger entry for token usage: User={UserId}, Model={ModelId}, SourceEventId={SourceEventId} (already recorded)",
-                notification.UserId, notification.ModelId, notification.EventId);
         }
         catch (Exception ex)
         {

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Repositories/ILedgerEntryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Repositories/ILedgerEntryRepository.cs
@@ -60,4 +60,19 @@ internal interface ILedgerEntryRepository : IRepository<LedgerEntry, Guid>
         int page = 1,
         int pageSize = 20,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts the LedgerEntry and commits the change immediately. Returns
+    /// <c>false</c> when the insert violates the <c>(source_event_id)</c> UNIQUE
+    /// partial index — an outbox replay or concurrent pod already wrote the
+    /// row for this <c>IDomainEvent.EventId</c> (CF-2 / #1938). On <c>false</c>
+    /// the tracked entity is detached so subsequent <c>SaveChanges</c> on the
+    /// same scoped context don't retry it.
+    /// </summary>
+    /// <remarks>
+    /// Inline-commit pattern. Used by <see cref="Api.BoundedContexts.BusinessSimulations.Application.Interfaces.ILedgerTrackingService.TrackTokenUsageAsync"/>
+    /// where the rest of the service relies on a downstream UoW pipeline that
+    /// would otherwise turn a 23505 into an unhandled exception.
+    /// </remarks>
+    Task<bool> AddAndCommitAsync(LedgerEntry entry, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Infrastructure/Persistence/LedgerEntryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Infrastructure/Persistence/LedgerEntryRepository.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.BusinessSimulations.Domain.Repositories;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.BusinessSimulations.Infrastructure.Persistence;
@@ -44,6 +45,31 @@ internal class LedgerEntryRepository : RepositoryBase, ILedgerEntryRepository
         await DbContext.LedgerEntries
             .AddAsync(entity, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AddAndCommitAsync(LedgerEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        CollectDomainEvents(entry);
+
+        await DbContext.LedgerEntries
+            .AddAsync(entry, cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox replay or concurrent pod already inserted the
+            // row keyed by source_event_id. Detach and signal the caller to skip.
+            _ = ex;
+            DbContext.Entry(entry).State = EntityState.Detached;
+            return false;
+        }
     }
 
     public Task UpdateAsync(LedgerEntry entity, CancellationToken cancellationToken = default)

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Infrastructure/Services/LedgerTrackingService.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Infrastructure/Services/LedgerTrackingService.cs
@@ -74,7 +74,16 @@ internal sealed class LedgerTrackingService : ILedgerTrackingService
             metadata: metadata,
             sourceEventId: sourceEventId);
 
-        await _repository.AddAsync(entry, cancellationToken).ConfigureAwait(false);
+        // CF-2 / #1938 deferred follow-up: inline-commit so a 23505 violation on
+        // (source_event_id) is caught here and demoted to a no-op log line, rather
+        // than escaping the downstream UoW pipeline as an unhandled exception.
+        if (!await _repository.AddAndCommitAsync(entry, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogInformation(
+                "Skipping duplicate ledger entry for token usage: User={UserId}, Model={ModelId}, SourceEventId={SourceEventId} (already recorded)",
+                userId, modelId, sourceEventId);
+            return;
+        }
 
         _logger.LogInformation(
             "Ledger entry created for token usage: User={UserId}, Model={ModelId}, Tokens={Tokens}, Cost=${Cost}",

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/CreateProposalMigrationOnApprovalHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/CreateProposalMigrationOnApprovalHandler.cs
@@ -5,7 +5,6 @@ using Api.BoundedContexts.UserLibrary.Domain.Entities;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.EventHandlers;
-using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.UserLibrary.Application.EventHandlers;
@@ -105,19 +104,14 @@ internal sealed class CreateProposalMigrationOnApprovalHandler : DomainEventHand
             userId: shareRequest.UserId,
             sourceEventId: domainEvent.EventId);
 
-        try
+        // CF-2 / #1938 deferred follow-up: AddAndCommitAsync wraps AddAsync + an
+        // inline SaveChangesAsync with a 23505 catch. Returns false when an outbox
+        // replay (#1535 at-least-once delivery) or concurrent pod already wrote the
+        // row keyed by this EventId — log and skip silently so the legitimate
+        // replay doesn't surface as an alarm.
+        if (!await _migrationRepo.AddAndCommitAsync(migration, cancellationToken).ConfigureAwait(false))
         {
-            await _migrationRepo.AddAsync(migration, cancellationToken).ConfigureAwait(false);
-        }
-        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
-        {
-            // CF-2 / #1938: outbox replay (#1535 at-least-once delivery) for a ShareRequest
-            // approval already processed. The partial UNIQUE index on
-            // proposal_migrations.source_event_id blocked the duplicate insert. Return
-            // without throwing so the base DomainEventHandlerBase doesn't log this as a
-            // failure — legitimate replays are not failures.
             Logger.LogInformation(
-                ex,
                 "Skipping duplicate ProposalMigration for ShareRequest {ShareRequestId}: SourceEventId={SourceEventId} (already recorded)",
                 shareRequest.Id, domainEvent.EventId);
             return;

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IProposalMigrationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IProposalMigrationRepository.cs
@@ -14,6 +14,23 @@ public interface IProposalMigrationRepository
     Task AddAsync(ProposalMigration migration, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Inserts the ProposalMigration and commits the change immediately. Returns
+    /// <c>false</c> when the insert violates the <c>(source_event_id)</c> UNIQUE
+    /// partial index — i.e. an outbox replay or a concurrent pod already wrote
+    /// the row for this <c>IDomainEvent.EventId</c> (CF-2 / #1938). On <c>false</c>
+    /// the tracked entity is detached so subsequent <c>SaveChanges</c> on the same
+    /// scoped context don't retry it.
+    /// </summary>
+    /// <remarks>
+    /// Inline-commit pattern mirroring <c>NotificationRepository.AddAndCommitAsync</c>
+    /// (CF-1) and <c>ProcessingMetricsService.RecordStepDurationAsync</c> (CF-2 partial).
+    /// Required for the proposal-migration handler because the rest of the BC saves
+    /// downstream via the UoW pipeline — that pipeline turns a 23505 into an
+    /// unhandled exception, so the dedup needs to land here before the row escapes.
+    /// </remarks>
+    Task<bool> AddAndCommitAsync(ProposalMigration migration, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a ProposalMigration by its ID.
     /// </summary>
     Task<ProposalMigration?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/ProposalMigrationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/ProposalMigrationRepository.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Infrastructure.Entities.UserLibrary;
 using Api.Middleware.Exceptions;
 using Microsoft.EntityFrameworkCore;
@@ -26,6 +27,28 @@ public sealed class ProposalMigrationRepository : RepositoryBase, IProposalMigra
     {
         var entity = MapToEntity(migration);
         await DbContext.Set<ProposalMigrationEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AddAndCommitAsync(ProposalMigration migration, CancellationToken cancellationToken = default)
+    {
+        var entity = MapToEntity(migration);
+        await DbContext.Set<ProposalMigrationEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // CF-2 / #1938: outbox replay or concurrent pod already inserted the row.
+            // Detach so the next SaveChanges on this scoped context doesn't retry,
+            // and signal the caller to skip downstream work.
+            _ = ex;
+            DbContext.Entry(entity).State = EntityState.Detached;
+            return false;
+        }
     }
 
     public async Task<ProposalMigration?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)

--- a/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/LedgerTrackingServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/LedgerTrackingServiceTests.cs
@@ -26,6 +26,14 @@ public sealed class LedgerTrackingServiceTests
         _repositoryMock = new Mock<ILedgerEntryRepository>();
         _loggerMock = new Mock<ILogger<LedgerTrackingService>>();
         _service = new LedgerTrackingService(_repositoryMock.Object, _loggerMock.Object);
+
+        // CF-2 deferred follow-up (#1938): TrackTokenUsageAsync now uses
+        // AddAndCommitAsync (inline-commit + 23505 catch). Default to "row
+        // inserted successfully" so the existing tests don't have to opt in;
+        // any test that needs to assert the lost-race path overrides this.
+        _repositoryMock
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
     }
 
     #region TrackTokenUsageAsync
@@ -37,15 +45,15 @@ public sealed class LedgerTrackingServiceTests
         var userId = Guid.NewGuid();
         LedgerEntry? capturedEntry = null;
         _repositoryMock
-            .Setup(r => r.AddAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
             .Callback<LedgerEntry, CancellationToken>((entry, _) => capturedEntry = entry)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         // Act
         await _service.TrackTokenUsageAsync(userId, "openai/gpt-4o-mini", 1500, 0.005m, "chat");
 
         // Assert
-        _repositoryMock.Verify(r => r.AddAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()), Times.Once);
         capturedEntry.Should().NotBeNull();
         capturedEntry!.Type.Should().Be(LedgerEntryType.Expense);
         capturedEntry.Category.Should().Be(LedgerCategory.TokenUsage);
@@ -65,7 +73,7 @@ public sealed class LedgerTrackingServiceTests
         await _service.TrackTokenUsageAsync(Guid.NewGuid(), "free-model", 100, 0m, "chat");
 
         // Assert - no repository call should be made
-        _repositoryMock.Verify(r => r.AddAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repositoryMock.Verify(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -134,9 +142,9 @@ public sealed class LedgerTrackingServiceTests
         // Arrange
         LedgerEntry? capturedEntry = null;
         _repositoryMock
-            .Setup(r => r.AddAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
             .Callback<LedgerEntry, CancellationToken>((entry, _) => capturedEntry = entry)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         // Act
         await _service.TrackTokenUsageAsync(Guid.NewGuid(), "model", 100, 0.01m, "qa");
@@ -147,18 +155,37 @@ public sealed class LedgerTrackingServiceTests
     }
 
     [Fact]
+    public async Task TrackTokenUsageAsync_WhenAddAndCommitLostRace_ShouldReturnWithoutThrowing()
+    {
+        // CF-2 deferred follow-up (#1938): when AddAndCommitAsync returns false an
+        // outbox replay or a concurrent pod won the insert race. The service must
+        // log and exit silently — no rethrow, no further repository calls.
+        _repositoryMock
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _service.TrackTokenUsageAsync(
+            Guid.NewGuid(), "openai/gpt-4o-mini", 1500, 0.005m, "chat",
+            sourceEventId: Guid.NewGuid());
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        _repositoryMock.Verify(
+            r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task TrackTokenUsageAsync_WithNullEndpoint_ShouldSucceed()
     {
-        // Arrange
-        _repositoryMock
-            .Setup(r => r.AddAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        // Arrange — default AddAndCommitAsync setup from the ctor returns true.
 
         // Act
         await _service.TrackTokenUsageAsync(Guid.NewGuid(), "model", 100, 0.01m, null);
 
         // Assert
-        _repositoryMock.Verify(r => r.AddAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.AddAndCommitAsync(It.IsAny<LedgerEntry>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/CreateProposalMigrationOnApprovalHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/CreateProposalMigrationOnApprovalHandlerTests.cs
@@ -38,6 +38,16 @@ public sealed class CreateProposalMigrationOnApprovalHandlerTests : IDisposable
             _mockShareRequestRepo.Object,
             _mockMigrationRepo.Object,
             _mockLogger.Object);
+
+        // CF-2 deferred follow-up (#1938): handler now uses AddAndCommitAsync
+        // (inline-commit + 23505 catch). Default to "row inserted successfully"
+        // so the existing happy-path tests don't have to opt in; any test that
+        // needs to assert the lost-race path overrides this.
+        _mockMigrationRepo
+            .Setup(r => r.AddAndCommitAsync(
+                It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
     }
 
     public void Dispose() => _db.Dispose();
@@ -63,7 +73,7 @@ public sealed class CreateProposalMigrationOnApprovalHandlerTests : IDisposable
         // Assert
         await act.Should().NotThrowAsync();
         _mockMigrationRepo.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
@@ -94,7 +104,7 @@ public sealed class CreateProposalMigrationOnApprovalHandlerTests : IDisposable
         // Assert
         await act.Should().NotThrowAsync();
         _mockMigrationRepo.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
@@ -125,7 +135,7 @@ public sealed class CreateProposalMigrationOnApprovalHandlerTests : IDisposable
         // Assert
         await act.Should().NotThrowAsync();
         _mockMigrationRepo.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
@@ -158,10 +168,62 @@ public sealed class CreateProposalMigrationOnApprovalHandlerTests : IDisposable
         // Assert
         await act.Should().NotThrowAsync();
         _mockMigrationRepo.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAddAndCommitLostRace_LogsAndReturnsWithoutThrowing()
+    {
+        // CF-2 deferred follow-up (#1938): when the partial UNIQUE index on
+        // proposal_migrations.source_event_id blocks our insert (outbox replay
+        // already won the race) AddAndCommitAsync returns false. The handler
+        // must log and exit silently — no rethrow, no further work.
+        var userId = Guid.NewGuid();
+        var libraryEntryId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+        var privateGameId = Guid.NewGuid();
+
+        var shareRequest = Api.BoundedContexts.SharedGameCatalog.Domain.Entities.ShareRequest.Create(
+            userId, libraryEntryId, ContributionType.NewGameProposal);
+
+        var domainEvent = new ShareRequestApprovedEvent(
+            shareRequestId: shareRequest.Id,
+            adminId: Guid.NewGuid(),
+            targetSharedGameId: sharedGameId);
+
+        _mockShareRequestRepo
+            .Setup(r => r.GetByIdAsync(shareRequest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(shareRequest);
+
+        _db.UserLibraryEntries.Add(new UserLibraryEntryEntity
+        {
+            Id = libraryEntryId,
+            UserId = userId,
+            PrivateGameId = privateGameId
+        });
+        await _db.SaveChangesAsync();
+
+        // Override the default setup: a concurrent dispatch already inserted
+        // the row, so AddAndCommitAsync now returns false.
+        _mockMigrationRepo
+            .Setup(r => r.AddAndCommitAsync(
+                It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var act = () => _handler.Handle(domainEvent, TestContext.Current.CancellationToken);
+
+        // Assert — handler exits cleanly; AddAndCommitAsync was called exactly once.
+        await act.Should().NotThrowAsync();
+        _mockMigrationRepo.Verify(
+            r => r.AddAndCommitAsync(
+                It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -198,7 +260,7 @@ public sealed class CreateProposalMigrationOnApprovalHandlerTests : IDisposable
         // Assert
         await act.Should().NotThrowAsync();
         _mockMigrationRepo.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.IsAny<Api.BoundedContexts.UserLibrary.Domain.Entities.ProposalMigration>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);


### PR DESCRIPTION
## Summary

Closes the deferred tightening noted in PR #1981. The two counter handlers whose save fires downstream of the handler — `CreateProposalMigrationOnApprovalHandler` (via MediatR UoW pipeline) and `LedgerTrackingService.TrackTokenUsageAsync` (via the service → repo chain) — now run their insert under inline-commit-with-catch instead of relying on the upstream pipeline to swallow the 23505.

Mirrors the CF-1 `NotificationRepository.AddAndCommitAsync` shape introduced in PR #1943.

Resolves issue #1993.

## What changes

### Repository surface
- `IProposalMigrationRepository.AddAndCommitAsync(ProposalMigration, ct) → bool`
- `ILedgerEntryRepository.AddAndCommitAsync(LedgerEntry, ct) → bool`
- Both implementations: `AddAsync` + `DbContext.SaveChangesAsync` wrapped in `catch DbUpdateException when CounterTableIdempotency.IsUniqueViolation(ex)`; detach the tracked entity on `false` return.

### Caller wiring
- `CreateProposalMigrationOnApprovalHandler` — drops the defense-in-depth try/catch around `AddAsync` (was inert in production); calls the new `AddAndCommitAsync`; logs Information + returns on false.
- `LedgerTrackingService.TrackTokenUsageAsync` — same shape. `TokenUsageLedgerEventHandler` keeps its outer `catch (Exception)` as a safety net for any other failure that must not block the main flow, but drops the now-redundant `catch (DbUpdateException)` layer.

### Tests
- `LedgerTrackingServiceTests` — ctor default `AddAndCommitAsync → true`; switched 3 happy-path mocks/verifies; new test `TrackTokenUsageAsync_WhenAddAndCommitLostRace_ShouldReturnWithoutThrowing`.
- `CreateProposalMigrationOnApprovalHandlerTests` — ctor default `true`; switched 6 verifies; new test `Handle_WhenAddAndCommitLostRace_LogsAndReturnsWithoutThrowing`.

40/40 affected tests pass locally. `dotnet build` clean (0 errors).

## Why

Before this PR, the 23505 catch on these two handlers was unreachable in production: the save fired *past* the handler in the UoW pipeline, so the catch intercepted nothing. Operators kept seeing the noisy LogError on every legitimate outbox replay (#1535 at-least-once delivery). This PR makes the catch land at the actual save point and demote the log to Information.

## Test plan

- [x] `dotnet build apps/api/src/Api` — clean
- [x] `dotnet test --filter "LedgerTrackingServiceTests|CreateProposalMigrationOnApprovalHandlerTests|TokenUsageLedgerEventHandlerTests"` — 40/40 pass
- [ ] Integration follow-up (optional): Testcontainers test that drives the inline save path against a real Postgres UNIQUE index and asserts the no-op skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)