### PR TITLE
docs(claude-md): clear #1887 from flaky baseline (PR #2038 closeout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,11 +262,13 @@ tests/Api.Tests/          # Backend test suite
 ## Known Flaky Tests
 
 Tests confirmed failing on `main-dev` baseline independently of any specific PR.
-Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale).
+Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale) → 2026-06-09 (#1887 PdfDocument_SevenStateProgression cleared via PR #2038, baseline now empty).
 
 | Test | File | First observed | Reason | Action |
 |---|---|---|---|---|
-| `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates` | `apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs:788` | 2026-06-04 | Expects 6 `DomainEvents` but finds 7 — regression from PR #1873 (added `PdfDocumentDeleted` event but did not update the count). | Tracked in #1887. |
+| _(none — baseline currently clean)_ | | | | |
+
+**Resolved 2026-06-09 (#1887)**: `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates` (fix PR [#2038](https://github.com/meepleAi-app/meepleai-monorepo/pull/2038)) — assertion split into `HaveCount(7)` + typed `OfType<>()` (6 `PdfStateChangedEvent` + 1 `KbDocIndexedEvent` raised on the Ready transition for the activity rail, per BE-3 #1590 B2). The previous baseline entry misattributed the 7th event to PR #1873's `PdfDocumentDeleted` — actual extra event is `KbDocIndexedEvent` from `TransitionTo()` (`PdfDocument.cs:433-443`).
 
 **Resolved 2026-05-22**: 3 documented baseline failures fixed + 1 stale entry removed.
 - `Should_Fail_When_GameId_Is_Empty` — fixed by adding `Cascade(CascadeMode.Stop)` to `CreateRuleConflictFaqCommandValidator.RuleFor(x => x.GameId)` so the async `GameExists` check (which calls `GameRef.Shared(Guid.Empty)` → `ArgumentException`) is skipped when `NotEmpty()` already failed.


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #2038 (which fixed `PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates`). The test code is now green, but `CLAUDE.md § Known Flaky Tests` still listed the entry — this PR clears it.

- Remove the obsolete `PdfDocument_SevenStateProgression` row from the baseline table.
- Mark the baseline currently empty (`_(none — baseline currently clean)_`).
- Add a 2026-06-09 entry to the triage history with a correction: the 7th event is `KbDocIndexedEvent` raised from `TransitionTo()` when entering `Ready` (`PdfDocument.cs:433-443`, BE-3 #1590 B2), **not** `PdfDocumentDeleted` from PR #1873 as the previous baseline entry suggested.

## Why correct the misattribution

The previous note risked future regressions: an engineer chasing a similar baseline mismatch would have grepped for `PdfDocumentDeleted` events and not found anything explaining the count. Recording the real source (`KbDocIndexedEvent` on `Ready`) makes the next debug session take seconds instead of minutes.

## Test plan

- [x] No code changes; markdown only.
- [ ] Lychee link check passes (PR #2038 link present).

Refs #1887, #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)