### PR TITLE
feat(game-detail): rename tab labels to "Agente" / "Toolkit" (#2010 Strategy 1)

### DIFF
--- a/apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatThreadView.invariants.test.tsx
@@ -89,7 +89,13 @@ vi.mock('../RagEnhancementsBadge', () => ({
   RagEnhancementsBadge: () => <div data-testid="rag-badge-mock" />,
 }));
 
-vi.mock('@/components/chat/ChatInfoPanel', () => ({
+// Path is `chat-unified/ChatInfoPanel` (matches the actual relative import in
+// ChatThreadView). The previous `@/components/chat/ChatInfoPanel` target did
+// not exist, so the mock never intercepted — the real `ChatInfoPanel` loaded,
+// invoked `useTranslation()` without an `<IntlProvider>` ancestor, and crashed
+// the render (`<body><div /></body>` with `[React Intl] Could not find
+// required `intl` object`). Found in #2010 PR CI 2026-06-08.
+vi.mock('@/components/chat-unified/ChatInfoPanel', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ChatInfoPanel: ({ citations, suggestedQuestions }: any) => (
     <div data-testid="chat-info-panel">

--- a/apps/web/src/components/chat-unified/__tests__/ChatThreadView.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/ChatThreadView.test.tsx
@@ -81,8 +81,12 @@ vi.mock('../RagEnhancementsBadge', () => ({
   RagEnhancementsBadge: () => <div data-testid="rag-badge-mock" />,
 }));
 
-// Mock ChatInfoPanel
-vi.mock('@/components/chat/ChatInfoPanel', () => ({
+// Mock ChatInfoPanel — path is `chat-unified/ChatInfoPanel` (the actual relative
+// import in ChatThreadView). The previous `@/components/chat/ChatInfoPanel`
+// target did not exist, so the mock never intercepted — the real component
+// loaded, invoked `useTranslation()` without an `<IntlProvider>` ancestor, and
+// crashed the render. Found in #2010 PR CI 2026-06-08.
+vi.mock('@/components/chat-unified/ChatInfoPanel', () => ({
   ChatInfoPanel: ({ citations, suggestedQuestions }: any) => (
     <div data-testid="chat-info-panel">
       <span data-testid="citation-count">{citations?.length ?? 0}</span>

--- a/apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx
+++ b/apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx
@@ -37,14 +37,16 @@ describe('GameTabsPanel', () => {
 
   it('respects the initialTab prop', () => {
     render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" initialTab="toolbox" />);
-    expect(screen.getByRole('tab', { name: /toolbox/i })).toHaveAttribute('aria-selected', 'true');
+    // Label is "Toolkit" (Newman Strategy 1 — #2010); the underlying tab id is `toolbox`.
+    expect(screen.getByRole('tab', { name: /toolkit/i })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('switches the selected tab on click', () => {
     render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" />);
-    const aiChatTab = screen.getByRole('tab', { name: /ai chat/i });
-    fireEvent.click(aiChatTab);
-    expect(aiChatTab).toHaveAttribute('aria-selected', 'true');
+    // Label is "Agente" (Newman Strategy 1 — #2010); the underlying tab id is `aiChat`.
+    const agentTab = screen.getByRole('tab', { name: /agente/i });
+    fireEvent.click(agentTab);
+    expect(agentTab).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByRole('tab', { name: /info/i })).toHaveAttribute('aria-selected', 'false');
   });
 

--- a/apps/web/src/components/game-detail/mobile/__tests__/GameDetailsDrawer.test.tsx
+++ b/apps/web/src/components/game-detail/mobile/__tests__/GameDetailsDrawer.test.tsx
@@ -35,9 +35,10 @@ describe('GameDetailsDrawer', () => {
 
   it('switches tabs when clicked', () => {
     render(<GameDetailsDrawer open={true} onOpenChange={() => {}} gameId="game-1" />);
-    const aiChatTab = screen.getByRole('tab', { name: /ai chat/i });
-    fireEvent.click(aiChatTab);
-    expect(aiChatTab).toHaveAttribute('aria-selected', 'true');
+    // Label is "Agente" (Newman Strategy 1 — #2010); the underlying tab id is `aiChat`.
+    const agentTab = screen.getByRole('tab', { name: /agente/i });
+    fireEvent.click(agentTab);
+    expect(agentTab).toHaveAttribute('aria-selected', 'true');
   });
 
   it('respects initialTab prop', () => {

--- a/apps/web/src/components/game-detail/tabs/__tests__/types.test.ts
+++ b/apps/web/src/components/game-detail/tabs/__tests__/types.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { GAME_TABS, isGameTabId } from '../types';
+
+// Newman Strategy 1 regression — #2010 spec-panel 2026-06-08.
+// Labels track the sp4-game-detail.jsx mockup; IDs remain stable so existing
+// `?tab=aiChat`/`?tab=toolbox` URLs + legacy `agent/page.tsx` + `toolbox/page.tsx`
+// redirects keep working. If a rename ever happens, ship a proper deprecation
+// strategy (Newman Strategy 2 — redirects + window) — not a silent ID swap.
+
+describe('GAME_TABS', () => {
+  it('keeps tab IDs stable (URL contract)', () => {
+    expect(GAME_TABS.map(t => t.id)).toEqual([
+      'info',
+      'aiChat',
+      'toolbox',
+      'houseRules',
+      'partite',
+    ]);
+  });
+
+  it('renders the sp4-game-detail.jsx mockup labels', () => {
+    const labels = Object.fromEntries(GAME_TABS.map(t => [t.id, t.label]));
+    expect(labels.info).toBe('Info');
+    expect(labels.aiChat).toBe('Agente');
+    expect(labels.toolbox).toBe('Toolkit');
+    expect(labels.houseRules).toBe('House Rules');
+    expect(labels.partite).toBe('Partite');
+  });
+});
+
+describe('isGameTabId', () => {
+  it.each(['info', 'aiChat', 'toolbox', 'houseRules', 'partite'] as const)(
+    'accepts canonical ID %s',
+    id => {
+      expect(isGameTabId(id)).toBe(true);
+    }
+  );
+
+  // Display labels are NOT valid IDs — guards against accidental rename.
+  it.each(['agente', 'toolkit', 'Agente', 'Toolkit'])(
+    'rejects mockup-label string %s as tab ID',
+    label => {
+      expect(isGameTabId(label)).toBe(false);
+    }
+  );
+
+  it.each([null, undefined, '', 'unknown'])('rejects %s', value => {
+    expect(isGameTabId(value)).toBe(false);
+  });
+});

--- a/apps/web/src/components/game-detail/tabs/types.ts
+++ b/apps/web/src/components/game-detail/tabs/types.ts
@@ -48,10 +48,14 @@ export interface GameTabDescriptor {
   icon: string;
 }
 
+// Display labels — IDs are stable (Newman Strategy 1, #2010 spec-panel 2026-06-08):
+// renaming IDs would break `?tab=aiChat`/`?tab=toolbox` deep-links + legacy
+// redirects in `agent/page.tsx` + `toolbox/page.tsx`. Labels are presentation-only
+// and safe to update to match the sp4-game-detail.jsx mockup ("Agente" / "Toolkit").
 export const GAME_TABS: readonly GameTabDescriptor[] = [
   { id: 'info', label: 'Info', icon: '📖' },
-  { id: 'aiChat', label: 'AI Chat', icon: '🤖' },
-  { id: 'toolbox', label: 'Toolbox', icon: '🧰' },
+  { id: 'aiChat', label: 'Agente', icon: '🤖' },
+  { id: 'toolbox', label: 'Toolkit', icon: '🧰' },
   { id: 'houseRules', label: 'House Rules', icon: '🏠' },
   { id: 'partite', label: 'Partite', icon: '🎲' },
 ] as const;


### PR DESCRIPTION
## Summary

- Rename `GAME_TABS` labels `"AI Chat"` → `"Agente"` and `"Toolbox"` → `"Toolkit"` to match the `sp4-game-detail.jsx` mockup
- IDs (`aiChat`, `toolbox`) **unchanged** — preserves existing `?tab=<id>` deep-links + legacy redirects in `library/[gameId]/agent/page.tsx` and `library/[gameId]/toolbox/page.tsx`
- Adds a new regression test asserting IDs remain stable + labels match the mockup + `isGameTabId` rejects mockup-label strings as IDs

## Context

This is the Strategy 1 implementation for **Blocker 4** of issue [#2010](https://github.com/meepleAi-app/meepleai-monorepo/issues/2010). The spec-panel synthesis on 2026-06-08 (Newman + Crispin) concluded that label-only changes are the right default — renaming tab IDs would break user bookmarks, legacy server-side redirects, and Playwright seed scripts, while the mockup intent (Italian display labels) is fully satisfied without any URL contract changes.

Synthesis comment: [#2010 comment-4646733809](https://github.com/meepleAi-app/meepleai-monorepo/issues/2010#issuecomment-4646733809).

## What changed

| File | Change |
|---|---|
| `apps/web/src/components/game-detail/tabs/types.ts` | Label edits + multi-line comment documenting the Strategy 1 rationale |
| `apps/web/src/components/game-detail/tabs/__tests__/types.test.ts` (new) | 15 regression tests — IDs stable, labels match mockup, `isGameTabId` rejects renamed labels as IDs |
| `apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx` | Matcher updates `/toolbox/i` → `/toolkit/i`, `/ai chat/i` → `/agente/i` (consumer tests are otherwise data-driven on `GAME_TABS`) |
| `apps/web/src/components/game-detail/mobile/__tests__/GameDetailsDrawer.test.tsx` | Same matcher update for the mobile drawer test |

## What did NOT change

- `LibroGameDetailView` — separate render path for libro/gamebook games; has its own hardcoded labels out of `GAME_TABS` scope.
- `en.json` `chat.title` i18n key — belongs to the chat feature, not the game-detail tabs.
- JSDoc comments in `agent/page.tsx` and `toolbox/page.tsx` — legacy redirect documentation kept verbatim.
- 3 new tab IDs (`recensioni` / `dischi` / `documenti`) — still gated by blockers 1/2/3 in #2010 (stakeholder input required before they can be added to `GAME_TABS`).

## Verification

- `pnpm vitest run` on 4 targeted suites — **35/35 pass**
- `pnpm typecheck` — clean
- `pnpm lint-staged` (pre-commit) — pass
- Diff scope verified via `git diff --stat`: 4 files, +67 / −9

## Test plan

- [x] Run targeted tests on `types.test.ts` + `GameTabsPanel.test.tsx` + `GameDetailDesktop.test.tsx` + `GameDetailsDrawer.test.tsx`
- [x] Typecheck passes
- [x] No URL contract changes (verified via `tabs/types.ts` IDs untouched)
- [ ] CI green (will follow on PR open)

## Refs

- Issue: #2010 (F3 game-detail rebuild preconditions)
- Companion sub-issue: #2011 (F2.2 AddGameDrawer follow-on, closed earlier today)
- Umbrella: #1974
- Spec-panel synthesis comment: https://github.com/meepleAi-app/meepleai-monorepo/issues/2010#issuecomment-4646733809
- Mockup: `admin-mockups/design_files/sp4-game-detail.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
