### PR TITLE
ci(backend): #1960 add dotnet publish verify step to catch warnings-as-errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,21 @@ jobs:
       - name: Build Solution (Release)
         run: dotnet build MeepleAI.Api.sln --no-restore --configuration Release
 
+      # #1960 — Replicate the Docker production publish so warnings-as-errors
+      # surface BEFORE merge instead of at deploy time. PR #1892 introduced a
+      # CS8604 that compiled cleanly under `dotnet build` but failed under
+      # `dotnet publish -c Release` with `TreatWarningsAsErrors=true` (csproj
+      # line 10). The bug survived 4 days because no staging deploy ran in
+      # between. ~30-60s marginal cost on the runner; major safety win.
+      - name: Verify production-grade publish (catch warnings-as-errors)
+        run: |
+          dotnet publish src/Api/Api.csproj \
+            -c Release \
+            -p:SkipAnalyzers=true \
+            -p:GenerateDocumentationFile=false \
+            -o /tmp/publish-verify \
+            --no-restore
+
       - name: Package build artifacts
         # Tar+zstd preserves symlinks and timestamps; small overhead vs raw upload
         # but avoids the artifact-v4+ silent permission stripping on bin/ executables.


### PR DESCRIPTION
## Summary

Adds a `dotnet publish -c Release` verification step to the `build-backend` job so warnings-as-errors regressions surface at PR time instead of at staging deploy.

## Why (from #1960)

PR #1892 introduced a CS8604 nullable warning in `UploadCustomCoverCommandHandler.cs:59` that:
- ✅ Compiled cleanly under `dotnet build` / `dotnet test`
- ❌ Failed under `dotnet publish -c Release` (Docker build) with `TreatWarningsAsErrors=true` (project-wide setting in `Api.csproj:10`)

The bug survived 4 days because no staging deploy ran between PR #1892 (2026-06-04) and PR #1957 (2026-06-07). Deploy run [27089623661](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27089623661) finally exposed it ("Build and Push API Image" failure), blocking the release. Hotfix PR #1958 was a 1-character fix.

## Change

One new step between `Build Solution (Release)` and `Package build artifacts`:

```yaml
- name: Verify production-grade publish (catch warnings-as-errors)
  run: |
    dotnet publish src/Api/Api.csproj \
      -c Release \
      -p:SkipAnalyzers=true \
      -p:GenerateDocumentationFile=false \
      -o /tmp/publish-verify \
      --no-restore
```

This replicates the exact invocation from `apps/api/src/Api/Dockerfile:51-55` so any future warnings-as-errors regression is caught at PR time.

## Cost

~30-60s additional runner time on the `build-backend` job (which already takes 5-10min). NuGet restore is cached, and `--no-restore` keeps us from re-downloading packages. Net safety win is significant.

## Test plan

- [x] Workflow YAML validates (no syntax errors — checked via vim/IDE)
- [x] Commit-message hook passed
- [x] No production code touched — CI-only change
- [ ] CI run on this PR will execute the new step end-to-end and prove it succeeds against current main-dev sources (which are clean post PR #1958 hotfix)

## Refs

- Issue: #1960
- Original escape: PR #1892
- Hotfix: PR #1958
- Trigger deploy: [run 27089623661](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27089623661)

🤖 Generated with [Claude Code](https://claude.com/claude-code)