### PR TITLE
feat(api): /health/seed endpoint with seed_state field (#2126 Tier 1 D3)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs
@@ -1,0 +1,157 @@
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Api.Infrastructure.Health.Checks;
+
+/// <summary>
+/// Reports the RAG seed state — whether the database has been seeded with
+/// PDF documents, text chunks, and vector embeddings.
+///
+/// Surfaces a coarse-grained <c>seed_state</c> field that lets monitoring
+/// (and the developer hitting <c>/health/ready</c> after <c>make dev</c>) see
+/// at a glance whether the stack is actually ready to serve RAG queries.
+///
+/// State machine (counts from <see cref="MeepleAiDbContext.PdfDocuments"/>,
+/// <see cref="MeepleAiDbContext.TextChunks"/>,
+/// <see cref="MeepleAiDbContext.VectorDocuments"/>):
+///
+/// <list type="bullet">
+///   <item>
+///     <description><c>empty</c> — no PDFs, no chunks, no embeddings.
+///     `make dev` was just run and the runtime indexer has not produced
+///     anything yet, or <c>make dev-from-snapshot</c> was never used.</description>
+///   </item>
+///   <item>
+///     <description><c>indexing</c> — chunks and embeddings exist but at
+///     least one PDF is still in a pre-<c>Ready</c> processing state
+///     (Pending / Uploading / Extracting / Chunking / Embedding /
+///     Indexing). Either runtime indexing is in flight or a bake is mid-flight.</description>
+///   </item>
+///   <item>
+///     <description><c>partial_failed</c> — sidecar invariant is violated:
+///     <c>chunk_count != embedding_count</c>, OR at least one PDF is in
+///     state <c>Failed</c>. RAG returns degraded recall. Equivalent to
+///     <c>snapshot-verify.sh</c> exit code 6 (#2126 D7) but applied to the
+///     live DB.</description>
+///   </item>
+///   <item>
+///     <description><c>ready</c> — every PDF is <c>Ready</c>, chunks and
+///     embeddings agree, RAG can serve at full recall.</description>
+///   </item>
+/// </list>
+///
+/// Refs: #2126 Tier 1 D3, spec
+/// docs/for-developers/specs/2026-04-10-seed-pdf-pre-indexed-design.md
+/// </summary>
+public sealed class SeedStateHealthCheck : IHealthCheck
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly ILogger<SeedStateHealthCheck> _logger;
+
+    public SeedStateHealthCheck(MeepleAiDbContext db, ILogger<SeedStateHealthCheck> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    /// <summary>Public enum-as-strings so the health endpoint payload stays stable.</summary>
+    public static class SeedStates
+    {
+        public const string Empty = "empty";
+        public const string Indexing = "indexing";
+        public const string PartialFailed = "partial_failed";
+        public const string Ready = "ready";
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var pdfTotal = await _db.PdfDocuments
+                .AsNoTracking()
+                .CountAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var pdfReady = await _db.PdfDocuments
+                .AsNoTracking()
+                .CountAsync(d => d.ProcessingState == "Ready", cancellationToken)
+                .ConfigureAwait(false);
+
+            var pdfFailed = await _db.PdfDocuments
+                .AsNoTracking()
+                .CountAsync(d => d.ProcessingState == "Failed", cancellationToken)
+                .ConfigureAwait(false);
+
+            var chunkCount = await _db.TextChunks
+                .AsNoTracking()
+                .CountAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var embeddingCount = await _db.VectorDocuments
+                .AsNoTracking()
+                .CountAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            string seedState = DeriveSeedState(pdfTotal, pdfReady, pdfFailed, chunkCount, embeddingCount);
+
+            var data = new Dictionary<string, object>(StringComparer.Ordinal)
+            {
+                ["seed_state"] = seedState,
+                ["pdf_total"] = pdfTotal,
+                ["pdf_ready"] = pdfReady,
+                ["pdf_failed"] = pdfFailed,
+                ["chunk_count"] = chunkCount,
+                ["embedding_count"] = embeddingCount,
+            };
+
+            // We never surface this as Unhealthy — even an empty DB is a valid state
+            // for a freshly-restored stack. We use Degraded to flag attention without
+            // breaking /health/ready (which only fails on Critical), so monitoring can
+            // still alert when a partial bake degrades recall.
+            return seedState switch
+            {
+                SeedStates.PartialFailed => HealthCheckResult.Degraded(
+                    $"RAG partial-failed: chunks={chunkCount} embeddings={embeddingCount} failed_pdfs={pdfFailed}",
+                    data: data),
+                _ => HealthCheckResult.Healthy(
+                    $"seed_state={seedState} (pdfs={pdfTotal}/{pdfReady}, chunks={chunkCount}, embeddings={embeddingCount})",
+                    data: data),
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SeedStateHealthCheck failed to query DB counts");
+            return HealthCheckResult.Unhealthy("Failed to query seed-state counts", ex);
+        }
+    }
+
+    /// <summary>
+    /// Pure function so we can unit-test the state machine without spinning up postgres.
+    /// </summary>
+    public static string DeriveSeedState(int pdfTotal, int pdfReady, int pdfFailed, int chunkCount, int embeddingCount)
+    {
+        if (pdfTotal == 0 && chunkCount == 0 && embeddingCount == 0)
+        {
+            return SeedStates.Empty;
+        }
+
+        // Bake failed mid-way: chunks and embeddings disagree, or a PDF ended in Failed.
+        if (chunkCount != embeddingCount || pdfFailed > 0)
+        {
+            return SeedStates.PartialFailed;
+        }
+
+        // All PDFs are processed and counts agree → ready.
+        if (pdfTotal > 0 && pdfTotal == pdfReady && chunkCount > 0 && embeddingCount > 0)
+        {
+            return SeedStates.Ready;
+        }
+
+        // PDFs exist but some are still pre-Ready (Pending/Uploading/.../Indexing),
+        // or counts are zero on one side only — indexing is in flight.
+        return SeedStates.Indexing;
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
@@ -171,6 +171,16 @@ public static class HealthCheckServiceExtensions
             tags: new[] { HealthCheckTags.External, HealthCheckTags.NonCritical },
             timeout: TimeSpan.FromSeconds(5));
 
+        // Seed / RAG state (#2126 D3). NonCritical so it never breaks
+        // /health/ready (which is the Critical predicate); the field lives on
+        // /health/seed and is also surfaced via the Data dictionary so the
+        // top-level /health endpoint readers can inspect it without extra calls.
+        builder.AddCheck<SeedStateHealthCheck>(
+            "seed_state",
+            HealthStatus.Degraded,
+            tags: new[] { HealthCheckTags.Seed, HealthCheckTags.NonCritical },
+            timeout: TimeSpan.FromSeconds(5));
+
         return builder;
     }
 }

--- a/apps/api/src/Api/Infrastructure/Health/Models/HealthCheckTags.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Models/HealthCheckTags.cs
@@ -31,6 +31,14 @@ public static class HealthCheckTags
     /// </summary>
     public const string Storage = "storage";
 
+    /// <summary>
+    /// Seed-data / RAG indexing pipeline (#2126 D3). The
+    /// <c>SeedStateHealthCheck</c> reports whether the DB is
+    /// <c>empty</c>, <c>indexing</c>, <c>partial_failed</c>, or <c>ready</c>
+    /// for RAG queries — orthogonal to whether external services are up.
+    /// </summary>
+    public const string Seed = "seed";
+
     // Criticality levels
     /// <summary>
     /// Critical service - application cannot function without it.

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -744,6 +744,35 @@ app.MapHealthChecks("/health/config", new Microsoft.AspNetCore.Diagnostics.Healt
     }
 });
 
+// Seed / RAG state probe (#2126 D3). Surfaces the SeedStateHealthCheck Data
+// (seed_state, pdf_total, pdf_ready, pdf_failed, chunk_count, embedding_count)
+// at a stable JSON path so a dev (or a monitoring scrape) can see whether the
+// stack is `empty`, `indexing`, `partial_failed`, or `ready` without parsing
+// the noisier global /health response.
+app.MapHealthChecks("/health/seed", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains(Api.Infrastructure.Health.Models.HealthCheckTags.Seed),
+    ResponseWriter = async (context, report) =>
+    {
+        context.Response.ContentType = "application/json";
+        var seedCheck = report.Entries.FirstOrDefault(e => string.Equals(e.Key, "seed_state", StringComparison.Ordinal));
+        var data = seedCheck.Value.Data ?? new Dictionary<string, object>(StringComparer.Ordinal);
+        var result = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            status = report.Status.ToString(),
+            seed_state = data.TryGetValue("seed_state", out var s) ? s : "unknown",
+            pdf_total = data.TryGetValue("pdf_total", out var pt) ? pt : 0,
+            pdf_ready = data.TryGetValue("pdf_ready", out var pr) ? pr : 0,
+            pdf_failed = data.TryGetValue("pdf_failed", out var pf) ? pf : 0,
+            chunk_count = data.TryGetValue("chunk_count", out var cc) ? cc : 0,
+            embedding_count = data.TryGetValue("embedding_count", out var ec) ? ec : 0,
+            description = seedCheck.Value.Description,
+            duration = seedCheck.Value.Duration.TotalMilliseconds,
+        }, healthCheckJsonOptions);
+        await context.Response.WriteAsync(result).ConfigureAwait(false);
+    }
+});
+
 // API-01: Create v1 API route group and map routing files
 var v1Api = app.MapGroup("/api/v1");
 

--- a/apps/api/tests/Api.Tests/Infrastructure/Health/Checks/SeedStateHealthCheckTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Health/Checks/SeedStateHealthCheckTests.cs
@@ -1,0 +1,110 @@
+using Api.Infrastructure.Health.Checks;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Health.Checks;
+
+/// <summary>
+/// Unit tests for the pure state-machine inside <see cref="SeedStateHealthCheck"/>.
+/// The DB-bound <c>CheckHealthAsync</c> path is exercised by integration tests
+/// against the real DbContext — this class only locks down
+/// <see cref="SeedStateHealthCheck.DeriveSeedState"/>.
+///
+/// Refs: #2126 D3 (seed_state field on /health/seed).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Issue", "2126")]
+public sealed class SeedStateHealthCheckTests
+{
+    [Fact]
+    public void DeriveSeedState_AllZero_ReturnsEmpty()
+    {
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 0, pdfReady: 0, pdfFailed: 0, chunkCount: 0, embeddingCount: 0);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.Empty);
+    }
+
+    [Fact]
+    public void DeriveSeedState_AllPdfsReady_CountsMatch_ReturnsReady()
+    {
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 113, pdfReady: 113, pdfFailed: 0, chunkCount: 8599, embeddingCount: 8599);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.Ready);
+    }
+
+    [Fact]
+    public void DeriveSeedState_SomePdfsFailed_ReturnsPartialFailed()
+    {
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 113, pdfReady: 110, pdfFailed: 3, chunkCount: 8400, embeddingCount: 8400);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.PartialFailed);
+    }
+
+    [Fact]
+    public void DeriveSeedState_ChunkEmbeddingMismatch_ReturnsPartialFailed()
+    {
+        // Sidecar invariant violated — same condition as D7 exit code 6 but
+        // applied to the live DB rather than to a snapshot sidecar.
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 113, pdfReady: 113, pdfFailed: 0, chunkCount: 8599, embeddingCount: 8500);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.PartialFailed);
+    }
+
+    [Fact]
+    public void DeriveSeedState_PdfsExistButNotAllReady_ReturnsIndexing()
+    {
+        // 8 PDFs uploaded, only 3 processed so far, no failures, counts agree.
+        // Runtime indexing in flight.
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 8, pdfReady: 3, pdfFailed: 0, chunkCount: 240, embeddingCount: 240);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.Indexing);
+    }
+
+    [Fact]
+    public void DeriveSeedState_ChunksWithoutEmbeddings_ReturnsPartialFailed()
+    {
+        // Embedding-service crashed mid-bake: chunking succeeded but embedding 0.
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 10, pdfReady: 10, pdfFailed: 0, chunkCount: 500, embeddingCount: 0);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.PartialFailed);
+    }
+
+    [Fact]
+    public void DeriveSeedState_PdfsExistChunksZero_ReturnsIndexing()
+    {
+        // PDFs uploaded but chunking has not started yet.
+        var state = SeedStateHealthCheck.DeriveSeedState(
+            pdfTotal: 5, pdfReady: 0, pdfFailed: 0, chunkCount: 0, embeddingCount: 0);
+        state.Should().Be(SeedStateHealthCheck.SeedStates.Indexing);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, 0, 0)]
+    [InlineData(113, 113, 0, 8599, 8599)]
+    public void DeriveSeedState_ProducesStableEnumStrings(
+        int pdfTotal, int pdfReady, int pdfFailed, int chunkCount, int embeddingCount)
+    {
+        // Lock down the enum strings so the public /health/seed contract is
+        // not silently broken by a typo refactor.
+        var state = SeedStateHealthCheck.DeriveSeedState(pdfTotal, pdfReady, pdfFailed, chunkCount, embeddingCount);
+        new[]
+        {
+            SeedStateHealthCheck.SeedStates.Empty,
+            SeedStateHealthCheck.SeedStates.Indexing,
+            SeedStateHealthCheck.SeedStates.PartialFailed,
+            SeedStateHealthCheck.SeedStates.Ready,
+        }.Should().Contain(state);
+    }
+
+    [Fact]
+    public void SeedStates_AreLowercaseSnakeCase()
+    {
+        // Public JSON contract: lowercase + snake_case so consumers don't have
+        // to deal with ".NET enum case" inconsistencies.
+        SeedStateHealthCheck.SeedStates.Empty.Should().Be("empty");
+        SeedStateHealthCheck.SeedStates.Indexing.Should().Be("indexing");
+        SeedStateHealthCheck.SeedStates.PartialFailed.Should().Be("partial_failed");
+        SeedStateHealthCheck.SeedStates.Ready.Should().Be("ready");
+    }
+}


### PR DESCRIPTION
Refs #2126 — Tier 1 **D3**

## Summary

Adds a coarse-grained RAG readiness probe so a developer running `make dev` (or a monitoring scrape) can tell at a glance whether the stack is `empty`, `indexing`, `partial_failed`, or `ready` — orthogonal to whether external services (postgres, redis, embedding-service) are up.

Today the only way to answer "is RAG actually working yet?" is to query the DB directly. After this PR:

```bash
$ curl -s http://localhost:8080/health/seed | jq .
{
  "status": "Healthy",
  "seed_state": "empty",
  "pdf_total": 0,
  "pdf_ready": 0,
  "pdf_failed": 0,
  "chunk_count": 0,
  "embedding_count": 0,
  "description": "seed_state=empty (pdfs=0/0, chunks=0, embeddings=0)",
  "duration": 12.3
}
```

## State machine

`SeedStateHealthCheck.DeriveSeedState(...)` is a pure function so the state machine can be unit-tested without postgres:

| State | Condition |
|---|---|
| `empty` | `pdf_total=0 && chunk_count=0 && embedding_count=0` |
| `indexing` | PDFs exist but some still pre-`Ready`, counts agree |
| `partial_failed` | `chunk_count != embedding_count`, **or** any PDF in `Failed` |
| `ready` | every PDF `Ready` + counts agree |

## Files

| File | Change |
|---|---|
| `apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs` | **new** IHealthCheck + pure state-machine helper |
| `apps/api/src/Api/Infrastructure/Health/Models/HealthCheckTags.cs` | new `Seed` tag, with docstring tying it back to #2126 |
| `apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs` | register `seed_state` check (Degraded / NonCritical / 5s timeout) |
| `apps/api/src/Api/Program.cs` | map `/health/seed` endpoint with a small ResponseWriter that promotes the Data dictionary to top-level JSON |
| `apps/api/tests/Api.Tests/Infrastructure/Health/Checks/SeedStateHealthCheckTests.cs` | **new** 10 unit tests covering each state, the partial-failed branches (failed PDF / count mismatch / chunks-without-embeddings), and the lowercase-snake_case enum-string contract |

## Wired into existing infra (no churn)

- Reuses `MeepleAiDbContext` (no new DbContext)
- Reuses the existing `HealthCheckServiceExtensions.AddComprehensiveHealthChecks` registration site
- Mirrors the response-writer pattern from `/health/config`
- Test placement / `[Trait("Category", TestCategories.Unit)]` mirrors `RedisRateLimitingHealthCheckTests`
- Registered as `Degraded` + `NonCritical` so it never breaks `/health/ready` (which only fires on `Critical`). `partial_failed` surfaces Degraded so monitoring can alert without blocking the readiness probe.

## Verification

```
$ dotnet build apps/api/src/Api
Build succeeded.   Errors: 0, Warnings: 0

$ dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~SeedStateHealthCheckTests"
Passed!  - Failed: 0. Passed: 10. Skipped: 0. Total: 10.
```

## Roadmap for #2126

| Tier | Deliverable | Status |
|---|---|---|
| 1 | D1 `make seed-status` + D2 `make dev` banner | ✅ Merged (#2130) |
| 1 | **D3 `/health/seed` `seed_state`** | **this PR** |
| 3 | D7 sidecar invariant (`chunk_count == embedding_count`) | 🚧 PR #2134 |
| 3 | D9 schema-version guard (`seed_table_schema_version`) | 🚧 PR #2134 |
| 2 | D6 audit log | next |
| 2 | D4 GHA `seed-snapshot-bake.yml` workflow | next (R2 / GHCR decision) |
| 2 | D5 README freshness badge | future (depends on D4) |
| 3 | D8 weekly RAG smoke regression | future (depends on D4) |

## Companion notes

The same `chunk_count == embedding_count` invariant is checked offline against a snapshot sidecar in PR #2134 (`snapshot-verify.sh` exit code 6). This PR is the live-DB sibling — together they catch the failure mode at bake time AND at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)