### PR TITLE
fix(hub): #2043 Bug 2 — redirect /hub to /hub/games

### DIFF
--- a/apps/web/src/app/(public)/hub/page.tsx
+++ b/apps/web/src/app/(public)/hub/page.tsx
@@ -1,0 +1,18 @@
+/**
+ * /hub — section index. Redirects to `/hub/games` (default tab).
+ *
+ * Issue #2043 Bug 2: a direct visit to `/hub` returned 404 because no `page.tsx`
+ * existed at the section root — only the `games/` subroute was defined. The hub
+ * is currently a single-section landing (public catalog); when more sections
+ * (toolkits, agents, kb) land here, this redirect can be replaced by a real
+ * index page or a server-side decision based on the visitor's profile.
+ *
+ * Temporary 307 (not permanent) — see ADR / discussion if/when section landing
+ * becomes a real page so browsers don't cache 308 forever.
+ */
+
+import { redirect } from 'next/navigation';
+
+export default function HubIndexPage(): never {
+  redirect('/hub/games');
+}


### PR DESCRIPTION
## Summary

Fix Bug 2 of #2043: direct visits to \`/hub\` returned 404 because no \`page.tsx\` existed at the section root; only \`/hub/games/page.tsx\` was defined.

Add a server-side 307 redirect at \`apps/web/src/app/(public)/hub/page.tsx\` to \`/hub/games\` (current default tab).

## Implementation

\`\`\`tsx
import { redirect } from 'next/navigation';

export default function HubIndexPage(): never {
  redirect('/hub/games');
}
\`\`\`

## Why 307 and not 308

If/when the hub gains a real landing (toolkits + agents + kb summary, visitor-aware decision) we replace this page. A 307 keeps it cheap to undo — browsers won't have cached a permanent redirect.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] After merge + dev server: visit \`/hub\` → expect 307 → \`/hub/games\`

Refs #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)