### PR TITLE
feat(infra): markdown audit trail for seed-index-publish (#2126 Tier 2 D6)

### DIFF
--- a/docs/for-developers/workflows/snapshot-seed-workflow.md
+++ b/docs/for-developers/workflows/snapshot-seed-workflow.md
@@ -209,6 +209,23 @@ Senza i secret, il **bake smoke gira lo stesso** (non pubblica), ma il **full ba
 > bash scripts/snapshot-verify.sh
 > ```
 
+## Audit trail (#2126 D6)
+
+Ogni publish riuscito appende una riga a `data/snapshots/AUDIT.md` (committable markdown). La riga viene scritta **dopo** l'upload di dump+sha+sidecar+`latest.txt` e dopo la rotation — un fail su qualsiasi step precedente esce con `set -e` senza scrivere, garantendo che il trail combaci con il bucket.
+
+Schema della tabella:
+
+```markdown
+| Published at | Basename | App commit | EF migration | seed_schema | PDFs | Chunks | Embeddings | Model | Published by |
+```
+
+`Published by` è auto-risolto: `GITHUB_ACTOR` se siamo in GHA, `git config user.email` localmente, `whoami` come fallback. Niente token.
+
+Query rapide:
+- *«Chi ha pubblicato lo snapshot del 15 aprile?»* → `git blame data/snapshots/AUDIT.md` sulla riga del 2026-04-15.
+- *«Cronologia ultimi 30 giorni»* → `git log --since='30 days ago' -- data/snapshots/AUDIT.md`.
+- *«Quale snapshot serviva il dev X durante l'incident del 2026-06-11 alle 14:00?»* → cerca la riga il cui `Published at` precede 14:00 (era il `latest.txt` puntato).
+
 ## Testing
 
 ### Manual e2e con `ci.yml`

--- a/infra/scripts/seed-index-publish.sh
+++ b/infra/scripts/seed-index-publish.sh
@@ -55,4 +55,72 @@ $AWS_S3 ls "s3://$SEED_BLOB_BUCKET/$PREFIX/" \
         $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.meta.json"   || true
       done
 
+# ───────────────────────────────────────────────────────────────────────
+# Audit trail (#2126 D6).
+#
+# Append-only markdown row per successful publish. Lives in
+# `data/snapshots/AUDIT.md` and is committable — git blame + git log answer
+# "who published what, when, against which commit, with what counts" in
+# 30 seconds. Written here (AFTER the upload + retention rotation) so the
+# trail tracks what is REALLY in the bucket: a failed upload exits earlier
+# via `set -e` and no entry is appended → no divergence between markdown
+# and bucket.
+#
+# The header is created on the first call so a fresh data/snapshots/
+# directory bootstraps without ceremony.
+# ───────────────────────────────────────────────────────────────────────
+AUDIT_FILE="$OUT_DIR/AUDIT.md"
+META_PATH="$OUT_DIR/$BASENAME.meta.json"
+
+if [ ! -f "$AUDIT_FILE" ]; then
+    log "creating audit trail header at $AUDIT_FILE"
+    cat > "$AUDIT_FILE" <<'HEADER'
+# Seed snapshot publish audit (#2126 D6)
+
+Append-only trail of `make seed-index-publish` runs that completed an upload
+to the seed blob bucket. Each row is written by
+`infra/scripts/seed-index-publish.sh` *after* the dump, sha, sidecar, and
+`latest.txt` are all in the bucket (failure exits earlier and writes no row,
+so this trail matches the bucket).
+
+Use `git blame` to answer "who published this snapshot" and `git log
+data/snapshots/AUDIT.md` for the chronological sequence.
+
+| Published at | Basename | App commit | EF migration | seed_schema | PDFs | Chunks | Embeddings | Model | Published by |
+|---|---|---|---|---|---|---|---|---|---|
+HEADER
+fi
+
+# Resolve "who" — in CI we have GITHUB_ACTOR / GITHUB_RUN_ID; locally we fall
+# back to git user.email, then to `whoami`. Never expose tokens; this is just
+# a human-readable label.
+PUBLISHED_BY="${GITHUB_ACTOR:-}"
+if [ -z "$PUBLISHED_BY" ]; then
+    PUBLISHED_BY=$(git config user.email 2>/dev/null || echo "")
+fi
+if [ -z "$PUBLISHED_BY" ]; then
+    PUBLISHED_BY=$(whoami 2>/dev/null || echo "unknown")
+fi
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+    PUBLISHED_BY="$PUBLISHED_BY (GHA run $GITHUB_RUN_ID)"
+fi
+
+# Read sidecar fields for the row; default values stay friendly when an old
+# sidecar predates the field (e.g. seed_table_schema_version on snapshots
+# baked before #2126 D9).
+PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+APP_COMMIT=$(jq -r '.app_commit // "?"' "$META_PATH")
+EF_HEAD=$(jq -r '.ef_migration_head // "?"' "$META_PATH")
+SEED_SCHEMA=$(jq -r '.seed_table_schema_version // 0' "$META_PATH")
+PDF_COUNT=$(jq -r '.pdf_count // 0' "$META_PATH")
+CHUNK_COUNT=$(jq -r '.chunk_count // 0' "$META_PATH")
+EMB_COUNT=$(jq -r '.embedding_count // 0' "$META_PATH")
+EMB_MODEL=$(jq -r '.embedding_model // "?"' "$META_PATH")
+
+log "appending audit row → $AUDIT_FILE"
+printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+    "$PUBLISHED_AT" "$BASENAME" "$APP_COMMIT" "$EF_HEAD" "$SEED_SCHEMA" \
+    "$PDF_COUNT" "$CHUNK_COUNT" "$EMB_COUNT" "$EMB_MODEL" "$PUBLISHED_BY" \
+    >> "$AUDIT_FILE"
+
 log "OK"


### PR DESCRIPTION
Refs #2126 — Tier 2 **D6**

## Summary

Append-only `data/snapshots/AUDIT.md` markdown trail that records every successful seed-snapshot publish. Designed via `/sc:spec-panel` socratic — explicit, evidence-backed answer to Nygard's *"who consults this audit log?"* question.

## Why markdown (and not a DB table)

- **Primary actor**: a developer / on-call answering *"what snapshot was served on day X, who baked it, against which commit, with what counts"*. That maps 1:1 to the `git blame` + `git log` workflow — no extra tool required.
- **Atomicity**: written **after** dump+sha+sidecar+`latest.txt` uploads AND after retention rotation. `set -e` on any earlier failure aborts before the audit row → the trail and the bucket cannot diverge.
- **No new surface**: zero EF migrations, zero new dependencies. The file lives next to the `*.meta.json` sidecars that are already committable.

## Row shape

```markdown
| Published at | Basename | App commit | EF migration | seed_schema | PDFs | Chunks | Embeddings | Model | Published by |
```

`Published by` is auto-resolved with a defensive cascade:
- `$GITHUB_ACTOR` when running under GitHub Actions (D4's `workflow_dispatch` / cron runs are attributed to whoever triggered/scheduled them)
- `git config user.email` locally
- `whoami` as final fallback

Plus `$GITHUB_RUN_ID` appended when present so a row links straight to its GHA run logs.

Old sidecars predating #2126 D9 (no `seed_table_schema_version` field) fall back to `0` via `jq -r '.seed_table_schema_version // 0'` — legacy snapshots can be onboarded retroactively without breaking the schema.

## Header bootstrap

`AUDIT.md` is committable but the **first** publish into a fresh `data/snapshots/` directory creates the header itself — no template to maintain manually, no ceremony on a new checkout.

## Files

| File | Change |
|---|---|
| `infra/scripts/seed-index-publish.sh` | new audit block after the rotation loop, with long-form rationale comment in the script |
| `docs/for-developers/workflows/snapshot-seed-workflow.md` | new "Audit trail (#2126 D6)" section: row schema + 3 canonical queries (`git blame`, `git log`, *"which snapshot served the incident at X o'clock"*) |

## Verification

Local smoke against a synthetic sidecar (extracted audit block, real publish flow exercised in production by D4 workflows):

```
$ bash -n infra/scripts/seed-index-publish.sh
✓ syntax OK

$ # (smoke fixture)
✓ append OK
| 2026-06-10T22:57:03Z | meepleai_seed_20260611T000000Z_test_abc123
  | abc123def | 20260610094431_AddWikidataQidColumnsToSharedGames | 1
  | 113 | 8599 | 8599 | intfloat/multilingual-e5-base | test-user |
```

## Roadmap for #2126

| Tier | Deliverable | Status |
|---|---|---|
| 1 | D1 + D2 (status target + dev banner) | ✅ Merged (#2130) |
| 1 | D3 (`/health/seed` endpoint)         | 🚧 PR #2135 |
| 2 | D4 (GHA bake workflows)              | 🚧 PR #2154 |
| 3 | D7 + D9 (verify-gate exit codes 5/6) | 🚧 PR #2134 |
| 2 | **D6 (markdown audit log)**          | **this PR** |
| 2 | D5 (README freshness badge)          | future (depends on D4 + D6) |
| 3 | D8 (weekly RAG smoke regression)     | future (depends on D4) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)