### PR TITLE
fix(api): #2123 sanitize BGG beacon body fields (cs/log-forging hotfix)

### DIFF
--- a/apps/api/src/Api/Routing/BggAttemptBeaconEndpoints.cs
+++ b/apps/api/src/Api/Routing/BggAttemptBeaconEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.Helpers;
 using Api.Observability;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -50,17 +51,33 @@ internal static class BggAttemptBeaconEndpoints
     /// Process logic split out for unit-test access — increments the Prometheus
     /// counter with the truncated <c>path</c> tag and logs a structured warning.
     /// </summary>
+    /// <remarks>
+    /// The beacon body is anonymous user input. Both <c>Path</c> and <c>Src</c>
+    /// MUST be passed through <see cref="LogSanitizer.Sanitize(string?, int)"/>
+    /// before reaching the log sink to neutralize CRLF injection / log forging
+    /// (CodeQL <c>cs/log-forging</c>, ADR-058). The Prometheus tag is also
+    /// truncated to bound cardinality.
+    /// </remarks>
     internal static void ProcessBeacon(BggAttemptBeaconRequest? body, ILogger logger)
     {
-        var path = string.IsNullOrWhiteSpace(body?.Path) ? "unknown" : Truncate(body.Path!, 256);
+        var rawPath = body?.Path;
+        var path = string.IsNullOrWhiteSpace(rawPath) ? "unknown" : Truncate(rawPath!, 256);
         MeepleAiMetrics.BggUrlAttemptedRender.Add(
             1,
             new KeyValuePair<string, object?>("path", path));
+
+        // Sanitize before logging: user input (Path, Src) must NOT reach the
+        // log sink without LogSanitizer.Sanitize, which strips CR/LF and
+        // bounds length. The counter `path` tag is already safe — it is
+        // either the literal "unknown" or a Truncated string used as a
+        // Prometheus label (CodeQL sanitizers-extensions barrier registered).
+        var safePath = LogSanitizer.Sanitize(path, 256);
+        var safeSrc = LogSanitizer.Sanitize(body?.Src ?? "(missing)", 256);
         logger.LogWarning(
             "BGG ToS violation attempt observed at path '{Path}' (src='{Src}'). " +
             "FE custom Image loader rewrote to placeholder. Issue #2123.",
-            path,
-            Truncate(body?.Src ?? "(missing)", 256));
+            safePath,
+            safeSrc);
     }
 
     private static string Truncate(string value, int max) =>


### PR DESCRIPTION
## Summary

CodeQL csharp post-merge of #2125 surfaced 2 new `cs/log-forging` alerts in `Api.Routing.BggAttemptBeaconEndpoints.ProcessBeacon`. The anonymous beacon body fields `Path` and `Src` were truncated but not passed through `LogSanitizer.Sanitize` before reaching the log sink.

This PR routes both fields through `LogSanitizer.Sanitize(value, 256)` to neutralize CRLF injection per ADR-058.

## Why CodeQL flagged

`POST /api/v1/metrics/bgg-attempt` is anonymous by design (would mask SSR / signed-out / search-engine surfaces). The body therefore counts as fully untrusted user input. CodeQL's taint flow tracks `body.Path → Truncate → ILogger` and `body.Src → Truncate → ILogger`; truncation is not a registered sanitizer barrier.

## Fix

```csharp
var safePath = LogSanitizer.Sanitize(path, 256);
var safeSrc = LogSanitizer.Sanitize(body?.Src ?? "(missing)", 256);
logger.LogWarning(
    "BGG ToS violation attempt observed at path '{Path}' (src='{Src}'). " +
    "FE custom Image loader rewrote to placeholder. Issue #2123.",
    safePath,
    safeSrc);
```

The Prometheus `path` tag remains the unsanitized-but-truncated value — Prometheus labels are not log-forging sinks (already covered by the CodeQL sanitizers-extensions barrier).

## Tests

`BggAttemptBeaconEndpointsTests` (6/6 green): existing assertions still pass because they verify the Prometheus tag (which uses the pre-sanitize `path` variable), not the sanitized log argument.

## Refs

- Alert source: https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/27306218269/job/80664704793
- ADR-058 (PII-safe logging)
- `docs/for-developers/security/pii-safe-logging.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)