### PR TITLE
feat(kb-hub): add bottom drop-zone CTA under the PDF list (#1974 F10)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
@@ -71,6 +71,7 @@ const MESSAGES: Record<string, string> = {
   'pages.library.gameDetail.kb.header.titleSuffix': 'Knowledge Base',
   'pages.library.gameDetail.kb.header.uploadCta': '+ Carica PDF',
   'pages.library.gameDetail.kb.header.reindexAllCta': 'Re-index all',
+  'pages.library.gameDetail.kb.header.dropZoneCta': 'Trascina un PDF qui o clicca per caricarlo',
   'pages.library.gameDetail.kb.stats.docs': '{count} documenti',
   'pages.library.gameDetail.kb.stats.docsLabel': 'Documenti',
   'pages.library.gameDetail.kb.stats.chunksLabel': 'Chunks',

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -164,6 +164,8 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
     headerSubtitle: t('pages.library.gameDetail.kb.header.titleSuffix'),
     uploadCta: t('pages.library.gameDetail.kb.header.uploadCta'),
     reindexAllCta: t('pages.library.gameDetail.kb.header.reindexAllCta'),
+    // F10 #1974: bottom drop-zone CTA — discoverable upload affordance.
+    dropZoneCta: t('pages.library.gameDetail.kb.header.dropZoneCta'),
     indexingBadge: t('pages.library.gameDetail.kb.stats.indexingBadge'),
     indexingDescription: t('pages.library.gameDetail.kb.stats.indexingDescription'),
     statsStrip: {

--- a/apps/web/src/components/features/kb-hub/HubDefault.tsx
+++ b/apps/web/src/components/features/kb-hub/HubDefault.tsx
@@ -58,6 +58,10 @@ export interface HubDefaultLabels {
   // hub does not render the badge slot.
   readonly indexingBadge?: string;
   readonly indexingDescription?: string;
+  // F10 #1974 — bottom drop-zone CTA label (mockup: "Trascina un PDF o
+  // clicca per caricarlo"). Optional — when undefined the hub omits the
+  // drop zone (legacy consumers get no regression).
+  readonly dropZoneCta?: string;
 }
 
 export interface HubDefaultProps {
@@ -255,6 +259,32 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
           <PdfRow key={pdf.id} pdf={pdf} labels={labels.pdfRow} onActionClick={onPdfAction} />
         ))}
       </div>
+
+      {/*
+        F10 #1974 (audit 2026-06-07): bottom drop-zone CTA. The mockup
+        ships a dashed-bordered tappable region under the PDF list that
+        invites the user to drop a PDF (or click). Pre-fix the only upload
+        affordance was the small "+ Carica PDF" button in the header —
+        easy to miss on a wide screen and discovery-unfriendly for new
+        users. We render the same `onUpload` handler so the click path
+        stays unchanged; drag-and-drop wiring is deferred to the upload
+        flow itself (Issue #1816 P3 / future PR). The CTA only renders
+        when the caller provides a label, so consumers that don't want
+        the affordance pay nothing.
+      */}
+      {labels.dropZoneCta && (
+        <button
+          type="button"
+          onClick={onUpload}
+          data-slot="kb-hub-default-drop-zone"
+          className="m-4 flex w-[calc(100%-2rem)] items-center justify-center gap-2 rounded-md border-2 border-dashed border-entity-kb/30 bg-entity-kb/4 px-4 py-5 text-sm font-bold text-entity-kb transition-colors hover:border-entity-kb/55 hover:bg-entity-kb/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+        >
+          <span aria-hidden="true" className="text-base">
+            ⬆
+          </span>
+          <span>{labels.dropZoneCta}</span>
+        </button>
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
@@ -154,6 +154,45 @@ describe('HubDefault (Issue #1481)', () => {
     expect(screen.queryByText(/embeddings$/)).not.toBeInTheDocument();
   });
 
+  it('does NOT render the bottom drop-zone CTA when labels.dropZoneCta is missing (F10 #1974)', () => {
+    const { container } = render(
+      <HubDefault
+        game={baseGame}
+        documentCount={2}
+        coverageLevel="Basic"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        onUpload={() => {}}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    expect(
+      container.querySelector('[data-slot="kb-hub-default-drop-zone"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the bottom drop-zone CTA and wires onUpload when label is provided (F10 #1974)', () => {
+    const onUpload = vi.fn();
+    const { container } = render(
+      <HubDefault
+        game={baseGame}
+        documentCount={2}
+        coverageLevel="Basic"
+        pdfs={basePdfs}
+        labels={{ ...baseLabels, dropZoneCta: 'Trascina un PDF qui o clicca per caricarlo' }}
+        onUpload={onUpload}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    const dropZone = container.querySelector('[data-slot="kb-hub-default-drop-zone"]');
+    expect(dropZone).toBeInTheDocument();
+    expect(dropZone).toHaveTextContent('Trascina un PDF qui o clicca per caricarlo');
+    fireEvent.click(dropZone!);
+    expect(onUpload).toHaveBeenCalledTimes(1);
+  });
+
   it('renders each stat as a separate tag-style chip (F5 #1974)', () => {
     // F5 regression guard: the stats strip moved from a single dot-separated
     // mono line to a row of bordered chips so the metrics are scannable at

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1889,7 +1889,8 @@
           "header": {
             "titleSuffix": "Knowledge Base",
             "uploadCta": "+ Upload PDF",
-            "reindexAllCta": "⟳ Re-index all"
+            "reindexAllCta": "⟳ Re-index all",
+            "dropZoneCta": "Drop a PDF here or click to upload"
           },
           "stats": {
             "docs": "{count, plural, =0 {No documents} =1 {1 document} other {# documents}}",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1939,7 +1939,8 @@
           "header": {
             "titleSuffix": "Knowledge Base",
             "uploadCta": "+ Carica PDF",
-            "reindexAllCta": "⟳ Re-index all"
+            "reindexAllCta": "⟳ Re-index all",
+            "dropZoneCta": "Trascina un PDF qui o clicca per caricarlo"
           },
           "stats": {
             "docs": "{count, plural, =0 {Nessun documento} =1 {1 documento} other {# documenti}}",


### PR DESCRIPTION
## Summary

F10 audit finding (#1974): the only upload affordance on `/library/[gameId]/kb` was the small "+ Carica PDF" button in the header — easy to miss on wide screens and discovery-unfriendly for new users. The mockup ships a tappable dashed-bordered drop-zone under the PDF list inviting "Drop a PDF here or click to upload".

## Changes

- **`HubDefault.tsx`**: add optional `labels.dropZoneCta`. When present, render a dashed-border button under the PDF list wired to the existing `onUpload` handler. Drag-and-drop wiring deferred — click path is identical to the header CTA. Optional → legacy consumers (admin/dev surfaces) pay nothing.
- **`_content.tsx`**: pass `dropZoneCta` translation.
- **`it.json` + `en.json`**: add `pages.library.gameDetail.kb.header.dropZoneCta`.

## Tests

- 2 new regression guards (omitted → no zone; provided → zone + `onUpload` wired)
- KbHubContent test labels updated (1 new key)

## Verification

- 20/20 HubDefault + KbHubContent green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)