### PR TITLE
feat(shared-games): close gaps G1+G2+G5 on admin import workflow

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs
@@ -173,6 +173,15 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
             {
                 entity.BggCoverR2Key = bggCoverR2Key;
             }
+            else
+            {
+                // Final review F1: surface the silent-no-op branch.
+                // Production repository.AddAsync tracks the entity; if this lookup ever returns null,
+                // the cover key is lost without trace. Log so a regression is visible in logs.
+                _logger.LogWarning(
+                    "BggCoverR2Key={Key} downloaded for game={GameId} but EF entity not found in DbContext — repository contract may have changed",
+                    bggCoverR2Key, sharedGame.Id);
+            }
         }
 
         // STEP 6: Link PDF → SharedGame

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
@@ -23,6 +24,7 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
     private readonly IPdfDocumentRepository _pdfRepository;
     private readonly ISharedGameRepository _gameRepository;
     private readonly IBggApiService _bggApiService;
+    private readonly IBggCoverDownloader _bggCoverDownloader;
     private readonly IUnitOfWork _unitOfWork;
     private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<CreateSharedGameFromPdfCommandHandler> _logger;
@@ -31,6 +33,7 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
         IPdfDocumentRepository pdfRepository,
         ISharedGameRepository gameRepository,
         IBggApiService bggApiService,
+        IBggCoverDownloader bggCoverDownloader,
         IUnitOfWork unitOfWork,
         MeepleAiDbContext dbContext,
         ILogger<CreateSharedGameFromPdfCommandHandler> logger)
@@ -38,6 +41,7 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
         _pdfRepository = pdfRepository ?? throw new ArgumentNullException(nameof(pdfRepository));
         _gameRepository = gameRepository ?? throw new ArgumentNullException(nameof(gameRepository));
         _bggApiService = bggApiService ?? throw new ArgumentNullException(nameof(bggApiService));
+        _bggCoverDownloader = bggCoverDownloader ?? throw new ArgumentNullException(nameof(bggCoverDownloader));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -109,6 +113,23 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
             }
         }
 
+        // STEP 4.5: Re-upload BGG cover image to our storage (Gap G2)
+        // On failure (null returned), fall back to BGG direct URL — no exception thrown.
+        string? bggCoverR2Key = null;
+        if (command.SelectedBggId.HasValue && bggDetails?.ImageUrl is { Length: > 0 } bggImageUrl)
+        {
+            bggCoverR2Key = await _bggCoverDownloader
+                .DownloadAndUploadAsync(command.SelectedBggId.Value, bggImageUrl, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (bggCoverR2Key is null)
+            {
+                _logger.LogWarning(
+                    "BGG cover re-upload skipped/failed for BggId={BggId}, falling back to direct URL",
+                    command.SelectedBggId.Value);
+            }
+        }
+
         // STEP 5: Create SharedGame aggregate
         var status = command.RequiresApproval ? "Draft" : "Published";
         var statusEquals = string.Equals(status, "Draft", StringComparison.Ordinal);
@@ -138,6 +159,21 @@ internal sealed class CreateSharedGameFromPdfCommandHandler : ICommandHandler<Cr
 
         // Add aggregate to repository
         await _gameRepository.AddAsync(sharedGame, cancellationToken).ConfigureAwait(false);
+
+        // STEP 5.1: Persist BggCoverR2Key on EF-tracked entity (Gap G2)
+        // entity.ImageUrl remains BGG CDN URL (convention F4): CoverUrlResolver is the
+        // authoritative display source; ImageUrl is legacy fallback for direct-projection consumers.
+        if (bggCoverR2Key is not null)
+        {
+            var entity = await _dbContext.Set<SharedGameEntity>()
+                .FirstOrDefaultAsync(e => e.Id == sharedGame.Id, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (entity is not null)
+            {
+                entity.BggCoverR2Key = bggCoverR2Key;
+            }
+        }
 
         // STEP 6: Link PDF → SharedGame
         // Note: This requires a SharedGameDocument entity or association table

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommand.cs
@@ -6,6 +6,8 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 
 /// <summary>
 /// Command to update an existing shared game in the catalog.
+/// Supports core fields, taxonomy collections (categories, mechanics, designers, publishers),
+/// and BggId. Null collections mean "do not change"; empty list means "clear".
 /// </summary>
 internal record UpdateSharedGameCommand(
     Guid GameId,
@@ -21,5 +23,10 @@ internal record UpdateSharedGameCommand(
     string ImageUrl,
     string ThumbnailUrl,
     GameRulesDto? Rules,
-    Guid ModifiedBy
+    Guid ModifiedBy,
+    int? BggId = null,
+    List<string>? Categories = null,
+    List<string>? Mechanics = null,
+    List<string>? Designers = null,
+    List<string>? Publishers = null
 ) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -52,7 +53,7 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
-            throw new InvalidOperationException($"Shared game {command.GameId} not found");
+            throw new NotFoundException("SharedGame", command.GameId.ToString());
         }
 
         GameRules? rules = null;
@@ -89,7 +90,7 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
 
             if (entity is null)
             {
-                throw new InvalidOperationException($"SharedGame entity {command.GameId} not found in DbContext");
+                throw new NotFoundException("SharedGame", command.GameId.ToString());
             }
 
             if (command.BggId.HasValue)
@@ -132,7 +133,9 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
         entity.Categories.Clear();
         foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
         {
-            var category = await _dbContext.GameCategories.FirstOrDefaultAsync(c => c.Name == name, ct).ConfigureAwait(false);
+            var category = await _dbContext.GameCategories
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Name == name, ct).ConfigureAwait(false);
             if (category is null)
             {
                 category = new GameCategoryEntity
@@ -144,6 +147,19 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
                 };
                 await _dbContext.GameCategories.AddAsync(category, ct).ConfigureAwait(false);
             }
+            else
+            {
+                var tracked = _dbContext.ChangeTracker.Entries<GameCategoryEntity>()
+                    .FirstOrDefault(e => e.Entity.Id == category.Id);
+                if (tracked != null)
+                {
+                    category = tracked.Entity;
+                }
+                else
+                {
+                    _dbContext.Attach(category);
+                }
+            }
             entity.Categories.Add(category);
         }
     }
@@ -153,7 +169,9 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
         entity.Mechanics.Clear();
         foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
         {
-            var mechanic = await _dbContext.GameMechanics.FirstOrDefaultAsync(m => m.Name == name, ct).ConfigureAwait(false);
+            var mechanic = await _dbContext.GameMechanics
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.Name == name, ct).ConfigureAwait(false);
             if (mechanic is null)
             {
                 mechanic = new GameMechanicEntity
@@ -165,6 +183,19 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
                 };
                 await _dbContext.GameMechanics.AddAsync(mechanic, ct).ConfigureAwait(false);
             }
+            else
+            {
+                var tracked = _dbContext.ChangeTracker.Entries<GameMechanicEntity>()
+                    .FirstOrDefault(e => e.Entity.Id == mechanic.Id);
+                if (tracked != null)
+                {
+                    mechanic = tracked.Entity;
+                }
+                else
+                {
+                    _dbContext.Attach(mechanic);
+                }
+            }
             entity.Mechanics.Add(mechanic);
         }
     }
@@ -174,7 +205,9 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
         entity.Designers.Clear();
         foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
         {
-            var designer = await _dbContext.GameDesigners.FirstOrDefaultAsync(d => d.Name == name, ct).ConfigureAwait(false);
+            var designer = await _dbContext.GameDesigners
+                .AsNoTracking()
+                .FirstOrDefaultAsync(d => d.Name == name, ct).ConfigureAwait(false);
             if (designer is null)
             {
                 designer = new GameDesignerEntity
@@ -185,6 +218,19 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
                 };
                 await _dbContext.GameDesigners.AddAsync(designer, ct).ConfigureAwait(false);
             }
+            else
+            {
+                var tracked = _dbContext.ChangeTracker.Entries<GameDesignerEntity>()
+                    .FirstOrDefault(e => e.Entity.Id == designer.Id);
+                if (tracked != null)
+                {
+                    designer = tracked.Entity;
+                }
+                else
+                {
+                    _dbContext.Attach(designer);
+                }
+            }
             entity.Designers.Add(designer);
         }
     }
@@ -194,7 +240,9 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
         entity.Publishers.Clear();
         foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
         {
-            var publisher = await _dbContext.GamePublishers.FirstOrDefaultAsync(p => p.Name == name, ct).ConfigureAwait(false);
+            var publisher = await _dbContext.GamePublishers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Name == name, ct).ConfigureAwait(false);
             if (publisher is null)
             {
                 publisher = new GamePublisherEntity
@@ -204,6 +252,19 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
                     CreatedAt = DateTime.UtcNow
                 };
                 await _dbContext.GamePublishers.AddAsync(publisher, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                var tracked = _dbContext.ChangeTracker.Entries<GamePublisherEntity>()
+                    .FirstOrDefault(e => e.Entity.Id == publisher.Id);
+                if (tracked != null)
+                {
+                    publisher = tracked.Entity;
+                }
+                else
+                {
+                    _dbContext.Attach(publisher);
+                }
             }
             entity.Publishers.Add(publisher);
         }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs
@@ -1,27 +1,42 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 
 /// <summary>
 /// Handler for updating an existing shared game.
+/// Supports core fields (via domain UpdateInfo) and optional manual updates of
+/// BggId + taxonomy collections (categories, mechanics, designers, publishers).
 /// </summary>
+/// <remarks>
+/// Uses MeepleAiDbContext directly for relationship management — same pattern as
+/// UpdateSharedGameFromBggCommandHandler. The repository abstraction does not
+/// support tracked Include for collection-replace semantics.
+/// </remarks>
 internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSharedGameCommand, Unit>
 {
     private readonly ISharedGameRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<UpdateSharedGameCommandHandler> _logger;
 
     public UpdateSharedGameCommandHandler(
         ISharedGameRepository repository,
         IUnitOfWork unitOfWork,
+        MeepleAiDbContext dbContext,
         ILogger<UpdateSharedGameCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -33,36 +48,76 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
             "Updating shared game: {GameId}, ModifiedBy: {UserId}",
             command.GameId, command.ModifiedBy);
 
+        // ─── 1. Update aggregate core fields via domain method ─────────────
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false);
         if (game is null)
         {
             throw new InvalidOperationException($"Shared game {command.GameId} not found");
         }
 
-        // Create rules value object if provided
         GameRules? rules = null;
         if (command.Rules is not null)
         {
             rules = GameRules.Create(command.Rules.Content, command.Rules.Language);
         }
 
-        // Update aggregate
         game.UpdateInfo(
-            command.Title,
-            command.YearPublished,
-            command.Description,
-            command.MinPlayers,
-            command.MaxPlayers,
-            command.PlayingTimeMinutes,
-            command.MinAge,
-            command.ComplexityRating,
-            command.AverageRating,
-            command.ImageUrl,
-            command.ThumbnailUrl,
-            rules,
-            command.ModifiedBy);
+            command.Title, command.YearPublished, command.Description,
+            command.MinPlayers, command.MaxPlayers, command.PlayingTimeMinutes,
+            command.MinAge, command.ComplexityRating, command.AverageRating,
+            command.ImageUrl, command.ThumbnailUrl, rules, command.ModifiedBy);
 
         _repository.Update(game);
+
+        // ─── 2. Update entity-level fields (BggId + collections) ────────────
+        // Only fetched if any non-null new field is present; null = no change.
+        var needsEntityUpdate = command.BggId.HasValue
+            || command.Categories is not null
+            || command.Mechanics is not null
+            || command.Designers is not null
+            || command.Publishers is not null;
+
+        if (needsEntityUpdate)
+        {
+            var entity = await _dbContext.Set<SharedGameEntity>()
+                .Include(e => e.Categories)
+                .Include(e => e.Mechanics)
+                .Include(e => e.Designers)
+                .Include(e => e.Publishers)
+                .FirstOrDefaultAsync(e => e.Id == command.GameId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (entity is null)
+            {
+                throw new InvalidOperationException($"SharedGame entity {command.GameId} not found in DbContext");
+            }
+
+            if (command.BggId.HasValue)
+            {
+                entity.BggId = command.BggId.Value;
+            }
+
+            if (command.Categories is not null)
+            {
+                await ReplaceCategoriesAsync(entity, command.Categories, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (command.Mechanics is not null)
+            {
+                await ReplaceMechanicsAsync(entity, command.Mechanics, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (command.Designers is not null)
+            {
+                await ReplaceDesignersAsync(entity, command.Designers, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (command.Publishers is not null)
+            {
+                await ReplacePublishersAsync(entity, command.Publishers, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
@@ -70,5 +125,87 @@ internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSha
             command.GameId);
 
         return Unit.Value;
+    }
+
+    private async Task ReplaceCategoriesAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Categories.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var category = await _dbContext.GameCategories.FirstOrDefaultAsync(c => c.Name == name, ct).ConfigureAwait(false);
+            if (category is null)
+            {
+                category = new GameCategoryEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    Slug = name.ToLowerInvariant().Replace(" ", "-"),
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GameCategories.AddAsync(category, ct).ConfigureAwait(false);
+            }
+            entity.Categories.Add(category);
+        }
+    }
+
+    private async Task ReplaceMechanicsAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Mechanics.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var mechanic = await _dbContext.GameMechanics.FirstOrDefaultAsync(m => m.Name == name, ct).ConfigureAwait(false);
+            if (mechanic is null)
+            {
+                mechanic = new GameMechanicEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    Slug = name.ToLowerInvariant().Replace(" ", "-"),
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GameMechanics.AddAsync(mechanic, ct).ConfigureAwait(false);
+            }
+            entity.Mechanics.Add(mechanic);
+        }
+    }
+
+    private async Task ReplaceDesignersAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Designers.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var designer = await _dbContext.GameDesigners.FirstOrDefaultAsync(d => d.Name == name, ct).ConfigureAwait(false);
+            if (designer is null)
+            {
+                designer = new GameDesignerEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GameDesigners.AddAsync(designer, ct).ConfigureAwait(false);
+            }
+            entity.Designers.Add(designer);
+        }
+    }
+
+    private async Task ReplacePublishersAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Publishers.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var publisher = await _dbContext.GamePublishers.FirstOrDefaultAsync(p => p.Name == name, ct).ConfigureAwait(false);
+            if (publisher is null)
+            {
+                publisher = new GamePublisherEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GamePublishers.AddAsync(publisher, ct).ConfigureAwait(false);
+            }
+            entity.Publishers.Add(publisher);
+        }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandValidator.cs
@@ -60,6 +60,47 @@ internal sealed class UpdateSharedGameCommandValidator : AbstractValidator<Updat
         RuleFor(x => x.Rules)
             .SetValidator(new GameRulesDtoValidator()!)
             .When(x => x.Rules is not null);
+
+        RuleFor(x => x.BggId)
+            .GreaterThan(0)
+            .When(x => x.BggId.HasValue)
+            .WithMessage("BggId must be a positive integer when provided");
+
+        RuleFor(x => x.Categories)
+            .Must(c => c == null || c.Count <= 20)
+            .WithMessage("Categories cannot exceed 20 items");
+
+        RuleForEach(x => x.Categories)
+            .NotEmpty()
+            .MaximumLength(100)
+            .When(x => x.Categories != null);
+
+        RuleFor(x => x.Mechanics)
+            .Must(m => m == null || m.Count <= 30)
+            .WithMessage("Mechanics cannot exceed 30 items");
+
+        RuleForEach(x => x.Mechanics)
+            .NotEmpty()
+            .MaximumLength(100)
+            .When(x => x.Mechanics != null);
+
+        RuleFor(x => x.Designers)
+            .Must(d => d == null || d.Count <= 20)
+            .WithMessage("Designers cannot exceed 20 items");
+
+        RuleForEach(x => x.Designers)
+            .NotEmpty()
+            .MaximumLength(200)
+            .When(x => x.Designers != null);
+
+        RuleFor(x => x.Publishers)
+            .Must(p => p == null || p.Count <= 20)
+            .WithMessage("Publishers cannot exceed 20 items");
+
+        RuleForEach(x => x.Publishers)
+            .NotEmpty()
+            .MaximumLength(200)
+            .When(x => x.Publishers != null);
     }
 
     private static bool BeValidUrl(string url)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -1,0 +1,92 @@
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+internal sealed class BggCoverDownloader : IBggCoverDownloader
+{
+    private readonly HttpClient _httpClient;
+    private readonly IBlobStorageService _blobStorageService;
+    private readonly ILogger<BggCoverDownloader> _logger;
+
+    public BggCoverDownloader(
+        HttpClient httpClient,
+        IBlobStorageService blobStorageService,
+        ILogger<BggCoverDownloader> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _blobStorageService = blobStorageService ?? throw new ArgumentNullException(nameof(blobStorageService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string?> DownloadAndUploadAsync(
+        int bggId,
+        string remoteImageUrl,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(remoteImageUrl))
+        {
+            return null;
+        }
+
+        var resourceKey = $"bgg-cover-{bggId}";
+
+        try
+        {
+            using var response = await _httpClient
+                .GetAsync(remoteImageUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "BGG cover download failed: BggId={BggId}, Url={Url}, Status={Status}",
+                    bggId, remoteImageUrl, response.StatusCode);
+                return null;
+            }
+
+            var imageStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var _ = imageStream.ConfigureAwait(false);
+
+            // Derive a safe filename from the URL path
+            var fileName = $"cover-{bggId}{GetExtension(remoteImageUrl)}";
+
+            var storageResult = await _blobStorageService
+                .StoreAsync(imageStream, fileName, BlobCategory.GameImage, resourceKey, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!storageResult.Success)
+            {
+                _logger.LogWarning(
+                    "BGG cover upload failed: BggId={BggId}, Error={Error}",
+                    bggId, storageResult.ErrorMessage);
+                return null;
+            }
+
+            _logger.LogInformation(
+                "BGG cover uploaded successfully: BggId={BggId}, R2Key={Key}",
+                bggId, resourceKey);
+            return resourceKey;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Unexpected error in BGG cover download/upload: BggId={BggId}", bggId);
+            return null;
+        }
+    }
+
+    private static string GetExtension(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var path = uri.AbsolutePath;
+            var ext = Path.GetExtension(path);
+            return string.IsNullOrEmpty(ext) || ext.Length > 5 ? ".jpg" : ext.ToLowerInvariant();
+        }
+        catch
+        {
+            return ".jpg";
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -5,10 +5,10 @@ using Api.Services.Pdf;
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 
 /// <summary>
-/// Issue #1852 (Gap A): centralizes cover-URL resolution with the priority
-/// L3 (user custom) -> L4 (PDF-derived) -> L2 (Wikidata) -> null.
-/// Each layer falls through to the next when its R2 key is missing or the
-/// blob storage cannot mint a presigned URL (returns null in dev / local).
+/// Issue #1852 (Gap A) + Gap G2 (2026-06-08): centralizes cover-URL resolution
+/// with the priority L3 (user custom) -> L4 (PDF-derived) -> L2.5 (BGG re-uploaded)
+/// -> L2 (Wikidata) -> null. Each layer falls through to the next when its R2 key
+/// is missing or the blob storage cannot mint a presigned URL (returns null in dev / local).
 /// </summary>
 internal static class CoverUrlResolver
 {
@@ -52,6 +52,21 @@ internal static class CoverUrlResolver
             if (url is not null) return url;
         }
 
+        // L2.5 BGG re-uploaded cover (Gap G2)
+        // Note: BGG asset stored under raw resource key (no suffix) — different from
+        // L4 PDF which appends "-preview.webp" and L2 Wikidata which appends ".webp".
+        if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
+        {
+            var url = await blobStorage
+                .GetPresignedDownloadUrlAsync(
+                    sharedGame.BggCoverR2Key,
+                    BlobCategory.GameImage,
+                    sharedGame.BggCoverR2Key)
+                .ConfigureAwait(false);
+            if (url is not null) return url;
+        }
+
+        // L2 Wikidata cover
         if (!string.IsNullOrWhiteSpace(sharedGame.WikidataCoverR2Key))
         {
             var url = await blobStorage

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -53,8 +53,11 @@ internal static class CoverUrlResolver
         }
 
         // L2.5 BGG re-uploaded cover (Gap G2)
-        // Note: BGG asset stored under raw resource key (no suffix) — different from
-        // L4 PDF which appends "-preview.webp" and L2 Wikidata which appends ".webp".
+        // Asymmetry vs L4/L2: BGG cover is stored as a single asset under the raw
+        // resource key (set by BggCoverDownloader.DownloadAndUploadAsync), with no
+        // -preview.webp or .webp suffix. The blob service treats arg 1 as the literal
+        // storage object path; arg 3 is the cache identifier (same key here is fine
+        // because the storage object IS the cache target).
         if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
         {
             var url = await blobStorage

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverDownloader.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Downloads a cover image from a remote URL (typically BGG CDN) and re-uploads
+/// it to our internal blob storage. Returns the R2 key on success, null on failure
+/// (caller falls back to direct remote URL).
+/// </summary>
+internal interface IBggCoverDownloader
+{
+    /// <summary>
+    /// Downloads the image at <paramref name="remoteImageUrl"/> and stores it in blob
+    /// storage with a key derived from <paramref name="bggId"/>.
+    /// </summary>
+    /// <returns>The R2 key on success; null if download or upload failed (logged).</returns>
+    Task<string?> DownloadAndUploadAsync(
+        int bggId,
+        string remoteImageUrl,
+        CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -167,6 +167,13 @@ internal static class SharedGameCatalogServiceExtensions
                 .WithDescription("Runs every 15 min to evict shared-game detail tags for top-N most-viewed games and the search-games list tag"));
         });
 
+        // Gap G2: BGG cover re-upload service (typed HttpClient pattern).
+        // 10s timeout — BGG CDN images are typically < 500 KB.
+        services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+        });
+
         // Issue #1903 M5.2: register HttpClients, keyed catalog providers,
         // aggregator, and Quartz CatalogSeedFetchJob.
         RegisterCatalogSeedProviders(services);

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -80,6 +80,14 @@ public class SharedGameEntity
     public string? WikidataCoverAttribution { get; set; }
 
     /// <summary>
+    /// Gap G2 (issue: BGG cover re-upload).
+    /// R2 key for cover image downloaded from BGG and re-uploaded to our storage.
+    /// Resolved by CoverUrlResolver L2.5 layer (between L4 PDF and L2 Wikidata).
+    /// Null when no BGG enrichment was applied or download failed.
+    /// </summary>
+    public string? BggCoverR2Key { get; set; }
+
+    /// <summary>
     /// Issue #1929 Task C Macro 3a (DEC-B-8, DEC-C-8) — E2E test seeding scope marker.
     /// Explicit column (NOT shadow property) to avoid EF Core 9 + Npgsql null-after-save bug.
     /// Stamped on insert by SeedTestLibraryGameCommandHandler; consumed by

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -137,6 +137,12 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .HasColumnName("pdf_cover_r2_key")
             .IsRequired(false);
 
+        // Gap G2 (BGG cover re-upload) — BGG-sourced cover image re-uploaded to our storage.
+        builder.Property(e => e.BggCoverR2Key)
+            .HasMaxLength(256)
+            .HasColumnName("bgg_cover_r2_key")
+            .IsRequired(false);
+
         builder.Property(e => e.WikidataCoverSourceUrl)
             .HasMaxLength(2048)
             .HasColumnName("wikidata_cover_source_url")

--- a/apps/api/src/Api/Infrastructure/Migrations/20260608161038_AddBggCoverR2KeyToSharedGames.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260608161038_AddBggCoverR2KeyToSharedGames.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608161038_AddBggCoverR2KeyToSharedGames")]
+    partial class AddBggCoverR2KeyToSharedGames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260608161038_AddBggCoverR2KeyToSharedGames.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260608161038_AddBggCoverR2KeyToSharedGames.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBggCoverR2KeyToSharedGames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "LastLockoutEventId",
+                table: "users",
+                newName: "last_lockout_event_id");
+
+            migrationBuilder.AddColumn<string>(
+                name: "bgg_cover_r2_key",
+                table: "shared_games",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "bgg_cover_r2_key",
+                table: "shared_games");
+
+            migrationBuilder.RenameColumn(
+                name: "last_lockout_event_id",
+                table: "users",
+                newName: "LastLockoutEventId");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260608161038_AddBggCoverR2KeyToSharedGames.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260608161038_AddBggCoverR2KeyToSharedGames.cs
@@ -10,11 +10,8 @@ namespace Api.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.RenameColumn(
-                name: "LastLockoutEventId",
-                table: "users",
-                newName: "last_lockout_event_id");
-
+            // Note: last_lockout_event_id was already added as snake_case by migration
+            // 20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1. No rename needed.
             migrationBuilder.AddColumn<string>(
                 name: "bgg_cover_r2_key",
                 table: "shared_games",
@@ -29,11 +26,6 @@ namespace Api.Infrastructure.Migrations
             migrationBuilder.DropColumn(
                 name: "bgg_cover_r2_key",
                 table: "shared_games");
-
-            migrationBuilder.RenameColumn(
-                name: "last_lockout_event_id",
-                table: "users",
-                newName: "LastLockoutEventId");
         }
     }
 }

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Api.BoundedContexts.SharedGameCatalog.Application;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
@@ -10,6 +11,7 @@ using Api.Middleware.Exceptions;
 using Api.Models;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace Api.Routing;
 
@@ -250,15 +252,80 @@ internal static class SharedGameCatalogWizardEndpoints
     /// <summary>
     /// Handler for wizard game creation endpoint (final step).
     /// Creates SharedGame from extracted metadata with optional BGG enrichment.
+    /// G5: Supports Idempotency-Key header (UUID) for double-submit protection.
+    /// Cache key: wizard:create:{userId}:{idempotencyKey}, TTL 5 min.
+    /// Body hash (SHA256) stored in envelope to detect key-reuse with different payload (IETF §2.6).
     /// </summary>
     private static async Task<IResult> HandleWizardCreateGame(
         CreateGameFromPdfRequest request,
         HttpContext context,
         IMediator mediator,
+        IDistributedCache cache,
         ILogger<Program> logger,
         CancellationToken ct)
     {
         var userId = context.User.GetUserId();
+
+        // G5: Idempotency-Key support
+        string? idempotencyKey = null;
+        if (context.Request.Headers.TryGetValue("Idempotency-Key", out var keyValues) && keyValues.Count > 0)
+        {
+            idempotencyKey = keyValues[0];
+        }
+
+        // F2 (review finding, IETF draft-ietf-httpapi-idempotency-key §2.6): hash body to detect
+        // key-reuse with a different payload before executing the command.
+        string? requestBodyHash = null;
+        if (!string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            var bodyJson = System.Text.Json.JsonSerializer.Serialize(request);
+            var hashBytes = SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(bodyJson));
+            requestBodyHash = Convert.ToHexString(hashBytes);
+        }
+
+        if (!string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            var cacheKey = $"wizard:create:{userId}:{idempotencyKey}";
+            var cachedBytes = await cache.GetAsync(cacheKey, ct).ConfigureAwait(false);
+            if (cachedBytes is { Length: > 0 })
+            {
+                var cachedEnvelopeJson = System.Text.Encoding.UTF8.GetString(cachedBytes);
+                var cached = System.Text.Json.JsonSerializer.Deserialize<IdempotencyCachedEnvelope>(cachedEnvelopeJson);
+                if (cached is not null)
+                {
+                    // F2: mismatch on body hash → 422 (IETF draft-ietf-httpapi-idempotency-key §2.6)
+                    if (!string.Equals(cached.BodyHash, requestBodyHash, StringComparison.Ordinal))
+                    {
+                        logger.LogWarning(
+                            "Idempotency-Key reused with different body: Key={Key}, UserId={UserId}",
+                            idempotencyKey, userId);
+                        return Results.UnprocessableEntity(new
+                        {
+                            error = "idempotency_key_body_mismatch",
+                            message = "Idempotency-Key was previously used with a different request body."
+                        });
+                    }
+
+                    logger.LogInformation(
+                        "Idempotency-Key hit: returning cached gameId={GameId} for key={Key}",
+                        cached.GameId, idempotencyKey);
+
+                    // F1: restore real status from cache so client sees true Draft/Published
+                    return Results.Created(
+                        $"/api/v1/admin/shared-games/{cached.GameId}",
+                        new CreateGameFromPdfResult
+                        {
+                            GameId = cached.GameId,
+                            ApprovalStatus = cached.ApprovalStatus,
+                            QualityScore = 0.0,
+                            DuplicateWarning = false,
+                            DuplicateTitles = [],
+                            BggEnrichmentApplied = cached.BggEnrichmentApplied,
+                            EnrichedWithBggId = cached.EnrichedWithBggId
+                        });
+                }
+            }
+        }
 
         // Determine if user is Admin (auto-publish) or Editor (requires approval)
         var isAdmin = context.User.IsInRole("Admin");
@@ -286,6 +353,28 @@ internal static class SharedGameCatalogWizardEndpoints
             logger.LogInformation(
                 "Wizard game created successfully: GameId={GameId}, Status={Status}, BggEnriched={BggEnriched}",
                 result.GameId, result.ApprovalStatus, result.BggEnrichmentApplied);
+
+            // G5: Persist idempotency envelope in cache after successful create.
+            // F1+F2: envelope includes ApprovalStatus + BggEnrichment + BodyHash for safe replay.
+            if (!string.IsNullOrWhiteSpace(idempotencyKey) && !string.IsNullOrWhiteSpace(requestBodyHash))
+            {
+                var cacheKey = $"wizard:create:{userId}:{idempotencyKey}";
+                var envelope = new IdempotencyCachedEnvelope
+                {
+                    GameId = result.GameId,
+                    ApprovalStatus = result.ApprovalStatus,
+                    BggEnrichmentApplied = result.BggEnrichmentApplied,
+                    EnrichedWithBggId = result.EnrichedWithBggId,
+                    BodyHash = requestBodyHash
+                };
+                var envelopeJson = System.Text.Json.JsonSerializer.Serialize(envelope);
+                var envelopeBytes = System.Text.Encoding.UTF8.GetBytes(envelopeJson);
+                var cacheOptions = new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5)
+                };
+                await cache.SetAsync(cacheKey, envelopeBytes, cacheOptions, ct).ConfigureAwait(false);
+            }
 
             return Results.Created($"/api/v1/admin/shared-games/{result.GameId}", result);
         }
@@ -433,4 +522,19 @@ internal static class SharedGameCatalogWizardEndpoints
 
         return Results.Ok(result);
     }
+}
+
+/// <summary>
+/// G5: envelope persisted in Redis/in-memory cache for Idempotency-Key replay.
+/// Stores the gameId + status fields needed to replay HTTP 201 truthfully (F1),
+/// plus the SHA256 of the original request body for IETF idempotency-key
+/// body-mismatch detection (F2 — RFC draft-ietf-httpapi-idempotency-key §2.6).
+/// </summary>
+internal sealed record IdempotencyCachedEnvelope
+{
+    public Guid GameId { get; init; }
+    public string ApprovalStatus { get; init; } = string.Empty;
+    public bool BggEnrichmentApplied { get; init; }
+    public int? EnrichedWithBggId { get; init; }
+    public string BodyHash { get; init; } = string.Empty;
 }

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs
@@ -373,7 +373,19 @@ internal static class SharedGameCatalogWizardEndpoints
                 {
                     AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5)
                 };
-                await cache.SetAsync(cacheKey, envelopeBytes, cacheOptions, ct).ConfigureAwait(false);
+                // Final review F2: swallow transient cache failures so the 201 still reaches the client.
+                // If we propagated, the game would be persisted but the caller would see 500 + retry would
+                // create a duplicate (cache cold, no envelope). Standard IETF idempotency-key pattern.
+                try
+                {
+                    await cache.SetAsync(cacheKey, envelopeBytes, cacheOptions, ct).ConfigureAwait(false);
+                }
+                catch (Exception cacheEx) when (cacheEx is not OperationCanceledException)
+                {
+                    logger.LogError(cacheEx,
+                        "Idempotency cache write failed for key={Key}, gameId={GameId} — created 201 still returned, but future retries with same key will re-execute",
+                        idempotencyKey, result.GameId);
+                }
             }
 
             return Results.Created($"/api/v1/admin/shared-games/{result.GameId}", result);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
@@ -570,6 +570,11 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
         savedEntity.Should().NotBeNull("downloader should have set BggCoverR2Key on the tracked entity");
         savedEntity!.BggCoverR2Key.Should().Be(expectedR2Key);
 
+        // Polish: also verify the value survives a full DbContext round-trip query
+        var persistedEntity = await _dbContext.Set<SharedGameEntity>()
+            .FirstAsync(e => e.Id == result.GameId);
+        persistedEntity.BggCoverR2Key.Should().Be(expectedR2Key);
+
         // ImageUrl remains BGG direct URL (convention F4 — CoverUrlResolver is authoritative display source)
         savedEntity.ImageUrl.Should().Be("https://cf.geekdo-images.com/abc.jpg");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
@@ -4,9 +4,11 @@ using PdfFileName = Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects.F
 using PdfFileSize = Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects.FileSize;
 using PdfLanguageCode = Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects.LanguageCode;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Models;
 using Api.Services;
 using Api.SharedKernel.Application.Services;
@@ -34,6 +36,7 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
     private readonly Mock<IPdfDocumentRepository> _pdfRepositoryMock;
     private readonly Mock<ISharedGameRepository> _gameRepositoryMock;
     private readonly Mock<IBggApiService> _bggApiServiceMock;
+    private readonly Mock<IBggCoverDownloader> _bggCoverDownloaderMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly MeepleAiDbContext _dbContext;
     private readonly Mock<ILogger<CreateSharedGameFromPdfCommandHandler>> _loggerMock;
@@ -46,6 +49,13 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
         _bggApiServiceMock = new Mock<IBggApiService>();
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _loggerMock = new Mock<ILogger<CreateSharedGameFromPdfCommandHandler>>();
+
+        // Default: downloader returns null (no-op fallback) for all calls.
+        // Tests that verify cover upload success set up explicit returns.
+        _bggCoverDownloaderMock = new Mock<IBggCoverDownloader>();
+        _bggCoverDownloaderMock
+            .Setup(d => d.DownloadAndUploadAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
 
         // InMemory database for duplicate check query (uses _dbContext.Set<SharedGameEntity>())
         var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
@@ -61,6 +71,7 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
             _pdfRepositoryMock.Object,
             _gameRepositoryMock.Object,
             _bggApiServiceMock.Object,
+            _bggCoverDownloaderMock.Object,
             _unitOfWorkMock.Object,
             _dbContext,
             _loggerMock.Object);
@@ -498,6 +509,97 @@ public sealed class CreateSharedGameFromPdfCommandHandlerTests : IDisposable
         result.ApprovalStatus.Should().Be("Published");
         result.DuplicateWarning.Should().BeFalse(); // empty DB = no duplicates
         result.DuplicateTitles.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region BGG Cover Re-upload (Gap G2)
+
+    [Fact]
+    public async Task Handle_WithBggIdAndCoverDownloadSuccess_SetsBggCoverR2KeyOnEntity()
+    {
+        // Arrange
+        var pdfId = Guid.NewGuid();
+        var bggId = 13;
+        var expectedR2Key = "bgg-cover-13";
+        var command = CreateValidCommand(pdfDocumentId: pdfId, title: "Catan", selectedBggId: bggId);
+
+        SetupPdfFound(pdfId);
+        SetupBggDetails(bggId, CreateBggDetails(bggId: bggId, imageUrl: "https://cf.geekdo-images.com/abc.jpg"));
+
+        // The mock AddAsync callback seeds the entity into InMemory DbContext so the handler
+        // can find it when setting BggCoverR2Key via FirstOrDefaultAsync.
+        _gameRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()))
+            .Returns<SharedGame, CancellationToken>(async (g, ct) =>
+            {
+                var entity = new SharedGameEntity
+                {
+                    Id = g.Id,
+                    Title = g.Title,
+                    Description = g.Description,
+                    YearPublished = g.YearPublished,
+                    MinPlayers = g.MinPlayers,
+                    MaxPlayers = g.MaxPlayers,
+                    PlayingTimeMinutes = g.PlayingTimeMinutes,
+                    MinAge = g.MinAge,
+                    ImageUrl = g.ImageUrl,
+                    ThumbnailUrl = g.ThumbnailUrl,
+                    CreatedBy = g.CreatedBy,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.Set<SharedGameEntity>().AddAsync(entity, ct);
+                await _dbContext.SaveChangesAsync(ct);
+            });
+
+        _bggCoverDownloaderMock
+            .Setup(d => d.DownloadAndUploadAsync(bggId, "https://cf.geekdo-images.com/abc.jpg", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedR2Key);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.BggEnrichmentApplied.Should().BeTrue();
+
+        // Verify BggCoverR2Key was set on the EF-tracked entity.
+        // Note: _unitOfWork.SaveChangesAsync is mocked, but EF InMemory change tracking
+        // reflects the modification in-memory. We look up the entity by its saved ID.
+        var savedEntity = _dbContext.ChangeTracker.Entries<SharedGameEntity>()
+            .FirstOrDefault(e => e.Entity.BggCoverR2Key == expectedR2Key)?.Entity;
+        savedEntity.Should().NotBeNull("downloader should have set BggCoverR2Key on the tracked entity");
+        savedEntity!.BggCoverR2Key.Should().Be(expectedR2Key);
+
+        // ImageUrl remains BGG direct URL (convention F4 — CoverUrlResolver is authoritative display source)
+        savedEntity.ImageUrl.Should().Be("https://cf.geekdo-images.com/abc.jpg");
+    }
+
+    [Fact]
+    public async Task Handle_WithBggIdAndCoverDownloadFailure_FallsBackToDirectUrl()
+    {
+        // Arrange
+        var pdfId = Guid.NewGuid();
+        var bggId = 13;
+        var command = CreateValidCommand(pdfDocumentId: pdfId, title: "Catan", selectedBggId: bggId);
+
+        SetupPdfFound(pdfId);
+        SetupBggDetails(bggId, CreateBggDetails(bggId: bggId, imageUrl: "https://cf.geekdo-images.com/abc.jpg"));
+
+        _gameRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Downloader returns null (failure / already configured as default no-op)
+
+        // Act — should not throw; fallback is silent
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.BggEnrichmentApplied.Should().BeTrue();
+        result.GameId.Should().NotBe(Guid.Empty);
+        _bggCoverDownloaderMock.Verify(
+            d => d.DownloadAndUploadAsync(bggId, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs
@@ -177,6 +177,57 @@ public sealed class UpdateSharedGameCommandHandlerTests : IDisposable
         reloaded.BggId.Should().Be(13);
     }
 
+    [Fact]
+    public async Task Handle_WithNullCategories_PreservesExistingCategories()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var entity = SeedGameEntity(gameId, userId);
+        entity.Categories.Add(new GameCategoryEntity { Id = Guid.NewGuid(), Name = "Strategy", Slug = "strategy", CreatedAt = DateTime.UtcNow });
+        entity.Mechanics.Add(new GameMechanicEntity { Id = Guid.NewGuid(), Name = "Dice Rolling", Slug = "dice-rolling", CreatedAt = DateTime.UtcNow });
+        _dbContext.Set<SharedGameEntity>().Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var domainAggregate = BuildAggregate(gameId, userId);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        // Pass BggId only, leave taxonomy collections as null
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: entity.Title,
+            YearPublished: entity.YearPublished,
+            Description: entity.Description,
+            MinPlayers: entity.MinPlayers,
+            MaxPlayers: entity.MaxPlayers,
+            PlayingTimeMinutes: entity.PlayingTimeMinutes,
+            MinAge: entity.MinAge,
+            ComplexityRating: entity.ComplexityRating,
+            AverageRating: entity.AverageRating,
+            ImageUrl: entity.ImageUrl,
+            ThumbnailUrl: entity.ThumbnailUrl,
+            Rules: null,
+            ModifiedBy: userId,
+            BggId: 42);
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        var reloaded = await _dbContext.Set<SharedGameEntity>()
+            .Include(g => g.Categories)
+            .Include(g => g.Mechanics)
+            .FirstAsync(g => g.Id == gameId);
+
+        reloaded.Categories.Select(c => c.Name).Should().BeEquivalentTo(new[] { "Strategy" });
+        reloaded.Mechanics.Select(m => m.Name).Should().BeEquivalentTo(new[] { "Dice Rolling" });
+        reloaded.BggId.Should().Be(42);
+    }
+
     private static SharedGameEntity SeedGameEntity(Guid gameId, Guid createdBy)
     {
         return new SharedGameEntity

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs
@@ -1,0 +1,219 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Handlers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class UpdateSharedGameCommandHandlerTests : IDisposable
+{
+    private readonly Mock<ISharedGameRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<UpdateSharedGameCommandHandler>> _loggerMock = new();
+    private readonly MeepleAiDbContext _dbContext;
+
+    public UpdateSharedGameCommandHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"update-shared-game-{Guid.NewGuid()}")
+            .Options;
+        _dbContext = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task Handle_WithCoreFieldsOnly_UpdatesGameSuccessfully()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var domainAggregate = BuildAggregate(gameId, userId);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: "Wingspan ITA",
+            YearPublished: 2019,
+            Description: "Updated description",
+            MinPlayers: 1,
+            MaxPlayers: 5,
+            PlayingTimeMinutes: 70,
+            MinAge: 10,
+            ComplexityRating: 2.4m,
+            AverageRating: 8.1m,
+            ImageUrl: "https://cdn/img.webp",
+            ThumbnailUrl: "https://cdn/thumb.webp",
+            Rules: null,
+            ModifiedBy: userId);
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(MediatR.Unit.Value);
+        _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithCategoriesAndMechanics_ReplacesCollections()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var entity = SeedGameEntity(gameId, userId);
+        entity.Categories.Add(new GameCategoryEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "Old",
+            Slug = "old",
+            CreatedAt = DateTime.UtcNow
+        });
+        _dbContext.Set<SharedGameEntity>().Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var domainAggregate = BuildAggregate(gameId, userId);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: entity.Title,
+            YearPublished: entity.YearPublished,
+            Description: entity.Description,
+            MinPlayers: entity.MinPlayers,
+            MaxPlayers: entity.MaxPlayers,
+            PlayingTimeMinutes: entity.PlayingTimeMinutes,
+            MinAge: entity.MinAge,
+            ComplexityRating: entity.ComplexityRating,
+            AverageRating: entity.AverageRating,
+            ImageUrl: entity.ImageUrl,
+            ThumbnailUrl: entity.ThumbnailUrl,
+            Rules: null,
+            ModifiedBy: userId,
+            Categories: new List<string> { "Strategy", "Negotiation" },
+            Mechanics: new List<string> { "Dice Rolling" });
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        var reloaded = await _dbContext.Set<SharedGameEntity>()
+            .Include(g => g.Categories)
+            .Include(g => g.Mechanics)
+            .FirstAsync(g => g.Id == gameId);
+
+        reloaded.Categories.Select(c => c.Name).Should().BeEquivalentTo(new[] { "Strategy", "Negotiation" });
+        reloaded.Mechanics.Select(m => m.Name).Should().BeEquivalentTo(new[] { "Dice Rolling" });
+    }
+
+    [Fact]
+    public async Task Handle_WithBggIdProvided_UpdatesBggIdScalar()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var entity = SeedGameEntity(gameId, userId);
+        entity.BggId = null;
+        _dbContext.Set<SharedGameEntity>().Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var domainAggregate = BuildAggregate(gameId, userId);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: entity.Title,
+            YearPublished: entity.YearPublished,
+            Description: entity.Description,
+            MinPlayers: entity.MinPlayers,
+            MaxPlayers: entity.MaxPlayers,
+            PlayingTimeMinutes: entity.PlayingTimeMinutes,
+            MinAge: entity.MinAge,
+            ComplexityRating: entity.ComplexityRating,
+            AverageRating: entity.AverageRating,
+            ImageUrl: entity.ImageUrl,
+            ThumbnailUrl: entity.ThumbnailUrl,
+            Rules: null,
+            ModifiedBy: userId,
+            BggId: 13);
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        var reloaded = await _dbContext.Set<SharedGameEntity>().FirstAsync(g => g.Id == gameId);
+        reloaded.BggId.Should().Be(13);
+    }
+
+    private static SharedGameEntity SeedGameEntity(Guid gameId, Guid createdBy)
+    {
+        return new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Wingspan",
+            Description = "Bird-themed engine builder",
+            YearPublished = 2019,
+            MinPlayers = 1,
+            MaxPlayers = 5,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = "https://cdn/old.webp",
+            ThumbnailUrl = "https://cdn/old-thumb.webp",
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            CreatedBy = createdBy
+        };
+    }
+
+    private static SharedGame BuildAggregate(Guid gameId, Guid createdBy)
+    {
+        // Use the public Create factory; Id is generated internally.
+        // We only need a valid domain object for the repository mock to return.
+        return SharedGame.Create(
+            title: "Wingspan",
+            yearPublished: 2019,
+            description: "Bird-themed engine builder",
+            minPlayers: 1,
+            maxPlayers: 5,
+            playingTimeMinutes: 60,
+            minAge: 10,
+            complexityRating: null,
+            averageRating: null,
+            imageUrl: "https://cdn/old.webp",
+            thumbnailUrl: "https://cdn/old-thumb.webp",
+            rules: null,
+            createdBy: createdBy,
+            bggId: null);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+public sealed class BggCoverDownloaderTests
+{
+    private readonly Mock<IBlobStorageService> _blobMock = new();
+    private readonly Mock<ILogger<BggCoverDownloader>> _loggerMock = new();
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnSuccess_ReturnsR2Key()
+    {
+        // Arrange
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x89, 0x50, 0x4E, 0x47 /* fake PNG header */ });
+        _blobMock.Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<string>(),
+                BlobCategory.GameImage,
+                "bgg-cover-13",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(Success: true, FileId: "bgg-cover-13", FilePath: "bgg-cover-13", FileSizeBytes: 4, ErrorMessage: null));
+
+        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/abc.jpg", CancellationToken.None);
+
+        // Assert
+        result.Should().Be("bgg-cover-13");
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnHttpError_ReturnsNull()
+    {
+        // Arrange
+        var httpClient = BuildHttpClient(HttpStatusCode.NotFound);
+        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/missing.jpg", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+        _blobMock.Verify(b => b.StoreAsync(
+            It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnUploadFailure_ReturnsNull()
+    {
+        // Arrange
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x01 });
+        _blobMock.Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(Success: false, FileId: null, FilePath: null, FileSizeBytes: 0, ErrorMessage: "S3 unavailable"));
+
+        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/abc.jpg", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static HttpClient BuildHttpClient(HttpStatusCode statusCode, byte[]? content = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = content is null ? null : new ByteArrayContent(content)
+            });
+        return new HttpClient(handler.Object);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Models;
@@ -50,7 +51,9 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
             {
                 builder.ConfigureTestServices(services =>
                 {
-                    // Mock BGG API to avoid real calls
+                    // Mock BGG API to avoid real calls.
+                    // Returns full details so SharedGame.Create() gets non-empty
+                    // description/imageUrl/thumbnailUrl (domain validation requires them).
                     services.RemoveAll(typeof(Api.Services.IBggApiService));
                     var mockBggApi = new Mock<Api.Services.IBggApiService>();
                     mockBggApi
@@ -58,8 +61,37 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
                         .Returns(Task.FromResult(new List<BggSearchResultDto>()));
                     mockBggApi
                         .Setup(x => x.GetGameDetailsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                        .Returns(Task.FromResult<BggGameDetailsDto?>(null));
+                        .Returns(Task.FromResult<BggGameDetailsDto?>(new BggGameDetailsDto(
+                            174430,
+                            "Test Game BGG",
+                            "A test board game description for idempotency integration tests.",
+                            2020,
+                            2,
+                            4,
+                            60,
+                            30,
+                            120,
+                            10,
+                            7.5,
+                            7.0,
+                            10000,
+                            2.5,
+                            "https://example.com/thumbnail.jpg",
+                            "https://example.com/image.jpg",
+                            new List<string> { "Strategy" },
+                            new List<string> { "Worker Placement" },
+                            new List<string> { "Test Designer" },
+                            new List<string> { "Test Publisher" })));
                     services.AddScoped(_ => mockBggApi.Object);
+
+                    // Mock IBggCoverDownloader to return null (tolerated fallback — no R2 upload).
+                    // Without this mock the typed HttpClient tries to make a real HTTP call.
+                    services.RemoveAll(typeof(IBggCoverDownloader));
+                    var mockCoverDownloader = new Mock<IBggCoverDownloader>();
+                    mockCoverDownloader
+                        .Setup(x => x.DownloadAndUploadAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                        .Returns(Task.FromResult<string?>(null));
+                    services.AddScoped(_ => mockCoverDownloader.Object);
 
                     // Allow all auth for test purposes
                     services.AddAuthentication(TestAuthenticationHandler.SchemeName)
@@ -99,12 +131,40 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Helper: seed a minimal PdfDocumentEntity so the handler can find the PDF
+    // Helper: seed a minimal UserEntity (once) + PdfDocumentEntity so the
+    // handler can resolve UploadedByUserId FK constraint.
     // ─────────────────────────────────────────────────────────────────────────
+    private bool _userSeeded;
+
+    private async Task EnsureUserSeededAsync(MeepleAiDbContext db)
+    {
+        if (_userSeeded) return;
+        var existing = await db.Users.AsNoTracking()
+            .AnyAsync(u => u.Id == _testUserId);
+        if (!existing)
+        {
+            db.Users.Add(new UserEntity
+            {
+                Id = _testUserId,
+                Email = $"idempotency-test-{_testUserId:N}@test.local",
+                DisplayName = "Idempotency Test Admin",
+                PasswordHash = "test-hash",
+                Role = "Admin",
+                Tier = "free",
+                CreatedAt = DateTime.UtcNow,
+                EmailVerified = true
+            });
+            await db.SaveChangesAsync();
+        }
+        _userSeeded = true;
+    }
+
     private async Task<Guid> SeedOrphanPdfAsync()
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await EnsureUserSeededAsync(db);
 
         var pdfId = Guid.NewGuid();
         db.PdfDocuments.Add(new PdfDocumentEntity
@@ -169,7 +229,9 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
             MaxPlayers = 4,
             PlayingTimeMinutes = 60,
             MinAge = 10,
-            SelectedBggId = null
+            // SelectedBggId triggers the BGG mock which supplies description/imageUrl/thumbnailUrl
+            // required by SharedGame.Create() domain validation.
+            SelectedBggId = 174430
         };
 
         // Act — first submit
@@ -213,7 +275,8 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 60,
-            MinAge = 10
+            MinAge = 10,
+            SelectedBggId = 174430
         };
         var requestB_differentBody = requestA with
         {
@@ -252,7 +315,8 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
             MaxPlayers = 4,
             PlayingTimeMinutes = 60,
             MinAge = 10,
-            SelectedBggId = null
+            // Use distinct BggIds: shared_games has a unique-per-non-null index on bgg_id.
+            SelectedBggId = 174430
         };
         var requestB = new CreateGameFromPdfRequest
         {
@@ -262,7 +326,7 @@ public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
             MaxPlayers = 4,
             PlayingTimeMinutes = 60,
             MinAge = 10,
-            SelectedBggId = null
+            SelectedBggId = 174431
         };
 
         // Act — two independent keys → two independent creates

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs
@@ -1,0 +1,290 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Models;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Integration;
+
+/// <summary>
+/// Integration tests for G5: Idempotency-Key support on POST /admin/shared-games/wizard/create.
+/// Verifies double-submit protection, body-mismatch 422, and different-key independence.
+/// Uses in-process IDistributedCache (AddDistributedMemoryCache) via IntegrationWebApplicationFactory
+/// with Redis:Enabled=false (default), which is sufficient for same-process idempotency verification.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WizardCreateIdempotencyTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private Guid _testUserId;
+
+    public WizardCreateIdempotencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"wizard_idempotency_test_{Guid.NewGuid():N}";
+        _testUserId = Guid.NewGuid();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    // Mock BGG API to avoid real calls
+                    services.RemoveAll(typeof(Api.Services.IBggApiService));
+                    var mockBggApi = new Mock<Api.Services.IBggApiService>();
+                    mockBggApi
+                        .Setup(x => x.SearchGamesAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                        .Returns(Task.FromResult(new List<BggSearchResultDto>()));
+                    mockBggApi
+                        .Setup(x => x.GetGameDetailsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                        .Returns(Task.FromResult<BggGameDetailsDto?>(null));
+                    services.AddScoped(_ => mockBggApi.Object);
+
+                    // Allow all auth for test purposes
+                    services.AddAuthentication(TestAuthenticationHandler.SchemeName)
+                        .AddScheme<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions, TestAuthenticationHandler>(
+                            TestAuthenticationHandler.SchemeName, _ => { });
+
+                    var allowAllPolicy = new AuthorizationPolicyBuilder()
+                        .AddAuthenticationSchemes(TestAuthenticationHandler.SchemeName)
+                        .RequireAssertion(_ => true)
+                        .Build();
+                    services.AddAuthorization(options =>
+                    {
+                        options.DefaultPolicy = allowAllPolicy;
+                        options.AddPolicy("AdminOrEditorPolicy", allowAllPolicy);
+                        options.AddPolicy("AdminOnlyPolicy", allowAllPolicy);
+                    });
+                });
+            });
+
+        // Migrate DB
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+        _client.DefaultRequestHeaders.Add(TestAuthenticationHandler.UserIdHeader, _testUserId.ToString());
+        _client.DefaultRequestHeaders.Add(TestAuthenticationHandler.RoleHeader, "Admin");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helper: seed a minimal PdfDocumentEntity so the handler can find the PDF
+    // ─────────────────────────────────────────────────────────────────────────
+    private async Task<Guid> SeedOrphanPdfAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = $"test-{pdfId:N}.pdf",
+            FilePath = $"/tmp/test-{pdfId:N}.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = _testUserId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready"
+        });
+        await db.SaveChangesAsync();
+
+        return pdfId;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helper: count SharedGames by extracted title (for duplicate-game assertion)
+    // ─────────────────────────────────────────────────────────────────────────
+    private async Task<int> CountGamesByTitleAsync(string title)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        return await db.SharedGames
+            .AsNoTracking()
+            .CountAsync(g => g.Title == title);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helper: POST to wizard/create with Idempotency-Key header
+    // ─────────────────────────────────────────────────────────────────────────
+    private async Task<HttpResponseMessage> PostWithIdempotencyKeyAsync(
+        CreateGameFromPdfRequest request,
+        string idempotencyKey)
+    {
+        var message = new HttpRequestMessage(HttpMethod.Post, "/api/v1/admin/shared-games/wizard/create")
+        {
+            Content = JsonContent.Create(request)
+        };
+        message.Headers.Add("Idempotency-Key", idempotencyKey);
+        return await _client.SendAsync(message);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DoubleSubmit_WithSameIdempotencyKey_ReturnsSameGameId()
+    {
+        // Arrange — seed a PDF the handler can find
+        var pdfDocumentId = await SeedOrphanPdfAsync();
+
+        var idempotencyKey = Guid.NewGuid().ToString();
+        var request = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfDocumentId,
+            ExtractedTitle = $"Idempotency Test Game {Guid.NewGuid():N}",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            SelectedBggId = null
+        };
+
+        // Act — first submit
+        var firstResponse = await PostWithIdempotencyKeyAsync(request, idempotencyKey);
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.Created,
+            "first submission with a valid PDF should create a game");
+
+        var firstResult = await firstResponse.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+        firstResult.Should().NotBeNull();
+
+        // Act — second submit with identical body + same key
+        var secondResponse = await PostWithIdempotencyKeyAsync(request, idempotencyKey);
+
+        // Assert — HTTP 201, same gameId
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.Created,
+            "idempotent replay should return 201 from cache");
+
+        var secondResult = await secondResponse.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+        secondResult.Should().NotBeNull();
+        secondResult!.GameId.Should().Be(firstResult!.GameId,
+            "second submit with same Idempotency-Key should return the cached gameId");
+
+        // Assert — only 1 game created in DB
+        var gameCount = await CountGamesByTitleAsync(request.ExtractedTitle);
+        gameCount.Should().Be(1, "idempotent replay must not create a second game");
+    }
+
+    [Fact]
+    public async Task SameIdempotencyKey_WithDifferentBody_Returns422()
+    {
+        // F2 (review finding): IETF draft-ietf-httpapi-idempotency-key §2.6
+        // Arrange
+        var pdfA = await SeedOrphanPdfAsync();
+        var pdfB = await SeedOrphanPdfAsync();
+
+        var key = Guid.NewGuid().ToString();
+        var requestA = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfA,
+            ExtractedTitle = $"Original Game {Guid.NewGuid():N}",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10
+        };
+        var requestB_differentBody = requestA with
+        {
+            PdfDocumentId = pdfB,
+            ExtractedTitle = "Completely Different Title"
+        };
+
+        // Act — first submit succeeds
+        var first = await PostWithIdempotencyKeyAsync(requestA, key);
+        first.StatusCode.Should().Be(HttpStatusCode.Created,
+            "first submission with valid PDF should succeed");
+
+        // Act — second submit with same key but different body
+        var second = await PostWithIdempotencyKeyAsync(requestB_differentBody, key);
+
+        // Assert — 422 Unprocessable Entity per IETF spec §2.6
+        second.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity,
+            "reusing an Idempotency-Key with a different request body must return HTTP 422");
+    }
+
+    [Fact]
+    public async Task DoubleSubmit_WithDifferentIdempotencyKeys_CreatesTwoGames()
+    {
+        // Arrange — each key is independent
+        var pdfA = await SeedOrphanPdfAsync();
+        var pdfB = await SeedOrphanPdfAsync();
+
+        var titleA = $"Game Alpha {Guid.NewGuid():N}";
+        var titleB = $"Game Beta {Guid.NewGuid():N}";
+
+        var requestA = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfA,
+            ExtractedTitle = titleA,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            SelectedBggId = null
+        };
+        var requestB = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfB,
+            ExtractedTitle = titleB,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            SelectedBggId = null
+        };
+
+        // Act — two independent keys → two independent creates
+        var responseA = await PostWithIdempotencyKeyAsync(requestA, Guid.NewGuid().ToString());
+        var responseB = await PostWithIdempotencyKeyAsync(requestB, Guid.NewGuid().ToString());
+
+        // Assert — both 201 and distinct gameIds
+        responseA.StatusCode.Should().Be(HttpStatusCode.Created);
+        responseB.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var resultA = await responseA.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+        var resultB = await responseB.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+
+        resultA.Should().NotBeNull();
+        resultB.Should().NotBeNull();
+        resultA!.GameId.Should().NotBe(resultB!.GameId,
+            "different Idempotency-Keys should produce distinct games");
+
+        // Both games exist in DB
+        var countA = await CountGamesByTitleAsync(titleA);
+        var countB = await CountGamesByTitleAsync(titleB);
+        countA.Should().Be(1);
+        countB.Should().Be(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-08-admin-shared-game-gap-closure-g1-g2-g5.md
+++ b/docs/superpowers/plans/2026-06-08-admin-shared-game-gap-closure-g1-g2-g5.md
@@ -1,0 +1,1829 @@
+# Admin Shared Game — Gap Closure G1/G2/G5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Chiudere 3 gap reali sul workflow admin shared-game import esistente: (G1) edit manuale di tag fields + BggId su `UpdateSharedGameCommand`, (G2) re-upload BGG cover image sul nostro storage durante create-from-PDF, (G5) Idempotency-Key support su `POST /admin/shared-games/wizard/create`.
+
+**Architecture:**
+- G1 estende command esistente seguendo pattern già accettato in `UpdateSharedGameFromBggCommandHandler` (DB context + Clear/AddRange su collections); aggiunge `BggId` come scalar update.
+- G2 introduce `BggCoverDownloader` service che fetcha BGG image URL → uploada a `IBlobStorageService` con resource key `bgg-cover-{bggId}` → salva `BggCoverR2Key` su `SharedGameEntity`; estende `CoverUrlResolver` con layer L2.5 BGG (priority L3 user → L4 PDF → L2.5 BGG → L2 Wikidata).
+- G5 usa Redis cache (`IAiResponseCacheService` già DI-registered) per persist `Idempotency-Key → gameId` con TTL 5 min; check pre-Send nel wizard endpoint.
+
+**Tech Stack:** .NET 9 + EF Core (Postgres + Testcontainers per integration) + xUnit + Moq + FluentValidation + MediatR + Redis cache wrapper esistente.
+
+**Scope explicit out:**
+- G3 (UI tab labels) — cosmetic, defer
+- G4 (single-page vs 3-step wizard UX) — design choice esistente, defer
+- G6 (admin quota bypass) — falso positivo, `UploadPdfForGameExtractionCommandHandler:13` già senza quota check
+- Frontend changes — questo plan è backend-only (no UI changes). Eventuale FE estensione del form `/admin/shared-games/[id]` per esporre tag fields nell'edit è follow-up separato.
+
+---
+
+## File Structure
+
+### Files to CREATE
+
+| Path | Responsibility |
+|------|----------------|
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverDownloader.cs` | Interface for downloader service |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs` | Implementation: fetch BGG image + upload to blob storage |
+| `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddBggCoverR2KeyToSharedGames.cs` | EF migration adding column |
+| `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs` | New unit test class (currently missing) |
+| `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs` | New unit test class for downloader |
+| `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs` | New integration test (Testcontainers) for double-submit |
+
+### Files to MODIFY
+
+| Path | What changes |
+|------|--------------|
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommand.cs` | Add `List<string>? Categories, Mechanics, Designers, Publishers; int? BggId` fields |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandValidator.cs` | Validate new fields (length, count, BggId positive) |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs` | Use `MeepleAiDbContext` DI to update collections + BggId via Clear/Add pattern |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs` | Register `IBggCoverDownloader` + dbContext into UpdateSharedGameCommandHandler if needed |
+| `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs` | Add `string? BggCoverR2Key` property |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs` | Configure `BggCoverR2Key` column (nullable, varchar) |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs` | Add L2.5 layer (BggCoverR2Key) between L4 (Pdf) and L2 (Wikidata) |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs` | Step 5: invoke `IBggCoverDownloader` if `SelectedBggId` present; fallback to direct URL on failure |
+| `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs` | `HandleWizardCreateGame`: read `Idempotency-Key` header, check Redis cache, return existing gameId on hit |
+| `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs` | Add `SetBggCoverR2Key(string?)` domain method (no event, infrastructure concern) |
+| `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs` | Add 2 new tests for cover re-upload (success + fallback) |
+
+---
+
+## Phase 1 — G1: UpdateSharedGameCommand extension
+
+**Goal:** Permettere all'edit form di `/admin/shared-games/[id]` di aggiornare manualmente `Categories`, `Mechanics`, `Designers`, `Publishers`, `BggId` oltre ai core fields già supportati.
+
+**Pattern reference:** `UpdateSharedGameFromBggCommandHandler.cs:46-118` — usa `MeepleAiDbContext.Set<SharedGameEntity>().Include(...)` + Clear/foreach Add pattern per collections.
+
+### Task 1.1: Extend `UpdateSharedGameCommand` record
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommand.cs`
+
+- [ ] **Step 1.1.1: Update command record signature**
+
+Replace the entire content of `UpdateSharedGameCommand.cs` with:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Command to update an existing shared game in the catalog.
+/// Supports core fields, taxonomy collections (categories, mechanics, designers, publishers),
+/// and BggId. Null collections mean "do not change"; empty list means "clear".
+/// </summary>
+internal record UpdateSharedGameCommand(
+    Guid GameId,
+    string Title,
+    int YearPublished,
+    string Description,
+    int MinPlayers,
+    int MaxPlayers,
+    int PlayingTimeMinutes,
+    int MinAge,
+    decimal? ComplexityRating,
+    decimal? AverageRating,
+    string ImageUrl,
+    string ThumbnailUrl,
+    GameRulesDto? Rules,
+    Guid ModifiedBy,
+    int? BggId = null,
+    List<string>? Categories = null,
+    List<string>? Mechanics = null,
+    List<string>? Designers = null,
+    List<string>? Publishers = null
+) : ICommand<Unit>;
+```
+
+- [ ] **Step 1.1.2: Verify compilation**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj -c Debug --nologo`
+Expected: build succeeds with 0 errors. Pre-existing warnings are acceptable.
+
+- [ ] **Step 1.1.3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommand.cs
+git commit -m "feat(shared-games): extend UpdateSharedGameCommand with taxonomy fields and BggId
+
+Gap G1 from spec docs/superpowers/specs/2026-06-08-admin-shared-game-import-spec-panel-review.md.
+Null collections = no change semantics; empty = clear. BggId optional scalar.
+Handler/validator changes in subsequent tasks."
+```
+
+### Task 1.2: Update validator
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandValidator.cs`
+
+- [ ] **Step 1.2.1: Read current validator to preserve existing rules**
+
+Run: `Read apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandValidator.cs`
+
+You will use the existing rule structure as a template. Look at how core field rules are written, then append the new rules.
+
+- [ ] **Step 1.2.2: Append validation rules for new fields**
+
+Inside the validator's constructor, after the existing rules, add:
+
+```csharp
+RuleFor(x => x.BggId)
+    .GreaterThan(0)
+    .When(x => x.BggId.HasValue)
+    .WithMessage("BggId must be a positive integer when provided");
+
+RuleFor(x => x.Categories)
+    .Must(c => c == null || c.Count <= 20)
+    .WithMessage("Categories cannot exceed 20 items");
+
+RuleForEach(x => x.Categories)
+    .NotEmpty()
+    .MaximumLength(100)
+    .When(x => x.Categories != null);
+
+RuleFor(x => x.Mechanics)
+    .Must(m => m == null || m.Count <= 30)
+    .WithMessage("Mechanics cannot exceed 30 items");
+
+RuleForEach(x => x.Mechanics)
+    .NotEmpty()
+    .MaximumLength(100)
+    .When(x => x.Mechanics != null);
+
+RuleFor(x => x.Designers)
+    .Must(d => d == null || d.Count <= 20)
+    .WithMessage("Designers cannot exceed 20 items");
+
+RuleForEach(x => x.Designers)
+    .NotEmpty()
+    .MaximumLength(200)
+    .When(x => x.Designers != null);
+
+RuleFor(x => x.Publishers)
+    .Must(p => p == null || p.Count <= 20)
+    .WithMessage("Publishers cannot exceed 20 items");
+
+RuleForEach(x => x.Publishers)
+    .NotEmpty()
+    .MaximumLength(200)
+    .When(x => x.Publishers != null);
+```
+
+- [ ] **Step 1.2.3: Verify compilation**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj -c Debug --nologo`
+Expected: build succeeds with 0 errors.
+
+- [ ] **Step 1.2.4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandValidator.cs
+git commit -m "feat(shared-games): add validation rules for taxonomy and BggId in UpdateSharedGameCommand
+
+Limits: 20 categories/designers/publishers, 30 mechanics. Per-item length caps."
+```
+
+### Task 1.3: Create unit test class for UpdateSharedGameCommandHandler
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs`
+
+- [ ] **Step 1.3.1: Inspect existing handler test pattern for reference**
+
+Run: `Read apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs` (first ~60 lines)
+
+Note the fixture setup (Moq, InMemory DbContext or Testcontainers, repository mocks).
+
+- [ ] **Step 1.3.2: Write the failing test file (3 tests)**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Handlers;
+
+public sealed class UpdateSharedGameCommandHandlerTests
+{
+    private readonly Mock<ISharedGameRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<UpdateSharedGameCommandHandler>> _loggerMock = new();
+    private readonly MeepleAiDbContext _dbContext;
+
+    public UpdateSharedGameCommandHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"update-shared-game-{Guid.NewGuid()}")
+            .Options;
+        _dbContext = new MeepleAiDbContext(options);
+    }
+
+    [Fact]
+    public async Task Handle_WithCoreFieldsOnly_UpdatesGameSuccessfully()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingEntity = SeedGameEntity(gameId);
+
+        var domainAggregate = BuildAggregateFromEntity(existingEntity);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: "Wingspan ITA",
+            YearPublished: 2019,
+            Description: "Updated description",
+            MinPlayers: 1,
+            MaxPlayers: 5,
+            PlayingTimeMinutes: 70,
+            MinAge: 10,
+            ComplexityRating: 2.4m,
+            AverageRating: 8.1m,
+            ImageUrl: "https://cdn/img.webp",
+            ThumbnailUrl: "https://cdn/thumb.webp",
+            Rules: null,
+            ModifiedBy: userId);
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(Unit.Value);
+        _repositoryMock.Verify(r => r.Update(It.IsAny<SharedGame>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithCategoriesAndMechanics_ReplacesCollections()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var entity = SeedGameEntity(gameId);
+        entity.Categories.Add(new GameCategoryEntity { Id = Guid.NewGuid(), Name = "Old", Slug = "old", CreatedAt = DateTime.UtcNow });
+        _dbContext.Set<SharedGameEntity>().Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var domainAggregate = BuildAggregateFromEntity(entity);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: entity.Title,
+            YearPublished: entity.YearPublished,
+            Description: entity.Description,
+            MinPlayers: entity.MinPlayers,
+            MaxPlayers: entity.MaxPlayers,
+            PlayingTimeMinutes: entity.PlayingTimeMinutes,
+            MinAge: entity.MinAge,
+            ComplexityRating: entity.ComplexityRating,
+            AverageRating: entity.AverageRating,
+            ImageUrl: entity.ImageUrl,
+            ThumbnailUrl: entity.ThumbnailUrl,
+            Rules: null,
+            ModifiedBy: userId,
+            Categories: new List<string> { "Strategy", "Negotiation" },
+            Mechanics: new List<string> { "Dice Rolling" });
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        var reloaded = await _dbContext.Set<SharedGameEntity>()
+            .Include(g => g.Categories)
+            .Include(g => g.Mechanics)
+            .FirstAsync(g => g.Id == gameId);
+
+        reloaded.Categories.Select(c => c.Name).Should().BeEquivalentTo(new[] { "Strategy", "Negotiation" });
+        reloaded.Mechanics.Select(m => m.Name).Should().BeEquivalentTo(new[] { "Dice Rolling" });
+    }
+
+    [Fact]
+    public async Task Handle_WithBggIdProvided_UpdatesBggIdScalar()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var entity = SeedGameEntity(gameId);
+        entity.BggId = null;
+        _dbContext.Set<SharedGameEntity>().Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var domainAggregate = BuildAggregateFromEntity(entity);
+        _repositoryMock.Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(domainAggregate);
+
+        var command = new UpdateSharedGameCommand(
+            GameId: gameId,
+            Title: entity.Title,
+            YearPublished: entity.YearPublished,
+            Description: entity.Description,
+            MinPlayers: entity.MinPlayers,
+            MaxPlayers: entity.MaxPlayers,
+            PlayingTimeMinutes: entity.PlayingTimeMinutes,
+            MinAge: entity.MinAge,
+            ComplexityRating: entity.ComplexityRating,
+            AverageRating: entity.AverageRating,
+            ImageUrl: entity.ImageUrl,
+            ThumbnailUrl: entity.ThumbnailUrl,
+            Rules: null,
+            ModifiedBy: userId,
+            BggId: 13);
+
+        var handler = new UpdateSharedGameCommandHandler(
+            _repositoryMock.Object, _unitOfWorkMock.Object, _dbContext, _loggerMock.Object);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        var reloaded = await _dbContext.Set<SharedGameEntity>().FirstAsync(g => g.Id == gameId);
+        reloaded.BggId.Should().Be(13);
+    }
+
+    private static SharedGameEntity SeedGameEntity(Guid gameId)
+    {
+        return new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Wingspan",
+            Description = "Bird-themed engine builder",
+            YearPublished = 2019,
+            MinPlayers = 1,
+            MaxPlayers = 5,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = "https://cdn/old.webp",
+            ThumbnailUrl = "https://cdn/old-thumb.webp",
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        };
+    }
+
+    private static SharedGame BuildAggregateFromEntity(SharedGameEntity entity)
+    {
+        return SharedGame.Create(
+            title: entity.Title,
+            yearPublished: entity.YearPublished,
+            description: entity.Description,
+            minPlayers: entity.MinPlayers,
+            maxPlayers: entity.MaxPlayers,
+            playingTimeMinutes: entity.PlayingTimeMinutes,
+            minAge: entity.MinAge,
+            complexityRating: entity.ComplexityRating,
+            averageRating: entity.AverageRating,
+            imageUrl: entity.ImageUrl,
+            thumbnailUrl: entity.ThumbnailUrl,
+            rules: null,
+            createdBy: entity.CreatedBy,
+            bggId: entity.BggId);
+    }
+}
+```
+
+- [ ] **Step 1.3.3: Run tests — expect FAIL (compilation error: handler ctor signature changed)**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~UpdateSharedGameCommandHandlerTests" --nologo`
+Expected: FAIL — handler constructor doesn't yet accept `MeepleAiDbContext`. This is the failing test signal.
+
+If aggregates `SharedGame.Create` signature has drifted from this plan's example, adapt the `BuildAggregateFromEntity` helper to current production signature (read `SharedGame.cs:347` for the `Create` method to align).
+
+- [ ] **Step 1.3.4: Commit failing tests**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UpdateSharedGameCommandHandlerTests.cs
+git commit -m "test(shared-games): add UpdateSharedGameCommandHandler tests (failing, handler ctor pending)"
+```
+
+### Task 1.4: Refactor handler to support new fields
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs`
+
+- [ ] **Step 1.4.1: Replace handler implementation**
+
+Replace the entire content of `UpdateSharedGameCommandHandler.cs` with:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Handler for updating an existing shared game.
+/// Supports core fields (via domain UpdateInfo) and optional manual updates of
+/// BggId + taxonomy collections (categories, mechanics, designers, publishers).
+/// </summary>
+/// <remarks>
+/// Uses MeepleAiDbContext directly for relationship management — same pattern as
+/// UpdateSharedGameFromBggCommandHandler. The repository abstraction does not
+/// support tracked Include for collection-replace semantics.
+/// </remarks>
+internal sealed class UpdateSharedGameCommandHandler : ICommandHandler<UpdateSharedGameCommand, Unit>
+{
+    private readonly ISharedGameRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<UpdateSharedGameCommandHandler> _logger;
+
+    public UpdateSharedGameCommandHandler(
+        ISharedGameRepository repository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext dbContext,
+        ILogger<UpdateSharedGameCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Unit> Handle(UpdateSharedGameCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        _logger.LogInformation(
+            "Updating shared game: {GameId}, ModifiedBy: {UserId}",
+            command.GameId, command.ModifiedBy);
+
+        // ─── 1. Update aggregate core fields via domain method ─────────────
+        var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false);
+        if (game is null)
+        {
+            throw new InvalidOperationException($"Shared game {command.GameId} not found");
+        }
+
+        GameRules? rules = null;
+        if (command.Rules is not null)
+        {
+            rules = GameRules.Create(command.Rules.Content, command.Rules.Language);
+        }
+
+        game.UpdateInfo(
+            command.Title, command.YearPublished, command.Description,
+            command.MinPlayers, command.MaxPlayers, command.PlayingTimeMinutes,
+            command.MinAge, command.ComplexityRating, command.AverageRating,
+            command.ImageUrl, command.ThumbnailUrl, rules, command.ModifiedBy);
+
+        _repository.Update(game);
+
+        // ─── 2. Update entity-level fields (BggId + collections) ────────────
+        // Only fetched if any non-null new field is present; null = no change.
+        var needsEntityUpdate = command.BggId.HasValue
+            || command.Categories is not null
+            || command.Mechanics is not null
+            || command.Designers is not null
+            || command.Publishers is not null;
+
+        if (needsEntityUpdate)
+        {
+            var entity = await _dbContext.Set<SharedGameEntity>()
+                .Include(e => e.Categories)
+                .Include(e => e.Mechanics)
+                .Include(e => e.Designers)
+                .Include(e => e.Publishers)
+                .FirstOrDefaultAsync(e => e.Id == command.GameId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (entity is null)
+            {
+                throw new InvalidOperationException($"SharedGame entity {command.GameId} not found in DbContext");
+            }
+
+            if (command.BggId.HasValue)
+            {
+                entity.BggId = command.BggId.Value;
+            }
+
+            if (command.Categories is not null)
+            {
+                await ReplaceCategoriesAsync(entity, command.Categories, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (command.Mechanics is not null)
+            {
+                await ReplaceMechanicsAsync(entity, command.Mechanics, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (command.Designers is not null)
+            {
+                await ReplaceDesignersAsync(entity, command.Designers, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (command.Publishers is not null)
+            {
+                await ReplacePublishersAsync(entity, command.Publishers, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Shared game updated successfully: {GameId}",
+            command.GameId);
+
+        return Unit.Value;
+    }
+
+    private async Task ReplaceCategoriesAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Categories.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var category = await _dbContext.GameCategories.FirstOrDefaultAsync(c => c.Name == name, ct).ConfigureAwait(false);
+            if (category is null)
+            {
+                category = new GameCategoryEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    Slug = name.ToLowerInvariant().Replace(" ", "-"),
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GameCategories.AddAsync(category, ct).ConfigureAwait(false);
+            }
+            entity.Categories.Add(category);
+        }
+    }
+
+    private async Task ReplaceMechanicsAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Mechanics.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var mechanic = await _dbContext.GameMechanics.FirstOrDefaultAsync(m => m.Name == name, ct).ConfigureAwait(false);
+            if (mechanic is null)
+            {
+                mechanic = new GameMechanicEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    Slug = name.ToLowerInvariant().Replace(" ", "-"),
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GameMechanics.AddAsync(mechanic, ct).ConfigureAwait(false);
+            }
+            entity.Mechanics.Add(mechanic);
+        }
+    }
+
+    private async Task ReplaceDesignersAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Designers.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var designer = await _dbContext.GameDesigners.FirstOrDefaultAsync(d => d.Name == name, ct).ConfigureAwait(false);
+            if (designer is null)
+            {
+                designer = new GameDesignerEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GameDesigners.AddAsync(designer, ct).ConfigureAwait(false);
+            }
+            entity.Designers.Add(designer);
+        }
+    }
+
+    private async Task ReplacePublishersAsync(SharedGameEntity entity, List<string> names, CancellationToken ct)
+    {
+        entity.Publishers.Clear();
+        foreach (var name in names.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.Ordinal))
+        {
+            var publisher = await _dbContext.GamePublishers.FirstOrDefaultAsync(p => p.Name == name, ct).ConfigureAwait(false);
+            if (publisher is null)
+            {
+                publisher = new GamePublisherEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.GamePublishers.AddAsync(publisher, ct).ConfigureAwait(false);
+            }
+            entity.Publishers.Add(publisher);
+        }
+    }
+}
+```
+
+- [ ] **Step 1.4.2: Run tests — expect PASS**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~UpdateSharedGameCommandHandlerTests" --nologo`
+Expected: 3 tests pass.
+
+If a test fails because production signature of `SharedGame.Create` or `SharedGame.UpdateInfo` differs from the assumptions, **read the current production source** and adapt the test, not the production code. Production drift wins.
+
+- [ ] **Step 1.4.3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateSharedGameCommandHandler.cs
+git commit -m "feat(shared-games): handler supports manual update of taxonomy + BggId
+
+G1 closure. Pattern mirrors UpdateSharedGameFromBggCommandHandler:
+DbContext.Set<SharedGameEntity>.Include(...) + Clear/Add per collection.
+Null collection = no change; empty = clear. Tests in same PR."
+```
+
+### Task 1.5: Verify no existing callers break
+
+- [ ] **Step 1.5.1: Search for existing UpdateSharedGameCommand instantiations**
+
+Run: `Grep pattern="new UpdateSharedGameCommand\(" path="apps/api/src/Api" output_mode="content"`
+Expected: list of call sites (likely few, in routing or handlers).
+
+- [ ] **Step 1.5.2: Verify each call site still compiles**
+
+All new params (BggId, Categories, Mechanics, Designers, Publishers) have defaults `= null`, so existing call sites should compile unchanged. If any caller breaks, restore signature compatibility — do not modify callers in this PR.
+
+Run: `dotnet build apps/api/src/Api/Api.csproj --nologo`
+Expected: 0 errors.
+
+- [ ] **Step 1.5.3: Run full SharedGameCatalog test slice**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SharedGameCatalog" --nologo`
+Expected: all green. If pre-existing reds appear, document as out-of-scope baseline (do not fix in this PR).
+
+- [ ] **Step 1.5.4: Commit if any minor adjustments**
+
+If adjustments made:
+```bash
+git add -A
+git commit -m "chore(shared-games): align call sites after UpdateSharedGameCommand extension"
+```
+Otherwise skip.
+
+---
+
+## Phase 2 — G2: BGG cover re-upload on our storage
+
+**Goal:** Quando `CreateSharedGameFromPdfCommandHandler` riceve `SelectedBggId`, scaricare `bggDetails.ImageUrl` da BGG CDN, ri-uploadare via `IBlobStorageService` con resource key `bgg-cover-{bggId}`, e salvare `BggCoverR2Key` in `SharedGameEntity`. Fallback su URL diretto BGG se download/upload fallisce.
+
+### Task 2.1: Add BggCoverR2Key column to SharedGameEntity
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs`
+
+- [ ] **Step 2.1.1: Read existing entity to identify insertion point**
+
+Run: `Read apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs`
+
+Locate where existing R2Key fields are declared (search for `PdfCoverR2Key` or `WikidataCoverR2Key`).
+
+- [ ] **Step 2.1.2: Add property next to existing R2Key fields**
+
+After `PdfCoverR2Key` property declaration (and `WikidataCoverR2Key` if present), add:
+
+```csharp
+/// <summary>
+/// Gap G2 (issue: BGG cover re-upload).
+/// R2 key for cover image downloaded from BGG and re-uploaded to our storage.
+/// Resolved by CoverUrlResolver L2.5 layer (between L4 PDF and L2 Wikidata).
+/// Null when no BGG enrichment was applied or download failed.
+/// </summary>
+public string? BggCoverR2Key { get; set; }
+```
+
+- [ ] **Step 2.1.3: Configure EF mapping**
+
+Open `SharedGameEntityConfiguration.cs`. Locate where `PdfCoverR2Key` is configured (typical pattern: `builder.Property(e => e.PdfCoverR2Key).HasMaxLength(...)`).
+
+After that mapping, add:
+
+```csharp
+builder.Property(e => e.BggCoverR2Key)
+    .HasMaxLength(256)
+    .IsRequired(false);
+```
+
+If the configuration class does not exist (fluent config inlined in DbContext OnModelCreating), find that OnModelCreating block and add the equivalent there.
+
+- [ ] **Step 2.1.4: Verify compilation**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj --nologo`
+Expected: 0 errors.
+
+- [ ] **Step 2.1.5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+git commit -m "feat(shared-games): add BggCoverR2Key column to SharedGameEntity
+
+Gap G2. nullable varchar(256). Mapping pending in next migration commit."
+```
+
+### Task 2.2: Generate EF migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddBggCoverR2KeyToSharedGames.cs` (auto-generated)
+
+- [ ] **Step 2.2.1: Generate migration**
+
+Run from `apps/api/src/Api`:
+```bash
+dotnet ef migrations add AddBggCoverR2KeyToSharedGames --output-dir Infrastructure/Migrations
+```
+Expected: 3 files created (migration .cs, .Designer.cs, snapshot updated).
+
+- [ ] **Step 2.2.2: Inspect generated migration**
+
+Run: `Read apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddBggCoverR2KeyToSharedGames.cs`
+
+Verify the `Up()` method only adds `BggCoverR2Key` column to `shared_games` (or whatever the actual table name is), nullable. If migration touches other tables, **stop** — entity/config drift exists. Re-run discovery before continuing.
+
+- [ ] **Step 2.2.3: Apply migration to local dev DB**
+
+Run from `apps/api/src/Api`:
+```bash
+dotnet ef database update
+```
+Expected: migration applied without errors.
+
+- [ ] **Step 2.2.4: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(shared-games): EF migration adds BggCoverR2Key column
+
+Gap G2. Reversible Down() preserves zero-downtime rollback."
+```
+
+### Task 2.3: Define `IBggCoverDownloader` interface
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverDownloader.cs`
+
+- [ ] **Step 2.3.1: Create interface file**
+
+Write:
+
+```csharp
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Downloads a cover image from a remote URL (typically BGG CDN) and re-uploads
+/// it to our internal blob storage. Returns the R2 key on success, null on failure
+/// (caller falls back to direct remote URL).
+/// </summary>
+internal interface IBggCoverDownloader
+{
+    /// <summary>
+    /// Downloads the image at <paramref name="remoteImageUrl"/> and stores it in blob
+    /// storage with a key derived from <paramref name="bggId"/>.
+    /// </summary>
+    /// <returns>The R2 key on success; null if download or upload failed (logged).</returns>
+    Task<string?> DownloadAndUploadAsync(
+        int bggId,
+        string remoteImageUrl,
+        CancellationToken cancellationToken);
+}
+```
+
+- [ ] **Step 2.3.2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverDownloader.cs
+git commit -m "feat(shared-games): IBggCoverDownloader interface (Gap G2 scaffolding)"
+```
+
+### Task 2.4: Write failing tests for `BggCoverDownloader`
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs`
+
+- [ ] **Step 2.4.1: Write test file (3 scenarios)**
+
+Create:
+
+```csharp
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+public sealed class BggCoverDownloaderTests
+{
+    private readonly Mock<IBlobStorageService> _blobMock = new();
+    private readonly Mock<ILogger<BggCoverDownloader>> _loggerMock = new();
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnSuccess_ReturnsR2Key()
+    {
+        // Arrange
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x89, 0x50, 0x4E, 0x47 /* fake PNG header */ });
+        _blobMock.Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<string>(),
+                BlobCategory.GameImage,
+                "bgg-cover-13",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(Success: true, FilePath: "bgg-cover-13", FileSizeBytes: 4, ErrorMessage: null));
+
+        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/abc.jpg", CancellationToken.None);
+
+        // Assert
+        result.Should().Be("bgg-cover-13");
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnHttpError_ReturnsNull()
+    {
+        // Arrange
+        var httpClient = BuildHttpClient(HttpStatusCode.NotFound);
+        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/missing.jpg", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+        _blobMock.Verify(b => b.StoreAsync(
+            It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnUploadFailure_ReturnsNull()
+    {
+        // Arrange
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x01 });
+        _blobMock.Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(Success: false, FilePath: null, FileSizeBytes: 0, ErrorMessage: "S3 unavailable"));
+
+        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/abc.jpg", CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static HttpClient BuildHttpClient(HttpStatusCode statusCode, byte[]? content = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = content is null ? null : new ByteArrayContent(content)
+            });
+        return new HttpClient(handler.Object);
+    }
+}
+```
+
+**Note on test infrastructure dependencies:** If `BlobStorageResult` record signature differs from this plan's assumption (params: `Success`, `FilePath`, `FileSizeBytes`, `ErrorMessage`), read its current definition under `Api.Services.Pdf` namespace and align test arrange clauses. Production wins.
+
+- [ ] **Step 2.4.2: Run tests — expect FAIL (BggCoverDownloader class does not exist)**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~BggCoverDownloaderTests" --nologo`
+Expected: compile error / class not found.
+
+- [ ] **Step 2.4.3: Commit failing tests**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
+git commit -m "test(shared-games): add BggCoverDownloader failing tests (implementation pending)"
+```
+
+### Task 2.5: Implement `BggCoverDownloader`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs`
+
+- [ ] **Step 2.5.1: Write implementation**
+
+Create:
+
+```csharp
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+internal sealed class BggCoverDownloader : IBggCoverDownloader
+{
+    private readonly HttpClient _httpClient;
+    private readonly IBlobStorageService _blobStorageService;
+    private readonly ILogger<BggCoverDownloader> _logger;
+
+    public BggCoverDownloader(
+        HttpClient httpClient,
+        IBlobStorageService blobStorageService,
+        ILogger<BggCoverDownloader> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _blobStorageService = blobStorageService ?? throw new ArgumentNullException(nameof(blobStorageService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string?> DownloadAndUploadAsync(
+        int bggId,
+        string remoteImageUrl,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(remoteImageUrl))
+        {
+            return null;
+        }
+
+        var resourceKey = $"bgg-cover-{bggId}";
+
+        try
+        {
+            using var response = await _httpClient
+                .GetAsync(remoteImageUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "BGG cover download failed: BggId={BggId}, Url={Url}, Status={Status}",
+                    bggId, remoteImageUrl, response.StatusCode);
+                return null;
+            }
+
+            await using var imageStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+            // Derive a safe filename from the URL path
+            var fileName = $"cover-{bggId}{GetExtension(remoteImageUrl)}";
+
+            var storageResult = await _blobStorageService
+                .StoreAsync(imageStream, fileName, BlobCategory.GameImage, resourceKey, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!storageResult.Success)
+            {
+                _logger.LogWarning(
+                    "BGG cover upload failed: BggId={BggId}, Error={Error}",
+                    bggId, storageResult.ErrorMessage);
+                return null;
+            }
+
+            _logger.LogInformation(
+                "BGG cover uploaded successfully: BggId={BggId}, R2Key={Key}",
+                bggId, resourceKey);
+            return resourceKey;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Unexpected error in BGG cover download/upload: BggId={BggId}", bggId);
+            return null;
+        }
+    }
+
+    private static string GetExtension(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var path = uri.AbsolutePath;
+            var ext = Path.GetExtension(path);
+            return string.IsNullOrEmpty(ext) || ext.Length > 5 ? ".jpg" : ext.ToLowerInvariant();
+        }
+        catch
+        {
+            return ".jpg";
+        }
+    }
+}
+```
+
+- [ ] **Step 2.5.2: Register DI in SharedGameCatalogServiceExtensions**
+
+Open `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs`.
+
+Inside the extension method that registers SharedGameCatalog services, add:
+
+```csharp
+services.AddHttpClient<IBggCoverDownloader, BggCoverDownloader>(client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(10);
+});
+```
+
+This registers `BggCoverDownloader` as scoped via `AddHttpClient` (typed client pattern).
+
+- [ ] **Step 2.5.3: Run tests — expect PASS**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~BggCoverDownloaderTests" --nologo`
+Expected: 3 tests pass.
+
+- [ ] **Step 2.5.4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+git commit -m "feat(shared-games): BggCoverDownloader implementation + HttpClient DI
+
+Gap G2. 10s timeout, BlobCategory.GameImage, resource key bgg-cover-{id}.
+On http or storage error returns null (caller fallback to direct URL)."
+```
+
+### Task 2.6: Extend `CoverUrlResolver` with L2.5 BGG layer
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs`
+
+- [ ] **Step 2.6.1: Update `ResolvePublicAsync` to insert L2.5 BGG between L4 and L2**
+
+Replace `ResolvePublicAsync` body with:
+
+```csharp
+public static async Task<string?> ResolvePublicAsync(
+    SharedGameEntity sharedGame,
+    IBlobStorageService blobStorage)
+{
+    ArgumentNullException.ThrowIfNull(sharedGame);
+    ArgumentNullException.ThrowIfNull(blobStorage);
+
+    // L4 PDF-derived cover
+    if (!string.IsNullOrWhiteSpace(sharedGame.PdfCoverR2Key))
+    {
+        var url = await blobStorage
+            .GetPresignedDownloadUrlAsync(
+                $"{sharedGame.PdfCoverR2Key}-preview.webp",
+                BlobCategory.GameImage,
+                sharedGame.PdfCoverR2Key)
+            .ConfigureAwait(false);
+        if (url is not null) return url;
+    }
+
+    // L2.5 BGG re-uploaded cover (Gap G2)
+    if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
+    {
+        var url = await blobStorage
+            .GetPresignedDownloadUrlAsync(
+                sharedGame.BggCoverR2Key, // BGG upload stored under raw resource key
+                BlobCategory.GameImage,
+                sharedGame.BggCoverR2Key)
+            .ConfigureAwait(false);
+        if (url is not null) return url;
+    }
+
+    // L2 Wikidata cover
+    if (!string.IsNullOrWhiteSpace(sharedGame.WikidataCoverR2Key))
+    {
+        var url = await blobStorage
+            .GetPresignedDownloadUrlAsync(
+                $"{sharedGame.WikidataCoverR2Key}.webp",
+                BlobCategory.GameImage,
+                sharedGame.WikidataCoverR2Key)
+            .ConfigureAwait(false);
+        if (url is not null) return url;
+    }
+
+    return null;
+}
+```
+
+- [ ] **Step 2.6.2: Update XML doc comment at class level**
+
+Update the class-level comment from `L3 (user) -> L4 (PDF) -> L2 (Wikidata)` to:
+
+```csharp
+/// <summary>
+/// Issue #1852 (Gap A) + Gap G2 (2026-06-08): centralizes cover-URL resolution
+/// with the priority L3 (user custom) -> L4 (PDF-derived) -> L2.5 (BGG re-uploaded)
+/// -> L2 (Wikidata) -> null. Each layer falls through to the next when its R2 key
+/// is missing or the blob storage cannot mint a presigned URL.
+/// </summary>
+```
+
+- [ ] **Step 2.6.3: Verify compilation + existing resolver tests**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj --nologo`
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~CoverUrlResolver" --nologo`
+Expected: build green, existing resolver tests still pass (we only ADD a layer, no behavior change for entities without `BggCoverR2Key`).
+
+- [ ] **Step 2.6.4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+git commit -m "feat(shared-games): CoverUrlResolver L2.5 BGG layer between L4 PDF and L2 Wikidata
+
+Gap G2. Backward compatible: entities without BggCoverR2Key skip the new layer."
+```
+
+### Task 2.7: Integrate downloader into `CreateSharedGameFromPdfCommandHandler`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs`
+
+- [ ] **Step 2.7.1: Inject `IBggCoverDownloader` into handler**
+
+Update constructor and field:
+
+```csharp
+private readonly IBggCoverDownloader _bggCoverDownloader;
+```
+
+Add to constructor parameters and assignment (replicate the existing pattern of `??throw ArgumentNullException`).
+
+- [ ] **Step 2.7.2: Modify Step 4/5 to attempt cover re-upload**
+
+After the existing Step 4 BGG enrichment block (`bggDetails` populated), and BEFORE Step 5 (SharedGame.Create), add:
+
+```csharp
+// STEP 4.5: BGG cover re-upload (Gap G2)
+string? bggCoverR2Key = null;
+if (bggDetails is not null && !string.IsNullOrWhiteSpace(bggDetails.ImageUrl) && command.SelectedBggId.HasValue)
+{
+    bggCoverR2Key = await _bggCoverDownloader
+        .DownloadAndUploadAsync(command.SelectedBggId.Value, bggDetails.ImageUrl, cancellationToken)
+        .ConfigureAwait(false);
+
+    if (bggCoverR2Key is null)
+    {
+        _logger.LogWarning(
+            "BGG cover re-upload failed for BggId={BggId}, falling back to direct CDN URL",
+            command.SelectedBggId.Value);
+        // bggDetails.ImageUrl is still used as imageUrl below (existing behavior preserved)
+    }
+}
+```
+
+- [ ] **Step 2.7.3: Persist `BggCoverR2Key` on the entity after `_gameRepository.AddAsync`**
+
+The `SharedGame` domain aggregate doesn't (and shouldn't) carry the R2 key directly — it's infrastructure metadata. After `_gameRepository.AddAsync(sharedGame, cancellationToken)`, set it on the EF-tracked entity:
+
+```csharp
+if (bggCoverR2Key is not null)
+{
+    var entity = await _dbContext.Set<SharedGameEntity>()
+        .FirstOrDefaultAsync(e => e.Id == sharedGame.Id, cancellationToken)
+        .ConfigureAwait(false);
+    if (entity is not null)
+    {
+        entity.BggCoverR2Key = bggCoverR2Key;
+    }
+}
+```
+
+Note: this runs BEFORE `SaveChangesAsync` (Step 8), so the new column is persisted in the same transaction.
+
+- [ ] **Step 2.7.4: Verify compilation**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj --nologo`
+Expected: 0 errors.
+
+- [ ] **Step 2.7.5: Add 2 tests to existing handler test class**
+
+Open `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs`.
+
+Find the test class, add a `Mock<IBggCoverDownloader>` field and pass it to the handler ctor in fixture setup.
+
+Then append at the end of the class:
+
+```csharp
+[Fact]
+public async Task Handle_WithBggId_InvokesCoverDownloaderAndPersistsR2Key()
+{
+    // Arrange
+    _bggCoverDownloaderMock
+        .Setup(d => d.DownloadAndUploadAsync(13, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync("bgg-cover-13");
+
+    // ... existing arrange that sets bggDetails with ImageUrl and command with SelectedBggId=13 ...
+
+    // Act
+    var result = await _sut.Handle(command, CancellationToken.None);
+
+    // Assert
+    _bggCoverDownloaderMock.Verify(d => d.DownloadAndUploadAsync(13, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+
+    var entity = await _dbContext.Set<SharedGameEntity>().FirstOrDefaultAsync(e => e.Id == result.GameId);
+    entity!.BggCoverR2Key.Should().Be("bgg-cover-13");
+}
+
+[Fact]
+public async Task Handle_WithBggId_OnDownloaderFailure_ContinuesWithoutBggCoverR2Key()
+{
+    // Arrange
+    _bggCoverDownloaderMock
+        .Setup(d => d.DownloadAndUploadAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((string?)null);
+
+    // ... existing arrange ...
+
+    // Act
+    var result = await _sut.Handle(command, CancellationToken.None);
+
+    // Assert
+    var entity = await _dbContext.Set<SharedGameEntity>().FirstOrDefaultAsync(e => e.Id == result.GameId);
+    entity!.BggCoverR2Key.Should().BeNull();
+    // Existing imageUrl fallback (BGG direct URL) preserved — verify via separate assertion if the SUT exposes it.
+}
+```
+
+**Note:** the existing test class may not have an `_dbContext` field or `_bggCoverDownloaderMock`. Read the file first to identify what to add and where (the goal is mirror the field+ctor injection used for other mocks).
+
+- [ ] **Step 2.7.6: Run tests — expect PASS**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~CreateSharedGameFromPdfCommandHandlerTests" --nologo`
+Expected: existing tests pass + 2 new tests pass.
+
+If existing tests now fail with "Constructor signature mismatch" or "missing mock", update the existing test fixture to include `Mock<IBggCoverDownloader>` with default no-op setup (`SetupSequence` returning null) — this preserves backward compatibility for tests not exercising BGG enrichment.
+
+- [ ] **Step 2.7.7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameFromPdfCommandHandler.cs apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameFromPdfCommandHandlerTests.cs
+git commit -m "feat(shared-games): CreateSharedGameFromPdf re-uploads BGG cover to our storage
+
+Gap G2. New Step 4.5 invokes IBggCoverDownloader if SelectedBggId present.
+On failure, falls back to direct BGG URL (preserves existing imageUrl behavior).
+2 new handler tests + ctor injection of IBggCoverDownloader."
+```
+
+---
+
+## Phase 3 — G5: Idempotency-Key on wizard create
+
+**Goal:** Prevenire creazione di duplicate shared games su double-submit. L'admin client genera `Idempotency-Key` (UUID v4) e lo invia come header su `POST /admin/shared-games/wizard/create`. Lo stesso key entro 5 min ritorna lo stesso `gameId` senza ri-eseguire il comando.
+
+**Strategy:** Redis cache check (chiave `wizard:create:{userId}:{idempotencyKey}` → value `gameId`). TTL 5 min. Pre-Send check + Post-Send write.
+
+### Task 3.1: Identify the Redis cache abstraction
+
+- [ ] **Step 3.1.1: Discover existing cache service interface**
+
+Run: `Grep pattern="IAiResponseCacheService|IHybridCacheService|interface I.*Cache" path="apps/api/src/Api" output_mode="files_with_matches" head_limit=10`
+
+Expected: list of cache abstractions. Pick the one used most broadly (typically `IAiResponseCacheService` or `IHybridCacheService` — read its interface to confirm it supports `GetAsync<T>` and `SetAsync<T>(key, value, TTL)`).
+
+- [ ] **Step 3.1.2: Read the chosen interface signature**
+
+Read the cache service interface to confirm method signatures. Document chosen interface name (e.g., `IHybridCacheService`) in the next task.
+
+If no suitable abstraction exists, use `IDistributedCache` from `Microsoft.Extensions.Caching.Distributed` (always available with Redis configured).
+
+### Task 3.2: Write failing test for double-submit idempotency
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs`
+
+- [ ] **Step 3.2.1: Inspect existing wizard integration tests for pattern**
+
+Run: `Glob pattern="apps/api/tests/Api.Tests/**/*Wizard*.cs"`
+
+Pick the closest existing pattern (probably a Testcontainers-based integration test that POSTs to the endpoint and asserts response).
+
+- [ ] **Step 3.2.2: Write the failing test**
+
+Create:
+
+```csharp
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Integration;
+
+[Trait("Category", "Integration")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WizardCreateIdempotencyTests : IClassFixture<ApiIntegrationTestFixture>
+{
+    private readonly ApiIntegrationTestFixture _fixture;
+
+    public WizardCreateIdempotencyTests(ApiIntegrationTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task DoubleSubmit_WithSameIdempotencyKey_ReturnsSameGameId()
+    {
+        // Arrange
+        var client = await _fixture.AuthenticateAsAdminAsync();
+        var pdfDocumentId = await _fixture.UploadOrphanPdfAsync(client);
+
+        var idempotencyKey = Guid.NewGuid().ToString();
+        var request = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfDocumentId,
+            ExtractedTitle = "Idempotency Test Game",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            SelectedBggId = null
+        };
+
+        // Act — first submit
+        var firstResponse = await PostWithIdempotencyKey(client, request, idempotencyKey);
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var firstResult = await firstResponse.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+
+        // Act — second submit identical
+        var secondResponse = await PostWithIdempotencyKey(client, request, idempotencyKey);
+
+        // Assert — same gameId, no new game created
+        secondResponse.StatusCode.Should().BeOneOf(HttpStatusCode.Created, HttpStatusCode.OK);
+        var secondResult = await secondResponse.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+        secondResult!.GameId.Should().Be(firstResult!.GameId);
+
+        var gameCount = await _fixture.CountGamesByTitleAsync("Idempotency Test Game");
+        gameCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SameIdempotencyKey_WithDifferentBody_Returns422()
+    {
+        // F2 (review finding): IETF draft-ietf-httpapi-idempotency-key §2.6
+        // Arrange
+        var client = await _fixture.AuthenticateAsAdminAsync();
+        var pdfA = await _fixture.UploadOrphanPdfAsync(client);
+        var pdfB = await _fixture.UploadOrphanPdfAsync(client);
+
+        var key = Guid.NewGuid().ToString();
+        var requestA = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfA,
+            ExtractedTitle = "Original",
+            MinPlayers = 2, MaxPlayers = 4, PlayingTimeMinutes = 60, MinAge = 10
+        };
+        var requestB_differentBody = requestA with { PdfDocumentId = pdfB, ExtractedTitle = "Different" };
+
+        // Act
+        var first = await PostWithIdempotencyKey(client, requestA, key);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await PostWithIdempotencyKey(client, requestB_differentBody, key);
+
+        // Assert
+        second.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task DoubleSubmit_WithDifferentIdempotencyKeys_CreatesTwoGames()
+    {
+        // Arrange
+        var client = await _fixture.AuthenticateAsAdminAsync();
+        var pdfA = await _fixture.UploadOrphanPdfAsync(client);
+        var pdfB = await _fixture.UploadOrphanPdfAsync(client);
+
+        var requestA = new CreateGameFromPdfRequest
+        {
+            PdfDocumentId = pdfA,
+            ExtractedTitle = "Game A",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            SelectedBggId = null
+        };
+        var requestB = requestA with { PdfDocumentId = pdfB, ExtractedTitle = "Game B" };
+
+        // Act
+        var responseA = await PostWithIdempotencyKey(client, requestA, Guid.NewGuid().ToString());
+        var responseB = await PostWithIdempotencyKey(client, requestB, Guid.NewGuid().ToString());
+
+        // Assert
+        responseA.StatusCode.Should().Be(HttpStatusCode.Created);
+        responseB.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var resultA = await responseA.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+        var resultB = await responseB.Content.ReadFromJsonAsync<CreateGameFromPdfResult>();
+        resultA!.GameId.Should().NotBe(resultB!.GameId);
+    }
+
+    private static async Task<HttpResponseMessage> PostWithIdempotencyKey(
+        HttpClient client,
+        CreateGameFromPdfRequest request,
+        string idempotencyKey)
+    {
+        var message = new HttpRequestMessage(HttpMethod.Post, "/api/v1/admin/shared-games/wizard/create")
+        {
+            Content = JsonContent.Create(request)
+        };
+        message.Headers.Add("Idempotency-Key", idempotencyKey);
+        return await client.SendAsync(message);
+    }
+}
+```
+
+**Note on fixture helpers:** `ApiIntegrationTestFixture.AuthenticateAsAdminAsync`, `UploadOrphanPdfAsync`, `CountGamesByTitleAsync` likely don't exist with these exact names. Read the existing fixture file (search via `Grep pattern="class ApiIntegrationTestFixture" path="apps/api/tests"`) and adapt: either use existing methods or extend the fixture with the missing helpers in the same commit.
+
+- [ ] **Step 3.2.3: Run tests — expect FAIL**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WizardCreateIdempotencyTests" --nologo`
+Expected: FAIL — second submit creates a 2nd game (no idempotency yet).
+
+- [ ] **Step 3.2.4: Commit failing tests**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardCreateIdempotencyTests.cs
+git commit -m "test(shared-games): wizard create idempotency double-submit tests (failing, implementation pending)"
+```
+
+### Task 3.3: Implement Idempotency-Key check in `HandleWizardCreateGame`
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs`
+
+- [ ] **Step 3.3.0: Define cached envelope record at bottom of `SharedGameCatalogWizardEndpoints.cs`**
+
+After the closing brace of the static class `SharedGameCatalogWizardEndpoints`, add (still inside `namespace Api.Routing`):
+
+```csharp
+/// <summary>
+/// G5: envelope persisted in Redis cache for Idempotency-Key replay.
+/// Stores the gameId + status fields needed to replay HTTP 201 truthfully,
+/// plus the SHA256 of the original request body for IETF idempotency-key
+/// body-mismatch detection (RFC draft-ietf-httpapi-idempotency-key §2.6).
+/// </summary>
+internal sealed record IdempotencyCachedEnvelope
+{
+    public Guid GameId { get; init; }
+    public string ApprovalStatus { get; init; } = string.Empty;
+    public bool BggEnrichmentApplied { get; init; }
+    public int? EnrichedWithBggId { get; init; }
+    public string BodyHash { get; init; } = string.Empty;
+}
+```
+
+- [ ] **Step 3.3.1: Inject cache service into the handler**
+
+In `SharedGameCatalogWizardEndpoints.HandleWizardCreateGame` (~line 254), add `IHybridCacheService cache` (or whichever cache abstraction was chosen in Task 3.1) to the parameter list. ASP.NET minimal API DI will resolve it.
+
+The new signature:
+
+```csharp
+private static async Task<IResult> HandleWizardCreateGame(
+    CreateGameFromPdfRequest request,
+    HttpContext context,
+    IMediator mediator,
+    IHybridCacheService cache, // or the chosen interface
+    ILogger<Program> logger,
+    CancellationToken ct)
+```
+
+Replace `IHybridCacheService` with the actual interface name discovered in Task 3.1.
+
+- [ ] **Step 3.3.2: Add idempotency check at top of handler body**
+
+Insert at the beginning of the handler body, before `var userId = context.User.GetUserId();`:
+
+```csharp
+var userId = context.User.GetUserId();
+
+// G5: Idempotency-Key support
+string? idempotencyKey = null;
+if (context.Request.Headers.TryGetValue("Idempotency-Key", out var keyValues) && keyValues.Count > 0)
+{
+    idempotencyKey = keyValues[0];
+}
+
+// F2 (review finding, Nygard+Wiegers): hash body to detect key-reuse with different payload
+string? requestBodyHash = null;
+if (!string.IsNullOrWhiteSpace(idempotencyKey))
+{
+    var bodyJson = System.Text.Json.JsonSerializer.Serialize(request);
+    using var sha = System.Security.Cryptography.SHA256.Create();
+    var hashBytes = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(bodyJson));
+    requestBodyHash = Convert.ToHexString(hashBytes);
+}
+
+if (!string.IsNullOrWhiteSpace(idempotencyKey))
+{
+    var cacheKey = $"wizard:create:{userId}:{idempotencyKey}";
+    var cachedEnvelopeJson = await cache.GetAsync<string>(cacheKey, ct).ConfigureAwait(false);
+    if (!string.IsNullOrWhiteSpace(cachedEnvelopeJson))
+    {
+        var cached = System.Text.Json.JsonSerializer.Deserialize<IdempotencyCachedEnvelope>(cachedEnvelopeJson);
+        if (cached is not null)
+        {
+            // F2: mismatch on body hash → 422 (IETF draft-ietf-httpapi-idempotency-key §2.6)
+            if (!string.Equals(cached.BodyHash, requestBodyHash, StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "Idempotency-Key reused with different body: Key={Key}, UserId={UserId}",
+                    idempotencyKey, userId);
+                return Results.UnprocessableEntity(new
+                {
+                    error = "idempotency_key_body_mismatch",
+                    message = "Idempotency-Key was previously used with a different request body."
+                });
+            }
+
+            logger.LogInformation(
+                "Idempotency-Key hit: returning cached gameId={GameId} for key={Key}",
+                cached.GameId, idempotencyKey);
+
+            // F1: restore real status from cache so client sees true Draft/Published
+            return Results.Created(
+                $"/api/v1/admin/shared-games/{cached.GameId}",
+                new CreateGameFromPdfResult
+                {
+                    GameId = cached.GameId,
+                    ApprovalStatus = cached.ApprovalStatus,
+                    QualityScore = 0.0,
+                    DuplicateWarning = false,
+                    DuplicateTitles = new List<string>(),
+                    BggEnrichmentApplied = cached.BggEnrichmentApplied,
+                    EnrichedWithBggId = cached.EnrichedWithBggId
+                });
+        }
+    }
+}
+```
+
+**Remove** the earlier `var userId = context.User.GetUserId();` line since we moved it to the top of this block (avoid double declaration).
+
+- [ ] **Step 3.3.3: Persist gameId after successful create**
+
+In the existing `try` block, after `var result = await mediator.Send(command, ct).ConfigureAwait(false);`, BEFORE the `return Results.Created(...)`, add:
+
+```csharp
+if (!string.IsNullOrWhiteSpace(idempotencyKey) && !string.IsNullOrWhiteSpace(requestBodyHash))
+{
+    var cacheKey = $"wizard:create:{userId}:{idempotencyKey}";
+    // F1+F2: cache envelope preserves status + bggEnrichment + bodyHash for safe replay
+    var envelope = new IdempotencyCachedEnvelope
+    {
+        GameId = result.GameId,
+        ApprovalStatus = result.ApprovalStatus,
+        BggEnrichmentApplied = result.BggEnrichmentApplied,
+        EnrichedWithBggId = result.EnrichedWithBggId,
+        BodyHash = requestBodyHash
+    };
+    var envelopeJson = System.Text.Json.JsonSerializer.Serialize(envelope);
+    await cache
+        .SetAsync(cacheKey, envelopeJson, TimeSpan.FromMinutes(5), ct)
+        .ConfigureAwait(false);
+}
+```
+
+Adapt `cache.SetAsync` signature to whatever the chosen cache service exposes (some take `DistributedCacheEntryOptions` instead).
+
+- [ ] **Step 3.3.4: Verify compilation**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj --nologo`
+Expected: 0 errors.
+
+- [ ] **Step 3.3.5: Run integration tests — expect PASS**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WizardCreateIdempotencyTests" --nologo`
+Expected: both tests pass.
+
+If 1st test fails because the `Idempotency-Key` header is dropped during cache reconstruction, the issue is the cached response shape: the test asserts `secondResult.GameId.Should().Be(firstResult.GameId)` — make sure the cached path returns `Results.Created` with a body containing `GameId` equal to the cached value.
+
+- [ ] **Step 3.3.6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogWizardEndpoints.cs
+git commit -m "feat(shared-games): Idempotency-Key support on wizard/create endpoint
+
+Gap G5. Header Idempotency-Key (UUID) + Redis cache (key wizard:create:{userId}:{key})
+with 5 min TTL. Same key entro TTL ritorna gameId cached. Tests in same PR."
+```
+
+---
+
+## Phase 4 — Final integration & PR
+
+### Task 4.1: Run full SharedGameCatalog test slice
+
+- [ ] **Step 4.1.1: Run all SharedGameCatalog tests**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SharedGameCatalog" --nologo`
+Expected: all green. Baseline regressions (pre-existing failing tests documented in CLAUDE.md `Known Flaky Tests`) acceptable.
+
+- [ ] **Step 4.1.2: Run DocumentProcessing test slice (for cross-bc impact)**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~DocumentProcessing" --nologo`
+Expected: all green.
+
+### Task 4.2: Manual smoke verify on dev env
+
+- [ ] **Step 4.2.1: Start dev stack**
+
+From `infra/`: `make dev`
+Wait until `make logs s=api` shows API ready.
+
+- [ ] **Step 4.2.2: Verify G1 — update game with tag fields**
+
+Use a curl/HTTP client to PATCH `/api/v1/admin/shared-games/{id}` with a payload containing `categories: ["Strategy"]`, `mechanics: ["Dice Rolling"]`, `bggId: 13`. Verify subsequent GET returns these fields.
+
+- [ ] **Step 4.2.3: Verify G2 — create game with BGG selection re-uploads cover**
+
+Walk through the wizard via `/admin/shared-games/new` selecting a BGG match. After create, query the DB: `SELECT BggCoverR2Key FROM shared_games WHERE id = '<new_game_id>'`. Expected: non-null R2 key.
+
+- [ ] **Step 4.2.4: Verify G5 — double-submit returns same gameId**
+
+POST `/api/v1/admin/shared-games/wizard/create` twice with same `Idempotency-Key`. Verify both responses have identical `gameId`.
+
+### Task 4.3: Open PR
+
+- [ ] **Step 4.3.1: Create feature branch (if not already)**
+
+```bash
+git checkout main-dev
+git pull --ff-only
+# Verify HEAD is main-dev:
+git branch --show-current  # must print main-dev
+git checkout -b feature/admin-shared-game-gap-closure-g1-g2-g5
+```
+
+If the previous commits were made on `main-dev` directly, rebase them onto a feature branch first.
+
+- [ ] **Step 4.3.2: Push and open PR**
+
+```bash
+git push -u origin feature/admin-shared-game-gap-closure-g1-g2-g5
+
+gh pr create --base main-dev --title "feat(shared-games): close gaps G1+G2+G5 on admin import workflow" --body "$(cat <<'EOF'
+## Summary
+
+Closes 3 gaps identified by spec-panel review on the existing admin shared-game import workflow (see [spec](../docs/superpowers/specs/2026-06-08-admin-shared-game-import-spec-panel-review.md)).
+
+- **G1**: `UpdateSharedGameCommand` now supports manual edit of `Categories`, `Mechanics`, `Designers`, `Publishers`, `BggId` via DbContext-include pattern (mirrors `UpdateSharedGameFromBggCommandHandler`).
+- **G2**: `CreateSharedGameFromPdfCommandHandler` Step 4.5 invokes new `BggCoverDownloader` to re-upload BGG cover to our blob storage. New `BggCoverR2Key` column on `SharedGameEntity`. `CoverUrlResolver` extended with L2.5 layer (priority: L3 user → L4 PDF → L2.5 BGG → L2 Wikidata). On download/upload failure, falls back to direct BGG URL (existing behavior).
+- **G5**: `POST /admin/shared-games/wizard/create` supports `Idempotency-Key` header via Redis cache. Same key within 5 min returns cached `gameId` (HTTP 201 with `ApprovalStatus: "Cached"` to signal replay).
+
+## Out of scope (documented in plan)
+
+- **G3** UI tab labels (cosmetic)
+- **G4** single-page vs 3-step wizard UX redesign (design choice)
+- **G6** admin quota bypass — false positive: `UploadPdfForGameExtractionCommandHandler:13` already quota-free by design
+
+## Test plan
+
+- [x] Unit: `UpdateSharedGameCommandHandlerTests` (3 new) — core, taxonomy replace, BggId scalar
+- [x] Unit: `BggCoverDownloaderTests` (3 new) — happy, http error, upload error
+- [x] Unit: `CreateSharedGameFromPdfCommandHandlerTests` (2 new) — re-upload success + fallback
+- [x] Integration: `WizardCreateIdempotencyTests` (2 new) — double-submit dedup + different keys create 2 games
+- [x] Validator extended for taxonomy + BggId
+- [x] EF migration `AddBggCoverR2KeyToSharedGames` applied locally
+- [x] Manual smoke G1/G2/G5 verified on dev env
+
+## Migrations
+
+- 1 new migration: `<timestamp>_AddBggCoverR2KeyToSharedGames` — adds nullable `BggCoverR2Key varchar(256)` to `shared_games`. Zero-downtime; reversible.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4.3.3: Verify CI**
+
+Wait for CI status. Expected required checks pass (only `GitGuardian Security Checks` is hard required on `main-dev` per P196).
+
+If CI fails on a check NOT in baseline known-flaky list, investigate and fix in this PR.
+
+### Task 4.4: Merge after approval
+
+- [ ] **Step 4.4.1: Wait for review or self-approve if no reviewers configured**
+
+- [ ] **Step 4.4.2: Merge via normal PR merge (no admin override needed if CI green)**
+
+```bash
+gh pr merge --merge --delete-branch
+```
+
+If admin override is required because of CodeQL csharp pending (analysis-only, non-blocking per P196 baseline), use:
+```bash
+gh pr merge --admin --merge --delete-branch
+```
+
+### Task 4.5: Close umbrella issue if exists
+
+- [ ] **Step 4.5.1: Comment + close**
+
+If this PR is tracked by an umbrella issue, post status summary referencing the spec + PR, then close `--reason completed`.
+
+---
+
+## Self-Review Checklist (Plan author)
+
+Reviewed against the spec consolidato (`docs/superpowers/specs/2026-06-08-admin-shared-game-import-spec-panel-review.md`):
+
+1. **Spec coverage**:
+   - DEC-1 saga atomica BGG-prima — already in `CreateSharedGameFromPdfCommandHandler`, ✅ no work.
+   - DEC-2 BGG manual select — already enforced UI-side, ✅ no work.
+   - DEC-3 `/{uuid}` post-create edit — already in `/admin/shared-games/[id]/client.tsx`, ✅ no work. G1 task extends backend command to match UI form's fields.
+   - DEC-4 cover re-upload on our storage — ✅ Phase 2 G2.
+   - DEC-5 Admin-only — already enforced by `AdminOnlyPolicy` on wizard endpoints, ✅ no work.
+   - DEC-6 admin quota exempt — already in `UploadPdfForGameExtractionCommandHandler` design, ✅ no work.
+   - AC-9 edit form full fields — ✅ G1 backend enables it (FE form already exposes them per `/admin/shared-games/[id]` discovery).
+   - AC-10 RowVersion concurrency — pre-existing pattern in `EntityConfigurations` (cfr. CLAUDE.md). Not touched.
+   - AC-11 publish — `QuickPublishSharedGameCommand` exists, no work.
+   - AC-12 idempotency — ✅ G5.
+
+2. **Placeholder scan**: no TBD/TODO/"implement later"/"similar to Task N". All code blocks complete or accompanied by inline read-current-source directives.
+
+3. **Type consistency**:
+   - `UpdateSharedGameCommand` record name consistent across tasks 1.1–1.5.
+   - `IBggCoverDownloader.DownloadAndUploadAsync` signature consistent across tasks 2.3–2.7.
+   - `BggCoverR2Key` field name consistent across tasks 2.1–2.7.
+   - `Idempotency-Key` header consistent across tasks 3.2–3.3.
+
+4. **Known drift risks** flagged inline:
+   - `SharedGame.Create` signature may have drifted; plan instructs to read current source and align test.
+   - `BlobStorageResult` constructor params may differ; plan instructs to verify before mock setup.
+   - `IHybridCacheService` interface name may differ; plan instructs Task 3.1 discovery before Task 3.2.
+   - `ApiIntegrationTestFixture` helpers may not exist; plan instructs to read fixture and extend if missing.
+
+---
+
+## Review Findings & Applied Fixes (2026-06-08, post `/sc:spec-panel --mode critique`)
+
+Spec-panel review condotta con Fowler (architecture) + Crispin (testing) + Nygard (failure modes) + Wiegers (contract). 4 MAJ + 3 MIN findings identificati.
+
+### MAJ fixes applied inline
+
+| # | Finding | Esperto | Fix applicato |
+|---|---------|---------|---------------|
+| **F1** | Cache value G5 perde `ApprovalStatus` reale — replay restituiva placeholder "Cached" come contract change | Nygard | Task 3.3.0 + 3.3.2: cache JSON envelope `IdempotencyCachedEnvelope` con `GameId + ApprovalStatus + BggEnrichmentApplied + EnrichedWithBggId + BodyHash`. Replay restituisce status reale |
+| **F2** | Idempotency-Key con body diverso non rifiutato (viola IETF draft-ietf-httpapi-idempotency-key §2.6) | Nygard + Wiegers | Task 3.3.2: SHA256 del body, cache hash, mismatch → 422 Unprocessable Entity. Task 3.2.2: nuovo test `SameIdempotencyKey_WithDifferentBody_Returns422` |
+
+### MAJ flagged for implementer judgment (no inline fix)
+
+| # | Finding | Esperto | Note |
+|---|---------|---------|------|
+| **F3** | Task 1.3 test `Handle_WithCategoriesAndMechanics_ReplacesCollections` mescola InMemory DbContext + repository mock. `_repository.Update(domain)` è no-op su InMemory, test verifica solo side-effect entity-level (categories Add). Test funziona ma è fragile | Fowler + Crispin | **Note for implementer**: il test passa ma copre solo "entity field replacement", NON "aggregate Update flow". Se durante implementation emerge che il repository pattern reale richiede ITransaction o DbContext shared, considera l'aggiunta di un test integration Testcontainers `UpdateSharedGameHandlerIntegrationTests` per coverage completa. Pattern accettato come compromesso unit-test efficiency vs full coverage |
+| **F4** | Dopo re-upload BGG cover, `entity.ImageUrl` rimane = URL diretto BGG CDN. Due source-of-truth: `ImageUrl` field + `BggCoverR2Key` via resolver | Fowler | **Convenzione documentata**: `CoverUrlResolver` è l'authoritative source per cover URL al display layer. `entity.ImageUrl` resta come fallback legacy per consumer pre-resolver (alcuni query handler proiettano direttamente `entity.ImageUrl`). Non modificare `ImageUrl` durante saga: cambiare la convenzione richiede audit cross-BC (out of scope) |
+
+### MIN findings deferred
+
+- **F5** (Wiegers, validator limits 20/30 arbitrary): documenta nel commit body i numeri come "initial heuristic, tune in follow-up after observing real catalog stats". Defer.
+- **F6** (Crispin, test fixture helpers assumed): plan already includes inline disclaimer at Task 3.2.2. Considera linkare il path `Grep pattern="class ApiIntegrationTestFixture" path="apps/api/tests"` nel discovery step.
+- **F7** (Fowler, L2.5 key asymmetry vs L4 `-preview.webp`): aggiungi inline comment nel `CoverUrlResolver`: `// BGG cover stored as single asset (no thumbnail derivative) — different from L4 PDF which has -preview.webp suffix`.
+
+### Quality scoring post-review
+
+| Dimensione | Pre-review | Post-review | Delta |
+|-----------|-----------|-------------|-------|
+| Contract correctness | 7/10 | 9/10 | +2 (F1+F2) |
+| Testability | 8/10 | 8.5/10 | +0.5 (F2 test added) |
+| Implementation guidance | 8/10 | 9/10 | +1 (F3+F4 notes) |
+| **Overall** | **7.6/10** | **8.8/10** | **+1.2** |
+
+---
+
+## Execution Handoff
+
+Plan complete (review-applied) and saved to `docs/superpowers/plans/2026-06-08-admin-shared-game-gap-closure-g1-g2-g5.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Pattern P120 (model mix based on task complexity: haiku for trivial scaffolding, sonnet for handler refactor). Pattern P186 (trust-but-verify implementer reports).
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints for review.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-06-08-admin-shared-game-import-spec-panel-review.md
+++ b/docs/superpowers/specs/2026-06-08-admin-shared-game-import-spec-panel-review.md
@@ -1,0 +1,505 @@
+---
+title: "Admin Shared Game Import Workflow — Spec Panel Review"
+date: 2026-06-08
+panel: [Cockburn, Wiegers, Adzic, Fowler, Nygard, Crispin]
+mode: discussion
+focus: [requirements, architecture, testing]
+status: ready-for-plan
+bounded_contexts: [SharedGameCatalog, DocumentProcessing, KnowledgeBase, Administration]
+related:
+  - PR #1980 (BGG admin gate)
+  - PR #1892 (admin custom cover upload)
+  - PR #1903 (BGG user-side block ADR)
+---
+
+# Admin Shared Game Import Workflow — Spec Panel Consolidated Review
+
+## 0. Summary
+
+Workflow admin per popolare il catalogo `SharedGameCatalog` partendo dal solo PDF del regolamento, arricchendo i metadati via BoardGameGeek (BGG) come fonte esterna, ed eseguendo refinement (compresa publish) nella pagina `/admin/shared-games/{uuid}`.
+
+La spec riusa la saga `ImportGameFromPdfCommand` esistente (Nygard-style 3-step + compensation), estendendola con `BggId` nel metadata DTO e con upload cover su storage interno.
+
+**Status**: 6 decisioni lockate da utente in panel discussion (3 P0 + 3 secondarie). Ready for `/superpowers:writing-plans`.
+
+---
+
+## 1. User story originale (verbatim)
+
+> *"Come admin, voglio creare un gioco da inserire tra i shared games. Ho il pdf del regolamento. Dopo averlo creato, voglio raccogliere i metadati del gioco dall'esterno e poi, nella pagina /admin/shared-games/{uuid gioco} eseguire l'edit."*
+
+**Riformulazione canonica** (post panel synthesis): l'ordine letterale "*creare poi raccogliere*" era una semplificazione di linguaggio. L'ordine implementativo lockato è **arricchimento BGG prima, create-via-saga-atomica dopo, edit fine + publish nella pagina `/admin/shared-games/{uuid}`** (cfr. § 3, DEC-1).
+
+---
+
+## 2. Use Case UC-ADM-01
+
+```
+UC-ADM-01: Importa shared game da regolamento PDF
+Primary Actor: Admin (role = Admin)
+Stakeholders & Interests:
+  - Admin: vuole popolare il catalogo rapidamente con dati BGG-validati
+  - User finale: vuole giochi con metadata ricchi e PDF indexato per RAG
+  - System: vuole record consistenti senza orphan PDF in DB
+
+Goal Level: ☁ summary (composto da 3 sub-goal)
+Scope: SharedGameCatalog (scrittura), DocumentProcessing (lettura/scrittura PDF), KnowledgeBase (trigger indexing)
+
+Preconditions:
+  - Admin autenticato con role Admin (verifica via useAdminRole + admin gate route)
+  - PDF del regolamento disponibile (≤ 50MB, MIME application/pdf)
+
+Postconditions Success:
+  - SharedGame creato in status Draft con metadata BGG-arricchiti (o manuali)
+  - PdfDocument linkato come Rulebook v1.0 attivo
+  - Indexing in stato pending|completed|failed (warning se failed)
+  - Admin atterra su /admin/shared-games/{gameId} con UI di edit
+
+Postconditions Failure:
+  - Nessun SharedGame orfano in DB (compensation eseguita)
+  - PdfDocument orphan rimane in DB (recuperabile da admin in altro flow)
+
+Main Success Scenario (MSS):
+  1. Admin naviga a /admin/shared-games e clicca "Importa nuovo gioco"
+  2. Sistema apre /admin/shared-games/new (wizard 3-step)
+  3. STEP 1 — Upload PDF
+     Admin carica PDF → sistema valida (size/MIME/quota=esente) → memorizza orphan
+     Sistema mostra preview metadata estratti (es. titolo da SmolDocling, se disponibile)
+  4. STEP 2 — Cerca su BGG
+     Admin digita query (precompilato con title estratto se presente) → "Cerca su BGG"
+     Sistema interroga BGG XML API → mostra top 10 risultati (manuale-select obbligatorio)
+     Admin seleziona match → sistema fetch detail BGG + download cover image
+  5. STEP 3 — Review metadata
+     Form precompilato con dati BGG: admin può editare ogni campo
+     Cover image precaricata da BGG (re-upload interno via STORAGE_PROVIDER)
+     Admin clicca "Crea gioco"
+  6. Sistema esegue saga ImportGameFromPdfCommand (atomica)
+  7. Sistema redirige a /admin/shared-games/{gameId} con success toast
+     (toast include IndexingStatus: "pending"|"failed" + correlationId per debug)
+  8. Pagina edit espone form completo + RagReadinessIndicator + CTA "Pubblica"
+  9. Admin esegue eventuale edit fine → save → vedi AC-9..10
+  10. Admin clicca "Pubblica" quando ready → game passa a status Published
+
+Extensions:
+  3a. PDF upload fail (size/MIME/storage) → errore inline al field, admin re-tenta
+  4a. BGG offline (timeout 10s × 3 retry) → fallback manuale (vedi Adzic Scenario 2)
+  4b. BGG rate-limit 429 → countdown UX (useBggRateLimit), retry possibile dopo cooldown
+  4c. Multi-match BGG con ambiguità → admin sceglie esplicitamente (no auto-select)
+  4d. Zero match BGG → admin procede in manuale (no BGG → bggId=null nel record)
+  6a. Saga step 2 (link PDF) fail → compensation auto-delete game → user-facing error
+  6b. Saga step 3 (indexing enqueue) fail → game creato + warning persistente in UI
+  9a. Concurrency edit con RowVersion mismatch → 409 + diff UI (vedi Adzic Scenario 3)
+```
+
+---
+
+## 3. Decisions Log (utente-lockate)
+
+| ID | Decisione | Rationale | Locked by |
+|----|-----------|-----------|-----------|
+| **DEC-1** | Saga atomica: arricchimento BGG **prima** del create | Letterale "create poi raccogli" era semplificazione di linguaggio. Atomic = no stato intermedio incoerente, no rollback complesso, allineato a saga esistente | User reply 2026-06-08 ("Ho semplificato") |
+| **DEC-2** | BGG match: **sempre manuale**, no auto-select anche con high confidence | Priorità precisione catalogo > latenza. Riduce false-positive. Stabile per test (no flakiness ML confidence) | User reply 2026-06-08 ("manuale sempre") |
+| **DEC-3** | `/admin/shared-games/{uuid}` = destinazione **post-create** per edit fine + publish | Single responsibility per page: `/new` = wizard creazione, `/{uuid}` = edit + publish. Mainstream interpretation | User reply 2026-06-08 ("si") |
+| **DEC-4** | Cover image: **re-upload sul nostro storage** durante saga | Indipendenza da BGG uptime per immagini pubbliche. Usa STORAGE_PROVIDER factory esistente + pattern PR #1892 CoverUrlResolver pre-wired (P178). Failure handling: vedi F6 in § 7 | AskUserQuestion 2026-06-08 (opzione 2) |
+| **DEC-5** | Permission: **solo role Admin** | Coerente con BGG admin-gate PR #1980 e admin route gate generico. Editor/SuperAdmin: TBD future iteration | AskUserQuestion 2026-06-08 |
+| **DEC-6** | Quota PDF: **admin esente** da `PdfUploadQuotaService` | Uso operativo del catalogo non deve essere limitato come utente free/paid. Bypass via role check | AskUserQuestion 2026-06-08 |
+
+---
+
+## 4. Acceptance Criteria (Wiegers SMART)
+
+| ID | AC | Misurabilità |
+|----|----|---|
+| **AC-1** | Solo utente con role = `Admin` può accedere a `/admin/shared-games/new` e a `/admin/shared-games/{uuid}`. Non-admin riceve 403. | Unit test handler + E2E gate route |
+| **AC-2** | Upload PDF accetta `application/pdf` ≤ 50MB. Altri MIME/size superato → errore specifico al field. | Unit test `UploadPdfCommandValidator` + manual UX |
+| **AC-3** | Sistema interroga BGG XML API v2 con query string. p95 < 5s. Retry max 3 con exponential backoff. | Integration test con BGG mock + perf assertion |
+| **AC-4** | Selezione match BGG precompila: title, year, description, minPlayers, maxPlayers, playingTimeMinutes, minAge, categories, mechanics, designers, publishers, **bggId**, cover image. | Integration test saga end-to-end |
+| **AC-5** | Admin può sovrascrivere ogni campo precompilato prima di "Crea gioco". | E2E Playwright editing |
+| **AC-6** | "Crea gioco" invoca `ImportGameFromPdfCommand`. Su successo: game in status = `Draft`, PDF linked come Rulebook v1.0 attivo, indexing async dispatched. | Integration test handler |
+| **AC-7** | Sistema redirige a `/admin/shared-games/{gameId}` entro 2s dal 201. Success toast contiene `IndexingStatus` + `CorrelationId`. | E2E timing assertion |
+| **AC-8** | Se `IndexingStatus = "failed"`, pagina `/{uuid}` mostra warning persistente con CTA "Riavvia indexing" (re-dispatch `IndexDocumentCommand`). | Integration test + manual UX |
+| **AC-9** | Pagina `/admin/shared-games/{uuid}` espone edit form per: Title, Description, Year, MinPlayers, MaxPlayers, PlayingTimeMinutes, MinAge, Categories, Mechanics, Publishers, Designers, CoverImage, BggId. NON editabili: Id, CreatedAt, CreatedBy. | Component test `GameForm` |
+| **AC-10** | Salvataggio edit invoca `UpdateSharedGameCommand` con `RowVersion`. Conflict → 409 + diff UI. Successo → `UpdatedAt` + `UpdatedBy` aggiornati. | Integration test concurrency |
+| **AC-11** | Admin può transizionare Draft → Published via CTA "Pubblica". CTA visibile solo se `Status = Draft`. Invoca `PublishSharedGameCommand`. | Integration test state machine |
+| **AC-12** | Idempotency: doppio submit "Crea gioco" con stesso `Idempotency-Key` (UUID v4 generato client) entro 5 min → restituisce identico `gameId` (no duplicate). | Integration test idempotency |
+
+---
+
+## 5. Scenarios Given/When/Then (Adzic)
+
+### Scenario 1 — Happy path completo (BGG match unico)
+
+```gherkin
+Feature: Importa shared game da PDF con arricchimento BGG
+
+Scenario: Admin crea CATAN da PDF con match BGG univoco
+  Given sono autenticato come Admin
+  And nel catalogo non esiste un gioco con bggId = 13
+  When carico il PDF "catan-rulebook-it.pdf" (3.2 MB)
+  Then vedo "PDF caricato come bozza" e pulsante "Cerca su BGG"
+
+  When inserisco "Catan" nella ricerca BGG e clicco "Cerca"
+  Then ricevo una lista di risultati BGG ordinati per rilevanza
+  And il primo risultato è { bggId: 13, name: "CATAN", year: 1995 }
+
+  When seleziono il primo risultato
+  Then il form metadata si precompila con:
+    | campo            | valore                                |
+    | title            | CATAN                                 |
+    | yearPublished    | 1995                                  |
+    | minPlayers       | 3                                     |
+    | maxPlayers       | 4                                     |
+    | playingTimeMinutes | 90                                  |
+    | minAge           | 10                                    |
+    | designers        | ["Klaus Teuber"]                      |
+    | publishers       | ["KOSMOS"]                            |
+    | categories       | ["Strategy", "Negotiation"]           |
+    | bggId            | 13                                    |
+  And la cover image è scaricata da BGG e re-uploadata su nostro storage
+  And vedo preview cover dal nostro CDN (non da BGG)
+
+  When clicco "Crea gioco"
+  Then la saga ImportGameFromPdfCommand esegue 3 step atomici
+  And ricevo redirect a "/admin/shared-games/{gameId}"
+  And il game ha status "Draft"
+  And il PDF è linked come Rulebook v1.0 attivo
+  And indexingStatus = "pending"
+  And vedo banner "Indicizzazione in corso, ~2 min" con CorrelationId
+
+  When l'indexing completa async (≤2 min)
+  Then RagReadinessIndicator passa a "Pronto"
+  And banner indexing scompare
+```
+
+### Scenario 2 — BGG offline → fallback manuale
+
+```gherkin
+Scenario: Admin completa creazione anche con BGG irraggiungibile
+  Given BGG XML API è offline (timeout dopo 10s × 3 retry = ~30s totali)
+  And ho caricato un PDF valido
+
+  When clicco "Cerca su BGG"
+  Then vedo errore "BGG non raggiungibile. Procedi con metadata manuali."
+  And il form metadata è vuoto ma editabile
+  And vedo CTA "Riprova BGG" e "Procedi senza BGG"
+
+  When scelgo "Procedi senza BGG"
+  And compilo manualmente: title="Wingspan", yearPublished=2019, minPlayers=1, maxPlayers=5
+  And carico una cover image manualmente dal mio file system
+  And clicco "Crea gioco"
+  Then il game è creato in Draft
+  And nel record bggId è null
+  And cover image è uploaded su nostro storage (path admin custom upload)
+  And nessun campo BGG-only è popolato
+```
+
+### Scenario 3 — Edit post-creazione con concurrency
+
+```gherkin
+Scenario: Due admin editano lo stesso game in concorrenza
+  Given esiste game { id: "abc-123", title: "Wingspan", rowVersion: v1 }
+  And Admin-A apre /admin/shared-games/abc-123
+  And Admin-B apre /admin/shared-games/abc-123 (stesso rowVersion: v1)
+
+  When Admin-A modifica title="Wingspan ITA" e salva
+  Then il salvataggio ha successo (200) e rowVersion diventa v2
+
+  When Admin-B modifica minPlayers=2 e salva (con rowVersion: v1 stale)
+  Then ricevo errore 409 ConflictException con messaggio:
+    "Il gioco è stato modificato da Admin-A alle HH:MM. Ricarica e riprova."
+  And vedo diff tra il mio editing e la versione corrente in v2
+  And ho 2 opzioni UI: "Ricarica e perdi modifiche" / "Sovrascrivi forzato"
+
+  When clicco "Ricarica e perdi modifiche"
+  Then la pagina reloada con rowVersion=v2 e dati di Admin-A
+  And i miei edit vengono persi (warning toast)
+```
+
+### Edge scenarios (da implementare come sub-issue)
+
+- **E1**: Multi-match BGG (5+ risultati con stesso title) → manual select obbligatorio (no auto)
+- **E2**: PDF già linked a un altro game nel frattempo → saga fail 409 in step 2 → compensation + error UI
+- **E3**: Admin abbandona wizard dopo upload PDF → orphan PDF rimane (cleanup via cron, vedi `RetryFailedPdfsJob`)
+- **E4**: Indexing fallisce ma admin pubblica comunque → game pubblicato ma RAG search non funziona → warning UI persistente
+
+---
+
+## 6. Architecture mapping (Fowler)
+
+### 6.1 Component map (esistente vs nuovo)
+
+| Component | Path | Status | Modifica richiesta |
+|-----------|------|--------|---------------------|
+| `ImportGameFromPdfCommand` | `BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromPdfCommand.cs` | ✅ esiste | ➕ Aggiungi `int? BggId` a `ImportGameMetadataDto` |
+| `ImportGameFromPdfCommandHandler` | stesso path | ✅ esiste | 🔧 Propaga `BggId` a `CreateSharedGameCommand` (oggi hardcoded `null` riga 150) |
+| `CreateSharedGameCommand` | `BoundedContexts/SharedGameCatalog/Application/Commands/` | ✅ esiste (accetta già BggId) | nessuna |
+| `AddDocumentToSharedGameCommand` | stesso BC | ✅ esiste | nessuna |
+| `UploadPdfCommand` (orphan) | `BoundedContexts/DocumentProcessing/Application/Commands/` | ✅ esiste | ⚠️ Verifica supporto upload **senza** gameId (orphan mode) |
+| `SearchBggGamesQuery` | TBD | ❓ verificare bridge MediatR | 🆕 Crea se manca (`useSearchBggGames` FE chiama endpoint) |
+| `GetBggGameDetailQuery` | TBD | ❓ verificare | 🆕 Crea se manca (per fetch full detail post-select) |
+| `UpdateSharedGameCommand` | TBD | ❓ verificare | 🆕 Crea se manca (NO mega-update; SRP) |
+| `PublishSharedGameCommand` | TBD | ❓ verificare | 🆕 Crea se manca |
+| `CoverUrlResolver` | `BoundedContexts/SharedGameCatalog/...` (pre-wired PR #1892) | ✅ esiste | 🔧 Usa per resolve cover post-upload |
+| `STORAGE_PROVIDER` factory | `infra/secrets/storage.secret` | ✅ esiste | nessuna |
+| `useSearchBggGames` | `apps/web/src/hooks/queries/` | ✅ esiste | nessuna |
+| `useBggRateLimit` | `apps/web/src/lib/domain-hooks/` | ✅ esiste | 🔧 Wire countdown UX in wizard step 2 |
+| `BggSearchPanel` | `apps/web/src/components/admin/shared-games/` | ✅ esiste | 🔧 Probabile riuso parziale in wizard |
+| `GameForm` | stesso path | ✅ esiste | 🔧 Riuso in step 3 wizard + page `/{uuid}` |
+| `EditGameDrawer` | stesso path | ✅ esiste | Considera se page `/{uuid}` riusa drawer o full-page form |
+| `PdfUploadSection` | stesso path | ✅ esiste | 🔧 Riuso in step 1 wizard |
+| `ImageUpload` | stesso path | ✅ esiste | 🔧 Riuso in step 3 wizard |
+| `RagReadinessIndicator` | `.../rag-setup/` | ✅ esiste | 🔧 Mount nella page `/{uuid}` |
+| `PdfIndexingStatus` | stesso path | ✅ esiste | 🔧 Mount nella page `/{uuid}` |
+| Page `/admin/shared-games/new` | TBD | 🆕 da creare | Wizard 3-step orchestrator |
+| Page `/admin/shared-games/[uuid]` | TBD | ❓ verificare esistenza | 🆕 Crea se manca |
+
+### 6.2 Sequence flow (wizard create)
+
+```
+Admin Browser              Next.js API Route        .NET API (MediatR)         BGG XML API     Storage
+     │                          │                         │                          │              │
+     │── 1. Upload PDF ──────────────────────────────────►│                          │              │
+     │                          │                         │── UploadPdfCommand ─────────────────────►│
+     │                          │                         │◄── PdfDocumentId ────────────────────────┤
+     │◄── PdfDocumentId ──────────────────────────────────┤                          │              │
+     │                          │                         │                          │              │
+     │── 2. Search "Catan" ─────────────────────────────►│                          │              │
+     │                          │                         │── SearchBggGamesQuery ──►│              │
+     │                          │                         │◄── [match1, match2, …] ──┤              │
+     │◄── results ────────────────────────────────────────┤                          │              │
+     │                          │                         │                          │              │
+     │── 3. Select bggId=13 ────────────────────────────►│                          │              │
+     │                          │                         │── GetBggGameDetailQuery ►│              │
+     │                          │                         │◄── full detail + cover ──┤              │
+     │                          │                         │── download cover ────────────────────────►│
+     │                          │                         │◄── cover URL nostro CDN ─────────────────┤
+     │◄── metadata + coverUrl ────────────────────────────┤                          │              │
+     │                          │                         │                          │              │
+     │── 4. ImportGameFromPdf ──────────────────────────►│                          │              │
+     │   (Idempotency-Key UUID)│                         │── saga step 1: Create ──►│ (DB)         │
+     │                          │                         │── saga step 2: Link PDF ►│ (DB)         │
+     │                          │                         │── saga step 3: Index ───►│ (async)      │
+     │◄── { gameId, status, correlationId } ──────────────┤                          │              │
+     │                          │                         │                          │              │
+     │── 5. Redirect /admin/shared-games/{gameId} ──────►│                          │              │
+```
+
+### 6.3 Pagina `/admin/shared-games/[uuid]` — composition
+
+```
+┌─ Page layout admin ────────────────────────────────────┐
+│ Header: titolo gioco + Status badge (Draft/Published)  │
+│ ─────────────────────────────────────────────────────  │
+│ ┌─ Tab "Dettagli" (default) ───┐ ┌─ Tab "RAG" ──────┐ │
+│ │ GameForm (edit campi)         │ │ RagReadinessIndic │ │
+│ │ - Title, Year, Description    │ │ PdfIndexingStatus │ │
+│ │ - Players, Time, Age          │ │ CTA "Riavvia indx"│ │
+│ │ - Categories (TagInput)       │ │                   │ │
+│ │ - Mechanics (TagInput)        │ └───────────────────┘ │
+│ │ - Designers, Publishers       │                       │
+│ │ - BggId (editabile)           │ ┌─ Tab "PDFs" ─────┐ │
+│ │ - CoverImage (ImageUpload)    │ │ PdfDocumentList   │ │
+│ │ [Save] (PATCH UpdateShared..)│ │ + Upload nuovo    │ │
+│ └───────────────────────────────┘ └───────────────────┘ │
+│                                                          │
+│ ─────────────────────────────────────────────────────   │
+│ Footer: [Pubblica] (se Status=Draft) | [Elimina] (danger)│
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Failure modes (Nygard)
+
+| # | Failure | Probabilità | Detection | Mitigation | UX |
+|---|---------|-------------|-----------|------------|-----|
+| **F1** | BGG XML API timeout/5xx | 🟡 media | HTTP timeout 10s + retry 3 backoff | Fallback manuale (Scenario 2) | Errore esplicito + CTA "Procedi senza BGG" |
+| **F2** | BGG rate-limit 429 | 🔴 alta in burst | `useBggRateLimit` esistente | Coda client + countdown | "Riprova tra Xs" countdown visibile |
+| **F3** | PDF upload fail (size/MIME/storage) | 🟡 media | `UploadPdfCommandValidator` | Errore inline al field | Causa specifica visibile (es. "File 67MB supera limite 50MB") |
+| **F4** | Saga step 2 fail (link PDF) | 🟢 bassa | Try/catch in handler:51 | Compensation `DeleteSharedGameCommand` (esistente) | Error toast: "Import fallito, riprova" |
+| **F5** | Compensation FALLISCE (DELETE game fail dopo step 2 fail) | 🟢 molto bassa | Log warning handler:69 | Orphan game rimane → cron cleanup futuro | Error toast generico + log per ops |
+| **F6** | Download cover BGG fail | 🟡 media (CDN flaky) | HTTP exception in cover downloader | Fallback: salva ImageUrl=BGG-direct (degraded), warning UI | Banner "Cover non scaricata, link diretto temporaneo" |
+| **F7** | Re-upload cover su nostro storage fail | 🟢 bassa | Storage exception | Stesso F6: fallback link BGG diretto | Stesso F6 |
+| **F8** | Indexing fail (RAG/Qdrant down) | 🟡 media | `IndexingStatus = "failed"` in result | Game creato + warning persistente | RagReadinessIndicator rosso + CTA "Riavvia indexing" |
+| **F9** | Doppio-submit "Crea gioco" | 🟡 media (user impazienza) | Idempotency-Key middleware | Stesso `gameId` ritornato | UI disable button after first click + spinner |
+| **F10** | PDF già linked nel frattempo | 🟢 bassa | DB FK constraint o saga check | Saga fail 409 in step 2 → compensation | Error: "PDF già usato da altro gioco" |
+| **F11** | Admin abbandona wizard dopo upload PDF | 🟡 alta (UX reale) | TTL su orphan PDF | Cron cleanup orphan dopo N giorni | Nessuna UX (silenzioso) |
+| **F12** | RowVersion concurrency edit | 🟡 media | `DbUpdateConcurrencyException` | 409 + diff UI (Scenario 3) | Vedi AC-10 |
+
+### Operational requirements
+
+- 📊 **Observability**: ogni step della saga deve loggare con `gameId`, `pdfId`, `bggId`, `requestedBy`, **`correlationId`** (nuovo, propagato da request). Handler attuale già logga base info.
+- 🔁 **Idempotency**: header `Idempotency-Key` (UUID v4 client) con TTL 5 min in Redis (esistente).
+- ⏱️ **Timeout E2E saga**: < 30s escluso indexing async.
+- 🧹 **Orphan PDF cleanup**: TTL N giorni (defer al follow-up, non blocker MVP).
+
+---
+
+## 8. Quality attributes & Testing strategy (Crispin)
+
+### NFR table
+
+| Attributo | Target | Verifica |
+|-----------|--------|----------|
+| Perf — upload PDF p95 | < 5s per 10MB | Load test K6 |
+| Perf — BGG search p95 | < 5s | Integration test con BGG mock |
+| Perf — saga E2E p95 | < 30s (excl. indexing) | Integration test Testcontainers |
+| Perf — redirect post-create | < 2s | E2E Playwright timing |
+| Reliability — BGG offline | flow utilizzabile manuale | Chaos test mock BGG down |
+| Reliability — compensation | 100% rollback su step 2 fail | Unit test handler con mock failure |
+| Security — permission gate | 403 per non-admin su `/new` e `/{uuid}` | Integration test auth |
+| Security — Idempotency | no duplicate game su double-submit | Integration test |
+| A11y — wizard + edit page | axe AA pass (gate blocking) | E2E axe (gate esistente, vedi CLAUDE.md a11y restore) |
+| UX — wizard keyboard nav | drag-drop ha alternativa keyboard | Manual a11y review |
+| i18n — IT/EN keys | tutte le stringhe i18n-ized | grep raw strings + test renderWithIntl |
+
+### Testing pyramid
+
+```
+          ╱╲
+         ╱E2╲     ▸ 1 happy path Playwright (Scenario 1)
+        ╱────╲    ▸ 1 fallback BGG Playwright (Scenario 2)
+       ╱ Integ ╲  ▸ 4-5 Testcontainers: saga atomic, compensation, idempotency, concurrency, permission
+      ╱─────────╲
+     ╱  Unit/CH  ╲ ▸ 15-20: validator, BGG mock, error mapping, RowVersion handler
+    ╱──────────────╲
+```
+
+### Edge cases mandatori per test
+
+1. **BGG zero-match** → form vuoto, admin manuale, bggId=null
+2. **BGG multi-match (10+)** → admin select obbligatorio, no auto
+3. **Idempotency double-submit** identico body → 1 game in DB
+4. **Idempotency triple-submit** body diverso, stesso key → 1 game (primo vince)
+5. **PDF già linked** → 409 saga step 2 → compensation eseguita
+6. **Compensation FAIL** → log warning, orphan game tracked
+7. **Concurrency edit** → 409 + diff UI (Scenario 3)
+8. **Permission non-admin** → 403 + redirect login
+
+---
+
+## 9. Quality scoring spec finale
+
+| Dimensione | Original | Post-panel | Delta |
+|-----------|----------|------------|-------|
+| Clarity | 4/10 | 9/10 | +5 (DEC-1..6 risolvono ambiguità) |
+| Completeness | 3/10 | 9/10 | +6 (12 AC + 3 scenarios + NFR table) |
+| Testability | 2/10 | 9/10 | +7 (Given/When/Then + pyramid + edge cases) |
+| Consistency | 6/10 | 9/10 | +3 (allineata a saga esistente + pattern PR #1892) |
+| **Overall** | **3.75/10** | **9.0/10** | **+5.25** |
+
+---
+
+## 10. Roadmap
+
+### 🟧 P1 — Pre-implementation verifies (1-2h)
+
+- **V1**: Verifica esistenza `UpdateSharedGameCommand` + `PublishSharedGameCommand` (MediatR bridge)
+- **V2**: Verifica esistenza route `/admin/shared-games/[uuid]/page.tsx`
+- **V3**: Verifica `SearchBggGamesQuery` + `GetBggGameDetailQuery` come MediatR commands (oltre l'hook FE)
+- **V4**: Verifica supporto orphan PDF upload in `UploadPdfCommand` (senza gameId obbligatorio)
+- **V5**: Verifica `CoverUrlResolver` API surface per cover re-upload
+
+### 🟨 P2 — Backend deltas (1-2g)
+
+- **B1**: Estendi `ImportGameMetadataDto` con `int? BggId`
+- **B2**: Propaga `BggId` in `ImportGameFromPdfCommandHandler.CreateSharedGameAsync` (riga 150 oggi `null`)
+- **B3**: Crea command + handler mancanti identificati in V1-V5
+- **B4**: Aggiungi `Idempotency-Key` middleware support su `ImportGameFromPdfCommand`
+- **B5**: Aggiungi `CorrelationId` propagazione nel saga
+- **B6**: Bypass `PdfUploadQuotaService` per role Admin (DEC-6)
+- **B7**: Cover downloader service (BGG URL → STORAGE_PROVIDER upload, con fallback F6/F7)
+
+### 🟩 P3 — Frontend wizard (2-3g)
+
+- **F1**: Page `/admin/shared-games/new` orchestrator (3-step state machine)
+- **F2**: Step 1 wizard riuso `PdfUploadSection` (orphan mode)
+- **F3**: Step 2 wizard riuso `BggSearchPanel` + `useBggRateLimit` countdown
+- **F4**: Step 3 wizard form review riuso `GameForm` + `ImageUpload`
+- **F5**: i18n IT/EN keys batched (pattern P201)
+- **F6**: a11y verify (drag-drop keyboard, listbox roles, axe AA)
+
+### 🟪 P4 — Page `/{uuid}` edit (1-2g se nuova, 0.5g se esiste)
+
+- **E1**: Page route + layout (tabs Dettagli/RAG/PDFs)
+- **E2**: Edit form full riuso `GameForm`
+- **E3**: Mount `RagReadinessIndicator` + `PdfIndexingStatus`
+- **E4**: CTA "Pubblica" (visible if Status=Draft) + `PublishSharedGameCommand`
+- **E5**: Concurrency handling 409 + diff UI
+
+### 🟦 P5 — Test suite (parallelo a P2-P4)
+
+- Unit handler tests (15-20)
+- Integration saga tests (5)
+- E2E Playwright happy + fallback (2)
+- A11y axe gate (auto)
+
+### Effort indicativo totale
+
+5-7 giorni full-stack incluse pre-verifies (P1) e test suite (P5).
+
+---
+
+## 11. Follow-ups / Future work
+
+- **FU-1** (P3): Editor role permission (DEC-5 escalation)
+- **FU-2** (P3): Auto-extracted title da PDF via SmolDocling come seed BGG search
+- **FU-3** (P3): Orphan PDF cleanup cron (F11)
+- **FU-4** (P3): Compensation failure recovery automatic (F5)
+- **FU-5** (P3): Bulk import (CSV o multi-PDF) → out-of-scope MVP
+- **FU-6** (P3): Auto-match BGG opt-in con confidence threshold (DEC-2 reverse)
+- **FU-7** (P3): Versioning Rulebook PDF (admin sostituisce v1.0 con v1.1) — usa `VersionBadge` esistente
+
+---
+
+## 12. References (codebase grounding)
+
+### Backend
+
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromPdfCommand.cs:31` — saga command + DTO
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromPdfCommandHandler.cs:36` — handler 3-step saga
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommand.cs` — PDF upload (verifica orphan support)
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfUploadQuotaService.cs` — quota da bypassare per admin
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/` — `IndexDocumentCommand` (fire-and-forget step 3)
+
+### Frontend
+
+- `apps/web/src/components/admin/shared-games/BggSearchPanel.tsx` — riuso parziale wizard step 2
+- `apps/web/src/components/admin/shared-games/GameForm.tsx` — riuso step 3 + page `/{uuid}`
+- `apps/web/src/components/admin/shared-games/EditGameDrawer.tsx` — pattern edit (valutare drawer vs page)
+- `apps/web/src/components/admin/shared-games/PdfUploadSection.tsx` — riuso step 1
+- `apps/web/src/components/admin/shared-games/ImageUpload.tsx` — riuso step 3 (manual cover)
+- `apps/web/src/components/admin/shared-games/rag-setup/RagReadinessIndicator.tsx` — mount page `/{uuid}`
+- `apps/web/src/components/admin/shared-games/PdfIndexingStatus.tsx` — mount page `/{uuid}`
+- `apps/web/src/hooks/queries/useSearchBggGames.ts` — BGG search hook (admin-gated)
+- `apps/web/src/lib/domain-hooks/useBggRateLimit.ts` — rate-limit countdown UX
+- `apps/web/src/lib/api/clients/bggClient.ts` — BGG API client
+
+### Patterns & memory
+
+- **CLAUDE.md** § Code Standards — CQRS rule, RowVersion concurrency, soft delete, audit
+- **MEMORY** P178 — CoverUrlResolver pre-wired discovery (PR #1892)
+- **MEMORY** P179 — Spec-panel blob storage signature trust-but-verify
+- **MEMORY** P201 — i18n batched via atomic Python merge
+- **MEMORY** F2 PR #1980 — BGG admin gate `useAdminRole`
+
+---
+
+## 13. Glossary
+
+| Term | Definition |
+|------|-----------|
+| Shared game | Gioco nel `SharedGameCatalog` BC, visibile a tutti gli utenti del catalogo condiviso |
+| Orphan PDF | `PdfDocument` caricato in DB ma non ancora linkato a un game |
+| Saga | Pattern transazionale a step con compensation per atomicità distribuita (Nygard) |
+| BGG | BoardGameGeek, fonte esterna per metadata giochi (XML API v2) |
+| Draft / Published | Status del game; Draft = visibile solo admin, Published = visibile catalog pubblico |
+| RowVersion | EF Core optimistic concurrency token (`[Timestamp] byte[]`) |
+| Idempotency-Key | UUID v4 client-generated per dedup di submit ripetuti |
+| Indexing | Processo RAG: chunking PDF + embedding + vector storage in Qdrant |
+| CoverUrlResolver | Service pre-wired (PR #1892) per resolve cover URL con fallback chain |
+
+---
+
+**Spec status**: ✅ ready-for-plan
+**Next step suggerito**: `/superpowers:writing-plans` su questa spec per generare TDD plan implementativo


### PR DESCRIPTION
## Summary

Closes three gaps on the admin shared-game wizard identified in the spec-panel review:

- **G1** — `UpdateSharedGameCommand` taxonomy extension: adds `GenreIds`, `MechanicIds`, `PublisherName`, `DesignerName`, `MinPlayers`, `MaxPlayers`, `MinPlaytime`, `MaxPlaytime`, `Complexity`, `AverageRating`, `BggId` fields; command validator + handler updated; 16 unit tests green.
- **G2** — BGG cover re-upload: new `IBggCoverDownloader` interface + `BggCoverDownloader` typed-HttpClient implementation; `CoverUrlResolver` gains L2.5 BGG layer; `BggCoverR2Key` column added to `SharedGameEntity` via EF migration; handler persists the R2 key on create; 3 unit tests green.
- **G5** — Idempotency-Key support on `POST /api/v1/admin/shared-games/wizard/create`: header `Idempotency-Key` (UUID) + `IDistributedCache` (Redis) caching with 5-minute TTL; SHA-256 body hash for mismatch detection (HTTP 422 per IETF draft §2.6); cache key `wizard:create:{userId}:{idempotencyKey}`; 3 integration tests green.

## Migration note

Migration `20260608161038_AddBggCoverR2KeyToSharedGames` adds `bgg_cover_r2_key varchar(256) NULL` to `shared_games`. A fix commit (`613159195`) removes an erroneous `RenameColumn` call that would have failed on any DB where `last_lockout_event_id` was already created in snake_case by migration `20260606200624_AddIdempotencyGuardsToAuthAndInvitations_Iso1`.

## Test plan

- [ ] `dotnet test --filter "BoundedContext=SharedGameCatalog"` — all green (includes G1 unit, G2 unit, G5 integration)
- [ ] `dotnet test --filter "FullyQualifiedName~WizardCreateIdempotencyTests"` — 3/3 green
- [ ] No regressions in `dotnet test --filter "Category=Unit"` baseline
- [ ] Migration applies cleanly on a fresh DB: `dotnet ef database update`
- [ ] Smoke: `POST /api/v1/admin/shared-games/wizard/create` with `Idempotency-Key` header returns same `gameId` on retry; different key creates new game; body mismatch with same key returns 422

## Checklist

- [x] CQRS: endpoint uses `IMediator.Send()` — no direct service injection
- [x] Soft-delete / audit columns untouched
- [x] No Phase 1 or Phase 2 code modified in Phase 3 commits
- [x] `IBggCoverDownloader` mocked in integration tests (`services.RemoveAll` + `AddScoped`)
- [x] Unique `bgg_id` index respected in different-keys test (BggId 174430 vs 174431)

🤖 Generated with [Claude Code](https://claude.com/claude-code)