### PR TITLE
ci(deploy): #1959 fix spurious Deploy via SSH failure via Python heredoc

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1055,14 +1055,22 @@ jobs:
               fi
               sleep 3
             done
-            docker exec meepleai-api curl -sf http://localhost:8080/health | python3 -c "
-            import sys,json
-            d=json.load(sys.stdin)
+            # #1959 — previously `... | python3 -c "<multi-line script>"` broke
+            # under appleboy/ssh-action quoting: argv arrived as `python3 -c`
+            # with `-c` interpreted as a file path (FileNotFoundError on
+            # /opt/meepleai/repo/infra/-c), yielding a spurious step failure
+            # despite the deploy succeeding. Heredoc avoids the quoting issue
+            # and is robust under SSH multi-line shell invocation.
+            docker exec meepleai-api curl -sf http://localhost:8080/health > /tmp/staging-health.json
+            python3 << 'PY' || exit 1
+            import json
+            with open('/tmp/staging-health.json') as f:
+                d = json.load(f)
             healthy = [c['name'] for c in d['checks'] if c['status']=='Healthy']
             print(f'Healthy services: {len(healthy)}')
             assert any(c['name']=='postgres' and c['status']=='Healthy' for c in d['checks']), 'postgres unhealthy'
             assert any(c['name']=='redis' and c['status']=='Healthy' for c in d['checks']), 'redis unhealthy'
-            " || exit 1
+            PY
 
             # Issue #1578 — AI container health (only for recreated services).
             # Container names per compose: embedding-service→meepleai-embedding,


### PR DESCRIPTION
## Summary

Replaces the inline `... | python3 -c "<multi-line script>"` health-check assertion in \`deploy-staging.yml\` with a heredoc that reads from a temp file. The previous form broke under \`appleboy/ssh-action\` multi-line shell quoting.

## Why (from #1959)

Deploy run [27090737862](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27090737862) reported the **'Deploy via SSH'** step as `failure`, yet operationally everything succeeded (migration applied, API container restarted, staging public HTTP 200, smoke tests green).

Log signature:
```
FileNotFoundError: [Errno 2] No such file or directory: '/opt/meepleai/repo/infra/-c'
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Root cause: the `appleboy/ssh-action` script-block quoting mangled the multi-line `python3 -c "..."` invocation. argv arrived as `python3 -c` with `-c` interpreted as a positional file path (relative to cwd `/opt/meepleai/repo/infra`) — hence `FileNotFoundError`. The curl pipe was also lost, hence `JSONDecodeError` on empty stdin.

Net effect: false alarm trained engineers to ignore deploy failure notifications. Real failures could be missed.

## Fix

Heredoc form is robust under SSH multi-line invocation:

```diff
- docker exec meepleai-api curl -sf .../health | python3 -c "
- import sys,json
- d=json.load(sys.stdin)
- ...
- " || exit 1
+ docker exec meepleai-api curl -sf .../health > /tmp/staging-health.json
+ python3 << 'PY' || exit 1
+ import json
+ with open('/tmp/staging-health.json') as f:
+     d = json.load(f)
+ ...
+ PY
```

The Python assertions are unchanged (same postgres/redis healthy checks). Only the shell invocation form moves to file-based input + heredoc.

## Test plan

- [x] YAML syntax valid (no IDE warnings)
- [x] commit-message hook passed
- [ ] Real verification happens at the next staging deploy run — workflow change cannot be locally tested end-to-end without an SSH target. Next deploy after merge will exercise the heredoc form.

## Refs

- Issue: #1959
- Affected file: `.github/workflows/deploy-staging.yml:1058-1065` → now `1058-1075`
- Trigger run: [27090737862](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27090737862)

🤖 Generated with [Claude Code](https://claude.com/claude-code)