### PR TITLE
feat(chat): i18n + optional agent meta block on ChatInfoPanel (#1974 F11 polish)

### DIFF
--- a/apps/web/src/components/chat-unified/ChatInfoPanel.tsx
+++ b/apps/web/src/components/chat-unified/ChatInfoPanel.tsx
@@ -2,15 +2,24 @@
  * ChatInfoPanel - Right sidebar panel for ChatThreadView (desktop only)
  *
  * Shows:
+ * - Agent meta (name + type, F11 #1974 polish)
  * - Game info (linked game title)
  * - Citations from assistant messages
  * - Suggested follow-up questions
+ *
+ * F11 #1974 (audit 2026-06-07) polish:
+ * - Hardcoded IT strings ("Gioco collegato", "Citazioni (N)", "Domande
+ *   suggerite") moved to `chat.infoPanel.*` i18n keys (it.json + en.json).
+ * - Optional `agent` section added at the top — renders only when the
+ *   parent passes an agent prop, so legacy consumers (no agent context)
+ *   are unaffected.
  */
 
 'use client';
 
 import React from 'react';
 
+import { useTranslation } from '@/hooks/useTranslation';
 import type { Citation } from '@/types';
 
 import { CitationBadge } from './CitationBadge';
@@ -19,11 +28,23 @@ import { CitationBadge } from './CitationBadge';
 // Types
 // ============================================================================
 
+export interface ChatInfoPanelAgentMeta {
+  /** Display-ready name (e.g. "Tutor", "Auto (Orchestrator)"). */
+  readonly name: string;
+  /** Optional typology label (e.g. "tutor", "auto"). Surfaced for power users. */
+  readonly typology?: string;
+}
+
 export interface ChatInfoPanelProps {
   game: { id: string; title: string } | null;
   citations: Citation[];
   suggestedQuestions: string[];
   onQuestionClick: (question: string) => void;
+  /**
+   * F11 #1974: optional agent meta block at the top of the panel. Hidden when
+   * undefined so threads without an agent context still render cleanly.
+   */
+  agent?: ChatInfoPanelAgentMeta;
 }
 
 // ============================================================================
@@ -35,19 +56,38 @@ export function ChatInfoPanel({
   citations,
   suggestedQuestions,
   onQuestionClick,
+  agent,
 }: ChatInfoPanelProps) {
+  const { t } = useTranslation();
+
   return (
-    <div className="hidden lg:flex w-[340px] flex-shrink-0 flex-col border-l border-border/50 bg-card/50 p-4 overflow-y-auto">
+    <div
+      className="hidden lg:flex w-[340px] flex-shrink-0 flex-col border-l border-border/50 bg-card/50 p-4 overflow-y-auto"
+      data-slot="chat-info-panel"
+    >
+      {agent && (
+        <div className="mb-4" data-slot="chat-info-panel-agent">
+          <h4 className="text-sm font-semibold font-quicksand mb-1">
+            {t('chat.infoPanel.agentSectionHeading')}
+          </h4>
+          <p className="text-xs text-foreground">{agent.name}</p>
+          {agent.typology && (
+            <p className="mt-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+              {t('chat.infoPanel.agentTypeLabel')}: {agent.typology}
+            </p>
+          )}
+        </div>
+      )}
       {game && (
-        <div className="mb-4">
+        <div className="mb-4" data-slot="chat-info-panel-game">
           <h4 className="text-sm font-semibold font-quicksand mb-1">{game.title}</h4>
-          <p className="text-xs text-muted-foreground">Gioco collegato</p>
+          <p className="text-xs text-muted-foreground">{t('chat.infoPanel.linkedGameLabel')}</p>
         </div>
       )}
       {citations.length > 0 && (
-        <div className="mb-4">
+        <div className="mb-4" data-slot="chat-info-panel-citations">
           <h4 className="text-sm font-semibold font-quicksand mb-2">
-            Citazioni ({citations.length})
+            {t('chat.infoPanel.citationsHeading', { count: citations.length })}
           </h4>
           <div className="flex flex-wrap gap-1">
             {citations.slice(0, 20).map((c, i) => (
@@ -57,8 +97,10 @@ export function ChatInfoPanel({
         </div>
       )}
       {suggestedQuestions.length > 0 && (
-        <div>
-          <h4 className="text-sm font-semibold font-quicksand mb-2">Domande suggerite</h4>
+        <div data-slot="chat-info-panel-suggestions">
+          <h4 className="text-sm font-semibold font-quicksand mb-2">
+            {t('chat.infoPanel.suggestedQuestionsHeading')}
+          </h4>
           <div className="space-y-1">
             {suggestedQuestions.map((q, i) => (
               <button

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -900,6 +900,14 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
           citations={allCitations}
           suggestedQuestions={suggestedQuestions}
           onQuestionClick={handleQuestionClick}
+          agent={
+            thread?.agentTypology
+              ? {
+                  name: AGENT_NAMES[(thread.agentTypology as AgentType) ?? 'auto'],
+                  typology: thread.agentTypology,
+                }
+              : undefined
+          }
         />
       </div>
     </div>

--- a/apps/web/src/components/chat-unified/__tests__/ChatInfoPanel.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatInfoPanel.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * ChatInfoPanel — F11 #1974 polish regression tests.
+ *
+ * Verifies the i18n cleanup (chat.infoPanel.* keys) + the new optional
+ * agent meta block introduced by the audit follow-on.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { describe, it, expect, vi } from 'vitest';
+
+import { ChatInfoPanel } from '../ChatInfoPanel';
+
+// Mock the citation badge so this suite doesn't have to feed it a full
+// citation contract — its only purpose here is to verify the panel slot
+// renders when citations are non-empty.
+vi.mock('../CitationBadge', () => ({
+  CitationBadge: ({ citation }: { citation: { documentId: string; pageNumber: number } }) => (
+    <span data-testid={`citation-${citation.documentId}-${citation.pageNumber}`}>citation</span>
+  ),
+}));
+
+const MESSAGES: Record<string, string> = {
+  'chat.infoPanel.linkedGameLabel': 'Linked game',
+  'chat.infoPanel.citationsHeading': 'Citations ({count})',
+  'chat.infoPanel.suggestedQuestionsHeading': 'Suggested questions',
+  'chat.infoPanel.agentSectionHeading': 'Agent',
+  'chat.infoPanel.agentTypeLabel': 'Type',
+};
+
+function renderPanel(props: Partial<React.ComponentProps<typeof ChatInfoPanel>> = {}) {
+  const defaultProps: React.ComponentProps<typeof ChatInfoPanel> = {
+    game: null,
+    citations: [],
+    suggestedQuestions: [],
+    onQuestionClick: vi.fn(),
+  };
+  return render(
+    <IntlProvider locale="en" messages={MESSAGES}>
+      <ChatInfoPanel {...defaultProps} {...props} />
+    </IntlProvider>
+  );
+}
+
+describe('ChatInfoPanel — F11 #1974 polish', () => {
+  it('renders the root slot wrapper', () => {
+    const { container } = renderPanel();
+    expect(container.querySelector('[data-slot="chat-info-panel"]')).toBeInTheDocument();
+  });
+
+  it('does NOT render the agent block when no agent prop is provided', () => {
+    const { container } = renderPanel();
+    expect(container.querySelector('[data-slot="chat-info-panel-agent"]')).not.toBeInTheDocument();
+  });
+
+  it('renders the agent block (name + heading) when agent prop is provided', () => {
+    renderPanel({ agent: { name: 'Tutor' } });
+    expect(screen.getByText('Agent')).toBeInTheDocument();
+    expect(screen.getByText('Tutor')).toBeInTheDocument();
+  });
+
+  it('renders the agent typology label when provided', () => {
+    renderPanel({ agent: { name: 'Tutor', typology: 'tutor' } });
+    expect(screen.getByText(/Type: tutor/)).toBeInTheDocument();
+  });
+
+  it('does NOT render the typology line when agent.typology is omitted', () => {
+    renderPanel({ agent: { name: 'Auto (Orchestrator)' } });
+    expect(screen.queryByText(/Type:/)).not.toBeInTheDocument();
+  });
+
+  it('renders the linked-game label from i18n when game prop is provided', () => {
+    renderPanel({ game: { id: 'g1', title: 'Catan' } });
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('Linked game')).toBeInTheDocument();
+  });
+
+  it('renders the citations heading with the count baked in', () => {
+    renderPanel({
+      citations: [
+        { documentId: 'd1', pageNumber: 1 },
+        { documentId: 'd2', pageNumber: 2 },
+        { documentId: 'd3', pageNumber: 3 },
+        // @ts-expect-error — test fixture, only the fields the badge mock reads matter.
+      ] as Citation[],
+    });
+    expect(screen.getByText('Citations (3)')).toBeInTheDocument();
+  });
+
+  it('renders the suggested-questions heading + buttons from i18n', () => {
+    renderPanel({ suggestedQuestions: ['How do I win?', 'Best opening?'] });
+    expect(screen.getByText('Suggested questions')).toBeInTheDocument();
+    expect(screen.getByText('How do I win?')).toBeInTheDocument();
+    expect(screen.getByText('Best opening?')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -329,7 +329,14 @@
     "send": "Send",
     "sources": "Sources",
     "thinking": "Thinking...",
-    "title": "AI Chat"
+    "title": "AI Chat",
+    "infoPanel": {
+      "linkedGameLabel": "Linked game",
+      "citationsHeading": "Citations ({count})",
+      "suggestedQuestionsHeading": "Suggested questions",
+      "agentSectionHeading": "Agent",
+      "agentTypeLabel": "Type"
+    }
   },
   "common": {
     "all": "All",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -320,7 +320,14 @@
     "send": "Invia",
     "sources": "Fonti",
     "thinking": "Sto pensando...",
-    "title": "Chat AI"
+    "title": "Chat AI",
+    "infoPanel": {
+      "linkedGameLabel": "Gioco collegato",
+      "citationsHeading": "Citazioni ({count})",
+      "suggestedQuestionsHeading": "Domande suggerite",
+      "agentSectionHeading": "Agente",
+      "agentTypeLabel": "Tipo"
+    }
   },
   "common": {
     "all": "Tutti",


### PR DESCRIPTION
## Summary

F11 polish follow-on from the 2026-06-07 audit (#1974): the right sidebar panel was already mounted (`ChatThreadView.tsx:898`, 340px, lg+) but shipped three hardcoded IT labels (Gioco collegato / Citazioni (N) / Domande suggerite) and lacked the agent-meta section the mockup ships at the top of the rail.

## Changes

- **`it.json` + `en.json`**: add `chat.infoPanel.{linkedGameLabel, citationsHeading, suggestedQuestionsHeading, agentSectionHeading, agentTypeLabel}`.
- **`ChatInfoPanel`**: wire `useTranslation`; every previously-IT label resolves via the new keys. Optional `agent?: { name; typology? }` prop renders a small block at the top. `data-slot` attributes added to every section for test scoping.
- **`ChatThreadView`**: pass `agent` from `thread.agentTypology` → `AGENT_NAMES[...]`; null-guard `thread?.`.

## Tests

New `ChatInfoPanel.test.tsx` (8 cases) covers the i18n rendering, the optional agent-block conditional, and the citations heading template. Local `IntlProvider` so the suite doesn't depend on the runtime locales file.

## Verification

- 8/8 ChatInfoPanel.test.tsx green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)