### PR TITLE
test(web): #1972 M6 bump vitest 4.1.0 exact plus 16 file v4 mock fixes

### DIFF
--- a/apps/web/__tests__/lib/utils/export.test.ts
+++ b/apps/web/__tests__/lib/utils/export.test.ts
@@ -69,11 +69,11 @@ vi.mock('html2canvas', () => ({
 
 // Mock jsPDF
 vi.mock('jspdf', () => ({
-  default: vi.fn().mockImplementation(() => ({
-    addImage: vi.fn(),
-    addPage: vi.fn(),
-    save: vi.fn(),
-  })),
+  default: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.addImage = vi.fn();
+    this.addPage = vi.fn();
+    this.save = vi.fn();
+  }),
 }));
 
 describe('Export Utilities', () => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -226,8 +226,8 @@
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
     "@vitejs/plugin-react": "^6.0.2",
-    "@vitest/coverage-v8": "^3.2.4",
-    "@vitest/ui": "^3.2.4",
+    "@vitest/coverage-v8": "4.1.0",
+    "@vitest/ui": "4.1.0",
     "autoprefixer": "^10.5.0",
     "axe-core": "^4.11.4",
     "chromatic": "^17.0.1",
@@ -264,7 +264,7 @@
     "tsx": "^4.22.3",
     "typescript": "5.9.3",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^3.2.4",
+    "vitest": "4.1.0",
     "vitest-axe": "^0.1.0"
   },
   "pnpm": {

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -455,11 +455,11 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0)
       '@vitest/ui':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0)
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
@@ -569,11 +569,11 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: 4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       vitest-axe:
         specifier: ^0.1.0
-        version: 0.1.0(vitest@3.2.4)
+        version: 0.1.0(vitest@4.1.0)
 
 packages:
 
@@ -583,10 +583,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@apidevtools/json-schema-ref-parser@11.7.2':
     resolution: {integrity: sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==}
@@ -2046,10 +2042,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
 
   '@jest/diff-sequences@30.3.0':
     resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
@@ -4826,11 +4818,11 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -4838,8 +4830,11 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=7.3.2'
@@ -4852,22 +4847,31 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/ui@3.2.4':
-    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/ui@4.1.0':
+    resolution: {integrity: sha512-sTSDtVM1GOevRGsCNhp1mBUHKo9Qlc55+HCreFT4fe99AHxl1QQNXSL3uj4Pkjh5yEuWZIx8E2tVC94nnBZECQ==}
     peerDependencies:
-      vitest: 3.2.4
+      vitest: 4.1.0
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -5139,8 +5143,8 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.8:
-    resolution: {integrity: sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==}
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -5418,6 +5422,10 @@ packages:
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@2.4.2:
@@ -6451,8 +6459,8 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   expect@30.3.0:
@@ -7200,10 +7208,6 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -7274,11 +7278,11 @@ packages:
     resolution: {integrity: sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==}
     engines: {node: '>=12'}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -7542,8 +7546,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   mailosaur@11.1.1:
     resolution: {integrity: sha512-qU4lawXFrsPpOttLvwQjOJYJhRrUjygQSSMcCrSCNdgDRps/96fvqrWVptoX7IQ1QfKlv26cl264Fv6DKbduOw==}
@@ -8001,6 +8005,10 @@ packages:
 
   objectorarray@1.0.5:
     resolution: {integrity: sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==}
+
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -9186,8 +9194,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -9299,9 +9307,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -9470,10 +9475,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
-
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -9496,9 +9497,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
@@ -9507,20 +9505,16 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -9851,11 +9845,6 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-tsconfig-paths@6.1.1:
     resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
     peerDependencies:
@@ -9909,26 +9898,33 @@ packages:
     peerDependencies:
       vitest: '>=0.16.0'
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=7.3.2'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -10236,11 +10232,6 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@apidevtools/json-schema-ref-parser@11.7.2':
     dependencies:
@@ -11759,8 +11750,6 @@ snapshots:
   '@inquirer/type@4.0.5(@types/node@25.9.1)':
     optionalDependencies:
       '@types/node': 25.9.1
-
-  '@istanbuljs/schema@0.1.3': {}
 
   '@jest/diff-sequences@30.3.0': {}
 
@@ -14227,7 +14216,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -14624,24 +14613,19 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.8
-      debug: 4.4.3
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14651,9 +14635,18 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/expect@4.1.0':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -14664,15 +14657,19 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/pretty-format@4.1.0':
     dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.1.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/runner@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -14680,22 +14677,30 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/ui@3.2.4(vitest@3.2.4)':
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/ui@4.1.0(vitest@4.1.0)':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.0
       fflate: 0.8.2
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -15018,11 +15023,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.8:
+  ast-v8-to-istanbul@1.0.3:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
-      js-tokens: 9.0.1
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -15328,6 +15333,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -16524,7 +16531,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -16552,7 +16559,7 @@ snapshots:
   expand-template@2.0.3:
     optional: true
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
   expect@30.3.0:
     dependencies:
@@ -17315,14 +17322,6 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -17419,9 +17418,9 @@ snapshots:
 
   js-library-detector@6.7.0: {}
 
-  js-tokens@4.0.0: {}
+  js-tokens@10.0.0: {}
 
-  js-tokens@9.0.1: {}
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -17715,7 +17714,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -18401,6 +18400,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   objectorarray@1.0.5: {}
+
+  obug@2.1.2: {}
 
   once@1.4.0:
     dependencies:
@@ -19874,7 +19875,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -20043,10 +20044,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   stubborn-fs@2.0.0:
     dependencies:
       stubborn-utils: 1.0.2
@@ -20192,12 +20189,6 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 13.0.6
-      minimatch: 10.2.4
-
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
@@ -20220,25 +20211,18 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.1.2: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -20616,28 +20600,6 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
@@ -20664,7 +20626,7 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest-axe@0.1.0(vitest@3.2.4):
+  vitest-axe@0.1.0(vitest@4.1.0):
     dependencies:
       aria-query: 5.3.2
       axe-core: 4.11.4
@@ -20672,52 +20634,37 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(@vitest/ui@3.2.4)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/ui@4.1.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.2.2
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.2
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.12
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      '@vitest/ui': 4.1.0(vitest@4.1.0)
       jsdom: 29.1.1(@noble/hashes@2.2.0)(canvas@3.2.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vm-browserify@1.1.2: {}
 

--- a/apps/web/src/__tests__/components/collection/CollectionDashboard.test.tsx
+++ b/apps/web/src/__tests__/components/collection/CollectionDashboard.test.tsx
@@ -161,11 +161,7 @@ function createTestQueryClient() {
 
 function renderWithProviders(component: React.ReactElement) {
   const queryClient = createTestQueryClient();
-  return render(
-    <QueryClientProvider client={queryClient}>
-      {component}
-    </QueryClientProvider>
-  );
+  return render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>);
 }
 
 // ============================================================================
@@ -173,8 +169,31 @@ function renderWithProviders(component: React.ReactElement) {
 // ============================================================================
 
 describe('CollectionDashboard', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // vi.clearAllMocks() only clears call history, NOT mockReturnValue implementations.
+    // Clear first, then re-establish defaults so tests that override hooks
+    // (Empty States, Loading States) don't bleed into subsequent tests
+    // (e.g. Accessibility, Pagination). #1972 M6 vitest v4: test isolation fix.
     vi.clearAllMocks();
+
+    const { useLibrary, useLibraryStats, useLibraryQuota } =
+      await import('@/hooks/queries/useLibrary');
+    vi.mocked(useLibrary).mockReturnValue({
+      data: mockLibraryResponse,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useLibrary>);
+    vi.mocked(useLibraryStats).mockReturnValue({
+      data: mockLibraryStats,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useLibraryStats>);
+    vi.mocked(useLibraryQuota).mockReturnValue({
+      data: mockQuota,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useLibraryQuota>);
+
     // Stub window.matchMedia required by MeepleCard in jsdom
     vi.stubGlobal('matchMedia', (query: string) => ({
       matches: false,

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/__tests__/page.test.tsx
@@ -21,15 +21,13 @@ function render(ui: React.ReactElement): RenderResult {
 }
 
 // jsdom doesn't implement URL.createObjectURL / revokeObjectURL.
-// Stub them so <img src={...}> and revoke-on-unmount work in tests.
-if (typeof URL.createObjectURL === 'undefined') {
-  // @ts-expect-error — assign for jsdom
-  URL.createObjectURL = () => 'blob:mock';
-}
-if (typeof URL.revokeObjectURL === 'undefined') {
-  // @ts-expect-error — assign for jsdom
-  URL.revokeObjectURL = () => {};
-}
+// Stub them unconditionally: vitest v4 exposes the Node.js native
+// URL.createObjectURL which strictly requires a real Blob instance,
+// but fake-indexeddb returns plain objects on retrieval. Always replace.
+// @ts-expect-error — assign for jsdom / vitest v4 compat
+URL.createObjectURL = () => 'blob:mock';
+// @ts-expect-error — assign for jsdom / vitest v4 compat
+URL.revokeObjectURL = () => {};
 
 function makeFakeFile(name = 'snap.png'): File {
   return new File([new Blob(['fake'], { type: 'image/png' })], name, { type: 'image/png' });

--- a/apps/web/src/app/admin/(dashboard)/agents/usage/__tests__/usage-page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/agents/usage/__tests__/usage-page.test.tsx
@@ -59,7 +59,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/lib/api/core/httpClient', () => ({
-  HttpClient: vi.fn(() => ({})),
+  HttpClient: class {},
 }));
 
 vi.mock('@/hooks/useSetNavConfig', () => ({

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/__tests__/page.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/lib/api/clients/sharedGamesClient', () => ({
 }));
 
 vi.mock('@/lib/api/core/httpClient', () => ({
-  HttpClient: vi.fn(() => ({})),
+  HttpClient: class {},
 }));
 
 vi.mock('@/hooks/useSetNavConfig', () => ({

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/__tests__/page.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@/lib/api/clients/sharedGamesClient', () => ({
 }));
 
 vi.mock('@/lib/api/core/httpClient', () => ({
-  HttpClient: vi.fn(() => ({})),
+  HttpClient: class {},
 }));
 
 // next/navigation: minimal hoisted mocks for the deep-link query-param sync

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/processing/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/processing/__tests__/page.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/lib/api/clients/adminClient', () => ({
 }));
 
 vi.mock('@/lib/api/core/httpClient', () => ({
-  HttpClient: vi.fn(() => ({})),
+  HttpClient: class {},
 }));
 
 const mockHealth = {

--- a/apps/web/src/components/admin/mechanic-extractor/analyses/__tests__/MechanicAnalysesListCard.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/analyses/__tests__/MechanicAnalysesListCard.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/lib/api/clients/adminClient', () => ({
 }));
 
 vi.mock('@/lib/api/core/httpClient', () => ({
-  HttpClient: vi.fn(() => ({})),
+  HttpClient: class {},
 }));
 
 import { MechanicAnalysesListCard } from '../MechanicAnalysesListCard';

--- a/apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
@@ -61,11 +61,13 @@ beforeEach(() => {
     responseText: JSON.stringify({ documentId: 'doc-123', fileName: 'rules.pdf' }),
   };
   vi.clearAllMocks();
-  // Vitest 2+/Node 24 made global.XMLHttpRequest read-only — mirror fix #1031.
-  vi.stubGlobal(
-    'XMLHttpRequest',
-    vi.fn(() => mockXHR)
-  );
+  // Vitest v4 fix: arrow/plain function constructors don't bind `this` to the
+  // instance, so open/send etc. are set on a throwaway object and never tracked.
+  // Use a function-with-this constructor + Object.assign so the instance shares
+  // the same vi.fn() references as mockXHR (mirror of M2 canary fix).
+  vi.stubGlobal('XMLHttpRequest', function (this: any) {
+    Object.assign(this, mockXHR);
+  });
 });
 
 afterEach(() => {

--- a/apps/web/src/components/features/library/custom-cover/__tests__/CropDialog.test.tsx
+++ b/apps/web/src/components/features/library/custom-cover/__tests__/CropDialog.test.tsx
@@ -3,15 +3,14 @@ import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 
 import { CropDialog } from '../CropDialog';
 
-// jsdom doesn't implement URL.createObjectURL / revokeObjectURL.
-if (typeof URL.createObjectURL === 'undefined') {
-  // @ts-expect-error — assign for jsdom
-  URL.createObjectURL = vi.fn(() => 'blob:mock');
-}
-if (typeof URL.revokeObjectURL === 'undefined') {
-  // @ts-expect-error — assign for jsdom
-  URL.revokeObjectURL = vi.fn();
-}
+// Stub URL.createObjectURL / revokeObjectURL unconditionally so they are
+// always vi.fn() spies. vitest v4 exposes the native Node.js implementation
+// which (a) strictly requires a real Blob and (b) is not a spy, causing
+// "is not a spy or a call to a spy!" errors on expect(URL.revokeObjectURL).
+// @ts-expect-error — override for vitest v4 / jsdom compat
+URL.createObjectURL = vi.fn(() => 'blob:mock');
+// @ts-expect-error — override for vitest v4 / jsdom compat
+URL.revokeObjectURL = vi.fn();
 
 // Reset mocks before each test.
 beforeEach(() => {

--- a/apps/web/src/components/profile/__tests__/AvatarUpload.test.tsx
+++ b/apps/web/src/components/profile/__tests__/AvatarUpload.test.tsx
@@ -184,7 +184,7 @@ describe('AvatarUpload', () => {
 
   describe('Crop Dialog', () => {
     it('opens crop dialog when valid image is selected', async () => {
-      // Mock FileReader
+      // Mock FileReader (vitest v4: must be a real constructor)
       const mockFileReader = {
         readAsDataURL: vi.fn(),
         result: 'data:image/jpeg;base64,mockdata',
@@ -192,11 +192,15 @@ describe('AvatarUpload', () => {
         onerror: null as ((e: ProgressEvent<FileReader>) => void) | null,
       };
 
+      function MockFileReader(this: unknown) {
+        return mockFileReader;
+      }
+
       vi.spyOn(global, 'FileReader').mockImplementation(
-        () => mockFileReader as unknown as FileReader
+        MockFileReader as unknown as () => FileReader
       );
 
-      // Mock Image with proper event handling
+      // Mock Image with proper event handling (vitest v4: must be a real constructor)
       const mockImage = {
         width: 500,
         height: 500,
@@ -207,7 +211,11 @@ describe('AvatarUpload', () => {
         removeEventListener: vi.fn(),
       };
 
-      vi.spyOn(global, 'Image').mockImplementation(() => mockImage as unknown as HTMLImageElement);
+      function MockImage(this: typeof mockImage) {
+        return mockImage;
+      }
+
+      vi.spyOn(global, 'Image').mockImplementation(MockImage as unknown as () => HTMLImageElement);
 
       render(<AvatarUpload {...defaultProps} />);
 

--- a/apps/web/src/components/session/__tests__/PhotoUploadModal.test.tsx
+++ b/apps/web/src/components/session/__tests__/PhotoUploadModal.test.tsx
@@ -267,19 +267,23 @@ describe('PhotoUploadModal', () => {
     const onUploadComplete = vi.fn();
     const onOpenChange = vi.fn();
 
-    // Mock XHR
-    const xhrMock = {
-      open: vi.fn(),
-      send: vi.fn(),
-      upload: { addEventListener: vi.fn() },
-      addEventListener: vi.fn(),
-      status: 201,
-      responseText: JSON.stringify(mockAttachmentResponse),
-    };
-
-    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(
-      () => xhrMock as unknown as XMLHttpRequest
-    );
+    // Mock XHR — v4 fix: function-with-this constructor so open/send/etc. are
+    // tracked on the instance that the component actually uses.
+    function makeXhrMock() {
+      return {
+        open: vi.fn(),
+        send: vi.fn(),
+        upload: { addEventListener: vi.fn() },
+        addEventListener: vi.fn(),
+        status: 201,
+        responseText: JSON.stringify(mockAttachmentResponse),
+      };
+    }
+    let xhrMock: ReturnType<typeof makeXhrMock>;
+    xhrMock = makeXhrMock();
+    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(function (this: any) {
+      Object.assign(this, xhrMock);
+    } as unknown as () => XMLHttpRequest);
 
     render(
       <PhotoUploadModal
@@ -316,18 +320,21 @@ describe('PhotoUploadModal', () => {
   });
 
   it('shows error on XHR failure', async () => {
-    const xhrMock = {
-      open: vi.fn(),
-      send: vi.fn(),
-      upload: { addEventListener: vi.fn() },
-      addEventListener: vi.fn(),
-      status: 400,
-      responseText: JSON.stringify({ error: 'File too large' }),
-    };
-
-    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(
-      () => xhrMock as unknown as XMLHttpRequest
-    );
+    function makeXhrMock() {
+      return {
+        open: vi.fn(),
+        send: vi.fn(),
+        upload: { addEventListener: vi.fn() },
+        addEventListener: vi.fn(),
+        status: 400,
+        responseText: JSON.stringify({ error: 'File too large' }),
+      };
+    }
+    let xhrMock: ReturnType<typeof makeXhrMock>;
+    xhrMock = makeXhrMock();
+    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(function (this: any) {
+      Object.assign(this, xhrMock);
+    } as unknown as () => XMLHttpRequest);
 
     render(<PhotoUploadModal {...defaultProps} />);
 
@@ -350,16 +357,19 @@ describe('PhotoUploadModal', () => {
   });
 
   it('shows error on XHR network error', async () => {
-    const xhrMock = {
-      open: vi.fn(),
-      send: vi.fn(),
-      upload: { addEventListener: vi.fn() },
-      addEventListener: vi.fn(),
-    };
-
-    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(
-      () => xhrMock as unknown as XMLHttpRequest
-    );
+    function makeXhrMock() {
+      return {
+        open: vi.fn(),
+        send: vi.fn(),
+        upload: { addEventListener: vi.fn() },
+        addEventListener: vi.fn(),
+      };
+    }
+    let xhrMock: ReturnType<typeof makeXhrMock>;
+    xhrMock = makeXhrMock();
+    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(function (this: any) {
+      Object.assign(this, xhrMock);
+    } as unknown as () => XMLHttpRequest);
 
     render(<PhotoUploadModal {...defaultProps} />);
 
@@ -386,18 +396,21 @@ describe('PhotoUploadModal', () => {
   // ================================================================
 
   it('includes snapshotIndex in FormData when provided', async () => {
-    const xhrMock = {
-      open: vi.fn(),
-      send: vi.fn(),
-      upload: { addEventListener: vi.fn() },
-      addEventListener: vi.fn(),
-      status: 201,
-      responseText: JSON.stringify(mockAttachmentResponse),
-    };
-
-    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(
-      () => xhrMock as unknown as XMLHttpRequest
-    );
+    function makeXhrMock() {
+      return {
+        open: vi.fn(),
+        send: vi.fn(),
+        upload: { addEventListener: vi.fn() },
+        addEventListener: vi.fn(),
+        status: 201,
+        responseText: JSON.stringify(mockAttachmentResponse),
+      };
+    }
+    let xhrMock: ReturnType<typeof makeXhrMock>;
+    xhrMock = makeXhrMock();
+    vi.spyOn(window, 'XMLHttpRequest').mockImplementation(function (this: any) {
+      Object.assign(this, xhrMock);
+    } as unknown as () => XMLHttpRequest);
 
     render(<PhotoUploadModal {...defaultProps} snapshotIndex={3} />);
 

--- a/apps/web/src/components/session/__tests__/RandomTools.test.tsx
+++ b/apps/web/src/components/session/__tests__/RandomTools.test.tsx
@@ -19,22 +19,30 @@ vi.mock('framer-motion', async () => {
   return {
     ...actual,
     motion: {
-      div: ({ children, ...props }: { children?: React.ReactNode }) => <div {...props}>{children}</div>,
-      span: ({ children, ...props }: { children?: React.ReactNode }) => <span {...props}>{children}</span>,
-      svg: ({ children, ...props }: { children?: React.ReactNode }) => <svg {...props}>{children}</svg>,
+      div: ({ children, ...props }: { children?: React.ReactNode }) => (
+        <div {...props}>{children}</div>
+      ),
+      span: ({ children, ...props }: { children?: React.ReactNode }) => (
+        <span {...props}>{children}</span>
+      ),
+      svg: ({ children, ...props }: { children?: React.ReactNode }) => (
+        <svg {...props}>{children}</svg>
+      ),
     },
     AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   };
 });
 
-// Mock audio
+// Mock audio — class-based so vitest v4 can use it with `new`
+class MockAudio {
+  play = vi.fn().mockResolvedValue(undefined);
+  pause = vi.fn();
+  currentTime = 0;
+  volume = 1;
+}
+
 beforeEach(() => {
-  vi.spyOn(window, 'Audio').mockImplementation(() => ({
-    play: vi.fn().mockResolvedValue(undefined),
-    pause: vi.fn(),
-    currentTime: 0,
-    volume: 1,
-  } as unknown as HTMLAudioElement));
+  vi.spyOn(window, 'Audio').mockImplementation(MockAudio as unknown as typeof Audio);
 });
 
 describe('CountdownTimer', () => {
@@ -167,9 +175,30 @@ describe('CoinFlip', () => {
 
   it('shows flip history stats when history is provided', () => {
     const flipHistory: CoinFlipResult[] = [
-      { id: '1', sessionId: 's1', participantId: 'u1', participantName: 'P1', result: 'heads', timestamp: new Date() },
-      { id: '2', sessionId: 's1', participantId: 'u1', participantName: 'P1', result: 'tails', timestamp: new Date() },
-      { id: '3', sessionId: 's1', participantId: 'u1', participantName: 'P1', result: 'heads', timestamp: new Date() },
+      {
+        id: '1',
+        sessionId: 's1',
+        participantId: 'u1',
+        participantName: 'P1',
+        result: 'heads',
+        timestamp: new Date(),
+      },
+      {
+        id: '2',
+        sessionId: 's1',
+        participantId: 'u1',
+        participantName: 'P1',
+        result: 'tails',
+        timestamp: new Date(),
+      },
+      {
+        id: '3',
+        sessionId: 's1',
+        participantId: 'u1',
+        participantName: 'P1',
+        result: 'heads',
+        timestamp: new Date(),
+      },
     ];
 
     render(<CoinFlip {...defaultProps} flipHistory={flipHistory} />);
@@ -181,7 +210,14 @@ describe('CoinFlip', () => {
 
   it('displays heads and tails labels', () => {
     const flipHistory: CoinFlipResult[] = [
-      { id: '1', sessionId: 's1', participantId: 'u1', participantName: 'P1', result: 'heads', timestamp: new Date() },
+      {
+        id: '1',
+        sessionId: 's1',
+        participantId: 'u1',
+        participantName: 'P1',
+        result: 'heads',
+        timestamp: new Date(),
+      },
     ];
 
     render(<CoinFlip {...defaultProps} flipHistory={flipHistory} />);
@@ -253,9 +289,7 @@ describe('WheelSpinner', () => {
   });
 
   it('disables spin with less than 2 options', () => {
-    const options: WheelOption[] = [
-      { id: '1', label: 'Solo', color: '#ff0000', weight: 1 },
-    ];
+    const options: WheelOption[] = [{ id: '1', label: 'Solo', color: '#ff0000', weight: 1 }];
 
     render(<WheelSpinner {...defaultProps} options={options} />);
 

--- a/apps/web/src/hooks/__tests__/usePdfStatus.test.ts
+++ b/apps/web/src/hooks/__tests__/usePdfStatus.test.ts
@@ -114,10 +114,10 @@ describe('usePdfStatus', () => {
     vi.useFakeTimers();
     mockEventSourceInstances = [];
 
-    // Wrap in vi.fn() so we can assert calls
-    global.EventSource = vi.fn((url: string) => {
-      return new MockEventSource(url);
-    }) as unknown as typeof EventSource;
+    // Vitest v4: `vi.fn((url) => new X(url))` no longer invokes the arrow callback
+    // when called with `new`. Assign the class directly; constructor pushes into
+    // `mockEventSourceInstances` for assertions (see line 78).
+    global.EventSource = MockEventSource as unknown as typeof EventSource;
   });
 
   afterEach(() => {
@@ -138,7 +138,7 @@ describe('usePdfStatus', () => {
     it('creates EventSource with correct URL', () => {
       renderHook(() => usePdfStatus('test-doc-123', { enableSSE: true }));
 
-      expect(global.EventSource).toHaveBeenCalledWith('/api/v1/pdfs/test-doc-123/status/stream');
+      expect(mockEventSourceInstances[0]?.url).toBe('/api/v1/pdfs/test-doc-123/status/stream');
     });
 
     it('marks connection as connected on SSE open', async () => {

--- a/apps/web/src/lib/domain-hooks/__tests__/useTurnOrder.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useTurnOrder.test.ts
@@ -51,25 +51,42 @@ function mockFetch(status: number, body: unknown) {
 
 // ── tests ──────────────────────────────────────────────────────────────────────
 
+// ── MockEventSource class (Vitest v4: arrow constructor mocks are not called as constructors) ──
+
+interface MockEventSourceInstance {
+  url: string;
+  withCredentials: boolean;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  readyState: number;
+}
+
+let mockEventSourceInstances: MockEventSourceInstance[] = [];
+
+class MockEventSource {
+  url: string;
+  withCredentials: boolean;
+  close = vi.fn();
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  readyState = 0; // CONNECTING
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = options?.withCredentials ?? false;
+    mockEventSourceInstances.push(this as MockEventSourceInstance);
+  }
+}
+
 describe('useTurnOrder', () => {
-  let mockEventSource: {
-    close: ReturnType<typeof vi.fn>;
-    addEventListener: ReturnType<typeof vi.fn>;
-    removeEventListener: ReturnType<typeof vi.fn>;
-    readyState: number;
-  };
+  // Convenience alias for the most-recently-created instance
+  let mockEventSource: MockEventSourceInstance;
 
   beforeEach(() => {
-    mockEventSource = {
-      close: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      readyState: 0, // CONNECTING
-    };
-
-    global.EventSource = vi
-      .fn()
-      .mockImplementation(() => mockEventSource) as unknown as typeof EventSource;
+    mockEventSourceInstances = [];
+    // Vitest v4: assign the class directly — do NOT wrap in vi.fn(() => new …)
+    global.EventSource = MockEventSource as unknown as typeof EventSource;
   });
 
   afterEach(() => {
@@ -322,10 +339,12 @@ describe('useTurnOrder', () => {
 
       renderHook(() => useTurnOrder({ sessionId: 'sess-123', apiBaseUrl: '' }));
 
-      expect(global.EventSource).toHaveBeenCalledWith(
-        expect.stringContaining('/api/v1/game-sessions/sess-123/stream/v2'),
-        expect.objectContaining({ withCredentials: true })
+      // Vitest v4: assert via instance properties, not vi.fn call tracking
+      expect(mockEventSourceInstances).toHaveLength(1);
+      expect(mockEventSourceInstances[0]?.url).toContain(
+        '/api/v1/game-sessions/sess-123/stream/v2'
       );
+      expect(mockEventSourceInstances[0]?.withCredentials).toBe(true);
     });
 
     it('closes the EventSource on unmount', async () => {
@@ -335,7 +354,7 @@ describe('useTurnOrder', () => {
 
       unmount();
 
-      expect(mockEventSource.close).toHaveBeenCalled();
+      expect(mockEventSourceInstances[0]?.close).toHaveBeenCalled();
     });
 
     it('registers a session:toolkit event listener', async () => {
@@ -343,7 +362,7 @@ describe('useTurnOrder', () => {
 
       renderHook(() => useTurnOrder({ sessionId: 'sess-123', apiBaseUrl: '' }));
 
-      expect(mockEventSource.addEventListener).toHaveBeenCalledWith(
+      expect(mockEventSourceInstances[0]?.addEventListener).toHaveBeenCalledWith(
         'session:toolkit',
         expect.any(Function)
       );

--- a/apps/web/src/stores/contextual-hand/__tests__/store.test.ts
+++ b/apps/web/src/stores/contextual-hand/__tests__/store.test.ts
@@ -672,20 +672,24 @@ describe('useContextualHandStore', () => {
       capturedOnMessage = null;
       capturedOnError = null;
 
+      // #1972 M6 vitest v4: arrow functions cannot be used as constructors with `new`.
+      // Use regular function so `this` is bound and `new EventSource(...)` works.
       vi.stubGlobal(
         'EventSource',
-        vi.fn().mockImplementation(() => {
-          const instance = {
-            close: mockClose,
-            onmessage: null as ((e: MessageEvent) => void) | null,
-            onerror: null as (() => void) | null,
-          };
+        vi.fn().mockImplementation(function (this: {
+          close: () => void;
+          onmessage: ((e: MessageEvent) => void) | null;
+          onerror: (() => void) | null;
+        }) {
+          this.close = mockClose;
+          this.onmessage = null;
+          this.onerror = null;
           // Capture callbacks after they're assigned in the next microtask
+          const self = this;
           setTimeout(() => {
-            capturedOnMessage = instance.onmessage;
-            capturedOnError = instance.onerror;
+            capturedOnMessage = self.onmessage;
+            capturedOnError = self.onerror;
           }, 0);
-          return instance;
         })
       );
     });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html', 'lcov', 'cobertura'],
       reportsDirectory: './coverage',
-      all: true,
       clean: true,
       include: ['src/**/*.{js,jsx,ts,tsx}'],
       exclude: [


### PR DESCRIPTION
## Summary

Phase 2 M6 milestone per [#1972](https://github.com/meepleAi-app/meepleai-monorepo/issues/1972) vitest v4 migration. Bumps vitest 3.2.4 → 4.1.0 exact + companions and adapts 16 test files to vitest v4 constructor mock semantics.

## Bump

- `vitest`: `^3.2.4` → `4.1.0` (exact pin per DEC-2c hard cutover rollback)
- `@vitest/coverage-v8`: `^3.2.4` → `4.1.0`
- `@vitest/ui`: `^3.2.4` → `4.1.0`
- `vitest.config.ts`: remove deprecated `coverage.all: true` (v4 uses `coverage.include` explicit, already present)

## Breaking change addressed

Vitest v4 no longer invokes arrow factories on `new` keyword. Patterns like `vi.fn().mockImplementation(() => ({ method: vi.fn() }))` silently fail because the constructor wraps an arrow that never executes (returns `undefined`). Three fix flavors applied per call site:

1. **Class direct assignment** — when constructor tracking via instance array already exists (M2 canary `usePdfStatus` pattern):
   ```ts
   // BEFORE (broken on v4)
   global.EventSource = vi.fn((url) => new MockEventSource(url)) as unknown as typeof EventSource;
   // AFTER
   global.EventSource = MockEventSource as unknown as typeof EventSource;
   ```
   `toHaveBeenCalledWith` assertions adapted to use `mockEventSourceInstances[0]?.url`.

2. **Function-with-this** — when test relies on shared mock reference (preserves test API):
   ```ts
   vi.spyOn(window, 'XMLHttpRequest').mockImplementation(function (this: any) {
     Object.assign(this, xhrMock);
   });
   ```

3. **Class with instance property mocks** — for module factories:
   ```ts
   vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: class {} }));
   ```

## Files fixed (16)

| Pattern | File | Failures |
|---|---|---|
| P4 EventSource class | `usePdfStatus.test.ts` (M2 canary regression) | 12 |
| P4 EventSource class | `useTurnOrder.test.ts` | 2 |
| P6 Audio class | `RandomTools.test.tsx` | 21 |
| P5 FileReader+Image fn-this | `AvatarUpload.test.tsx` | 12 |
| P7 XHR fn-this | `PhotoUploadModal.test.tsx` | 4 |
| P7 XHR fn-this | `PdfUploadSection.priority.test.tsx` | 2 |
| P1 constructor fn-this | `contextual-hand/store.test.ts` | 3 |
| P2 Blob jsdom + URL stub | `photos/page.test.tsx` | 2 |
| P3 URL spy unconditional | `CropDialog.test.tsx` | 1 |
| HttpClient class | `usage-page.test.tsx` | TBD |
| HttpClient class | `processing/page.test.tsx` | TBD |
| HttpClient class | `mechanic-extractor/page.test.tsx` | TBD |
| HttpClient class | `mechanic-extractor/analyses/page.test.tsx` | TBD |
| HttpClient class | `MechanicAnalysesListCard.test.tsx` | TBD |
| Test isolation (mockReturnValue reset) | `CollectionDashboard.test.tsx` | 3 |
| P10 jspdf fn-this | `export.test.ts` | 3 |

## DEC-2b SMART validation

| Criterion | v3.2.4 baseline | v4.1.0 post-fix | Status |
|---|---|---|---|
| Test count | 20956 total | 20956 total | SAME ✅ |
| Test failures | 2 | **0** | -2 ✅ |
| Test passed | 20922 | 20924 | +2 ✅ |
| Test skipped | 32 | 32 | 0 ✅ |
| Runtime | 1290.45s | 1007.71s | **-22% faster** ✅ |
| Coverage delta | N/A (cleanup) | < 0.5pp expected | TBD on CI |
| All shards green | NO (2 fail) | YES (0 fail) | ✅ |
| Flake retries | N/A | 0 | ✅ |

## References

- Plan: [`docs/superpowers/plans/2026-06-09-large-medium-remaining-plan.md`](../blob/main-dev/docs/superpowers/plans/2026-06-09-large-medium-remaining-plan.md) § Phase 2 M6
- Audit M1: [`docs/superpowers/audits/2026-06-09-issue-1972-vitest-v4-audit.md`](../blob/main-dev/docs/superpowers/audits/2026-06-09-issue-1972-vitest-v4-audit.md)
- DEC-2 LOCKED: sess.46f spec-panel + user-locked (Option B mid-ground, SMART gate, hard cutover rollback)
- Prior milestones shipped:
  - M1 audit deliverable (PR #2058)
  - M2 PoC canary `alert-config.api.test.ts` (PR #2060)
  - M3 Pattern 3 URL polyfill (PR #2074)
  - M4 Pattern 1 jscodeshift batch (PR #2064)
  - M5 verify-only NO-OP (sess.46g discovery)

## Next milestone

**M7 CI verde 4 shards + 7-day post-merge runtime alert** (DEC-2c monitoring activation).

## Notes

- M2 PR #2060 fix was actually broken on v4 (relied on `vi.fn(arrow)` invoking callback) — corrected in this PR.
- M3 PR #2074 global URL polyfill protected some files but `CropDialog.test.tsx` had local `if (typeof === 'undefined')` override that needed unconditional treatment too.
- Single mega-PR per user decision to ship bump + 16-file fix inline (not split per pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)