### PR TITLE
feat(ci): seed-snapshot bake workflows + R2 publish (#2126 Tier 2 D4)

### DIFF
--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -1,0 +1,182 @@
+name: Seed Snapshot Bake (CI smoke — ci.yml manifest)
+
+# Tier 2 D4 of #2126 — Seed snapshot freshness pipeline.
+#
+# Purpose: catch regressions in the bake pipeline *before* they reach the
+# slow weekly full bake. Runs against `ci.yml` (3 PDFs, bake in ~10 min) on
+# every push that touches anything that could break the seed pipeline:
+#
+#   - any of the seeder manifests (dev/staging/prod/ci)
+#   - any EF migration .cs file
+#   - any of the seed-* / snapshot-* / wait-for-healthy shell scripts
+#   - the bake docker compose files
+#   - the seed-schema.version sentinel (#2126 D9)
+#
+# This workflow is a *gate*: failure means a developer has broken the bake
+# pipeline. The full bake (`seed-snapshot-bake-full.yml`) trusts that this
+# smoke ran first.
+#
+# Companion: PR #2134 (D7+D9 verify gates) — those exit codes 5/6 fire here
+# if the bake produces a sidecar that violates the invariants.
+
+on:
+  push:
+    branches:
+      - main-dev
+      - main-staging
+    paths:
+      - 'apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/*.yml'
+      - 'apps/api/src/Api/Migrations/**'
+      - 'infra/scripts/seed-index-*.sh'
+      - 'infra/scripts/snapshot-*.sh'
+      - 'infra/scripts/wait-for-healthy.sh'
+      - 'infra/docker-compose.yml'
+      - 'infra/compose.dev.yml'
+      - 'infra/seed-schema.version'
+      - '.github/workflows/seed-snapshot-bake-ci.yml'
+  pull_request:
+    paths:
+      - 'apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/*.yml'
+      - 'apps/api/src/Api/Migrations/**'
+      - 'infra/scripts/seed-index-*.sh'
+      - 'infra/scripts/snapshot-*.sh'
+      - 'infra/seed-schema.version'
+      - '.github/workflows/seed-snapshot-bake-ci.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Upload the smoke dump to the seed blob bucket (default: no, smoke only)'
+        required: false
+        default: 'false'
+        type: boolean
+
+# Only one CI bake at a time per ref — bake jobs share a postgres container
+# instance, so two parallel runs on the same SHA would clobber each other.
+# A newer push cancels older runs.
+concurrency:
+  group: seed-snapshot-bake-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bake-ci-smoke:
+    name: Bake ci.yml (3 PDFs) + verify gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      SEED_CATALOG_MANIFEST_OVERRIDE: ci
+      # Even the 3-PDF bake can occasionally hit the "embedding service is
+      # warming" path; give it 25 min instead of the default 3h.
+      SEED_INDEX_TIMEOUT: '1500'
+      SEED_INDEX_POLL: '10'
+      SEED_INDEX_FAILURE_PCT: '0' # ci.yml MUST not have failures
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify ci.yml manifest is present and small
+        run: |
+          set -euo pipefail
+          MANIFEST=apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml
+          test -f "$MANIFEST" || { echo "::error::missing $MANIFEST"; exit 1; }
+          PDF_COUNT=$(grep -cE '^\s*- pdfPath:' "$MANIFEST" || true)
+          echo "ci.yml declares $PDF_COUNT PDFs"
+          # ci.yml is supposed to stay small. If it grew past a sane bound,
+          # the smoke is no longer a smoke — fail loudly so somebody splits
+          # it back out or moves the test to the full bake.
+          if [ "$PDF_COUNT" -gt 10 ]; then
+            echo "::error::ci.yml has grown to $PDF_COUNT PDFs — exceeds CI smoke budget (cap 10)"
+            exit 1
+          fi
+
+      - name: Install jq (required by seed scripts)
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run bake
+        working-directory: infra
+        env:
+          # Seed secrets are NOT injected for the smoke bake — the local
+          # postgres + embedding service are sufficient. If the user passes
+          # `--publish=true`, the secrets-gate step below provides them.
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          mkdir -p "$SEED_INDEX_OUT_DIR"
+          # `make seed-index` brings up the bake stack, runs the seeder, polls
+          # processing_jobs, and dumps. CI runner is ephemeral, so we don't
+          # bother with `make dev-down`.
+          make seed-index
+
+      - name: Run verify gates (exit codes 2/3/4/5/6)
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          # The verify script exits 0 on success and a distinct code per gate;
+          # `set -e` plus an explicit invocation gives us the GHA-visible error.
+          bash scripts/snapshot-verify.sh
+
+      - name: Surface seed-status
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: bash scripts/seed-status.sh || true
+
+      - name: Upload sidecar as workflow artifact (90-day retention)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-snapshot-ci-meta-${{ github.run_id }}
+          path: |
+            data/snapshots/*.meta.json
+            data/snapshots/.latest
+          retention-days: 14
+          if-no-files-found: warn
+
+      # ──────────────────────────────────────────────────────────────────
+      # Optional publish path (off by default). The dispatch input exists so
+      # a maintainer can produce a real, signed dump from the CI manifest
+      # without spinning up `make seed-index-publish` locally — useful when
+      # the e2e snapshot needs refreshing.
+      #
+      # SECRETS REQUIRED (configure in the repo Settings → Secrets and
+      # variables → Actions):
+      #   SEED_BLOB_S3_ENDPOINT     e.g. https://<accountid>.r2.cloudflarestorage.com
+      #   SEED_BLOB_S3_ACCESS_KEY
+      #   SEED_BLOB_S3_SECRET_KEY
+      #   SEED_BLOB_BUCKET          e.g. meepleai-seed-snapshots
+      #
+      # The job falls back gracefully when any of them is missing.
+      # ──────────────────────────────────────────────────────────────────
+      - name: Optional — publish smoke dump
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        working-directory: infra
+        env:
+          S3_ENDPOINT: ${{ secrets.SEED_BLOB_S3_ENDPOINT }}
+          S3_ACCESS_KEY: ${{ secrets.SEED_BLOB_S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.SEED_BLOB_S3_SECRET_KEY }}
+          SEED_BLOB_BUCKET: ${{ secrets.SEED_BLOB_BUCKET }}
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          set -euo pipefail
+          : "${S3_ENDPOINT:?SEED_BLOB_S3_ENDPOINT secret not configured}"
+          : "${S3_ACCESS_KEY:?SEED_BLOB_S3_ACCESS_KEY secret not configured}"
+          : "${S3_SECRET_KEY:?SEED_BLOB_S3_SECRET_KEY secret not configured}"
+          : "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET secret not configured}"
+          # `seed-index-publish.sh` reads storage.secret on disk; synthesize one
+          # from the GH Actions secrets for the duration of the job.
+          mkdir -p secrets
+          cat > secrets/storage.secret <<EOF
+          S3_ENDPOINT=${S3_ENDPOINT}
+          S3_ACCESS_KEY=${S3_ACCESS_KEY}
+          S3_SECRET_KEY=${S3_SECRET_KEY}
+          SEED_BLOB_BUCKET=${SEED_BLOB_BUCKET}
+          EOF
+          chmod 600 secrets/storage.secret
+          bash scripts/seed-index-publish.sh

--- a/.github/workflows/seed-snapshot-bake-full.yml
+++ b/.github/workflows/seed-snapshot-bake-full.yml
@@ -1,0 +1,167 @@
+name: Seed Snapshot Bake (Full — dev.yml manifest)
+
+# Tier 2 D4 of #2126 — Seed snapshot freshness pipeline.
+#
+# Purpose: produce a fresh full snapshot from `dev.yml` (113+ PDFs) so the
+# bucket pointer `latest.txt` never gets older than ~7 days. This is the
+# heartbeat that defeats silent drift, and the artifact that
+# `make dev-from-snapshot` consumes on every developer machine.
+#
+# Trigger model (three layers, all converge on the same publish step):
+#
+#   1. weekly cron (Sundays 03:00 UTC) — anti-drift heartbeat. Survives even
+#      if nobody touches the manifests for a month.
+#   2. workflow_dispatch — manual escape hatch for "I broke the snapshot and
+#      need a fresh one NOW" or "I want to validate a runner change without
+#      waiting a week".
+#   3. NO automatic path-based push trigger here. The CI smoke
+#      (`seed-snapshot-bake-ci.yml`) catches manifest/migration breakage
+#      cheaply; the full bake is slow and expensive, so we only spend it on
+#      a schedule and on demand. The path-based "I changed dev.yml, give me
+#      a fresh snapshot before the next dev-from-snapshot" use-case is
+#      handled by the SLO: the cron runs at most 7 days behind, and the
+#      `snapshot-verify.sh` exit codes (D9 schema-version drift) flag the
+#      need to manually dispatch in the meantime.
+#
+# Tied SLO (R-SNAP-FRESH-02 amendment):
+#   - bake budget:     ≤ 6h  (GitHub-hosted ubuntu-latest, no GPU)
+#   - freshness:       ≤ 7 days from latest published snapshot
+#   - on bake failure: the previous snapshot keeps serving until the next
+#                      successful run; the run logs are the audit trail
+#                      until D6 lands the markdown trail.
+#
+# Companion: PR #2134 (D7+D9 verify gates) blocks the publish step if the
+# resulting sidecar fails the invariants — preventing a half-baked snapshot
+# from clobbering `latest.txt`.
+
+on:
+  schedule:
+    # Sunday 03:00 UTC. Picked so failures land before Monday morning EU
+    # working hours and a maintainer can react.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Upload to the seed blob bucket on success (default: yes)'
+        required: false
+        default: 'true'
+        type: boolean
+      failure_pct:
+        description: 'Max % of PDFs allowed to fail before abort (default: 15)'
+        required: false
+        default: '15'
+        type: string
+
+# Hard-serialize. A second cron tick or manual dispatch must NOT race the
+# in-flight bake (they'd share the bake postgres). Cancel-in-progress is
+# false because the bake is too expensive to throw away mid-flight.
+concurrency:
+  group: seed-snapshot-bake-full
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bake-full:
+    name: Bake dev.yml + verify gates + publish
+    runs-on: ubuntu-latest
+    # 6h is the GitHub-hosted job limit. The bake budget is sized to fit.
+    # If we ever overrun, the next dispatch can rerun, OR we move to a
+    # self-hosted runner with persistent SmolDocling model cache.
+    timeout-minutes: 360
+
+    env:
+      # Default manifest is `dev.yml` (no override).
+      SEED_INDEX_TIMEOUT: '20000' # ~5.5h, just under the job limit
+      SEED_INDEX_POLL: '30'
+      SEED_INDEX_FAILURE_PCT: ${{ github.event.inputs.failure_pct || '15' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install jq + AWS CLI (required by seed-index-publish.sh)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq awscli
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Bake (dev.yml manifest, ~3–6h on CPU)
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          mkdir -p "$SEED_INDEX_OUT_DIR"
+          make seed-index
+
+      - name: Run verify gates (exit codes 2/3/4/5/6)
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          # If this fails we DO NOT publish — `latest.txt` keeps pointing at
+          # the previous good snapshot.
+          bash scripts/snapshot-verify.sh
+
+      - name: Surface seed-status full report
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: bash scripts/seed-status.sh || true
+
+      - name: Upload sidecar as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-snapshot-full-meta-${{ github.run_id }}
+          path: |
+            data/snapshots/*.meta.json
+            data/snapshots/.latest
+          retention-days: 90
+          if-no-files-found: warn
+
+      # ──────────────────────────────────────────────────────────────────
+      # Publish step — the WHOLE POINT of this workflow.
+      # The cron path always publishes (unattended); dispatch defaults to
+      # publish but can be turned off via `inputs.publish=false` for "I just
+      # want to validate the bake didn't break, please don't move latest.txt".
+      # ──────────────────────────────────────────────────────────────────
+      - name: Publish to seed blob bucket
+        if: |
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        working-directory: infra
+        env:
+          S3_ENDPOINT: ${{ secrets.SEED_BLOB_S3_ENDPOINT }}
+          S3_ACCESS_KEY: ${{ secrets.SEED_BLOB_S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.SEED_BLOB_S3_SECRET_KEY }}
+          SEED_BLOB_BUCKET: ${{ secrets.SEED_BLOB_BUCKET }}
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          set -euo pipefail
+          : "${S3_ENDPOINT:?SEED_BLOB_S3_ENDPOINT secret not configured}"
+          : "${S3_ACCESS_KEY:?SEED_BLOB_S3_ACCESS_KEY secret not configured}"
+          : "${S3_SECRET_KEY:?SEED_BLOB_S3_SECRET_KEY secret not configured}"
+          : "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET secret not configured}"
+          # `seed-index-publish.sh` reads storage.secret on disk; synthesize
+          # one from the GH Actions secrets for this job.
+          mkdir -p secrets
+          cat > secrets/storage.secret <<EOF
+          S3_ENDPOINT=${S3_ENDPOINT}
+          S3_ACCESS_KEY=${S3_ACCESS_KEY}
+          S3_SECRET_KEY=${S3_SECRET_KEY}
+          SEED_BLOB_BUCKET=${SEED_BLOB_BUCKET}
+          EOF
+          chmod 600 secrets/storage.secret
+          bash scripts/seed-index-publish.sh
+
+      - name: Notify on failure (placeholder for D6 audit trail)
+        if: failure()
+        run: |
+          echo "::warning::Bake failed at $(date -u +%FT%TZ). The previous snapshot remains the published one (latest.txt unchanged)."
+          echo "::warning::Manual dispatch can be retried via the workflow_dispatch UI on this workflow."
+          # When D6 lands, this step will append a Failed entry to
+          # data/snapshots/AUDIT.md and open a PR. For now we just log.

--- a/docs/for-developers/workflows/snapshot-seed-workflow.md
+++ b/docs/for-developers/workflows/snapshot-seed-workflow.md
@@ -143,6 +143,45 @@ Il target `make seed-index-publish` mantiene gli ultimi **3 snapshot** sul bucke
 
 `snapshots/latest.txt` è un piccolo file testuale con il basename dello snapshot corrente, aggiornato ad ogni publish. `snapshot-fetch.sh` lo legge per scoprire cosa scaricare senza dover listare il bucket.
 
+## Automated bake — GitHub Actions (#2126 D4)
+
+Due workflow gestiscono il bake automatico:
+
+| Workflow | Manifest | Trigger | Budget | Publish |
+|---|---|---|---|---|
+| `.github/workflows/seed-snapshot-bake-ci.yml` | `ci.yml` (3 PDF) | push/PR su seeder, migrations, scripts, manifests, `seed-schema.version` + `workflow_dispatch` | 30 min | opt-in (dispatch input `publish=true`) |
+| `.github/workflows/seed-snapshot-bake-full.yml` | `dev.yml` (113+ PDF) | weekly cron (Sun 03:00 UTC) + `workflow_dispatch` | 360 min | default on (off-switch su dispatch) |
+
+Razionale dei trigger (R-SNAP-FRESH-02 amendment):
+
+- **CI smoke (push-trigger)** — cattura *regressions del pipeline di bake* a basso costo. Il `ci.yml` ha 3 PDF, lo bake è < 15 min sul runner Ubuntu standard. Se questo workflow rompe, una PR rompe il bake reale: blocca prima della merge.
+- **Full bake (weekly cron)** — *anti-drift heartbeat*. Anche se nessuno tocca `dev.yml` per un mese, ogni domenica notte lo snapshot pubblicato è ≤ 7 giorni vecchio. La SLO di freschezza nasce da qui.
+- **Workflow_dispatch** — escape hatch: «ho appena mergiato una migration che bumpa `seed-schema.version`, non aspetto domenica».
+
+### Secret richiesti
+
+I 2 workflow leggono `secrets.SEED_BLOB_*` solo quando *pubblicano*. Da configurare in **Settings → Secrets and variables → Actions** del repo:
+
+| Secret | Esempio | Note |
+|---|---|---|
+| `SEED_BLOB_S3_ENDPOINT` | `https://<accountid>.r2.cloudflarestorage.com` | per R2; AWS S3 = vuoto / regione |
+| `SEED_BLOB_S3_ACCESS_KEY` | `…` | access key con WRITE sul bucket |
+| `SEED_BLOB_S3_SECRET_KEY` | `…` | secret key gemella |
+| `SEED_BLOB_BUCKET` | `meepleai-seed-snapshots` | name del bucket |
+
+Senza i secret, il **bake smoke gira lo stesso** (non pubblica), ma il **full bake fail-fast** allo step `Publish to seed blob bucket` per evitare un cron silenzioso che non muove `latest.txt`.
+
+### Cosa succede se il bake fallisce
+
+`snapshot-verify.sh` exit codes (vedi sopra) si applicano *prima* del publish. Se il sidecar fallisce i gate (`5` = schema-version drift, `6` = invariant violation), il publish step è skippato dal workflow. `latest.txt` continua a puntare allo snapshot precedente — degradato, non broken. Il maintainer riceve un fail su GHA Actions, e l'artifact metadata è retained 90 giorni per debug.
+
+> Tip: per riprodurre localmente uno step del workflow, lancialo come al solito sul tuo host:
+> ```bash
+> cd infra
+> SEED_CATALOG_MANIFEST_OVERRIDE=ci SEED_INDEX_TIMEOUT=1500 make seed-index
+> bash scripts/snapshot-verify.sh
+> ```
+
 ## Testing
 
 ### Manual e2e con `ci.yml`


### PR DESCRIPTION
Refs #2126 — Tier 2 **D4** (single deliverable, two workflows)

## Summary

Automates the seed-snapshot bake so `make dev-from-snapshot` never goes more than ~7 days behind `main-dev`, and so a pipeline regression is caught on PR — long before the slow weekly bake.

Two workflows, one trigger model each:

| Workflow | Manifest | Trigger | Budget | Publish |
|---|---|---|---|---|
| `.github/workflows/seed-snapshot-bake-ci.yml` | `ci.yml` (3 PDF) | push/PR on seeder/migration/script paths + `workflow_dispatch` | 30 min | opt-in |
| `.github/workflows/seed-snapshot-bake-full.yml` | `dev.yml` (113+ PDF) | weekly cron Sun 03:00 UTC + `workflow_dispatch` | 360 min | default on |

## Trigger model — validated via `/sc:spec-panel` socratic

The expert-panel session on 2026-06-10 raised three questions, answered with evidence:

- **Nygard — atomicity bake/publish**: dump is local, publish is separate. Audit is written by publish, not by bake → no divergence between "what's in the bucket" and the trail. (Audit log lands in PR #TBD as D6.)
- **Wiegers — snapshot size**: 113 PDFs × 8 599 chunks × 768-dim ≈ 50–150 MB compressed. GHCR Free 0.5 GB doesn't fit ≥ 4 snapshots. **R2/S3 already exists** in `storage.secret` → reuse, no migration.
- **Nygard — SLO**: ubuntu-latest CPU bake estimated 3–7 h with SmolDocling as bottleneck. The 6h GitHub-hosted limit is borderline; the CI smoke + weekly cron is the right shape, the path-based push trigger on the full bake is NOT (cost too high). If a developer just bumped `seed-schema.version`, they use `workflow_dispatch`.

## Trigger rationale (R-SNAP-FRESH-02 amendment)

- **CI smoke (push)** catches pipeline regressions cheaply on every PR that touches the seeder, an EF migration, a `seed-*` / `snapshot-*` shell script, the bake compose files, or `infra/seed-schema.version` (D9). Failure here blocks the merge of the bake-breaking PR.
- **Full bake (weekly cron)** is the anti-drift heartbeat. Even if nobody touches `dev.yml` for a month, the bucket pointer is at most 7 days stale on a clean dev machine.
- **`workflow_dispatch`** on both is the escape hatch for "I just bumped `seed-schema.version`, don't wait for Sunday".

## Verify gates wired in

Both workflows call `snapshot-verify.sh` between the bake and the publish, so the exit codes 5/6 from PR #2134 (D9 schema-version + D7 invariant) fail-fast the workflow if the resulting sidecar is corrupt. Publish only runs on green — `latest.txt` never points at a half-baked snapshot.

## Secret model

R2/S3 secrets are read **only when publishing**:

| Secret | Example | Required for |
|---|---|---|
| `SEED_BLOB_S3_ENDPOINT` | `https://<accountid>.r2.cloudflarestorage.com` | full bake publish + CI dispatch with `publish=true` |
| `SEED_BLOB_S3_ACCESS_KEY` | … | idem |
| `SEED_BLOB_S3_SECRET_KEY` | … | idem |
| `SEED_BLOB_BUCKET` | `meepleai-seed-snapshots` | idem |

CI smoke runs **without** the secrets (skips publish). Full bake fails-fast at the publish step if any secret is unset — to prevent a silent cron that doesn't move the pointer.

## Documentation

`docs/for-developers/workflows/snapshot-seed-workflow.md` gains a new "Automated bake — GitHub Actions" section with the trigger matrix, secret list, failure handling, and a "reproduce locally" snippet.

## Roadmap for #2126

| Tier | Deliverable | Status |
|---|---|---|
| 1 | D1 + D2 (status target + dev banner) | ✅ Merged (#2130) |
| 1 | D3 (`/health/seed` endpoint)         | 🚧 PR #2135 |
| 2 | **D4 (GHA bake workflows)**          | **this PR** |
| 3 | D7 (sidecar invariant)               | 🚧 PR #2134 |
| 3 | D9 (schema-version guard)            | 🚧 PR #2134 |
| 2 | D6 (markdown audit log)              | next |
| 2 | D5 (README freshness badge)          | depends on D4 + D6 |
| 3 | D8 (weekly RAG smoke regression)     | depends on D4 |

## Verification

```bash
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/seed-snapshot-bake-ci.yml')); print('ci.yml OK')"
ci.yml OK
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/seed-snapshot-bake-full.yml')); print('full.yml OK')"
full.yml OK
```

Real bake validation will happen on first `workflow_dispatch` of the CI smoke (no secret setup required) once this lands on `main-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)