### PR TITLE
fix(smoldocling): pin Python 3.11.x via deadsnakes (resolves torch._dynamo crash)

### DIFF
--- a/apps/smoldocling-service/Dockerfile
+++ b/apps/smoldocling-service/Dockerfile
@@ -35,10 +35,30 @@ FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
 
 WORKDIR /app
 
-# Install only runtime system dependencies (NO build-essential)
+# Install runtime system dependencies. Python comes from the deadsnakes PPA so
+# we get a *current* Python 3.11.x — the Ubuntu 22.04 default `python3.11`
+# package on this CUDA base is the fossil **3.11.0rc1** (Aug 2022 release
+# candidate), which is missing `sys.get_int_max_str_digits` (added only in the
+# 3.11.0 final). torch >= 2.12 `polyfills/sys.py:31` decorates
+# `@substitute_in_graph(sys.get_int_max_str_digits, ...)` unconditionally for
+# Python 3.11+, so on rc1 the module raises AttributeError mid-init. The
+# partially-loaded module leaves `sys.intern` already registered in
+# `VariableBuilder._id_dispatch`, so any subsequent `import torch._dynamo`
+# attempt (transformers does several via lazy loaders) then crashes with the
+# user-visible "Duplicate dispatch rule for sys.intern" instead of the real
+# AttributeError. Pinning a *current* 3.11.x via deadsnakes resolves both.
+#
+# DEBIAN_FRONTEND=noninteractive prevents `python3.11-distutils` (pulled via
+# deadsnakes) from blocking on the `tzdata` geographic-area prompt. Verified
+# locally 2026-06-10: without it the build hung at `Geographic area:`.
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Python
+    software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    # Python 3.11 (deadsnakes — current 3.11.x, not Ubuntu's stale rc1)
     python3.11 \
+    python3.11-distutils \
     python3-pip \
     # HTTP client for health checks
     curl \


### PR DESCRIPTION
## Problem

The `meepleai-smoldocling` container has been crash-looping at startup with the misleading error:

```
ValueError: Duplicate dispatch rule for <built-in function intern>:
already registered in VariableBuilder's id dispatch map
```

## Root cause (Python 3.11.0rc1 fossil)

The runtime stage `FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04` ships Ubuntu 22.04's default `python3.11` apt package, which on this CUDA image base is still pinned at **`3.11.0rc1`** (August 2022 release candidate, never bumped to the 3.11.0 final). `python --version` inside the container confirms it.

`3.11.0rc1` is missing `sys.get_int_max_str_digits` (added only in the 3.11.0 final, backported as part of CVE-2020-10735). torch ≥ 2.12 `polyfills/sys.py:31` unconditionally decorates that attribute for any `sys.version_info >= (3, 11)`:

```python
@substitute_in_graph(sys.get_int_max_str_digits, can_constant_fold_through=True)
def get_int_max_str_digits() -> int: ...
```

On rc1 the `polyfills/sys.py` module raises `AttributeError` mid-init — but by line 31 the `@substitute_in_graph(sys.intern, …)` decorator at line 19 has already registered `sys.intern` in the cached `VariableBuilder._id_dispatch` map. When transformers later re-imports `torch._dynamo` via its lazy loader chain (`AutoProcessor` → `processing_utils` → `modeling_utils` → `flex_attention` → `@torch.compiler.disable` → `import torch._dynamo`), the partial sidecar tries to register `sys.intern` again and the real `AttributeError` gets shadowed by the user-visible "Duplicate dispatch rule" message.

The sibling AI services (`reranker`, `embedding`) don't hit this because their Dockerfiles use `FROM python:3.11-slim` (3.11.15 today).

## Fix

`apps/smoldocling-service/Dockerfile`:

1. **Install Python via the deadsnakes PPA** (`ppa:deadsnakes/ppa`) so the runtime gets a current 3.11.15 instead of Ubuntu's fossil rc1.
2. **`ENV DEBIAN_FRONTEND=noninteractive`** so `python3.11-distutils` doesn't hang on the `tzdata` "Geographic area:" prompt during the PPA install (caught locally; without it the build hangs forever at "#13 61.60 Geographic area:").
3. **Long-form comment** in the Dockerfile documenting the trap so the next person to bump the base image knows why we can't just rely on the default `python3.11` package.

## Verification

```bash
$ docker run --rm --entrypoint python meepleai-smoldocling-service:latest \
    -c "import sys; print(sys.version.split()[0]); print('has get_int_max_str_digits:', hasattr(sys, 'get_int_max_str_digits')); import torch._dynamo; print('torch._dynamo: OK')"
3.11.15
has get_int_max_str_digits: True
torch._dynamo: OK

$ docker compose up -d smoldocling-service
$ docker ps --filter "name=meepleai-smoldocling" --format "table {{.Names}}\t{{.Status}}"
NAMES                  STATUS
meepleai-smoldocling   Up 29 seconds (healthy)

$ docker logs meepleai-smoldocling --tail=5
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8002 (Press CTRL+C to quit)
INFO:     127.0.0.1:34346 - "GET /health HTTP/1.1" 200 OK
```

## Discovery

Found while preparing to run `make seed-index` for the seed-snapshot freshness work in #2126. Once this lands, a fresh bake against `main-dev` HEAD (`20260610094431_AddWikidataQidColumnsToSharedGames`) can be produced and uploaded to replace the 56-day-stale `2026-04-15` snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)