### PR TITLE
feat(kb-hub): per-doc processing-state badges on PdfRow (#1974 F6)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
@@ -165,13 +165,16 @@ function renderWithIntl(node: ReactNode): ReturnType<typeof render> {
 
 const GAME_ID = '11111111-1111-1111-1111-111111111111';
 
-function pdfFixture(overrides: Partial<{ id: string; name: string; bytes: number }> = {}): {
+function pdfFixture(
+  overrides: Partial<{ id: string; name: string; bytes: number; processingState: string }> = {}
+): {
   id: string;
   name: string;
   pageCount: number;
   fileSizeBytes: number;
   uploadedAt: string;
   source: 'Custom';
+  processingState: string;
 } {
   return {
     id: overrides.id ?? 'p1',
@@ -180,6 +183,9 @@ function pdfFixture(overrides: Partial<{ id: string; name: string; bytes: number
     fileSizeBytes: overrides.bytes ?? 47185920,
     uploadedAt: '2026-05-20T00:00:00Z',
     source: 'Custom',
+    // F6 #1974: BE field — keeps the orchestrator default-mapping path
+    // exercised when tests don't care, and lets specific tests override.
+    processingState: overrides.processingState ?? 'Ready',
   };
 }
 
@@ -353,6 +359,79 @@ describe('KbHubContent orchestrator (Issue #1481)', () => {
     expect(container.querySelector('[data-slot="kb-hub-stats-card"]')).not.toBeInTheDocument();
     expect(container.querySelector('[data-slot="kb-hub-raptor-panel"]')).toBeInTheDocument();
     expect(container.querySelectorAll('[data-slot="kb-hub-pdf-row"]')).toHaveLength(2);
+  });
+
+  describe('F6 #1974 — per-doc processing-state badges', () => {
+    function withReadyStatus() {
+      mockUseUserKbStatus.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          gameId: GAME_ID,
+          isIndexed: true,
+          documentCount: 1,
+          coverageScore: 70,
+          coverageLevel: 'Standard',
+          suggestedQuestions: [],
+        },
+      });
+    }
+
+    it('renders the "Ready" badge when BE ProcessingState=Ready', () => {
+      withReadyStatus();
+      mockUseGamePdfs.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: [pdfFixture({ id: 'p1', processingState: 'Ready' })],
+      });
+      const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+      const badge = container.querySelector('[data-slot="kb-hub-pdf-status"]');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute('data-status', 'ready');
+    });
+
+    it('collapses BE transient phases (Pending|Uploading|Extracting|Chunking|Embedding|Indexing) to the "indexing" badge', () => {
+      const phases = ['Pending', 'Uploading', 'Extracting', 'Chunking', 'Embedding', 'Indexing'];
+      for (const phase of phases) {
+        withReadyStatus();
+        mockUseGamePdfs.mockReturnValue({
+          isLoading: false,
+          isError: false,
+          data: [pdfFixture({ id: 'p1', processingState: phase })],
+        });
+        const { container, unmount } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+        const badge = container.querySelector('[data-slot="kb-hub-pdf-status"]');
+        expect(badge, `phase=${phase}`).toBeInTheDocument();
+        expect(badge, `phase=${phase}`).toHaveAttribute('data-status', 'indexing');
+        unmount();
+      }
+    });
+
+    it('renders the "Failed" badge when BE ProcessingState=Failed', () => {
+      withReadyStatus();
+      mockUseGamePdfs.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: [pdfFixture({ id: 'p1', processingState: 'Failed' })],
+      });
+      const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+      const badge = container.querySelector('[data-slot="kb-hub-pdf-status"]');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute('data-status', 'failed');
+    });
+
+    it('defaults to the "indexing" badge for unknown BE states (forward-compat)', () => {
+      withReadyStatus();
+      mockUseGamePdfs.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: [pdfFixture({ id: 'p1', processingState: 'SomeNewPhaseTheBeAddsLater' })],
+      });
+      const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+      const badge = container.querySelector('[data-slot="kb-hub-pdf-status"]');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute('data-status', 'indexing');
+    });
   });
 
   it('opens reindex modal when reindex-all CTA clicked', () => {

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -32,6 +32,7 @@ import {
   type HubDefaultLabels,
   type KbPdf,
   type PdfAction,
+  type PdfStatus,
   type RaptorPanelLabels,
   type ReindexCostRow,
   type ReindexModalLabels,
@@ -81,13 +82,46 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+/**
+ * F6 #1974 (audit 2026-06-07): map the BE `GamePdfDto.ProcessingState`
+ * (Pending|Uploading|Extracting|Chunking|Embedding|Indexing|Ready|Failed)
+ * to the FE `PdfStatus` union (ready|indexing|stale|failed) so PdfRow
+ * can render a colored status badge per the mockup.
+ *
+ * Mapping rationale: every transient pipeline phase collapses to
+ * "indexing" because the FE only renders one in-progress badge. "Ready"
+ * is the only success terminal; "Failed" surfaces explicitly so the
+ * user can retry. Unknown values fall back to "indexing" to avoid a
+ * confidently-wrong success state when the BE adds a new phase later.
+ * The "stale" badge has no BE source today — reserved for a future
+ * Issue when re-embedding gates land.
+ */
+function mapProcessingStateToPdfStatus(state: string): PdfStatus {
+  switch (state) {
+    case 'Ready':
+      return 'ready';
+    case 'Failed':
+      return 'failed';
+    case 'Pending':
+    case 'Uploading':
+    case 'Extracting':
+    case 'Chunking':
+    case 'Embedding':
+    case 'Indexing':
+    default:
+      return 'indexing';
+  }
+}
+
 function mapPdfs(pdfs: ReadonlyArray<GamePdfDto>): ReadonlyArray<KbPdf> {
   return pdfs.map(p => ({
     id: p.id,
     name: p.name,
     sizeFormatted: formatFileSize(p.fileSizeBytes),
     uploadedAtRelative: formatRelativeDate(p.uploadedAt),
-    // status + chunks deferred (P83 — BE schema doesn't expose them yet)
+    // F6 #1974: wire BE ProcessingState → PdfRow status badge.
+    status: mapProcessingStateToPdfStatus(p.processingState),
+    // chunks deferred (P83 — BE schema doesn't expose per-doc chunk counts yet)
   }));
 }
 

--- a/apps/web/src/components/features/kb-hub/PdfRow.tsx
+++ b/apps/web/src/components/features/kb-hub/PdfRow.tsx
@@ -82,6 +82,7 @@ export function PdfRow(props: PdfRowProps): ReactElement {
       {pdf.status ? (
         <span
           data-slot="kb-hub-pdf-status"
+          data-status={pdf.status}
           className={clsx(
             'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-display text-[10px] font-bold uppercase tracking-wider',
             STATUS_BG[pdf.status]

--- a/apps/web/src/lib/api/schemas/pdf.schemas.ts
+++ b/apps/web/src/lib/api/schemas/pdf.schemas.ts
@@ -59,6 +59,12 @@ export const GamePdfDtoSchema = z.object({
   uploadedAt: z.string().datetime({ offset: true }),
   source: z.string(), // "Custom" or "Catalog"
   language: z.string().nullable().optional(),
+  // F6 #1974 (audit 2026-06-07): the BE `GamePdfDto` ships
+  // `ProcessingState` (Pending|Uploading|Extracting|Chunking|Embedding|
+  // Indexing|Ready|Failed) but the FE was discarding it, so PdfRow had
+  // no per-doc status badge. Default "Pending" keeps legacy / not-yet-
+  // redeployed BE payloads parsing without throwing.
+  processingState: z.string().default('Pending'),
 });
 
 export type GamePdfDto = z.infer<typeof GamePdfDtoSchema>;


### PR DESCRIPTION
## Summary

F6 audit finding (#1974): mockup ships colored status badges per PDF row (Ready · Indexing · Failed) but live shipped only "name + size + uploaded + Apri dettaglio" because the FE was discarding the BE `GamePdfDto.ProcessingState` field. The PdfRow primitive already had a conditional badge slot — it just never received data.

## Fix

- **`pdf.schemas.ts`**: extend `GamePdfDtoSchema` with `processingState` (default "Pending" so legacy / not-yet-redeployed BE payloads parse without throwing).
- **`_content.tsx` `mapPdfs`**: BE `ProcessingState` → FE `PdfStatus` union via switch.
  - Pending|Uploading|Extracting|Chunking|Embedding|Indexing → `indexing`
  - Ready → `ready`
  - Failed → `failed`
  - Unknown → `indexing` (forward-compat: don't leak as success)
- **`PdfRow.tsx`**: add `data-status` attribute on the badge span (test scoping, no visual change).

## Tests

- 4 new regression guards: Ready / 6 transient phases collapse to indexing / Failed / unknown forward-compat.
- `pdfFixture` extended with optional `processingState` override.

## Verification

- 13/13 KbHubContent.test.tsx green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)