### PR TITLE
feat(lint): #2070 extend lint:tokens to admin-mockups (DS-17-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       # DS-17-2 (mockup-to-app fidelity, 2026-06-09):
       # Blocking guard against NEW legacy CSS variable literals in admin-mockups
       # (`var(--bg-base|--gaming-*|--nh-*|--e-*)`). Whitelist-incremental — the
-      # baseline ceiling is the current count snapshotted at PR #NNNN; if a new
+      # baseline ceiling is the current count snapshotted at PR #2077; if a new
       # mockup introduces another reference the gate fails. Replace with
       # canonical semantic tokens (--background, --foreground, --card, --border,
       # --primary, …). Bridge unwind tracked in DS-16.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,29 @@ jobs:
             audits/2026-05-12-token-violations.md
           retention-days: 14
 
+      # DS-17-2 (mockup-to-app fidelity, 2026-06-09):
+      # Blocking guard against NEW legacy CSS variable literals in admin-mockups
+      # (`var(--bg-base|--gaming-*|--nh-*|--e-*)`). Whitelist-incremental — the
+      # baseline ceiling is the current count snapshotted at PR #NNNN; if a new
+      # mockup introduces another reference the gate fails. Replace with
+      # canonical semantic tokens (--background, --foreground, --card, --border,
+      # --primary, …). Bridge unwind tracked in DS-16.
+      # Spec: docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md
+      # Sub-issue: #2070 · Umbrella: #2063
+      - name: Mockup legacy token guard (DS-17-2)
+        run: pnpm lint:tokens:mockups --strict --max-baseline 1500
+        # Note: script resolves REPO_ROOT from __dirname; runs from apps/web (job default) but scans admin-mockups/**.
+
+      - name: Upload mockup token violations report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mockup-token-violations-${{ github.run_number }}
+          path: |
+            audits/2026-06-09-mockup-token-violations.json
+            audits/2026-06-09-mockup-token-violations.md
+          retention-days: 14
+
   # Frontend Typecheck — fast-fail check (~1 min). Independent job for
   # parallel execution with lint.
   frontend-typecheck:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,8 @@ Exemption: `text-white` / `border-white` / `ring-white` ARE allowed when the sam
 
 Run `pnpm lint:tokens` to regenerate the inventory in `audits/2026-05-12-token-violations.md`.
 
+**Mockup legacy token guard — DS-17-2 (#2070)** — `pnpm lint:tokens:mockups` scans `admin-mockups/**/*.{html,jsx,css}` for forbidden CSS literals (`var(--bg-base)`, `var(--gaming-*)`, `var(--nh-*)`, `var(--e-*)`) and writes `audits/2026-06-09-mockup-token-violations.{json,md}`. CI runs `--strict --max-baseline 1500` as a whitelist-incremental gate: existing literals are tolerated until DS-16 unwinds the bridge, but a NEW occurrence introduced by a mockup edit fails the build. Use canonical semantic tokens for new mockup CSS (`--background`, `--foreground`, `--card`, `--border`, `--primary`, …). Spec: [`docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md`](./docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md). Umbrella: [#2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063).
+
 **Deferred decisions** (planned for DS-16):
 - `--admin-*` token family (admin inline gradients still file-level eslint-disable).
 - `--mc-*` MeepleCard palette consolidation.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "lint": "eslint . --max-warnings=510",
     "lint:fix": "eslint . --fix",
     "lint:tokens": "node scripts/lint-tokens.mjs",
+    "lint:tokens:mockups": "node scripts/lint-tokens-mockups.mjs",
     "typecheck": "tsc --noEmit",
     "test:e2e:groups": "dotenv -e .env.test -- playwright test",
     "storybook": "storybook dev -p 6006",

--- a/apps/web/scripts/__tests__/lint-tokens-mockups.test.ts
+++ b/apps/web/scripts/__tests__/lint-tokens-mockups.test.ts
@@ -1,0 +1,188 @@
+/**
+ * lint-tokens-mockups.test.ts — unit tests for lint-tokens-mockups.mjs (DS-17-2)
+ *
+ * Run: pnpm vitest run scripts/__tests__/lint-tokens-mockups.test.ts
+ *
+ * Refs:
+ *   - Spec:     docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md
+ *   - Issue:    #2070 (DS-17-2)
+ *   - Umbrella: #2063 (DS-17 Mockup-to-App Fidelity)
+ *   - Plan:     docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md §4.1
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { LEGACY_TOKEN_REGEX, findViolationsInText, lintFiles } from '../lint-tokens-mockups.mjs';
+
+const TMP_DIR = resolve(tmpdir(), `lint-tokens-mockups-tests-${process.pid}`);
+
+beforeAll(() => {
+  if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('LEGACY_TOKEN_REGEX', () => {
+  it('matches all 4 forbidden token families', () => {
+    const samples = [
+      'color: var(--bg-base);',
+      'background: var(--gaming-blue);',
+      'border-color: var(--nh-bg-2);',
+      'fill: var(--e-1);',
+    ];
+    for (const s of samples) {
+      const re = new RegExp(LEGACY_TOKEN_REGEX.source, LEGACY_TOKEN_REGEX.flags);
+      expect(re.test(s), `should match: ${s}`).toBe(true);
+    }
+  });
+
+  it('does NOT match canonical semantic tokens', () => {
+    const samples = [
+      'color: var(--background);',
+      'background: var(--foreground);',
+      'border-color: var(--muted-foreground);',
+      'color: var(--card);',
+      'background: var(--border-strong);',
+      'color: var(--primary);',
+    ];
+    for (const s of samples) {
+      const re = new RegExp(LEGACY_TOKEN_REGEX.source, LEGACY_TOKEN_REGEX.flags);
+      expect(re.test(s), `should NOT match: ${s}`).toBe(false);
+    }
+  });
+
+  it('does NOT match unrelated var() patterns', () => {
+    const samples = [
+      'transition: var(--transition);',
+      'box-shadow: var(--shadow-md);',
+      'color: var(--accent);',
+    ];
+    for (const s of samples) {
+      const re = new RegExp(LEGACY_TOKEN_REGEX.source, LEGACY_TOKEN_REGEX.flags);
+      expect(re.test(s), `should NOT match: ${s}`).toBe(false);
+    }
+  });
+});
+
+describe('findViolationsInText', () => {
+  it('returns empty array for clean text', () => {
+    const result = findViolationsInText('body { color: var(--foreground); }', 'clean.css');
+    expect(result).toEqual([]);
+  });
+
+  it('detects single violation with line and column', () => {
+    const text = 'body {\n  color: var(--bg-base);\n}';
+    const result = findViolationsInText(text, 'sample.css');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      file: 'sample.css',
+      line: 2,
+      token: 'bg-base',
+    });
+    expect(result[0].column).toBeGreaterThan(0);
+  });
+
+  it('detects multiple violations across all 4 families on multi-line input', () => {
+    const text = [
+      'body {',
+      '  color: var(--bg-base);',
+      '  background: var(--gaming-blue);',
+      '  border: 1px solid var(--nh-bg-2);',
+      '  fill: var(--e-1);',
+      '}',
+    ].join('\n');
+    const result = findViolationsInText(text, 'multi.css');
+    expect(result).toHaveLength(4);
+    const tokens = result.map(v => v.token).sort();
+    expect(tokens).toEqual(['bg-base', 'e-1', 'gaming-blue', 'nh-bg-2']);
+  });
+
+  it('detects multiple violations on the same line', () => {
+    const text = 'background: linear-gradient(var(--bg-base), var(--gaming-blue));';
+    const result = findViolationsInText(text, 'same-line.css');
+    expect(result).toHaveLength(2);
+    expect(result[0].line).toBe(1);
+    expect(result[1].line).toBe(1);
+  });
+
+  it('handles empty input', () => {
+    expect(findViolationsInText('', 'empty.css')).toEqual([]);
+  });
+});
+
+describe('lintFiles (glob integration)', () => {
+  it('finds violations across HTML, CSS, JSX files in a directory', () => {
+    const subdir = resolve(TMP_DIR, 'lint-mixed');
+    mkdirSync(subdir, { recursive: true });
+
+    writeFileSync(
+      resolve(subdir, 'page.html'),
+      '<style>body { background: var(--bg-base); }</style>',
+      'utf-8'
+    );
+    writeFileSync(resolve(subdir, 'theme.css'), 'a { color: var(--gaming-blue); }', 'utf-8');
+    writeFileSync(
+      resolve(subdir, 'comp.jsx'),
+      'const styles = { color: "var(--nh-bg-2)" };',
+      'utf-8'
+    );
+    writeFileSync(resolve(subdir, 'clean.css'), 'body { color: var(--foreground); }', 'utf-8');
+
+    const result = lintFiles('lint-mixed/**/*.{html,jsx,css}', TMP_DIR);
+    expect(result.fileCount).toBe(4);
+    expect(result.violations).toHaveLength(3);
+
+    const filesWithViolations = new Set(result.violations.map(v => v.file));
+    expect(filesWithViolations.size).toBe(3);
+  });
+
+  it('returns zero violations when no legacy tokens are present', () => {
+    const subdir = resolve(TMP_DIR, 'lint-clean');
+    mkdirSync(subdir, { recursive: true });
+    writeFileSync(
+      resolve(subdir, 'page.html'),
+      '<style>body { color: var(--foreground); }</style>',
+      'utf-8'
+    );
+
+    const result = lintFiles('lint-clean/**/*.{html,jsx,css}', TMP_DIR);
+    expect(result.fileCount).toBe(1);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('respects ignore patterns', () => {
+    const subdir = resolve(TMP_DIR, 'lint-ignore');
+    mkdirSync(resolve(subdir, 'node_modules'), { recursive: true });
+    writeFileSync(
+      resolve(subdir, 'node_modules', 'noise.css'),
+      'body { color: var(--bg-base); }',
+      'utf-8'
+    );
+    writeFileSync(resolve(subdir, 'real.css'), 'body { color: var(--bg-base); }', 'utf-8');
+
+    const result = lintFiles('lint-ignore/**/*.{html,jsx,css}', TMP_DIR);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].file).toContain('real.css');
+  });
+
+  it('returns sorted, stable output (file then line then column)', () => {
+    const subdir = resolve(TMP_DIR, 'lint-stable');
+    mkdirSync(subdir, { recursive: true });
+    writeFileSync(resolve(subdir, 'b-second.css'), 'a { color: var(--gaming-blue); }', 'utf-8');
+    writeFileSync(
+      resolve(subdir, 'a-first.css'),
+      'a { color: var(--bg-base); }\nb { color: var(--gaming-blue); }',
+      'utf-8'
+    );
+
+    const result = lintFiles('lint-stable/**/*.{html,jsx,css}', TMP_DIR);
+    expect(result.violations).toHaveLength(3);
+    expect(result.violations[0].file).toContain('a-first.css');
+    expect(result.violations[2].file).toContain('b-second.css');
+  });
+});

--- a/apps/web/scripts/lint-tokens-mockups.mjs
+++ b/apps/web/scripts/lint-tokens-mockups.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/**
+ * lint-tokens-mockups.mjs — legacy CSS token literal reporter for admin-mockups (DS-17-2)
+ *
+ * Scans mockup HTML/CSS/JSX files for forbidden legacy token references and
+ * fails the build when the count exceeds a baseline threshold (whitelist
+ * incremental — existing violations tolerated, new ones blocked).
+ *
+ * Forbidden token families:
+ *   - var(--bg-base)
+ *   - var(--gaming-*)
+ *   - var(--nh-*)
+ *   - var(--e-*)
+ *
+ * Whitelist-incremental rationale (plan §7 R3):
+ *   The token bridge (DS-16 pending) still maps these names at runtime, so the
+ *   existing mockups have not been migrated yet. We snapshot the current count
+ *   as a hard ceiling so NEW violations are rejected; the ceiling drops once
+ *   DS-16 migrates the literals upstream.
+ *
+ * Usage:
+ *   node lint-tokens-mockups.mjs                       # inventory dump, exit 0
+ *   node lint-tokens-mockups.mjs --strict --max-baseline 6   # CI gate
+ *   node lint-tokens-mockups.mjs --scope "<glob>"      # override default scope
+ *
+ * Exit codes:
+ *   0  inventory written OR strict run within baseline
+ *   1  strict run exceeded baseline (NEW violation introduced)
+ *   2  invocation error (bad flag, IO failure)
+ *
+ * Refs:
+ *   Spec:     docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md
+ *   Issue:    #2070 (DS-17-2)
+ *   Umbrella: #2063 (DS-17 Mockup-to-App Fidelity)
+ *   Plan:     docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md §4.1
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { globSync } from 'glob';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const AUDIT_DIR = resolve(REPO_ROOT, 'audits');
+const JSON_OUT = resolve(AUDIT_DIR, '2026-06-09-mockup-token-violations.json');
+const MD_OUT = resolve(AUDIT_DIR, '2026-06-09-mockup-token-violations.md');
+
+// ---------------------------------------------------------------------------
+// Regex & defaults — exported for unit testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches forbidden legacy CSS variable literals inside `var(...)` calls.
+ *
+ * Forbidden families (1+ lowercase chars / digits / hyphens after the prefix):
+ *   - `bg-base`     — single literal (no wildcard tail)
+ *   - `gaming-*`    — e.g. `gaming-blue`, `gaming-accent-gradient`
+ *   - `nh-*`        — e.g. `nh-bg-2`, `nh-text-primary`
+ *   - `e-*`         — e.g. `e-agent-h`, `e-game-l`, `e-1` (per CLAUDE.md token bridge map)
+ *
+ * Canonical semantic tokens (--background, --foreground, --muted-foreground,
+ * --card, --border, --primary, --secondary, --accent, --destructive, --shadow-*,
+ * --transition, …) do NOT start with any of the forbidden prefixes, so they
+ * are intentionally not matched.
+ */
+export const LEGACY_TOKEN_REGEX =
+  /var\(--(bg-base|gaming-[a-z0-9][a-z0-9-]*|nh-[a-z0-9][a-z0-9-]*|e-[a-z0-9][a-z0-9-]*)\)/g;
+
+export const DEFAULT_GLOB = 'admin-mockups/**/*.{html,jsx,css}';
+
+export const DEFAULT_IGNORE = [
+  '**/node_modules/**',
+  '**/.next/**',
+  '**/dist/**',
+  '**/.git/**',
+  '**/coverage/**',
+];
+
+// ---------------------------------------------------------------------------
+// Core lint primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan a single text blob for forbidden token literals.
+ * Returns an array of `{ file, line, column, token, match }` records sorted by line/column.
+ */
+export function findViolationsInText(text, filePath) {
+  if (!text || typeof text !== 'string') return [];
+  const out = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    // Fresh regex per line — global flag is stateful across calls.
+    const re = new RegExp(LEGACY_TOKEN_REGEX.source, LEGACY_TOKEN_REGEX.flags);
+    for (const m of lines[i].matchAll(re)) {
+      out.push({
+        file: filePath,
+        line: i + 1,
+        column: (m.index ?? 0) + 1,
+        token: m[1],
+        match: m[0],
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Lint a glob of files relative to `repoRoot`.
+ * Returns `{ fileCount, violations }`; `violations` is stable-sorted by file then line then column.
+ */
+export function lintFiles(globPattern, repoRoot, opts = {}) {
+  const ignore = opts.ignore ?? DEFAULT_IGNORE;
+  const absoluteFiles = globSync(globPattern, {
+    cwd: repoRoot,
+    ignore,
+    absolute: true,
+    nodir: true,
+  });
+
+  const allViolations = [];
+  for (const abs of absoluteFiles) {
+    const rel = relative(repoRoot, abs).replace(/\\/g, '/');
+    const text = readFileSync(abs, 'utf-8');
+    allViolations.push(...findViolationsInText(text, rel));
+  }
+
+  allViolations.sort((a, b) => {
+    if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+    if (a.line !== b.line) return a.line - b.line;
+    return a.column - b.column;
+  });
+
+  return { fileCount: absoluteFiles.length, violations: allViolations };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function groupBy(items, keyFn) {
+  const out = {};
+  for (const it of items) {
+    const k = keyFn(it);
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
+function buildJsonReport({ fileCount, violations }, baseline) {
+  const byFile = groupBy(violations, (v) => v.file);
+  const byFamily = groupBy(violations, (v) => v.token.split('-')[0]);
+  return {
+    generatedAt: new Date().toISOString(),
+    scope: DEFAULT_GLOB,
+    legacyFamilies: ['bg-base', 'gaming-*', 'nh-*', 'e-*'],
+    totalViolations: violations.length,
+    fileCount,
+    filesAffected: Object.keys(byFile).length,
+    baselineMaxViolations: baseline,
+    byFile,
+    byFamily,
+    violations,
+  };
+}
+
+function buildMdReport(report) {
+  const lines = [
+    '# Mockup Token Violations — Inventory (DS-17-2)',
+    '',
+    '| Field | Value |',
+    '|---|---|',
+    `| **Date** | ${report.generatedAt.slice(0, 10)} |`,
+    `| **Generator** | \`pnpm lint:tokens:mockups\` (DS-17-2) |`,
+    `| **Spec** | [\`2026-06-09-mockup-to-app-drift-spec-panel-review.md\`](../docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md) |`,
+    `| **Scope** | \`${report.scope}\` |`,
+    `| **Total violations** | ${report.totalViolations} |`,
+    `| **Files scanned** | ${report.fileCount} |`,
+    `| **Files affected** | ${report.filesAffected} |`,
+    `| **Baseline ceiling** | ${report.baselineMaxViolations === null ? '_(none — inventory mode)_' : report.baselineMaxViolations} |`,
+    '',
+    '## Forbidden legacy families',
+    '',
+    'These names will be REMOVED in DS-16 (token bridge unwind). New mockup work must use the canonical semantic tokens (`--background`, `--foreground`, `--muted-foreground`, `--card`, `--border`, `--primary`, …).',
+    '',
+    '| Family | Pattern | Count |',
+    '|---|---|---|',
+  ];
+  const familyOrder = [
+    ['bg', 'bg-base', 'var(--bg-base)'],
+    ['gaming', 'gaming-*', 'var(--gaming-*)'],
+    ['nh', 'nh-*', 'var(--nh-*)'],
+    ['e', 'e-*', 'var(--e-*)'],
+  ];
+  for (const [familyKey, displayName, pattern] of familyOrder) {
+    lines.push(`| \`${displayName}\` | \`${pattern}\` | ${report.byFamily[familyKey] ?? 0} |`);
+  }
+  lines.push('', '## Violations by file', '', '| File | Count |', '|---|---|');
+  const fileEntries = Object.entries(report.byFile).sort((a, b) => b[1] - a[1]);
+  for (const [file, count] of fileEntries) {
+    lines.push(`| \`${file}\` | ${count} |`);
+  }
+  if (fileEntries.length === 0) {
+    lines.push('| _(none)_ | 0 |');
+  }
+  lines.push(
+    '',
+    '## CI gate semantics',
+    '',
+    '- Default (`pnpm lint:tokens:mockups`) = inventory only, exit 0.',
+    '- Strict (`pnpm lint:tokens:mockups --strict --max-baseline N`) = exit 1 when count > N. CI passes N as a frozen ceiling; introducing a NEW violation fails the gate.',
+    '- Whitelist is intentional (plan §7 R3): existing mockup literals carried over from the bridge era are tolerated until DS-16 unwinds the bridge upstream.',
+    '',
+    '## Refs',
+    '',
+    '- Sub-issue: [#2070](https://github.com/meepleAi-app/meepleai-monorepo/issues/2070)',
+    '- Umbrella: [#2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063)',
+    '- Plan: [`2026-06-09-ds-17-phase-1-implementation-plan.md`](../docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md) §4.1',
+    '- Companion JSON: [`2026-06-09-mockup-token-violations.json`](./2026-06-09-mockup-token-violations.json)',
+    ''
+  );
+  return lines.join('\n');
+}
+
+export function writeReports(report, outPaths) {
+  const { jsonOut, mdOut } = outPaths;
+  if (!existsSync(dirname(jsonOut))) mkdirSync(dirname(jsonOut), { recursive: true });
+  if (!existsSync(dirname(mdOut))) mkdirSync(dirname(mdOut), { recursive: true });
+  writeFileSync(jsonOut, JSON.stringify(report, null, 2) + '\n', 'utf-8');
+  writeFileSync(mdOut, buildMdReport(report), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { strict: false, maxBaseline: null, scope: DEFAULT_GLOB, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--strict') args.strict = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--max-baseline') {
+      const n = Number.parseInt(argv[++i], 10);
+      if (Number.isNaN(n) || n < 0) {
+        throw new Error(`--max-baseline requires a non-negative integer, got: ${argv[i]}`);
+      }
+      args.maxBaseline = n;
+    } else if (a.startsWith('--max-baseline=')) {
+      const n = Number.parseInt(a.slice('--max-baseline='.length), 10);
+      if (Number.isNaN(n) || n < 0) {
+        throw new Error(`--max-baseline requires a non-negative integer, got: ${a}`);
+      }
+      args.maxBaseline = n;
+    } else if (a === '--scope') {
+      args.scope = argv[++i];
+    } else if (a.startsWith('--scope=')) {
+      args.scope = a.slice('--scope='.length);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'lint-tokens-mockups.mjs — legacy CSS token literal reporter (DS-17-2)',
+      '',
+      'Usage:',
+      '  node lint-tokens-mockups.mjs                          # inventory dump, exit 0',
+      '  node lint-tokens-mockups.mjs --strict --max-baseline N  # CI gate',
+      '  node lint-tokens-mockups.mjs --scope "<glob>"         # override default scope',
+      '',
+      `Default scope: ${DEFAULT_GLOB}`,
+      'Forbidden families: var(--bg-base), var(--gaming-*), var(--nh-*), var(--e-*)',
+      '',
+      'Exit codes: 0 ok | 1 baseline exceeded | 2 invocation error',
+      '',
+    ].join('\n')
+  );
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`[lint:tokens:mockups] ERROR: ${err.message}\n`);
+    printHelp();
+    process.exit(2);
+  }
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (args.strict && args.maxBaseline === null) {
+    process.stderr.write(
+      '[lint:tokens:mockups] ERROR: --strict requires --max-baseline N\n'
+    );
+    process.exit(2);
+  }
+
+  const result = lintFiles(args.scope, REPO_ROOT);
+  const report = buildJsonReport(result, args.maxBaseline);
+  writeReports(report, { jsonOut: JSON_OUT, mdOut: MD_OUT });
+
+  const summary =
+    `[lint:tokens:mockups] ${result.violations.length} violations across ${report.filesAffected} files ` +
+    `(scanned ${result.fileCount} files, scope: ${args.scope})\n` +
+    `  JSON: ${relative(REPO_ROOT, JSON_OUT)}\n` +
+    `  MD:   ${relative(REPO_ROOT, MD_OUT)}\n`;
+  process.stdout.write(summary);
+
+  if (args.strict && result.violations.length > args.maxBaseline) {
+    process.stderr.write(
+      `[lint:tokens:mockups] FAIL: ${result.violations.length} violations exceed --max-baseline ${args.maxBaseline}\n` +
+        '       A new legacy token literal was introduced. Either:\n' +
+        '         1. Replace with a canonical semantic token (--background, --foreground, --card, --border, --primary, …)\n' +
+        '         2. If intentional inventory regression, raise --max-baseline in CI workflow (rare)\n'
+    );
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+// CLI guard — only run main() when invoked directly (cross-platform Windows safe via pathToFileURL).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    process.stderr.write(`[lint:tokens:mockups] UNEXPECTED: ${err.stack || err.message}\n`);
+    process.exit(2);
+  });
+}

--- a/audits/2026-05-12-token-violations.md
+++ b/audits/2026-05-12-token-violations.md
@@ -25,3 +25,7 @@
 - Rule is in `warn` mode during DS-3 inventory + DS-4..DS-11 cluster migrations.
 - Switched to `error` in DS-12 once `pnpm lint:tokens --max-warnings 0` is green.
 - Companion JSON: [`2026-05-12-token-violations.json`](./2026-05-12-token-violations.json).
+
+## Related audits
+
+- [`2026-06-09-mockup-token-violations.md`](./2026-06-09-mockup-token-violations.md) — DS-17-2 sister audit for `admin-mockups/**` legacy CSS variable literals (`var(--bg-base|--gaming-*|--nh-*|--e-*)`). Scope-disjoint from this report; whitelist-incremental baseline of 1500 violations carried over from the token bridge era pending DS-16 unwind.

--- a/audits/2026-06-09-mockup-token-violations.json
+++ b/audits/2026-06-09-mockup-token-violations.json
@@ -1,0 +1,10535 @@
+{
+  "generatedAt": "2026-06-09T12:02:13.203Z",
+  "scope": "admin-mockups/**/*.{html,jsx,css}",
+  "legacyFamilies": [
+    "bg-base",
+    "gaming-*",
+    "nh-*",
+    "e-*"
+  ],
+  "totalViolations": 1500,
+  "fileCount": 334,
+  "filesAffected": 13,
+  "baselineMaxViolations": 1500,
+  "byFile": {
+    "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html": 273,
+    "admin-mockups/standalone/meeple-card-visual--carousel-3d.html": 189,
+    "admin-mockups/standalone/meeple-card-visual--flip-card.html": 201,
+    "admin-mockups/standalone/meeple-card-visual--grid-view.html": 204,
+    "admin-mockups/standalone/meeple-card-visual--list-view.html": 201,
+    "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html": 210,
+    "admin-mockups/standalone/meeple-card-visual--table-view.html": 210,
+    "admin-mockups/standalone/play-records--detail.html": 2,
+    "admin-mockups/standalone/play-records--list.html": 2,
+    "admin-mockups/standalone/play-records--new-step1-game.html": 2,
+    "admin-mockups/standalone/play-records--new-step2-players.html": 2,
+    "admin-mockups/standalone/play-records--new-step3-summary.html": 2,
+    "admin-mockups/standalone/play-records--stats.html": 2
+  },
+  "byFamily": {
+    "e": 1488,
+    "bg": 12
+  },
+  "violations": [
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 70,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 70,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 70,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 84,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 84,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 84,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 101,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 101,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 101,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 102,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 102,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 102,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 103,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 103,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 103,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 104,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 104,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 104,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 105,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 105,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 105,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 106,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 106,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 106,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 114,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 114,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 114,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 115,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 115,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 115,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 116,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 116,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 116,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 117,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 117,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 117,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 118,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 118,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 118,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 119,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 119,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 119,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 133,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 133,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 133,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 134,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 134,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 134,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 135,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 135,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 135,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 136,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 136,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 136,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 137,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 137,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 137,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 198,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 198,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 198,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 199,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 199,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 199,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 297,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 298,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 299,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 300,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 301,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 302,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 303,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 303,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 303,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 304,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 304,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 304,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 305,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 305,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 305,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 306,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 306,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 306,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 307,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 307,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 307,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 308,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 308,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 308,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 309,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 309,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 310,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 310,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 313,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 313,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 313,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 314,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 314,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 314,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 375,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 375,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 375,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 376,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 376,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 376,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 377,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 377,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 377,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 378,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 378,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 378,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 379,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 379,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 379,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 380,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 380,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 380,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 486,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 486,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 486,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 530,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 530,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 530,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 573,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 573,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 573,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 612,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 612,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 612,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 615,
+      "column": 106,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 615,
+      "column": 122,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 615,
+      "column": 138,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 649,
+      "column": 54,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 649,
+      "column": 70,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 649,
+      "column": 86,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 672,
+      "column": 54,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 672,
+      "column": 70,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 672,
+      "column": 86,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 678,
+      "column": 276,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 678,
+      "column": 296,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 678,
+      "column": 316,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 679,
+      "column": 252,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 679,
+      "column": 271,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 679,
+      "column": 290,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 694,
+      "column": 509,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 694,
+      "column": 525,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 694,
+      "column": 541,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 694,
+      "column": 573,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 694,
+      "column": 589,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 694,
+      "column": 605,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 625,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 644,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 663,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 698,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 717,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 736,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 891,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 910,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 695,
+      "column": 929,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 696,
+      "column": 630,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 696,
+      "column": 647,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 696,
+      "column": 664,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 696,
+      "column": 697,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 696,
+      "column": 714,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 696,
+      "column": 731,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 711,
+      "column": 76,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 711,
+      "column": 92,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 711,
+      "column": 108,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 718,
+      "column": 63,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 718,
+      "column": 79,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 718,
+      "column": 95,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 740,
+      "column": 76,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 740,
+      "column": 93,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 740,
+      "column": 110,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 754,
+      "column": 63,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 754,
+      "column": 80,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 754,
+      "column": 97,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 797,
+      "column": 72,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 797,
+      "column": 88,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 797,
+      "column": 104,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 799,
+      "column": 116,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 799,
+      "column": 132,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 799,
+      "column": 148,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 813,
+      "column": 72,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 813,
+      "column": 90,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 813,
+      "column": 108,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 815,
+      "column": 109,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 815,
+      "column": 127,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 815,
+      "column": 145,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 826,
+      "column": 80,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 826,
+      "column": 100,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 826,
+      "column": 120,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 828,
+      "column": 72,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 828,
+      "column": 92,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 828,
+      "column": 112,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 830,
+      "column": 116,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 830,
+      "column": 136,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 830,
+      "column": 156,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 904,
+      "column": 33,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 904,
+      "column": 49,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/mockup-meeplecard/meeple-card-visual-test.html",
+      "line": 904,
+      "column": 65,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 91,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 91,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 91,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 104,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 104,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 104,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 120,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 120,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 120,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 121,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 121,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 121,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 122,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 122,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 122,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 123,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 123,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 123,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 124,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 124,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 124,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 125,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 125,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 125,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 132,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 132,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 132,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 133,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 133,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 133,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 134,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 134,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 134,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 135,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 135,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 135,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 136,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 136,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 136,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 137,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 137,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 137,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 149,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 149,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 149,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 150,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 150,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 150,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 151,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 151,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 151,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 152,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 152,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 152,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 153,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 153,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 153,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 210,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 210,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 210,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 211,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 211,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 211,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 303,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 304,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 305,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 306,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 307,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 308,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 309,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 309,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 310,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 310,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 311,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 311,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 311,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 312,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 312,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 312,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 313,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 313,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 313,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 314,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 314,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 314,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 315,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 315,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 315,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 316,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 316,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 316,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 319,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 319,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 319,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 320,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 320,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 320,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 377,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 377,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 377,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 378,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 378,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 378,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 379,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 379,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 379,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 380,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 380,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 380,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 381,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 381,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 381,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 382,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 382,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 382,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--carousel-3d.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 91,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 91,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 91,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 104,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 104,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 104,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 120,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 120,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 120,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 121,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 121,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 121,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 122,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 122,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 122,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 123,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 123,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 123,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 124,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 124,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 124,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 125,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 125,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 125,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 132,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 132,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 132,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 133,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 133,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 133,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 134,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 134,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 134,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 135,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 135,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 135,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 136,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 136,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 136,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 137,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 137,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 137,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 149,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 149,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 149,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 150,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 150,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 150,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 151,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 151,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 151,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 152,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 152,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 152,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 153,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 153,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 153,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 210,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 210,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 210,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 211,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 211,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 211,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 303,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 304,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 305,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 306,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 307,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 308,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 309,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 309,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 310,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 310,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 311,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 311,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 311,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 312,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 312,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 312,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 313,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 313,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 313,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 314,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 314,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 314,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 315,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 315,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 315,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 316,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 316,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 316,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 319,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 319,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 319,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 320,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 320,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 320,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 377,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 377,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 377,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 378,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 378,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 378,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 379,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 379,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 379,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 380,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 380,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 380,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 381,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 381,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 381,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 382,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 382,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 382,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 467,
+      "column": 76,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 467,
+      "column": 92,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 467,
+      "column": 108,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 474,
+      "column": 63,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 474,
+      "column": 79,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 474,
+      "column": 95,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 496,
+      "column": 76,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 496,
+      "column": 93,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 496,
+      "column": 110,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 510,
+      "column": 63,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 510,
+      "column": 80,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--flip-card.html",
+      "line": 510,
+      "column": 97,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 91,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 91,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 91,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 104,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 104,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 104,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 120,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 120,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 120,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 121,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 121,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 121,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 122,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 122,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 122,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 123,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 123,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 123,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 124,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 124,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 124,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 125,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 125,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 125,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 132,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 132,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 132,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 133,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 133,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 133,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 134,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 134,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 134,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 135,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 135,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 135,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 136,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 136,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 136,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 137,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 137,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 137,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 149,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 149,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 149,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 150,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 150,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 150,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 151,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 151,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 151,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 152,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 152,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 152,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 153,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 153,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 153,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 210,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 210,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 210,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 211,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 211,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 211,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 303,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 304,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 305,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 306,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 307,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 308,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 309,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 309,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 310,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 310,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 311,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 311,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 311,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 312,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 312,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 312,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 313,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 313,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 313,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 314,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 314,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 314,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 315,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 315,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 315,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 316,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 316,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 316,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 319,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 319,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 319,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 320,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 320,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 320,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 377,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 377,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 377,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 378,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 378,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 378,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 379,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 379,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 379,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 380,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 380,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 380,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 381,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 381,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 381,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 382,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 382,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 382,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 471,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 471,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 471,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 515,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 515,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 515,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 558,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 558,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 558,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 597,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 597,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 597,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 600,
+      "column": 106,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 600,
+      "column": 122,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--grid-view.html",
+      "line": 600,
+      "column": 138,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 91,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 91,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 91,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 104,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 104,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 104,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 120,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 120,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 120,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 121,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 121,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 121,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 122,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 122,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 122,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 123,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 123,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 123,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 124,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 124,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 124,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 125,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 125,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 125,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 132,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 132,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 132,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 133,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 133,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 133,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 134,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 134,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 134,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 135,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 135,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 135,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 136,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 136,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 136,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 137,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 137,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 137,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 149,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 149,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 149,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 150,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 150,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 150,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 151,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 151,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 151,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 152,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 152,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 152,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 153,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 153,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 153,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 210,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 210,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 210,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 211,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 211,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 211,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 303,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 304,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 305,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 306,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 307,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 308,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 309,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 309,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 310,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 310,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 311,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 311,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 311,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 312,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 312,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 312,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 313,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 313,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 313,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 314,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 314,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 314,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 315,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 315,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 315,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 316,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 316,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 316,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 319,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 319,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 319,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 320,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 320,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 320,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 377,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 377,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 377,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 378,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 378,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 378,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 379,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 379,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 379,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 380,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 380,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 380,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 381,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 381,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 381,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 382,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 382,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 382,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 467,
+      "column": 54,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 467,
+      "column": 70,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 467,
+      "column": 86,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 490,
+      "column": 54,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 490,
+      "column": 70,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 490,
+      "column": 86,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 496,
+      "column": 276,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 496,
+      "column": 296,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 496,
+      "column": 316,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 497,
+      "column": 252,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 497,
+      "column": 271,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--list-view.html",
+      "line": 497,
+      "column": 290,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 91,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 91,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 91,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 104,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 104,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 104,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 120,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 120,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 120,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 121,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 121,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 121,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 122,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 122,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 122,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 123,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 123,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 123,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 124,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 124,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 124,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 125,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 125,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 125,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 132,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 132,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 132,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 133,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 133,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 133,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 134,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 134,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 134,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 135,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 135,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 135,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 136,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 136,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 136,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 137,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 137,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 137,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 149,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 149,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 149,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 150,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 150,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 150,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 151,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 151,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 151,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 152,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 152,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 152,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 153,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 153,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 153,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 210,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 210,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 210,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 211,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 211,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 211,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 303,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 304,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 305,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 306,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 307,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 308,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 309,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 309,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 310,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 310,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 311,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 311,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 311,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 312,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 312,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 312,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 313,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 313,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 313,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 314,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 314,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 314,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 315,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 315,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 315,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 316,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 316,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 316,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 319,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 319,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 319,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 320,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 320,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 320,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 377,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 377,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 377,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 378,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 378,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 378,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 379,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 379,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 379,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 380,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 380,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 380,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 381,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 381,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 381,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 382,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 382,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 382,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 466,
+      "column": 72,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 466,
+      "column": 88,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 466,
+      "column": 104,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 468,
+      "column": 116,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 468,
+      "column": 132,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 468,
+      "column": 148,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 482,
+      "column": 72,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 482,
+      "column": 90,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 482,
+      "column": 108,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 484,
+      "column": 109,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 484,
+      "column": 127,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 484,
+      "column": 145,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 495,
+      "column": 80,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 495,
+      "column": 100,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 495,
+      "column": 120,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 497,
+      "column": 72,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 497,
+      "column": 92,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 497,
+      "column": 112,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 499,
+      "column": 116,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 499,
+      "column": 136,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html",
+      "line": 499,
+      "column": 156,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 91,
+      "column": 29,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 91,
+      "column": 45,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 91,
+      "column": 61,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 104,
+      "column": 78,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 104,
+      "column": 94,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 104,
+      "column": 110,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 120,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 120,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 120,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 121,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 121,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 121,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 122,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 122,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 122,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 123,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 123,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 123,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 124,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 124,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 124,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 125,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 125,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 125,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 132,
+      "column": 37,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 132,
+      "column": 53,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 132,
+      "column": 69,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 133,
+      "column": 40,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 133,
+      "column": 59,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 133,
+      "column": 78,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 134,
+      "column": 38,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 134,
+      "column": 55,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 134,
+      "column": 72,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 135,
+      "column": 41,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 135,
+      "column": 61,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 135,
+      "column": 81,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 136,
+      "column": 37,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 136,
+      "column": 53,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 136,
+      "column": 69,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 137,
+      "column": 39,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 137,
+      "column": 57,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 137,
+      "column": 75,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 149,
+      "column": 67,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 149,
+      "column": 83,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 149,
+      "column": 99,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 150,
+      "column": 70,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 150,
+      "column": 89,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 150,
+      "column": 108,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 151,
+      "column": 68,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 151,
+      "column": 85,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 151,
+      "column": 102,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 152,
+      "column": 71,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 152,
+      "column": 91,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 152,
+      "column": 111,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 153,
+      "column": 67,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 153,
+      "column": 83,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 153,
+      "column": 99,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 210,
+      "column": 53,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 210,
+      "column": 69,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 210,
+      "column": 85,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 211,
+      "column": 54,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 211,
+      "column": 71,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 211,
+      "column": 88,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 43,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 63,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 83,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 130,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 150,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 170,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 212,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 232,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 252,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 297,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 317,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 303,
+      "column": 337,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 42,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 61,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 80,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 126,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 145,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 164,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 205,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 224,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 243,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 287,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 306,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 304,
+      "column": 325,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 40,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 57,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 74,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 118,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 135,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 152,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 191,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 208,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 225,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 267,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 284,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 305,
+      "column": 301,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 39,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 55,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 71,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 114,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 130,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 146,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 184,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 200,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 216,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 257,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 273,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 306,
+      "column": 289,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 39,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 55,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 71,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 114,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 130,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 146,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 184,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 200,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 216,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 257,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 273,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 307,
+      "column": 289,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 41,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 59,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 77,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 122,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 140,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 158,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 198,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 216,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 234,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 277,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 295,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 308,
+      "column": 313,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 309,
+      "column": 49,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 309,
+      "column": 69,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 309,
+      "column": 89,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 310,
+      "column": 48,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 310,
+      "column": 67,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 310,
+      "column": 86,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 311,
+      "column": 46,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 311,
+      "column": 63,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 311,
+      "column": 80,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 312,
+      "column": 45,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 312,
+      "column": 61,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 312,
+      "column": 77,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 313,
+      "column": 47,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 313,
+      "column": 65,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 313,
+      "column": 83,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 314,
+      "column": 51,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 314,
+      "column": 71,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 314,
+      "column": 91,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 315,
+      "column": 50,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 315,
+      "column": 69,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 315,
+      "column": 88,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 316,
+      "column": 48,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 316,
+      "column": 65,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 316,
+      "column": 82,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 319,
+      "column": 64,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 319,
+      "column": 84,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 319,
+      "column": 104,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 320,
+      "column": 63,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 320,
+      "column": 82,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 320,
+      "column": 101,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 377,
+      "column": 56,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 377,
+      "column": 72,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 377,
+      "column": 88,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 378,
+      "column": 59,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 378,
+      "column": 78,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 378,
+      "column": 97,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 379,
+      "column": 57,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 379,
+      "column": 74,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 379,
+      "column": 91,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 380,
+      "column": 60,
+      "token": "e-document-h",
+      "match": "var(--e-document-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 380,
+      "column": 80,
+      "token": "e-document-s",
+      "match": "var(--e-document-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 380,
+      "column": 100,
+      "token": "e-document-l",
+      "match": "var(--e-document-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 381,
+      "column": 56,
+      "token": "e-chat-h",
+      "match": "var(--e-chat-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 381,
+      "column": 72,
+      "token": "e-chat-s",
+      "match": "var(--e-chat-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 381,
+      "column": 88,
+      "token": "e-chat-l",
+      "match": "var(--e-chat-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 382,
+      "column": 58,
+      "token": "e-player-h",
+      "match": "var(--e-player-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 382,
+      "column": 76,
+      "token": "e-player-s",
+      "match": "var(--e-player-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 382,
+      "column": 94,
+      "token": "e-player-l",
+      "match": "var(--e-player-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 429,
+      "column": 72,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 429,
+      "column": 88,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 429,
+      "column": 104,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 438,
+      "column": 18,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 438,
+      "column": 34,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 438,
+      "column": 50,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 466,
+      "column": 509,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 466,
+      "column": 525,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 466,
+      "column": 541,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 466,
+      "column": 573,
+      "token": "e-game-h",
+      "match": "var(--e-game-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 466,
+      "column": 589,
+      "token": "e-game-s",
+      "match": "var(--e-game-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 466,
+      "column": 605,
+      "token": "e-game-l",
+      "match": "var(--e-game-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 625,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 644,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 663,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 698,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 717,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 736,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 891,
+      "token": "e-session-h",
+      "match": "var(--e-session-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 910,
+      "token": "e-session-s",
+      "match": "var(--e-session-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 467,
+      "column": 929,
+      "token": "e-session-l",
+      "match": "var(--e-session-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 468,
+      "column": 630,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 468,
+      "column": 647,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 468,
+      "column": 664,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 468,
+      "column": 697,
+      "token": "e-agent-h",
+      "match": "var(--e-agent-h)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 468,
+      "column": 714,
+      "token": "e-agent-s",
+      "match": "var(--e-agent-s)"
+    },
+    {
+      "file": "admin-mockups/standalone/meeple-card-visual--table-view.html",
+      "line": 468,
+      "column": 731,
+      "token": "e-agent-l",
+      "match": "var(--e-agent-l)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--detail.html",
+      "line": 61,
+      "column": 17,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--detail.html",
+      "line": 278,
+      "column": 46,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--list.html",
+      "line": 61,
+      "column": 17,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--list.html",
+      "line": 278,
+      "column": 46,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--new-step1-game.html",
+      "line": 61,
+      "column": 17,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--new-step1-game.html",
+      "line": 278,
+      "column": 46,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--new-step2-players.html",
+      "line": 61,
+      "column": 17,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--new-step2-players.html",
+      "line": 278,
+      "column": 46,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--new-step3-summary.html",
+      "line": 61,
+      "column": 17,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--new-step3-summary.html",
+      "line": 278,
+      "column": 46,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--stats.html",
+      "line": 61,
+      "column": 17,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    },
+    {
+      "file": "admin-mockups/standalone/play-records--stats.html",
+      "line": 278,
+      "column": 46,
+      "token": "bg-base",
+      "match": "var(--bg-base)"
+    }
+  ]
+}

--- a/audits/2026-06-09-mockup-token-violations.md
+++ b/audits/2026-06-09-mockup-token-violations.md
@@ -1,0 +1,54 @@
+# Mockup Token Violations — Inventory (DS-17-2)
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-06-09 |
+| **Generator** | `pnpm lint:tokens:mockups` (DS-17-2) |
+| **Spec** | [`2026-06-09-mockup-to-app-drift-spec-panel-review.md`](../docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md) |
+| **Scope** | `admin-mockups/**/*.{html,jsx,css}` |
+| **Total violations** | 1500 |
+| **Files scanned** | 334 |
+| **Files affected** | 13 |
+| **Baseline ceiling** | 1500 |
+
+## Forbidden legacy families
+
+These names will be REMOVED in DS-16 (token bridge unwind). New mockup work must use the canonical semantic tokens (`--background`, `--foreground`, `--muted-foreground`, `--card`, `--border`, `--primary`, …).
+
+| Family | Pattern | Count |
+|---|---|---|
+| `bg-base` | `var(--bg-base)` | 12 |
+| `gaming-*` | `var(--gaming-*)` | 0 |
+| `nh-*` | `var(--nh-*)` | 0 |
+| `e-*` | `var(--e-*)` | 1488 |
+
+## Violations by file
+
+| File | Count |
+|---|---|
+| `admin-mockups/mockup-meeplecard/meeple-card-visual-test.html` | 273 |
+| `admin-mockups/standalone/meeple-card-visual--multi-entity-grid.html` | 210 |
+| `admin-mockups/standalone/meeple-card-visual--table-view.html` | 210 |
+| `admin-mockups/standalone/meeple-card-visual--grid-view.html` | 204 |
+| `admin-mockups/standalone/meeple-card-visual--flip-card.html` | 201 |
+| `admin-mockups/standalone/meeple-card-visual--list-view.html` | 201 |
+| `admin-mockups/standalone/meeple-card-visual--carousel-3d.html` | 189 |
+| `admin-mockups/standalone/play-records--detail.html` | 2 |
+| `admin-mockups/standalone/play-records--list.html` | 2 |
+| `admin-mockups/standalone/play-records--new-step1-game.html` | 2 |
+| `admin-mockups/standalone/play-records--new-step2-players.html` | 2 |
+| `admin-mockups/standalone/play-records--new-step3-summary.html` | 2 |
+| `admin-mockups/standalone/play-records--stats.html` | 2 |
+
+## CI gate semantics
+
+- Default (`pnpm lint:tokens:mockups`) = inventory only, exit 0.
+- Strict (`pnpm lint:tokens:mockups --strict --max-baseline N`) = exit 1 when count > N. CI passes N as a frozen ceiling; introducing a NEW violation fails the gate.
+- Whitelist is intentional (plan §7 R3): existing mockup literals carried over from the bridge era are tolerated until DS-16 unwinds the bridge upstream.
+
+## Refs
+
+- Sub-issue: [#2070](https://github.com/meepleAi-app/meepleai-monorepo/issues/2070)
+- Umbrella: [#2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063)
+- Plan: [`2026-06-09-ds-17-phase-1-implementation-plan.md`](../docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md) §4.1
+- Companion JSON: [`2026-06-09-mockup-token-violations.json`](./2026-06-09-mockup-token-violations.json)


### PR DESCRIPTION
## Summary

DS-17-2 (Wave 1b) ships a whitelist-incremental CI gate that scans `admin-mockups/**/*.{html,jsx,css}` for forbidden legacy CSS token literals (`var(--bg-base)`, `var(--gaming-*)`, `var(--nh-*)`, `var(--e-*)`). Existing mockup literals are tolerated until DS-16 unwinds the token bridge upstream; the gate fails the build if a NEW occurrence appears.

Pairs with DS-17-4 (#2072 / PR #2075) — same Wave 1 of the Phase 1 implementation plan (PR #2073), orthogonal contract.

## What changed

| File | Purpose |
|---|---|
| ` apps/web/scripts/lint-tokens-mockups.mjs` | New pure-grep scanner. Exports `LEGACY_TOKEN_REGEX`, `findViolationsInText`, `lintFiles`, `writeReports`. CLI: `--strict --max-baseline N` for CI; `--scope` override; `--help`. |
| ` apps/web/scripts/__tests__/lint-tokens-mockups.test.ts` | 12 vitest cases: regex coverage (4 families + canonical exclusions), per-line line/column reporting, multi-violation aggregation, glob integration, ignore-pattern respect, stable sort. |
| ` audits/2026-06-09-mockup-token-violations.{json,md}` | Generated baseline inventory snapshot. **1500 violations** across 13 files (1488 in `--e-*` entity HSL palette, 12 in `--bg-base`). |
| ` audits/2026-05-12-token-violations.md` | Cross-link to the new sister audit (Notes section). |
| ` .github/workflows/ci.yml` | New blocking step `Mockup legacy token guard (DS-17-2)` running ` pnpm lint:tokens:mockups --strict --max-baseline 1500` + artifact upload. |
| ` apps/web/package.json` | New ` lint:tokens:mockups` script. |
| ` CLAUDE.md` § Active Freezes / Token Canonicalization | New DS-17-2 paragraph documenting the gate semantics and pointer to the spec. |

## DP-2 lock (plan §5)

Opt B (custom mjs grep) chosen over Opt A (`@html-eslint/parser` flat-config extension): cheaper, no new devDep, aligned with the existing `lint-tokens.mjs` and DS-17-4 `validate-fidelity.mjs` idioms.

## Test plan

- [x] ` pnpm vitest run scripts/__tests__/lint-tokens-mockups.test.ts` → 12/12 PASS
- [x] ` pnpm typecheck` → clean
- [x] Smoke E2E: dropped fixture with ` var(--bg-base) + var(--gaming-blue)` into ` admin-mockups/design_files/`, ran ` --strict --max-baseline 1500` → **exit 1** with diagnostic; removed fixture, re-ran → **exit 0** at 1500.
- [ ] CI ` Frontend - Lint` job passes the new step at baseline
- [ ] CI uploads ` mockup-token-violations-<run>` artifact

## Acceptance criteria (#2070)

- [x] Lint extension covers ` admin-mockups/**/*.{html,jsx,css}`
- [x] Legacy token names bloccati: ` --bg-base`, ` --gaming-*`, ` --nh-*`, ` --e-*`
- [x] Inventory rigenerato (esistenti tollerati ma documentati, nuove vietate)
- [x] CI gate updated (` ci.yml` Frontend - Lint job)
- [x] CLAUDE.md aggiornato
- [x] Smoke test E2E: fixture HTML con violazione → CI rosso; rimuoverla → verde

## Refs

- Sub-issue: #2070 (DS-17-2)
- Umbrella: #2063 (DS-17 Mockup-to-App Fidelity)
- Spec: ` docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md` (PR #2068)
- Plan: ` docs/superpowers/plans/2026-06-09-ds-17-phase-1-implementation-plan.md` §4.1 (PR #2073)
- Sibling: DS-17-4 #2072 (PR #2075) — same Wave 1.

Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)