### PR TITLE
test(api): #1972 M2 PoC canary alert-config refactor to class MockHttpClient

### DIFF
--- a/apps/web/src/lib/api/__tests__/alert-config.api.test.ts
+++ b/apps/web/src/lib/api/__tests__/alert-config.api.test.ts
@@ -7,15 +7,24 @@
 
 import type { AlertConfiguration, UpdateAlertConfiguration } from '../schemas/alert-config.schemas';
 
-// Mock HttpClient before import
+// Mock HttpClient before import.
+// #1972 M2 PoC canary (sess.46g): vitest v4 rejects arrow-mock used with `new` keyword
+// (`() => ({})` not a constructor). Replace `vi.fn().mockImplementation(() => ({}))` with
+// a real `class MockHttpClient` so `new HttpClient(...)` resolves correctly under both
+// vitest v2.x and v4.x. The mocked `get`/`put` are shared closure refs so per-test
+// `mockResolvedValueOnce` chains keep working.
 const mockGet = vi.fn();
 const mockPut = vi.fn();
 
+class MockHttpClient {
+  // ESLint local rule + readability: instance fields so each `new HttpClient()` exposes
+  // the same shared spies. Constructor-arg shape ignored — caller-side stub.
+  get = mockGet;
+  put = mockPut;
+}
+
 vi.mock('../core/httpClient', () => ({
-  HttpClient: vi.fn().mockImplementation(() => ({
-    get: mockGet,
-    put: mockPut,
-  })),
+  HttpClient: MockHttpClient,
 }));
 
 // Import after mock


### PR DESCRIPTION
## Summary

**Phase 2 M2 PoC canary** for vitest v4 migration. Pivot from original canary candidate (already v4-ready) to a genuinely broken Pattern 1 file.

## Discovery during M2

\`usePdfStatus.test.ts\` (M1 audit canary candidate) was found to **already ship with \`class MockEventSource\` pattern v4-ready** (line 64-100 + 24/24 tests pass on current vitest v2.x). Similarly, the shared helper \`mockEventSource.ts\` is fully refactored to class.

Pivoted canary to **\`alert-config.api.test.ts\`** — a genuinely broken Pattern 1 file:

```diff
-vi.mock('../core/httpClient', () => ({
-  HttpClient: vi.fn().mockImplementation(() => ({
-    get: mockGet,
-    put: mockPut,
-  })),
-}));
+class MockHttpClient {
+  get = mockGet;
+  put = mockPut;
+}
+vi.mock('../core/httpClient', () => ({
+  HttpClient: MockHttpClient,
+}));
```

## Pattern shift template (DEC-2a B mid-ground codemod target)

This refactor is the **template for the remaining 12 Pattern 1 files** in the M4 batch:

| Before | After |
|---|---|
| `Module: vi.fn().mockImplementation(() => ({...}))` | `class MockModule { ... } / vi.mock(...) → MockModule` |
| Closure spy refs preserved | Same closure spy refs preserved as instance fields |
| `new Module(...)` fails on v4 | `new Module(...)` resolves correctly on v2 + v4 |

## Test plan

- [x] Backward-compat verified on current vitest v2.x: **6/6 tests pass** locally
- [x] No production code touched
- [x] Closure spy refs (\`mockGet\`, \`mockPut\`) preserved so per-test \`mockResolvedValueOnce\` chains continue to work
- [x] commit-message hook passed
- [ ] CI shard 1/2/3 + Fast green (validates pattern in CI sandbox)

## M2 learning for M4 batch

**Audit refinement**: M1 audit listed 13 Pattern 1 files via grep. M2 discovery suggests:
- True Pattern 1 broken count may be ≤13 (some files may already use class via local definition)
- Pattern 4 false-positive count is high (shared helper \`mockEventSource.ts\` already refactored; consumers inherit the pattern)
- Update audit doc + re-categorize candidates after M2 merges

## Refs

- Issue: #1972 (DEC-2 locked sess.46f)
- Audit: \`docs/superpowers/audits/2026-06-09-issue-1972-vitest-v4-audit.md\` (PR #2058 merged)
- Plan: \`docs/superpowers/plans/2026-06-09-large-medium-remaining-plan.md\` § Phase 2
- Pattern reference: DEC-2a B mid-ground (codemod template established here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)