### PR TITLE
fix(library): ConnectionBar pill counts (agentCount + chatThreadCount) (#2034)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/GameDetailDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/GameDetailDto.cs
@@ -59,7 +59,14 @@ internal record GameDetailDto(
     // consumer (apps/web/src/components/.../GameDetailDesktop.tsx reads
     // game?.designers?.[0]?.name). Null only if the DTO is constructed without the
     // optional parameter (e.g. legacy paths) — current handler never produces null.
-    IReadOnlyList<string>? Designers = null
+    IReadOnlyList<string>? Designers = null,
+
+    // Issue #2034 — ConnectionBar pill counts (replaces FE-side hardcoded zeros).
+    // AgentCount: total active AgentDefinitions linked to this SharedGame
+    // (community-published, cross-user — AgentDefinition.GameId points to SharedGame).
+    // ChatThreadCount: chat threads owned by the requesting user for this game.
+    int AgentCount = 0,
+    int ChatThreadCount = 0
 );
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetGameDetailQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetGameDetailQueryHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.UserLibrary.Application.DTOs;
 using Api.BoundedContexts.UserLibrary.Application.Queries;
@@ -18,6 +19,8 @@ internal class GetGameDetailQueryHandler : IQueryHandler<GetGameDetailQuery, Gam
     private readonly IUserLibraryRepository _libraryRepository;
     private readonly ISharedGameRepository _sharedGameRepository;
     private readonly IGameLabelRepository _labelRepository;
+    private readonly IAgentDefinitionRepository _agentDefinitionRepository;
+    private readonly IChatThreadRepository _chatThreadRepository;
     private readonly HybridCache _cache;
     private readonly ILogger<GetGameDetailQueryHandler> _logger;
 
@@ -31,12 +34,16 @@ internal class GetGameDetailQueryHandler : IQueryHandler<GetGameDetailQuery, Gam
         IUserLibraryRepository libraryRepository,
         ISharedGameRepository sharedGameRepository,
         IGameLabelRepository labelRepository,
+        IAgentDefinitionRepository agentDefinitionRepository,
+        IChatThreadRepository chatThreadRepository,
         HybridCache cache,
         ILogger<GetGameDetailQueryHandler> logger)
     {
         _libraryRepository = libraryRepository ?? throw new ArgumentNullException(nameof(libraryRepository));
         _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
         _labelRepository = labelRepository ?? throw new ArgumentNullException(nameof(labelRepository));
+        _agentDefinitionRepository = agentDefinitionRepository ?? throw new ArgumentNullException(nameof(agentDefinitionRepository));
+        _chatThreadRepository = chatThreadRepository ?? throw new ArgumentNullException(nameof(chatThreadRepository));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -137,6 +144,18 @@ internal class GetGameDetailQueryHandler : IQueryHandler<GetGameDetailQuery, Gam
                     CreatedAt: l.CreatedAt
                 )).ToArray();
 
+                // Issue #2034 — ConnectionBar pill counts. AgentCount is cross-user
+                // (AgentDefinition.GameId points to the shared catalog game), while
+                // ChatThreadCount is scoped to the requesting user.
+                var agentCount = await _agentDefinitionRepository
+                    .CountActiveByGameIdsAsync(new[] { query.GameId }, cancel)
+                    .ConfigureAwait(false);
+
+                var userThreads = await _chatThreadRepository
+                    .FindByUserIdAndGameIdAsync(query.UserId, query.GameId, cancel)
+                    .ConfigureAwait(false);
+                var chatThreadCount = userThreads.Count;
+
                 _logger.LogInformation("Retrieved game detail for {GameId} for user {UserId}", query.GameId, query.UserId);
 
                 return new GameDetailDto(
@@ -190,7 +209,11 @@ internal class GetGameDetailQueryHandler : IQueryHandler<GetGameDetailQuery, Gam
                     Designers: sharedGame.Designers
                         .Select(d => d.Name)
                         .Where(name => !string.IsNullOrWhiteSpace(name))
-                        .ToList()
+                        .ToList(),
+
+                    // Issue #2034: ConnectionBar pill counts.
+                    AgentCount: agentCount,
+                    ChatThreadCount: chatThreadCount
                 );
             },
             options: CacheOptions,

--- a/apps/api/tests/Api.Tests/Unit/UserLibrary/GetGameDetailQueryHandlerDesignersTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/UserLibrary/GetGameDetailQueryHandlerDesignersTests.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.UserLibrary.Application.Queries;
@@ -29,10 +31,24 @@ public sealed class GetGameDetailQueryHandlerDesignersTests
         // Issue #2790: HybridCache cannot be mocked (sealed). Use an in-memory L1 instance.
         HybridCache cache = TestDbContextFactory.CreateInMemoryHybridCache();
 
+        // Issue #2034: handler now also depends on agent + chat-thread repos for
+        // ConnectionBar pill counts. These tests don't exercise that surface, so
+        // we stub the queries to return empty (counts default to 0).
+        var agentRepo = new Mock<IAgentDefinitionRepository>();
+        agentRepo
+            .Setup(r => r.CountActiveByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.FindByUserIdAndGameIdAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChatThread>());
+
         return new GetGameDetailQueryHandler(
             libraryRepo.Object,
             sharedGameRepo.Object,
             labelRepo.Object,
+            agentRepo.Object,
+            chatThreadRepo.Object,
             cache,
             NullLogger<GetGameDetailQueryHandler>.Instance);
     }

--- a/apps/api/tests/Api.Tests/Unit/UserLibrary/GetGameDetailQueryHandlerPillCountsTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/UserLibrary/GetGameDetailQueryHandlerPillCountsTests.cs
@@ -1,0 +1,197 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserLibrary.Application.Queries;
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Unit.UserLibrary;
+
+/// <summary>
+/// Issue #2034: <see cref="GetGameDetailQueryHandler"/> must surface AgentCount
+/// (cross-user agents linked to the SharedGame) and ChatThreadCount (the
+/// caller's own chat threads for the game) so ConnectionBar pills can render
+/// solid counts instead of the hardcoded zeros in <c>GameDetailDesktop.tsx</c>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserLibrary")]
+public sealed class GetGameDetailQueryHandlerPillCountsTests
+{
+    private static GetGameDetailQueryHandler CreateHandler(
+        Mock<IUserLibraryRepository> libraryRepo,
+        Mock<ISharedGameRepository> sharedGameRepo,
+        Mock<IGameLabelRepository> labelRepo,
+        Mock<IAgentDefinitionRepository> agentRepo,
+        Mock<IChatThreadRepository> chatThreadRepo)
+    {
+        HybridCache cache = TestDbContextFactory.CreateInMemoryHybridCache();
+
+        return new GetGameDetailQueryHandler(
+            libraryRepo.Object,
+            sharedGameRepo.Object,
+            labelRepo.Object,
+            agentRepo.Object,
+            chatThreadRepo.Object,
+            cache,
+            NullLogger<GetGameDetailQueryHandler>.Instance);
+    }
+
+    private static (SharedGame sharedGame, UserLibraryEntry libraryEntry) BuildCatan(Guid userId)
+    {
+        var sharedGame = SharedGame.Create(
+            title: "Catan",
+            yearPublished: 1995,
+            description: "Trade, build, and settle the island of Catan.",
+            minPlayers: 3,
+            maxPlayers: 4,
+            playingTimeMinutes: 90,
+            minAge: 10,
+            complexityRating: 2.3m,
+            averageRating: 7.1m,
+            imageUrl: "https://example.com/catan.jpg",
+            thumbnailUrl: "https://example.com/catan-thumb.jpg",
+            rules: null,
+            createdBy: userId,
+            bggId: 13);
+
+        var libraryEntry = new UserLibraryEntry(Guid.NewGuid(), userId, sharedGame.Id);
+        return (sharedGame, libraryEntry);
+    }
+
+    private static Mock<IUserLibraryRepository> StubLibrary(UserLibraryEntry entry, Guid userId, Guid gameId)
+    {
+        var repo = new Mock<IUserLibraryRepository>();
+        repo.Setup(r => r.GetUserGameWithStatsAsync(userId, gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entry);
+        return repo;
+    }
+
+    private static Mock<ISharedGameRepository> StubSharedGame(SharedGame game)
+    {
+        var repo = new Mock<ISharedGameRepository>();
+        repo.Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+        return repo;
+    }
+
+    private static Mock<IGameLabelRepository> StubLabels(Guid entryId)
+    {
+        var repo = new Mock<IGameLabelRepository>();
+        repo.Setup(r => r.GetLabelsForEntryAsync(entryId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<GameLabel>());
+        return repo;
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAgentCount_FromAgentRepositoryQueryForThisGame()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var (sharedGame, libraryEntry) = BuildCatan(userId);
+
+        var libraryRepo = StubLibrary(libraryEntry, userId, sharedGame.Id);
+        var sharedGameRepo = StubSharedGame(sharedGame);
+        var labelRepo = StubLabels(libraryEntry.Id);
+
+        var agentRepo = new Mock<IAgentDefinitionRepository>();
+        agentRepo
+            .Setup(r => r.CountActiveByGameIdsAsync(
+                It.Is<IReadOnlyList<Guid>>(ids => ids.Count == 1 && ids[0] == sharedGame.Id),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.FindByUserIdAndGameIdAsync(userId, sharedGame.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChatThread>());
+
+        var handler = CreateHandler(libraryRepo, sharedGameRepo, labelRepo, agentRepo, chatThreadRepo);
+
+        // Act
+        var result = await handler.Handle(new GetGameDetailQuery(userId, sharedGame.Id), CancellationToken.None);
+
+        // Assert
+        result.AgentCount.Should().Be(3);
+        agentRepo.Verify(
+            r => r.CountActiveByGameIdsAsync(
+                It.Is<IReadOnlyList<Guid>>(ids => ids.Count == 1 && ids[0] == sharedGame.Id),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsChatThreadCount_ForOwningUserThisGameOnly()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var (sharedGame, libraryEntry) = BuildCatan(userId);
+
+        var libraryRepo = StubLibrary(libraryEntry, userId, sharedGame.Id);
+        var sharedGameRepo = StubSharedGame(sharedGame);
+        var labelRepo = StubLabels(libraryEntry.Id);
+
+        var agentRepo = new Mock<IAgentDefinitionRepository>();
+        agentRepo
+            .Setup(r => r.CountActiveByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        // Two threads owned by the requesting user for this game.
+        var thread1 = new ChatThread(Guid.NewGuid(), userId, gameId: sharedGame.Id, agentType: "rules");
+        var thread2 = new ChatThread(Guid.NewGuid(), userId, gameId: sharedGame.Id, agentType: "rules");
+
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.FindByUserIdAndGameIdAsync(userId, sharedGame.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { thread1, thread2 });
+
+        var handler = CreateHandler(libraryRepo, sharedGameRepo, labelRepo, agentRepo, chatThreadRepo);
+
+        // Act
+        var result = await handler.Handle(new GetGameDetailQuery(userId, sharedGame.Id), CancellationToken.None);
+
+        // Assert
+        result.ChatThreadCount.Should().Be(2);
+        chatThreadRepo.Verify(
+            r => r.FindByUserIdAndGameIdAsync(userId, sharedGame.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsZeroCounts_WhenNoAgentsNoThreads()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var (sharedGame, libraryEntry) = BuildCatan(userId);
+
+        var libraryRepo = StubLibrary(libraryEntry, userId, sharedGame.Id);
+        var sharedGameRepo = StubSharedGame(sharedGame);
+        var labelRepo = StubLabels(libraryEntry.Id);
+
+        var agentRepo = new Mock<IAgentDefinitionRepository>();
+        agentRepo
+            .Setup(r => r.CountActiveByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.FindByUserIdAndGameIdAsync(userId, sharedGame.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ChatThread>());
+
+        var handler = CreateHandler(libraryRepo, sharedGameRepo, labelRepo, agentRepo, chatThreadRepo);
+
+        // Act
+        var result = await handler.Handle(new GetGameDetailQuery(userId, sharedGame.Id), CancellationToken.None);
+
+        // Assert
+        result.AgentCount.Should().Be(0);
+        result.ChatThreadCount.Should().Be(0);
+    }
+}

--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -103,11 +103,16 @@ export function GameDetailDesktop({
     heroMetadata.push({ label: `Complessità ${game.complexityRating.toFixed(1)}` });
   }
 
+  // #2034: agentCount + chatCount now flow from /library/{gameId} instead of
+  // being hardcoded zeros. `agentCount` is cross-user (AgentDefinitions linked
+  // to this SharedGame); `chatThreadCount` is the requesting user's own
+  // threads for the game. Both default to 0 when the BE field is undefined
+  // (legacy response shapes).
   const gameConnections = game
     ? buildGameConnections({
-        agentCount: 0,
+        agentCount: game.agentCount ?? 0,
         kbCount: game.hasCustomPdf || game.hasRagAccess ? 1 : 0,
-        chatCount: 0,
+        chatCount: game.chatThreadCount ?? 0,
         sessionCount: game.timesPlayed ?? 0,
       })
     : [];

--- a/apps/web/src/hooks/queries/useLibrary.ts
+++ b/apps/web/src/hooks/queries/useLibrary.ts
@@ -827,6 +827,12 @@ export interface LibraryGameDetail {
   }>;
   // Issue #1824 L3: user-custom cover R2 key (null if no custom cover)
   customCoverR2Key?: string | null;
+  // Issue #2034 — ConnectionBar pill counts surfaced from /library/{gameId}.
+  // `agentCount` is cross-user (AgentDefinitions linked to this SharedGame);
+  // `chatThreadCount` is the requesting user's threads for the game. Both
+  // optional + default 0 so legacy BE responses don't break callers.
+  agentCount?: number;
+  chatThreadCount?: number;
 }
 
 /**
@@ -1017,6 +1023,9 @@ export function useLibraryGameDetail(
         recentSessions: gameDetail.recentSessions ?? undefined,
         // Issue #1824 L3: user-custom cover R2 key
         customCoverR2Key: gameDetail.customCoverR2Key ?? null,
+        // Issue #2034 — ConnectionBar pill counts from BE (zod-defaulted to 0).
+        agentCount: gameDetail.agentCount,
+        chatThreadCount: gameDetail.chatThreadCount,
       };
 
       // Add extended info from SharedGame if available (categories, mechanics, designers)

--- a/apps/web/src/lib/api/schemas/__tests__/library.pill-counts.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/library.pill-counts.test.ts
@@ -1,0 +1,86 @@
+/**
+ * GameDetailDtoSchema — ConnectionBar pill counts (#2034 FE)
+ *
+ * Smoke tests for the Zod schema after the BE was extended with
+ * `AgentCount` + `ChatThreadCount` on GameDetailDto (commit on
+ * feature/issue-2034-connection-bar-pill-counts). These fields replace the
+ * FE-side hardcoded zeros in `GameDetailDesktop.tsx`. They default to 0 so
+ * legacy responses that don't carry the fields parse cleanly.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { GameDetailDtoSchema } from '../library.schemas';
+
+describe('GameDetailDtoSchema #2034 ConnectionBar pill counts', () => {
+  const validBase = {
+    id: 'a1b2c3d4-1111-4111-8111-111111111111',
+    userId: 'a1b2c3d4-2222-4222-8222-222222222222',
+    gameId: 'a1b2c3d4-3333-4333-8333-333333333333',
+    gameTitle: 'Catan',
+    gamePublisher: '',
+    gameYearPublished: 1995,
+    gameDescription: 'Settlers',
+    gameIconUrl: null,
+    gameImageUrl: null,
+    minPlayers: 3,
+    maxPlayers: 4,
+    playTimeMinutes: 120,
+    complexityRating: 2.28,
+    averageRating: 7.09,
+    addedAt: '2026-06-08T14:37:26.056526Z',
+    notes: null,
+    isFavorite: false,
+    currentState: 'Owned',
+    stateChangedAt: '2026-06-08T18:03:48.813Z',
+    stateNotes: null,
+    isAvailableForPlay: true,
+    timesPlayed: 0,
+    lastPlayed: null,
+    winRate: 'N/A',
+    avgDuration: 'N/A',
+  };
+
+  it('accepts both pill counts as non-negative integers', () => {
+    const parsed = GameDetailDtoSchema.parse({
+      ...validBase,
+      agentCount: 3,
+      chatThreadCount: 5,
+    });
+    expect(parsed.agentCount).toBe(3);
+    expect(parsed.chatThreadCount).toBe(5);
+  });
+
+  it('defaults missing pill counts to 0 (backward compat with legacy BE)', () => {
+    const parsed = GameDetailDtoSchema.parse(validBase);
+    expect(parsed.agentCount).toBe(0);
+    expect(parsed.chatThreadCount).toBe(0);
+  });
+
+  it('rejects negative pill counts', () => {
+    expect(() =>
+      GameDetailDtoSchema.parse({
+        ...validBase,
+        agentCount: -1,
+        chatThreadCount: 0,
+      }),
+    ).toThrow();
+    expect(() =>
+      GameDetailDtoSchema.parse({
+        ...validBase,
+        agentCount: 0,
+        chatThreadCount: -2,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects non-integer pill counts', () => {
+    expect(() =>
+      GameDetailDtoSchema.parse({
+        ...validBase,
+        agentCount: 1.5,
+        chatThreadCount: 0,
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/web/src/lib/api/schemas/library.schemas.ts
+++ b/apps/web/src/lib/api/schemas/library.schemas.ts
@@ -342,6 +342,14 @@ export const GameDetailDtoSchema = z.object({
   // by the mapper (a future fallback wire can consume it when sharedGame fetch
   // fails — see useLibrary.ts:1023-1029).
   designers: z.array(z.string()).nullable().optional(),
+
+  // Issue #2034 — ConnectionBar pill counts. Replaces FE-side hardcoded zeros
+  // in GameDetailDesktop.tsx (`agentCount: 0`, `chatCount: 0`). `agentCount` is
+  // cross-user (AgentDefinitions linked to this SharedGame); `chatThreadCount`
+  // is the requesting user's own thread count for the game. Defaults to 0 to
+  // tolerate legacy BE responses that don't surface the fields yet.
+  agentCount: z.number().int().nonnegative().optional().default(0),
+  chatThreadCount: z.number().int().nonnegative().optional().default(0),
 });
 
 export type GameDetailDto = z.infer<typeof GameDetailDtoSchema>;


### PR DESCRIPTION
## Summary

Resolves #2034 — `ConnectionBar` pills "Agent" and "Chat" now show solid counts when the user has agents/threads bound to the game, instead of always rendering empty `+` indicators (mockup parity with `sp3-shared-game-detail.jsx`).

**BE** (commit `fa846e9fc`): `GameDetailDto` gains two new positional params at the end of the record (`AgentCount`, `ChatThreadCount`, both defaulted to 0). `GetGameDetailQueryHandler`:
- Injects `IAgentDefinitionRepository` + `IChatThreadRepository` (both already DI-registered in `KnowledgeBaseServiceExtensions.cs:409,412`).
- `AgentCount` = `agentRepo.CountActiveByGameIdsAsync([gameId])` — **cross-user** (AgentDefinition.GameId points to the SharedGame, agents are community-published).
- `ChatThreadCount` = `chatThreadRepo.FindByUserIdAndGameIdAsync(user, game).Count` — **per-user**.

Note: the issue body asked for `userAgentCount`. We named the field `AgentCount` because `AgentDefinition.GameId` references the *shared* game catalog, not the user's private game; agents are not user-scoped. Documented in the DTO comment.

**FE** (commit `b7a953ab2`):
- `GameDetailDtoSchema` (Zod) accepts both fields as non-negative integers, defaulting to 0.
- `LibraryGameDetail` interface gains the same two optional fields; mapper at `useLibrary.ts:1020` forwards them.
- `GameDetailDesktop.tsx` replaces the hardcoded zeros with `game.agentCount ?? 0` / `game.chatThreadCount ?? 0` in `buildGameConnections`.

## Test plan

- [x] BE — `GetGameDetailQueryHandlerPillCountsTests` 3/3 (agent count returned, chat thread count returned, zero defaults)
- [x] BE — Existing `GetGameDetailQueryHandlerDesignersTests` still 2/2 (updated to pass empty-stub mocks for new ctor args)
- [x] FE — `library.pill-counts.test.ts` 4/4 (accepts both counts, defaults to 0, rejects negatives, rejects non-integers)
- [x] FE — `library.designers.test.ts` 4/4 (regression check)
- [ ] Manual smoke: not done (API not running locally at time of verification)

## Known baseline issues

- Frontend Static gate may show 1 RED (`layout.ts:14:13` TS2344) — preexisting on `main-dev`, not introduced by this PR. See `feedback_frontend_static_gate_baseline.md`.

## Out-of-scope

- `kbCount` semantic ambiguity (shared KB vs user-custom PDF) noted in issue body — not addressed here.
- `publicAgentCount` / `publicToolkitCount` for `/shared-games/[slug]` — different surface, different PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)