### PR TITLE
feat(catalog): #1823 M4 Wikimedia Commons license fetcher

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -300,6 +300,23 @@ internal static class SharedGameCatalogServiceExtensions
             client.Timeout = TimeSpan.FromSeconds(30);
         });
 
+        // Issue #1823 M4 (ADR DEC-3b/3c/3e): Wikimedia Commons license fetcher.
+        // Consumed by the M8 orchestrator AFTER the Wikidata SPARQL pass resolves
+        // a wdt:P18 IRI to a filename. Shares the 5 RPS IWikimediaRateLimiter
+        // (registered as Singleton above) with WikidataCatalogProvider so the
+        // combined SPARQL + Commons traffic stays under the cap. The S1075
+        // suppression below covers the public Commons API endpoint just like
+        // the other catalog providers.
+#pragma warning disable S1075 // URIs should not be hardcoded
+        const string CommonsBaseUrl = "https://commons.wikimedia.org/";
+#pragma warning restore S1075
+        services.AddHttpClient<IWikimediaCommonsClient, WikimediaCommonsClient>(client =>
+        {
+            client.BaseAddress = new Uri(CommonsBaseUrl);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(CatalogUserAgent);
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+
         services.AddHttpClient<BggCatalogProvider>(client =>
         {
             client.BaseAddress = new Uri(BggBaseUrl);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/CommonsLicenseResult.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/CommonsLicenseResult.cs
@@ -1,0 +1,44 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Outcome of <see cref="IWikimediaCommonsClient.FetchLicenseAsync"/>.
+/// Phase B foundation for issue #1823 L2 cover enrichment.
+/// </summary>
+/// <param name="RawLicense">
+/// The raw <c>extmetadata.LicenseShortName</c> value returned by the Commons
+/// API (e.g. <c>"CC BY-SA 4.0"</c>, <c>"CC0"</c>, <c>"Public domain"</c>).
+/// <c>null</c> when the file is missing, the metadata is absent, or the request
+/// failed (see <see cref="NotAvailable"/>).
+/// </param>
+/// <param name="IsWhitelisted">
+/// <c>true</c> when <see cref="RawLicense"/> matches the DEC-3c whitelist
+/// (PD / CC0 / CC-BY / CC-BY-SA, any version) per
+/// <see cref="LicenseValidator.IsWhitelisted"/>. Always <c>false</c> when
+/// <see cref="RawLicense"/> is <c>null</c>.
+/// </param>
+/// <param name="Attribution">
+/// The plain-text artist credit derived from <c>extmetadata.Artist</c>, intended
+/// for persistence in <c>shared_games.cover_attribution</c>. <c>null</c> when
+/// the Artist field is missing (typical for CC0 / public domain works) or when
+/// the file lookup failed.
+/// </param>
+internal sealed record CommonsLicenseResult(string? RawLicense, bool IsWhitelisted, string? Attribution)
+{
+    /// <summary>
+    /// Sentinel result used when the Commons API call failed, the file is
+    /// missing, or the response did not include the required metadata fields.
+    /// Callers (M8 orchestrator) treat this as "skip cover enrichment for this
+    /// game" — not as an exception.
+    /// </summary>
+    public static CommonsLicenseResult NotAvailable() => new(null, false, null);
+
+    /// <summary>
+    /// Successful result with the raw license string, the whitelist verdict, and
+    /// an optional attribution string.
+    /// </summary>
+    /// <param name="rawLicense">Raw <c>extmetadata.LicenseShortName</c> value.</param>
+    /// <param name="whitelisted">Whitelist verdict from <see cref="LicenseValidator.IsWhitelisted"/>.</param>
+    /// <param name="attribution">Plain-text artist credit, or <c>null</c> when absent.</param>
+    public static CommonsLicenseResult Found(string rawLicense, bool whitelisted, string? attribution) =>
+        new(rawLicense, whitelisted, attribution);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs
@@ -1,0 +1,52 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Fetches license metadata for a Wikimedia Commons file. Phase B foundation for
+/// issue #1823 L2 cover enrichment. Consumed by the cover enrichment orchestrator
+/// (M8) AFTER the Wikidata SPARQL pass (M3) has resolved a <c>wdt:P18</c> IRI to
+/// a filename.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ADR <c>adr-2026-06-09-wikidata-enrichment-architecture.md</c>:
+/// <list type="bullet">
+///   <item>DEC-3b — Commons fetcher is intentionally separate from
+///   <c>WikidataCatalogProvider</c> so each client owns a single responsibility
+///   (catalog seed vs license fetch). Both consume the shared
+///   <see cref="IWikimediaRateLimiter"/> to coordinate the 5 RPS cap.</item>
+///   <item>DEC-3c — License whitelist is enforced by
+///   <see cref="LicenseValidator"/>; only the whitelisted licenses (PD / CC0 /
+///   CC-BY / CC-BY-SA, any version) survive into <c>shared_games.cover_license</c>.</item>
+///   <item>DEC-3e — 5 RPS shared cap across Wikidata SPARQL + Commons API,
+///   enforced by <see cref="IWikimediaRateLimiter.AcquireAsync"/> consumed
+///   BEFORE every HTTP call.</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal interface IWikimediaCommonsClient
+{
+    /// <summary>
+    /// Fetches license metadata for a Commons file via the imageinfo API.
+    /// </summary>
+    /// <param name="filename">
+    /// Filename in URL-encoded form (e.g. <c>"Brass%20Birmingham%20cover.jpg"</c>) as
+    /// extracted from a Wikidata <c>wdt:P18</c> IRI (Special:FilePath). The implementation
+    /// internally calls <see cref="Uri.UnescapeDataString(string)"/> before constructing the API
+    /// call, because the Commons API expects the raw filename, not the URL-encoded form.
+    /// DO NOT pre-decode the filename upstream — pass it through as received from Wikidata
+    /// to avoid double-decoding bugs (e.g. <c>%2520</c> → <c>%20</c> → <c>space</c>
+    /// vs. <c>%20</c> → <c>space</c>).
+    /// </param>
+    /// <param name="ct">Cancellation token. <see cref="OperationCanceledException"/> is rethrown.</param>
+    /// <returns>
+    /// A <see cref="CommonsLicenseResult"/> that is either:
+    /// <list type="bullet">
+    ///   <item><see cref="CommonsLicenseResult.NotAvailable"/> when the file is missing,
+    ///   the response is malformed, or the API returns 5xx (caller decides retry);</item>
+    ///   <item><see cref="CommonsLicenseResult.Found"/> with the raw license, a
+    ///   whitelist flag (<see cref="LicenseValidator.IsWhitelisted"/>), and an optional
+    ///   attribution string (extracted from <c>extmetadata.Artist</c>).</item>
+    /// </list>
+    /// </returns>
+    Task<CommonsLicenseResult> FetchLicenseAsync(string filename, CancellationToken ct);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
@@ -1,0 +1,235 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Typed <see cref="HttpClient"/> wrapper that calls the Wikimedia Commons
+/// imageinfo API to retrieve license metadata for a file referenced by a
+/// Wikidata <c>wdt:P18</c> IRI. Phase B foundation for issue #1823 (ADR DEC-3b /
+/// DEC-3c / DEC-3e).
+/// </summary>
+/// <remarks>
+/// <para>
+/// API contract: <c>GET /w/api.php?action=query&amp;prop=imageinfo&amp;iiprop=extmetadata&amp;titles=File:{name}&amp;format=json</c>.
+/// The Commons API returns a <c>query.pages.{pageId}.imageinfo[0].extmetadata</c>
+/// blob; this client extracts only <c>LicenseShortName</c> and <c>Artist</c>,
+/// validates the license against the DEC-3c whitelist via
+/// <see cref="LicenseValidator"/>, and returns a structured result.
+/// </para>
+/// <para>
+/// Failure semantics: 5xx responses, malformed JSON, missing pages, and missing
+/// metadata all collapse into <see cref="CommonsLicenseResult.NotAvailable"/>
+/// with a warning log line. The M8 orchestrator decides whether to skip the
+/// game or queue a retry; this client never propagates exceptions for transient
+/// failures. <see cref="OperationCanceledException"/> is the sole exception
+/// rethrown, so caller cancellation is respected.
+/// </para>
+/// </remarks>
+internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
+{
+    private const string ApiPath = "w/api.php";
+
+    /// <summary>
+    /// Strips HTML tags from the Commons <c>Artist</c> field, which is returned
+    /// as HTML fragment (typically a <c>&lt;a&gt;...&lt;/a&gt;</c> wrapping the user
+    /// name). Anchored, non-greedy, DoS-safe via a 200ms timeout.
+    /// </summary>
+    private static readonly Regex HtmlTagPattern = new(
+        @"<[^>]+>",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(200));
+
+    private readonly HttpClient _http;
+    private readonly IWikimediaRateLimiter _rateLimiter;
+    private readonly ILogger<WikimediaCommonsClient> _logger;
+
+    public WikimediaCommonsClient(
+        HttpClient http,
+        IWikimediaRateLimiter rateLimiter,
+        ILogger<WikimediaCommonsClient> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _rateLimiter = rateLimiter ?? throw new ArgumentNullException(nameof(rateLimiter));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<CommonsLicenseResult> FetchLicenseAsync(string filename, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(filename))
+        {
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        // DEC-3b pitfall: the filename arrives URL-encoded (the wdt:P18 IRI
+        // routes through Special:FilePath, which percent-encodes spaces and
+        // diacritics). The imageinfo API expects the raw filename as the
+        // titles= value (the query-string encoding wraps it once, NOT twice).
+        var decoded = Uri.UnescapeDataString(filename);
+        var title = "File:" + decoded;
+
+        // DEC-3e: acquire BEFORE the HTTP call so the 5 RPS token bucket is
+        // consumed even when the upstream call ultimately fails (a 5xx still
+        // counts against the rate cap from Wikimedia's perspective).
+        await _rateLimiter.AcquireAsync(ct).ConfigureAwait(false);
+
+        try
+        {
+            var path = $"{ApiPath}?action=query&prop=imageinfo&iiprop=extmetadata&titles={Uri.EscapeDataString(title)}&format=json";
+
+            using var req = new HttpRequestMessage(HttpMethod.Get, path);
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Commons imageinfo HTTP {Status} for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
+                    (int)resp.StatusCode,
+                    filename,
+                    decoded);
+                return CommonsLicenseResult.NotAvailable();
+            }
+
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            return ParseResponse(body, filename, decoded);
+        }
+        // OperationCanceledException is intentionally NOT caught: it is not a
+        // subclass of HttpRequestException or JsonException, so it propagates
+        // naturally to honour caller cancellation (see XML doc on the interface).
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons imageinfo network failure for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons imageinfo returned malformed JSON for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+    }
+
+    /// <summary>
+    /// Parses the imageinfo response body, returning <see cref="CommonsLicenseResult.NotAvailable"/>
+    /// for any missing-data case (page id <c>-1</c>, no <c>imageinfo</c> array,
+    /// no <c>LicenseShortName</c>) and logging a warning. Catches <see cref="JsonException"/>
+    /// upstream — see <see cref="FetchLicenseAsync"/>.
+    /// </summary>
+    private CommonsLicenseResult ParseResponse(string body, string filename, string decoded)
+    {
+        using var doc = JsonDocument.Parse(body);
+
+        if (!doc.RootElement.TryGetProperty("query", out var query) ||
+            !query.TryGetProperty("pages", out var pages) ||
+            pages.ValueKind != JsonValueKind.Object)
+        {
+            _logger.LogWarning(
+                "Commons imageinfo missing query.pages for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        // The Commons API returns pages as an object keyed by pageId. A pageId
+        // of "-1" indicates the file does not exist. There is exactly one entry
+        // per request (we query a single title), so the first property is
+        // sufficient — we deliberately do not iterate over additional entries.
+        using var enumerator = pages.EnumerateObject().GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            _logger.LogWarning(
+                "Commons imageinfo returned empty pages object for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        var page = enumerator.Current;
+        if (string.Equals(page.Name, "-1", StringComparison.Ordinal))
+        {
+            _logger.LogInformation(
+                "Commons file '{Filename}' (decoded='{Decoded}') not found (page id -1).",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        return ExtractFromPage(page.Value, filename, decoded);
+    }
+
+    private CommonsLicenseResult ExtractFromPage(JsonElement page, string filename, string decoded)
+    {
+        if (!page.TryGetProperty("imageinfo", out var imageinfo) ||
+            imageinfo.ValueKind != JsonValueKind.Array ||
+            imageinfo.GetArrayLength() == 0)
+        {
+            _logger.LogWarning(
+                "Commons imageinfo array missing or empty for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        var first = imageinfo[0];
+        if (!first.TryGetProperty("extmetadata", out var extmetadata))
+        {
+            _logger.LogWarning(
+                "Commons extmetadata missing for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        var rawLicense = TryReadStringProperty(extmetadata, "LicenseShortName");
+        if (string.IsNullOrWhiteSpace(rawLicense))
+        {
+            _logger.LogWarning(
+                "Commons LicenseShortName missing for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
+
+        var attribution = TryReadStringProperty(extmetadata, "Artist");
+        var attributionText = string.IsNullOrWhiteSpace(attribution)
+            ? null
+            : StripHtmlTags(attribution!);
+
+        var whitelisted = LicenseValidator.IsWhitelisted(rawLicense);
+        return CommonsLicenseResult.Found(rawLicense, whitelisted, attributionText);
+    }
+
+    /// <summary>
+    /// Reads <c>extmetadata.{name}.value</c> safely. Returns <c>null</c> when
+    /// the property is missing, the <c>value</c> sub-property is missing, or
+    /// the value is not a string.
+    /// </summary>
+    private static string? TryReadStringProperty(JsonElement extmetadata, string name)
+    {
+        if (!extmetadata.TryGetProperty(name, out var entry)) return null;
+        if (!entry.TryGetProperty("value", out var value)) return null;
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+    }
+
+    /// <summary>
+    /// Strips HTML tags from a Commons <c>Artist</c> field. The Commons API
+    /// returns the artist credit as HTML (typically a
+    /// <c>&lt;a&gt;User Name&lt;/a&gt;</c> anchor); this method extracts the
+    /// inner text so it can be stored as plain text in
+    /// <c>shared_games.cover_attribution</c>. Idempotent on tag-free input.
+    /// </summary>
+    private static string StripHtmlTags(string artistHtml)
+    {
+        return HtmlTagPattern.Replace(artistHtml, string.Empty).Trim();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs
@@ -1,0 +1,462 @@
+using System.Net;
+using System.Text;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Unit tests for <see cref="WikimediaCommonsClient"/> — Phase B foundation for
+/// issue #1823 L2 cover enrichment (ADR DEC-3b/3c/3e).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Validates the contract documented on
+/// <see cref="IWikimediaCommonsClient.FetchLicenseAsync"/>:
+/// <list type="bullet">
+///   <item><c>filename</c> arrives URL-encoded (extracted from a Wikidata <c>wdt:P18</c>
+///   IRI returning a Special:FilePath redirect). The client MUST decode via
+///   <see cref="Uri.UnescapeDataString"/> before constructing the API call.</item>
+///   <item>Rate limiter acquires BEFORE the HTTP call (5 RPS shared cap, DEC-3e).</item>
+///   <item>License is validated against <see cref="LicenseValidator"/> whitelist (DEC-3c).</item>
+///   <item>5xx, malformed JSON, missing page, missing metadata all return
+///   <see cref="CommonsLicenseResult.NotAvailable"/> with a warning log — never throw.</item>
+///   <item><see cref="OperationCanceledException"/> is rethrown (cancellation respected).</item>
+/// </list>
+/// </para>
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class WikimediaCommonsClientTests
+{
+    private const string CommonsBaseUrl = "https://commons.wikimedia.org/";
+
+    private static WikimediaCommonsClient CreateClient(
+        HttpMessageHandler handler,
+        IWikimediaRateLimiter? rateLimiter = null)
+    {
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri(CommonsBaseUrl)
+        };
+
+        return new WikimediaCommonsClient(
+            http,
+            rateLimiter ?? new Mock<IWikimediaRateLimiter>().Object,
+            new Mock<ILogger<WikimediaCommonsClient>>().Object);
+    }
+
+    private static Mock<HttpMessageHandler> HandlerReturning(HttpStatusCode statusCode, string body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        return handler;
+    }
+
+    private static Mock<HttpMessageHandler> HandlerCapturing(
+        HttpStatusCode statusCode,
+        string body,
+        List<HttpRequestMessage> captured)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured.Add(req))
+            .ReturnsAsync(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        return handler;
+    }
+
+    /// <summary>
+    /// Canonical Commons imageinfo response wrapped around the supplied
+    /// <c>LicenseShortName</c> and <c>Artist</c>. Page id <c>12345</c> mirrors a
+    /// real successful lookup.
+    /// </summary>
+    private static string BuildImageInfoResponse(string licenseShortName, string? artistHtml = null)
+    {
+        var artistFragment = artistHtml is null
+            ? string.Empty
+            : $",\"Artist\":{{\"value\":\"{artistHtml}\",\"source\":\"commons-desc-page\"}}";
+
+        return $@"{{
+  ""query"": {{
+    ""pages"": {{
+      ""12345"": {{
+        ""pageid"": 12345,
+        ""ns"": 6,
+        ""title"": ""File:Brass Birmingham cover.jpg"",
+        ""imageinfo"": [
+          {{
+            ""extmetadata"": {{
+              ""LicenseShortName"": {{ ""value"": ""{licenseShortName}"", ""source"": ""commons-desc-page"" }}
+              {artistFragment}
+            }}
+          }}
+        ]
+      }}
+    }}
+  }}
+}}";
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // URL decoding — DEC-3b pitfall: filename from wdt:P18 IRI is URL-encoded.
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchLicenseAsync_UrlEncodedFilename_DecodesBeforeApiCall()
+    {
+        var captured = new List<HttpRequestMessage>();
+        var handler = HandlerCapturing(HttpStatusCode.OK,
+            BuildImageInfoResponse("CC BY-SA 4.0"),
+            captured);
+        var client = CreateClient(handler.Object);
+
+        // Input matches the URL-encoded form returned by a wdt:P18 Special:FilePath
+        // redirect (spaces → %20). The API title parameter must arrive as
+        // "File:Brass Birmingham cover.jpg" — the API will re-encode the spaces
+        // as part of the query string, but the underlying title MUST be decoded.
+        await client.FetchLicenseAsync("Brass%20Birmingham%20cover.jpg", CancellationToken.None);
+
+        captured.Should().HaveCount(1);
+        var requestUri = captured[0].RequestUri!.ToString();
+
+        // The query string ends up percent-encoded again by the URL builder, but
+        // the LOGICAL title value should be the decoded "File:Brass Birmingham cover.jpg".
+        // Match against either the literal decoded form or the standard re-encoding
+        // (%20 or '+' — both are valid query-string encodings of space).
+        var titleValue = ExtractTitleParam(requestUri);
+        titleValue.Should().Be("File:Brass Birmingham cover.jpg",
+            "the Commons API expects the raw filename, not the URL-encoded form from wdt:P18");
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_PlainFilename_PassesThroughUnchanged()
+    {
+        var captured = new List<HttpRequestMessage>();
+        var handler = HandlerCapturing(HttpStatusCode.OK,
+            BuildImageInfoResponse("CC0"),
+            captured);
+        var client = CreateClient(handler.Object);
+
+        await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        captured.Should().HaveCount(1);
+        ExtractTitleParam(captured[0].RequestUri!.ToString())
+            .Should().Be("File:Cover.jpg",
+                "plain filenames without escape sequences pass through unchanged");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // License validation — DEC-3c whitelist
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("CC BY-SA 4.0")]
+    [InlineData("CC BY 2.0")]
+    [InlineData("CC0")]
+    [InlineData("Public domain")]
+    public async Task FetchLicenseAsync_WhitelistedLicense_ReturnsFoundWithIsWhitelistedTrue(string license)
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK, BuildImageInfoResponse(license));
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.RawLicense.Should().Be(license);
+        result.IsWhitelisted.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("All rights reserved")]
+    [InlineData("CC BY-NC 4.0")]
+    [InlineData("CC BY-ND 3.0")]
+    [InlineData("Fair use")]
+    public async Task FetchLicenseAsync_NonWhitelistedLicense_ReturnsFoundWithIsWhitelistedFalse(string license)
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK, BuildImageInfoResponse(license));
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.RawLicense.Should().Be(license);
+        result.IsWhitelisted.Should().BeFalse();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Page / metadata absence
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchLicenseAsync_MissingPage_ReturnsNotAvailable()
+    {
+        // Commons API returns pageId "-1" when the file does not exist.
+        const string Body = @"{
+  ""query"": {
+    ""pages"": {
+      ""-1"": {
+        ""ns"": 6,
+        ""title"": ""File:Missing.jpg"",
+        ""missing"": """"
+      }
+    }
+  }
+}";
+        var handler = HandlerReturning(HttpStatusCode.OK, Body);
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Missing.jpg", CancellationToken.None);
+
+        result.RawLicense.Should().BeNull();
+        result.IsWhitelisted.Should().BeFalse();
+        result.Attribution.Should().BeNull();
+        result.Should().Be(CommonsLicenseResult.NotAvailable());
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_MissingExtmetadata_ReturnsNotAvailable()
+    {
+        // imageinfo present but extmetadata.LicenseShortName is missing.
+        const string Body = @"{
+  ""query"": {
+    ""pages"": {
+      ""12345"": {
+        ""pageid"": 12345,
+        ""title"": ""File:Cover.jpg"",
+        ""imageinfo"": [
+          {
+            ""extmetadata"": {}
+          }
+        ]
+      }
+    }
+  }
+}";
+        var handler = HandlerReturning(HttpStatusCode.OK, Body);
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().Be(CommonsLicenseResult.NotAvailable());
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_MissingImageinfoArray_ReturnsNotAvailable()
+    {
+        // pages.{id} present but no imageinfo array.
+        const string Body = @"{
+  ""query"": {
+    ""pages"": {
+      ""12345"": {
+        ""pageid"": 12345,
+        ""title"": ""File:Cover.jpg""
+      }
+    }
+  }
+}";
+        var handler = HandlerReturning(HttpStatusCode.OK, Body);
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().Be(CommonsLicenseResult.NotAvailable());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Rate limiter — DEC-3e: acquire BEFORE HTTP call
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchLicenseAsync_AcquiresRateLimiterBeforeHttpCall()
+    {
+        var sequence = new List<string>();
+
+        var rateLimiter = new Mock<IWikimediaRateLimiter>();
+        rateLimiter.Setup(rl => rl.AcquireAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add("acquire"))
+            .Returns(ValueTask.CompletedTask);
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback(() => sequence.Add("http"))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(BuildImageInfoResponse("CC0"),
+                    Encoding.UTF8, "application/json")
+            });
+
+        var client = CreateClient(handler.Object, rateLimiter.Object);
+
+        await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        sequence.Should().Equal(new[] { "acquire", "http" },
+            because: "DEC-3e mandates the 5 RPS token bucket is consumed BEFORE the outbound HTTP request to coordinate the shared cap across Wikidata SPARQL + Commons API consumers");
+        rateLimiter.Verify(rl => rl.AcquireAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // HTTP failure modes
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task FetchLicenseAsync_Http5xx_LogsWarningAndReturnsNotAvailable(HttpStatusCode status)
+    {
+        var logger = new Mock<ILogger<WikimediaCommonsClient>>();
+        var handler = HandlerReturning(status, "{}");
+
+        var http = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri(CommonsBaseUrl)
+        };
+        var client = new WikimediaCommonsClient(
+            http,
+            new Mock<IWikimediaRateLimiter>().Object,
+            logger.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().Be(CommonsLicenseResult.NotAvailable(),
+            "5xx is a server-side outage — caller decides retry, client never throws upstream");
+        logger.Invocations
+            .Should().Contain(i => i.Method.Name == nameof(ILogger.Log)
+                && (LogLevel)i.Arguments[0] == LogLevel.Warning,
+                $"5xx ({(int)status}) must surface a warning log line for observability");
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_HttpCancellation_RethrowsOperationCanceledException()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("caller cancelled"));
+
+        var client = CreateClient(handler.Object);
+
+        await client.Invoking(c => c.FetchLicenseAsync("Cover.jpg", CancellationToken.None))
+            .Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_MalformedJson_LogsWarningAndReturnsNotAvailable()
+    {
+        var logger = new Mock<ILogger<WikimediaCommonsClient>>();
+        var handler = HandlerReturning(HttpStatusCode.OK, "<<< not json >>>");
+
+        var http = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri(CommonsBaseUrl)
+        };
+        var client = new WikimediaCommonsClient(
+            http,
+            new Mock<IWikimediaRateLimiter>().Object,
+            logger.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().Be(CommonsLicenseResult.NotAvailable());
+        logger.Invocations
+            .Should().Contain(i => i.Method.Name == nameof(ILogger.Log)
+                && (LogLevel)i.Arguments[0] == LogLevel.Warning);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Attribution extraction
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FetchLicenseAsync_ExtractsArtistAttribution_StripsHtmlTags()
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK,
+            BuildImageInfoResponse("CC BY-SA 4.0", artistHtml: "<a href=\\\"//commons.wikimedia.org/wiki/User:JohnDoe\\\">John Doe</a>"));
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Attribution.Should().Be("John Doe",
+            "Artist field arrives HTML-encoded from Commons; the inner text is the attribution to display in shared_games.cover_attribution");
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_NoArtistField_ReturnsNullAttribution()
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK, BuildImageInfoResponse("CC0"));
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Attribution.Should().BeNull("CC0 / public domain images typically omit the Artist field");
+        result.IsWhitelisted.Should().BeTrue();
+        result.RawLicense.Should().Be("CC0");
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_PlainTextArtist_ReturnsAsIs()
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK,
+            BuildImageInfoResponse("CC BY 4.0", artistHtml: "Jane Smith"));
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchLicenseAsync("Cover.jpg", CancellationToken.None);
+
+        result.Attribution.Should().Be("Jane Smith");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Extracts the decoded <c>titles=</c> query parameter from a request URI.
+    /// The Commons API call is constructed as
+    /// <c>w/api.php?action=query&amp;...&amp;titles={Uri.EscapeDataString("File:" + decoded)}&amp;format=json</c>;
+    /// this helper re-decodes the percent-encoding so assertions can match
+    /// against the logical title string.
+    /// </summary>
+    private static string ExtractTitleParam(string requestUri)
+    {
+        var queryStart = requestUri.IndexOf('?');
+        if (queryStart < 0) return string.Empty;
+
+        var query = requestUri[(queryStart + 1)..];
+        foreach (var pair in query.Split('&'))
+        {
+            var equalsIndex = pair.IndexOf('=');
+            if (equalsIndex < 0) continue;
+
+            var key = pair[..equalsIndex];
+            if (!string.Equals(key, "titles", StringComparison.Ordinal)) continue;
+
+            var rawValue = pair[(equalsIndex + 1)..];
+            // Decode '+' as space (form encoding) before percent decoding.
+            return Uri.UnescapeDataString(rawValue.Replace('+', ' '));
+        }
+
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

Implements **M4** of issue [#1823](https://github.com/meepleAi-app/meepleai-monorepo/issues/1823) Wikidata L2 cover enrichment — the typed `HttpClient` wrapper that calls the Wikimedia Commons `imageinfo` API to retrieve license metadata for a file referenced by a Wikidata `wdt:P18` IRI.

ADR: [`adr-2026-06-09-wikidata-enrichment-architecture.md`](../blob/main-dev/docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md) — decisions **DEC-3b** (Commons fetcher separate from `WikidataCatalogProvider`, shared rate-limiter), **DEC-3c** (license whitelist), **DEC-3e** (5 RPS shared cap).

## Scope (4 files)

| File | Status | Purpose |
|------|--------|---------|
| `BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs` | new | Public interface, with detailed XML doc on the URL-encoded `filename` contract |
| `BoundedContexts/SharedGameCatalog/Infrastructure/Services/CommonsLicenseResult.cs` | new | Immutable result record — `NotAvailable()` / `Found(raw, whitelisted, attribution)` factories |
| `BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs` | new | Typed `HttpClient` impl — acquires rate-limiter token, calls `w/api.php`, parses, validates |
| `BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs` | modified | `AddHttpClient<IWikimediaCommonsClient, WikimediaCommonsClient>` placed immediately after `WikidataCatalogProvider` to minimise merge conflicts with parallel M3 / M6 / M7 work |
| `tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs` | new | 23 unit tests (see below) |

## Pitfall documented (DEC-3b)

The `filename` parameter arrives **URL-encoded** because it is extracted from a Wikidata `wdt:P18` IRI (which routes through `Special:FilePath`, percent-encoding spaces / diacritics). The Commons `imageinfo` API expects the **raw** filename in `titles=File:{name}` — the query-string wrapping handles the re-encoding. Double-decoding upstream would corrupt filenames containing literal `%` (e.g. `100%25_complete.jpg`).

The implementation calls `Uri.UnescapeDataString(filename)` exactly once, and the XML doc comment on `IWikimediaCommonsClient.FetchLicenseAsync` warns explicitly:

> DO NOT pre-decode the filename upstream — pass it through as received from Wikidata to avoid double-decoding bugs.

## DEC-3e contract

Rate-limiter is acquired **before** the outbound HTTP call — even when the upstream returns 5xx, the bucket is consumed because Wikimedia still counts the request against the shared 5 RPS cap. The test `FetchLicenseAsync_AcquiresRateLimiterBeforeHttpCall` enforces this via sequential `Mock.Callback` instrumentation.

## DEC-3c contract

Raw `extmetadata.LicenseShortName` is fed straight into the existing `LicenseValidator.IsWhitelisted(string?)` (shipped in PR #2099). The result includes `IsWhitelisted` so the M8 orchestrator can decide whether to proceed with the cover or skip it.

## Failure semantics

| Case | Behaviour |
|------|-----------|
| HTTP 5xx (500/502/503/504) | `LogWarning` + return `NotAvailable()` |
| Network failure (`HttpRequestException`) | `LogWarning` + return `NotAvailable()` |
| Malformed JSON | `LogWarning` + return `NotAvailable()` |
| Page id `-1` (file missing) | `LogInformation` + return `NotAvailable()` |
| `imageinfo` array absent | `LogWarning` + return `NotAvailable()` |
| `LicenseShortName` absent | `LogWarning` + return `NotAvailable()` |
| Cancellation | `OperationCanceledException` **propagated** |
| `Artist` HTML-encoded | Tags stripped via DoS-safe regex → plain text |
| `Artist` missing | `Attribution = null` (typical for CC0 / PD works) |

## Test coverage (23 tests, all green)

```
Superato!     - Non superati:     0. Superati:    23. Ignorati:     0. Totale:    23. Durata: 219 ms
```

- `FetchLicenseAsync_UrlEncodedFilename_DecodesBeforeApiCall` — captures outbound URI, asserts `titles=File:Brass Birmingham cover.jpg` (decoded)
- `FetchLicenseAsync_PlainFilename_PassesThroughUnchanged`
- `FetchLicenseAsync_WhitelistedLicense_ReturnsFoundWithIsWhitelistedTrue` — 4 theory cases (CC BY-SA 4.0, CC BY 2.0, CC0, Public domain)
- `FetchLicenseAsync_NonWhitelistedLicense_ReturnsFoundWithIsWhitelistedFalse` — 4 theory cases (All rights reserved, CC BY-NC 4.0, CC BY-ND 3.0, Fair use)
- `FetchLicenseAsync_MissingPage_ReturnsNotAvailable` (page id `-1`)
- `FetchLicenseAsync_MissingExtmetadata_ReturnsNotAvailable`
- `FetchLicenseAsync_MissingImageinfoArray_ReturnsNotAvailable`
- `FetchLicenseAsync_AcquiresRateLimiterBeforeHttpCall` (sequential callback ordering)
- `FetchLicenseAsync_Http5xx_LogsWarningAndReturnsNotAvailable` — 4 theory cases (500/502/503/504)
- `FetchLicenseAsync_HttpCancellation_RethrowsOperationCanceledException`
- `FetchLicenseAsync_MalformedJson_LogsWarningAndReturnsNotAvailable`
- `FetchLicenseAsync_ExtractsArtistAttribution_StripsHtmlTags` (`<a>John Doe</a>` → `John Doe`)
- `FetchLicenseAsync_NoArtistField_ReturnsNullAttribution`
- `FetchLicenseAsync_PlainTextArtist_ReturnsAsIs`

Regression check on adjacent suites: 51/51 pass (`LicenseValidatorTests` + `InMemoryWikimediaRateLimiterTests`); 153/153 pass across the whole `SharedGameCatalog.Infrastructure.Services` namespace.

## Out of scope

- **M3** — `WikidataCatalogProvider.FetchCoverImageAsync(qid)` (parallel PR; will pass the URL-encoded filename to this client)
- **M6** — `IWebpVariantGenerator` (ImageSharp)
- **M7** — `ICoverR2UploadPipeline` (AWSSDK.S3)
- **M8** — orchestrator wiring M3 → M4 → M6 → M7

## Phase B foundations consumed

- `IWikimediaRateLimiter` + `InMemoryWikimediaRateLimiter` (PR #2099) — Singleton-registered, shared across SPARQL + Commons consumers
- `LicenseValidator.IsWhitelisted` (PR #2099) — DEC-3c whitelist regex

## Test plan

- [x] Unit tests pass locally (`dotnet test --filter "FullyQualifiedName~WikimediaCommonsClientTests"` → 23/23)
- [x] No regressions in `LicenseValidatorTests` / `InMemoryWikimediaRateLimiterTests` (51/51)
- [x] No regressions in `SharedGameCatalog.Infrastructure.Services` namespace (153/153)
- [x] Production build clean (`dotnet build apps/api/src/Api/Api.csproj`)
- [x] Sonar analyzers clean (S2737 catch-rethrow refactored; S1751 single-iteration loop refactored; CS0419 ambiguous cref qualified)
- [ ] CI green on PR