### PR TITLE
feat(catalog): #1823 M6 WebP variant generator

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -198,6 +198,13 @@ internal static class SharedGameCatalogServiceExtensions
         // batch (HPA=1), so an in-memory limiter is sufficient.
         services.AddSingleton<IWikimediaRateLimiter, InMemoryWikimediaRateLimiter>();
 
+        // Issue #1823 Phase B M6 (ADR DEC-3d): WebP variant generator backed by
+        // SixLabors.ImageSharp 3.1.12 — managed C#, no native deps. Produces
+        // 200x300 aspect-ratio-preserving center crops at WebP quality 85 for
+        // R2-hosted cover thumbnails. Singleton — the generator is stateless
+        // and ImageSharp's encoder/decoder pipeline is thread-safe.
+        services.AddSingleton<IWebpVariantGenerator, WebpVariantGenerator>();
+
         // Issue #1823 Phase B (ADR DEC-3h): R2 cover upload pipeline. Singleton
         // because the underlying AmazonS3Client is thread-safe and reuses
         // a connection pool — matching the BlobStorageServiceFactory lifetime.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWebpVariantGenerator.cs
@@ -1,0 +1,51 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Generates resized + cropped WebP variants of source cover images. Production
+/// callers pass a 200x300 target (2:3 portrait) matching the BoardGameGeek
+/// thumbnail convention. Used by the Wikidata L2 cover enrichment pipeline
+/// (issue #1823) to normalize Wikimedia Commons originals (PNG/JPEG/WebP/GIF/
+/// BMP/TIFF) before R2 upload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementation choice (ADR DEC-3d, locked sess.46h post-spike): SixLabors.
+/// ImageSharp 3.x — managed C#, no native deps. The fully-managed runtime
+/// avoids the platform-specific shared-library headaches of SkiaSharp /
+/// Magick.NET on Linux Alpine container images.
+/// </para>
+/// <para>
+/// Lifetime: register as a SINGLETON via DI. ImageSharp itself is thread-safe
+/// for the read-only encoder/decoder pipeline and the generator holds no
+/// per-call state — see DI registration in
+/// <c>SharedGameCatalogServiceExtensions.AddSharedGameCatalogContext</c>.
+/// </para>
+/// </remarks>
+public interface IWebpVariantGenerator
+{
+    /// <summary>
+    /// Generates a WebP variant of the original image, cropped to the requested
+    /// aspect ratio (centered crop) and resized to fit within the target
+    /// dimensions.
+    /// </summary>
+    /// <param name="originalImage">
+    /// Source image bytes. Auto-detected formats: PNG, JPEG, WebP, GIF, BMP,
+    /// TIFF (all supported decoders bundled by ImageSharp 3.1.12).
+    /// </param>
+    /// <param name="width">Target width in pixels (must be &gt; 0).</param>
+    /// <param name="height">Target height in pixels (must be &gt; 0).</param>
+    /// <param name="ct">Cancellation token propagated to the encoder.</param>
+    /// <returns>WebP-encoded byte array (quality 85).</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="originalImage"/> is null/empty or the
+    /// dimensions are not strictly positive.
+    /// </exception>
+    /// <exception cref="ImageProcessingException">
+    /// Thrown when the source bytes are unreadable, corrupted, or encoded in an
+    /// unsupported format.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="ct"/> fires before completion.
+    /// </exception>
+    Task<byte[]> GenerateWebpAsync(byte[] originalImage, int width, int height, CancellationToken ct);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ImageProcessingException.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ImageProcessingException.cs
@@ -1,0 +1,20 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Thrown by <see cref="IWebpVariantGenerator"/> when the source image bytes
+/// cannot be decoded — either because they are corrupted, truncated, or encoded
+/// in a format ImageSharp does not recognize.
+/// </summary>
+/// <remarks>
+/// Surfaces as a typed domain exception so callers (the cover enrichment
+/// pipeline) can distinguish "bad upstream payload" from "infrastructure error"
+/// and apply the appropriate retry / quarantine policy. Per CLAUDE.md pitfall
+/// #2568, we never leak <see cref="System.InvalidOperationException"/> from
+/// the infrastructure layer for input-shape failures.
+/// </remarks>
+public sealed class ImageProcessingException : Exception
+{
+    public ImageProcessingException(string message) : base(message) { }
+
+    public ImageProcessingException(string message, Exception inner) : base(message, inner) { }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGenerator.cs
@@ -1,0 +1,124 @@
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.Processing;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// <see cref="IWebpVariantGenerator"/> backed by SixLabors.ImageSharp 3.1.12.
+/// Produces aspect-ratio-preserving center crops at the requested dimensions
+/// and encodes the result as WebP quality 85 — the empirical sweet spot for
+/// cover thumbnails (visually indistinguishable from quality 90 at ~30% smaller
+/// payload).
+/// </summary>
+/// <remarks>
+/// ADR DEC-3d: managed C# only, no native deps. ImageSharp 3.1.12 bundles
+/// PNG/JPEG/WebP/GIF/BMP/TIFF decoders and the libwebp-compatible encoder used
+/// here. Singleton-safe — see DI registration in
+/// <see cref="DependencyInjection.SharedGameCatalogServiceExtensions"/>.
+/// </remarks>
+internal sealed class WebpVariantGenerator : IWebpVariantGenerator
+{
+    /// <summary>
+    /// WebP encoder quality. 85 is the project standard for cover thumbnails
+    /// (matches <c>GamebookPhotoStorageService</c> JPEG quality and produces
+    /// ~30% smaller payloads than quality 90 with no visible difference at the
+    /// 200x300 target resolution).
+    /// </summary>
+    private const int WebpQuality = 85;
+
+    private readonly ILogger<WebpVariantGenerator> _logger;
+
+    public WebpVariantGenerator(ILogger<WebpVariantGenerator> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<byte[]> GenerateWebpAsync(
+        byte[] originalImage,
+        int width,
+        int height,
+        CancellationToken ct)
+    {
+        if (originalImage is null || originalImage.Length == 0)
+        {
+            throw new ArgumentException(
+                "Source image bytes are required.",
+                nameof(originalImage));
+        }
+
+        if (width <= 0)
+        {
+            throw new ArgumentException(
+                $"Target width must be > 0 (got {width}).",
+                nameof(width));
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentException(
+                $"Target height must be > 0 (got {height}).",
+                nameof(height));
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        Image image;
+        try
+        {
+            // LoadAsync auto-detects PNG/JPEG/WebP/GIF/BMP/TIFF from the
+            // magic-byte header — see ImageSharp.Formats.IImageFormatDetector.
+            using var sourceStream = new MemoryStream(originalImage, writable: false);
+            image = await Image.LoadAsync(sourceStream, ct).ConfigureAwait(false);
+        }
+        catch (UnknownImageFormatException ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to decode source image: unknown/unsupported format ({Bytes} bytes).",
+                originalImage.Length);
+            throw new ImageProcessingException(
+                "Source image format is not recognized or supported.", ex);
+        }
+        catch (InvalidImageContentException ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to decode source image: corrupted content ({Bytes} bytes).",
+                originalImage.Length);
+            throw new ImageProcessingException(
+                "Source image content is corrupted or truncated.", ex);
+        }
+
+        try
+        {
+            // ResizeMode.Crop = aspect-ratio-preserving CENTER crop, then resize
+            // to fit the target Size exactly. This is the BoardGameGeek
+            // thumbnail convention reproduced for #1823 cover normalization.
+            image.Mutate(x => x.Resize(new ResizeOptions
+            {
+                Mode = ResizeMode.Crop,
+                Size = new Size(width, height),
+            }));
+
+            using var outputStream = new MemoryStream();
+            await image.SaveAsWebpAsync(
+                outputStream,
+                new WebpEncoder { Quality = WebpQuality },
+                ct).ConfigureAwait(false);
+
+            return outputStream.ToArray();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to resize/encode WebP variant at {Width}x{Height}.",
+                width, height);
+            throw new ImageProcessingException(
+                $"Failed to generate WebP variant: {ex.Message}", ex);
+        }
+        finally
+        {
+            image.Dispose();
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WebpVariantGeneratorTests.cs
@@ -1,0 +1,252 @@
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Xunit;
+
+// SUT exception type clashes with SixLabors.ImageSharp.ImageProcessingException
+// (a transient parent type from the imaging pipeline). Alias the SUT type so
+// tests unambiguously target our domain exception.
+using DomainImageProcessingException = Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services.ImageProcessingException;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Unit tests for <see cref="WebpVariantGenerator"/> — issue #1823 M6.
+/// Verifies aspect-ratio-preserving center crop + WebP encoding via
+/// SixLabors.ImageSharp 3.1.12 (ADR DEC-3d: managed C#, no native deps).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class WebpVariantGeneratorTests
+{
+    private const int TargetWidth = 200;
+    private const int TargetHeight = 300;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Happy path — aspect-ratio-preserving center crop produces expected output
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateWebpAsync_LargeImage_ResizesAndCropsTo200x300()
+    {
+        var pngBytes = await CreateSolidImagePngAsync(width: 800, height: 600, color: Color.Red);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, CancellationToken.None);
+
+        output.Should().NotBeNullOrEmpty();
+        using var decoded = Image.Load(output);
+        decoded.Width.Should().Be(TargetWidth,
+            "ResizeMode.Crop must enforce exact target dimensions");
+        decoded.Height.Should().Be(TargetHeight,
+            "ResizeMode.Crop must enforce exact target dimensions");
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_SquareImage_CropsCenterTo200x300()
+    {
+        // 600x600 source → 200x300 output: ImageSharp.Crop preserves the 2:3 aspect
+        // ratio by clipping the wider/taller edges (centered) before resizing.
+        var pngBytes = await CreateSolidImagePngAsync(width: 600, height: 600, color: Color.Blue);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, CancellationToken.None);
+
+        using var decoded = Image.Load(output);
+        decoded.Width.Should().Be(TargetWidth);
+        decoded.Height.Should().Be(TargetHeight);
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_PortraitImage_ResizesAndCropsTo200x300()
+    {
+        // 400x800 → 200x300: source aspect 1:2 vs target 2:3, requires crop top/bottom
+        // (since source is "taller" than target ratio).
+        var pngBytes = await CreateSolidImagePngAsync(width: 400, height: 800, color: Color.Green);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, CancellationToken.None);
+
+        using var decoded = Image.Load(output);
+        decoded.Width.Should().Be(TargetWidth);
+        decoded.Height.Should().Be(TargetHeight);
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_DefaultDimensions_200x300_AspectRatio()
+    {
+        // Explicit test for the canonical cover thumbnail (200x300, 2:3 portrait).
+        // This is the dimension production callers will pass per #1823 spec.
+        var pngBytes = await CreateSolidImagePngAsync(width: 1000, height: 1500, color: Color.Yellow);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(pngBytes, 200, 300, CancellationToken.None);
+
+        using var decoded = Image.Load(output);
+        decoded.Width.Should().Be(200);
+        decoded.Height.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_OutputIsWebpFormat()
+    {
+        // WebP magic bytes per RFC 6386: "RIFF" at offset 0, "WEBP" at offset 8.
+        // This is the cheapest way to verify the encoder ran (vs JPEG/PNG fallback).
+        var pngBytes = await CreateSolidImagePngAsync(width: 400, height: 400, color: Color.Black);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, CancellationToken.None);
+
+        output.Should().HaveCountGreaterThanOrEqualTo(12);
+        System.Text.Encoding.ASCII.GetString(output, 0, 4).Should().Be("RIFF",
+            "WebP container starts with RIFF magic bytes");
+        System.Text.Encoding.ASCII.GetString(output, 8, 4).Should().Be("WEBP",
+            "WebP container has WEBP signature at offset 8");
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_JpegInput_OutputsWebp()
+    {
+        // ImageSharp auto-detects input format. Verify JPEG → WebP works
+        // (production sources are PNG/JPEG/WebP per Wikimedia Commons).
+        var jpegBytes = await CreateSolidImageJpegAsync(width: 800, height: 600, color: Color.Purple);
+        var sut = CreateSut();
+
+        var output = await sut.GenerateWebpAsync(jpegBytes, TargetWidth, TargetHeight, CancellationToken.None);
+
+        output.Should().NotBeNullOrEmpty();
+        System.Text.Encoding.ASCII.GetString(output, 0, 4).Should().Be("RIFF");
+        System.Text.Encoding.ASCII.GetString(output, 8, 4).Should().Be("WEBP");
+        using var decoded = Image.Load(output);
+        decoded.Width.Should().Be(TargetWidth);
+        decoded.Height.Should().Be(TargetHeight);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Input validation (ArgumentException)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateWebpAsync_NullInput_ThrowsArgumentException()
+    {
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(null!, TargetWidth, TargetHeight, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>(
+            "null input is a programmer error and must surface as ArgumentException");
+    }
+
+    [Fact]
+    public async Task GenerateWebpAsync_EmptyInput_ThrowsArgumentException()
+    {
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(Array.Empty<byte>(), TargetWidth, TargetHeight, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task GenerateWebpAsync_ZeroOrNegativeWidth_ThrowsArgumentException(int width)
+    {
+        var pngBytes = await CreateSolidImagePngAsync(width: 100, height: 100, color: Color.Red);
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(pngBytes, width, TargetHeight, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task GenerateWebpAsync_ZeroOrNegativeHeight_ThrowsArgumentException(int height)
+    {
+        var pngBytes = await CreateSolidImagePngAsync(width: 100, height: 100, color: Color.Red);
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(pngBytes, TargetWidth, height, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ImageProcessingException — unreadable / unsupported sources
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateWebpAsync_CorruptedImage_ThrowsImageProcessingException()
+    {
+        // 64 random bytes that do not match any known image magic header.
+        var corrupted = new byte[] {
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+            0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+        };
+        var sut = CreateSut();
+
+        var act = async () => await sut.GenerateWebpAsync(corrupted, TargetWidth, TargetHeight, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainImageProcessingException>(
+            "unreadable sources should surface as a typed domain exception, not raw ImageSharp errors");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Cancellation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateWebpAsync_Cancellation_ThrowsOperationCanceledException()
+    {
+        var pngBytes = await CreateSolidImagePngAsync(width: 400, height: 400, color: Color.Red);
+        var sut = CreateSut();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await sut.GenerateWebpAsync(pngBytes, TargetWidth, TargetHeight, cts.Token);
+
+        // OperationCanceledException OR TaskCanceledException (derived from OCE).
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "callers must be able to abort via the cancellation token");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static WebpVariantGenerator CreateSut() => new(NullLogger<WebpVariantGenerator>.Instance);
+
+    private static async Task<byte[]> CreateSolidImagePngAsync(int width, int height, Color color)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        image.Mutate(x => x.BackgroundColor(color));
+        using var ms = new MemoryStream();
+        await image.SaveAsync(ms, new PngEncoder());
+        return ms.ToArray();
+    }
+
+    private static async Task<byte[]> CreateSolidImageJpegAsync(int width, int height, Color color)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        image.Mutate(x => x.BackgroundColor(color));
+        using var ms = new MemoryStream();
+        await image.SaveAsync(ms, new JpegEncoder { Quality = 90 });
+        return ms.ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

Phase B M6 of issue [#1823](https://github.com/meepleAi-app/meepleai-monorepo/issues/1823) (Wikidata L2 cover enrichment): introduces the WebP variant generator that downstream M8 (orchestrator) and M7 (R2 upload) will consume.

- **New** `IWebpVariantGenerator` + `WebpVariantGenerator` (`SixLabors.ImageSharp` 3.1.12 wrapper, managed C# — ADR [DEC-3d](../blob/main-dev/docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md))
- **New** `ImageProcessingException` (typed domain failure; pitfall #2568)
- **DI** registered as `Singleton` in `SharedGameCatalogServiceExtensions` (stateless service, ImageSharp encoder/decoder thread-safe; pitfall #2565)

## Behavior

- Input: PNG / JPEG / WebP / GIF / BMP / TIFF byte array
- Resize: `ResizeMode.Crop` — aspect-ratio-preserving **center crop**, then exact-size resize to target W×H
- Encode: WebP **quality 85** (sweet spot for cover thumbnails — matches `GamebookPhotoStorageService` JPEG convention)
- Validation: `ArgumentException` for null/empty bytes or non-positive dimensions
- Decode failure: `ImageProcessingException` (wraps `UnknownImageFormatException` / `InvalidImageContentException`)
- Cancellation: `OperationCanceledException` propagates without being swallowed (S2737-compliant `when (ex is not OperationCanceledException)` filter)

## Test coverage

16 unit tests in `WebpVariantGeneratorTests` (all green):

| Group | Cases |
|---|---|
| Resize + crop | `Large 800x600 → 200x300` · `Square 600x600` · `Portrait 400x800` · `Canonical 1000x1500 → 200x300` |
| Format | `Output is WebP (RIFF/WEBP magic bytes)` · `JPEG input → WebP output` |
| Input validation | `null` · `empty` · `zero/negative width (3 cases)` · `zero/negative height (3 cases)` |
| Error surfaces | `Corrupted bytes → ImageProcessingException` |
| Cancellation | `Pre-cancelled token → OperationCanceledException` |

Run locally:

```
dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj \
  --filter "FullyQualifiedName~WebpVariantGeneratorTests"
```

## Out of scope

- **M3** Wikidata SPARQL cover lookup (`WikidataCatalogProvider.FetchCoverImageAsync`) — separate parallel PR
- **M4** Wikimedia Commons license validator (`IWikimediaCommonsClient.FetchLicenseAsync`) — already merged
- **M7** R2 / S3 upload pipeline (`ICoverR2UploadPipeline`) — separate parallel PR
- **M8** Orchestrator wiring M3 → M4 → M6 → M7 — final integration PR

## Test plan

- [ ] CI: `dotnet test --filter "FullyQualifiedName~WebpVariantGeneratorTests"` green
- [ ] CI: full backend test suite green (no regressions)
- [ ] Manual: spot-check that `WebpVariantGenerator` is resolvable from DI via `ServiceProvider.GetRequiredService<IWebpVariantGenerator>()` during M8 wiring