### PR TITLE
fix(migrations): #2013 remove duplicate test_run_id columns from Add_TestRunId migration

### DIFF
--- a/apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.cs
@@ -5,24 +5,32 @@
 namespace Api.Infrastructure.Migrations
 {
     /// <summary>
-    /// Consolidates the TestRunId schema drift accumulated across 3 prior PRs:
-    /// - PR #1936 (Issue #1928 Task B, sess.39-40): DEC-B-8 explicit columns on
-    ///   Users + GameNightEvents + GameNightSessions + GameNightRsvps + GameNightInvitations.
-    /// - PR #1951 (Issue #1929 Macro 3a, sess.42): DEC-C-8 on UserLibraryEntries + SharedGames.
-    /// - PR #1954 (Issue #1929 Macro 4, sess.43): UserGameSessions (this PR — adds property).
+    /// Materializes the TestRunId column on the 3 entities NOT already covered by
+    /// `20260606074943_AddSourceEventIdToCounterTables_CF2` (which had silently picked
+    /// up 5 of the 8 drifted columns during its "drift recovery" pass):
+    /// - UserLibraryEntries (PR #1951 / Issue #1929 Macro 3a, sess.42)
+    /// - SharedGames (PR #1951 / Issue #1929 Macro 3a, sess.42)
+    /// - UserGameSessions/game_sessions (PR #1954 / Issue #1929 Macro 4, sess.43 — this PR)
     ///
-    /// In all 3 PRs the TestRunId property + EF configuration were added to the entity
-    /// model, but the column was materialized only via `EnsureCreatedAsync` inside the
-    /// `SharedTestcontainersFixture` integration test fixture. No EF Core migration was
-    /// generated, leaving `MeepleAiDbContextModelSnapshot` out-of-sync with the entity
-    /// classes. This migration adds the column physically to all 8 tables in a single
-    /// `Up()` to reconcile the snapshot with the model.
+    /// **2026-06-08 fix (Issue #2013, smoke failure):** the original Up() called
+    /// `AddColumn` on all 8 tables, but the prior CF2 migration had already added
+    /// `test_run_id` to 5 of them (users, game_night_events, game_night_invitations,
+    /// game_night_rsvps, game_night_sessions). On a fresh DB the CF2 migration runs
+    /// first (older timestamp) and the consolidation here then fails on the first
+    /// duplicate AddColumn with "column already exists". This crashed the API at
+    /// startup and turned the nightly E2E smoke red.
     ///
-    /// Acceptance criterion (verifiable): on `main-dev` HEAD prior to this PR,
-    /// <code>grep -l "test_run_id" apps/api/src/Api/Infrastructure/Migrations/*.cs</code>
-    /// (excluding *.Designer.cs + *Snapshot.cs) returns zero matches. After this PR,
-    /// only this file matches — confirming this is the first migration to materialize
-    /// the column and is NOT a duplicate of any prior schema change.
+    /// Background (pre-fix): in PRs #1936/#1951/#1954 the TestRunId property + EF
+    /// configuration were added to the entity model, but the column was materialized
+    /// only via `EnsureCreatedAsync` inside the `SharedTestcontainersFixture`
+    /// integration test fixture. PR-CF2 quietly captured the resulting snapshot
+    /// drift; the consolidation here was authored without knowing the CF2 file had
+    /// already taken 5 of the 8 columns. The fix scopes this migration down to the
+    /// remaining 3 tables.
+    ///
+    /// Verification: <code>grep -n 'test_run_id' apps/api/src/Api/Infrastructure/Migrations/*.cs</code>
+    /// (excluding *.Designer.cs + *Snapshot.cs) returns each `test_run_id` column
+    /// in exactly ONE migration file.
     /// </summary>
     /// <example>
     /// Future contributors adding TestRunId to a new entity for E2E seeding (DEC-B-8
@@ -44,13 +52,11 @@ namespace Api.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "test_run_id",
-                table: "users",
-                type: "character varying(64)",
-                maxLength: 64,
-                nullable: true);
-
+            // NOTE (Issue #2013, 2026-06-08): the 5 AddColumn calls for
+            // users / game_night_events / game_night_invitations / game_night_rsvps /
+            // game_night_sessions were removed because CF2 (timestamp 20260606074943)
+            // already adds those columns earlier in the migration sequence. Keeping
+            // them here caused "column already exists" on every fresh-DB migrate.
             migrationBuilder.AddColumn<string>(
                 name: "test_run_id",
                 table: "user_library_entries",
@@ -72,34 +78,6 @@ namespace Api.Infrastructure.Migrations
                 maxLength: 64,
                 nullable: true);
 
-            migrationBuilder.AddColumn<string>(
-                name: "test_run_id",
-                table: "game_night_sessions",
-                type: "character varying(64)",
-                maxLength: 64,
-                nullable: true);
-
-            migrationBuilder.AddColumn<string>(
-                name: "test_run_id",
-                table: "game_night_rsvps",
-                type: "character varying(64)",
-                maxLength: 64,
-                nullable: true);
-
-            migrationBuilder.AddColumn<string>(
-                name: "test_run_id",
-                table: "game_night_invitations",
-                type: "character varying(64)",
-                maxLength: 64,
-                nullable: true);
-
-            migrationBuilder.AddColumn<string>(
-                name: "test_run_id",
-                table: "game_night_events",
-                type: "character varying(64)",
-                maxLength: 64,
-                nullable: true);
-
             migrationBuilder.CreateIndex(
                 name: "ix_game_sessions_test_run_id",
                 table: "game_sessions",
@@ -110,13 +88,11 @@ namespace Api.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Symmetry with Up(): only drop the 3 columns this migration created.
+            // CF2 owns the Down() for the other 5 tables.
             migrationBuilder.DropIndex(
                 name: "ix_game_sessions_test_run_id",
                 table: "game_sessions");
-
-            migrationBuilder.DropColumn(
-                name: "test_run_id",
-                table: "users");
 
             migrationBuilder.DropColumn(
                 name: "test_run_id",
@@ -129,22 +105,6 @@ namespace Api.Infrastructure.Migrations
             migrationBuilder.DropColumn(
                 name: "test_run_id",
                 table: "game_sessions");
-
-            migrationBuilder.DropColumn(
-                name: "test_run_id",
-                table: "game_night_sessions");
-
-            migrationBuilder.DropColumn(
-                name: "test_run_id",
-                table: "game_night_rsvps");
-
-            migrationBuilder.DropColumn(
-                name: "test_run_id",
-                table: "game_night_invitations");
-
-            migrationBuilder.DropColumn(
-                name: "test_run_id",
-                table: "game_night_events");
         }
     }
 }


### PR DESCRIPTION
## Summary

Removes 5 duplicate `AddColumn<test_run_id>` calls from `Add_TestRunId_To_UserGameSessions` (timestamp `20260607061447`). The prior CF2 migration (`20260606074943`) had silently captured those same 5 columns during its drift recovery pass, so a fresh-DB migrate now succeeds without "column already exists".

Closes #2013.

## Root cause

Nightly E2E smoke run [27124617968](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27124617968) failed at API startup:

```
2026-06-08 08:21:03.294 UTC [94] ERROR:  column "test_run_id" of relation "users" already exists
2026-06-08 08:21:03.294 UTC [94] STATEMENT:  ALTER TABLE users ADD test_run_id character varying(64)
Unhandled exception. Npgsql.PostgresException (0x80004005): 42701
```

The API crashed → web container had no upstream → pre-test diagnostics reported `login HTTP 000` → Playwright never started → P0 smoke red.

Two migrations both added `test_run_id` to 5 of the same 8 tables:

| Migration | Tables added |
|---|---|
| `20260606074943_AddSourceEventIdToCounterTables_CF2` (CF2 — "drift recovery") | users, game_night_events, game_night_invitations, game_night_rsvps, game_night_sessions |
| `20260607061447_Add_TestRunId_To_UserGameSessions` (PR #1954 — "consolidation") | **all 8** (including the 5 CF2 had already taken) |

On a fresh DB the migration runner applies them in timestamp order: CF2 succeeds on the 5 tables → consolidation runs next → first `AddColumn` on `users` throws → API process dies.

The CF2 file comments (lines 11-20) explicitly acknowledged the drift, but PR #1954 was authored against a branch that did not see those comments and re-added the same 5 columns.

## What changes

`apps/api/src/Api/Infrastructure/Migrations/20260607061447_Add_TestRunId_To_UserGameSessions.cs`:

- `Up()` reduced from 8 `AddColumn` calls to 3:
  - `user_library_entries` (Macro 3a / PR #1951)
  - `shared_games` (Macro 3a / PR #1951)
  - `game_sessions` (Macro 4 / PR #1954 — this migration's actual reason to exist)
- `CreateIndex` on `ix_game_sessions_test_run_id` preserved.
- `Down()` mirrored — only drops what `Up()` created. The other 5 tables are owned by CF2's `Down()`.
- Doc comment rewritten to explain the conflict + point future contributors at CF2 for the other 5 tables.

`MeepleAiDbContextModelSnapshot.cs` is unchanged — the final model state already has `TestRunId` on all 8 entities; only the migration sequence needed scoping.

## Verification

- `dotnet build` (in `apps/api/src/Api`): 0 warnings, 0 errors.
- `grep` confirms ownership is now disjoint:
  - CF2 owns 5 tables (users, game_night_*).
  - This migration owns 3 tables (user_library_entries, shared_games, game_sessions).
  - Union: 8 tables, no overlap.
- ModelSnapshot reference count for `test_run_id`/`TestRunId`: 19 (unchanged).

## Test plan

- [ ] CI: backend build + tests green.
- [ ] Nightly E2E smoke re-runs green on the next scheduled trigger (or via `workflow_dispatch`).
- [ ] Existing dev environments that have already applied this migration with the 8-column version stay untouched — EF tracks migrations by ID, not by content checksum, so a rebuild against this file does not re-run.
- [ ] Fresh staging DBs apply both migrations cleanly via `dotnet ef database update`.

## Refs

- Issue: #2013 (SMOKE FAILURE)
- Conflicting migrations: PR-CF2 timestamp `20260606074943` + PR #1954 (Issue #1929 Macro 4)
- Background context: memory pattern P195 schema-drift-consolidated-in-single-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
