### PR TITLE
feat(library): #2012 AddGameDrawer telemetry instrumentation

### DIFF
--- a/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
+++ b/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
@@ -27,6 +27,7 @@ import { CatalogSearchStep } from '@/app/(authenticated)/library/CatalogSearchSt
 import { UserWizardClient } from '@/app/(authenticated)/library/private/add/client';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
 import { useTranslation } from '@/hooks/useTranslation';
+import { trackEvent } from '@/lib/analytics/track-event';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -93,17 +94,30 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
     };
   }, []);
 
+  // #2012 — Telemetry: drawer-open event drives the conversion-funnel
+  // denominator (open → choice rate, manual:catalog ratio, abandonment).
+  useEffect(() => {
+    if (open) {
+      trackEvent('library_addgame_drawer_opened');
+    }
+  }, [open]);
+
   // Reset to choice step after close animation finishes
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
       if (!isOpen) {
+        // #2012 — Telemetry: closing while still on the choice step counts
+        // as abandonment (user opened the drawer but selected neither option).
+        if (step === 'choice') {
+          trackEvent('library_addgame_drawer_closed_without_choice');
+        }
         onClose();
         closeTimerRef.current = setTimeout(() => {
           setStep('choice');
         }, 300);
       }
     },
-    [onClose]
+    [onClose, step]
   );
 
   // Called by CatalogSearchStep after game is successfully added to library.
@@ -146,7 +160,10 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
                 icon={<PenLine className="h-6 w-6" />}
                 title={t('pages.library.addGame.manualLabel')}
                 description={t('pages.library.addGame.manualDescription')}
-                onClick={() => setStep('manual')}
+                onClick={() => {
+                  trackEvent('library_addgame_choice_selected', { choice: 'manual' });
+                  setStep('manual');
+                }}
               />
 
               <ChoiceCard
@@ -154,7 +171,10 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
                 icon={<BookOpen className="h-6 w-6" />}
                 title={t('pages.library.addGame.catalogLabel')}
                 description={t('pages.library.addGame.catalogDescription')}
-                onClick={() => setStep('catalog')}
+                onClick={() => {
+                  trackEvent('library_addgame_choice_selected', { choice: 'catalog' });
+                  setStep('catalog');
+                }}
               />
             </div>
           )}

--- a/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
@@ -18,6 +18,8 @@ import userEvent from '@testing-library/user-event';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 
+import { trackEvent } from '@/lib/analytics/track-event';
+
 import { renderWithIntl } from '../../../../__tests__/fixtures/common-fixtures';
 import { AddGameDrawer, AddGameDrawerController } from '../AddGameDrawer';
 
@@ -53,6 +55,12 @@ vi.mock('@/app/(authenticated)/library/private/add/client', () => ({
       </button>
     </div>
   ),
+}));
+
+// #2012 — telemetry instrumentation for AddGameDrawer conversion funnel.
+// Tests assert trackEvent is called with the expected event name + props.
+vi.mock('@/lib/analytics/track-event', () => ({
+  trackEvent: vi.fn(),
 }));
 
 // Mock CatalogSearchStep — contains React Query hooks
@@ -261,6 +269,70 @@ describe('AddGameDrawer', () => {
       await user.keyboard('{Escape}');
 
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Telemetry (#2012)', () => {
+    // T3 conversion funnel instrumentation: measure drawer-open → choice
+    // conversion rate, manual vs catalog ratio, abandonment without choice.
+    // Once 2 weeks of data are collected, T3 UX writing review can land
+    // with Adzic-style measurable thresholds (#2012 acceptance criteria).
+
+    it('tracks library_addgame_drawer_opened when drawer opens', () => {
+      renderDrawer({ open: true });
+
+      expect(trackEvent).toHaveBeenCalledWith('library_addgame_drawer_opened');
+    });
+
+    it('does not track drawer_opened when drawer stays closed', () => {
+      renderDrawer({ open: false });
+
+      expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('tracks choice_selected with choice=manual on manual click', async () => {
+      const user = userEvent.setup();
+      renderDrawer({ open: true });
+      (trackEvent as Mock).mockClear();
+
+      await user.click(screen.getByTestId('add-game-choice-manual'));
+
+      expect(trackEvent).toHaveBeenCalledWith('library_addgame_choice_selected', {
+        choice: 'manual',
+      });
+    });
+
+    it('tracks choice_selected with choice=catalog on catalog click', async () => {
+      const user = userEvent.setup();
+      renderDrawer({ open: true });
+      (trackEvent as Mock).mockClear();
+
+      await user.click(screen.getByTestId('add-game-choice-catalog'));
+
+      expect(trackEvent).toHaveBeenCalledWith('library_addgame_choice_selected', {
+        choice: 'catalog',
+      });
+    });
+
+    it('tracks closed_without_choice when drawer is closed from choice step (Escape)', async () => {
+      const user = userEvent.setup();
+      renderDrawer({ open: true });
+      (trackEvent as Mock).mockClear();
+
+      await user.keyboard('{Escape}');
+
+      expect(trackEvent).toHaveBeenCalledWith('library_addgame_drawer_closed_without_choice');
+    });
+
+    it('does NOT track closed_without_choice when drawer is closed after a choice was selected', async () => {
+      const user = userEvent.setup();
+      renderDrawer({ open: true });
+      await user.click(screen.getByTestId('add-game-choice-manual'));
+      (trackEvent as Mock).mockClear();
+
+      await user.keyboard('{Escape}');
+
+      expect(trackEvent).not.toHaveBeenCalledWith('library_addgame_drawer_closed_without_choice');
     });
   });
 });


### PR DESCRIPTION
## Summary

Wire 3 conversion-funnel events to the analytics layer so the **T3 UX writing review (#2012)** — currently deferred per spec-panel synthesis 2026-06-08 — can land with Adzic-style measurable thresholds after ~2 weeks of data collection.

**Events emitted**:
- `library_addgame_drawer_opened` — denominator (drawer open count)
- `library_addgame_choice_selected({choice: 'manual' | 'catalog'})` — branch ratio
- `library_addgame_drawer_closed_without_choice` — abandonment numerator

## Why

#2012 acceptance criteria require an *observed problem* (user feedback / conversion telemetry / hallway test) before the UX writing review can run. The funnel data this PR collects unlocks:
- **Open → Choice conversion rate** = `choice_selected / drawer_opened`
- **Manual vs Catalog ratio** = `manual / catalog` branch share
- **Abandonment rate** = `closed_without_choice / drawer_opened`

Once 2 weeks of data are in, copy review can land with concrete thresholds (e.g. *"if abandonment > X% → review copy for hesitation triggers"*).

## Implementation

- `useEffect` on `[open]` fires `drawer_opened` once per open transition
- `ChoiceCard` `onClick` handlers fire `choice_selected` before `setStep`
- `handleOpenChange` checks `step === 'choice'` before firing abandonment; added `step` to `useCallback` deps so the closure reads the live value (instead of the stale value captured at first render)
- Uses existing `trackEvent` from `@/lib/analytics/track-event` (dev-mode console logger today, ready to wire to a real provider when product picks one)

## Test plan

- [x] New `describe('Telemetry (#2012)')` block with 6 vitest cases:
  - tracks `drawer_opened` when drawer opens
  - does NOT track `drawer_opened` when drawer stays closed
  - tracks `choice_selected({choice: 'manual'})` on manual click
  - tracks `choice_selected({choice: 'catalog'})` on catalog click
  - tracks `closed_without_choice` when closed from choice step (Escape)
  - does NOT track `closed_without_choice` when closed after a choice was selected (guard case)
- [x] 30/30 tests pass in \`AddGameDrawer.test.tsx\` (5 new + 25 pre-existing, no regression)
- [x] TDD discipline: tests written first, watched 4 fail (RED), then minimal implementation to GREEN
- [x] \`pnpm typecheck\` clean
- [x] \`eslint AddGameDrawer.tsx\` clean (test file is in default ignore pattern — pre-existing)

## Refs

- Issue: #2012 (F2.2 T3 UX writing review — deferred)
- Spec-panel synthesis: comment on #2010 (2026-06-08)
- Umbrella: #1974 (closed)
- Existing telemetry surface: \`apps/web/src/lib/analytics/flywheel-events.ts\` (`trackGameAdded` already wired to success path via `AddGameWizardProvider.tsx:84`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)