### PR TITLE
feat(catalog): #1823 M8 EnrichCatalogCoverCommand orchestrator

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommand.cs
@@ -1,0 +1,32 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Phase B M8 — orchestrates the Wikidata L2 cover enrichment
+/// pipeline for a single <see cref="SharedGameCatalog.Domain.Aggregates.SharedGame"/>.
+/// Reads <c>WikidataQid</c> from the aggregate, fetches the
+/// <c>wdt:P18</c> image filename (M3), validates the Commons license against
+/// the DEC-3c whitelist (M4), downloads the raw image bytes (M4 extension),
+/// generates a 200x300 WebP variant (M6), uploads to R2 with a deterministic
+/// per-game key (M7), then stamps the four cover columns +
+/// <c>WikidataQidLastVerifiedAt</c> on the aggregate (DEC-3i).
+/// </summary>
+/// <remarks>
+/// Outcome is reported via <see cref="EnrichCatalogCoverResult"/>:
+/// <list type="bullet">
+///   <item><see cref="EnrichCatalogCoverResult.Success"/> on full pipeline success.</item>
+///   <item><see cref="EnrichCatalogCoverResult.Skipped"/> for expected business
+///   reasons (QID missing, image not on Wikidata, license not whitelisted, recently
+///   enriched, etc.). Per CLAUDE.md pitfall #2568 these are NEVER thrown.</item>
+///   <item><see cref="EnrichCatalogCoverResult.Failed"/> for technical errors
+///   (image-decoding error, R2 upload error). Idempotent retry is safe because
+///   the R2 key is deterministic.</item>
+/// </list>
+/// <para>
+/// Game-not-found surfaces as <see cref="Api.Middleware.Exceptions.NotFoundException"/>
+/// (HTTP 404 via the exception middleware).
+/// </para>
+/// </remarks>
+internal sealed record EnrichCatalogCoverCommand(Guid GameId)
+    : ICommand<EnrichCatalogCoverResult>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -1,0 +1,253 @@
+using Amazon.S3;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.Observability;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Handler for <see cref="EnrichCatalogCoverCommand"/>. Orchestrates the Phase B
+/// services (M3 Wikidata SPARQL + M4 Commons license/image + M6 WebP variant +
+/// M7 R2 upload) per the ADR <c>adr-2026-06-09-wikidata-enrichment-architecture.md</c>
+/// flow. Issue #1823 Phase B M8.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Idempotency: the R2 key is deterministic
+/// (<c>covers/{gameId}/cover.webp</c> physical / <c>covers/{gameId}/cover</c>
+/// stored — see <see cref="ICoverR2UploadPipeline"/> XML doc) so a retry after
+/// a DB save failure simply overwrites the same object. The handler therefore
+/// does NOT require an atomic-audit envelope around the side-effecting R2
+/// upload — see feedback memory
+/// <c>atomic_audit_and_external_side_effects</c>.
+/// </para>
+/// <para>
+/// Freshness window: ADR DEC-3i. Games with
+/// <see cref="SharedGameCatalog.Domain.Aggregates.SharedGame.WikidataQidLastVerifiedAt"/>
+/// &lt; 90 days old are skipped (re-verification cron will handle them later).
+/// Older entries trigger a refresh of all four cover columns.
+/// </para>
+/// </remarks>
+internal sealed class EnrichCatalogCoverCommandHandler
+    : ICommandHandler<EnrichCatalogCoverCommand, EnrichCatalogCoverResult>
+{
+    /// <summary>
+    /// Days between successive enrichment runs for the same game. ADR DEC-3i
+    /// targets quarterly cadence — chosen as 90 days here to leave a small
+    /// safety margin against the M15 cron drift.
+    /// </summary>
+    private static readonly TimeSpan FreshnessWindow = TimeSpan.FromDays(90);
+
+    private const string MetricTagOutcome = "outcome";
+    private const string OutcomeSuccess = "success";
+    private const string OutcomeSkipped = "skipped";
+    private const string OutcomeFailed = "failed";
+
+    // Stable, machine-readable skip / failure reasons. Surfaced on the result
+    // record AND as metric attribute tags so dashboards can break down
+    // outcomes by cause.
+    public const string SkipReasonQidMissing = "qid-missing";
+    public const string SkipReasonAlreadyEnrichedRecent = "already-enriched-recent";
+    public const string SkipReasonImageNotAvailable = "image-not-available-p18";
+    public const string SkipReasonLicenseNotWhitelisted = "license-not-whitelisted";
+    public const string SkipReasonImageBytesNotAvailable = "image-bytes-not-available";
+    public const string FailReasonImageProcessing = "image-processing-error";
+    public const string FailReasonR2Upload = "r2-upload-error";
+
+    private const int WebpTargetWidth = 200;
+    private const int WebpTargetHeight = 300;
+
+    private readonly ISharedGameRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly WikidataCatalogProvider _wikidataProvider;
+    private readonly IWikimediaCommonsClient _commonsClient;
+    private readonly IWebpVariantGenerator _webpGenerator;
+    private readonly ICoverR2UploadPipeline _r2UploadPipeline;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<EnrichCatalogCoverCommandHandler> _logger;
+
+    public EnrichCatalogCoverCommandHandler(
+        ISharedGameRepository repository,
+        IUnitOfWork unitOfWork,
+        WikidataCatalogProvider wikidataProvider,
+        IWikimediaCommonsClient commonsClient,
+        IWebpVariantGenerator webpGenerator,
+        ICoverR2UploadPipeline r2UploadPipeline,
+        TimeProvider timeProvider,
+        ILogger<EnrichCatalogCoverCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _wikidataProvider = wikidataProvider ?? throw new ArgumentNullException(nameof(wikidataProvider));
+        _commonsClient = commonsClient ?? throw new ArgumentNullException(nameof(commonsClient));
+        _webpGenerator = webpGenerator ?? throw new ArgumentNullException(nameof(webpGenerator));
+        _r2UploadPipeline = r2UploadPipeline ?? throw new ArgumentNullException(nameof(r2UploadPipeline));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EnrichCatalogCoverResult> Handle(
+        EnrichCatalogCoverCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Load aggregate. Game-not-found → 404 (pitfall #2568).
+        var game = await _repository
+            .GetByIdAsync(request.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (game is null)
+        {
+            throw new NotFoundException("SharedGame", request.GameId.ToString());
+        }
+
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+
+        // 2. Freshness window (DEC-3i preparation). Both the column AND a non-null
+        //    R2 key are required to short-circuit — a verified-but-cleared entry
+        //    must still re-enrich.
+        if (game.WikidataQidLastVerifiedAt is { } lastVerifiedAt
+            && !string.IsNullOrWhiteSpace(game.WikidataCoverR2Key)
+            && (nowUtc - lastVerifiedAt) < FreshnessWindow)
+        {
+            EmitOutcomeMetric(OutcomeSkipped, SkipReasonAlreadyEnrichedRecent);
+            return new EnrichCatalogCoverResult.Skipped(SkipReasonAlreadyEnrichedRecent);
+        }
+
+        // 3. WikidataQid must already be assigned (e.g. by the M9 scheduler or
+        //    by the catalog seed promotion pipeline). Without it the SPARQL
+        //    query has nothing to bind.
+        if (string.IsNullOrWhiteSpace(game.WikidataQid))
+        {
+            EmitOutcomeMetric(OutcomeSkipped, SkipReasonQidMissing);
+            return new EnrichCatalogCoverResult.Skipped(SkipReasonQidMissing);
+        }
+
+        // 4. M3 — Wikidata SPARQL wdt:P18 lookup.
+        var coverImage = await _wikidataProvider
+            .FetchCoverImageAsync(game.WikidataQid, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!coverImage.HasImage || string.IsNullOrWhiteSpace(coverImage.Filename))
+        {
+            EmitOutcomeMetric(OutcomeSkipped, SkipReasonImageNotAvailable);
+            _logger.LogInformation(
+                "SharedGame {GameId} QID {Qid} has no wdt:P18 claim; skipping enrichment.",
+                game.Id, game.WikidataQid);
+            return new EnrichCatalogCoverResult.Skipped(SkipReasonImageNotAvailable);
+        }
+
+        // 5. M4 — Commons imageinfo license fetch + DEC-3c whitelist gate.
+        var licenseResult = await _commonsClient
+            .FetchLicenseAsync(coverImage.Filename, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!licenseResult.IsWhitelisted || string.IsNullOrWhiteSpace(licenseResult.RawLicense))
+        {
+            EmitOutcomeMetric(OutcomeSkipped, SkipReasonLicenseNotWhitelisted);
+            _logger.LogInformation(
+                "SharedGame {GameId} QID {Qid} Commons file '{Filename}' license '{License}' not whitelisted; skipping.",
+                game.Id, game.WikidataQid, coverImage.Filename, licenseResult.RawLicense);
+            return new EnrichCatalogCoverResult.Skipped(SkipReasonLicenseNotWhitelisted);
+        }
+
+        // 6. M4 extension — Commons Special:FilePath image bytes download.
+        var originalBytes = await _commonsClient
+            .FetchImageBytesAsync(coverImage.Filename, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (originalBytes is null || originalBytes.Length == 0)
+        {
+            EmitOutcomeMetric(OutcomeSkipped, SkipReasonImageBytesNotAvailable);
+            _logger.LogWarning(
+                "SharedGame {GameId} QID {Qid} Commons file '{Filename}' image bytes not available; skipping.",
+                game.Id, game.WikidataQid, coverImage.Filename);
+            return new EnrichCatalogCoverResult.Skipped(SkipReasonImageBytesNotAvailable);
+        }
+
+        // 7. M6 — WebP variant generation (200x300 center-crop, quality 85).
+        byte[] webpBytes;
+        try
+        {
+            webpBytes = await _webpGenerator
+                .GenerateWebpAsync(originalBytes, WebpTargetWidth, WebpTargetHeight, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ImageProcessingException ex)
+        {
+            EmitOutcomeMetric(OutcomeFailed, FailReasonImageProcessing);
+            _logger.LogWarning(ex,
+                "SharedGame {GameId} QID {Qid} WebP encoding failed for file '{Filename}'.",
+                game.Id, game.WikidataQid, coverImage.Filename);
+            return new EnrichCatalogCoverResult.Failed(FailReasonImageProcessing, ex.Message);
+        }
+
+        // 8. M7 — R2 upload. The pipeline returns the suffix-stripped key
+        //    contract per CoverUrlResolver.cs:73-79.
+        string r2Key;
+        try
+        {
+            r2Key = await _r2UploadPipeline
+                .UploadAsync(game.Id, webpBytes, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            EmitOutcomeMetric(OutcomeFailed, FailReasonR2Upload);
+            _logger.LogWarning(ex,
+                "SharedGame {GameId} QID {Qid} R2 upload failed.",
+                game.Id, game.WikidataQid);
+            return new EnrichCatalogCoverResult.Failed(FailReasonR2Upload, ex.Message);
+        }
+
+        // 9. Domain state update + persistence.
+        game.SetWikidataCover(
+            r2Key,
+            licenseResult.RawLicense,
+            licenseResult.Attribution,
+            coverImage.SourceUrl,
+            nowUtc);
+
+        _repository.Update(game);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // 10. Success metric + result.
+        EmitOutcomeMetric(OutcomeSuccess);
+        _logger.LogInformation(
+            "SharedGame {GameId} QID {Qid} enriched with cover key '{R2Key}' license '{License}'.",
+            game.Id, game.WikidataQid, r2Key, licenseResult.RawLicense);
+
+        return new EnrichCatalogCoverResult.Success(
+            r2Key,
+            licenseResult.RawLicense,
+            licenseResult.Attribution,
+            coverImage.SourceUrl);
+    }
+
+    /// <summary>
+    /// Emits the <c>meepleai.wikidata.enrichment.attempts.total</c> counter
+    /// tagged by outcome. ADR DEC-3g.
+    /// </summary>
+    private static void EmitOutcomeMetric(string outcome, string? reason = null)
+    {
+        if (reason is null)
+        {
+            MeepleAiMetrics.WikidataEnrichmentAttempts.Add(
+                1,
+                new KeyValuePair<string, object?>(MetricTagOutcome, outcome));
+        }
+        else
+        {
+            MeepleAiMetrics.WikidataEnrichmentAttempts.Add(
+                1,
+                new KeyValuePair<string, object?>(MetricTagOutcome, outcome),
+                new KeyValuePair<string, object?>("reason", reason));
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverResult.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverResult.cs
@@ -1,0 +1,52 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Discriminated outcome of <see cref="EnrichCatalogCoverCommand"/>. Distinguishes
+/// pipeline success from expected business skips (e.g. QID missing, license not
+/// whitelisted) and unexpected technical failures (image processing or R2
+/// upload errors).
+/// </summary>
+/// <remarks>
+/// Pattern matches CLAUDE.md pitfall #2568: handlers MUST NOT throw
+/// <see cref="System.InvalidOperationException"/> for business outcomes. Only
+/// <see cref="Api.Middleware.Exceptions.NotFoundException"/> /
+/// <see cref="Api.Middleware.Exceptions.ConflictException"/> are allowed as
+/// route-mapped exceptions; everything else collapses into one of the three
+/// variants below.
+/// </remarks>
+internal abstract record EnrichCatalogCoverResult
+{
+    /// <summary>Private constructor — prevents external inheritance.</summary>
+    private protected EnrichCatalogCoverResult() { }
+
+    /// <summary>
+    /// Successful enrichment: the four cover columns + <c>WikidataQidLastVerifiedAt</c>
+    /// are now persisted on the aggregate.
+    /// </summary>
+    /// <param name="R2Key">Deterministic R2 key WITHOUT the <c>.webp</c> suffix (CoverUrlResolver appends it).</param>
+    /// <param name="License">Whitelisted Commons license string (e.g. <c>"CC BY-SA 4.0"</c>).</param>
+    /// <param name="Attribution">Plain-text Artist credit, or <see langword="null"/> for CC0 / PD works.</param>
+    /// <param name="SourceUrl">Canonical Wikidata entity URL used as the attribution back-link.</param>
+    public sealed record Success(
+        string R2Key,
+        string License,
+        string? Attribution,
+        string SourceUrl) : EnrichCatalogCoverResult;
+
+    /// <summary>
+    /// Skipped for an expected business reason — the orchestrator decided NOT
+    /// to enrich (e.g. QID missing, license not whitelisted, recently enriched).
+    /// Not retriable until the underlying state changes.
+    /// </summary>
+    /// <param name="Reason">Stable, machine-readable skip reason (used for metrics tagging).</param>
+    public sealed record Skipped(string Reason) : EnrichCatalogCoverResult;
+
+    /// <summary>
+    /// Failed due to a technical error (image processing, R2 upload).
+    /// Idempotent retry is safe — the deterministic R2 key means a successful
+    /// re-run overwrites cleanly.
+    /// </summary>
+    /// <param name="Reason">Stable, machine-readable failure category (used for metrics tagging).</param>
+    /// <param name="Details">Optional human-readable detail (e.g. exception message).</param>
+    public sealed record Failed(string Reason, string? Details) : EnrichCatalogCoverResult;
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/EnrichCatalogCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/EnrichCatalogCoverCommandValidator.cs
@@ -1,0 +1,21 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="EnrichCatalogCoverCommand"/>. Only enforces the
+/// minimal command-shape invariants. Business rules (QID present / license
+/// whitelisted / freshness) live on the handler so they map to
+/// <see cref="EnrichCatalogCoverResult.Skipped"/> outcomes rather than HTTP 400.
+/// Issue #1823 Phase B M8.
+/// </summary>
+internal sealed class EnrichCatalogCoverCommandValidator : AbstractValidator<EnrichCatalogCoverCommand>
+{
+    public EnrichCatalogCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("GameId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -690,6 +690,16 @@ public sealed class SharedGame : AggregateRoot<Guid>
     /// Thrown when <paramref name="r2Key"/>, <paramref name="license"/>, or
     /// <paramref name="sourceUrl"/> are null/whitespace.
     /// </exception>
+    /// <remarks>
+    /// Treated as a non-audited background flag (consistent with
+    /// <see cref="SetPdfCoverR2Key"/>): does NOT update <c>_modifiedAt</c> /
+    /// <c>_modifiedBy</c>. The dedicated <c>WikidataQidLastVerifiedAt</c> column
+    /// already records the enrichment timestamp — more informative than the
+    /// generic modifiedAt and tied to the M15 quarterly re-verification cron.
+    /// Avoids the half-audit anti-pattern where <c>_modifiedAt</c> would be
+    /// fresh but <c>_modifiedBy</c> stale (no user actor on a system-automated
+    /// pipeline).
+    /// </remarks>
     public void SetWikidataCover(
         string r2Key,
         string license,
@@ -711,7 +721,6 @@ public sealed class SharedGame : AggregateRoot<Guid>
         _wikidataCoverAttribution = string.IsNullOrWhiteSpace(attribution) ? null : attribution;
         _wikidataCoverSourceUrl = sourceUrl;
         _wikidataQidLastVerifiedAt = verifiedAt;
-        _modifiedAt = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -49,6 +49,17 @@ public sealed class SharedGame : AggregateRoot<Guid>
     // Issue #1852: L4 PDF cover key, denormalized from PdfDocumentEntity.CoverR2Key
     // via PdfCoverGeneratedEventHandler. Set via SetPdfCoverR2Key().
     private string? _pdfCoverR2Key;
+    // Issue #1823 Phase B M8: Wikidata cover state. Set via SetWikidataCover()
+    // after successful enrichment orchestration (M3 SPARQL + M4 license + M6
+    // WebP + M7 R2 upload). QID itself is set independently via
+    // AssignWikidataQid() (typically by the M9 scheduler resolving from the
+    // catalog seed pipeline).
+    private string? _wikidataQid;
+    private string? _wikidataCoverR2Key;
+    private string? _wikidataCoverLicense;
+    private string? _wikidataCoverAttribution;
+    private string? _wikidataCoverSourceUrl;
+    private DateTime? _wikidataQidLastVerifiedAt;
     private bool _isDeleted;
     private Guid _createdBy;
     private Guid? _modifiedBy;
@@ -164,6 +175,47 @@ public sealed class SharedGame : AggregateRoot<Guid>
     /// Issue #1852.
     /// </summary>
     public string? PdfCoverR2Key => _pdfCoverR2Key;
+
+    /// <summary>
+    /// Gets the Wikidata QID identifying this game on Wikidata (e.g. <c>"Q98056728"</c>).
+    /// Set by <see cref="AssignWikidataQid"/> when the catalog seed pipeline resolves
+    /// a match. Read by the M8 cover enrichment orchestrator to issue the
+    /// <c>wdt:P18</c> SPARQL query. Issue #1823.
+    /// </summary>
+    public string? WikidataQid => _wikidataQid;
+
+    /// <summary>
+    /// Gets the R2 key of the L2 Wikidata-sourced cover image (WITHOUT <c>.webp</c>
+    /// suffix, per the contract enforced by <c>CoverUrlResolver</c>). Issue #1823.
+    /// </summary>
+    public string? WikidataCoverR2Key => _wikidataCoverR2Key;
+
+    /// <summary>
+    /// Gets the whitelisted license identifier persisted alongside the Wikidata
+    /// cover (e.g. <c>"CC BY-SA 4.0"</c>). Issue #1823 ADR DEC-3c.
+    /// </summary>
+    public string? WikidataCoverLicense => _wikidataCoverLicense;
+
+    /// <summary>
+    /// Gets the optional plain-text attribution credit extracted from the Commons
+    /// <c>extmetadata.Artist</c> field. <see langword="null"/> for CC0 / public-domain
+    /// works that omit the Artist field. Issue #1823.
+    /// </summary>
+    public string? WikidataCoverAttribution => _wikidataCoverAttribution;
+
+    /// <summary>
+    /// Gets the canonical Wikidata entity URL used as the attribution back-link
+    /// (e.g. <c>https://www.wikidata.org/wiki/Q98056728</c>). Issue #1823.
+    /// </summary>
+    public string? WikidataCoverSourceUrl => _wikidataCoverSourceUrl;
+
+    /// <summary>
+    /// Gets the timestamp of the last successful enrichment / re-verification of
+    /// the Wikidata cover. Used by the M8 orchestrator to skip recently-enriched
+    /// games (&lt; 90gg) and by the M15 quarterly re-verification cron.
+    /// Issue #1823 ADR DEC-3i.
+    /// </summary>
+    public DateTime? WikidataQidLastVerifiedAt => _wikidataQidLastVerifiedAt;
 
     /// <summary>
     /// Gets whether this game has been soft-deleted.
@@ -311,7 +363,13 @@ public sealed class SharedGame : AggregateRoot<Guid>
         Guid? agentDefinitionId = null,
         GameDataStatus gameDataStatus = GameDataStatus.Complete,
         bool hasUploadedPdf = false,
-        string? pdfCoverR2Key = null) : base(id)
+        string? pdfCoverR2Key = null,
+        string? wikidataQid = null,
+        string? wikidataCoverR2Key = null,
+        string? wikidataCoverLicense = null,
+        string? wikidataCoverAttribution = null,
+        string? wikidataCoverSourceUrl = null,
+        DateTime? wikidataQidLastVerifiedAt = null) : base(id)
     {
         _id = id;
         _title = title;
@@ -330,6 +388,12 @@ public sealed class SharedGame : AggregateRoot<Guid>
         _gameDataStatus = gameDataStatus;
         _hasUploadedPdf = hasUploadedPdf;
         _pdfCoverR2Key = pdfCoverR2Key;
+        _wikidataQid = wikidataQid;
+        _wikidataCoverR2Key = wikidataCoverR2Key;
+        _wikidataCoverLicense = wikidataCoverLicense;
+        _wikidataCoverAttribution = wikidataCoverAttribution;
+        _wikidataCoverSourceUrl = wikidataCoverSourceUrl;
+        _wikidataQidLastVerifiedAt = wikidataQidLastVerifiedAt;
         _isDeleted = isDeleted;
         _createdBy = createdBy;
         _modifiedBy = modifiedBy;
@@ -558,6 +622,96 @@ public sealed class SharedGame : AggregateRoot<Guid>
             return;
 
         _pdfCoverR2Key = coverR2Key;
+    }
+
+    /// <summary>
+    /// Wikidata QID format guard. <c>^Q\d+$</c>, anchored + compiled + 200ms
+    /// timeout — DoS-safe even on adversarial inputs. Matches the pattern used
+    /// by <c>WikidataCatalogProvider</c>.
+    /// </summary>
+    private static readonly System.Text.RegularExpressions.Regex WikidataQidPattern = new(
+        @"^Q\d+$",
+        System.Text.RegularExpressions.RegexOptions.CultureInvariant
+            | System.Text.RegularExpressions.RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(200));
+
+    /// <summary>
+    /// Assigns a Wikidata QID to this game. Used by the catalog seed promotion
+    /// pipeline (or admin tooling) to wire a SharedGame to its Wikidata entity
+    /// BEFORE the M8 cover enrichment orchestrator runs.
+    /// Idempotent: returns silently when the supplied QID matches the current value.
+    /// Issue #1823 Phase B.
+    /// </summary>
+    /// <param name="qid">The Wikidata Q-number (e.g. <c>"Q98056728"</c>). Must match <c>^Q\d+$</c>.</param>
+    /// <param name="modifiedBy">The user / system actor performing the assignment.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="qid"/> is null/whitespace, fails the QID
+    /// pattern, exceeds 32 chars, or <paramref name="modifiedBy"/> is <see cref="Guid.Empty"/>.
+    /// </exception>
+    public void AssignWikidataQid(string qid, Guid modifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(qid))
+            throw new ArgumentException("WikidataQid cannot be empty.", nameof(qid));
+
+        if (qid.Length > 32)
+            throw new ArgumentException("WikidataQid cannot exceed 32 characters.", nameof(qid));
+
+        if (!WikidataQidPattern.IsMatch(qid))
+            throw new ArgumentException("WikidataQid must match ^Q\\d+$.", nameof(qid));
+
+        if (modifiedBy == Guid.Empty)
+            throw new ArgumentException("ModifiedBy cannot be empty.", nameof(modifiedBy));
+
+        if (string.Equals(_wikidataQid, qid, StringComparison.Ordinal))
+            return;
+
+        _wikidataQid = qid;
+        _modifiedBy = modifiedBy;
+        _modifiedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Records the L2 Wikidata-sourced cover image after the M8 enrichment
+    /// orchestrator successfully fetches + license-validates + WebP-encodes +
+    /// uploads to R2. Updates all four cover columns atomically and stamps
+    /// <c>WikidataQidLastVerifiedAt</c> for the M15 quarterly re-verification
+    /// cron (ADR DEC-3i). Issue #1823 Phase B.
+    /// </summary>
+    /// <param name="r2Key">
+    /// Deterministic R2 key WITHOUT the <c>.webp</c> suffix (e.g.
+    /// <c>"covers/{gameId}/cover"</c>). The <c>CoverUrlResolver</c> appends the
+    /// suffix when minting presigned URLs — see <c>CoverUrlResolver.cs:73-79</c>.
+    /// </param>
+    /// <param name="license">Whitelisted license identifier (e.g. <c>"CC BY-SA 4.0"</c>).</param>
+    /// <param name="attribution">Optional plain-text Artist credit; <see langword="null"/> for CC0 / PD works.</param>
+    /// <param name="sourceUrl">Canonical Wikidata entity URL used as the attribution back-link.</param>
+    /// <param name="verifiedAt">UTC timestamp of the successful enrichment / re-verification.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="r2Key"/>, <paramref name="license"/>, or
+    /// <paramref name="sourceUrl"/> are null/whitespace.
+    /// </exception>
+    public void SetWikidataCover(
+        string r2Key,
+        string license,
+        string? attribution,
+        string sourceUrl,
+        DateTime verifiedAt)
+    {
+        if (string.IsNullOrWhiteSpace(r2Key))
+            throw new ArgumentException("R2 key cannot be empty.", nameof(r2Key));
+
+        if (string.IsNullOrWhiteSpace(license))
+            throw new ArgumentException("License cannot be empty.", nameof(license));
+
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            throw new ArgumentException("Source URL cannot be empty.", nameof(sourceUrl));
+
+        _wikidataCoverR2Key = r2Key;
+        _wikidataCoverLicense = license;
+        _wikidataCoverAttribution = string.IsNullOrWhiteSpace(attribution) ? null : attribution;
+        _wikidataCoverSourceUrl = sourceUrl;
+        _wikidataQidLastVerifiedAt = verifiedAt;
+        _modifiedAt = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -307,6 +307,15 @@ internal static class SharedGameCatalogServiceExtensions
         // combined SPARQL + Commons traffic stays under the cap. The S1075
         // suppression below covers the public Commons API endpoint just like
         // the other catalog providers.
+        //
+        // Issue #1823 M8 invariant: do NOT add a ConfigurePrimaryHttpMessageHandler
+        // that sets AllowAutoRedirect=false. FetchImageBytesAsync calls
+        // commons.wikimedia.org/wiki/Special:FilePath/{filename}, which returns
+        // a 302 redirect to upload.wikimedia.org/<cdn-url>. The default handler
+        // AllowAutoRedirect=true is what makes the image bytes accessible — a
+        // false setting would surface the 302 HTML body as bytes, which would
+        // then fail at WebP decoding (FailReasonImageProcessing) instead of the
+        // expected SkipReasonImageBytesNotAvailable on real 404s.
 #pragma warning disable S1075 // URIs should not be hardcoded
         const string CommonsBaseUrl = "https://commons.wikimedia.org/";
 #pragma warning restore S1075

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -145,7 +145,13 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             entity.AgentDefinitionId,
             (GameDataStatus)entity.GameDataStatus,
             entity.HasUploadedPdf,
-            pdfCoverR2Key: entity.PdfCoverR2Key);
+            pdfCoverR2Key: entity.PdfCoverR2Key,
+            wikidataQid: entity.WikidataQid,
+            wikidataCoverR2Key: entity.WikidataCoverR2Key,
+            wikidataCoverLicense: entity.WikidataCoverLicense,
+            wikidataCoverAttribution: entity.WikidataCoverAttribution,
+            wikidataCoverSourceUrl: entity.WikidataCoverSourceUrl,
+            wikidataQidLastVerifiedAt: entity.WikidataQidLastVerifiedAt);
 
         // Issue #2035: Hydrate designers from the M:N join — only when the caller
         // eager-loaded the navigation (GetByIdAsync), otherwise the EF Core
@@ -185,6 +191,13 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             RulesExternalUrl = game.Rules?.ExternalUrl,
             HasUploadedPdf = game.HasUploadedPdf,
             PdfCoverR2Key = game.PdfCoverR2Key,
+            // Issue #1823 Phase B M8 — propagate Wikidata enrichment state.
+            WikidataQid = game.WikidataQid,
+            WikidataCoverR2Key = game.WikidataCoverR2Key,
+            WikidataCoverLicense = game.WikidataCoverLicense,
+            WikidataCoverAttribution = game.WikidataCoverAttribution,
+            WikidataCoverSourceUrl = game.WikidataCoverSourceUrl,
+            WikidataQidLastVerifiedAt = game.WikidataQidLastVerifiedAt,
             // SearchVector managed by PostgreSQL trigger
             CreatedBy = game.CreatedBy,
             ModifiedBy = game.ModifiedBy,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs
@@ -49,4 +49,35 @@ internal interface IWikimediaCommonsClient
     /// </list>
     /// </returns>
     Task<CommonsLicenseResult> FetchLicenseAsync(string filename, CancellationToken ct);
+
+    /// <summary>
+    /// Issue #1823 Phase B M8 — downloads the raw image bytes for a Commons file
+    /// via the <c>Special:FilePath/{filename}</c> redirect endpoint. Consumed by
+    /// the cover enrichment orchestrator AFTER the M4 license check succeeds, so
+    /// only whitelisted images incur the (possibly large) image-download cost.
+    /// </summary>
+    /// <param name="filename">
+    /// Same URL-encoded contract as <see cref="FetchLicenseAsync"/>: filename
+    /// arrives in the raw form extracted from a Wikidata <c>wdt:P18</c> IRI.
+    /// The implementation decodes via <see cref="Uri.UnescapeDataString(string)"/>
+    /// then re-escapes when constructing the request URL — DO NOT pre-decode
+    /// upstream (same double-decoding pitfall documented on FetchLicenseAsync).
+    /// </param>
+    /// <param name="ct">Cancellation token. <see cref="OperationCanceledException"/> is rethrown.</param>
+    /// <returns>
+    /// The raw image bytes on success, or <see langword="null"/> when:
+    /// <list type="bullet">
+    ///   <item><paramref name="filename"/> is null/empty/whitespace;</item>
+    ///   <item>the Commons CDN returns 404 (file deleted);</item>
+    ///   <item>the Commons CDN returns 5xx (caller decides retry);</item>
+    ///   <item>the response body is empty.</item>
+    /// </list>
+    /// </returns>
+    /// <remarks>
+    /// Consumes the shared <see cref="IWikimediaRateLimiter"/> token bucket
+    /// BEFORE issuing the HTTP request (DEC-3e). HttpClient follows the
+    /// <c>Special:FilePath/{filename}</c> 302 redirect to
+    /// <c>upload.wikimedia.org/...</c> automatically (default redirect policy).
+    /// </remarks>
+    Task<byte[]?> FetchImageBytesAsync(string filename, CancellationToken ct);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
@@ -119,6 +119,67 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
         }
     }
 
+    /// <inheritdoc />
+    public async Task<byte[]?> FetchImageBytesAsync(string filename, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(filename))
+        {
+            return null;
+        }
+
+        // Same DEC-3b pitfall as FetchLicenseAsync: the filename arrives
+        // URL-encoded from the wdt:P18 Special:FilePath IRI. Decode internally
+        // before re-encoding for the request URL so callers do not have to
+        // worry about double-encoding.
+        var decoded = Uri.UnescapeDataString(filename);
+        var path = $"wiki/Special:FilePath/{Uri.EscapeDataString(decoded)}";
+
+        // DEC-3e: acquire BEFORE the HTTP call so the 5 RPS token bucket is
+        // consumed even when the upstream call ultimately fails.
+        await _rateLimiter.AcquireAsync(ct).ConfigureAwait(false);
+
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, path);
+            // Accept any image content; Commons serves PNG/JPEG/GIF/WebP/SVG/TIFF.
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*"));
+
+            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Commons FilePath HTTP {Status} for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
+                    (int)resp.StatusCode,
+                    filename,
+                    decoded);
+                return null;
+            }
+
+            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            if (bytes.Length == 0)
+            {
+                _logger.LogWarning(
+                    "Commons FilePath returned empty body for file '{Filename}' (decoded='{Decoded}').",
+                    filename,
+                    decoded);
+                return null;
+            }
+
+            return bytes;
+        }
+        // OperationCanceledException intentionally NOT caught: propagates to
+        // honour caller cancellation (see XML doc on the interface).
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons FilePath network failure for file '{Filename}' (decoded='{Decoded}').",
+                filename,
+                decoded);
+            return null;
+        }
+    }
+
     /// <summary>
     /// Parses the imageinfo response body, returning <see cref="CommonsLicenseResult.NotAvailable"/>
     /// for any missing-data case (page id <c>-1</c>, no <c>imageinfo</c> array,

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -80,6 +80,23 @@ public class SharedGameEntity
     public string? WikidataCoverAttribution { get; set; }
 
     /// <summary>
+    /// Issue #1823 Phase B M8 — Wikidata QID (e.g. <c>"Q98056728"</c>) that identifies this
+    /// game on Wikidata. Set by the M9 scheduler (or admin trigger) BEFORE the M8
+    /// enrichment orchestrator runs; the orchestrator reads this column to resolve
+    /// the SPARQL <c>wdt:P18</c> claim. Pattern <c>^Q\d+$</c>; max 32 chars covers
+    /// Q-numbers well past the current Wikidata range (~Q120M as of 2026).
+    /// </summary>
+    public string? WikidataQid { get; set; }
+
+    /// <summary>
+    /// Issue #1823 Phase B M8 (ADR DEC-3i) — timestamp of the last successful
+    /// QID + license re-verification. Used by the M15 quarterly re-verification
+    /// cron to skip recently-verified games and by the M8 orchestrator to detect
+    /// stale entries (&gt;90gg) that need refresh.
+    /// </summary>
+    public DateTime? WikidataQidLastVerifiedAt { get; set; }
+
+    /// <summary>
     /// Gap G2 (issue: BGG cover re-upload).
     /// R2 key for cover image downloaded from BGG and re-uploaded to our storage.
     /// Resolved by CoverUrlResolver L2.5 layer (between L4 PDF and L2 Wikidata).

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -158,6 +158,20 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .HasColumnName("wikidata_cover_attribution")
             .IsRequired(false);
 
+        // Issue #1823 Phase B M8 — Wikidata QID resolved against shared_games
+        // before the cover-enrichment orchestrator runs (ADR DEC-3a). Max 32
+        // chars covers Q-numbers well past the current Wikidata range.
+        builder.Property(e => e.WikidataQid)
+            .HasMaxLength(32)
+            .HasColumnName("wikidata_qid")
+            .IsRequired(false);
+
+        // Issue #1823 Phase B M8 (ADR DEC-3i) — quarterly re-verification
+        // timestamp. NULL until the M8 orchestrator first enriches successfully.
+        builder.Property(e => e.WikidataQidLastVerifiedAt)
+            .HasColumnName("wikidata_qid_last_verified_at")
+            .IsRequired(false);
+
         // Global query filter for soft deletes
         builder.HasQueryFilter(e => !e.IsDeleted);
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260610094431_AddWikidataQidColumnsToSharedGames.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260610094431_AddWikidataQidColumnsToSharedGames.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610094431_AddWikidataQidColumnsToSharedGames")]
+    partial class AddWikidataQidColumnsToSharedGames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260610094431_AddWikidataQidColumnsToSharedGames.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260610094431_AddWikidataQidColumnsToSharedGames.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWikidataQidColumnsToSharedGames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "wikidata_qid",
+                table: "shared_games",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "wikidata_qid_last_verified_at",
+                table: "shared_games",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "wikidata_qid",
+                table: "shared_games");
+
+            migrationBuilder.DropColumn(
+                name: "wikidata_qid_last_verified_at",
+                table: "shared_games");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
@@ -545,6 +545,24 @@ public class EnrichCatalogCoverCommandHandlerTests
         }
     }
 
+    /// <summary>
+    /// Test harness for the Commons HttpClient: dispatches by URL path to the
+    /// imageinfo API (license JSON) or to the Special:FilePath endpoint (raw
+    /// image bytes).
+    /// <para>
+    /// NOTE on redirect-following: in production, Commons returns a 302 redirect
+    /// from <c>commons.wikimedia.org/wiki/Special:FilePath/...</c> to
+    /// <c>upload.wikimedia.org/...</c>. <see cref="HttpClientHandler.AllowAutoRedirect"/>
+    /// defaults to <see langword="true"/> so the production
+    /// <see cref="WikimediaCommonsClient"/> transparently follows the redirect.
+    /// This in-memory handler short-circuits the redirect entirely (no 302 →
+    /// upload.wikimedia.org round-trip) and serves the bytes directly from the
+    /// Special:FilePath path. Any future change to the DI registration that
+    /// disables <c>AllowAutoRedirect</c> would NOT be caught by these tests —
+    /// such a change MUST be paired with an integration test or a documented
+    /// invariant on the typed HttpClient configuration.
+    /// </para>
+    /// </summary>
     private sealed class CommonsRoutingHandler : HttpMessageHandler
     {
         public string LicenseJson { get; set; } = string.Empty;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
@@ -1,0 +1,579 @@
+using System.Net;
+using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Handler-driven tests for <see cref="EnrichCatalogCoverCommandHandler"/>.
+/// Wires the REAL Phase B pipeline (M3 <see cref="WikidataCatalogProvider"/> +
+/// M4 <see cref="WikimediaCommonsClient"/> + M6 <see cref="WebpVariantGenerator"/>
+/// + M7 <see cref="CoverR2UploadPipeline"/>) and mocks ONLY the HTTP boundary
+/// (HttpMessageHandler instances) + the S3 client + the repository — per the
+/// feedback memory <c>acceptance_tests_must_exercise_real_pipeline</c> (PR #1555
+/// SP5 S2 lesson: fixture-only DTO setup masks handler-level gaps).
+/// Issue #1823 Phase B M8.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class EnrichCatalogCoverCommandHandlerTests
+{
+    private const string TestQid = "Q98056728";
+    private const string TestFilename = "Brass_Birmingham_cover.jpg";
+    private const string ExpectedSourceUrl = "https://www.wikidata.org/wiki/" + TestQid;
+    private static readonly DateTime FixedNowUtc = new(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Happy path
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ValidGameWithQid_SuccessfullyEnrichesCover()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC BY-SA 4.0", artistHtml: "John Doe");
+        harness.CommonsHandler.ImageBytes = await CreateSolidImagePngAsync(800, 600);
+
+        PutObjectRequest? capturedRequest = null;
+        harness.S3Mock
+            .Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Success>();
+        var success = (EnrichCatalogCoverResult.Success)result;
+        success.R2Key.Should().Be($"covers/{game.Id}/cover",
+            "DB key MUST NOT include .webp suffix — CoverUrlResolver appends it");
+        success.R2Key.Should().NotEndWith(".webp");
+        success.License.Should().Be("CC BY-SA 4.0");
+        success.Attribution.Should().Be("John Doe");
+        success.SourceUrl.Should().Be(ExpectedSourceUrl);
+
+        // Verify the aggregate was updated + persisted
+        game.WikidataCoverR2Key.Should().Be(success.R2Key);
+        game.WikidataCoverLicense.Should().Be("CC BY-SA 4.0");
+        game.WikidataCoverAttribution.Should().Be("John Doe");
+        game.WikidataCoverSourceUrl.Should().Be(ExpectedSourceUrl);
+        game.WikidataQidLastVerifiedAt.Should().Be(FixedNowUtc);
+
+        harness.RepoMock.Verify(r => r.Update(game), Times.Once);
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.Key.Should().Be($"covers/{game.Id}/cover.webp",
+            "physical R2 object key INCLUDES .webp suffix");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Game not found → NotFoundException (HTTP 404 via middleware)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_GameNotFound_ThrowsNotFoundException()
+    {
+        var harness = BuildHarness();
+        var gameId = Guid.NewGuid();
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        await harness.Sut
+            .Invoking(h => h.Handle(new EnrichCatalogCoverCommand(gameId), CancellationToken.None))
+            .Should().ThrowAsync<NotFoundException>();
+
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Skipped reasons
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_GameWithoutQid_ReturnsSkippedQidMissing()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: null);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Skipped>();
+        ((EnrichCatalogCoverResult.Skipped)result).Reason
+            .Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing);
+
+        harness.WikidataHandler.Requests.Should().BeEmpty(
+            "QID-missing must short-circuit BEFORE issuing any Wikidata SPARQL request");
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_GameAlreadyEnrichedRecent_ReturnsSkippedAlreadyEnrichedRecent()
+    {
+        var harness = BuildHarness();
+        // 30 days ago — well inside the 90-day freshness window.
+        var lastVerified = FixedNowUtc.AddDays(-30);
+        var game = BuildGame(
+            qid: TestQid,
+            wikidataCoverR2Key: $"covers/{Guid.NewGuid()}/cover",
+            wikidataCoverLicense: "CC BY 4.0",
+            wikidataCoverSourceUrl: ExpectedSourceUrl,
+            wikidataQidLastVerifiedAt: lastVerified);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Skipped>();
+        ((EnrichCatalogCoverResult.Skipped)result).Reason
+            .Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonAlreadyEnrichedRecent);
+
+        harness.WikidataHandler.Requests.Should().BeEmpty(
+            "freshness-window skip must short-circuit BEFORE the SPARQL call");
+    }
+
+    [Fact]
+    public async Task Handle_GameAlreadyEnrichedStale_RefreshesCover()
+    {
+        var harness = BuildHarness();
+        // 100 days ago — well outside the 90-day window.
+        var lastVerified = FixedNowUtc.AddDays(-100);
+        var game = BuildGame(
+            qid: TestQid,
+            wikidataCoverR2Key: "covers/stale/cover",
+            wikidataCoverLicense: "Old license",
+            wikidataCoverSourceUrl: ExpectedSourceUrl,
+            wikidataQidLastVerifiedAt: lastVerified);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        harness.CommonsHandler.ImageBytes = await CreateSolidImagePngAsync(400, 600);
+        harness.S3Mock
+            .Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Success>(
+            "stale entries (> 90 days) must trigger a refresh of all four cover columns");
+
+        game.WikidataCoverLicense.Should().Be("CC0");
+        game.WikidataQidLastVerifiedAt.Should().Be(FixedNowUtc);
+        game.WikidataCoverR2Key.Should().Be($"covers/{game.Id}/cover");
+    }
+
+    [Fact]
+    public async Task Handle_NoP18Image_ReturnsSkippedImageNotAvailable()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        // SPARQL returns empty bindings → no wdt:P18 claim
+        harness.WikidataHandler.SparqlJson = BuildSparqlEmptyResponse();
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Skipped>();
+        ((EnrichCatalogCoverResult.Skipped)result).Reason
+            .Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonImageNotAvailable);
+
+        harness.CommonsHandler.Requests.Should().BeEmpty(
+            "no wdt:P18 image means no Commons license/image calls are issued");
+    }
+
+    [Fact]
+    public async Task Handle_LicenseNotWhitelisted_ReturnsSkippedLicenseNotWhitelisted()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        // "All rights reserved" is NOT whitelisted (DEC-3c)
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("All rights reserved");
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Skipped>();
+        ((EnrichCatalogCoverResult.Skipped)result).Reason
+            .Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonLicenseNotWhitelisted);
+
+        harness.CommonsHandler.Requests
+            .Should().NotContain(r => r.RequestUri!.AbsolutePath.Contains("Special:FilePath", StringComparison.Ordinal),
+                "non-whitelisted license must short-circuit BEFORE downloading image bytes");
+    }
+
+    [Fact]
+    public async Task Handle_ImageBytesNotAvailable_ReturnsSkippedImageBytesNotAvailable()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC BY 4.0");
+        // Special:FilePath returns 404
+        harness.CommonsHandler.ImageStatus = HttpStatusCode.NotFound;
+        harness.CommonsHandler.ImageBytes = Array.Empty<byte>();
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Skipped>();
+        ((EnrichCatalogCoverResult.Skipped)result).Reason
+            .Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonImageBytesNotAvailable);
+
+        harness.S3Mock.Verify(
+            s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "image-bytes-not-available short-circuits BEFORE WebP + R2 upload");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Failed reasons
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_ImageProcessingError_ReturnsFailedImageProcessingError()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        // Corrupted image bytes → ImageSharp decode fails → WebpVariantGenerator
+        // throws ImageProcessingException
+        harness.CommonsHandler.ImageBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE };
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+        var failed = (EnrichCatalogCoverResult.Failed)result;
+        failed.Reason.Should().Be(EnrichCatalogCoverCommandHandler.FailReasonImageProcessing);
+        failed.Details.Should().NotBeNullOrEmpty(
+            "Failed.Details carries the exception message for diagnostics");
+
+        harness.S3Mock.Verify(
+            s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "image-processing error short-circuits BEFORE R2 upload");
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_R2UploadError_ReturnsFailedR2UploadError()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.LicenseJson = BuildImageInfoResponse("CC0");
+        harness.CommonsHandler.ImageBytes = await CreateSolidImagePngAsync(400, 600);
+
+        harness.S3Mock
+            .Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception("simulated R2 outage"));
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+        var failed = (EnrichCatalogCoverResult.Failed)result;
+        failed.Reason.Should().Be(EnrichCatalogCoverCommandHandler.FailReasonR2Upload);
+        failed.Details.Should().Contain("simulated R2 outage");
+
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "DB save must NOT run when R2 upload fails");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers — fixture builders + routing handlers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private sealed record TestHarness(
+        EnrichCatalogCoverCommandHandler Sut,
+        Mock<ISharedGameRepository> RepoMock,
+        Mock<IUnitOfWork> UowMock,
+        Mock<IAmazonS3> S3Mock,
+        WikidataSparqlHandler WikidataHandler,
+        CommonsRoutingHandler CommonsHandler,
+        FakeTimeProvider TimeProvider);
+
+    private static TestHarness BuildHarness()
+    {
+        var repo = new Mock<ISharedGameRepository>();
+        var uow = new Mock<IUnitOfWork>();
+        uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        var rateLimiter = new Mock<IWikimediaRateLimiter>();
+        rateLimiter.Setup(r => r.AcquireAsync(It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var sparqlHandler = new WikidataSparqlHandler();
+        var commonsHandler = new CommonsRoutingHandler();
+
+        var wikidataHttp = new HttpClient(sparqlHandler)
+        {
+            BaseAddress = new Uri("https://query.wikidata.org/")
+        };
+        var commonsHttp = new HttpClient(commonsHandler)
+        {
+            BaseAddress = new Uri("https://commons.wikimedia.org/")
+        };
+
+        var wikidataProvider = new WikidataCatalogProvider(
+            wikidataHttp,
+            NullLogger<WikidataCatalogProvider>.Instance,
+            rateLimiter.Object);
+        var commonsClient = new WikimediaCommonsClient(
+            commonsHttp,
+            rateLimiter.Object,
+            NullLogger<WikimediaCommonsClient>.Instance);
+        var webpGenerator = new WebpVariantGenerator(NullLogger<WebpVariantGenerator>.Instance);
+
+        var s3Mock = new Mock<IAmazonS3>();
+        var s3Opts = new S3StorageOptions
+        {
+            Endpoint = "https://test.r2.cloudflarestorage.com",
+            AccessKey = "test-access",
+            SecretKey = "test-secret",
+            BucketName = "test-bucket",
+            Region = "auto",
+            ForcePathStyle = false,
+        };
+        var r2Pipeline = new CoverR2UploadPipeline(
+            s3Mock.Object,
+            s3Opts,
+            NullLogger<CoverR2UploadPipeline>.Instance);
+
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(FixedNowUtc, TimeSpan.Zero));
+
+        var handler = new EnrichCatalogCoverCommandHandler(
+            repo.Object,
+            uow.Object,
+            wikidataProvider,
+            commonsClient,
+            webpGenerator,
+            r2Pipeline,
+            fakeTime,
+            NullLogger<EnrichCatalogCoverCommandHandler>.Instance);
+
+        return new TestHarness(handler, repo, uow, s3Mock, sparqlHandler, commonsHandler, fakeTime);
+    }
+
+    private static SharedGame BuildGame(
+        string? qid = TestQid,
+        string? wikidataCoverR2Key = null,
+        string? wikidataCoverLicense = null,
+        string? wikidataCoverAttribution = null,
+        string? wikidataCoverSourceUrl = null,
+        DateTime? wikidataQidLastVerifiedAt = null)
+    {
+        var createdAt = FixedNowUtc.AddDays(-180);
+        return new SharedGame(
+            id: Guid.NewGuid(),
+            title: "Test Game",
+            yearPublished: 2020,
+            description: "Test description",
+            minPlayers: 1,
+            maxPlayers: 4,
+            playingTimeMinutes: 60,
+            minAge: 12,
+            complexityRating: 3.0m,
+            averageRating: 7.5m,
+            imageUrl: "https://example.com/img.jpg",
+            thumbnailUrl: "https://example.com/thumb.jpg",
+            rules: null,
+            status: GameStatus.Published,
+            createdBy: Guid.NewGuid(),
+            modifiedBy: null,
+            createdAt: createdAt,
+            modifiedAt: null,
+            isDeleted: false,
+            bggId: 12345,
+            agentDefinitionId: null,
+            gameDataStatus: GameDataStatus.Complete,
+            hasUploadedPdf: false,
+            pdfCoverR2Key: null,
+            wikidataQid: qid,
+            wikidataCoverR2Key: wikidataCoverR2Key,
+            wikidataCoverLicense: wikidataCoverLicense,
+            wikidataCoverAttribution: wikidataCoverAttribution,
+            wikidataCoverSourceUrl: wikidataCoverSourceUrl,
+            wikidataQidLastVerifiedAt: wikidataQidLastVerifiedAt);
+    }
+
+    private static string BuildSparqlImageResponse(string filename) => $@"{{
+  ""head"": {{ ""vars"": [""image""] }},
+  ""results"": {{
+    ""bindings"": [{{
+      ""image"": {{
+        ""type"": ""uri"",
+        ""value"": ""http://commons.wikimedia.org/wiki/Special:FilePath/{filename}""
+      }}
+    }}]
+  }}
+}}";
+
+    private static string BuildSparqlEmptyResponse() => @"{
+  ""head"": { ""vars"": [""image""] },
+  ""results"": { ""bindings"": [] }
+}";
+
+    private static string BuildImageInfoResponse(string licenseShortName, string? artistHtml = null)
+    {
+        var artistFragment = artistHtml is null
+            ? string.Empty
+            : $",\"Artist\":{{\"value\":\"{artistHtml}\",\"source\":\"commons-desc-page\"}}";
+
+        return $@"{{
+  ""query"": {{
+    ""pages"": {{
+      ""12345"": {{
+        ""pageid"": 12345,
+        ""ns"": 6,
+        ""title"": ""File:{TestFilename}"",
+        ""imageinfo"": [
+          {{
+            ""extmetadata"": {{
+              ""LicenseShortName"": {{ ""value"": ""{licenseShortName}"", ""source"": ""commons-desc-page"" }}
+              {artistFragment}
+            }}
+          }}
+        ]
+      }}
+    }}
+  }}
+}}";
+    }
+
+    private static async Task<byte[]> CreateSolidImagePngAsync(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        image.Mutate(x => x.BackgroundColor(Color.SteelBlue));
+        using var ms = new MemoryStream();
+        await image.SaveAsync(ms, new PngEncoder());
+        return ms.ToArray();
+    }
+
+    private sealed class WikidataSparqlHandler : HttpMessageHandler
+    {
+        public string SparqlJson { get; set; } = string.Empty;
+        public HttpStatusCode Status { get; set; } = HttpStatusCode.OK;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            var content = new StringContent(SparqlJson, Encoding.UTF8, "application/sparql-results+json");
+            return Task.FromResult(new HttpResponseMessage(Status) { Content = content });
+        }
+    }
+
+    private sealed class CommonsRoutingHandler : HttpMessageHandler
+    {
+        public string LicenseJson { get; set; } = string.Empty;
+        public byte[] ImageBytes { get; set; } = Array.Empty<byte>();
+        public HttpStatusCode LicenseStatus { get; set; } = HttpStatusCode.OK;
+        public HttpStatusCode ImageStatus { get; set; } = HttpStatusCode.OK;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.Contains("api.php", StringComparison.Ordinal))
+            {
+                var content = new StringContent(LicenseJson, Encoding.UTF8, "application/json");
+                return Task.FromResult(new HttpResponseMessage(LicenseStatus) { Content = content });
+            }
+
+            if (path.Contains("Special:FilePath", StringComparison.Ordinal))
+            {
+                var content = new ByteArrayContent(ImageBytes);
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+                return Task.FromResult(new HttpResponseMessage(ImageStatus) { Content = content });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs
@@ -428,6 +428,237 @@ public class WikimediaCommonsClientTests
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // FetchImageBytesAsync — Issue #1823 Phase B M8 (image bytes download)
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static Mock<HttpMessageHandler> HandlerReturningBytes(HttpStatusCode statusCode, byte[] body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                var content = new ByteArrayContent(body);
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+                return new HttpResponseMessage(statusCode) { Content = content };
+            });
+        return handler;
+    }
+
+    private static Mock<HttpMessageHandler> HandlerCapturingBytes(
+        HttpStatusCode statusCode,
+        byte[] body,
+        List<HttpRequestMessage> captured)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured.Add(req))
+            .ReturnsAsync(() =>
+            {
+                var content = new ByteArrayContent(body);
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+                return new HttpResponseMessage(statusCode) { Content = content };
+            });
+        return handler;
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_ValidFilename_ReturnsImageBytes()
+    {
+        var expected = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0xAA, 0xBB, 0xCC };
+        var handler = HandlerReturningBytes(HttpStatusCode.OK, expected);
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(expected,
+            "Special:FilePath returns raw image bytes after following the 302 redirect to upload.wikimedia.org");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_UrlEncodedFilename_DecodesBeforeApiCall()
+    {
+        var captured = new List<HttpRequestMessage>();
+        var handler = HandlerCapturingBytes(HttpStatusCode.OK,
+            new byte[] { 0xAA, 0xBB },
+            captured);
+        var client = CreateClient(handler.Object);
+
+        await client.FetchImageBytesAsync("Brass%20Birmingham%20cover.jpg", CancellationToken.None);
+
+        captured.Should().HaveCount(1);
+        var requestPath = captured[0].RequestUri!.AbsolutePath;
+        requestPath.Should().StartWith("/wiki/Special:FilePath/",
+            "the M8 contract uses the Special:FilePath endpoint for raw image download");
+
+        var fileSegment = requestPath["/wiki/Special:FilePath/".Length..];
+        var decodedSegment = Uri.UnescapeDataString(fileSegment);
+        decodedSegment.Should().Be("Brass Birmingham cover.jpg",
+            "the same DEC-3b URL-decoding pitfall as FetchLicenseAsync — caller passes the raw wdt:P18 IRI form, the client decodes once before re-encoding");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_PlainFilename_PassesThroughUnchanged()
+    {
+        var captured = new List<HttpRequestMessage>();
+        var handler = HandlerCapturingBytes(HttpStatusCode.OK,
+            new byte[] { 0xAA }, captured);
+        var client = CreateClient(handler.Object);
+
+        await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        captured.Should().HaveCount(1);
+        captured[0].RequestUri!.AbsolutePath.Should().Be("/wiki/Special:FilePath/Cover.jpg",
+            "plain filenames without escape sequences pass through unchanged after the round-trip decode/encode");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_AcquiresRateLimiterBeforeHttpCall()
+    {
+        var sequence = new List<string>();
+
+        var rateLimiter = new Mock<IWikimediaRateLimiter>();
+        rateLimiter.Setup(rl => rl.AcquireAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add("acquire"))
+            .Returns(ValueTask.CompletedTask);
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback(() => sequence.Add("http"))
+            .ReturnsAsync(() =>
+            {
+                var content = new ByteArrayContent(new byte[] { 0xAA });
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+            });
+
+        var client = CreateClient(handler.Object, rateLimiter.Object);
+
+        await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        sequence.Should().Equal(new[] { "acquire", "http" },
+            because: "DEC-3e mandates the 5 RPS token bucket is consumed BEFORE the outbound HTTP request — shared cap across Wikidata SPARQL + Commons API consumers");
+        rateLimiter.Verify(rl => rl.AcquireAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_404_ReturnsNull()
+    {
+        var handler = HandlerReturningBytes(HttpStatusCode.NotFound, Array.Empty<byte>());
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchImageBytesAsync("Missing.jpg", CancellationToken.None);
+
+        result.Should().BeNull("404 maps to skip-this-game per the M8 orchestrator policy — file was deleted/renamed");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task FetchImageBytesAsync_Http5xx_LogsWarningAndReturnsNull(HttpStatusCode status)
+    {
+        var logger = new Mock<ILogger<WikimediaCommonsClient>>();
+        var handler = HandlerReturningBytes(status, Array.Empty<byte>());
+
+        var http = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri(CommonsBaseUrl)
+        };
+        var client = new WikimediaCommonsClient(
+            http,
+            new Mock<IWikimediaRateLimiter>().Object,
+            logger.Object);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("5xx is a server-side outage — caller decides retry, client never throws upstream");
+        logger.Invocations
+            .Should().Contain(i => i.Method.Name == nameof(ILogger.Log)
+                && (LogLevel)i.Arguments[0] == LogLevel.Warning,
+                $"5xx ({(int)status}) must surface a warning log line for observability");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_Cancellation_RethrowsOperationCanceledException()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("caller cancelled"));
+
+        var client = CreateClient(handler.Object);
+
+        await client.Invoking(c => c.FetchImageBytesAsync("Cover.jpg", CancellationToken.None))
+            .Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_NullOrEmptyFilename_ReturnsNullWithoutHttpCall()
+    {
+        var captured = new List<HttpRequestMessage>();
+        var handler = HandlerCapturingBytes(HttpStatusCode.OK, new byte[] { 0xAA }, captured);
+        var client = CreateClient(handler.Object);
+
+        (await client.FetchImageBytesAsync(string.Empty, CancellationToken.None)).Should().BeNull();
+        (await client.FetchImageBytesAsync("   ", CancellationToken.None)).Should().BeNull();
+
+        captured.Should().BeEmpty("defensive guard short-circuits before consuming a rate-limiter token or issuing HTTP");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_EmptyResponseBody_ReturnsNull()
+    {
+        var handler = HandlerReturningBytes(HttpStatusCode.OK, Array.Empty<byte>());
+        var client = CreateClient(handler.Object);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull("an empty body is not a usable image — skip enrichment for this game");
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_HttpRequestException_LogsWarningReturnsNull()
+    {
+        var logger = new Mock<ILogger<WikimediaCommonsClient>>();
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network error"));
+
+        var http = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri(CommonsBaseUrl)
+        };
+        var client = new WikimediaCommonsClient(
+            http,
+            new Mock<IWikimediaRateLimiter>().Object,
+            logger.Object);
+
+        var result = await client.FetchImageBytesAsync("Cover.jpg", CancellationToken.None);
+
+        result.Should().BeNull();
+        logger.Invocations
+            .Should().Contain(i => i.Method.Name == nameof(ILogger.Log)
+                && (LogLevel)i.Arguments[0] == LogLevel.Warning,
+                "network errors surface a warning log line for observability");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Wave 2 ship M8 of issue #1823 (Wikidata L2 cover enrichment). Implements the MediatR command + handler that orchestrates Phase B services (M3 + M4 + M6 + M7) to enrich `SharedGameEntity` with cover image, license, attribution + completes M1 ADR scope (adds `wikidata_qid` + `wikidata_qid_last_verified_at` columns the previous Wave 1 migrations omitted).

**Issue**: #1823 — Wikidata enrichment (ADR DEC-3a..3j)
**ADR**: `docs/for-claude/architecture/adr/adr-2026-06-09-wikidata-enrichment-architecture.md`
**Plan**: `docs/superpowers/plans/2026-06-10-wave-2-m8-orchestrator-prompt.md`
**Wave 1 PRs consumed**: #2104 (M3) · #2107 (M4) · #2109 (M6) · #2111 (M7)

## Scope

- **`IWikimediaCommonsClient.FetchImageBytesAsync(filename, ct)`** — Special:FilePath image download via the existing Commons HttpClient. Reuses `IWikimediaRateLimiter` (DEC-3e 5 RPS shared cap) + the same URL-decode pitfall semantics as `FetchLicenseAsync` (DEC-3b).
- **`EnrichCatalogCoverCommand(Guid GameId)`** + **`EnrichCatalogCoverCommandHandler`** under `Application/Commands/EnrichCatalogCover/`.
- **`EnrichCatalogCoverResult`** discriminated union: `Success(R2Key, License, Attribution, SourceUrl)` / `Skipped(Reason)` / `Failed(Reason, Details)` — pitfall #2568 compliant (no `InvalidOperationException` for business outcomes).
- **`EnrichCatalogCoverCommandValidator`** (FluentValidation: `GameId` non-empty).
- **EF migration `AddWikidataQidColumnsToSharedGames`** — adds `wikidata_qid VARCHAR(32) NULL` + `wikidata_qid_last_verified_at TIMESTAMPTZ NULL` (ADR DEC-3i prep). Closes the gap in ADR M1 (\"already shipped\") where these two columns were missing despite being referenced downstream.
- **`SharedGame` aggregate** — `WikidataQid` / `WikidataCoverR2Key` / `WikidataCoverLicense` / `WikidataCoverAttribution` / `WikidataCoverSourceUrl` / `WikidataQidLastVerifiedAt` properties + private backing fields + reconstruction-ctor params + behavior methods:
  - `AssignWikidataQid(qid, modifiedBy)` — caller assigns QID (e.g. M9 scheduler resolving from catalog seed). Idempotent + DoS-safe QID regex.
  - `SetWikidataCover(r2Key, license, attribution, sourceUrl, verifiedAt)` — sets all four cover columns + `WikidataQidLastVerifiedAt` atomically.
- **`SharedGameEntity` + `SharedGameEntityConfiguration` + `SharedGameRepository` mapping** — propagates the 6 new persistence columns.

## Orchestration flow

```
EnrichCatalogCoverCommandHandler.Handle(cmd, ct):
  1. repo.GetByIdAsync(gameId) — null → NotFoundException (404)
  2. Freshness window (< 90gg) — Skipped("already-enriched-recent")
  3. WikidataQid empty — Skipped("qid-missing")
  4. WikidataCatalogProvider.FetchCoverImageAsync(qid) — no P18 → Skipped("image-not-available-p18")
  5. IWikimediaCommonsClient.FetchLicenseAsync(filename) — not whitelisted → Skipped("license-not-whitelisted")
  6. IWikimediaCommonsClient.FetchImageBytesAsync(filename) — null → Skipped("image-bytes-not-available")
  7. IWebpVariantGenerator.GenerateWebpAsync(bytes, 200, 300) — ImageProcessingException → Failed("image-processing-error", msg)
  8. ICoverR2UploadPipeline.UploadAsync(gameId, webp) — AmazonS3Exception → Failed("r2-upload-error", msg)
  9. sharedGame.SetWikidataCover(r2Key, license, attribution, sourceUrl, nowUtc)
 10. repo.Update + UoW.SaveChangesAsync + emit metric outcome=success
```

R2 key contract preserved: returned key WITHOUT `.webp` suffix per `CoverUrlResolver.cs:73-79`.

**Idempotency**: R2 `UploadAsync` is safe to retry (deterministic `covers/{gameId}/cover.webp` overwrites cleanly), so no `[AtomicAudit]` envelope — feedback memory `atomic_audit_and_external_side_effects`.

**Metric**: emits `meepleai.wikidata.enrichment.attempts.total` (Counter, ADR DEC-3g) tagged `outcome=success|skipped|failed` + optional `reason=<stable-machine-string>`.

## Test coverage

**~20 new unit tests** following the `acceptance_tests_must_exercise_real_pipeline` feedback memory (PR #1555 SP5 S2 lesson — handler-driven, NOT fixture-only DTO setup):

- **10 `WikimediaCommonsClientTests.FetchImageBytesAsync_*`** — URL decoding, rate limiter ordering, 404/5xx/cancellation/empty body/network error handling, defensive null/empty filename short-circuit.
- **10 `EnrichCatalogCoverCommandHandlerTests`** — real `WikidataCatalogProvider` + real `WikimediaCommonsClient` + real `WebpVariantGenerator` + real `CoverR2UploadPipeline`; mocks ONLY `HttpMessageHandler` boundaries + `IAmazonS3` + `ISharedGameRepository`. `FakeTimeProvider` for deterministic freshness checks. Cases:
  - Happy path (verifies aggregate update + R2 key contract + S3 put-object + UoW.SaveChangesAsync).
  - `NotFoundException` (game not found).
  - All 5 Skipped reasons (qid-missing, already-enriched-recent, image-not-available-p18, license-not-whitelisted, image-bytes-not-available).
  - Stale (> 90gg) entry refresh.
  - 2 Failed reasons (image-processing-error, r2-upload-error).

Local `dotnet test --filter \"FullyQualifiedName~EnrichCatalogCover|FullyQualifiedName~WikimediaCommonsClient\"`: **46/46 passed**. Broader `Category=Unit&FullyQualifiedName~SharedGameCatalog` sweep: **2375/2391 passed** (16 skipped Testcontainers integration), no regression.

## Out-of-scope (deferred to Phase C / D)

- **M9** — `BackgroundService` scheduler that populates `WikidataQid` via catalog-seed-promotion (the current PR leaves `WikidataQid` assignable but never auto-populates).
- **M10** — Polly circuit breaker on Wikidata + Commons clients (DEC-3f).
- **M11** — Prometheus metric expansion beyond the 3 already shipped in Phase B + M8.
- **M12** — Admin trigger endpoint (CQRS routing) + FE wiring.
- **M13** — Dead-letter visibility page (BE + FE).
- **M14** — `<MeepleCard>` attribution footer (FE).
- **M15** — Quarterly QID re-verification cron consuming `WikidataQidLastVerifiedAt`.

## Migration plan

`apps/api/src/Api/Infrastructure/Migrations/20260610094431_AddWikidataQidColumnsToSharedGames.cs`:

```sql
ALTER TABLE shared_games ADD COLUMN wikidata_qid varchar(32) NULL;
ALTER TABLE shared_games ADD COLUMN wikidata_qid_last_verified_at timestamptz NULL;
```

Pure ADD COLUMN of nullable columns — no default value, no data backfill, no downtime. `Down` migration drops both cleanly.

## Test plan

- [x] `dotnet test --filter \"FullyQualifiedName~EnrichCatalogCover|FullyQualifiedName~WikimediaCommonsClient\"` — 46/46 green
- [x] `dotnet test --filter \"Category=Unit&FullyQualifiedName~SharedGameCatalog\"` — 2375/2391 green (16 Testcontainers skipped)
- [x] Build clean (0 errors, 0 warnings on API; pre-existing warnings on tests only)
- [x] EF migration generated + SQL inspected (nullable `varchar(32)` + `timestamptz`, no default)
- [ ] CI green (let CI confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)