### PR TITLE
feat(dashboard): wire BE completed-game-nights endpoint to Recenti slot (#1974 F20)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetCompletedGameNightsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetCompletedGameNightsQuery.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query to get the most recently completed game nights for the dashboard
+/// "Recenti" slot. F20 #1974 (audit 2026-06-07) — Asse C P2 follow-up.
+/// </summary>
+/// <param name="Limit">
+/// Maximum rows to return (DESC by CompletedAt). Defaults to 5 — matches
+/// the dashboard slot's visible card budget without forcing the FE to
+/// page; trimmed further on the FE if needed.
+/// </param>
+internal record GetCompletedGameNightsQuery(int Limit = 5) : IQuery<IReadOnlyList<GameNightDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetCompletedGameNightsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetCompletedGameNightsQueryHandler.cs
@@ -1,0 +1,53 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles retrieval of recently completed game nights.
+/// F20 #1974 (audit 2026-06-07): wires the dashboard "Recenti" slot
+/// (Asse C P2 follow-up). Mirrors <see cref="GetUpcomingGameNightsQueryHandler"/>
+/// in structure — fetches a batch of completed events and enriches them with
+/// the organizer display name via a single user lookup.
+/// </summary>
+internal sealed class GetCompletedGameNightsQueryHandler : IQueryHandler<GetCompletedGameNightsQuery, IReadOnlyList<GameNightDto>>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _context;
+
+    public GetCompletedGameNightsQueryHandler(
+        IGameNightEventRepository repository,
+        MeepleAiDbContext context)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<IReadOnlyList<GameNightDto>> Handle(GetCompletedGameNightsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var events = await _repository.GetCompletedAsync(query.Limit, cancellationToken).ConfigureAwait(false);
+
+        var organizerIds = events.Select(e => e.OrganizerId).Distinct().ToList();
+        var organizerNames = await GetUserDisplayNamesAsync(organizerIds, cancellationToken).ConfigureAwait(false);
+
+        return events.Select(e => GameNightMapperHelper.MapToDto(
+            e, organizerNames.GetValueOrDefault(e.OrganizerId, "Unknown"))).ToList();
+    }
+
+    private async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(List<Guid> userIds, CancellationToken cancellationToken)
+    {
+        var users = await _context.Users
+            .AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Email })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return users.ToDictionary(u => u.Id, u => u.DisplayName ?? u.Email ?? "Unknown");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
@@ -14,6 +14,18 @@ internal interface IGameNightEventRepository : IRepository<GameNightEvent, Guid>
     Task<IReadOnlyList<GameNightEvent>> GetUpcomingAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the most recently completed game nights, DESC by ScheduledAt.
+    /// F20 #1974 (audit 2026-06-07): wires the dashboard "Recenti" slot
+    /// (Asse C P2 follow-up). Also surfaces published events whose
+    /// scheduled time has passed, since the BE does not auto-mark
+    /// Published → Completed on a scheduler.
+    /// </summary>
+    /// <param name="limit">Maximum rows to return (capped at 50 in the
+    /// implementation for safety).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<GameNightEvent>> GetCompletedAsync(int limit, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets game nights where the user is organizer or invited.
     /// </summary>
     Task<IReadOnlyList<GameNightEvent>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -89,6 +89,31 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
         return entities.Select(MapToDomain).ToList();
     }
 
+    public async Task<IReadOnlyList<GameNightEvent>> GetCompletedAsync(int limit, CancellationToken cancellationToken = default)
+    {
+        // F20 #1974: dashboard "Recenti" slot. Sources events whose Status is
+        // "Completed" OR a published event whose scheduled date has already
+        // passed (the BE does not auto-mark Published → Completed on a
+        // scheduler, so we treat past Published events as effectively
+        // completed for the dashboard surface). Ordered DESC by ScheduledAt
+        // since the entity has no explicit CompletedAt column today. The
+        // 50-cap mirrors GetUpcomingAsync; the call-site requests fewer.
+        var cap = Math.Clamp(limit, 1, 50);
+        var now = DateTimeOffset.UtcNow;
+
+        var entities = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .Include(e => e.Sessions)
+            .Where(e => e.Status == nameof(GameNightStatus.Completed)
+                || (e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt < now))
+            .OrderByDescending(e => e.ScheduledAt)
+            .Take(cap)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
     public async Task<IReadOnlyList<GameNightEvent>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         var entities = await DbContext.GameNightEvents

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -45,6 +45,16 @@ internal static class GameNightEndpoints
             .WithSummary("Get my game nights")
             .WithDescription("Retrieves game nights where the user is organizer or invited.");
 
+        // F20 #1974 (audit 2026-06-07): dashboard "Recenti" slot — recently
+        // completed game nights for the Asse C P2 dashboard surface.
+        gameNights.MapGet("/completed", HandleGetCompletedGameNights)
+            .RequireAuthenticatedUser()
+            .Produces<IReadOnlyList<GameNightDto>>(200)
+            .Produces(401)
+            .WithName("GetCompletedGameNights")
+            .WithSummary("Get recently completed game nights")
+            .WithDescription("Retrieves recently completed (or scheduled-in-the-past published) game nights ordered DESC by ScheduledAt. Limit defaults to 5.");
+
         // Issue #950 (W1-PR2): regulars feed for Step 3 wizard suggestion list.
         gameNights.MapGet("/regulars", HandleGetRegulars)
             .RequireAuthenticatedUser()
@@ -459,6 +469,17 @@ internal static class GameNightEndpoints
         CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new GetUpcomingGameNightsQuery(), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    // F20 #1974 (audit 2026-06-07): dashboard "Recenti" slot.
+    private static async Task<IResult> HandleGetCompletedGameNights(
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken,
+        [FromQuery] int? limit = null)
+    {
+        var query = limit.HasValue ? new GetCompletedGameNightsQuery(limit.Value) : new GetCompletedGameNightsQuery();
+        var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -30,7 +30,7 @@ import { useMemo, type ReactElement } from 'react';
 import { useAuth } from '@/components/auth/AuthProvider';
 import { CascadeDrawerHost } from '@/components/dashboard/CascadeDrawerHost';
 import { useActiveSessions } from '@/hooks/queries/useActiveSessions';
-import { useUpcomingGameNights } from '@/hooks/queries/useGameNights';
+import { useCompletedGameNights, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
 import { useGames } from '@/hooks/queries/useGames';
 import { useLibraryStats } from '@/hooks/queries/useLibrary';
 import { useFriendsActivity } from '@/hooks/use-friends-activity';
@@ -73,6 +73,8 @@ export function DashboardClient(): ReactElement {
 
   // ── Data hooks (re-used from Stage 3 + asse-C additions) ─────────────────
   const upcomingGNQuery = useUpcomingGameNights();
+  // F20 #1974: dashboard "Recenti" slot — recently completed game nights.
+  const completedGNQuery = useCompletedGameNights({ limit: 5 });
   const sessionsQuery = useActiveSessions(10);
   const gamesQuery = useGames(undefined, undefined, 1, 20);
   const statsQuery = useLibraryStats();
@@ -112,17 +114,27 @@ export function DashboardClient(): ReactElement {
   );
 
   // ── Slot #2: Recenti (completed GameNights) ──────────────────────────────
-  // BE endpoint for completed GameNights is not yet wired (out of scope T1).
-  // For now we surface an empty section, which RecentiSection renders as `null`
-  // per spec MAJ-6 (silent fallback). When the BE endpoint lands, swap the
-  // empty array for the query result and adapt the projection.
+  // F20 #1974 (audit 2026-06-07): wires the BE `/game-nights/completed`
+  // endpoint shipped alongside this PR. Projection mirrors `prossimiCards`:
+  // map the BE `GameNightDto` to the `RecentiGameNightCard` contract that
+  // `RecentiSection` expects. `sessionCount` defaults to 0 until the BE
+  // surfaces it on the DTO; mini cover thumbnails are not yet exposed
+  // server-side so we pass an empty array (the card primitive already
+  // hides the cover stack in that case).
   const recentiCards = useMemo<ReadonlyArray<RecentiGameNightCard>>(() => {
-    return [];
-  }, []);
+    const data = completedGNQuery.data ?? [];
+    return data.slice(0, 3).map<RecentiGameNightCard>(gn => ({
+      id: gn.id,
+      title: gn.title,
+      date: gn.scheduledAt,
+      sessionCount: 0,
+      gamePreviewThumbnails: [],
+    }));
+  }, [completedGNQuery.data]);
 
   const recentiState: RecentiSectionState = deriveSectionState(
-    /* isLoading */ false,
-    /* isError */ false,
+    completedGNQuery.isLoading,
+    completedGNQuery.isError,
     recentiCards.length
   );
 
@@ -216,9 +228,8 @@ export function DashboardClient(): ReactElement {
           state={recentiState}
           gameNights={recentiCards}
           onRetry={() => {
-            // Placeholder until BE completed-GN endpoint lands; we refetch the
-            // upcoming source so the user gets *some* fresh data on retry.
-            void upcomingGNQuery.refetch();
+            // F20 #1974: wired to the completed-GN endpoint.
+            void completedGNQuery.refetch();
           }}
         />
 

--- a/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
@@ -56,6 +56,13 @@ vi.mock('@/hooks/queries/useGameNights', () => ({
     isError: false,
     refetch: refetchUpcoming,
   })),
+  // F20 #1974: dashboard "Recenti" slot.
+  useCompletedGameNights: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  })),
 }));
 
 vi.mock('@/hooks/queries/useLibrary', () => ({

--- a/apps/web/src/hooks/queries/useGameNights.ts
+++ b/apps/web/src/hooks/queries/useGameNights.ts
@@ -15,6 +15,9 @@ import type {
 export const gameNightKeys = {
   all: ['game-nights'] as const,
   upcoming: () => [...gameNightKeys.all, 'upcoming'] as const,
+  // F20 #1974: dashboard "Recenti" key; `limit` belongs to the key so
+  // different page sizes don't collide on the React Query cache.
+  completed: (limit?: number) => [...gameNightKeys.all, 'completed', limit ?? 5] as const,
   mine: () => [...gameNightKeys.all, 'mine'] as const,
   detail: (id: string) => [...gameNightKeys.all, id] as const,
   rsvps: (id: string) => [...gameNightKeys.all, id, 'rsvps'] as const,
@@ -27,6 +30,22 @@ export function useUpcomingGameNights(
   return useQuery({
     queryKey: gameNightKeys.upcoming(),
     queryFn: () => api.gameNights.getUpcoming(),
+    enabled,
+    ...(retry !== undefined ? { retry } : {}),
+  });
+}
+
+/**
+ * F20 #1974 (audit 2026-06-07): dashboard "Recenti" slot — recently
+ * completed game nights for the Asse C P2 dashboard surface.
+ */
+export function useCompletedGameNights(
+  options: { limit?: number; enabled?: boolean; retry?: number | boolean } = {}
+) {
+  const { limit, enabled = true, retry } = options;
+  return useQuery({
+    queryKey: gameNightKeys.completed(limit),
+    queryFn: () => api.gameNights.getCompleted(limit),
     enabled,
     ...(retry !== undefined ? { retry } : {}),
   });

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -23,6 +23,8 @@ import type { HttpClient } from '../core/httpClient';
 
 export interface GameNightsClient {
   getUpcoming(): Promise<GameNightDto[]>;
+  // F20 #1974: dashboard "Recenti" slot — recently completed game nights.
+  getCompleted(limit?: number): Promise<GameNightDto[]>;
   getMine(): Promise<GameNightDto[]>;
   getById(id: string): Promise<GameNightDto>;
   getRsvps(id: string): Promise<GameNightRsvpDto[]>;
@@ -45,6 +47,18 @@ export function createGameNightsClient({
   return {
     async getUpcoming() {
       const data = await httpClient.get<GameNightDto[]>('/api/v1/game-nights');
+      return z.array(GameNightDtoSchema).parse(data ?? []);
+    },
+
+    async getCompleted(limit) {
+      // F20 #1974: dashboard "Recenti" slot. `limit` is forwarded as a
+      // query param; the BE clamps to [1, 50] and defaults to 5 when
+      // omitted.
+      const url =
+        limit != null
+          ? `/api/v1/game-nights/completed?limit=${limit}`
+          : '/api/v1/game-nights/completed';
+      const data = await httpClient.get<GameNightDto[]>(url);
       return z.array(GameNightDtoSchema).parse(data ?? []);
     },
 


### PR DESCRIPTION
## Summary

F20 audit finding (#1974): the dashboard "Recenti completati" section was rendering as `null` because the BE endpoint hadn't been wired (`recentiCards = []` placeholder per `DashboardClient` comment). The Asse C P2 follow-up never landed, so the slot has been silently empty since dashboard launch.

## Backend

- **`IGameNightEventRepository.GetCompletedAsync(int limit, ct)`**: new method returning Completed events DESC by ScheduledAt, plus Published events whose ScheduledAt has already passed (BE doesn't auto-mark Published → Completed on a scheduler). Implementation caps `limit` to [1, 50].
- **`GetCompletedGameNightsQuery(Limit = 5)` + handler** — mirrors `GetUpcoming` pair, organizer-name enrichment via single user lookup.
- **`GET /api/v1/game-nights/completed?limit={n}`** endpoint registered in `GameNightEndpoints`.

## Frontend

- **`gameNightsClient.getCompleted(limit?)`** — same Zod parse path as `getUpcoming`.
- **`useCompletedGameNights({ limit, enabled, retry })`** hook + `gameNightKeys.completed(limit)` cache key.
- **`DashboardClient` Slot #2** — projection swapped from `[]` to `completedGNQuery.data.slice(0, 3).map(...)`; `recentiState` derived from new query; `onRetry` re-points to `completedGNQuery.refetch()`. `sessionCount = 0` + `gamePreviewThumbnails = []` because BE DTO doesn't surface those fields yet.

## Tests

- `useCompletedGameNights` mock added to dashboard suite's `vi.mock('@/hooks/queries/useGameNights', …)` block.
- 7/7 dashboard tests stay green.
- BE builds clean.

## Verification

- `pnpm typecheck` clean
- `dotnet build` clean
- 7/7 DashboardClient.test.tsx green

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)