### PR TITLE
chore(ci): remove nightly cron from e2e-smoke-real-backend (manual-only)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -1,8 +1,11 @@
-name: E2E Smoke Real Backend (nightly)
+name: E2E Smoke Real Backend (manual)
 
+# 2026-06-08: scheduled cron trigger removed by user request — smoke now runs
+# only on explicit `workflow_dispatch`. Re-enable the `schedule:` block below
+# if/when the nightly cadence is wanted back.
+#   schedule:
+#     - cron: '0 3 * * *'
 on:
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
 
 
@@ -274,7 +277,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[SMOKE FAILURE] Nightly E2E smoke real backend — ${today}`,
+              title: `[SMOKE FAILURE] E2E smoke real backend — ${today}`,
               labels: ['bug', 'P0', 'smoke-failure'],
-              body: `Nightly smoke run failed. See [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).\n\nCheck attached \`playwright-report-smoke\` artifact + the new \`Pre-test diagnostics\` step output for container/HTTP probe data.`
+              body: `Smoke run failed. See [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).\n\nCheck attached \`playwright-report-smoke\` artifact + the \`Pre-test diagnostics\` step output for container/HTTP probe data.`
             });


### PR DESCRIPTION
## Summary

Removes the `schedule: cron '0 3 * * *'` trigger from `e2e-smoke-real-backend.yml`. The workflow now runs only on explicit `workflow_dispatch`.

## Why

Per user direction (2026-06-08): auto-generated P0 smoke failures (e.g. #2013) cost more than they save when the suite is reliably re-runnable on demand via `gh workflow run`. Keeping the workflow alive (with `workflow_dispatch` preserved) means the smoke spec stays available as a manual gate without paying the operational noise of nightly false positives.

## What changed

- `on.schedule:` block removed and commented out with a hint for re-enabling.
- Workflow display name `(nightly)` → `(manual)` so the Actions UI shows the new posture at a glance.
- Auto-filed failure issue title/body wording dropped the word "Nightly" — the issue-creation step still runs on `workflow_dispatch` failures (so #2013-style P0 auto-triage is preserved).

Net: 1 file, +8 / -5 LOC.

## Verification

- `on:` block still includes `workflow_dispatch` — same trigger I used twice today to validate the #2013 fix on runs 27134029121 and 27136058178.
- Concurrency group + all 30+ post-`on:` steps untouched.
- Re-enable path: uncomment the two `schedule:` lines and the workflow goes back to 03:00 UTC.

## Refs

- Issue: #2013 (last auto-generated nightly failure — root cause `8961fb1d4` migration fix + `e1749eda6` smoke spec cleanup, both shipped today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)