### PR TITLE
fix(library): aria-hidden decorative icons in add-game drawer (#1974 F2.2 T6)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
+++ b/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
@@ -56,7 +56,15 @@ function ChoiceCard({ icon, title, description, onClick, 'data-testid': testId }
       ].join(' ')}
     >
       <div className="flex items-start gap-4">
-        <div className="flex-shrink-0 mt-0.5 text-orange-500">{icon}</div>
+        {/*
+          F2.2 T6 #1974 (audit 2026-06-07, a11y audit): icon is purely
+          decorative — the title + description below already convey the
+          choice. `aria-hidden` keeps screen readers from announcing
+          "image, image" before the meaningful label.
+        */}
+        <div aria-hidden="true" className="flex-shrink-0 mt-0.5 text-orange-500">
+          {icon}
+        </div>
         <div>
           <p className="font-semibold text-foreground">{title}</p>
           <p className="text-sm text-muted-foreground mt-1">{description}</p>

--- a/apps/web/src/app/(authenticated)/library/CatalogSearchStep.tsx
+++ b/apps/web/src/app/(authenticated)/library/CatalogSearchStep.tsx
@@ -238,11 +238,19 @@ export function CatalogSearchStep({ onSelect, onBack }: CatalogSearchStepProps) 
           aria-label={t('pages.library.addGame.catalog.backAriaLabel')}
           data-testid="catalog-search-back"
         >
-          <ArrowLeft className="h-4 w-4" />
+          {/* F2.2 T6 #1974 a11y audit: decorative icon — the button already
+              carries its accessible name via aria-label. */}
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </Button>
 
         <div className="relative flex-1">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          {/* F2.2 T6 #1974 a11y audit: decorative search glyph — the input
+              already carries its accessible name via aria-label + the
+              visible placeholder. */}
+          <Search
+            aria-hidden="true"
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+          />
           <input
             type="search"
             placeholder={t('pages.library.addGame.catalog.searchPlaceholder')}

--- a/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
@@ -139,6 +139,20 @@ describe('AddGameDrawer', () => {
       expect(screen.queryByTestId('user-wizard-client')).not.toBeInTheDocument();
       expect(screen.queryByTestId('catalog-search-step')).not.toBeInTheDocument();
     });
+
+    it('hides decorative choice-card icons from assistive tech (F2.2 T6 #1974)', () => {
+      // T6 a11y audit: the choice cards layer an icon next to the title +
+      // description. The icon is purely decorative — its wrapper must
+      // carry `aria-hidden="true"` so a screen reader announces "Add
+      // manually, Enter the game details…" instead of "image, Add
+      // manually, …". We assert at least one aria-hidden wrapper inside
+      // each choice card.
+      renderDrawer({ open: true });
+      const manualCard = screen.getByTestId('add-game-choice-manual');
+      const catalogCard = screen.getByTestId('add-game-choice-catalog');
+      expect(manualCard.querySelector('[aria-hidden="true"]')).not.toBeNull();
+      expect(catalogCard.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    });
   });
 
   describe('Step 1a: Manual wizard', () => {


### PR DESCRIPTION
## Summary

F2.2 T6 audit finding (#1974) — a11y audit of the AddGameDrawer + CatalogSearchStep. The decorative icons (PenLine / BookOpen on choice cards, ArrowLeft + Search in catalog step) were exposed to assistive tech, so screen readers announced "image, image, Add manually, Enter the game details…" instead of just the meaningful labels.

## Fix

Wrap each decorative icon (or its parent slot in ChoiceCard) in `aria-hidden="true"`. Accessible names continue to be supplied by visible title/description text + existing `aria-label` attrs.

## Tests

- New "hides decorative choice-card icons from assistive tech" case asserts both choice cards expose an `aria-hidden` wrapper.
- CatalogSearchStep suite stays at 22/22.

## Verification

- 24/24 AddGameDrawer.test.tsx green
- 22/22 CatalogSearchStep.test.tsx green
- `pnpm typecheck` clean

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)