### PR TITLE
feat(game-detail): extend hero meta strip with designer + complexity (#1974 F3 partial)

### DIFF
--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -66,9 +66,24 @@ export function GameDetailDesktop({
 
   const isNotInLibrary = !game;
 
+  // F3 #1974 (audit 2026-06-07, partial): extend the hero meta strip with
+  // designer + complexity entries so the live page surfaces the same
+  // identifier strip the mockup ships (sp4-game-detail.jsx — "designer ·
+  // anno · durata · players · complessità · rating ★"). Each entry is
+  // additive and skipped when the BE doesn't surface the field (catalog
+  // fallback may omit designers; private games never expose complexity).
+  // Ordering follows the mockup so the strip reads left → right as a
+  // scannable identity row.
   const heroMetadata: MeepleCardMetadata[] = [];
+  if (game?.designers && game.designers.length > 0) {
+    const primary = game.designers[0]?.name;
+    if (primary) heroMetadata.push({ label: primary });
+  }
   if (game?.gameYearPublished) {
     heroMetadata.push({ label: String(game.gameYearPublished) });
+  }
+  if (game?.playingTimeMinutes) {
+    heroMetadata.push({ label: `${game.playingTimeMinutes} min` });
   }
   if (game?.minPlayers && game?.maxPlayers) {
     const players =
@@ -77,8 +92,9 @@ export function GameDetailDesktop({
         : `${game.minPlayers}-${game.maxPlayers} giocatori`;
     heroMetadata.push({ label: players });
   }
-  if (game?.playingTimeMinutes) {
-    heroMetadata.push({ label: `${game.playingTimeMinutes} min` });
+  if (game?.complexityRating != null) {
+    // BGG weight comes in [1, 5] — one decimal is enough for the strip.
+    heroMetadata.push({ label: `Complessità ${game.complexityRating.toFixed(1)}` });
   }
 
   const gameConnections = game

--- a/apps/web/src/components/game-detail/__tests__/GameDetailDesktop.test.tsx
+++ b/apps/web/src/components/game-detail/__tests__/GameDetailDesktop.test.tsx
@@ -16,10 +16,20 @@ vi.mock('@/hooks/queries/useLibrary', () => ({
   useLibraryGameDetail: () => mockHookState,
 }));
 
-// Stub the MeepleCard so we don't need its full render tree
+// Stub the MeepleCard so we don't need its full render tree. F3 #1974
+// regression tests need to assert on the metadata strip; render each
+// metadata `label` inside the stub so `toHaveTextContent` can match
+// without pulling the full primitive.
 vi.mock('@/components/ui/data-display/meeple-card/MeepleCard', () => ({
-  MeepleCard: (props: { title?: string }) => (
-    <div data-testid="meeple-card">{props.title ?? 'no title'}</div>
+  MeepleCard: (props: { title?: string; metadata?: Array<{ label: string }> }) => (
+    <div data-testid="meeple-card">
+      {props.title ?? 'no title'}
+      {props.metadata?.map((m, i) => (
+        <span key={`meta-${i}`} data-testid={`meeple-card-meta-${i}`}>
+          {m.label}
+        </span>
+      ))}
+    </div>
   ),
 }));
 
@@ -109,5 +119,33 @@ describe('GameDetailDesktop', () => {
     expect(screen.getByTestId('meeple-card')).toHaveTextContent(/non in libreria/i);
     // Tabs still render (they handle isNotInLibrary internally)
     expect(screen.getByRole('tablist', { name: /dettagli gioco/i })).toBeInTheDocument();
+  });
+
+  it('extends the hero meta strip with designer + complexity when surfaced by the BE (F3 #1974)', () => {
+    // F3 partial: the live page used to show only "anno · giocatori · durata".
+    // The mockup ships the full identifier strip "designer · anno · durata
+    // · giocatori · complessità". This test asserts the additive labels are
+    // present when the catalog fallback enriches the library detail with the
+    // shared-game payload.
+    mockHookState.data = createGame({
+      designers: [{ id: 'd1', name: 'Klaus Teuber' }],
+      complexityRating: 2.3,
+    });
+    renderWithQuery(<GameDetailDesktop gameId={GAME_ID} />);
+    const hero = screen.getByTestId('meeple-card');
+    expect(hero).toHaveTextContent('Klaus Teuber');
+    expect(hero).toHaveTextContent(/Complessit.*2\.3/);
+  });
+
+  it('skips the designer entry when the BE payload omits it (catalog fallback miss)', () => {
+    // Private games / non-catalog entries don't ship designers — the strip
+    // must degrade gracefully (no empty label, no crash).
+    mockHookState.data = createGame({ designers: undefined });
+    renderWithQuery(<GameDetailDesktop gameId={GAME_ID} />);
+    const hero = screen.getByTestId('meeple-card');
+    expect(hero).not.toHaveTextContent('Klaus Teuber');
+    // The other strip items still render.
+    expect(hero).toHaveTextContent('1995');
+    expect(hero).toHaveTextContent('90 min');
   });
 });


### PR DESCRIPTION
## Summary

F3 partial from the 2026-06-07 audit (#1974): the live `/library/[gameId]` hero meta strip shows only "anno · giocatori · durata" while the mockup ships "designer · anno · durata · giocatori · complessità". Designer + complexity were silently dropped even though `LibraryGameDetail` already carries them (designers via catalog fallback in `useLibraryGameDetail`; complexity directly on the BE DTO).

## Fix

`GameDetailDesktop`: build `heroMetadata` in mockup order. Each entry is additive and skipped when the BE doesn't surface it. Complexity uses `toFixed(1)` so BGG weight reads "Complessità 2.3" not "2.3000…".

## Tests

- Extended the MeepleCard stub to render metadata labels inside the testid.
- 2 new cases: designer+complexity present → labels visible; designers omitted → graceful degradation.

## Verification

- 7/7 GameDetailDesktop.test.tsx green
- `pnpm typecheck` clean

## Out of scope

Full F3 rebuild (6-tab nav, descrizione/specifiche/house-rules/documenti sections, inline agent chat, sessions history) remains multi-week scope.

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)