### PR TITLE
feat(mockup-fidelity): #2072 acceptance criteria template + validator (DS-17-4)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "lint:fix": "eslint . --fix",
     "lint:tokens": "node scripts/lint-tokens.mjs",
     "lint:tokens:mockups": "node scripts/lint-tokens-mockups.mjs",
+    "lint:fidelity": "node scripts/mockup-annotations/validate-fidelity.mjs --all",
     "mockup-annotations:inject": "node scripts/mockup-annotations/inject-annotations.mjs",
     "mockup-annotations:audit": "node scripts/mockup-annotations/audit-coverage.mjs",
     "typecheck": "tsc --noEmit",

--- a/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
+++ b/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
@@ -1,0 +1,142 @@
+/**
+ * validate-fidelity.test.mjs — unit tests for validate-fidelity.mjs (DS-17-4)
+ *
+ * Run: pnpm vitest run scripts/mockup-annotations/__tests__/validate-fidelity.test.mjs
+ *      (vitest picks .mjs via vitest.config.ts pattern; if not, add to include glob)
+ *
+ * Refs: #2072 / #2063
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, unlinkSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { validate, FidelitySchema } from '../validate-fidelity.mjs';
+
+const TMP_DIR = resolve(tmpdir(), `mockup-fidelity-tests-${process.pid}`);
+
+// Mockup source file we reference in fidelity fixtures must actually exist.
+// Use a real file from admin-mockups/design_files/ for cross-reference success.
+const REAL_MOCKUP = 'admin-mockups/design_files/sp4-dashboard.html';
+
+beforeAll(() => {
+  if (!existsSync(TMP_DIR)) {
+    mkdirSync(TMP_DIR, { recursive: true });
+  }
+});
+
+afterAll(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+});
+
+function writeFixture(name, content) {
+  const filePath = resolve(TMP_DIR, name);
+  writeFixtureBody(filePath, content);
+  return filePath;
+}
+
+function writeFixtureBody(filePath, content) {
+  const body = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+  writeFileSync(filePath, body, 'utf-8');
+}
+
+describe('FidelitySchema (zod)', () => {
+  it('accepts minimal valid object with defaults', () => {
+    const result = FidelitySchema.safeParse({
+      mockup: {
+        source: REAL_MOCKUP,
+        states: ['default'],
+      },
+      acceptance: {
+        states_covered: ['default'],
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.acceptance.visual_diff_max_px).toBe(5);
+    expect(result.data?.acceptance.a11y_axe).toBe('AA');
+  });
+
+  it('rejects unknown state name', () => {
+    const result = FidelitySchema.safeParse({
+      mockup: { source: REAL_MOCKUP, states: ['typo-state'] },
+      acceptance: { states_covered: ['default'] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative visual_diff_max_px', () => {
+    const result = FidelitySchema.safeParse({
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: { states_covered: ['default'], visual_diff_max_px: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid date format', () => {
+    const result = FidelitySchema.safeParse({
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: { states_covered: ['default'], designer_approved_on: '2026/06/09' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('validate() cross-reference checks', () => {
+  it('PASS — valid fixture referencing existing mockup', async () => {
+    const file = writeFixture('valid.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default', 'loading'] },
+      acceptance: { states_covered: ['default', 'loading'] },
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(true);
+  });
+
+  it('FAIL — mockup.source does not exist', async () => {
+    const file = writeFixture('bad-source.fidelity.json', {
+      mockup: { source: 'admin-mockups/design_files/nonexistent.html', states: ['default'] },
+      acceptance: { states_covered: ['default'] },
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes('mockup.source'))).toBe(true);
+  });
+
+  it('FAIL — states and states_covered mismatch (set inequality)', async () => {
+    const file = writeFixture('state-mismatch.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default', 'loading'] },
+      acceptance: { states_covered: ['default'] }, // missing 'loading'
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes('states_covered'))).toBe(true);
+  });
+
+  it('FAIL — story_path referenced but missing (Phase 2+ check)', async () => {
+    const file = writeFixture('missing-story.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: {
+        states_covered: ['default'],
+        story_path: 'apps/web/.storybook/stories/nonexistent.stories.tsx',
+      },
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes('story_path'))).toBe(true);
+  });
+
+  it('FAIL — file not found', async () => {
+    const result = await validate(resolve(TMP_DIR, 'does-not-exist.fidelity.json'));
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/File not found/i);
+  });
+
+  it('FAIL — unsupported file extension', async () => {
+    const file = writeFixture('weird.fidelity.txt', 'not yaml not json');
+    const result = await validate(file);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes('Unsupported file extension'))).toBe(true);
+  });
+});

--- a/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
+++ b/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * validate-fidelity.mjs — validate mockup.fidelity.{json,yml} files (DS-17-4)
+ *
+ * Validates acceptance criteria files that define what "pixel-perfect" means
+ * for each mockup migration. Schema enforced via zod (already in apps/web).
+ *
+ * Phase 1 mode: JSON-only (no yaml devDep required, ship-it Wave 1 friendly).
+ * Phase 2 (DS-17-5 Storybook setup) will add `yaml` devDep + enable .yml parsing.
+ * For now, write fidelity files as .json. Template .yml exists as reference only.
+ *
+ * Usage:
+ *   node validate-fidelity.mjs <file.json|file.yml>
+ *   node validate-fidelity.mjs --all                  # scan repo for *.fidelity.{json,yml}
+ *   node validate-fidelity.mjs --schema               # print zod schema as JSON Schema
+ *
+ * Exit codes:
+ *   0  all validations passed
+ *   1  schema mismatch or missing referenced file
+ *   2  invocation error (missing arg, file not found)
+ *
+ * Refs:
+ *   Spec:    docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md
+ *   Issue:   #2072 (DS-17-4)
+ *   Umbrella: #2063
+ *   Plan:    docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md
+ */
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { z } from 'zod';
+import { globSync } from 'glob';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+
+// ---------------------------------------------------------------------------
+// Schema (zod) — single source of truth for mockup.fidelity contract
+// ---------------------------------------------------------------------------
+
+const StateName = z.enum(['default', 'empty', 'loading', 'error', 'sse', 'offline']);
+
+export const FidelitySchema = z.object({
+  mockup: z.object({
+    source: z.string().min(1).describe('Path to canonical mockup file (e.g. admin-mockups/design_files/sp4-dashboard.html)'),
+    states: z.array(StateName).min(1).describe('Which states this mockup covers'),
+  }),
+  acceptance: z.object({
+    visual_diff_max_px: z.number().int().nonnegative().default(5),
+    color_delta_e_max: z.number().nonnegative().default(3),
+    tokens_used: z.enum(['canonical_only', 'mixed_legacy_allowed']).default('canonical_only'),
+    legacy_token_names_forbidden: z.boolean().default(true),
+    states_covered: z.array(StateName).min(1),
+    a11y_axe: z.enum(['AA', 'AAA']).default('AA'),
+    a11y_violations_max: z.number().int().nonnegative().default(0),
+    responsive_breakpoints: z.array(z.number().int().positive()).min(1).default([375, 768, 1024, 1440]),
+    designer_approved_by: z.string().default(''),
+    designer_approved_on: z.string().regex(/^\d{4}-\d{2}-\d{2}$|^$/, 'ISO date YYYY-MM-DD or empty').default(''),
+    story_path: z.string().default(''),
+    fixtures_path: z.string().default(''),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+async function parseFile(filePath) {
+  const raw = readFileSync(filePath, 'utf-8');
+  const ext = filePath.toLowerCase();
+
+  if (ext.endsWith('.json')) {
+    return JSON.parse(raw);
+  }
+
+  if (ext.endsWith('.yml') || ext.endsWith('.yaml')) {
+    throw new Error(
+      `YAML parsing not enabled in Phase 1 (no "yaml" devDep). Convert ${filePath} to .json, ` +
+        `or wait for Phase 2 (DS-17-5) which adds yaml devDep. Template .yml is reference-only.`
+    );
+  }
+
+  throw new Error(`Unsupported file extension. Expected .json. Got: ${filePath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-reference checks
+// ---------------------------------------------------------------------------
+
+function crossReferenceCheck(fidelity, fidelityFilePath) {
+  const errors = [];
+
+  // mockup.source must exist
+  const sourcePath = resolve(REPO_ROOT, fidelity.mockup.source);
+  if (!existsSync(sourcePath)) {
+    errors.push(`mockup.source file does not exist: ${fidelity.mockup.source} (resolved: ${sourcePath})`);
+  }
+
+  // mockup.states must equal acceptance.states_covered (set equality)
+  const sourceSet = new Set(fidelity.mockup.states);
+  const coveredSet = new Set(fidelity.acceptance.states_covered);
+  if (sourceSet.size !== coveredSet.size || [...sourceSet].some((s) => !coveredSet.has(s))) {
+    errors.push(
+      `mockup.states and acceptance.states_covered must contain the same elements. ` +
+        `mockup.states=[${[...sourceSet].sort().join(',')}], states_covered=[${[...coveredSet].sort().join(',')}]`
+    );
+  }
+
+  // story_path: if non-empty, must exist (Phase 2+ requirement)
+  if (fidelity.acceptance.story_path) {
+    const storyPath = resolve(REPO_ROOT, fidelity.acceptance.story_path);
+    if (!existsSync(storyPath)) {
+      errors.push(`acceptance.story_path file does not exist: ${fidelity.acceptance.story_path}`);
+    }
+  }
+
+  // fixtures_path: same logic
+  if (fidelity.acceptance.fixtures_path) {
+    const fixturesPath = resolve(REPO_ROOT, fidelity.acceptance.fixtures_path);
+    if (!existsSync(fixturesPath)) {
+      errors.push(`acceptance.fixtures_path file does not exist: ${fidelity.acceptance.fixtures_path}`);
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Main validator
+// ---------------------------------------------------------------------------
+
+export async function validate(filePath) {
+  if (!existsSync(filePath)) {
+    return { ok: false, file: filePath, errors: [`File not found: ${filePath}`] };
+  }
+  if (statSync(filePath).isDirectory()) {
+    return { ok: false, file: filePath, errors: [`Path is a directory, not a file: ${filePath}`] };
+  }
+
+  let raw;
+  try {
+    raw = await parseFile(filePath);
+  } catch (err) {
+    return { ok: false, file: filePath, errors: [`Parse error: ${err.message}`] };
+  }
+
+  const parsed = FidelitySchema.safeParse(raw);
+  if (!parsed.success) {
+    const errs = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    return { ok: false, file: filePath, errors: errs };
+  }
+
+  const crossErrors = crossReferenceCheck(parsed.data, filePath);
+  if (crossErrors.length > 0) {
+    return { ok: false, file: filePath, errors: crossErrors };
+  }
+
+  return { ok: true, file: filePath, data: parsed.data };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--schema')) {
+    // Print zod schema as a navigable shape (simplified — full JSON Schema conversion is out of scope)
+    console.log(JSON.stringify({ schema: 'FidelitySchema', see: 'validate-fidelity.mjs source for zod definition' }, null, 2));
+    process.exit(0);
+  }
+
+  let files = [];
+
+  if (args.includes('--all')) {
+    files = globSync('**/*.fidelity.{json,yml,yaml}', {
+      cwd: REPO_ROOT,
+      ignore: ['**/node_modules/**', '**/.next/**', '**/.claude/**', '**/dist/**'],
+      absolute: true,
+    });
+    if (files.length === 0) {
+      console.log('No *.fidelity.{json,yml,yaml} files found.');
+      process.exit(0);
+    }
+  } else if (args.length === 0 || args[0].startsWith('--')) {
+    console.error('Usage: validate-fidelity.mjs <file> | --all | --schema');
+    process.exit(2);
+  } else {
+    files = [resolve(args[0])];
+  }
+
+  let allOk = true;
+  for (const f of files) {
+    const result = await validate(f);
+    const rel = relative(REPO_ROOT, f);
+    if (result.ok) {
+      console.log(`PASS  ${rel}`);
+    } else {
+      allOk = false;
+      console.error(`FAIL  ${rel}`);
+      for (const err of result.errors) {
+        console.error(`      - ${err}`);
+      }
+    }
+  }
+
+  process.exit(allOk ? 0 : 1);
+}
+
+// CLI guard — only run main() when invoked directly (not when imported as module)
+// Use pathToFileURL for cross-platform Windows compatibility (file:/// triple-slash)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`Unexpected error: ${err.message}`);
+    process.exit(2);
+  });
+}

--- a/docs/for-developers/frontend/mockup-fidelity-acceptance.md
+++ b/docs/for-developers/frontend/mockup-fidelity-acceptance.md
@@ -1,0 +1,188 @@
+# Mockup Fidelity Acceptance — `mockup.fidelity.{yml,json}` Schema
+
+**Origine**: DS-17-4 (#2072), parte di [Umbrella #2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063) DS-17 Mockup-to-App Fidelity.
+**Schema authority**: `apps/web/scripts/mockup-annotations/validate-fidelity.mjs` (`FidelitySchema` zod definition).
+**Spec doc**: [`docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md`](../../superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md) (Sezione 3 — Wiegers CRIT-5).
+
+---
+
+## TL;DR
+
+Ogni mockup migration deve essere accompagnata da un file `<mockup-name>.fidelity.{yml,json}` che definisce **misurabile** cosa significa "pixel-perfect" per quel mockup. Il file viene validato in CI (Phase 1: opt-in; Phase 4: blocking gate).
+
+- **Template**: [`templates/mockup.fidelity.yml.template`](./templates/mockup.fidelity.yml.template) (con inline docs)
+- **Esempio**: [`templates/examples/sp4-dashboard.fidelity.json`](./templates/examples/sp4-dashboard.fidelity.json) (JSON mode, no extra deps)
+- **Validator CLI**: `node apps/web/scripts/mockup-annotations/validate-fidelity.mjs <file>` (oppure `--all` per scan repo)
+
+---
+
+## Quando usarlo
+
+- ✅ **Phase 2+** (DS-17-6): ogni story `*.stories.tsx` deve avere `*.fidelity.yml` co-located
+- ✅ **Phase 1** (oggi): pilot per `sp4-dashboard` come standalone esempio
+- ⏭️ **Phase 3**: enforcement designer sign-off (campi `designer_approved_by` + `designer_approved_on` required pre-merge)
+- ⏭️ **Phase 4**: visual gate scoped legge `visual_diff_max_px` + `color_delta_e_max` come threshold
+
+---
+
+## Schema reference
+
+### `mockup.source` (string, required)
+
+Path al file mockup canonico relativo al repo root.
+- ✅ `admin-mockups/design_files/sp4-dashboard.html`
+- ❌ `./sp4-dashboard.html` (relative al fidelity file — non supportato)
+
+Validator verifica che il file esista. Errore se path inesistente.
+
+### `mockup.states` (array<StateName>, required, min 1)
+
+Quali stati questo mockup copre. Deve essere **set-equal** a `acceptance.states_covered`.
+
+Valid values:
+- `default` — happy path, populated data
+- `empty` — zero items / first-time user state
+- `loading` — initial fetch, skeleton screen
+- `error` — fetch failure, validation error
+- `sse` — Server-Sent Events streaming (chat, live session)
+- `offline` — PWA offline state (libro-game, cached views)
+
+### `acceptance.visual_diff_max_px` (int ≥0, default 5)
+
+Pixel delta massimo tollerato per block-level diff. Lower = stricter.
+- 5 = ragionevole per font hinting + sub-pixel rendering
+- 1-2 = strict, rischio falsi positivi su Windows/macOS font diff
+- 10+ = lax, perde drift visibile
+
+### `acceptance.color_delta_e_max` (float ≥0, default 3)
+
+Max Color Delta-E (CIEDE2000). <3 = imperceptible to most humans.
+
+### `acceptance.tokens_used` (`canonical_only` | `mixed_legacy_allowed`, default `canonical_only`)
+
+- `canonical_only`: post-DS-15 names obbligatori (`var(--bg)`, `var(--bg-card)`, ecc.)
+- `mixed_legacy_allowed`: **TEMPORARY waiver** — usare solo per mockup pre-Phase 3 cleanup. Documentare razionale in commit message.
+
+### `acceptance.legacy_token_names_forbidden` (boolean, default true)
+
+Se `true`, lint blocca `--bg-base`, `--gaming-*`, `--nh-*`, `--e-*`. Enforcement via DS-17-2 (`pnpm lint:tokens`).
+
+### `acceptance.states_covered` (array<StateName>, required, min 1)
+
+Stati implementati nella story / mockup. **Set-equal a `mockup.states`** — validator enforce.
+
+### `acceptance.a11y_axe` (`AA` | `AAA`, default `AA`)
+
+Livello WCAG da rispettare. Default AA per progetto (CLAUDE.md § "A11y restore COMPLETE 2026-05-18").
+
+### `acceptance.a11y_violations_max` (int ≥0, default 0)
+
+Max violazioni axe tollerate. 0 = strict (default).
+
+### `acceptance.responsive_breakpoints` (array<int>, default [375, 768, 1024, 1440])
+
+Breakpoint px da testare. Default copre mobile/tablet/desktop/wide.
+- Aggiungi `320` se mobile-first
+- Aggiungi `2560` se 4K-relevant
+
+### `acceptance.designer_approved_by` (string, default "")
+
+GitHub handle del designer che ha approvato (es. `@design-lead`). Required Phase 3+.
+
+### `acceptance.designer_approved_on` (string ISO date, default "")
+
+Data approvazione formato `YYYY-MM-DD`. Validator regex check.
+
+### `acceptance.story_path` (string, default "")
+
+Path Storybook story relativo a repo root. Phase 2+ campo. Validator verifica esistenza se non-empty.
+
+### `acceptance.fixtures_path` (string, default "")
+
+Path fixtures file (TypeScript const o JSON). Phase 2+ campo. Validator verifica esistenza se non-empty.
+
+---
+
+## Validator usage
+
+### Single file
+```bash
+node apps/web/scripts/mockup-annotations/validate-fidelity.mjs docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json
+# PASS  docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json
+```
+
+### Scan all fidelity files in repo
+```bash
+node apps/web/scripts/mockup-annotations/validate-fidelity.mjs --all
+```
+
+### Print schema
+```bash
+node apps/web/scripts/mockup-annotations/validate-fidelity.mjs --schema
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All validations passed |
+| 1 | Schema mismatch or missing referenced file |
+| 2 | Invocation error (missing arg, file not found) |
+
+---
+
+## YAML vs JSON mode
+
+| Mode | Pros | Cons | Status Phase 1 |
+|------|------|------|----------------|
+| **JSON** (`.json`) | No extra deps, works out-of-box | Verbose, no inline comments | ✅ **Active** |
+| **YAML** (`.yml` / `.yaml`) | Concise, inline comments | Requires `yaml` devDep + Vite plugin config | ⏸️ Deferred to Phase 2 (DS-17-5) |
+
+**Phase 1 = JSON-only**. Il template `.yml` esiste come reference (è human-readable + ha inline docs), ma il validator runtime rifiuta `.yml` con errore esplicito:
+
+```
+YAML parsing not enabled in Phase 1 (no "yaml" devDep). Convert <file> to .json,
+or wait for Phase 2 (DS-17-5) which adds yaml devDep. Template .yml is reference-only.
+```
+
+**Rationale**: Vite static-analyzer blocca `await import('yaml')` anche in try/catch (vite:import-analysis fails build). Per supportare YAML serve `yaml` devDep installato + lockfile update. Decisione deferred a Phase 2 per ridurre scope DS-17-4 (no lockfile diff in PR Wave 1).
+
+**Migration path Phase 1 → Phase 2**:
+1. Phase 2 DS-17-5 setup Storybook
+2. Add `yaml` to `apps/web` devDeps + `pnpm install` (lockfile update)
+3. Update `validate-fidelity.mjs` parseFile() per usare `import yaml from 'yaml'`
+4. Convertire `*.fidelity.json` esistenti a `*.fidelity.yml` (opzionale, JSON resta supportato)
+
+---
+
+## Anti-patterns
+
+- ❌ **Inventare campi custom** non in schema → validator FAIL. Discutere in spec doc prima di estendere.
+- ❌ **`tokens_used: mixed_legacy_allowed` permanente** → waiver dovrebbe essere temporary con TODO in commit
+- ❌ **`states_covered` ≠ `mockup.states`** → validator FAIL (set inequality)
+- ❌ **Path mockup.source relativo al fidelity file** → validator richiede path relativo al repo root
+- ❌ **Skip designer sign-off Phase 3+** → contro DEC-3 spec doc, blocking gate (Phase 4)
+
+---
+
+## Roadmap (post DS-17-4)
+
+| Phase | Item | Dipendenza |
+|-------|------|------------|
+| Phase 2 (DS-17-5) | Storybook setup → fidelity files co-located con stories | DS-17-4 done |
+| Phase 2 (DS-17-7) | `fixtures.json` pattern definito → `fixtures_path` populated | DS-17-5 done |
+| Phase 3 (DS-17-9..13) | Migration sweep mockup → ogni story ha fidelity file | DS-17-7 done |
+| Phase 4 (DS-17-14) | Visual gate scoped legge `visual_diff_max_px` | DS-17-13 done |
+| Phase 4 (DS-17-15) | Weekly drift report usa fidelity contract | DS-17-13 done |
+
+---
+
+## References
+
+- Issue: [#2072](https://github.com/meepleAi-app/meepleai-monorepo/issues/2072) — DS-17-4 Crea acceptance criteria template
+- Umbrella: [#2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063) — DS-17 Mockup-to-App Fidelity
+- Spec doc: `docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md` (Sezione 3 — Wiegers CRIT-5)
+- Plan doc: `docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md` (Sezione 4.2 — DS-17-4 tasks)
+- Validator source: `apps/web/scripts/mockup-annotations/validate-fidelity.mjs`
+- Template: `docs/for-developers/frontend/templates/mockup.fidelity.yml.template`
+- Esempio: `docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json`

--- a/docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json
+++ b/docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Pilot example for DS-17-4. JSON mode (no yaml devDep required). See mockup.fidelity.yml.template for YAML version with inline docs.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp4-dashboard.html",
+    "states": ["default", "empty", "loading", "error"]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 5,
+    "color_delta_e_max": 3,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": ["default", "empty", "loading", "error"],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [375, 768, 1024, 1440],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": ""
+  }
+}

--- a/docs/for-developers/frontend/templates/mockup.fidelity.yml.template
+++ b/docs/for-developers/frontend/templates/mockup.fidelity.yml.template
@@ -1,0 +1,70 @@
+# mockup.fidelity.yml — Acceptance criteria template (DS-17-4)
+#
+# Copy this file as <mockup-name>.fidelity.yml (or .json) co-located with the
+# Storybook story (Phase 2+) or in admin-mockups/design_files/ (Phase 1 standalone).
+#
+# Validation: pnpm lint:fidelity (or node apps/web/scripts/mockup-annotations/validate-fidelity.mjs <file>)
+#
+# YAML mode: requires `yaml` devDep in apps/web (not installed by default in Phase 1).
+# JSON mode: works out-of-the-box. Copy this template, convert to JSON, rename to .json.
+#
+# Schema authority: apps/web/scripts/mockup-annotations/validate-fidelity.mjs (FidelitySchema zod)
+# Spec: docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md
+# Issue: #2072 (DS-17-4) / Umbrella: #2063
+
+mockup:
+  # Path to canonical mockup file (relative to repo root)
+  source: admin-mockups/design_files/sp4-EXAMPLE.html
+  # Which states this mockup covers. Must match acceptance.states_covered exactly.
+  # Valid values: default | empty | loading | error | sse | offline
+  states:
+    - default
+    - empty
+    - loading
+    - error
+
+acceptance:
+  # ===== Visual diff (Phase 4 visual-gate-scoped, DS-17-14) =====
+  # Max pixel delta tolerated per block-level diff. Lower = stricter.
+  visual_diff_max_px: 5
+  # Max color Delta-E (CIEDE2000) tolerated. <3 = imperceptible to most humans.
+  color_delta_e_max: 3
+
+  # ===== Token discipline (DS-17-2 lint:tokens + DS-16 bridge removal) =====
+  # canonical_only: var(--bg), var(--bg-card), ecc. (post-DS-15 names)
+  # mixed_legacy_allowed: TEMPORARY waiver — only for mockup pre-Phase 3 cleanup
+  tokens_used: canonical_only
+  # If true, lint blocks --bg-base, --gaming-*, --nh-*, --e-* legacy names
+  legacy_token_names_forbidden: true
+
+  # ===== State coverage (Adzic CRIT-2 enforcement) =====
+  # MUST be set-equal to mockup.states above. Validator enforces.
+  states_covered:
+    - default
+    - empty
+    - loading
+    - error
+
+  # ===== Accessibility (axe-core) =====
+  # AA (WCAG 2.1 Level AA) is project default per CLAUDE.md "A11y restore COMPLETE 2026-05-18"
+  a11y_axe: AA
+  # Max violations tolerated. 0 = strict mode (default).
+  a11y_violations_max: 0
+
+  # ===== Responsive (Storybook viewports + Playwright Phase 4) =====
+  # Default 4 breakpoints. Add 320 if mobile-first or 2560 if 4K-relevant.
+  responsive_breakpoints:
+    - 375   # mobile
+    - 768   # tablet
+    - 1024  # desktop
+    - 1440  # wide
+
+  # ===== Designer sign-off (DEC-3 spec-panel review checklist) =====
+  # Required for Phase 3+ stories pre-merge. Empty in Phase 1 is OK.
+  designer_approved_by: ""   # GitHub handle, e.g. "@design-lead"
+  designer_approved_on: ""   # ISO date YYYY-MM-DD
+
+  # ===== Story metadata (populated in Phase 2+ when Storybook lands) =====
+  # Empty in Phase 1 is OK; validator skips cross-reference if empty.
+  story_path: ""              # e.g. apps/web/src/components/features/dashboard/dashboard.stories.tsx
+  fixtures_path: ""           # e.g. apps/web/src/components/features/dashboard/dashboard.fixtures.ts


### PR DESCRIPTION
## Summary

- DS-17-4 Phase 1 Wave 1a implementation
- Acceptance criteria template `mockup.fidelity.json` (con schema zod) + validator CLI + 10 unit test
- Risolve Wiegers CRIT-5 spec-panel review: `mockup.fidelity.{json,yml}` definisce misurabile cosa significa "pixel-perfect"

## Deliverable (6 file, 641 LOC)

- 📄 NEW: `apps/web/scripts/mockup-annotations/validate-fidelity.mjs` (script CLI + module export)
- 📄 NEW: `apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts` (10 unit test, 38ms)
- 📄 NEW: `docs/for-developers/frontend/templates/mockup.fidelity.yml.template` (YAML reference con inline docs)
- 📄 NEW: `docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json` (pilot esempio)
- 📄 NEW: `docs/for-developers/frontend/mockup-fidelity-acceptance.md` (schema docs)
- ✏️ EDITED: `apps/web/package.json` (+1 script `lint:fidelity`)

## Schema (FidelitySchema zod)

```
mockup:
  source: <path to canonical mockup>
  states: [default | empty | loading | error | sse | offline]+
acceptance:
  visual_diff_max_px: int (default 5)
  color_delta_e_max: float (default 3)
  tokens_used: canonical_only | mixed_legacy_allowed (default canonical_only)
  legacy_token_names_forbidden: bool (default true)
  states_covered: <set-equal a mockup.states>
  a11y_axe: AA | AAA (default AA)
  a11y_violations_max: int (default 0)
  responsive_breakpoints: [375, 768, 1024, 1440] (default)
  designer_approved_by: string (Phase 3+ required)
  designer_approved_on: ISO date YYYY-MM-DD
  story_path: string (Phase 2+, cross-reference check se non-empty)
  fixtures_path: string (Phase 2+, cross-reference check se non-empty)
```

## Decisione: JSON-only Phase 1, YAML deferred Phase 2

Vite static-analyzer blocca `await import('yaml')` anche in try/catch (vite:import-analysis fails build). Costo non giustificato Phase 1 (richiederebbe yaml devDep + lockfile update + Vite plugin config).

Phase 1 validator JSON-only. Template `.yml` resta come reference human-readable con inline docs (non parsato runtime). Phase 2 DS-17-5 (Storybook setup) aggiungerà yaml devDep + abiliterà parsing .yml retroattivamente.

## Test plan

- [x] 10/10 unit test PASS (vitest, 38ms)
- [x] CLI `node validate-fidelity.mjs <file>` exit 0 su esempio valido (sp4-dashboard)
- [x] CLI `--all` scan repo trova 1 file (esempio pilot)
- [x] `pnpm lint:fidelity` runs OK exit 0
- [x] CLI guard cross-platform Windows-safe (pathToFileURL, no template literal file://)
- [x] Schema validation: rejects unknown state name, negative numbers, invalid date format
- [x] Cross-reference: rejects missing mockup.source, mismatched states_covered, missing story_path

## Links

- Umbrella: #2063
- Plan: `docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md` (#2073)
- Spec doc: `docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md` (#2068 review)
- DS-17-2 Wave 1b pending: #2070 (next session)

Closes #2072

🤖 Generated with [Claude Code](https://claude.com/claude-code)
