### PR TITLE
feat(game-detail): SessionContributorsStrip + BE endpoint (#2036)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionContributorDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionContributorDto.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
+
+/// <summary>
+/// Issue #2036 — Session contributor (= registered user who participated in at least one
+/// finalized session for a given game), used by the ContributorsStrip avatar
+/// stack on game-detail pages.
+/// </summary>
+/// <param name="UserId">Identifier of the registered user.</param>
+/// <param name="DisplayName">Public display name (from <c>users.display_name</c>).</param>
+/// <param name="Initials">1–2 uppercase letters derived from the display name; the
+/// strip uses this as a fallback when an avatar image is missing.</param>
+/// <param name="SessionCount">Number of distinct finalized sessions of the game
+/// in which the user appears as a participant.</param>
+public record SessionContributorDto(
+    Guid UserId,
+    string DisplayName,
+    string Initials,
+    int SessionCount
+);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameSessionContributorsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameSessionContributorsQuery.cs
@@ -1,0 +1,23 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #2036 — Query the top session contributors for a game (i.e. registered
+/// users with at least one finalized session), ordered by descending session
+/// count. Used by the SessionContributorsStrip avatar component on the game-
+/// detail page (social proof). Public read.
+///
+/// Distinct from <c>GameContributor</c> (Issue #2746): that one tracks
+/// catalog-sharing contributions (toolkit/agent/KB publishing) and lives under
+/// the SharedGameCatalog BC. The two surface different "contributor" semantics
+/// on the same UI strip.
+/// </summary>
+/// <param name="GameId">Shared catalog game identifier.</param>
+/// <param name="Limit">
+/// Maximum contributors to return. Clamped to <c>[1, 50]</c> in the handler;
+/// the FE default and mockup show 8.
+/// </param>
+internal record GetGameSessionContributorsQuery(Guid GameId, int Limit = 8)
+    : IQuery<IReadOnlyList<SessionContributorDto>>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameSessionContributorsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGameSessionContributorsQueryHandler.cs
@@ -1,0 +1,118 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #2036 — Aggregates finalized session participants per game and surfaces
+/// the top N registered users (guest participants without a UserId are excluded).
+///
+/// Pipeline: SessionTrackingSessions (Finalized, non-deleted) → flatten
+/// Participants → drop guests (UserId == null) → GROUP BY UserId → COUNT →
+/// ORDER BY count desc → take limit → join Users.DisplayName.
+///
+/// The SQL stays a single round-trip thanks to the open-generic <c>SessionTrackingSessions</c>
+/// → <c>Participants</c> navigation already configured by the SessionTracking
+/// EF configuration. The post-join Users lookup is a second batched query
+/// (1 round-trip with <c>IN (...)</c>) — kept separate from the main GroupBy
+/// projection because EF 9 still emits sub-optimal SQL for "group + join entity
+/// in one shot" against nullable FKs.
+/// </summary>
+internal sealed class GetGameSessionContributorsQueryHandler
+    : IQueryHandler<GetGameSessionContributorsQuery, IReadOnlyList<SessionContributorDto>>
+{
+    // CA1861: avoid allocating a new array on every initials computation.
+    private static readonly char[] InitialsSeparators = { ' ', '\t' };
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetGameSessionContributorsQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<SessionContributorDto>> Handle(
+        GetGameSessionContributorsQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.GameId == Guid.Empty)
+        {
+            return Array.Empty<SessionContributorDto>();
+        }
+
+        var limit = Math.Clamp(query.Limit, 1, 50);
+        const string finalizedStatus = "Finalized";
+
+        var grouped = await _db.SessionTrackingSessions
+            .Where(s => s.GameId == query.GameId
+                        && s.Status == finalizedStatus
+                        && !s.IsDeleted)
+            .SelectMany(s => s.Participants)
+            .Where(p => p.UserId != null)
+            .GroupBy(p => p.UserId!.Value)
+            .Select(g => new { UserId = g.Key, SessionCount = g.Count() })
+            .OrderByDescending(x => x.SessionCount)
+            .ThenBy(x => x.UserId)
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (grouped.Count == 0)
+        {
+            return Array.Empty<SessionContributorDto>();
+        }
+
+        var userIds = grouped.Select(g => g.UserId).ToList();
+        var userNames = await _db.Users
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var nameLookup = userNames.ToDictionary(u => u.Id, u => u.DisplayName);
+
+        return grouped
+            .Select(g =>
+            {
+                var displayName = nameLookup.GetValueOrDefault(g.UserId) ?? "Unknown";
+                return new SessionContributorDto(
+                    UserId: g.UserId,
+                    DisplayName: displayName,
+                    Initials: ComputeInitials(displayName),
+                    SessionCount: g.SessionCount);
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// Returns 1–2 uppercase letters from the display name (first letter of the
+    /// first two whitespace-separated parts; falls back to the first letter when
+    /// the name is a single word). Empty/whitespace input returns "??" so the
+    /// caller can render a deterministic placeholder.
+    /// </summary>
+    private static string ComputeInitials(string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return "??";
+        }
+
+        var parts = displayName
+            .Split(InitialsSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+        if (parts.Length == 0)
+        {
+            return "??";
+        }
+
+        if (parts.Length == 1)
+        {
+            return parts[0][..1].ToUpperInvariant();
+        }
+
+        return $"{parts[0][0]}{parts[^1][0]}".ToUpperInvariant();
+    }
+}

--- a/apps/api/src/Api/Routing/GameEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameEndpoints.cs
@@ -9,7 +9,9 @@ using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.UserLibrary.Application.Queries;
+using SessionTrackingQueries = Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.Extensions;
 using Api.Infrastructure.Entities;
 using Api.Models.Requests;
@@ -237,6 +239,19 @@ internal static class GameEndpoints
         .WithTags("Games", "Sessions")
         .WithSummary("Get active sessions for a game")
         .WithDescription("Returns all currently active game sessions for a specific board game. Requires authentication.");
+
+        // Issue #2036 — Top session contributors for a game (registered users
+        // with at least one finalized session). Public read; used by the
+        // SessionContributorsStrip avatar component on /library/[gameId]. Path
+        // intentionally uses the literal "session-contributors" to avoid
+        // ambiguity with the sharing-based GameContributor endpoint at
+        // /shared-games/{id}/contributors (Issue #2746).
+        group.MapGet("/games/{gameId:guid}/session-contributors", HandleGetGameSessionContributors)
+        .AllowAnonymous()
+        .Produces<IReadOnlyList<SessionContributorDto>>(200)
+        .WithTags("Games", "Sessions")
+        .WithSummary("Get top session contributors for a game")
+        .WithDescription("Returns the top N registered users who have participated in at least one finalized session for this game, sorted by descending session count. Limit is clamped to [1,50] (default 8). Public endpoint accessible without authentication.");
 
         // Get all active sessions (with pagination)
         group.MapGet("/sessions/active", HandleGetActiveSessions)
@@ -550,6 +565,20 @@ internal static class GameEndpoints
         var query = new GetActiveSessionsByGameQuery(gameId);
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
 
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetGameSessionContributors(
+        Guid gameId,
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        // Issue #2036 — Limit ergonomics: omit → default 8 (mockup), explicit
+        // values outside [1,50] are clamped by the handler so the FE can pass
+        // any value safely.
+        var query = new SessionTrackingQueries.GetGameSessionContributorsQuery(gameId, limit ?? 8);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/GetGameSessionContributorsQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/GetGameSessionContributorsQueryHandlerIntegrationTests.cs
@@ -1,0 +1,282 @@
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Integration.SessionTracking;
+
+/// <summary>
+/// Issue #2036 — Integration tests for <see cref="GetGameSessionContributorsQueryHandler"/>.
+///
+/// Runs against a Postgres Testcontainers fixture because the handler relies on
+/// EF Core <c>GroupBy</c> + <c>OrderByDescending</c> + <c>Take</c> translation
+/// against a navigation collection — EF InMemory translates the pipeline
+/// differently and would mask shape issues on real Postgres.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Collection("Integration-GroupC")]
+public class GetGameSessionContributorsQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext? _dbContext;
+    private string? _connectionString;
+    private readonly string _databaseName = $"test_getgamecontributors_{Guid.NewGuid():N}";
+
+    public GetGameSessionContributorsQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(_connectionString);
+        _dbContext = await Api.Tests.Infrastructure.TestHelpers.CreateDbContextAndMigrateAsync(_connectionString);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact]
+    public async Task Handle_RanksContributorsBySessionCount_ForGivenGame()
+    {
+        // Arrange — 3 users, 1 game, sessions with distinct participation counts.
+        var gameId = SeedSharedGame(_dbContext!, "Catan");
+        var alice = SeedUser(_dbContext!, "alice@example.com", "Alice Adams");
+        var bob = SeedUser(_dbContext!, "bob@example.com", "Bob Bishop");
+        var carol = SeedUser(_dbContext!, "carol@example.com", "Carol Cipriani");
+
+        // Alice participates in 3 finalized sessions; Bob in 2; Carol in 1.
+        SeedFinalizedSession(_dbContext!, gameId, alice.Id, "Alice");
+        SeedFinalizedSession(_dbContext!, gameId, alice.Id, "Alice", coParticipant: (bob.Id, "Bob"));
+        SeedFinalizedSession(_dbContext!, gameId, alice.Id, "Alice", coParticipant: (bob.Id, "Bob"));
+        SeedFinalizedSession(_dbContext!, gameId, carol.Id, "Carol");
+
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new GetGameSessionContributorsQueryHandler(_dbContext);
+
+        // Act
+        var result = await handler.Handle(
+            new GetGameSessionContributorsQuery(gameId, Limit: 8),
+            TestContext.Current.CancellationToken);
+
+        // Assert — ordering: Alice (3), Bob (2), Carol (1).
+        result.Should().HaveCount(3);
+        result[0].UserId.Should().Be(alice.Id);
+        result[0].DisplayName.Should().Be("Alice Adams");
+        result[0].Initials.Should().Be("AA");
+        result[0].SessionCount.Should().Be(3);
+
+        result[1].UserId.Should().Be(bob.Id);
+        result[1].Initials.Should().Be("BB");
+        result[1].SessionCount.Should().Be(2);
+
+        result[2].UserId.Should().Be(carol.Id);
+        result[2].Initials.Should().Be("CC");
+        result[2].SessionCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesGuests_AndActiveSessions_AndDeletedSessions()
+    {
+        // Arrange
+        var gameId = SeedSharedGame(_dbContext!, "Pandemic");
+        var alice = SeedUser(_dbContext!, "alice@example.com", "Alice");
+
+        // Finalized session — counts.
+        SeedFinalizedSession(_dbContext!, gameId, alice.Id, "Alice");
+
+        // Active session — must NOT count.
+        SeedSession(_dbContext!, gameId, alice.Id, "Alice", status: "Active", isDeleted: false);
+
+        // Soft-deleted session — must NOT count.
+        SeedSession(_dbContext!, gameId, alice.Id, "Alice", status: "Finalized", isDeleted: true);
+
+        // Guest participant (UserId == null) in a finalized session — must NOT
+        // appear in results.
+        var guestSession = SeedSession(_dbContext!, gameId, alice.Id, "Alice", status: "Finalized", isDeleted: false);
+        guestSession.Participants.Add(new ParticipantEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = guestSession.Id,
+            UserId = null,
+            DisplayName = "Anonymous Guest",
+            JoinOrder = 2,
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new GetGameSessionContributorsQueryHandler(_dbContext);
+
+        // Act
+        var result = await handler.Handle(
+            new GetGameSessionContributorsQuery(gameId, Limit: 8),
+            TestContext.Current.CancellationToken);
+
+        // Assert — only Alice (across 2 finalized non-deleted sessions: the
+        // first SeedFinalizedSession + the guest one), guest excluded.
+        result.Should().ContainSingle();
+        result[0].UserId.Should().Be(alice.Id);
+        result[0].SessionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_ScopesByGameId_AndRespectsLimit()
+    {
+        // Arrange
+        var gameA = SeedSharedGame(_dbContext!, "Carcassonne");
+        var gameB = SeedSharedGame(_dbContext!, "Splendor");
+        var alice = SeedUser(_dbContext!, "alice@example.com", "Alice");
+        var bob = SeedUser(_dbContext!, "bob@example.com", "Bob");
+        var carol = SeedUser(_dbContext!, "carol@example.com", "Carol");
+
+        SeedFinalizedSession(_dbContext!, gameA, alice.Id, "Alice");
+        SeedFinalizedSession(_dbContext!, gameA, bob.Id, "Bob");
+        SeedFinalizedSession(_dbContext!, gameA, carol.Id, "Carol");
+
+        // Game B participation — must NOT leak into Game A query.
+        SeedFinalizedSession(_dbContext!, gameB, alice.Id, "Alice");
+        SeedFinalizedSession(_dbContext!, gameB, alice.Id, "Alice");
+
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new GetGameSessionContributorsQueryHandler(_dbContext);
+
+        // Act — limit=2, gameA scope.
+        var result = await handler.Handle(
+            new GetGameSessionContributorsQuery(gameA, Limit: 2),
+            TestContext.Current.CancellationToken);
+
+        // Assert — only 2 of the 3 contributors, all from gameA (Alice has 1
+        // session, not the leaked 3 from gameB).
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(c => c.SessionCount.Should().Be(1));
+        result.Select(c => c.UserId).Should().NotContain(_ => false); // sanity: all userIds in expected set
+        result.Select(c => c.UserId).Should().BeSubsetOf(new[] { alice.Id, bob.Id, carol.Id });
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmpty_ForUnknownGame_OrEmptyGuid()
+    {
+        var handler = new GetGameSessionContributorsQueryHandler(_dbContext!);
+
+        var empty = await handler.Handle(
+            new GetGameSessionContributorsQuery(Guid.Empty, Limit: 8),
+            TestContext.Current.CancellationToken);
+        empty.Should().BeEmpty();
+
+        var noSessions = await handler.Handle(
+            new GetGameSessionContributorsQuery(Guid.NewGuid(), Limit: 8),
+            TestContext.Current.CancellationToken);
+        noSessions.Should().BeEmpty();
+    }
+
+    private static Guid SeedSharedGame(MeepleAiDbContext db, string title)
+    {
+        var id = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            Status = 1, // Published — `int` here, not the GameStatus enum (= 2 for Published)
+            GameDataStatus = 5, // Complete
+            CreatedAt = DateTime.UtcNow,
+        });
+        return id;
+    }
+
+    private static UserEntity SeedUser(MeepleAiDbContext db, string email, string displayName)
+    {
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            DisplayName = displayName,
+            Role = "user",
+            CreatedAt = DateTime.UtcNow,
+            EmailVerified = true,
+            EmailVerifiedAt = DateTime.UtcNow,
+        };
+        db.Users.Add(user);
+        return user;
+    }
+
+    private static SessionEntity SeedFinalizedSession(
+        MeepleAiDbContext db,
+        Guid gameId,
+        Guid ownerUserId,
+        string ownerDisplayName,
+        (Guid UserId, string DisplayName)? coParticipant = null)
+    {
+        var session = SeedSession(db, gameId, ownerUserId, ownerDisplayName, status: "Finalized", isDeleted: false);
+        if (coParticipant.HasValue)
+        {
+            session.Participants.Add(new ParticipantEntity
+            {
+                Id = Guid.NewGuid(),
+                SessionId = session.Id,
+                UserId = coParticipant.Value.UserId,
+                DisplayName = coParticipant.Value.DisplayName,
+                JoinOrder = 2,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        return session;
+    }
+
+    private static SessionEntity SeedSession(
+        MeepleAiDbContext db,
+        Guid gameId,
+        Guid ownerUserId,
+        string ownerDisplayName,
+        string status,
+        bool isDeleted)
+    {
+        var sessionId = Guid.NewGuid();
+        var session = new SessionEntity
+        {
+            Id = sessionId,
+            UserId = ownerUserId,
+            GameId = gameId,
+            SessionCode = NextCode(),
+            SessionType = "Standard",
+            Status = status,
+            SessionDate = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = ownerUserId,
+            IsDeleted = isDeleted,
+            DeletedAt = isDeleted ? DateTime.UtcNow : null,
+            FinalizedAt = status == "Finalized" ? DateTime.UtcNow : null,
+        };
+        session.Participants.Add(new ParticipantEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            UserId = ownerUserId,
+            DisplayName = ownerDisplayName,
+            IsOwner = true,
+            JoinOrder = 1,
+            CreatedAt = DateTime.UtcNow,
+        });
+        db.SessionTrackingSessions.Add(session);
+        return session;
+    }
+
+    private static int _codeCounter;
+    private static string NextCode() =>
+        $"T{Interlocked.Increment(ref _codeCounter):D5}";
+}

--- a/apps/web/src/components/features/library/SessionContributorsStrip.tsx
+++ b/apps/web/src/components/features/library/SessionContributorsStrip.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable local/no-hardcoded-color-utility -- text-white on dynamic HSL avatar bg; mockup .e-bg pattern. DS-12 primitive — see sp3-shared-game-detail.jsx:660-690. */
+'use client';
+
+/**
+ * SessionContributorsStrip (Issue #2036) — Mockup parity with
+ * sp3-shared-game-detail.jsx:635-693.
+ *
+ * Avatar overlap stack of up to N registered users who participated in at
+ * least one finalized session for the game, ordered by descending session
+ * count. Renders nothing when the contributor list is empty so the strip
+ * doesn't claim layout space on games with no recorded play.
+ */
+
+import type { ReactElement } from 'react';
+
+import type { SessionContributorDto } from '@/lib/api/schemas';
+
+export interface SessionContributorsStripProps {
+  contributors: SessionContributorDto[];
+  /** When true, slice visible avatars to 5 (mobile / dense layouts). */
+  compact?: boolean;
+  /** Cap on visible avatars before the overflow "+N" chip kicks in. Default 8 (mockup). */
+  max?: number;
+  className?: string;
+}
+
+/**
+ * Deterministic hue [0, 360) derived from the UUID. Avoids name-clash
+ * conventions (two "Mario Rossi" users still get distinct colours). The
+ * mockup uses a curated palette per fake user — we map UUIDs to the full
+ * 360° wheel so the production avatars stay distinguishable when names
+ * collide.
+ */
+function hueFromUserId(userId: string): number {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i += 1) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
+}
+
+export function SessionContributorsStrip({
+  contributors,
+  compact = false,
+  max = 8,
+  className = '',
+}: SessionContributorsStripProps): ReactElement | null {
+  if (!contributors || contributors.length === 0) {
+    return null;
+  }
+
+  const visibleCount = compact ? Math.min(contributors.length, 5) : Math.min(contributors.length, max);
+  const visible = contributors.slice(0, visibleCount);
+  const overflow = contributors.length - visible.length;
+
+  return (
+    <div
+      data-testid="session-contributors-strip"
+      className={`flex items-center gap-3 rounded-lg border border-border bg-muted px-4 py-3.5 ${className}`}
+    >
+      <div className="flex-shrink-0">
+        <div className="font-[var(--font-jetbrains)] text-[9px] font-bold uppercase tracking-[0.08em] text-muted-foreground mb-0.5">
+          Top contributors
+        </div>
+        <div className="font-[var(--font-quicksand)] text-[13px] font-bold text-foreground">
+          {contributors.length} player{contributors.length === 1 ? '' : 's'}
+        </div>
+      </div>
+      <div className="flex flex-1 items-center min-w-0">
+        {visible.map((contributor, idx) => {
+          const hue = hueFromUserId(contributor.userId);
+          return (
+            <div
+              key={contributor.userId}
+              title={`${contributor.displayName} · ${contributor.sessionCount} session${contributor.sessionCount === 1 ? '' : 's'}`}
+              aria-label={`${contributor.displayName}, ${contributor.sessionCount} sessions`}
+              data-testid="session-contributor-avatar"
+              className="relative inline-flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-full border-2 border-background font-[var(--font-quicksand)] text-[11px] font-extrabold text-white"
+              style={{
+                background: `hsl(${hue} 60% 55%)`,
+                marginLeft: idx === 0 ? 0 : -8,
+                zIndex: visible.length - idx,
+              }}
+            >
+              {contributor.initials}
+            </div>
+          );
+        })}
+        {overflow > 0 && (
+          <div
+            data-testid="session-contributors-overflow"
+            aria-label={`${overflow} more contributors`}
+            className="ml-[-8px] flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-full border-2 border-background bg-card font-[var(--font-jetbrains)] text-[10px] font-extrabold text-muted-foreground"
+          >
+            +{overflow}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/library/__tests__/SessionContributorsStrip.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/SessionContributorsStrip.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * SessionContributorsStrip — render + overflow + a11y smoke tests (#2036).
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SessionContributorsStrip } from '../SessionContributorsStrip';
+
+import type { SessionContributorDto } from '@/lib/api/schemas';
+
+function makeContributor(
+  partial: Partial<SessionContributorDto> & { userId: string; displayName: string },
+): SessionContributorDto {
+  return {
+    userId: partial.userId,
+    displayName: partial.displayName,
+    initials: partial.initials ?? partial.displayName.slice(0, 2).toUpperCase(),
+    sessionCount: partial.sessionCount ?? 1,
+  };
+}
+
+describe('SessionContributorsStrip', () => {
+  it('renders nothing when there are no contributors', () => {
+    const { container } = render(<SessionContributorsStrip contributors={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the player-count footer (plural)', () => {
+    render(
+      <SessionContributorsStrip
+        contributors={[
+          makeContributor({ userId: 'a1b2c3d4-1111-4111-8111-111111111111', displayName: 'Alice' }),
+          makeContributor({ userId: 'a1b2c3d4-2222-4222-8222-222222222222', displayName: 'Bob' }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Top contributors')).toBeInTheDocument();
+    expect(screen.getByText('2 players')).toBeInTheDocument();
+  });
+
+  it('renders singular "player" when there is exactly one contributor', () => {
+    render(
+      <SessionContributorsStrip
+        contributors={[
+          makeContributor({ userId: 'a1b2c3d4-1111-4111-8111-111111111111', displayName: 'Solo' }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('1 player')).toBeInTheDocument();
+  });
+
+  it('renders up to `max` avatars and an overflow chip when contributors exceed max', () => {
+    const contributors = Array.from({ length: 10 }, (_, i) =>
+      makeContributor({
+        userId: `a1b2c3d4-${(i + 1).toString().padStart(4, '0')}-4111-8111-111111111111`,
+        displayName: `User ${i + 1}`,
+        initials: `U${i + 1}`,
+      }),
+    );
+
+    render(<SessionContributorsStrip contributors={contributors} max={8} />);
+
+    expect(screen.getAllByTestId('session-contributor-avatar')).toHaveLength(8);
+    const overflow = screen.getByTestId('session-contributors-overflow');
+    expect(overflow).toHaveTextContent('+2');
+    expect(overflow).toHaveAttribute('aria-label', '2 more contributors');
+  });
+
+  it('compact mode caps visible avatars at 5', () => {
+    const contributors = Array.from({ length: 8 }, (_, i) =>
+      makeContributor({
+        userId: `a1b2c3d4-${(i + 1).toString().padStart(4, '0')}-4111-8111-111111111111`,
+        displayName: `User ${i + 1}`,
+      }),
+    );
+
+    render(<SessionContributorsStrip contributors={contributors} compact />);
+
+    expect(screen.getAllByTestId('session-contributor-avatar')).toHaveLength(5);
+    expect(screen.getByTestId('session-contributors-overflow')).toHaveTextContent('+3');
+  });
+
+  it('avatar carries an accessible name + session-count tooltip', () => {
+    render(
+      <SessionContributorsStrip
+        contributors={[
+          makeContributor({
+            userId: 'a1b2c3d4-aaaa-4111-8111-111111111111',
+            displayName: 'Alice Anderson',
+            initials: 'AA',
+            sessionCount: 3,
+          }),
+        ]}
+      />,
+    );
+
+    const strip = screen.getByTestId('session-contributors-strip');
+    const avatar = within(strip).getByTestId('session-contributor-avatar');
+    expect(avatar).toHaveAttribute('aria-label', 'Alice Anderson, 3 sessions');
+    expect(avatar).toHaveAttribute('title', expect.stringContaining('Alice Anderson'));
+    expect(avatar).toHaveAttribute('title', expect.stringContaining('3 sessions'));
+    expect(avatar).toHaveTextContent('AA');
+  });
+
+  it('uses singular "session" tooltip when the user has exactly one session', () => {
+    render(
+      <SessionContributorsStrip
+        contributors={[
+          makeContributor({
+            userId: 'a1b2c3d4-bbbb-4111-8111-111111111111',
+            displayName: 'Bob',
+            initials: 'B',
+            sessionCount: 1,
+          }),
+        ]}
+      />,
+    );
+    const avatar = screen.getByTestId('session-contributor-avatar');
+    expect(avatar).toHaveAttribute('title', expect.stringContaining('1 session'));
+    expect(avatar.getAttribute('title')).not.toContain('1 sessions');
+  });
+
+  it('orders avatars in the same order as the input list', () => {
+    const contributors = [
+      makeContributor({ userId: 'a1b2c3d4-1111-4111-8111-111111111111', displayName: 'Alice', initials: 'A' }),
+      makeContributor({ userId: 'a1b2c3d4-2222-4222-8222-222222222222', displayName: 'Bob', initials: 'B' }),
+      makeContributor({ userId: 'a1b2c3d4-3333-4333-8333-333333333333', displayName: 'Carol', initials: 'C' }),
+    ];
+
+    render(<SessionContributorsStrip contributors={contributors} />);
+
+    const avatars = screen.getAllByTestId('session-contributor-avatar');
+    expect(avatars[0]).toHaveTextContent('A');
+    expect(avatars[1]).toHaveTextContent('B');
+    expect(avatars[2]).toHaveTextContent('C');
+  });
+});

--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -4,10 +4,12 @@ import { useState } from 'react';
 
 import { CustomCoverDialog } from '@/components/features/library/custom-cover/CustomCoverDialog';
 import { EditCoverOverlay } from '@/components/features/library/custom-cover/EditCoverOverlay';
+import { SessionContributorsStrip } from '@/components/features/library/SessionContributorsStrip';
 import { SplitViewLayout } from '@/components/layout/SplitViewLayout/SplitViewLayout';
 import { ConnectionBar, buildGameConnections } from '@/components/ui/data-display/connection-bar';
 import { MeepleCard } from '@/components/ui/data-display/meeple-card/MeepleCard';
 import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card/types';
+import { useGameSessionContributors } from '@/hooks/queries/useGameSessionContributors';
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
 import { useConnectionBarNav } from '@/hooks/useConnectionBarNav';
 
@@ -43,6 +45,11 @@ export function GameDetailDesktop({
 }: GameDetailDesktopProps) {
   const { data: game, isLoading, isError } = useLibraryGameDetail(gameId);
   const { handlePipClick } = useConnectionBarNav(gameId);
+  // #2036: Top session contributors strip. Public endpoint — runs even when
+  // the user hasn't actually added the game to their library yet (the share
+  // surfaces social proof before deciding to play). `enabled` gates on gameId
+  // being present so the hook doesn't fire with the empty-string sentinel.
+  const { data: contributors = [] } = useGameSessionContributors(gameId, 8, !!gameId);
   const [coverDialogOpen, setCoverDialogOpen] = useState(false);
 
   if (isLoading) {
@@ -157,6 +164,11 @@ export function GameDetailDesktop({
         )}
       </div>
       <ConnectionBar connections={gameConnections} onPipClick={handlePipClick} />
+      {/* #2036: SP3 mockup parity — avatar strip of past players. Strip
+          renders nothing when the contributor list is empty (no recorded
+          finalized sessions for this game), so it never claims layout space
+          on freshly-added games. */}
+      <SessionContributorsStrip contributors={contributors} />
     </div>
   );
 

--- a/apps/web/src/hooks/queries/useGameSessionContributors.ts
+++ b/apps/web/src/hooks/queries/useGameSessionContributors.ts
@@ -1,0 +1,41 @@
+/**
+ * useGameSessionContributors — TanStack Query hook for the session-contributor
+ * strip on game-detail pages (Issue #2036).
+ *
+ * Returns up to N registered users with at least one finalized session for
+ * the game, ordered by descending session count. Powers the
+ * `SessionContributorsStrip` avatar component.
+ *
+ * Distinct from `useGameContributors` (Issue #2746) which tracks
+ * catalog-sharing contributions (toolkit/agent/KB publishing) and hits
+ * `/api/v1/shared-games/{id}/contributors`.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { SessionContributorDto } from '@/lib/api/schemas';
+
+export const gameSessionContributorsKeys = {
+  all: ['game-session-contributors'] as const,
+  game: (gameId: string) => [...gameSessionContributorsKeys.all, gameId] as const,
+  list: (gameId: string, limit: number) =>
+    [...gameSessionContributorsKeys.game(gameId), { limit }] as const,
+};
+
+export function useGameSessionContributors(
+  gameId: string,
+  limit: number = 8,
+  enabled: boolean = true
+): UseQueryResult<SessionContributorDto[], Error> {
+  return useQuery({
+    queryKey: gameSessionContributorsKeys.list(gameId, limit),
+    queryFn: async (): Promise<SessionContributorDto[]> => {
+      return api.games.getSessionContributors(gameId, limit);
+    },
+    // Contributors only change when a session is finalized — 5-minute stale
+    // is a good balance between freshness and request volume.
+    staleTime: 5 * 60 * 1000,
+    enabled: enabled && !!gameId,
+  });
+}

--- a/apps/web/src/lib/api/clients/gamesClient.ts
+++ b/apps/web/src/lib/api/clients/gamesClient.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import {
   AcquireLockResultSchema,
   AgentDtoSchema,
+  SessionContributorDtoSchema,
   EditorLockSchema,
   GameFAQSchema,
   GameLeaderboardResponseSchema,
@@ -28,6 +29,7 @@ import {
   VersionTimelineSchema,
   type AcquireLockResult,
   type AgentDto,
+  type SessionContributorDto,
   type EditorLock,
   type Game,
   type GameFAQ,
@@ -286,6 +288,25 @@ export function createGamesClient({ httpClient }: CreateGamesClientParams) {
       const queryString = params.toString() ? `?${params.toString()}` : '';
       const url = `/api/v1/games/${encodeURIComponent(gameId)}/sessions${queryString}`;
       const response = await httpClient.get(url, z.array(GameSessionDtoSchema));
+      return response ?? [];
+    },
+
+    /**
+     * Get the top session contributors (registered users with finalized
+     * sessions) for a game (Issue #2036). Public endpoint — no auth required.
+     * The BE handler clamps `limit` to [1, 50]; the FE default and mockup
+     * show 8. The path uses the literal "session-contributors" to avoid
+     * ambiguity with the sharing-based contributors endpoint at
+     * `/shared-games/{id}/contributors` (Issue #2746).
+     */
+    async getSessionContributors(
+      gameId: string,
+      limit: number = 8
+    ): Promise<SessionContributorDto[]> {
+      const params = new URLSearchParams();
+      params.append('limit', limit.toString());
+      const url = `/api/v1/games/${encodeURIComponent(gameId)}/session-contributors?${params.toString()}`;
+      const response = await httpClient.get(url, z.array(SessionContributorDtoSchema));
       return response ?? [];
     },
 

--- a/apps/web/src/lib/api/schemas/games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/games.schemas.ts
@@ -505,3 +505,20 @@ export const PagedReviewsResultSchema = z.object({
 });
 
 export type PagedReviewsResult = z.infer<typeof PagedReviewsResultSchema>;
+
+// ========== Contributors (#2036) ==========
+
+/**
+ * Issue #2036 — Contributor strip avatar entry.
+ * BE handler: <c>GetGameContributorsQueryHandler</c>.
+ * The endpoint returns up to N registered users with at least one finalized
+ * session for the game, ordered by descending session count.
+ */
+export const SessionContributorDtoSchema = z.object({
+  userId: z.string().uuid(),
+  displayName: z.string(),
+  initials: z.string().min(1).max(2),
+  sessionCount: z.number().int().nonnegative(),
+});
+
+export type SessionContributorDto = z.infer<typeof SessionContributorDtoSchema>;


### PR DESCRIPTION
## Summary

Resolves #2036 — net-new `SessionContributorsStrip` avatar component rendered under the ConnectionBar on `/library/[gameId]` (mockup parity with `sp3-shared-game-detail.jsx:635-693`). Backed by a new public endpoint that aggregates finalized session participants per game.

### BE (`8a2c12e` / commit on branch)
- DTO: `SessionContributorDto { UserId, DisplayName, Initials, SessionCount }`
- Query: `GetGameSessionContributorsQuery(GameId, Limit=8)` — handler clamps Limit to `[1, 50]` and short-circuits on `Guid.Empty`.
- Pipeline: `SessionTrackingSessions (Finalized, !IsDeleted)` → `SelectMany Participants` → drop guests (`UserId == null`) → `GROUP BY UserId` → `COUNT` → `ORDER BY count desc, UserId` → `Take(limit)` → batched join on `Users.DisplayName`.
- Endpoint: `GET /api/v1/games/{gameId:guid}/session-contributors` → `AllowAnonymous`. Path uses explicit `session-contributors` literal so it doesn't get confused with the sharing-based `/shared-games/{id}/contributors` (#2746).

### FE
- Schema: `SessionContributorDtoSchema` (Zod) in `games.schemas.ts`.
- Client: `gamesClient.getSessionContributors(gameId, limit=8)`.
- Hook: `useGameSessionContributors` (TanStack Query, 5-min stale).
- Component: `SessionContributorsStrip.tsx` with deterministic HSL hue derived from the userId hash so colliding initials still get distinguishable colours.
- A11y: each avatar exposes `aria-label='${name}, ${n} sessions'` + matching tooltip; overflow chip exposes `'N more contributors'`.
- Wire: rendered after `ConnectionBar` in `GameDetailDesktop.tsx` — strip returns null when empty so layout doesn't shift on freshly-added games.

## Naming note

Two semantically distinct contributor concepts coexist in the codebase:

| Concept | Endpoint | Hook | Source |
|---|---|---|---|
| **Session contributors** (this PR) | `GET /games/{id}/session-contributors` | `useGameSessionContributors` | Aggregated session participants |
| **Sharing contributors** (#2746, pre-existing) | `GET /shared-games/{id}/contributors` | `useGameContributors` | Toolkit/agent/KB publishers |

Same SP3 mockup avatar strip can render either source — the prefix `Session` keeps the wiring unambiguous in imports.

## Test plan

- [x] BE — `GetGameSessionContributorsQueryHandlerIntegrationTests` 4/4 (Postgres Testcontainers):
  - `Handle_RanksContributorsBySessionCount_ForGivenGame`
  - `Handle_ExcludesGuests_AndActiveSessions_AndDeletedSessions`
  - `Handle_ScopesByGameId_AndRespectsLimit`
  - `Handle_ReturnsEmpty_ForUnknownGame_OrEmptyGuid`
- [x] FE — `SessionContributorsStrip.test.tsx` 8/8 (empty list, plural/singular copy, overflow, compact, a11y, ordering)
- [ ] Manual smoke: not done (API not running locally at time of verification)

## Known baseline issues

- Frontend Static gate may show 1 RED (`layout.ts:14:13` TS2344) — preexisting on `main-dev`, not introduced by this PR. See `feedback_frontend_static_gate_baseline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)