### PR TITLE
fix(kb-hub): remove KbStatsCard from user-facing kb page (#1974 F7)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
@@ -236,7 +236,7 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
 
   // #1816 P3-7 Phase 2 — indexing-pending state surface.
   describe('indexing-pending state (#1816 P3-7 Phase 2)', () => {
-    it('renders indexing badges on KbStatsCard + HubDefault when pdfs present and isIndexed=false', () => {
+    it('renders the indexing banner on HubDefault when pdfs present and isIndexed=false (F7 #1974: KbStatsCard no longer mounted on user surface)', () => {
       mockUseUserKbStatus.mockReturnValue({
         isLoading: false,
         isError: false,
@@ -257,13 +257,16 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
 
       const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
 
+      // F7: KbStatsCard removed from `/library/[gameId]/kb` → its dedicated
+      // indexing badge no longer appears. The HubDefault banner remains the
+      // single source of truth on this surface.
       expect(
         container.querySelector('[data-slot="kb-hub-stats-indexing-badge"]')
-      ).toBeInTheDocument();
+      ).not.toBeInTheDocument();
       expect(
         container.querySelector('[data-slot="kb-hub-default-indexing-banner"]')
       ).toBeInTheDocument();
-      // Audit-quoted IT copy renders end-to-end (orchestrator → child).
+      // Audit-quoted IT copy still renders end-to-end (orchestrator → HubDefault).
       expect(screen.getAllByText('⏳ Indicizzazione in corso').length).toBeGreaterThanOrEqual(1);
     });
 
@@ -325,7 +328,7 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
     });
   });
 
-  it('renders HubDefault + KbStatsCard + RaptorPanel when PDFs present', () => {
+  it('renders HubDefault + RaptorPanel when PDFs present (F7 #1974: KbStatsCard removed)', () => {
     mockUseUserKbStatus.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -345,7 +348,9 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
     });
     const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
     expect(container.querySelector('[data-slot="kb-hub-hub-default"]')).toBeInTheDocument();
-    expect(container.querySelector('[data-slot="kb-hub-stats-card"]')).toBeInTheDocument();
+    // F7 #1974: KbStatsCard removed from `/library/[gameId]/kb` user surface
+    // — the same data lives inside HubDefault's stats strip.
+    expect(container.querySelector('[data-slot="kb-hub-stats-card"]')).not.toBeInTheDocument();
     expect(container.querySelector('[data-slot="kb-hub-raptor-panel"]')).toBeInTheDocument();
     expect(container.querySelectorAll('[data-slot="kb-hub-pdf-row"]')).toHaveLength(2);
   });

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -24,14 +24,12 @@ import {
   DeleteDialog,
   EmptyState,
   HubDefault,
-  KbStatsCard,
   RaptorPanel,
   ReindexModal,
   type ActionsMenuLabels,
   type DeleteDialogLabels,
   type EmptyStateLabels,
   type HubDefaultLabels,
-  type KbStatsCardLabels,
   type KbPdf,
   type PdfAction,
   type RaptorPanelLabels,
@@ -199,28 +197,11 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
     },
   };
 
-  const statsCardLabels: KbStatsCardLabels = {
-    cardTitle: t('pages.library.gameDetail.kb.stats.cardTitle'),
-    cardSubtitle: t('pages.library.gameDetail.kb.stats.cardSubtitle'),
-    docsLabel: t('pages.library.gameDetail.kb.stats.docsLabel'),
-    chunksLabel: t('pages.library.gameDetail.kb.stats.chunksLabel'),
-    embeddingsLabel: t('pages.library.gameDetail.kb.stats.embeddingsLabel'),
-    lastReindexLabel: t('pages.library.gameDetail.kb.stats.lastReindexLabel'),
-    raptorLabel: t('pages.library.gameDetail.kb.stats.raptorLabel'),
-    coverageLabel: t('pages.library.gameDetail.kb.stats.coverageLabel'),
-    coverage: {
-      None: t('pages.library.gameDetail.kb.stats.coverage.None'),
-      Basic: t('pages.library.gameDetail.kb.stats.coverage.Basic'),
-      Standard: t('pages.library.gameDetail.kb.stats.coverage.Standard'),
-      Complete: t('pages.library.gameDetail.kb.stats.coverage.Complete'),
-    },
-    lifetimeCostLabel: t('pages.library.gameDetail.kb.stats.lifetimeCostLabel'),
-    sparklineLabel: t('pages.library.gameDetail.kb.stats.sparklineLabel'),
-    sparklineStart: t('pages.library.gameDetail.kb.stats.sparklineStart'),
-    sparklineEnd: t('pages.library.gameDetail.kb.stats.sparklineEnd'),
-    indexingBadge: t('pages.library.gameDetail.kb.stats.indexingBadge'),
-    indexingDescription: t('pages.library.gameDetail.kb.stats.indexingDescription'),
-  };
+  // F7 #1974: KbStatsCard labels removed from the user-facing kb page —
+  // the same data lives in the HubDefault stats strip. Translation keys
+  // under `pages.library.gameDetail.kb.stats.*` stay in the locale files
+  // because the KbStatsCard component is still consumed by admin / dev
+  // surfaces (see `@/components/features/kb-hub` barrel exports).
 
   const raptorLabels: RaptorPanelLabels = {
     title: t('pages.library.gameDetail.kb.raptor.title'),
@@ -368,13 +349,15 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
             indexingPending={indexingPending}
           />
 
-          <KbStatsCard
-            documentCount={status?.documentCount ?? 0}
-            coverageLevel={status?.coverageLevel ?? 'None'}
-            coverageScore={status?.coverageScore ?? 0}
-            labels={statsCardLabels}
-            indexingPending={indexingPending}
-          />
+          {/*
+            F7 #1974 (audit 2026-06-07): KbStatsCard removed from the
+            primary `/library/[gameId]/kb` layout. The mockup ships the
+            same `documentCount + coverage` info inside the HubDefault
+            stats strip; rendering a separate card below was pure UI
+            redundancy. The component itself stays in the
+            `@/components/features/kb-hub` barrel for the admin /
+            embedded surfaces that still want a dedicated card.
+          */}
 
           <RaptorPanel tier="free" labels={raptorLabels} />
         </>


### PR DESCRIPTION
## Summary

F7 audit finding (#1974): `/library/[gameId]/kb` rendered the HubDefault stats strip in the header AND a dedicated KbStatsCard underneath. Both surfaces showed the same data — implicit UI redundancy per the mockup.

## Fix

Drop the KbStatsCard mount + labels block from `_content.tsx`. The component itself stays in the kb-hub barrel for admin / embedded surfaces; translation keys also stay in the locale files (no churn for callers we don't own).

## Tests

- Indexing-banner test: assert only the HubDefault banner remains; the card slot is absent.
- HubDefault+RaptorPanel test: assert `kb-hub-stats-card` is NOT in the DOM (was previously asserting WAS present).

## Verification

- 9/9 KbHubContent.test.tsx green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)