### PR TITLE
fix(catalog): #2123 coalesce nullable ImageUrl/ThumbnailUrl for production build

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -79,8 +79,9 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 g.MinAge,
                 g.ComplexityRating,
                 g.AverageRating,
-                g.ImageUrl,
-                g.ThumbnailUrl,
+                // Issue #2123 — tombstone fields (entity columns now nullable post Phase A).
+                g.ImageUrl ?? string.Empty,
+                g.ThumbnailUrl ?? string.Empty,
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -109,8 +109,9 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 g.MinAge,
                 g.ComplexityRating,
                 g.AverageRating,
-                g.ImageUrl,
-                g.ThumbnailUrl,
+                // Issue #2123 — tombstone fields (entity columns now nullable post Phase A).
+                g.ImageUrl ?? string.Empty,
+                g.ThumbnailUrl ?? string.Empty,
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -74,8 +74,9 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
                 g.MinAge,
                 g.ComplexityRating,
                 g.AverageRating,
-                g.ImageUrl,
-                g.ThumbnailUrl,
+                // Issue #2123 — tombstone fields (entity columns now nullable post Phase A).
+                g.ImageUrl ?? string.Empty,
+                g.ThumbnailUrl ?? string.Empty,
                 (GameStatus)g.Status,
                 g.CreatedAt,
                 g.ModifiedAt,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -424,8 +424,9 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
                 p.Game.MinAge,
                 p.Game.ComplexityRating,
                 p.Game.AverageRating,
-                p.Game.ImageUrl,
-                p.Game.ThumbnailUrl,
+                // Issue #2123 — tombstone fields (entity columns now nullable post Phase A).
+                p.Game.ImageUrl ?? string.Empty,
+                p.Game.ThumbnailUrl ?? string.Empty,
                 (GameStatus)p.Game.Status,
                 p.Game.CreatedAt,
                 p.Game.ModifiedAt,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -132,8 +132,13 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             entity.MinAge,
             entity.ComplexityRating,
             entity.AverageRating,
-            entity.ImageUrl,
-            entity.ThumbnailUrl,
+            // Issue #2123 — entity.ImageUrl/ThumbnailUrl are now nullable post-Phase A
+            // nullify migration. SharedGame aggregate still types them as non-nullable
+            // (legacy contract; deprecation tombstone). Coerce to empty string here so
+            // null entity values don't blow up the aggregate constructor — FE consumers
+            // MUST prefer SharedGameDto.CoverUrl which is the R2-resolved replacement.
+            entity.ImageUrl ?? string.Empty,
+            entity.ThumbnailUrl ?? string.Empty,
             rules,
             (GameStatus)entity.Status,
             entity.CreatedBy,


### PR DESCRIPTION
## Summary

PR #2125 nullified \`SharedGameEntity.ImageUrl\` and \`ThumbnailUrl\` columns (Phase A) but did not update the 5 query handlers / repository that construct \`SharedGame\` aggregate or \`SharedGameDto\` from those fields. The aggregate and DTO still type them as non-nullable \`string\` (legacy contract, tombstones marked \`[Obsolete]\`).

Local \`dotnet build\` was clean because \`TreatWarningsAsErrors\` was not active for the dev build. The production Docker publish enables \`TreatWarningsAsErrors=true\` and surfaced **10 CS8604 "Possible null reference argument"** errors that blocked the API container rebuild on dev.

Discovered when rebuilding \`meepleai-api\` to run the Wikidata QID + M8 batch operational task (PR #2125 follow-up).

## Fix

Coalesce \`entity.ImageUrl\` → \`entity.ImageUrl ?? string.Empty\` in 5 sites:

| File | Sites |
|---|---|
| \`SharedGameRepository.cs\` | aggregate construction |
| \`SearchSharedGamesQueryHandler.cs\` | DTO projection |
| \`GetPendingApprovalGamesQueryHandler.cs\` | DTO projection |
| \`GetAllSharedGamesQueryHandler.cs\` | DTO projection |
| \`GetFilteredSharedGamesQueryHandler.cs\` | DTO projection |

The \`?? string.Empty\` is structurally invisible to FE consumers because the fields are \`[Obsolete]\` and FE prefers \`SharedGameDto.CoverUrl\` (R2-resolved). The tombstones remain on the DTO for one release cycle of deprecation telemetry, then removable.

## Verification

\`\`\`
dotnet publish src/Api/Api.csproj -c Release -p:SkipAnalyzers=true \
  -p:GenerateDocumentationFile=false -o /tmp/publish-verify --no-restore
# ✅ Api.dll published, 0 errors
\`\`\`

API container rebuild + restart green, endpoint \`POST /api/v1/admin/catalog/covers/enrich-batch\` reachable for operational batches.

## Refs

- Parent PR: #2125
- Issue: #2123
- Follow-up: M8 batch operational task encountered a separate HttpClient bubble on \`WikidataCatalogProvider.FetchCoverImageAsync\`; that's tracked separately (29/128 partial covers populated on dev before the bubble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)