### PR TITLE
feat(library): i18n + polished empty state for catalog search (#1974 F2.2 T1+T2)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/CatalogSearchStep.tsx
+++ b/apps/web/src/app/(authenticated)/library/CatalogSearchStep.tsx
@@ -12,6 +12,14 @@
  * - "Already in library" disabled state via useGameInLibraryStatus
  * - Calls POST /api/v1/library/games/{gameId} on select via useAddGameToLibrary
  * - On success → calls onSelect(gameId, gameName) to advance wizard to PDF step
+ *
+ * F2.2 #1974 (audit 2026-06-07) T1+T2:
+ *   T1 — all hardcoded EN strings moved to `pages.library.addGame.catalog.*`
+ *        i18n keys (it.json + en.json) so the catalog step reads in Italian
+ *        for the IT-default user base.
+ *   T2 — empty-results state upgraded from a single muted line to a
+ *        first-class block with heading + subtitle so an empty search
+ *        feels like a real state, not a render glitch.
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -24,6 +32,7 @@ import { toast } from '@/components/layout';
 import { Button } from '@/components/ui/primitives/button';
 import { useGameInLibraryStatus, useSharedGames } from '@/hooks/queries';
 import { useAddGameToLibrary } from '@/hooks/queries/useLibrary';
+import { useTranslation } from '@/hooks/useTranslation';
 import type { SharedGame } from '@/lib/api';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -37,9 +46,15 @@ interface SelectableGameCardProps {
   game: SharedGame;
   onSelect: (gameId: string, gameName: string) => void;
   isSelecting: boolean;
+  labels: {
+    noImage: string;
+    inLibraryBadge: string;
+    alreadyInLibrary: string;
+    selectCta: string;
+  };
 }
 
-function SelectableGameCard({ game, onSelect, isSelecting }: SelectableGameCardProps) {
+function SelectableGameCard({ game, onSelect, isSelecting, labels }: SelectableGameCardProps) {
   const { data: status } = useGameInLibraryStatus(game.id);
   const inLibrary = status?.inLibrary ?? false;
 
@@ -64,7 +79,7 @@ function SelectableGameCard({ game, onSelect, isSelecting }: SelectableGameCardP
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center text-muted-foreground text-xs">
-            No image
+            {labels.noImage}
           </div>
         )}
         {inLibrary && (
@@ -72,17 +87,14 @@ function SelectableGameCard({ game, onSelect, isSelecting }: SelectableGameCardP
             data-testid={`catalog-card-${game.id}-in-library-badge`}
             className="absolute top-1.5 right-1.5 bg-green-600 text-white text-xs font-medium px-1.5 py-0.5 rounded"
           >
-            In library
+            {labels.inLibraryBadge}
           </div>
         )}
       </div>
 
       {/* Info */}
       <div className="p-3 flex flex-col gap-2 flex-1">
-        <p
-          className="font-medium text-sm leading-tight line-clamp-2"
-          title={game.title}
-        >
+        <p className="font-medium text-sm leading-tight line-clamp-2" title={game.title}>
           {game.title}
         </p>
         {game.yearPublished > 0 && (
@@ -96,7 +108,7 @@ function SelectableGameCard({ game, onSelect, isSelecting }: SelectableGameCardP
           data-testid={`catalog-card-${game.id}-select-btn`}
           className="mt-auto w-full"
         >
-          {inLibrary ? 'Already in library' : 'Select'}
+          {inLibrary ? labels.alreadyInLibrary : labels.selectCta}
         </Button>
       </div>
     </div>
@@ -118,6 +130,37 @@ function CardSkeleton() {
   );
 }
 
+// ─── Empty state (F2.2 T2) ────────────────────────────────────────────────────
+
+interface CatalogSearchEmptyStateProps {
+  search: string;
+  heading: string;
+  subtitle: string;
+  emptyTemplate: string;
+}
+
+function CatalogSearchEmptyState({
+  search,
+  heading,
+  subtitle,
+  emptyTemplate,
+}: CatalogSearchEmptyStateProps) {
+  return (
+    <div
+      className="col-span-full flex flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-muted/20 px-6 py-10 text-center"
+      data-testid="catalog-search-empty"
+      role="status"
+    >
+      <span aria-hidden="true" className="text-3xl">
+        🔎
+      </span>
+      <h3 className="text-base font-semibold text-foreground">{heading}</h3>
+      <p className="text-sm text-muted-foreground">{emptyTemplate.replace('{search}', search)}</p>
+      <p className="text-xs text-muted-foreground">{subtitle}</p>
+    </div>
+  );
+}
+
 // ─── Main step ────────────────────────────────────────────────────────────────
 
 interface CatalogSearchStepProps {
@@ -131,6 +174,7 @@ interface CatalogSearchStepProps {
 }
 
 export function CatalogSearchStep({ onSelect, onBack }: CatalogSearchStepProps) {
+  const { t } = useTranslation();
   const [rawSearch, setRawSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [page, setPage] = useState(1);
@@ -163,18 +207,25 @@ export function CatalogSearchStep({ onSelect, onBack }: CatalogSearchStepProps) 
       setSelectingId(gameId);
       try {
         await addMutation.mutateAsync({ gameId });
-        toast.success(`"${gameName}" added to your library!`);
+        toast.success(t('pages.library.addGame.catalog.toastAdded', { gameName }));
         onSelect(gameId, gameName);
       } catch {
-        toast.error(`Could not add "${gameName}". Please try again.`);
+        toast.error(t('pages.library.addGame.catalog.toastError', { gameName }));
       } finally {
         setSelectingId(null);
       }
     },
-    [addMutation, onSelect],
+    [addMutation, onSelect, t]
   );
 
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
+
+  const cardLabels = {
+    noImage: t('pages.library.addGame.catalog.noImage'),
+    inLibraryBadge: t('pages.library.addGame.catalog.inLibraryBadge'),
+    alreadyInLibrary: t('pages.library.addGame.catalog.alreadyInLibrary'),
+    selectCta: t('pages.library.addGame.catalog.selectCta'),
+  };
 
   return (
     <div className="flex flex-col gap-4 px-4 py-4" data-testid="catalog-search-step">
@@ -184,7 +235,7 @@ export function CatalogSearchStep({ onSelect, onBack }: CatalogSearchStepProps) 
           variant="ghost"
           size="icon"
           onClick={onBack}
-          aria-label="Back to choice"
+          aria-label={t('pages.library.addGame.catalog.backAriaLabel')}
           data-testid="catalog-search-back"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -194,16 +245,16 @@ export function CatalogSearchStep({ onSelect, onBack }: CatalogSearchStepProps) 
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
             type="search"
-            placeholder="Search games…"
+            placeholder={t('pages.library.addGame.catalog.searchPlaceholder')}
             value={rawSearch}
-            onChange={(e) => setRawSearch(e.target.value)}
+            onChange={e => setRawSearch(e.target.value)}
             className={[
               'w-full pl-9 pr-3 py-2 text-sm rounded-md',
               'border border-input bg-background',
               'focus:outline-none focus:ring-2 focus:ring-ring',
             ].join(' ')}
             data-testid="catalog-search-input"
-            aria-label="Search games"
+            aria-label={t('pages.library.addGame.catalog.searchAriaLabel')}
           />
         </div>
       </div>
@@ -211,33 +262,33 @@ export function CatalogSearchStep({ onSelect, onBack }: CatalogSearchStepProps) 
       {/* Results count */}
       {data && (
         <p className="text-xs text-muted-foreground" data-testid="catalog-search-count">
-          {data.total} game{data.total !== 1 ? 's' : ''} found
+          {t('pages.library.addGame.catalog.resultCount', { count: data.total })}
         </p>
       )}
 
       {/* Grid */}
-      <div
-        className="grid grid-cols-2 sm:grid-cols-3 gap-3"
-        data-testid="catalog-search-grid"
-      >
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3" data-testid="catalog-search-grid">
         {isLoading
           ? Array.from({ length: PAGE_SIZE }).map((_, i) => <CardSkeleton key={i} />)
-          : data?.items.map((game) => (
+          : data?.items.map(game => (
               <SelectableGameCard
                 key={game.id}
                 game={game}
                 onSelect={handleSelect}
                 isSelecting={selectingId === game.id}
+                labels={cardLabels}
               />
             ))}
 
         {!isLoading && data?.items.length === 0 && (
-          <p
-            className="col-span-full text-center text-sm text-muted-foreground py-8"
-            data-testid="catalog-search-empty"
-          >
-            No games found for &quot;{debouncedSearch}&quot;.
-          </p>
+          <CatalogSearchEmptyState
+            search={debouncedSearch}
+            heading={t('pages.library.addGame.catalog.emptyResultsHeading')}
+            subtitle={t('pages.library.addGame.catalog.emptyResultsSubtitle')}
+            emptyTemplate={t('pages.library.addGame.catalog.emptyResults', {
+              search: debouncedSearch,
+            })}
+          />
         )}
       </div>
 

--- a/apps/web/src/app/(authenticated)/library/__tests__/CatalogSearchStep.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/CatalogSearchStep.test.tsx
@@ -13,9 +13,11 @@
  * - Back button calls onBack
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+
+import { renderWithIntl } from '@/__tests__/fixtures/common-fixtures';
 
 import { CatalogSearchStep } from '../CatalogSearchStep';
 
@@ -92,13 +94,40 @@ function makeGamesData(items = [GAME_1, GAME_2], total = 2) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function renderStep(props: {
-  onSelect?: (id: string, name: string) => void;
-  onBack?: () => void;
-} = {}) {
+// F2.2 #1974 T1: CatalogSearchStep is now i18n-aware; provide the new
+// `pages.library.addGame.catalog.*` keys to the IntlProvider so the
+// EN-default assertion strings below (e.g. "2 games found") still match.
+const I18N_MESSAGES: Record<string, string> = {
+  'pages.library.addGame.catalog.backAriaLabel': 'Back to choice',
+  'pages.library.addGame.catalog.searchPlaceholder': 'Search games…',
+  'pages.library.addGame.catalog.searchAriaLabel': 'Search games',
+  'pages.library.addGame.catalog.noImage': 'No image',
+  'pages.library.addGame.catalog.inLibraryBadge': 'In library',
+  'pages.library.addGame.catalog.alreadyInLibrary': 'Already in library',
+  'pages.library.addGame.catalog.selectCta': 'Select',
+  'pages.library.addGame.catalog.resultCount':
+    '{count, plural, =0 {No games found} =1 {1 game found} other {# games found}}',
+  'pages.library.addGame.catalog.emptyResults': 'No games found for "{search}".',
+  'pages.library.addGame.catalog.emptyResultsHeading': 'No results',
+  'pages.library.addGame.catalog.emptyResultsSubtitle':
+    'Try a different title or check the spelling.',
+  'pages.library.addGame.catalog.toastAdded': '"{gameName}" added to your library!',
+  'pages.library.addGame.catalog.toastError': 'Could not add "{gameName}". Please try again.',
+};
+
+function renderStep(
+  props: {
+    onSelect?: (id: string, name: string) => void;
+    onBack?: () => void;
+  } = {}
+) {
   const onSelect = props.onSelect ?? vi.fn();
   const onBack = props.onBack ?? vi.fn();
-  const result = render(<CatalogSearchStep onSelect={onSelect} onBack={onBack} />);
+  const result = renderWithIntl(
+    <CatalogSearchStep onSelect={onSelect} onBack={onBack} />,
+    undefined,
+    I18N_MESSAGES
+  );
   return { onSelect, onBack, ...result };
 }
 
@@ -270,9 +299,7 @@ describe('CatalogSearchStep', () => {
       renderStep();
 
       expect(screen.getByTestId('catalog-card-g1-in-library-badge')).toBeInTheDocument();
-      expect(
-        screen.queryByTestId('catalog-card-g2-in-library-badge'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('catalog-card-g2-in-library-badge')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2040,7 +2040,22 @@
         "manualLabel": "Add manually",
         "manualDescription": "Enter the game details. You can upload the rulebook and configure the AI agent later from the game detail page.",
         "catalogLabel": "From shared catalog",
-        "catalogDescription": "Search the community catalog and add a game in one click. Rulebook and AI agent setup come later."
+        "catalogDescription": "Search the community catalog and add a game in one click. Rulebook and AI agent setup come later.",
+        "catalog": {
+          "backAriaLabel": "Back to choice",
+          "searchPlaceholder": "Search games…",
+          "searchAriaLabel": "Search games",
+          "noImage": "No image",
+          "inLibraryBadge": "In library",
+          "alreadyInLibrary": "Already in library",
+          "selectCta": "Select",
+          "resultCount": "{count, plural, =0 {No games found} =1 {1 game found} other {# games found}}",
+          "emptyResults": "No games found for \"{search}\".",
+          "emptyResultsHeading": "No results",
+          "emptyResultsSubtitle": "Try a different title or check the spelling.",
+          "toastAdded": "\"{gameName}\" added to your library!",
+          "toastError": "Could not add \"{gameName}\". Please try again."
+        }
       },
       "catalogPagination": {
         "firstPage": "First page",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2090,7 +2090,22 @@
         "manualLabel": "Aggiungi manualmente",
         "manualDescription": "Inserisci i dettagli del gioco. Potrai caricare il regolamento e configurare l'agente AI dalla pagina di dettaglio.",
         "catalogLabel": "Da catalogo condiviso",
-        "catalogDescription": "Cerca nel catalogo della community e aggiungi un gioco con un click. Regolamento e setup agente in seguito."
+        "catalogDescription": "Cerca nel catalogo della community e aggiungi un gioco con un click. Regolamento e setup agente in seguito.",
+        "catalog": {
+          "backAriaLabel": "Torna alla scelta",
+          "searchPlaceholder": "Cerca giochi…",
+          "searchAriaLabel": "Cerca giochi",
+          "noImage": "Nessuna immagine",
+          "inLibraryBadge": "In libreria",
+          "alreadyInLibrary": "Già in libreria",
+          "selectCta": "Seleziona",
+          "resultCount": "{count, plural, =0 {Nessun gioco trovato} =1 {1 gioco trovato} other {# giochi trovati}}",
+          "emptyResults": "Nessun gioco trovato per «{search}».",
+          "emptyResultsHeading": "Nessun risultato",
+          "emptyResultsSubtitle": "Prova con un titolo diverso o controlla l'ortografia.",
+          "toastAdded": "«{gameName}» aggiunto alla tua libreria!",
+          "toastError": "Impossibile aggiungere «{gameName}». Riprova."
+        }
       },
       "catalogPagination": {
         "firstPage": "Prima pagina",


### PR DESCRIPTION
## Summary

F2.2 T1+T2 from the 2026-06-07 audit (#1974) — first two tasks of the 8-task AddGameDrawer rebuild plan, picked up as a quick win.

## T1 — i18n CatalogSearchStep

All hardcoded English ("No image", "In library", "Already in library", "Select", "Search games…", "Back to choice", "{n} game{s} found", "No games found for …", "added to your library!", "Could not add … Please try again.") moved to `pages.library.addGame.catalog.*` (it.json + en.json).

- `useTranslation` wired in `CatalogSearchStep`.
- Selectable card labels passed as a prop bag so the child stays presentational.

## T2 — Empty-results state upgrade

Single muted line replaced with a first-class block: dashed border, 🔎 illustration, `role="status"`, heading + subtitle + searched-term template. Existing `catalog-search-empty` testid preserved; the new block wraps it.

## Tests

Switched the suite to `renderWithIntl` with a self-contained EN message dictionary so the legacy assertions on plural counts and button labels keep passing. 22/22 tests green.

## Verification

- 22/22 CatalogSearchStep.test.tsx green
- `pnpm typecheck` clean

## Out of scope

T3-T8 (focus trap, toast variants, choice card copy, decomposition, etc.) remain as separate sub-issue / future PR work.

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)