### PR TITLE
test(api): #1887 PdfDocument seven-state expects 7 events on Ready

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs
@@ -784,9 +784,18 @@ public sealed class PdfPipelineIntegrationTests : IAsyncLifetime
         pdf.TransitionTo(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
         pdf.ProcessingState.Should().Be(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
 
-        // Verify domain events were emitted (6 transitions)
-        pdf.DomainEvents.Should().HaveCount(6);
-        pdf.DomainEvents.Should().AllBeOfType<Api.BoundedContexts.DocumentProcessing.Domain.Events.PdfStateChangedEvent>();
+        // Verify domain events were emitted: 6 PdfStateChangedEvent (one per transition)
+        // PLUS 1 KbDocIndexedEvent raised on entering the Ready terminal state (BE-3 #1590 B2 —
+        // user-meaningful "doc indexed" milestone for the activity rail).
+        pdf.DomainEvents.Should().HaveCount(7);
+        pdf.DomainEvents
+            .OfType<Api.BoundedContexts.DocumentProcessing.Domain.Events.PdfStateChangedEvent>()
+            .Should()
+            .HaveCount(6);
+        pdf.DomainEvents
+            .OfType<Api.BoundedContexts.DocumentProcessing.Domain.Events.KbDocIndexedEvent>()
+            .Should()
+            .HaveCount(1);
 
         // Verify final state persists (must call UpdateAsync to sync domain changes to EF tracked entity)
         await _pdfRepository.UpdateAsync(pdf, TestCancellationToken);


### PR DESCRIPTION
## Summary

Fixes the `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates` baseline failure (#1887) by acknowledging that `TransitionTo(Ready)` also raises a `KbDocIndexedEvent` for the activity-rail milestone (added in BE-3 #1590 B2, not PR #1873 as originally suspected).

## Why

6 state transitions emit 6 `PdfStateChangedEvent` + 1 final `KbDocIndexedEvent` = **7 events**. The test asserted `HaveCount(6)`.

## Change

Split the assertion so each event family is verified independently — preserves the intent of asserting the state machine's emission contract while staying correct after the BE-3 addition.

```diff
-        pdf.DomainEvents.Should().HaveCount(6);
-        pdf.DomainEvents.Should().AllBeOfType<...PdfStateChangedEvent>();
+        pdf.DomainEvents.Should().HaveCount(7);
+        pdf.DomainEvents.OfType<...PdfStateChangedEvent>().Should().HaveCount(6);
+        pdf.DomainEvents.OfType<...KbDocIndexedEvent>().Should().HaveCount(1);
```

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~PdfDocument_SevenStateProgression"` → **1 passed, 0 failed** locally
- [x] No new warnings introduced (only edits in the assertion block of one test)

## Refs

- Issue: #1887
- Source of the 7th event: `PdfDocument.cs:435` (`TransitionTo` → `if (newState == PdfProcessingState.Ready)` branch)
- BE-3 #1590 B2 origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)