### PR TITLE
feat(catalog): #1823 M3 Wikidata cover SPARQL fetch

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -130,6 +130,15 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
         var sourceUrl = $"https://www.wikidata.org/wiki/{qid}";
         var stopwatch = Stopwatch.StartNew();
 
+        // ADR DEC-3g: record SPARQL latency on every COMPLETED round-trip
+        // (success + non-success status) so ops can detect endpoint degradation.
+        // The flag is flipped AFTER SendAsync returns a response — network setup
+        // failures (DNS error, connection refused) that throw before a response
+        // is received are NOT counted (no round-trip to measure).
+        // The finally block guarantees emission across success, 5xx, body-read
+        // failures, JSON parse errors, and cancellation rethrow.
+        var roundTripCompleted = false;
+
         try
         {
             using var req = new HttpRequestMessage(
@@ -138,12 +147,8 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/sparql-results+json"));
 
             using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            roundTripCompleted = true;
             var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-
-            // ADR DEC-3g: record SPARQL latency on every completed round-trip
-            // (regardless of HTTP status) so ops can detect endpoint degradation.
-            stopwatch.Stop();
-            MeepleAiMetrics.WikidataSparqlLatency.Record(stopwatch.Elapsed.TotalSeconds);
 
             if (!resp.IsSuccessStatusCode)
             {
@@ -161,6 +166,14 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
         {
             _logger.LogWarning(ex, "Wikidata cover fetch failed for QID {Qid}", qid);
             return WikidataCoverImageResult.NotFound(qid);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            if (roundTripCompleted)
+            {
+                MeepleAiMetrics.WikidataSparqlLatency.Record(stopwatch.Elapsed.TotalSeconds);
+            }
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Observability;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
@@ -26,13 +29,26 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
         RegexOptions.CultureInvariant | RegexOptions.Compiled,
         TimeSpan.FromMilliseconds(200));
 
+    // Prefix matched against the Wikidata SPARQL IRI for P18 (image) bindings.
+    // Wikidata embeds the Commons filename after this prefix (URL-encoded per Wikidata convention).
+    // S1075 suppressed: this is the stable Wikidata IRI scheme returned by the SPARQL endpoint,
+    // not an internal infra URL.
+#pragma warning disable S1075 // URIs should not be hardcoded
+    private const string CommonsFilePathPrefix = "http://commons.wikimedia.org/wiki/Special:FilePath/";
+#pragma warning restore S1075
+
     private readonly HttpClient _http;
     private readonly ILogger<WikidataCatalogProvider> _logger;
+    private readonly IWikimediaRateLimiter _rateLimiter;
 
-    public WikidataCatalogProvider(HttpClient http, ILogger<WikidataCatalogProvider> logger)
+    public WikidataCatalogProvider(
+        HttpClient http,
+        ILogger<WikidataCatalogProvider> logger,
+        IWikimediaRateLimiter rateLimiter)
     {
         _http = http ?? throw new ArgumentNullException(nameof(http));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _rateLimiter = rateLimiter ?? throw new ArgumentNullException(nameof(rateLimiter));
     }
 
     public async Task<CatalogProviderResult> FetchAsync(CatalogProviderQuery query, CancellationToken ct)
@@ -72,6 +88,131 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
         {
             _logger.LogWarning(ex, "Wikidata fetch failed");
             return CatalogProviderResult.Empty(ex.GetType().Name);
+        }
+    }
+
+    /// <summary>
+    /// Issue #1823 Phase B M3 — fetches the Wikidata Commons cover filename
+    /// (<c>wdt:P18</c> claim) for the supplied QID.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Consumes the shared <see cref="IWikimediaRateLimiter"/> (ADR DEC-3e) BEFORE
+    /// issuing the SPARQL request so concurrent Wikidata + Commons clients cannot
+    /// burst past the published 5 RPS cap. Records latency on the
+    /// <c>meepleai.wikidata.sparql.latency_seconds</c> histogram per ADR DEC-3g.
+    /// </para>
+    /// <para>
+    /// Returns <see cref="WikidataCoverImageResult.NotFound(string)"/> when:
+    /// <list type="bullet">
+    ///   <item>the QID fails the safe regex (no SPARQL injection),</item>
+    ///   <item>the QID exists but has no <c>P18</c> claim,</item>
+    ///   <item>Wikidata returns a non-success HTTP status (caller decides retry),</item>
+    ///   <item>the response body is malformed.</item>
+    /// </list>
+    /// Cancellation propagates as <see cref="OperationCanceledException"/>.
+    /// </para>
+    /// </remarks>
+    public async Task<WikidataCoverImageResult> FetchCoverImageAsync(
+        string qid,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(qid) || !WikidataQidPattern.IsMatch(qid))
+        {
+            return WikidataCoverImageResult.NotFound(qid ?? string.Empty);
+        }
+
+        // ADR DEC-3e: shared 5 RPS cap. Acquire BEFORE the HTTP round-trip so
+        // Wikidata + Commons consumers cannot drift apart and exceed the cap.
+        await _rateLimiter.AcquireAsync(ct).ConfigureAwait(false);
+
+        var sparql = BuildCoverSparql(qid);
+        var sourceUrl = $"https://www.wikidata.org/wiki/{qid}";
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var req = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"{SparqlPath}?query={Uri.EscapeDataString(sparql)}&format=json");
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/sparql-results+json"));
+
+            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            // ADR DEC-3g: record SPARQL latency on every completed round-trip
+            // (regardless of HTTP status) so ops can detect endpoint degradation.
+            stopwatch.Stop();
+            MeepleAiMetrics.WikidataSparqlLatency.Record(stopwatch.Elapsed.TotalSeconds);
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Wikidata SPARQL cover fetch HTTP {Status} for QID {Qid}",
+                    (int)resp.StatusCode,
+                    qid);
+                return WikidataCoverImageResult.NotFound(qid);
+            }
+
+            return ParseCoverResponse(body, qid, sourceUrl);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Wikidata cover fetch failed for QID {Qid}", qid);
+            return WikidataCoverImageResult.NotFound(qid);
+        }
+    }
+
+    private static string BuildCoverSparql(string qid) => $@"
+SELECT ?image
+WHERE {{
+  BIND(wd:{qid} AS ?game)
+  OPTIONAL {{ ?game wdt:P18 ?image. }}
+}}
+LIMIT 1";
+
+    private static WikidataCoverImageResult ParseCoverResponse(string body, string qid, string sourceUrl)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("results", out var results) ||
+                !results.TryGetProperty("bindings", out var bindings) ||
+                bindings.ValueKind != JsonValueKind.Array ||
+                bindings.GetArrayLength() == 0)
+            {
+                return WikidataCoverImageResult.NotFound(qid);
+            }
+
+            var row = bindings[0];
+            if (!row.TryGetProperty("image", out var imageEl) ||
+                !imageEl.TryGetProperty("value", out var valueEl))
+            {
+                return WikidataCoverImageResult.NotFound(qid);
+            }
+
+            var iri = valueEl.GetString();
+            if (string.IsNullOrEmpty(iri) ||
+                !iri.StartsWith(CommonsFilePathPrefix, StringComparison.Ordinal))
+            {
+                return WikidataCoverImageResult.NotFound(qid);
+            }
+
+            // Preserve raw URL-encoded filename — Commons API + R2 keys downstream
+            // expect the Wikidata IRI convention (spaces as %20, etc.).
+            var filename = iri[CommonsFilePathPrefix.Length..];
+            if (string.IsNullOrEmpty(filename))
+            {
+                return WikidataCoverImageResult.NotFound(qid);
+            }
+
+            return WikidataCoverImageResult.Found(filename, sourceUrl);
+        }
+        catch (JsonException)
+        {
+            // Malformed response body — treat as no-result; caller decides retry.
+            return WikidataCoverImageResult.NotFound(qid);
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCoverImageResult.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCoverImageResult.cs
@@ -1,0 +1,32 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+/// <summary>
+/// Result of <see cref="WikidataCatalogProvider.FetchCoverImageAsync(string, CancellationToken)"/>.
+/// Encapsulates the optional Wikidata Commons filename (P18 property) and the canonical
+/// source URL for attribution purposes.
+/// </summary>
+/// <param name="Filename">
+/// Raw, URL-encoded Commons filename (e.g. <c>Brass%20Birmingham%20cover.jpg</c>). Preserved
+/// in encoded form because downstream Commons API + R2 keys expect the raw Wikidata IRI
+/// convention. <see langword="null"/> when no <c>wdt:P18</c> claim exists for the QID.
+/// </param>
+/// <param name="SourceUrl">
+/// Canonical Wikidata entity URL (e.g. <c>https://www.wikidata.org/wiki/Q98056728</c>).
+/// Always non-null — used by callers for provenance even when no image was found.
+/// </param>
+/// <remarks>
+/// Issue #1823 Phase B M3. ADR DEC-3a (extend existing provider).
+/// </remarks>
+public sealed record WikidataCoverImageResult(string? Filename, string SourceUrl)
+{
+    /// <summary>Convenience flag — <see langword="true"/> when <see cref="Filename"/> is non-null.</summary>
+    public bool HasImage => Filename is not null;
+
+    /// <summary>Constructs a result for the success case (image found).</summary>
+    public static WikidataCoverImageResult Found(string filename, string sourceUrl) =>
+        new(filename, sourceUrl);
+
+    /// <summary>Constructs a result for the not-found case (QID invalid, missing P18, or HTTP error).</summary>
+    public static WikidataCoverImageResult NotFound(string qid) =>
+        new(null, $"https://www.wikidata.org/wiki/{qid}");
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderCoverImageTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderCoverImageTests.cs
@@ -1,0 +1,299 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+
+/// <summary>
+/// Tests for <see cref="WikidataCatalogProvider.FetchCoverImageAsync(string, CancellationToken)"/>.
+/// Issue #1823 Phase B M3 — Wikidata cover SPARQL fetch.
+/// Spec: ADR DEC-3a (extend existing provider) + DEC-3e (shared 5 RPS rate-limiter) + DEC-3g (latency metric).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class WikidataCatalogProviderCoverImageTests
+{
+    private static (HttpClient client, Mock<HttpMessageHandler> handler) MakeClient(
+        HttpStatusCode status,
+        string body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/sparql-results+json"),
+            });
+        var client = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("https://query.wikidata.org/"),
+        };
+        return (client, handler);
+    }
+
+    private static WikidataCatalogProvider MakeProvider(
+        HttpClient client,
+        IWikimediaRateLimiter? rateLimiter = null)
+    {
+        rateLimiter ??= Mock.Of<IWikimediaRateLimiter>();
+        return new WikidataCatalogProvider(client, NullLogger<WikidataCatalogProvider>.Instance, rateLimiter);
+    }
+
+    private const string BodyWithImage = """
+        { "results": { "bindings": [{
+          "game":  {"value": "http://www.wikidata.org/entity/Q17215001"},
+          "image": {"value": "http://commons.wikimedia.org/wiki/Special:FilePath/Playing%20board%20game%20-%20Play%201048%201724352635173.jpg"}
+        }]}}
+        """;
+
+    private const string BodyNoImage = """
+        { "results": { "bindings": [{
+          "game":  {"value": "http://www.wikidata.org/entity/Q17215001"}
+        }]}}
+        """;
+
+    private const string BodyEmpty = """{"results":{"bindings":[]}}""";
+
+    [Fact]
+    public async Task FetchCoverImageAsync_ValidQid_WithP18_ReturnsFilenameAndSourceUrl()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeTrue();
+        result.Filename.Should().Be("Playing%20board%20game%20-%20Play%201048%201724352635173.jpg");
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q17215001");
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_ValidQid_NoP18_ReturnsNotFound()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyNoImage);
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        result.Filename.Should().BeNull();
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q17215001");
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_EmptyBindings_ReturnsNotFound()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyEmpty);
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        result.Filename.Should().BeNull();
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q17215001");
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_InvalidQidFormat_ReturnsNotFoundWithoutHttpCall()
+    {
+        var (client, handler) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("invalid", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        result.Filename.Should().BeNull();
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/invalid");
+
+        // No HTTP round-trip when QID fails regex validation.
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_QidWithSparqlInjectionAttempt_ReturnsNotFoundWithoutHttpCall()
+    {
+        var (client, handler) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var provider = MakeProvider(client);
+
+        // Injection attempt — must be rejected by regex.
+        var result = await provider.FetchCoverImageAsync("Q123} . ?x ?y ?z", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_AcquiresRateLimiterBeforeHttpCall()
+    {
+        var (client, handler) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var rateLimiterMock = new Mock<IWikimediaRateLimiter>(MockBehavior.Strict);
+
+        var rateLimiterAcquired = false;
+        var httpCalledBeforeRateLimiter = false;
+
+        rateLimiterMock
+            .Setup(r => r.AcquireAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                rateLimiterAcquired = true;
+                return ValueTask.CompletedTask;
+            });
+
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                if (!rateLimiterAcquired)
+                {
+                    httpCalledBeforeRateLimiter = true;
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(BodyWithImage, System.Text.Encoding.UTF8, "application/sparql-results+json"),
+                };
+            });
+
+        var provider = MakeProvider(client, rateLimiterMock.Object);
+
+        await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        rateLimiterMock.Verify(r => r.AcquireAsync(It.IsAny<CancellationToken>()), Times.Once());
+        httpCalledBeforeRateLimiter.Should().BeFalse("rate limiter must be acquired BEFORE the SPARQL HTTP call");
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_InvalidQid_DoesNotAcquireRateLimiter()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var rateLimiterMock = new Mock<IWikimediaRateLimiter>(MockBehavior.Strict);
+        // No setup — strict mock will throw if AcquireAsync is invoked.
+        var provider = MakeProvider(client, rateLimiterMock.Object);
+
+        var result = await provider.FetchCoverImageAsync("invalid", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        rateLimiterMock.Verify(
+            r => r.AcquireAsync(It.IsAny<CancellationToken>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_RecordsSparqlLatencyMetric_OnSuccess()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var provider = MakeProvider(client);
+
+        var recordedValues = new List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "meepleai.wikidata.sparql.latency_seconds")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((instrument, value, tags, state) =>
+        {
+            recordedValues.Add(value);
+        });
+        listener.Start();
+
+        await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        recordedValues.Should().HaveCount(1, "exactly one latency observation per successful SPARQL round-trip");
+        recordedValues[0].Should().BeGreaterThanOrEqualTo(0.0);
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_Http5xx_LogsWarningAndReturnsNotFound()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.InternalServerError, "boom");
+        var provider = MakeProvider(client);
+
+        // Should not throw — caller decides retry.
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        result.Filename.Should().BeNull();
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q17215001");
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_HttpCancellation_RethrowsOperationCanceledException()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("cancelled"));
+        var client = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("https://query.wikidata.org/"),
+        };
+        var provider = MakeProvider(client);
+
+        var act = async () => await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_MalformedJson_ReturnsNotFound()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, "not json at all");
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse();
+        result.Filename.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_FilenamePreservesUrlEncoding()
+    {
+        // Sanity: the Wikidata IRI uses URL-encoded filenames (per Wikidata convention).
+        // We must preserve the raw encoded form, NOT decode it — downstream Commons API
+        // and R2 keys expect the raw encoded filename.
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.Filename.Should().Contain("%20", "spaces must remain URL-encoded as %20");
+        result.Filename.Should().NotContain(" ", "no raw spaces — verify no accidental URL decoding");
+    }
+
+    [Fact]
+    public async Task FetchCoverImageAsync_DifferentQid_BuildsCorrectSourceUrl()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.OK, BodyWithImage);
+        var provider = MakeProvider(client);
+
+        var result = await provider.FetchCoverImageAsync("Q98056728", CancellationToken.None);
+
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q98056728");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderCoverImageTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderCoverImageTests.cs
@@ -296,4 +296,85 @@ public sealed class WikidataCatalogProviderCoverImageTests
 
         result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q98056728");
     }
+
+    /// <summary>
+    /// ADR DEC-3g — network setup failure (e.g. DNS error, connection refused)
+    /// raised BEFORE a response is received does NOT emit the SPARQL latency
+    /// metric: the metric measures completed round-trips only, not connection
+    /// attempts.
+    /// </summary>
+    [Fact]
+    public async Task FetchCoverImageAsync_NetworkError_DoesNotRecordSparqlLatencyMetric()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("simulated network error"));
+        var client = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("https://query.wikidata.org/"),
+        };
+        var provider = MakeProvider(client);
+
+        var recordedValues = new List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "meepleai.wikidata.sparql.latency_seconds")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((instrument, value, tags, state) =>
+        {
+            recordedValues.Add(value);
+        });
+        listener.Start();
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse("network error caught by provider");
+        recordedValues.Should().BeEmpty(
+            "metric should NOT be emitted when network setup fails before a response is received");
+    }
+
+    /// <summary>
+    /// ADR DEC-3g — a non-success HTTP status (5xx) still completes the SPARQL
+    /// round-trip, so the latency metric MUST be emitted. This locks the
+    /// contract previously broken when the metric lived inside the try block
+    /// after a non-cancellation exception path (code review finding score 85
+    /// on PR #2104).
+    /// </summary>
+    [Fact]
+    public async Task FetchCoverImageAsync_5xxResponse_RecordsSparqlLatencyMetric()
+    {
+        var (client, _) = MakeClient(HttpStatusCode.InternalServerError, "boom");
+        var provider = MakeProvider(client);
+
+        var recordedValues = new List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "meepleai.wikidata.sparql.latency_seconds")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((instrument, value, tags, state) =>
+        {
+            recordedValues.Add(value);
+        });
+        listener.Start();
+
+        var result = await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+
+        result.HasImage.Should().BeFalse("5xx response returns NotFound");
+        recordedValues.Should().HaveCount(
+            1,
+            "metric MUST be emitted on every completed round-trip, including non-success HTTP status");
+        recordedValues[0].Should().BeGreaterThanOrEqualTo(0.0);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -28,7 +29,7 @@ public sealed class WikidataCatalogProviderTests
     [Fact]
     public void Name_Equals_Wikidata()
     {
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
         provider.Name.Should().Be("wikidata");
     }
 
@@ -47,7 +48,7 @@ public sealed class WikidataCatalogProviderTests
           "playingTimeMinutes":{"value": "60"}
         }]}}
         """;
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
         var result = await provider.FetchAsync(new CatalogProviderQuery(BggId: 13, null, null), default);
 
         result.Success.Should().BeTrue();
@@ -66,7 +67,7 @@ public sealed class WikidataCatalogProviderTests
     public async Task FetchAsync_NoResults_ReturnsEmptyWithError()
     {
         const string body = """{"results":{"bindings":[]}}""";
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
         var result = await provider.FetchAsync(new CatalogProviderQuery(99999, null, null), default);
 
         result.Success.Should().BeFalse();
@@ -76,7 +77,7 @@ public sealed class WikidataCatalogProviderTests
     [Fact]
     public async Task FetchAsync_HttpError_ReturnsErrorMessage()
     {
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.InternalServerError, "boom"), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.InternalServerError, "boom"), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
         var result = await provider.FetchAsync(new CatalogProviderQuery(13, null, null), default);
 
         result.Success.Should().BeFalse();
@@ -86,7 +87,7 @@ public sealed class WikidataCatalogProviderTests
     [Fact]
     public async Task FetchAsync_AllNullInputs_ReturnsMissingParametersError()
     {
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
 
         var result = await provider.FetchAsync(new CatalogProviderQuery(null, null, null), default);
 
@@ -97,7 +98,7 @@ public sealed class WikidataCatalogProviderTests
     [Fact]
     public async Task FetchAsync_InvalidWikidataQid_ReturnsValidationError()
     {
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, "{}"), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
 
         var result = await provider.FetchAsync(new CatalogProviderQuery(null, "Q123} . ?x ?y ?z", null), default);
 
@@ -115,7 +116,7 @@ public sealed class WikidataCatalogProviderTests
           "gameLabel":   {"value": "Catan"}
         }]}}
         """;
-        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance);
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
 
         var result = await provider.FetchAsync(new CatalogProviderQuery(null, "Q98056728", null), default);
 


### PR DESCRIPTION
## Summary

Issue #1823 Phase B M3 — Wikidata cover SPARQL fetch. Extends `WikidataCatalogProvider` with `FetchCoverImageAsync(qid)` per ADR DEC-3a (no parallel client).

## Scope

- **New public method** `WikidataCatalogProvider.FetchCoverImageAsync(string qid, CancellationToken ct)` queries `wdt:P18` (image) property via SPARQL `BIND(wd:{qid} AS ?game)` + `OPTIONAL { ?game wdt:P18 ?image }` `LIMIT 1`.
- **New record** `WikidataCoverImageResult(string? Filename, string SourceUrl)` with `Found` / `NotFound` static factories + `HasImage` convenience flag.
- **Constructor extended** with `IWikimediaRateLimiter` dependency (already registered Singleton in `SharedGameCatalogServiceExtensions.cs:198` by PR #2099 — DI resolves automatically).
- **Filename preservation**: raw URL-encoded form extracted from `http://commons.wikimedia.org/wiki/Special:FilePath/<filename>` IRI (per Wikidata convention; downstream Commons API + R2 keys expect encoded form).

## Architecture compliance

- **ADR DEC-3a** — extends existing provider, no parallel client.
- **ADR DEC-3e** — `IWikimediaRateLimiter.AcquireAsync` invoked BEFORE every SPARQL round-trip; shared 5 RPS cap honoured across Wikidata + future Commons consumers.
- **ADR DEC-3g** — `MeepleAiMetrics.WikidataSparqlLatency` histogram recorded on every completed round-trip (success + non-2xx).
- **Pitfall #2568** — infra service, never throws on 5xx; logs warning + returns `WikidataCoverImageResult.NotFound(qid)` so caller decides retry. `OperationCanceledException` rethrown.

## Test cases (13 new, all green)

`WikidataCatalogProviderCoverImageTests`:
- `ValidQid_WithP18_ReturnsFilenameAndSourceUrl`
- `ValidQid_NoP18_ReturnsNotFound`
- `EmptyBindings_ReturnsNotFound`
- `InvalidQidFormat_ReturnsNotFoundWithoutHttpCall` (no HTTP roundtrip on regex fail)
- `QidWithSparqlInjectionAttempt_ReturnsNotFoundWithoutHttpCall`
- `AcquiresRateLimiterBeforeHttpCall` (Mock.Verify call order)
- `InvalidQid_DoesNotAcquireRateLimiter` (strict mock; skips limiter when regex fails)
- `RecordsSparqlLatencyMetric_OnSuccess` (`System.Diagnostics.Metrics.MeterListener` capture)
- `Http5xx_LogsWarningAndReturnsNotFound` (no throw)
- `HttpCancellation_RethrowsOperationCanceledException`
- `MalformedJson_ReturnsNotFound`
- `FilenamePreservesUrlEncoding` (sanity: `%20` not decoded to space)
- `DifferentQid_BuildsCorrectSourceUrl`

Existing `WikidataCatalogProviderTests` (7 tests) updated for new 3-arg constructor; all still pass.

## Verification

- `dotnet test --filter "FullyQualifiedName~WikidataCatalogProviderCoverImageTests"` → 13/13 pass (638 ms)
- `dotnet test --filter "FullyQualifiedName~WikidataCatalogProviderTests"` → 7/7 pass (212 ms)
- `dotnet test --filter "FullyQualifiedName~SharedGameCatalog&Category=Unit"` → 2297/2297 pass (16 pre-existing skips, 0 regressions)

## Phase B foundations consumed

- `IWikimediaRateLimiter` + `InMemoryWikimediaRateLimiter` — PR #2099
- `MeepleAiMetrics.WikidataSparqlLatency` — PR #2099

## Out of scope

- M4 — `IWikimediaCommonsClient.FetchLicenseAsync(filename)` (license whitelist check)
- M6 — `IWebpVariantGenerator` (ImageSharp variant pipeline)
- M7 — `ICoverR2UploadPipeline` (R2 upload)
- M8 — `EnrichCatalogCoverCommandHandler` orchestrator

## ADR reference

[`docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md) DEC-3a + DEC-3e + DEC-3g.

## Test plan

- [x] Unit tests for SPARQL fetch happy path
- [x] Unit tests for QID validation (no injection)
- [x] Unit tests for rate-limiter call order
- [x] Unit tests for metric recording
- [x] Unit tests for error paths (5xx, cancellation, malformed JSON)
- [x] Regression check: existing `WikidataCatalogProviderTests` + full SharedGameCatalog unit suite green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>