### PR TITLE
feat(kb-hub): re-skin stats strip as tag-style chips (#1974 F5)

### DIFF
--- a/apps/web/src/components/features/kb-hub/HubDefault.tsx
+++ b/apps/web/src/components/features/kb-hub/HubDefault.tsx
@@ -206,22 +206,29 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
           </div>
         )}
 
-        {/* Stats strip */}
-        <div
-          data-slot="kb-hub-default-stats-strip"
-          className="flex flex-wrap items-center gap-1 rounded-md border border-entity-kb/10 bg-entity-kb/6 px-3.5 py-2.5"
-        >
-          {statsStripItems.map((s, i, arr) => (
-            <span key={s.key} className="inline-flex items-center gap-1">
-              <span aria-hidden="true" className="text-xs">
+        {/*
+          F5 #1974 (audit 2026-06-07): re-styled the stats strip from a
+          single dot-separated mono line to a row of compact tag-style
+          pills. The mockup ships "4 DOC · 1247 CHUNK · 4891 EMBED · ULTIMA
+          IDX 3 GG FA · COPERTURA: STANDARD" as scannable bordered chips —
+          much easier to track at a glance than a continuous text run.
+          Each chip carries the icon + uppercase mono value; the legacy
+          interstitial `·` separator is dropped (the chip border carries
+          the visual rhythm now).
+        */}
+        <div data-slot="kb-hub-default-stats-strip" className="flex flex-wrap items-center gap-1.5">
+          {statsStripItems.map(s => (
+            <span
+              key={s.key}
+              data-slot="kb-hub-default-stats-chip"
+              className="inline-flex items-center gap-1 rounded-md border border-entity-kb/22 bg-entity-kb/6 px-2 py-0.5"
+            >
+              <span aria-hidden="true" className="text-[11px]">
                 {s.icon}
               </span>
-              <span className="font-mono text-[11px] font-semibold text-foreground">{s.text}</span>
-              {i < arr.length - 1 && (
-                <span aria-hidden="true" className="mx-1.5 text-muted-foreground opacity-50">
-                  ·
-                </span>
-              )}
+              <span className="font-mono text-[10.5px] font-bold uppercase tracking-wide text-foreground">
+                {s.text}
+              </span>
             </span>
           ))}
         </div>

--- a/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
@@ -154,6 +154,31 @@ describe('HubDefault (Issue #1481)', () => {
     expect(screen.queryByText(/embeddings$/)).not.toBeInTheDocument();
   });
 
+  it('renders each stat as a separate tag-style chip (F5 #1974)', () => {
+    // F5 regression guard: the stats strip moved from a single dot-separated
+    // mono line to a row of bordered chips so the metrics are scannable at
+    // a glance. Each visible stat must carry its own `kb-hub-default-stats-chip`
+    // slot so the chip styling cannot regress to a monolithic container.
+    const { container } = render(
+      <HubDefault
+        game={baseGame}
+        documentCount={4}
+        coverageLevel="Standard"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        chunks={1247}
+        embeddings={4891}
+        lastReindexRelative="3 gg fa"
+        onUpload={() => {}}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    const chips = container.querySelectorAll('[data-slot="kb-hub-default-stats-chip"]');
+    // docs + chunks + embeddings + lastReindex + coverage = 5 chips.
+    expect(chips).toHaveLength(5);
+  });
+
   it('renders deferred stats strip metrics when chunks/embeddings/lastReindex provided', () => {
     render(
       <HubDefault


### PR DESCRIPTION
## Summary

F5 audit finding (#1974): the HubDefault stats strip shipped as a single dot-separated mono line ("4 doc · 1247 chunk · 4891 embed · ultima idx 3 gg fa · copertura: STANDARD") inside a flat container. The mockup ships the same metrics as scannable bordered chips — much easier to track at a glance.

## Fix

Rewrite the strip as a row of `kb-hub-default-stats-chip` spans. Each chip carries its icon + uppercase mono value with an `entity-kb/22` border. Drop the legacy `·` interstitial separator. Container loses its bg/border — chips own their containment.

Visible metrics + labels unchanged — pure CSS + DOM shape restructure.

## Tests

- Regression guard: chip count matches the visible-metric count (5 when all P83-deferred props provided).

## Verification

- 9/9 HubDefault.test.tsx green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)