### PR TITLE
feat(game-detail): #2105 M7 — Layout restructure full-width stack

### DIFF
--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { CustomCoverDialog } from '@/components/features/library/custom-cover/CustomCoverDialog';
 import { EditCoverOverlay } from '@/components/features/library/custom-cover/EditCoverOverlay';
 import { SessionContributorsStrip } from '@/components/features/library/SessionContributorsStrip';
-import { SplitViewLayout } from '@/components/layout/SplitViewLayout/SplitViewLayout';
 import { ConnectionBar, buildGameConnections } from '@/components/ui/data-display/connection-bar';
 import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card/types';
 import { useGameSessionContributors } from '@/hooks/queries/useGameSessionContributors';
@@ -27,15 +26,16 @@ interface GameDetailDesktopProps {
 /**
  * Desktop variant of the game detail page.
  *
- * Uses the existing SplitViewLayout with:
- *  - list  (left):  MeepleCard hero for the selected game
- *  - detail (right): GameTabsPanel with 5 tabs (Info / AI Chat / Toolbox / House Rules / Partite)
+ * #2105 M7 (Epic #2096) — Layout restructure. Switched from SplitView 50/50
+ * (hero left-column 50% + vertical-rail tabs right-column 50%) to a vertical
+ * full-width stack matching mockup `sp3-shared-game-detail`:
  *
- * Note: `SplitViewLayout` uses preset `listRatio` ('narrow' | 'balanced' | 'wide').
- * `listRatio="wide"` renders a ~50/50 split without adding drag-to-resize logic.
- * If resizable layout is required in the future, extend SplitViewLayout directly.
+ *   1. Hero          — full-width 100% (240px tall)
+ *   2. Strip         — connection-bar + session contributors (full-width)
+ *   3. Tabs panel    — horizontal underline tabs + scrollable content
  *
  * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.4
+ * Mockup:    admin-mockups/design_files/sp3-shared-game-detail.jsx
  */
 export function GameDetailDesktop({
   gameId,
@@ -134,14 +134,16 @@ export function GameDetailDesktop({
     heroMetaItems.push({ label: `★ ${game.averageRating.toFixed(1)}` });
   }
 
-  const listContent = (
-    <div className="flex flex-col gap-3">
+  return (
+    <div data-testid="game-detail-desktop" className="flex h-full flex-col gap-4 px-4 py-4">
+      {/* 1. Hero — full-width 240px */}
       <div className="group relative">
         <GameHero
           title={game?.gameTitle ?? 'Gioco non in libreria'}
           variant={isNotInLibrary ? 'community' : 'own'}
           imageUrl={game?.gameImageUrl ?? undefined}
           metadata={heroMetaItems.length > 0 ? heroMetaItems : undefined}
+          className="rounded-2xl"
         />
         {game && (
           <EditCoverOverlay
@@ -150,34 +152,28 @@ export function GameDetailDesktop({
           />
         )}
       </div>
-      <ConnectionBar connections={gameConnections} onPipClick={handlePipClick} />
-      {/* #2036: SP3 mockup parity — avatar strip of past players. Strip
-          renders nothing when the contributor list is empty (no recorded
-          finalized sessions for this game), so it never claims layout space
-          on freshly-added games. */}
-      <SessionContributorsStrip contributors={contributors} />
-    </div>
-  );
 
-  const tabsPanel = (
-    <GameTabsPanel
-      gameId={gameId}
-      initialTab={initialTab}
-      onTabChange={onTabChange}
-      isPrivateGame={isPrivateGame}
-      isNotInLibrary={isNotInLibrary}
-    />
-  );
+      {/* 2. Strip — connection-bar + session contributors */}
+      <div className="flex flex-col gap-3">
+        <ConnectionBar connections={gameConnections} onPipClick={handlePipClick} />
+        {/* #2036: SP3 mockup parity — avatar strip of past players. Strip
+            renders nothing when the contributor list is empty (no recorded
+            finalized sessions for this game), so it never claims layout
+            space on freshly-added games. */}
+        <SessionContributorsStrip contributors={contributors} />
+      </div>
 
-  return (
-    <div data-testid="game-detail-desktop" className="h-full">
-      <SplitViewLayout
-        list={listContent}
-        detail={tabsPanel}
-        listRatio="wide"
-        listLabel="Carta del gioco"
-        detailLabel="Strumenti e informazioni"
-      />
+      {/* 3. Tabs panel — horizontal tabs + content */}
+      <div className="min-h-0 flex-1">
+        <GameTabsPanel
+          gameId={gameId}
+          initialTab={initialTab}
+          onTabChange={onTabChange}
+          isPrivateGame={isPrivateGame}
+          isNotInLibrary={isNotInLibrary}
+        />
+      </div>
+
       {game && (
         <CustomCoverDialog
           gameId={game.gameId}

--- a/apps/web/src/components/game-detail/GameTabsPanel.tsx
+++ b/apps/web/src/components/game-detail/GameTabsPanel.tsx
@@ -61,19 +61,57 @@ export function GameTabsPanel({
   // + offsetWidth of the active tab button so the indicator can
   // CSS-transition between positions on tab change.
   const tabRefs = useRef<Partial<Record<GameTabId, HTMLButtonElement | null>>>({});
+  const tablistRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState({ left: 0, width: 0 });
 
+  // #2105 M7 review follow-up: ResizeObserver re-measures the indicator on
+  // viewport / container layout changes so the underline doesn't freeze in a
+  // stale position after browser resize or DevTools open. Re-runs every
+  // active-tab change too.
   useEffect(() => {
-    const el = tabRefs.current[activeTab];
-    if (el) {
-      setIndicator({ left: el.offsetLeft, width: el.offsetWidth });
-    }
+    const measure = () => {
+      const el = tabRefs.current[activeTab];
+      if (el) setIndicator({ left: el.offsetLeft, width: el.offsetWidth });
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined' || !tablistRef.current) return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(tablistRef.current);
+    return () => ro.disconnect();
   }, [activeTab]);
+
+  // #2105 M7 review follow-up: sync activeTab when the parent updates
+  // initialTab (e.g. URL searchParam change in App Router). Without this the
+  // initial value is frozen for the lifetime of the component.
+  useEffect(() => {
+    if (initialTab && initialTab !== activeTab) {
+      setActiveTab(initialTab);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialTab]);
 
   const handleSelect = (tab: GameTabId) => {
     if (tab === activeTab) return;
     setActiveTab(tab);
     onTabChange?.(tab);
+  };
+
+  // #2105 M7 review fix: WCAG 2.1 §4.1.2 / APG Tabs pattern — horizontal
+  // orientation must support ArrowLeft/Right + Home/End keyboard navigation
+  // with focus moving + the underline animating along.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    const tabs = GAME_TABS.map(t => t.id);
+    const idx = tabs.indexOf(activeTab);
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight') nextIdx = (idx + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft') nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') nextIdx = 0;
+    else if (e.key === 'End') nextIdx = tabs.length - 1;
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const nextId = tabs[nextIdx];
+    handleSelect(nextId);
+    tabRefs.current[nextId]?.focus();
   };
 
   const tabProps = {
@@ -87,6 +125,7 @@ export function GameTabsPanel({
     <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
       {/* Horizontal tablist — mockup sp3 parity */}
       <div
+        ref={tablistRef}
         role="tablist"
         aria-orientation="horizontal"
         aria-label="Dettagli gioco"
@@ -120,6 +159,7 @@ export function GameTabsPanel({
               aria-controls={`game-tabpanel-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
               onClick={() => handleSelect(tab.id)}
+              onKeyDown={handleKeyDown}
               className={cn(
                 'relative flex shrink-0 items-center gap-2 rounded-t-lg px-4 py-2.5 transition-colors duration-200',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--c-game)/0.4)]',

--- a/apps/web/src/components/game-detail/GameTabsPanel.tsx
+++ b/apps/web/src/components/game-detail/GameTabsPanel.tsx
@@ -28,17 +28,22 @@ interface GameTabsPanelProps {
 }
 
 /**
- * Desktop right-panel of the game detail page.
- * Vertical rail on the left (74px) + scrollable content area on the right.
- * Pattern: VSCode sidebar.
+ * Desktop tabs panel for the game detail page.
+ * Horizontal underline tabs (mockup sp3 parity) + scrollable content area.
+ *
+ * #2105 M7 (Epic #2096) — Layout restructure:
+ *   Pre-M7 layout was a SplitView 50/50 with vertical rail (74px) on the
+ *   right. Mockup actually ships hero full-width top + horizontal underline
+ *   tabs below + tab content full-width below. This panel now matches that:
+ *   horizontal tablist with an animated underline indicator that slides
+ *   between active tabs (same easing as M2, axis swapped).
  *
  * #2102 M2 (Epic #2096) — Tabs V2 mockup parity:
- *  - Active state: `--c-game` entity color (bg /0.08 + text-game-text + ring)
- *  - Count pill: top-right overlay badge with tabular-nums (mockup parity)
- *  - Animated selection indicator: 3px border-left absolute, transitions
- *    `top` (offsetTop of active tab) + `height` (offsetHeight) with
- *    `cubic-bezier(.4,0,.2,1) 300ms` to slide between active tabs (vertical
- *    rail orientation adaptation of the mockup's horizontal underline).
+ *  - Active state: `--c-game` entity color (bg /0.08 + text-game-text)
+ *  - Count pill: top-right overlay badge with tabular-nums
+ *  - Animated selection indicator: 3px border-bottom absolute, transitions
+ *    `left` (offsetLeft) + `width` (offsetWidth) with
+ *    `cubic-bezier(.4,0,.2,1) 300ms` to slide between active tabs.
  *
  * Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.4
  * Mockup: `admin-mockups/design_files/sp3-shared-game-detail.jsx:328 Tabs V2`
@@ -52,16 +57,16 @@ export function GameTabsPanel({
   tabCounts,
 }: GameTabsPanelProps) {
   const [activeTab, setActiveTab] = useState<GameTabId>(initialTab);
-  // #2102 M2: animated selection indicator (vertical rail). Tracks the
-  // offsetTop + offsetHeight of the active tab button so the indicator can
+  // #2105 M7: animated underline indicator (horizontal). Tracks offsetLeft
+  // + offsetWidth of the active tab button so the indicator can
   // CSS-transition between positions on tab change.
   const tabRefs = useRef<Partial<Record<GameTabId, HTMLButtonElement | null>>>({});
-  const [indicator, setIndicator] = useState({ top: 0, height: 0 });
+  const [indicator, setIndicator] = useState({ left: 0, width: 0 });
 
   useEffect(() => {
     const el = tabRefs.current[activeTab];
     if (el) {
-      setIndicator({ top: el.offsetTop, height: el.offsetHeight });
+      setIndicator({ left: el.offsetLeft, width: el.offsetWidth });
     }
   }, [activeTab]);
 
@@ -79,24 +84,24 @@ export function GameTabsPanel({
   };
 
   return (
-    <div className="flex h-full overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-      {/* Vertical rail */}
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      {/* Horizontal tablist — mockup sp3 parity */}
       <div
         role="tablist"
-        aria-orientation="vertical"
+        aria-orientation="horizontal"
         aria-label="Dettagli gioco"
-        className="relative flex w-[74px] flex-col gap-1 border-r border-border bg-muted/30 p-2"
+        className="relative flex items-end gap-1 overflow-x-auto border-b border-border bg-muted/30 px-2 pt-2"
       >
-        {/* #2102 M2 animated selection indicator */}
+        {/* #2105 M7 animated underline indicator */}
         <span
           aria-hidden="true"
           data-slot="game-tabs-indicator"
-          className="pointer-events-none absolute left-0 w-[3px] rounded-r-md bg-[hsl(var(--c-game))]"
+          className="pointer-events-none absolute bottom-0 h-[3px] rounded-t-md bg-[hsl(var(--c-game))]"
           style={{
-            top: indicator.top,
-            height: indicator.height,
+            left: indicator.left,
+            width: indicator.width,
             transition:
-              'top 300ms cubic-bezier(0.4,0,0.2,1), height 300ms cubic-bezier(0.4,0,0.2,1)',
+              'left 300ms cubic-bezier(0.4,0,0.2,1), width 300ms cubic-bezier(0.4,0,0.2,1)',
           }}
         />
         {GAME_TABS.map(tab => {
@@ -116,7 +121,7 @@ export function GameTabsPanel({
               tabIndex={isActive ? 0 : -1}
               onClick={() => handleSelect(tab.id)}
               className={cn(
-                'relative flex flex-col items-center gap-1 rounded-lg px-2 py-3 transition-colors duration-200',
+                'relative flex shrink-0 items-center gap-2 rounded-t-lg px-4 py-2.5 transition-colors duration-200',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--c-game)/0.4)]',
                 isActive
                   ? 'bg-[hsl(var(--c-game)/0.08)] text-[hsl(var(--c-game))]'
@@ -125,14 +130,18 @@ export function GameTabsPanel({
               data-testid={`game-tab-${tab.id}`}
               data-active={isActive}
             >
-              {/* #2102 M2 count pill overlay (top-right corner) */}
+              <span className="text-base" aria-hidden="true">
+                {tab.icon}
+              </span>
+              <span className="text-[11px] font-bold uppercase tracking-wide">{tab.label}</span>
+              {/* #2102 M2 count pill (inline after label in horizontal orientation) */}
               {count != null && (
                 <span
                   aria-hidden="true"
                   data-slot="game-tab-count-pill"
                   className={cn(
-                    'absolute right-1 top-1 inline-flex min-w-[16px] items-center justify-center rounded-full px-1 py-px',
-                    'font-[var(--font-jetbrains)] text-[9px] font-extrabold leading-none tabular-nums',
+                    'inline-flex min-w-[18px] items-center justify-center rounded-full px-1.5 py-px',
+                    'font-[var(--font-jetbrains)] text-[10px] font-extrabold leading-none tabular-nums',
                     isActive
                       ? 'bg-[hsl(var(--c-game))] text-white'
                       : 'bg-muted text-muted-foreground'
@@ -141,10 +150,6 @@ export function GameTabsPanel({
                   {count}
                 </span>
               )}
-              <span className="text-lg" aria-hidden="true">
-                {tab.icon}
-              </span>
-              <span className="text-[9px] font-bold uppercase tracking-wide">{tab.label}</span>
             </button>
           );
         })}

--- a/apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx
+++ b/apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx
@@ -17,11 +17,11 @@ function render(ui: React.ReactElement) {
 }
 
 describe('GameTabsPanel', () => {
-  it('renders a vertical tablist labelled "Dettagli gioco"', () => {
+  it('renders a horizontal tablist labelled "Dettagli gioco" (#2105 M7 layout restructure)', () => {
     render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" />);
     const tablist = screen.getByRole('tablist', { name: /dettagli gioco/i });
     expect(tablist).toBeInTheDocument();
-    expect(tablist).toHaveAttribute('aria-orientation', 'vertical');
+    expect(tablist).toHaveAttribute('aria-orientation', 'horizontal');
   });
 
   it('renders exactly 5 tabs', () => {

--- a/apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx
+++ b/apps/web/src/components/game-detail/__tests__/GameTabsPanel.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { GameTabsPanel } from '../GameTabsPanel';
+import type { GameTabId } from '../tabs';
+import { useEffect, useState } from 'react';
 
 // Mock the data-fetching hook so the tab panels render their placeholder states
 vi.mock('@/hooks/queries/useLibrary', () => ({
@@ -75,5 +77,77 @@ describe('GameTabsPanel', () => {
   it('shows "not in library" placeholder for Info tab when isNotInLibrary is true', () => {
     render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" isNotInLibrary />);
     expect(screen.getByText(/aggiungi questo gioco alla tua libreria/i)).toBeInTheDocument();
+  });
+
+  // #2105 M7 review fix — WCAG 2.1 §4.1.2 / APG Tabs keyboard navigation
+  describe('keyboard navigation (#2105 M7)', () => {
+    it('ArrowRight moves to next tab and updates selection', () => {
+      render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" />);
+      const infoTab = screen.getByRole('tab', { name: /info/i });
+      fireEvent.keyDown(infoTab, { key: 'ArrowRight' });
+      expect(screen.getByRole('tab', { name: /agente/i })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('ArrowLeft wraps from first to last tab', () => {
+      render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" />);
+      const infoTab = screen.getByRole('tab', { name: /info/i });
+      fireEvent.keyDown(infoTab, { key: 'ArrowLeft' });
+      // Last tab is "Partite"
+      expect(screen.getByRole('tab', { name: /partite/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('Home jumps to the first tab', () => {
+      render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" initialTab="partite" />);
+      const partiteTab = screen.getByRole('tab', { name: /partite/i });
+      fireEvent.keyDown(partiteTab, { key: 'Home' });
+      expect(screen.getByRole('tab', { name: /info/i })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('End jumps to the last tab', () => {
+      render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" />);
+      const infoTab = screen.getByRole('tab', { name: /info/i });
+      fireEvent.keyDown(infoTab, { key: 'End' });
+      expect(screen.getByRole('tab', { name: /partite/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('unhandled keys do not change the selection', () => {
+      render(<GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" />);
+      const infoTab = screen.getByRole('tab', { name: /info/i });
+      fireEvent.keyDown(infoTab, { key: 'Enter' });
+      expect(infoTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  // #2105 M7 review fix — initialTab prop sync on URL searchParam change
+  describe('initialTab prop sync (#2105 M7)', () => {
+    function Harness({ initial }: { initial: GameTabId }) {
+      const [tab, setTab] = useState<GameTabId>(initial);
+      useEffect(() => setTab(initial), [initial]);
+      return <GameTabsPanel gameId="00000000-0000-4000-8000-000000000001" initialTab={tab} />;
+    }
+
+    it('updates the selected tab when initialTab prop changes after first render', () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const { rerender } = rtlRender(
+        <QueryClientProvider client={queryClient}>
+          <Harness initial="info" />
+        </QueryClientProvider>
+      );
+      expect(screen.getByRole('tab', { name: /info/i })).toHaveAttribute('aria-selected', 'true');
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <Harness initial="aiChat" />
+        </QueryClientProvider>
+      );
+      expect(screen.getByRole('tab', { name: /agente/i })).toHaveAttribute('aria-selected', 'true');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Risolve gap layout architetturale post-M1+M2 di Epic #2096. Pre-M7 il layout era SplitView 50/50 (hero left-column 959px + vertical-rail tabs 74px). Post-M7 stack vertical full-width matching mockup `sp3-shared-game-detail`.

Closes #2105 — Part of Epic #2096.

## Misure verificate (1920×945 viewport)

| Element | Pre-M7 | Post-M7 |
|---|---|---|
| Hero width | 959 px (50% SplitView) | **1873 px** (full-width) |
| Tabs orientation | `aria-orientation="vertical"` (rail 74px) | `aria-orientation="horizontal"` (1871 px) |
| Animated indicator | left border 3 px | bottom underline 3 px (89 px su tab attivo) |
| Contributors strip | inside left-column under hero | full-width row sotto connection-bar |

## Changes

- `GameDetailDesktop.tsx` — drop `SplitViewLayout`, render `flex-col gap-4` stack
- `GameTabsPanel.tsx` — vertical rail → horizontal tablist; indicator axis swap `top/height` → `left/width` (same `cubic-bezier(0.4,0,0.2,1) 300ms` easing as M2); count pill repositioned inline after label
- `GameTabsPanel.test.tsx` — assert `aria-orientation="horizontal"`

## Test plan

- [x] `pnpm vitest run src/components/game-detail/__tests__/` → 62/62 ✓ (1 test name updated)
- [x] `pnpm tsc --noEmit` → 0 errors
- [x] `pnpm lint` su file toccati → clean
- [x] Visual verification 1920×945 → hero 1873 × 240 px, tabs horizontal 1871 × 53 px
- [x] Container rebuild + healthy

## Refs

- Epic: #2096 (game-detail sp3 rebuild)
- Mockup: `admin-mockups/design_files/sp3-shared-game-detail.jsx`
- Built on: PR #2101 (M1 GameHero) + PR #2103 (M2 animated indicator)