### PR TITLE
feat(game-detail): designer + categories + mechanics rows + Descrizione section (#1974 F3 partial)

### DIFF
--- a/apps/web/src/components/game-detail/tabs/GameInfoTab.tsx
+++ b/apps/web/src/components/game-detail/tabs/GameInfoTab.tsx
@@ -59,6 +59,21 @@ export function GameInfoTab({ gameId, variant, isNotInLibrary }: GameTabProps) {
       </h3>
 
       <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-sm">
+        {/*
+          F3 #1974 (audit 2026-06-07, partial): expose Designer in the
+          spec list. The mockup ships designer as a first-class metadata
+          row, and `LibraryGameDetail` already carries it via the catalog
+          fallback in `useLibraryGameDetail`. Hidden when the BE doesn't
+          surface it (private games / non-catalog entries).
+        */}
+        {game.designers && game.designers.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">Designer</dt>
+            <dd className="font-medium text-foreground">
+              {game.designers.map(d => d.name).join(', ')}
+            </dd>
+          </>
+        )}
         {game.gamePublisher && (
           <>
             <dt className="text-muted-foreground">Editore</dt>
@@ -89,6 +104,22 @@ export function GameInfoTab({ gameId, variant, isNotInLibrary }: GameTabProps) {
             <dd className="font-medium text-foreground">{game.complexityRating.toFixed(2)} / 5</dd>
           </>
         )}
+        {game.categories && game.categories.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">Categorie</dt>
+            <dd className="font-medium text-foreground">
+              {game.categories.map(c => c.name).join(', ')}
+            </dd>
+          </>
+        )}
+        {game.mechanics && game.mechanics.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">Meccaniche</dt>
+            <dd className="font-medium text-foreground">
+              {game.mechanics.map(m => m.name).join(', ')}
+            </dd>
+          </>
+        )}
         {game.addedAt && (
           <>
             <dt className="text-muted-foreground">In libreria dal</dt>
@@ -99,10 +130,30 @@ export function GameInfoTab({ gameId, variant, isNotInLibrary }: GameTabProps) {
         )}
       </dl>
 
+      {/*
+        F3 #1974 partial: the description block used to render naked
+        below the dl. Introduce it with a small heading so it reads as
+        a dedicated "Descrizione" section per the mockup; the heading
+        is omitted (along with the block) when the BE doesn't surface a
+        description, so games without one don't show an empty section.
+      */}
       {game.description && (
-        <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
-          {game.description}
-        </p>
+        <section
+          data-testid="game-info-description"
+          className={cn('flex flex-col gap-2', variant === 'desktop' ? 'mt-2' : 'mt-1')}
+        >
+          <h4
+            className={cn(
+              'font-heading font-semibold text-foreground',
+              variant === 'desktop' ? 'text-base' : 'text-sm'
+            )}
+          >
+            Descrizione
+          </h4>
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+            {game.description}
+          </p>
+        </section>
       )}
     </div>
   );

--- a/apps/web/src/components/game-detail/tabs/__tests__/GameInfoTab.test.tsx
+++ b/apps/web/src/components/game-detail/tabs/__tests__/GameInfoTab.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * GameInfoTab — F3 partial #1974 regression tests.
+ *
+ * Validates the spec-list extensions (Designer / Categorie / Meccaniche)
+ * + the new Descrizione section heading introduced as part of the F3
+ * audit follow-on. The mock returns a minimal LibraryGameDetail shape so
+ * the suite doesn't need a real QueryClient or a full BE payload.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GameInfoTab } from '../GameInfoTab';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockState = { data: null as unknown, isLoading: false, isError: false };
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibraryGameDetail: () => mockState,
+}));
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const GAME_ID = '00000000-0000-4000-8000-000000000001';
+
+function baseGame(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    libraryEntryId: 'entry-1',
+    userId: 'user-1',
+    gameId: GAME_ID,
+    addedAt: '2025-01-01T00:00:00Z',
+    notes: null,
+    isFavorite: false,
+    currentState: 'owned',
+    stateChangedAt: null,
+    stateNotes: null,
+    isAvailableForPlay: true,
+    hasCustomPdf: false,
+    hasRagAccess: false,
+    gameTitle: 'Catan',
+    gamePublisher: 'Kosmos',
+    gameYearPublished: 1995,
+    gameIconUrl: null,
+    gameImageUrl: null,
+    description: 'Build, trade, settle.',
+    minPlayers: 3,
+    maxPlayers: 4,
+    playingTimeMinutes: 90,
+    complexityRating: 2.3,
+    averageRating: 7.2,
+    timesPlayed: 5,
+    lastPlayed: null,
+    winRate: null,
+    avgDuration: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockState.data = null;
+  mockState.isLoading = false;
+  mockState.isError = false;
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('GameInfoTab — F3 partial polish (#1974)', () => {
+  it('renders the Descrizione heading + body when the BE surfaces a description', () => {
+    mockState.data = baseGame();
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.getByText('Descrizione')).toBeInTheDocument();
+    expect(screen.getByText('Build, trade, settle.')).toBeInTheDocument();
+    expect(screen.getByTestId('game-info-description')).toBeInTheDocument();
+  });
+
+  it('omits the Descrizione section entirely when the BE returns no description', () => {
+    mockState.data = baseGame({ description: null });
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.queryByText('Descrizione')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('game-info-description')).not.toBeInTheDocument();
+  });
+
+  it('renders the Designer row when surfaced (catalog fallback)', () => {
+    mockState.data = baseGame({
+      designers: [{ id: 'd1', name: 'Klaus Teuber' }],
+    });
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.getByText('Designer')).toBeInTheDocument();
+    expect(screen.getByText('Klaus Teuber')).toBeInTheDocument();
+  });
+
+  it('joins multiple designers with comma-separated names', () => {
+    mockState.data = baseGame({
+      designers: [
+        { id: 'd1', name: 'Klaus Teuber' },
+        { id: 'd2', name: 'Benjamin Teuber' },
+      ],
+    });
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.getByText('Klaus Teuber, Benjamin Teuber')).toBeInTheDocument();
+  });
+
+  it('renders the Categorie row when the BE surfaces categories', () => {
+    mockState.data = baseGame({
+      categories: [
+        { id: 'c1', name: 'Strategy', slug: 'strategy' },
+        { id: 'c2', name: 'Economic', slug: 'economic' },
+      ],
+    });
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.getByText('Categorie')).toBeInTheDocument();
+    expect(screen.getByText('Strategy, Economic')).toBeInTheDocument();
+  });
+
+  it('renders the Meccaniche row when the BE surfaces mechanics', () => {
+    mockState.data = baseGame({
+      mechanics: [{ id: 'm1', name: 'Trading', slug: 'trading' }],
+    });
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.getByText('Meccaniche')).toBeInTheDocument();
+    expect(screen.getByText('Trading')).toBeInTheDocument();
+  });
+
+  it('omits Designer / Categorie / Meccaniche rows when the BE omits them', () => {
+    mockState.data = baseGame(); // no designers, categories, mechanics
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={false} />);
+    expect(screen.queryByText('Designer')).not.toBeInTheDocument();
+    expect(screen.queryByText('Categorie')).not.toBeInTheDocument();
+    expect(screen.queryByText('Meccaniche')).not.toBeInTheDocument();
+  });
+
+  it('omits the description block when the catalog fallback miss yields an empty payload', () => {
+    mockState.data = baseGame({ description: null, designers: undefined, categories: undefined });
+    render(<GameInfoTab gameId={GAME_ID} variant="mobile" isNotInLibrary={false} />);
+    expect(screen.queryByText('Descrizione')).not.toBeInTheDocument();
+  });
+
+  it('returns the not-in-library copy when the gate is on', () => {
+    render(<GameInfoTab gameId={GAME_ID} variant="desktop" isNotInLibrary={true} />);
+    expect(screen.getByText(/Aggiungi questo gioco alla tua libreria/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

F3 partial cut from the 2026-06-07 audit (#1974), follow-on to the hero meta-strip PR (#2005). The `GameInfoTab` spec list was missing the Designer / Categorie / Meccaniche rows the mockup ships, and the description body rendered naked under the dl instead of being introduced by a "Descrizione" section heading.

## Changes

- **`GameInfoTab.tsx`**:
  - Prepend a `Designer` row (joined names) when `game.designers` is non-empty (catalog fallback only).
  - Add `Categorie` + `Meccaniche` rows after `Complessità`, rendered only when the BE surfaces a non-empty list.
  - Wrap the description block in a `<section>` with a `Descrizione` `<h4>` heading + `data-testid="game-info-description"`. The whole block is skipped when `game.description` is null.
- **Tests**: new 9-case suite covers the new rows + description gating (heading present with desc / heading absent without / Designer row present + joined / Categorie + Meccaniche rendering / graceful degradation when BE omits the catalog enrichment).

## Verification

- 9/9 GameInfoTab.test.tsx green
- `pnpm typecheck` clean

## Notes

Second bite-size cut of F3 — meta strip extension (PR #2005) covered the hero, this PR covers the Info tab. Full game-detail rebuild (6 tabs, house rules, inline agent chat, sessions storiche) remains genuine multi-week scope.

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)