### PR TITLE
fix(migrations): #2022 restore search_vector tsvector in InitialCreate

### DIFF
--- a/apps/api/src/Api/Infrastructure/Migrations/20260608133755_InitialCreate.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260608133755_InitialCreate.cs
@@ -1411,6 +1411,18 @@ namespace Api.Infrastructure.Migrations
                     table.PrimaryKey("PK_notifications", x => x.id);
                 });
 
+            // 🔴 ATTENTION FOR FUTURE RE-SQUASHES (issue #2022): the `pgvector_embeddings`
+            // table also has a server-managed `search_vector tsvector` column
+            // (GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED) and a
+            // matching GIN index. EF Core cannot model GENERATED STORED tsvector via the
+            // standard `table.Column<>` API, and `PgVectorEmbeddingEntity` deliberately does
+            // NOT declare the column (see PgVectorEmbeddingEntity.cs line 51), so EF would
+            // not emit it from the model snapshot. The column + index are added below via
+            // `migrationBuilder.Sql(...)` right after the last `IX_pgvector_embeddings_*`
+            // CreateIndex call — search the file for "Issue #2022" to find that block.
+            // If you re-squash this migration, you MUST copy that Sql() block back; without
+            // it, `PgVectorStoreAdapter.EnsureCollectionExistsAsync` will fail on fresh
+            // deploys with `42703: column "search_vector" does not exist`.
             migrationBuilder.CreateTable(
                 name: "pgvector_embeddings",
                 columns: table => new
@@ -1428,6 +1440,7 @@ namespace Api.Infrastructure.Migrations
                     source_chunk_id = table.Column<Guid>(type: "uuid", nullable: true),
                     is_translation = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
                     role_tags = table.Column<int>(type: "integer", nullable: false)
+                    // NOTE: search_vector column intentionally NOT declared here — see banner above.
                 },
                 constraints: table =>
                 {
@@ -8431,14 +8444,39 @@ namespace Api.Infrastructure.Migrations
                 table: "pgvector_embeddings",
                 column: "vector_document_id");
 
-            // Issue #2022: search_vector tsvector + GIN index for hybrid full-text search.
-            // EF Core cannot model GENERATED ALWAYS AS (...) STORED for tsvector, so we use
-            // raw SQL here. The original 81 pre-squash migrations added these via raw SQL too;
-            // the column was lost during the migrations squash because PgVectorEmbeddingEntity
-            // does not declare it (it is server-managed). PgVectorStoreAdapter.EnsureCollectionExistsAsync
-            // also has a defensive ALTER TABLE IF NOT EXISTS fallback, but it runs AFTER the
-            // CREATE INDEX call and therefore cannot recover from a fresh-deploy on its own —
-            // the index creation fails with 42703: column "search_vector" does not exist.
+            // 🔴 Issue #2022: search_vector tsvector + GIN index for hybrid full-text search.
+            //
+            // WHY raw SQL inside an InitialCreate (vs. inline `table.Column<>` in the CreateTable above):
+            //   - EF Core's table.Column<> API has no first-class support for tsvector with
+            //     GENERATED ALWAYS AS (...) STORED. The `Npgsql:ComputedColumnSql` annotation
+            //     covers basic computed columns but is not surfaced through the squash code
+            //     generator for tsvector with stored persistence.
+            //   - PgVectorEmbeddingEntity.cs (line 51) deliberately does NOT map `search_vector`
+            //     as a CLR property: it is server-managed and any RAG export/import path treats
+            //     it as opaque. Keeping it server-only avoids forcing a tsvector ↔ string round-trip
+            //     through EF, which would also break the `Vector` non-comparability story.
+            //   - The original 81 pre-squash migrations created this column + index via raw SQL
+            //     (a `migrationBuilder.Sql()` block in the file that became
+            //     20240XXXXX_AddSearchVectorToPgVectorEmbeddings.cs). When the squash regenerated
+            //     `InitialCreate` from the EF model snapshot it dropped the raw SQL since the
+            //     entity has no matching property — this is the regression that produced #2022.
+            //
+            // 🔴 ATTENTION FOR FUTURE RE-SQUASHES: if you run `dotnet ef migrations add`
+            // to re-squash, this Sql() block will be lost again — see the banner over the
+            // CreateTable("pgvector_embeddings") call near line 1414. You MUST copy this
+            // block into the new InitialCreate before deleting the previous one. The
+            // accompanying integration test
+            // `MigrationRollbackIntegrationTests.MigrateUp_PgvectorEmbeddings_ShouldHaveSearchVectorColumnAndGinIndex`
+            // is the safety net — it will fail on a fresh DB if the column or GIN index is missing.
+            //
+            // 🔴 RUNTIME NOTE: `PgVectorStoreAdapter.EnsureCollectionExistsAsync` also has a
+            // defensive `ALTER TABLE … ADD COLUMN IF NOT EXISTS search_vector` fallback (lines
+            // 540-557) for legacy DBs that predate the original raw SQL migration. That
+            // fallback runs AFTER `CREATE INDEX … USING gin (search_vector)` (line 528-538) on
+            // the same code path, so it CANNOT recover a fresh deploy from this regression —
+            // the index creation fails with `42703: column "search_vector" does not exist`
+            // before the fallback can run. The migration is the only place that can fix this
+            // for fresh deploys.
             migrationBuilder.Sql(@"
                 ALTER TABLE pgvector_embeddings
                 ADD COLUMN IF NOT EXISTS search_vector tsvector

--- a/apps/api/src/Api/Infrastructure/Migrations/20260608133755_InitialCreate.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260608133755_InitialCreate.cs
@@ -8431,6 +8431,24 @@ namespace Api.Infrastructure.Migrations
                 table: "pgvector_embeddings",
                 column: "vector_document_id");
 
+            // Issue #2022: search_vector tsvector + GIN index for hybrid full-text search.
+            // EF Core cannot model GENERATED ALWAYS AS (...) STORED for tsvector, so we use
+            // raw SQL here. The original 81 pre-squash migrations added these via raw SQL too;
+            // the column was lost during the migrations squash because PgVectorEmbeddingEntity
+            // does not declare it (it is server-managed). PgVectorStoreAdapter.EnsureCollectionExistsAsync
+            // also has a defensive ALTER TABLE IF NOT EXISTS fallback, but it runs AFTER the
+            // CREATE INDEX call and therefore cannot recover from a fresh-deploy on its own —
+            // the index creation fails with 42703: column "search_vector" does not exist.
+            migrationBuilder.Sql(@"
+                ALTER TABLE pgvector_embeddings
+                ADD COLUMN IF NOT EXISTS search_vector tsvector
+                GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED;");
+
+            migrationBuilder.Sql(@"
+                CREATE INDEX IF NOT EXISTS idx_pgvector_embeddings_search_vector
+                ON pgvector_embeddings
+                USING gin (search_vector);");
+
             migrationBuilder.CreateIndex(
                 name: "ix_photo_batch_pages_batch_id",
                 table: "photo_batch_pages",

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/MigrationRollbackIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/MigrationRollbackIntegrationTests.cs
@@ -266,4 +266,51 @@ public sealed class MigrationRollbackIntegrationTests : IAsyncLifetime
         var pending = await dbContext1.Database.GetPendingMigrationsAsync(TestCancellationToken);
         pending.Should().BeEmpty();
     }
+
+    [Fact]
+    [Trait("Issue", "2022")]
+    public async Task MigrateUp_PgvectorEmbeddings_ShouldHaveSearchVectorColumnAndGinIndex()
+    {
+        // Arrange — Issue #2022: after the 81-migration squash, search_vector tsvector
+        // (originally added via raw SQL in legacy migrations + PgVectorStoreAdapter.EnsureCollectionExistsAsync)
+        // was lost from InitialCreate because the column is not declared on PgVectorEmbeddingEntity.
+        // Fresh-deploy fails when PgVectorStoreAdapter creates the GIN index on a missing column.
+        using var dbContext = _serviceProvider!.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync(TestCancellationToken);
+
+        var connection = dbContext.Database.GetDbConnection();
+        await connection.OpenAsync(TestCancellationToken);
+
+        // Act — Check search_vector column
+        var colCommand = connection.CreateCommand();
+        colCommand.CommandText = @"
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_name = 'pgvector_embeddings'
+              AND column_name = 'search_vector';
+        ";
+        var columnType = await colCommand.ExecuteScalarAsync(TestCancellationToken);
+
+        // Act — Check GIN index on search_vector
+        var idxCommand = connection.CreateCommand();
+        idxCommand.CommandText = @"
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'pgvector_embeddings'
+              AND indexname = 'idx_pgvector_embeddings_search_vector';
+        ";
+        var indexDef = await idxCommand.ExecuteScalarAsync(TestCancellationToken) as string;
+
+        // Assert
+        columnType.Should().NotBeNull(
+            "search_vector tsvector column is required by PgVectorStoreAdapter.EnsureCollectionExistsAsync "
+            + "when it builds the GIN index for hybrid FTS search (issue #2022)");
+        columnType!.ToString().Should().Be("tsvector");
+
+        indexDef.Should().NotBeNullOrEmpty(
+            "GIN index on search_vector enables hybrid full-text search (issue #2022)");
+        indexDef!.Should().Contain("gin", "the index must use GIN access method for tsvector");
+        indexDef.Should().Contain("search_vector", "the index must target the search_vector column");
+    }
 }


### PR DESCRIPTION
## Summary

The 81-migration squash (PR #2021) silently dropped the `search_vector tsvector` column + GIN index from `pgvector_embeddings`. EF Core can't model `GENERATED ALWAYS AS (...) STORED` for tsvector, so when the entity does not declare it the squash loses it. Result: fresh-deploys crash with `42703: column "search_vector" does not exist` at the first PDF reindex, because `PgVectorStoreAdapter.EnsureCollectionExistsAsync` tries to build the GIN index before its defensive `ALTER TABLE IF NOT EXISTS` fallback runs.

## What changed

- `apps/api/src/Api/Infrastructure/Migrations/20260608133755_InitialCreate.cs` — two `migrationBuilder.Sql(...)` blocks added right after the last `pgvector_embeddings` CreateIndex:
  - `ALTER TABLE pgvector_embeddings ADD COLUMN IF NOT EXISTS search_vector tsvector GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED;`
  - `CREATE INDEX IF NOT EXISTS idx_pgvector_embeddings_search_vector ON pgvector_embeddings USING gin (search_vector);`
- `apps/api/tests/Api.Tests/.../MigrationRollbackIntegrationTests.cs` — new `MigrateUp_PgvectorEmbeddings_ShouldHaveSearchVectorColumnAndGinIndex` checks both the column type (`tsvector`) and the GIN index `indexdef` on a Testcontainers Postgres instance.

Net +65 LOC, two files.

## Why not `HasComputedColumnSql` on the entity?

EF Core supports computed columns via `HasComputedColumnSql(...)`, but tsvector is a non-comparable type and the existing `PgVectorEmbeddingEntity` deliberately doesn't map `search_vector` (the comment at line 51 says so). Pulling it into the entity would force adding a mapped property whose only value is migration schema — and re-trigger the same issue on the next squash if the entity changes. Keeping the DDL in the migration matches the convention used by all other tsvector / GIN / hnsw constructs in this codebase.

## Verification

- ✅ `dotnet build` (Api) — 0 warnings / 0 errors.
- ✅ Integration test `MigrateUp_PgvectorEmbeddings_ShouldHaveSearchVectorColumnAndGinIndex` passes (7s).
- ✅ Full `MigrationRollbackIntegrationTests` class — 8/8 passed (16s), no regressions on the other 7 pre-existing tests.
- ✅ `Down()` rollback handled implicitly via `DropTable(pgvector_embeddings)` — column + index removed by cascade.
- ✅ Idempotent: both `IF NOT EXISTS` clauses guard against double-apply.

## Test plan

- [ ] CI integration job picks up the new test and stays green.
- [ ] Fresh-deploy smoke (manual or next nightly) reaches the first PDF reindex without the `42703` error.

## Refs

- Closes #2022
- Caused by: PR #2021 (`eff570a08` — squash 81 migrations into InitialCreate)
- Related: #2023 (reindex race condition) — separate PR, same DocumentProcessing cluster
- Related: #2024 (OOM batch reindex) — derivative, likely resolved once #2022 + #2023 land

🤖 Generated with [Claude Code](https://claude.com/claude-code)