### PR TITLE
feat(catalog-sync-be): #1907 record EnrichmentAttempt in BggImportQueueBackgroundService

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IEnrichmentQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IEnrichmentQueueRepository.cs
@@ -25,6 +25,21 @@ public interface IEnrichmentQueueRepository
         int limit,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns all pending (IsProcessed=false) entries for a specific shared game.
+    /// Used by <see cref="Api.Infrastructure.BackgroundServices.BggImportQueueBackgroundService"/>
+    /// (#1907) to cascade MarkProcessed when a BGG enrichment iteration reaches a terminal
+    /// outcome (success or max-retry failure).
+    /// </summary>
+    /// <remarks>
+    /// Multiple entries can exist for the same game (e.g. an admin manually enqueues a
+    /// Normal-priority entry while a Stale-priority entry from the skeleton sweep is
+    /// already pending). All of them collapse to Processed on the same terminal outcome.
+    /// </remarks>
+    Task<IReadOnlyList<EnrichmentQueueEntry>> GetPendingForGameAsync(
+        Guid sharedGameId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Persists changes to a previously loaded entry (e.g. MarkProcessed).</summary>
     Task UpdateAsync(EnrichmentQueueEntry entry, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepository.cs
@@ -87,6 +87,24 @@ internal sealed class EnrichmentQueueRepository : RepositoryBase, IEnrichmentQue
         return (items, total);
     }
 
+    public async Task<IReadOnlyList<EnrichmentQueueEntry>> GetPendingForGameAsync(
+        Guid sharedGameId,
+        CancellationToken cancellationToken = default)
+    {
+        if (sharedGameId == Guid.Empty)
+        {
+            throw new ArgumentException("SharedGameId cannot be Guid.Empty.", nameof(sharedGameId));
+        }
+
+        var rows = await DbContext.EnrichmentQueueEntries
+            .AsNoTracking()
+            .Where(e => e.SharedGameId == sharedGameId && !e.IsProcessed)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows.Select(MapToDomain).ToList();
+    }
+
     public Task UpdateAsync(EnrichmentQueueEntry entry, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entry);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ErrorCodeClassifier.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ErrorCodeClassifier.cs
@@ -1,0 +1,74 @@
+using System.Net;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Classifies exceptions raised during BGG enrichment iterations into structured machine-readable
+/// error codes (#1907). The codes drive the admin Failed Items panel grouping plus the
+/// <c>error_code</c> column on <c>enrichment_attempts</c>. Categories are deliberately coarse
+/// (network / schema / unknown) — the human-readable detail lives in <c>error_detail</c>.
+/// </summary>
+internal static class ErrorCodeClassifier
+{
+    /// <summary>BGG API replied with 429 Too Many Requests (rate-limit exceeded).</summary>
+    public const string BggRateLimit = "BGG_API_RATE_LIMIT_429";
+
+    /// <summary>BGG API replied with a 5xx server error. Appended with the numeric status (e.g. "BGG_SERVER_ERROR_503").</summary>
+    public const string BggServerErrorPrefix = "BGG_SERVER_ERROR_";
+
+    /// <summary>HTTP request timed out or was cancelled (network slow / DNS / TCP).</summary>
+    public const string BggTimeout = "BGG_TIMEOUT";
+
+    /// <summary>BGG response failed JSON/XML deserialization or aggregate factory invariant.</summary>
+    public const string SchemaMismatch = "SCHEMA_MISMATCH";
+
+    /// <summary>Catch-all for exceptions that don't map to a known category.</summary>
+    public const string Unknown = "UNKNOWN";
+
+    /// <summary>
+    /// Maps an exception to a structured error code. Never throws — callers can rely on a
+    /// non-null, non-empty return value even for unexpected exception shapes.
+    /// </summary>
+    public static string Classify(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        // Cancellation is treated as a timeout from the BGG iteration's POV: the iteration
+        // either ran past its own retry window or its outer scope was disposed mid-flight.
+        if (exception is TaskCanceledException or OperationCanceledException)
+        {
+            return BggTimeout;
+        }
+
+        if (exception is HttpRequestException http)
+        {
+            if (http.StatusCode is HttpStatusCode status)
+            {
+                if (status == HttpStatusCode.TooManyRequests)
+                {
+                    return BggRateLimit;
+                }
+
+                var code = (int)status;
+                if (code >= 500 && code < 600)
+                {
+                    return $"{BggServerErrorPrefix}{code}";
+                }
+            }
+
+            // No status code (DNS failure, TCP reset, TLS error) → treat as transient timeout
+            // class. Callers retry these on the same exponential schedule as 5xx and 429.
+            return BggTimeout;
+        }
+
+        if (exception is System.Text.Json.JsonException
+            || exception is System.Xml.XmlException
+            || exception is InvalidOperationException
+            || exception is ArgumentException)
+        {
+            return SchemaMismatch;
+        }
+
+        return Unknown;
+    }
+}

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/BggImportQueueBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/BggImportQueueBackgroundService.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Services;
 using Api.Models;
@@ -205,6 +207,22 @@ internal sealed class BggImportQueueBackgroundService : BackgroundService
                 _logger.LogInformation(
                     "Successfully imported BGG game: QueueId={QueueId}, BggId={BggId}, CreatedGameId={CreatedGameId}",
                     queueItemId, bggId, createdGameId.Value);
+
+                // #1907 — Persist EnrichmentAttempt row + cascade MarkProcessed on any pending
+                // EnrichmentQueueEntry for the same shared game. Only for enrichment jobs;
+                // import jobs (new game creation) don't have a paired EnrichmentQueueEntry row.
+                if (jobType == BggQueueJobType.Enrichment && sharedGameId.HasValue)
+                {
+                    await RecordEnrichmentOutcomeAsync(
+                        updateScope.ServiceProvider,
+                        sharedGameId.Value,
+                        catalogSyncRunId: null,
+                        retryCount: retryCount,
+                        success: true,
+                        errorCode: null,
+                        errorDetail: null,
+                        cancellationToken).ConfigureAwait(false);
+                }
             }
             else if (importException is InvalidOperationException { Message: var msg } && msg.Contains("already exists"))
             {
@@ -238,6 +256,32 @@ internal sealed class BggImportQueueBackgroundService : BackgroundService
                     "Failed to import BGG game: QueueId={QueueId}, BggId={BggId}, Attempt={Attempt}/{MaxAttempts}",
                     queueItemId, bggId, retryCount + 1, _config.MaxRetryAttempts);
 
+                // #1907 — Persist EnrichmentAttempt failure row only on the terminal attempt
+                // (intermediate retries don't produce admin-visible rows; the next retry will
+                // either succeed or hit the terminal path itself). Cascade MarkProcessed too.
+                var isTerminalFailure = retryCount + 1 >= _config.MaxRetryAttempts;
+                if (isTerminalFailure
+                    && jobType == BggQueueJobType.Enrichment
+                    && sharedGameId.HasValue)
+                {
+                    var classifiedCode = ErrorCodeClassifier.Classify(importException);
+                    var detail = importException.Message;
+                    if (detail.Length > 500)
+                    {
+                        detail = detail.Substring(0, 500);
+                    }
+
+                    await RecordEnrichmentOutcomeAsync(
+                        updateScope.ServiceProvider,
+                        sharedGameId.Value,
+                        catalogSyncRunId: null,
+                        retryCount: retryCount,
+                        success: false,
+                        errorCode: classifiedCode,
+                        errorDetail: detail,
+                        cancellationToken).ConfigureAwait(false);
+                }
+
                 if (retryCount + 1 < _config.MaxRetryAttempts)
                 {
                     var backoffDelay = TimeSpan.FromSeconds(
@@ -251,6 +295,68 @@ internal sealed class BggImportQueueBackgroundService : BackgroundService
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Persists an <see cref="EnrichmentAttempt"/> row plus cascades <c>MarkProcessed</c> on every
+    /// pending <see cref="EnrichmentQueueEntry"/> for the same shared game (#1907). Called on
+    /// both terminal outcomes (success or max-retry failure) of an enrichment iteration.
+    /// </summary>
+    /// <remarks>
+    /// Failures here are swallowed deliberately — the attempt log is best-effort observability
+    /// for the admin Failed Items panel, not on the critical path. The outer scope already
+    /// recorded the queue outcome via <c>MarkAsCompletedAsync</c> / <c>MarkAsFailedAsync</c>,
+    /// so any persistence problem here cannot retroactively roll the queue back.
+    /// </remarks>
+    private async Task RecordEnrichmentOutcomeAsync(
+        IServiceProvider serviceProvider,
+        Guid sharedGameId,
+        Guid? catalogSyncRunId,
+        int retryCount,
+        bool success,
+        string? errorCode,
+        string? errorDetail,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var attemptRepo = serviceProvider.GetRequiredService<IEnrichmentAttemptRepository>();
+            var queueRepo = serviceProvider.GetRequiredService<IEnrichmentQueueRepository>();
+            var unitOfWork = serviceProvider.GetRequiredService<IUnitOfWork>();
+
+            var attempt = success
+                ? EnrichmentAttempt.RecordSuccess(sharedGameId, catalogSyncRunId, retryCount)
+                : EnrichmentAttempt.RecordFailure(sharedGameId, catalogSyncRunId, errorCode!, errorDetail!, retryCount);
+
+            await attemptRepo.AddAsync(attempt, cancellationToken).ConfigureAwait(false);
+
+            // Cascade MarkProcessed onto every pending EnrichmentQueueEntry for this game.
+            // Multiple entries can coexist (admin Normal-priority + skeleton-sweep Stale-priority);
+            // a terminal outcome collapses all of them so the queue doesn't keep re-firing.
+            var pending = await queueRepo.GetPendingForGameAsync(sharedGameId, cancellationToken).ConfigureAwait(false);
+            foreach (var entry in pending)
+            {
+                entry.MarkProcessed();
+                await queueRepo.UpdateAsync(entry, cancellationToken).ConfigureAwait(false);
+            }
+
+            await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Recorded EnrichmentAttempt {AttemptId} for SharedGameId={SharedGameId} (Success={Success}, RetryCount={RetryCount}) + collapsed {PendingCount} queue entries",
+                attempt.Id, sharedGameId, success, retryCount, pending.Count);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            // Best-effort observability — never fail the queue iteration because of attempt-log persistence.
+            _logger.LogError(
+                ex,
+                "Failed to persist EnrichmentAttempt for SharedGameId={SharedGameId} (Success={Success}). " +
+                "Queue outcome already recorded; admin Failed Items panel may be missing this row.",
+                sharedGameId, success);
+        }
+#pragma warning restore CA1031
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/EnrichmentQueueRepositoryIntegrationTests.cs
@@ -186,6 +186,62 @@ public sealed class EnrichmentQueueRepositoryIntegrationTests : IAsyncLifetime
         total.Should().Be(2);
     }
 
+    // ===== #1907 GetPendingForGameAsync — cascade MarkProcessed support =====
+
+    [Fact]
+    public async Task GetPendingForGameAsync_EmptyGuid_Throws()
+    {
+        var act = () => _repository.GetPendingForGameAsync(Guid.Empty);
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetPendingForGameAsync_NoEntries_ReturnsEmpty()
+    {
+        var entries = await _repository.GetPendingForGameAsync(_gameAlphaId);
+        entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingForGameAsync_ReturnsAllPendingForTargetGame()
+    {
+        // Two pending entries for gameAlpha (Normal + Stale priority — both valid).
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Normal, "admin retry", _testUserId);
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Stale, "skeleton sweep", null);
+        // Distractor entries for other games — must NOT appear in the result.
+        await EnqueueAsync(_gameBetaId, EnrichmentPriority.Normal, "beta unrelated", _testUserId);
+        await EnqueueAsync(_gameGammaId, EnrichmentPriority.High, "gamma errata", _testUserId);
+
+        var entries = await _repository.GetPendingForGameAsync(_gameAlphaId);
+
+        entries.Should().HaveCount(2);
+        entries.Should().OnlyContain(e => e.SharedGameId == _gameAlphaId);
+        entries.Select(e => e.Priority).Should().BeEquivalentTo(
+            new[] { EnrichmentPriority.Normal, EnrichmentPriority.Stale });
+    }
+
+    [Fact]
+    public async Task GetPendingForGameAsync_ExcludesProcessedEntries()
+    {
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Normal, "first", _testUserId);
+        await EnqueueAsync(_gameAlphaId, EnrichmentPriority.Stale, "second", null);
+
+        // Mark the first one as processed — simulates a previous terminal outcome that
+        // cascaded MarkProcessed before a new admin-initiated retry was enqueued.
+        var (loaded, _) = await _repository.GetPendingAsync(priority: null, limit: 25);
+        var first = loaded.First(x => x.Entry.Reason == "first").Entry;
+        first.MarkProcessed();
+        await _repository.UpdateAsync(first);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var entries = await _repository.GetPendingForGameAsync(_gameAlphaId);
+
+        entries.Should().HaveCount(1);
+        entries[0].Reason.Should().Be("second");
+        entries[0].IsProcessed.Should().BeFalse();
+    }
+
     // ===== helpers =====
 
     private async Task<Guid> SeedSharedGameAsync(string title)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ErrorCodeClassifierTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ErrorCodeClassifierTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ErrorCodeClassifier"/> (#1907). Each test maps a representative
+/// exception shape onto the expected machine-readable error code so the admin Failed Items
+/// panel and the <c>enrichment_attempts.error_code</c> column stay stable as new exception
+/// types appear inside <see cref="Api.Infrastructure.BackgroundServices.BggImportQueueBackgroundService"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1907")]
+public sealed class ErrorCodeClassifierTests
+{
+    [Fact]
+    public void Classify_NullException_Throws()
+    {
+        var act = () => ErrorCodeClassifier.Classify(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_429_ReturnsRateLimit()
+    {
+        var ex = new HttpRequestException("rate-limited", null, HttpStatusCode.TooManyRequests);
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.BggRateLimit);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError, "BGG_SERVER_ERROR_500")]
+    [InlineData(HttpStatusCode.BadGateway, "BGG_SERVER_ERROR_502")]
+    [InlineData(HttpStatusCode.ServiceUnavailable, "BGG_SERVER_ERROR_503")]
+    [InlineData(HttpStatusCode.GatewayTimeout, "BGG_SERVER_ERROR_504")]
+    public void Classify_HttpRequestException_5xx_ReturnsServerErrorWithStatus(
+        HttpStatusCode status, string expected)
+    {
+        var ex = new HttpRequestException("server-error", null, status);
+        ErrorCodeClassifier.Classify(ex).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_NoStatus_ReturnsTimeout()
+    {
+        // DNS failure / TCP reset / TLS error → no status code on the exception
+        var ex = new HttpRequestException("dns-failure");
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.BggTimeout);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_4xx_NotMappedToRateLimit_ReturnsTimeout()
+    {
+        // 4xx other than 429 falls through to the no-mapping default. Currently
+        // collapses to BGG_TIMEOUT (transient retry class) rather than UNKNOWN so
+        // the existing retry/backoff logic exercises it. If we ever need a distinct
+        // 4xx category, split here.
+        var ex = new HttpRequestException("not-found", null, HttpStatusCode.NotFound);
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.BggTimeout);
+    }
+
+    [Fact]
+    public void Classify_TaskCanceledException_ReturnsTimeout()
+    {
+        ErrorCodeClassifier.Classify(new TaskCanceledException()).Should().Be(ErrorCodeClassifier.BggTimeout);
+    }
+
+    [Fact]
+    public void Classify_OperationCanceledException_ReturnsTimeout()
+    {
+        ErrorCodeClassifier.Classify(new OperationCanceledException()).Should().Be(ErrorCodeClassifier.BggTimeout);
+    }
+
+    [Fact]
+    public void Classify_JsonException_ReturnsSchemaMismatch()
+    {
+        var ex = new System.Text.Json.JsonException("bad shape");
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.SchemaMismatch);
+    }
+
+    [Fact]
+    public void Classify_XmlException_ReturnsSchemaMismatch()
+    {
+        var ex = new System.Xml.XmlException("bad xml");
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.SchemaMismatch);
+    }
+
+    [Fact]
+    public void Classify_InvalidOperationException_ReturnsSchemaMismatch()
+    {
+        // Domain factory invariants (EnrichmentAttempt.RecordSuccess etc.) raise InvalidOperationException
+        // for missing fields — semantically these are schema-mismatch failures too.
+        var ex = new InvalidOperationException("missing field");
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.SchemaMismatch);
+    }
+
+    [Fact]
+    public void Classify_UnknownException_ReturnsUnknown()
+    {
+        var ex = new NotSupportedException("alien failure");
+        ErrorCodeClassifier.Classify(ex).Should().Be(ErrorCodeClassifier.Unknown);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the **third hook integration point** from the #1874 spec into the existing 424-line \`BggImportQueueBackgroundService\` — scope 3 of every queue iteration now persists an \`EnrichmentAttempt\` row + cascades \`MarkProcessed\` onto every pending \`EnrichmentQueueEntry\` for the same shared game.

Conditional on \`jobType == BggQueueJobType.Enrichment\` so import-job paths stay completely untouched.

## What's new

### M1 — \`IEnrichmentQueueRepository.GetPendingForGameAsync(sharedGameId)\`
Returns all unprocessed entries for a specific shared game. Used by the cascade so a terminal outcome collapses every concurrent pending entry (admin Normal-priority + skeleton-sweep Stale-priority can coexist; both clear on the same iteration).

### M2 — \`ErrorCodeClassifier\` static helper
Maps common exception shapes to stable machine-readable codes:
- \`BGG_API_RATE_LIMIT_429\` — \`HttpRequestException\` with status 429
- \`BGG_SERVER_ERROR_{NNN}\` — \`HttpRequestException\` with 5xx status (numeric suffix)
- \`BGG_TIMEOUT\` — \`TaskCanceledException\` / \`OperationCanceledException\` / \`HttpRequestException\` without status
- \`SCHEMA_MISMATCH\` — \`JsonException\` / \`XmlException\` / \`InvalidOperationException\` / \`ArgumentException\`
- \`UNKNOWN\` — anything else

Best-effort: never throws, callers can rely on non-null non-empty return for any input.

### M3-M6 — \`BggImportQueueBackgroundService.RecordEnrichmentOutcomeAsync\` helper
Called on both terminal outcomes (success AND max-retry failure) of the iteration:
1. Builds \`EnrichmentAttempt.RecordSuccess\` or \`RecordFailure(classifiedCode, detail.Truncate(500), retryCount)\`
2. Persists via \`IEnrichmentAttemptRepository\`
3. \`GetPendingForGameAsync\` → cascade \`MarkProcessed\` on each
4. Single \`SaveChangesAsync\` for atomic unit-of-work

Exceptions during persistence are swallowed (CA1031 disabled with rationale comment) — observability is best-effort, the queue iteration must never fail because the audit log row didn't persist.

## Test plan

- [x] **14 unit tests** on \`ErrorCodeClassifier\` covering 429 / 5xx parametrized / no-status DNS / 4xx non-rate-limit / cancellation / Json / Xml / InvalidOperation / NotSupportedException / null guard — **all passed locally**
- [x] **4 integration tests** on \`GetPendingForGameAsync\` covering empty-guid throw / no-entries empty / multi-priority same-game / processed-exclusion — **all passed locally**
- [x] Solution build clean (\`dotnet build src/Api/Api.csproj\`): 0 errors, 0 warnings
- [x] No touch on existing rate-limit / retry / stale-recovery / cleanup loops (M9 regression smoke)

## Out of this PR (follow-up if needed)

End-to-end Acceptance Scenarios H + I from the issue body require \`IServiceProvider\` scaffolding for a full BackgroundService run. The unit-level coverage here validates each building block independently:
- \`ErrorCodeClassifier\` mapping invariants
- \`GetPendingForGameAsync\` repository semantics
- Cascade pattern via \`MarkProcessed\` chain (covered by the existing \`MarkProcessed\` test on \`EnrichmentQueueEntryTests\`)

If the maintainer wants Scenario H/I as full BackgroundService E2E, open a follow-up issue and we'll add the fixture.

## Refs

- Issue: #1907
- Parent spec: #1874 §4 item 3
- Plan: \`docs/superpowers/plans/2026-06-09-large-medium-remaining-plan.md\` § Phase 1 P1

🤖 Generated with [Claude Code](https://claude.com/claude-code)