### PR TITLE
fix(smoke): remove stale /games?tab=library redirect test (#2013 cascade)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/games.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/games.smoke.spec.ts
@@ -2,22 +2,13 @@ import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
 
-test.describe('SMOKE — /games redirect + /library games tab (real backend)', () => {
-  test('GET /games?tab=library redirects to /library and renders LibraryHub', async ({
-    page,
-    request,
-  }) => {
-    const { cookieHeader } = await smokeLogin(request);
-    await applySessionToPage(page, cookieHeader);
-    // PR #1567 (#1521) replaced /games with redirect('/library'); the ?tab=library
-    // query is dropped by the redirect.
-    await page.goto('/games?tab=library', { waitUntil: 'domcontentloaded' });
-    expect(new URL(page.url()).pathname).toBe('/library');
-    await page.waitForSelector('[data-slot="library-hub-v2"]', { timeout: 30_000 });
-    const errorState = await page.locator('[data-state="error"]').count();
-    expect(errorState).toBe(0);
-  });
-
+test.describe('SMOKE — /library games tab (real backend)', () => {
+  // The legacy `/games?tab=library` → `/library` redirect (PR #1567 / #1521) was
+  // removed in the Asse D P2 refactor (2026-06-05): `/games` is now a multi-tab
+  // hub orchestrator with Discover as the default tab. Unknown `?tab=` values
+  // fall back to Discover, so `/games?tab=library` no longer leaves `/games`.
+  // Hub coverage is owned by `apps/web/e2e/asse-d-p2-games-discover-hub.spec.ts`;
+  // `/library` direct entry is covered by the test below.
   test('/library games tab renders GamesResultsGrid (or empty state) — #1566', async ({
     page,
     request,


### PR DESCRIPTION
## Summary

Nightly smoke run [27134029121](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27134029121), triggered to validate yesterday's #2013 migration fix (`8961fb1d4`), surfaced a stale FE assertion in `games.smoke.spec.ts:6`:

```
Expected: "/library"
Received: "/games"
```

The Asse D P2 refactor (sess.36, 2026-06-05) replaced the unconditional `/games` → `/library` redirect with a multi-tab hub orchestrator on `/games` (Discover as the default tab, unknown `?tab=` values fall back to Discover). The smoke spec was still asserting the old behavior.

This PR removes the obsolete first test and keeps the existing `/library games tab renders GamesResultsGrid` test untouched. Hub coverage already lives in `apps/web/e2e/asse-d-p2-games-discover-hub.spec.ts`.

## What changed

- `apps/web/e2e/smoke-real-backend/games.smoke.spec.ts` — drop the obsolete redirect test, retitle the `describe` block, add a comment pointing future readers at the hub spec.

Net: -16 / +7 LOC, single file.

## Verification

- The deleted assertion (`expect(pathname).toBe('/library')`) was the entire failure mode of the run — 1 attempt + 2 Playwright retries, all 3 with identical expected/received.
- The retained test (line 21+) reaches `/library` directly via `page.goto('/library')` and was already SUCCESS in the same CI run.
- No production / backend changes.

## Test plan

- [ ] CI: smoke spec count drops by 1, the remaining `/library` test stays green.
- [ ] Trigger another nightly smoke (`gh workflow run e2e-smoke-real-backend.yml`) post-merge to confirm the smoke suite is now green end-to-end.

## Refs

- Parent: #2013 (smoke red — first cause was the migration duplicate, fixed in `8961fb1d4`; this PR clears the cascade)
- Hub coverage: `apps/web/e2e/asse-d-p2-games-discover-hub.spec.ts` (sess.36, PR shipping Discover/Catalogo/Trending/Community tabs + invalid fallback + `/discover` backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)