### PR TITLE
test(document-processing): #1887 fix PdfDocument_SevenStateProgression event count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,11 +262,13 @@ tests/Api.Tests/          # Backend test suite
 ## Known Flaky Tests
 
 Tests confirmed failing on `main-dev` baseline independently of any specific PR.
-Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale).
+Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale) → 2026-06-09 (#1887 PdfDocument_SevenStateProgression cleared, baseline now empty).
 
 | Test | File | First observed | Reason | Action |
 |---|---|---|---|---|
-| `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates` | `apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs:788` | 2026-06-04 | Expects 6 `DomainEvents` but finds 7 — regression from PR #1873 (added `PdfDocumentDeleted` event but did not update the count). | Tracked in #1887. |
+| _(none — baseline currently clean)_ | | | | |
+
+**Resolved 2026-06-09 (#1887)**: `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates` — assertion fixed from `HaveCount(6)` + `AllBeOfType<PdfStateChangedEvent>()` to `HaveCount(7)` + typed `OfType<>()` split (6 `PdfStateChangedEvent` + 1 `KbDocIndexedEvent` on Ready, per BE-3 #1590 B2). Reason in the previous baseline entry misattributed the 7th event to PR #1873's `PdfDocumentDeleted` — the actual extra event is `KbDocIndexedEvent` raised from `TransitionTo()` when the new state is `Ready` (see `PdfDocument.cs:433-443`).
 
 **Resolved 2026-05-22**: 3 documented baseline failures fixed + 1 stale entry removed.
 - `Should_Fail_When_GameId_Is_Empty` — fixed by adding `Cascade(CascadeMode.Stop)` to `CreateRuleConflictFaqCommandValidator.RuleFor(x => x.GameId)` so the async `GameExists` check (which calls `GameRef.Shared(Guid.Empty)` → `ArgumentException`) is skipped when `NotEmpty()` already failed.

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs
@@ -784,9 +784,15 @@ public sealed class PdfPipelineIntegrationTests : IAsyncLifetime
         pdf.TransitionTo(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
         pdf.ProcessingState.Should().Be(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
 
-        // Verify domain events were emitted (6 transitions)
-        pdf.DomainEvents.Should().HaveCount(6);
-        pdf.DomainEvents.Should().AllBeOfType<Api.BoundedContexts.DocumentProcessing.Domain.Events.PdfStateChangedEvent>();
+        // Verify domain events emitted: 6 PdfStateChangedEvent (one per transition) +
+        // 1 KbDocIndexedEvent on the Ready transition (BE-3 #1590 B2). Issue #1887.
+        pdf.DomainEvents.Should().HaveCount(7);
+        pdf.DomainEvents
+            .OfType<Api.BoundedContexts.DocumentProcessing.Domain.Events.PdfStateChangedEvent>()
+            .Should().HaveCount(6);
+        pdf.DomainEvents
+            .OfType<Api.BoundedContexts.DocumentProcessing.Domain.Events.KbDocIndexedEvent>()
+            .Should().HaveCount(1);
 
         // Verify final state persists (must call UpdateAsync to sync domain changes to EF tracked entity)
         await _pdfRepository.UpdateAsync(pdf, TestCancellationToken);


### PR DESCRIPTION
## Summary

- Fix flaky test `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates` (was expecting 6 events, actually emits 7).
- Update `CLAUDE.md § Known Flaky Tests` — baseline now empty.
- Closes #1887.

## Root cause

The test asserted `pdf.DomainEvents.Should().HaveCount(6)` + `AllBeOfType<PdfStateChangedEvent>()`. The 6-count was correct only for the `PdfStateChangedEvent` stream, but `TransitionTo()` also emits a `KbDocIndexedEvent` when the new state is `Ready` (`PdfDocument.cs:433-443`, added by BE-3 #1590 B2 for the activity rail). Total: 6 + 1 = 7.

The `CLAUDE.md` baseline entry misattributed the 7th event to PR #1873's `PdfDocumentDeleted` — the actual extra event is `KbDocIndexedEvent`. The corrected note clarifies this.

## Fix

Replace the count(6) + `AllBeOfType<>` assertion with a count(7) + typed `OfType<>()` split:

```csharp
pdf.DomainEvents.Should().HaveCount(7);
pdf.DomainEvents
    .OfType<PdfStateChangedEvent>()
    .Should().HaveCount(6);
pdf.DomainEvents
    .OfType<KbDocIndexedEvent>()
    .Should().HaveCount(1);
```

Documents the two kinds of events explicitly so a future event added inside `TransitionTo()` will surface as a per-kind count failure rather than a single aggregate-count mismatch.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates"` passes locally (1/1, 6s)
- [ ] CI Backend Fast green
- [ ] CI Backend Integration green

🤖 Generated with [Claude Code](https://claude.com/claude-code)