### PR TITLE
test(web): #1972 M3 Pattern 3 URL polyfill setup vitest v4 ready

### DIFF
--- a/apps/web/src/test-utils/browser-polyfills.ts
+++ b/apps/web/src/test-utils/browser-polyfills.ts
@@ -103,8 +103,16 @@ function setupScrollIntoView() {
  * Used by downloadFile utility and components that create download links.
  *
  * Implementation:
- * - createObjectURL: Returns a fake blob URL
- * - revokeObjectURL: Mock function (no-op)
+ * - createObjectURL: Returns a fake blob URL via vi.fn() (spy-able)
+ * - revokeObjectURL: Mock function via vi.fn() (spy-able)
+ *
+ * Vitest v4 / jsdom v27+ note (Issue #1972 Pattern 3):
+ * Previous gating with `if (typeof URL.createObjectURL === 'undefined')` skips on newer
+ * jsdom versions where URL.createObjectURL is exposed as a native non-spy-able function.
+ * That made `vi.spyOn(URL, 'createObjectURL').mockReturnValue(...)` fail at runtime in
+ * helpers like `httpClient.test-helpers.ts:setupDownloadMocks`. Using Object.defineProperty
+ * with writable+configurable=true unconditionally guarantees vi.spyOn can replace the
+ * property at test-time, regardless of jsdom/vitest version.
  *
  * @example
  * // Component using createObjectURL
@@ -116,12 +124,16 @@ function setupScrollIntoView() {
  * expect(createSpy).toHaveBeenCalledWith(blob);
  */
 function setupURLMethods() {
-  if (typeof URL.createObjectURL === 'undefined') {
-    URL.createObjectURL = vi.fn(() => 'blob:http://localhost/mock-object-url');
-  }
-  if (typeof URL.revokeObjectURL === 'undefined') {
-    URL.revokeObjectURL = vi.fn();
-  }
+  Object.defineProperty(URL, 'createObjectURL', {
+    writable: true,
+    configurable: true,
+    value: vi.fn(() => 'blob:http://localhost/mock-object-url'),
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    writable: true,
+    configurable: true,
+    value: vi.fn(),
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 M3 deliverable per [#1972](https://github.com/meepleAi-app/meepleai-monorepo/issues/1972) vitest v4 migration. Fixes **Pattern 3** (URL global spy setup) by removing the `if undefined` gate in `browser-polyfills.ts:setupURLMethods()` and using `Object.defineProperty` with `writable+configurable=true` unconditionally.

## Why

`vi.spyOn(URL, 'createObjectURL')` and `vi.spyOn(URL, 'revokeObjectURL')` fail on jsdom v27+ / vitest v4 because those methods are exposed as native non-spy-able functions. The previous polyfill:

```ts
if (typeof URL.createObjectURL === 'undefined') {
  URL.createObjectURL = vi.fn(() => 'blob:http://localhost/mock-object-url');
}
```

skips on newer jsdom (where the method is `'function'`, not `'undefined'`), leaving `vi.spyOn` to throw at runtime in helpers like `httpClient.test-helpers.ts:setupDownloadMocks` (lines 180-181, source-of-truth identified in M1 audit).

After this change, `vi.spyOn(URL, ...)` works regardless of jsdom/vitest version.

## What changed

Single file: `apps/web/src/test-utils/browser-polyfills.ts` (+20 / -8 lines)

- Replaced the gated assignment with `Object.defineProperty(URL, ...)` for both `createObjectURL` and `revokeObjectURL`.
- Added inline rationale comment referencing issue #1972 and the Pattern 3 root cause.

## Pattern 2 scope clarification

`PhotoUploadModal.test.tsx` (cited in issue body as Pattern 2 candidate) was inspected and found to use `createFile(name, size, type)` → `new File([buffer], name, { type })` REAL instances. Grep for plain object `{ type: 'image/...' }` returned 0 matches.

**No static Pattern 2 refactor needed in M3.** If Pattern 2 surfaces post-v4 bump in M6 CI run, capture there.

## Test plan

Verified backward-compat on vitest v3.2.4 (current pinned version, no bump yet):

- [x] `PhotoUploadModal.test.tsx`: 23/23 pass
- [x] `httpClient-dedup-download.test.ts` (consumer of `setupDownloadMocks`): 14/14 pass
- [x] `export.test.ts` (uses `URL.createObjectURL`): 3/3 pass
- [x] Full `lib/api/__tests__/` family: 315/315 pass across 22 files
- [x] Pre-push hooks: frontend build (Next.js 16.2.6) ✅, backend build ✅, port cleanup ✅

## References

- Plan: [`docs/superpowers/plans/2026-06-09-large-medium-remaining-plan.md`](../blob/main-dev/docs/superpowers/plans/2026-06-09-large-medium-remaining-plan.md) § Phase 2 M3
- Audit M1 (deliverable PR #2058): [`docs/superpowers/audits/2026-06-09-issue-1972-vitest-v4-audit.md`](../blob/main-dev/docs/superpowers/audits/2026-06-09-issue-1972-vitest-v4-audit.md)
- DEC-2 LOCKED: sess.46f spec-panel + user-locked (Option B mid-ground, SMART gate criteria, hard cutover rollback)
- Prior M2 canary: PR #2060 (alert-config.api.test.ts class MockHttpClient)
- Prior M4 batch: PR #2064 (13 file Pattern 1 jscodeshift)

## Next milestones

- M4 already shipped (PR #2064)
- M5 Pattern 4 batch — discovery: many files use shared `mockEventSource.ts` helper already class-based, verify scope via grep before sizing
- M6 vitest@4.1.0 exact bump + companion packages + `coverage.all: true` removal
- M7 CI verde 4 shards + 7-day post-merge runtime alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)