### PR TITLE
feat(security): BGG fail-closed gate via ESLint rule + next.config strip (refs #2123)

### DIFF
--- a/apps/web/eslint-rules/no-bgg-hostname.js
+++ b/apps/web/eslint-rules/no-bgg-hostname.js
@@ -1,0 +1,76 @@
+/**
+ * ESLint rule: no BoardGameGeek (BGG) hostnames in source.
+ *
+ * ADR-1903 (BGG ToS, Issue #2123): user-side BGG access is forbidden. The
+ * browser must never GET an asset from `cf.geekdo-images.com`, any
+ * `*.boardgamegeek.com` host, or any other BGG-owned domain. The backend may
+ * still call the BGG XML API server-to-server (admin-only flow under
+ * `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/BggCatalogProvider.cs`),
+ * but that path never touches `apps/web/`.
+ *
+ * This rule statically flags any string literal — `"..."`, `'...'`, or
+ * `` `...` `` — anywhere under `apps/web/src/` that mentions one of the
+ * forbidden hostnames. It is the **fail-closed gate** for #2123 because:
+ *
+ *   1. The Next.js `images.remotePatterns` allowlist still has a trailing
+ *      wildcard `**` (kept for badge / arbitrary CDN images until #2123 can
+ *      replace it with an explicit allowlist), so dropping the explicit
+ *      `cf.geekdo-images.com` entry from `next.config.js` is NOT sufficient
+ *      on its own — a literal BGG URL would still pass.
+ *   2. Even outside `<Image>`, anywhere a raw `<img src>` or a `fetch()` is
+ *      pointed at a BGG host, the user's browser performs the GET and the
+ *      ToS violation is committed.
+ *
+ * To suppress in the rare legitimate case (e.g. a comment quoting a URL for
+ * documentation purposes, or admin-only code where the policy is genuinely
+ * different):
+ *
+ *   // eslint-disable-next-line local/no-bgg-hostname -- <reason>
+ *
+ * Refs:
+ *   - ADR-1903 (BGG legal constraint)
+ *   - Issue #2123 (manifest + whitelist sweep)
+ *   - Epic #1823 (Wikidata / Wikimedia / R2 replacement pipeline)
+ */
+
+'use strict';
+
+const FORBIDDEN_HOSTNAME_PATTERN =
+  /(?:^|[^a-z0-9])(?:cf\.geekdo-images\.com|geekdo-images\.com|[a-z0-9-]+\.boardgamegeek\.com|boardgamegeek\.com)/i;
+
+function reportIfForbidden(context, node, raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return;
+  if (!FORBIDDEN_HOSTNAME_PATTERN.test(raw)) return;
+  context.report({
+    node,
+    messageId: 'forbidden',
+    data: { value: raw.length > 80 ? `${raw.slice(0, 77)}...` : raw },
+  });
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid BoardGameGeek-owned hostnames in source (ADR-1903 / Issue #2123 ToS).',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      forbidden:
+        'BGG-owned hostname is forbidden in user-side code (ADR-1903, Issue #2123). Found: {{value}}',
+    },
+  },
+  create(context) {
+    return {
+      Literal(node) {
+        reportIfForbidden(context, node, node.value);
+      },
+      TemplateElement(node) {
+        // node.value.cooked is the interpolation-free string between `${}`.
+        reportIfForbidden(context, node, node.value && node.value.cooked);
+      },
+    };
+  },
+};

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -22,6 +22,9 @@ import noHardcodedColorUtility from "./eslint-rules/no-hardcoded-color-utility.j
 // API proxy guard — apiClient.{get,post,...} paths must start with /api/v1/
 // (post-#1229 regression preventer; rationale in rule docstring)
 import apiClientV1Prefix from "./eslint-rules/api-client-v1-prefix.js";
+// BGG ToS fail-closed guard (ADR-1903, Issue #2123) — forbid BoardGameGeek
+// hostnames anywhere under apps/web/src/. Rationale in rule docstring.
+import noBggHostname from "./eslint-rules/no-bgg-hostname.js";
 
 export default [
   {
@@ -105,6 +108,7 @@ export default [
           "no-inline-hsl-v2": noInlineHslV2,
           "no-hardcoded-color-utility": noHardcodedColorUtility,
           "api-client-v1-prefix": apiClientV1Prefix,
+          "no-bgg-hostname": noBggHostname,
         },
       },
     },
@@ -259,6 +263,14 @@ export default [
       // class of bug fixed in PR #1229 (refs #1160). Rationale in the rule's
       // docstring at eslint-rules/api-client-v1-prefix.js.
       "local/api-client-v1-prefix": "error",
+
+      // BGG ToS fail-closed gate (ADR-1903, Issue #2123). Forbids any string
+      // literal under apps/web/src/ that mentions a BoardGameGeek-owned
+      // hostname (`cf.geekdo-images.com`, `**.boardgamegeek.com`). The
+      // images.remotePatterns wildcard in next.config.js would otherwise still
+      // let a literal BGG URL pass; this lint rule is the real fail-closed.
+      // Rationale in eslint-rules/no-bgg-hostname.js.
+      "local/no-bgg-hostname": "error",
     },
     settings: {
       react: {
@@ -675,6 +687,47 @@ export default [
           ],
         },
       ],
+    },
+  },
+
+  // BGG ToS fail-closed exemptions (ADR-1903, Issue #2123).
+  //
+  // The `local/no-bgg-hostname` rule is globally `error`, but a handful of
+  // legitimate consumers must be allowed:
+  //
+  //   - `src/lib/games/cover-utils.ts` — owns `BLOCKED_IMAGE_HOSTS`, the
+  //     authoritative deny-list that the rule itself enforces. The file is the
+  //     guard, not a violator.
+  //   - `src/lib/api/clients/bggClient.ts` + tests — admin-only server-to-server
+  //     BGG API client, allowed per ADR-1903 (admin flow is OK; user flow is not).
+  //   - `src/components/admin/shared-games/**` + `src/app/admin/(dashboard)/shared-games/**`
+  //     — admin UI for the BGG ingestion workflow (BggSearchPanel, GameForm,
+  //     external-link to boardgamegeek.com on detail page). Admin pages are
+  //     gated by `proxy.ts` `ADMIN_ONLY_ROUTES`; a regular user never reaches
+  //     them.
+  //   - `**/*.stories.tsx` / `**/*.story.tsx` — Storybook fixtures, not in the
+  //     production bundle (`storybook-static/**` already excluded above).
+  //   - `**/__tests__/**` + `**/*.test.{ts,tsx}` — unit tests that EXPECT the
+  //     deny-list to fire and therefore must reference BGG URLs.
+  {
+    files: [
+      "src/lib/games/cover-utils.ts",
+      "src/lib/api/clients/bggClient.ts",
+      "src/lib/api/clients/__tests__/bggClient.test.ts",
+      "src/components/admin/shared-games/**/*.{ts,tsx}",
+      "src/app/admin/(dashboard)/shared-games/**/*.{ts,tsx}",
+      "**/*.stories.tsx",
+      "**/*.story.tsx",
+      "**/__tests__/**/*.{ts,tsx}",
+      "**/*.test.{ts,tsx}",
+      // Playwright E2E specs: fixtures that simulate BGG payloads (catalog
+      // covers, admin import flows). The specs never reach a real production
+      // build and the fixtures are required so the test environment matches
+      // the historical seed shape.
+      "e2e/**/*.{ts,tsx}",
+    ],
+    rules: {
+      "local/no-bgg-hostname": "off",
     },
   },
 ];

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -118,7 +118,21 @@ const nextConfig = {
   output: 'standalone', // Enable Docker-optimized output
   compress: false, // Disable compression to prevent ERR_CONTENT_DECODING_FAILED in proxy
 
-  // Issue #2209: Next.js Image optimization - configure remote image domains
+  // Issue #2209: Next.js Image optimization - configure remote image domains.
+  // Issue #2123 (BGG ToS, ADR #1903): the previously-allowed explicit entries
+  // for `cf.geekdo-images.com` and `**.boardgamegeek.com` have been removed.
+  // user-side traffic to BGG-hosted assets is forbidden — when a stale row in
+  // the seed catalog still carries a `cf.geekdo-images.com` `imageUrl`,
+  // Next.js Image now refuses to optimise/serve it, the `<img>` onError fires
+  // and `MeepleCard`/`Cover` falls back to `GameCoverPlaceholder`. No GET ever
+  // reaches the BGG CDN.
+  //
+  // KNOWN LEAK — tracked separately in #2123: the trailing wildcard `**` would
+  // still let a literal `https://cf.geekdo-images.com/...` request pass
+  // through Next.js Image. The ESLint rule below (`local/no-bgg-hostname`) is
+  // the actual fail-closed gate; the wildcard pattern is kept until #2123 can
+  // replace it with an explicit allowlist of self-hosted (R2) and approved
+  // (Wikimedia) hostnames.
   images: {
     remotePatterns: [
       {
@@ -126,18 +140,9 @@ const nextConfig = {
         hostname: 'picsum.photos',
         pathname: '/**',
       },
-      {
-        protocol: 'https',
-        hostname: 'cf.geekdo-images.com',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: '**.boardgamegeek.com',
-        pathname: '/**',
-      },
       // Wildcard catch-all for user-provided / admin-provided image URLs
-      // (badge iconUrl, game cover images from arbitrary CDNs, etc.)
+      // (badge iconUrl, game cover images from arbitrary CDNs, etc.).
+      // FOLLOW-UP (#2123): replace with explicit allowlist.
       {
         protocol: 'https',
         hostname: '**',


### PR DESCRIPTION
Refs #2123 — does NOT close (manifest regen still needed)

## Context

#1822 already shipped the runtime fail-closed: `apps/web/src/lib/games/cover-utils.ts` keeps a `BLOCKED_IMAGE_HOSTS` deny-list (`cf.geekdo-images.com`, `geekdo-images.com`, `images.geekdo.com`), and `<Cover>` reads it via `shouldUsePlaceholder(imageUrl)` so any BGG URL flips the component to `GameCoverPlaceholder` before a browser GET ever fires.

This PR is the **static guard** that makes that posture non-regressable.

## Changes

### 1. `apps/web/next.config.js`
- Drop the explicit `cf.geekdo-images.com` and `**.boardgamegeek.com` entries from `images.remotePatterns`.
- Document the known leak: the trailing wildcard `**` pattern (kept because real badge / arbitrary CDN images still need it until #2123 lands an explicit allowlist) would still let a literal BGG URL pass through Next.js Image optimisation. The ESLint rule below is the real fail-closed gate.

### 2. `apps/web/eslint-rules/no-bgg-hostname.js` (new)
- Statically flags any `Literal` or `TemplateElement` string that mentions `cf.geekdo-images.com`, `**.geekdo-images.com`, `**.boardgamegeek.com`, or the bare `boardgamegeek.com` host.
- Registered as `"error"` globally so a fresh BGG URL pasted into a production component fails CI immediately.

### 3. `apps/web/eslint.config.mjs`
Override block to exempt the legitimate consumers:
- `lib/games/cover-utils.ts` — owns the deny-list registry itself.
- `lib/api/clients/bggClient.ts` + unit tests — admin-only server-to-server BGG XML API client. Allowed per ADR-1903 (admin = server flow OK).
- `components/admin/shared-games/**` and `app/admin/(dashboard)/shared-games/**` — admin UI for BGG ingestion. Gated by `proxy.ts` `ADMIN_ONLY_ROUTES`.
- `**/*.stories.tsx`, `**/*.story.tsx`, `**/__tests__/**`, `**/*.test.{ts,tsx}` — Storybook fixtures / unit tests, not in production bundle.
- `e2e/**` — Playwright specs that simulate the historical seed shape.

## Verification

```bash
cd apps/web && pnpm lint
# Before: 30 errors (all local/no-bgg-hostname)
# After:  0 errors, 9 warnings (pre-existing, unrelated)
```

Runtime behaviour verified upstream by #1822: even on a fresh `make dev` where `shared_games.image_url` still carries `https://cf.geekdo-images.com/...`, `<Cover>` matches the host against `BLOCKED_IMAGE_HOSTS` and renders the placeholder — the browser never issues the GET.

## Not done in this PR (tracked in #2123)

- **Regenerate the seed manifests** (`dev.yml`, `staging.yml`, `prod.yml` — 568 BGG URLs each, 142 entries with `bggEnhanced: true` each). The #1823 R2 / Wikidata / Wikimedia replacement pipeline already shipped the *schema* columns (`wikidata_cover_r2_key`, `pdf_cover_r2_key`, `bgg_cover_r2_key`, `wikidata_qid`) but the backfill job that populates them has not yet been run on any environment. Audit 2026-06-10:
  ```sql
  SELECT COUNT(*) AS total, COUNT(wikidata_cover_r2_key) AS w_r2,
         COUNT(pdf_cover_r2_key) AS p_r2, COUNT(bgg_cover_r2_key) AS bgg_r2,
         COUNT(wikidata_qid) AS w_qid
  FROM shared_games;
  -- 159 | 0 | 0 | 0 | 0
  ```
- **Replace the `**` wildcard** in `next.config.js` `remotePatterns` with an explicit allowlist of self-hosted (R2) and approved (Wikimedia) hostnames.
- **Documentation in CLAUDE.md § Active Freezes** stating the lint rule + freeze.

## Test plan

- [x] `pnpm lint` — 0 errors (was 30 errors after rule, 0 before; 9 pre-existing warnings on unrelated files)
- [ ] Manual: open `/hub/games` after merge, confirm `Cover` still renders placeholder for entries that carry a `cf.geekdo-images.com` URL. (Expected: identical behaviour to today's `main-dev`, since #1822's runtime check is the actual blocker.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)