### PR TITLE
fix(auth): #2116 SetRegistrationMode 500 — use current environment in both lookup and create

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SystemConfiguration.Application.Commands;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using MediatR;
+using Microsoft.AspNetCore.Hosting;
 using MediatRUnit = MediatR.Unit;
 
 namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
@@ -12,18 +13,24 @@ internal class SetRegistrationModeCommandHandler : ICommandHandler<SetRegistrati
 {
     private readonly IMediator _mediator;
     private readonly IConfigurationService _configService;
+    private readonly IWebHostEnvironment _environment;
 
-    public SetRegistrationModeCommandHandler(IMediator mediator, IConfigurationService configService)
+    public SetRegistrationModeCommandHandler(
+        IMediator mediator,
+        IConfigurationService configService,
+        IWebHostEnvironment environment)
     {
         _mediator = mediator;
         _configService = configService;
+        _environment = environment;
     }
 
     public async Task<MediatRUnit> Handle(SetRegistrationModeCommand request, CancellationToken cancellationToken)
     {
         var value = request.Enabled.ToString().ToLowerInvariant();
+        var environmentName = _environment.EnvironmentName;
         var existing = await _configService.GetConfigurationByKeyAsync(
-            "Registration:PublicEnabled", null, cancellationToken).ConfigureAwait(false);
+            "Registration:PublicEnabled", environmentName, cancellationToken).ConfigureAwait(false);
 
         if (existing is not null)
         {
@@ -43,7 +50,7 @@ internal class SetRegistrationModeCommandHandler : ICommandHandler<SetRegistrati
                     "Boolean",
                     "Controls whether public registration is enabled",
                     "Authentication",
-                    "Production",
+                    environmentName,
                     false,
                     request.AdminId),
                 cancellationToken).ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Handlers/SetRegistrationModeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Handlers/SetRegistrationModeCommandHandlerTests.cs
@@ -1,0 +1,172 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.SystemConfiguration.Application.Commands;
+using Api.BoundedContexts.SystemConfiguration.Application.DTOs;
+using Api.Models;
+using Api.Services;
+using Api.Tests.Constants;
+using MediatR;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Handlers;
+
+/// <summary>
+/// Unit tests for <see cref="SetRegistrationModeCommandHandler"/>.
+/// Regression test for issue #2116: hardcoded Environment="Production" in Create branch
+/// caused 23505 duplicate key violation when current environment != "Production".
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class SetRegistrationModeCommandHandlerTests
+{
+    private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<IConfigurationService> _mockConfigService;
+    private readonly Mock<IWebHostEnvironment> _mockEnvironment;
+    private readonly SetRegistrationModeCommandHandler _handler;
+
+    public SetRegistrationModeCommandHandlerTests()
+    {
+        _mockMediator = new Mock<IMediator>();
+        _mockConfigService = new Mock<IConfigurationService>();
+        _mockEnvironment = new Mock<IWebHostEnvironment>();
+
+        _handler = new SetRegistrationModeCommandHandler(
+            _mockMediator.Object,
+            _mockConfigService.Object,
+            _mockEnvironment.Object);
+    }
+
+    [Fact]
+    public async Task Handle_InDevelopmentEnv_NoExistingConfig_CreatesConfigWithCurrentEnvironment()
+    {
+        // Bug #2116: when running in Development and no row exists in DB,
+        // the Create branch must use the current environment (Development), NOT hardcode "Production".
+        // Otherwise INSERT (Key=Registration:PublicEnabled, Environment=Production) collides with
+        // any seed row already present at Environment="Production" -> 23505 duplicate key.
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Development");
+        _mockConfigService
+            .Setup(c => c.GetConfigurationByKeyAsync(
+                "Registration:PublicEnabled",
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMockConfigDto("Development"));
+
+        var adminId = Guid.NewGuid();
+        var cmd = new SetRegistrationModeCommand(true, adminId);
+
+        await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<CreateConfigurationCommand>(c =>
+                    c.Key == "Registration:PublicEnabled" &&
+                    c.Value == "true" &&
+                    c.Environment == "Development" &&
+                    c.CreatedByUserId == adminId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InProductionEnv_NoExistingConfig_CreatesConfigWithProductionEnvironment()
+    {
+        // Regression guard: prevent re-introducing a hardcoded string literal.
+        // Production environment must be derived from IWebHostEnvironment, not from a literal.
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Production");
+        _mockConfigService
+            .Setup(c => c.GetConfigurationByKeyAsync(
+                "Registration:PublicEnabled",
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMockConfigDto("Production"));
+
+        var adminId = Guid.NewGuid();
+        var cmd = new SetRegistrationModeCommand(false, adminId);
+
+        await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<CreateConfigurationCommand>(c =>
+                    c.Value == "false" &&
+                    c.Environment == "Production"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InDevelopmentEnv_ExistingConfig_SendsUpdateAndNotCreate()
+    {
+        // Idempotency guard for #2116: repeated toggles must hit the Update path, not duplicate-key.
+        // After the first call writes a row at Environment="Development", the second call must find it
+        // and Update it - it must NOT enter the Create branch and re-insert under a different Environment.
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Development");
+        var existingId = Guid.NewGuid();
+        var existingDto = new SystemConfigurationDto(
+            Id: existingId.ToString(),
+            Key: "Registration:PublicEnabled",
+            Value: "false",
+            ValueType: "Boolean",
+            Description: "Controls whether public registration is enabled",
+            Category: "Authentication",
+            IsActive: true,
+            RequiresRestart: false,
+            Environment: "Development",
+            Version: 1,
+            PreviousValue: null,
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow,
+            CreatedByUserId: Guid.Empty.ToString(),
+            UpdatedByUserId: null,
+            LastToggledAt: null);
+
+        _mockConfigService
+            .Setup(c => c.GetConfigurationByKeyAsync(
+                "Registration:PublicEnabled",
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDto);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<UpdateConfigValueCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMockConfigDto("Development"));
+
+        var adminId = Guid.NewGuid();
+        var cmd = new SetRegistrationModeCommand(true, adminId);
+
+        await _handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<UpdateConfigValueCommand>(c =>
+                    c.ConfigId == existingId &&
+                    c.NewValue == "true" &&
+                    c.UpdatedByUserId == adminId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static ConfigurationDto CreateMockConfigDto(string environment) =>
+        new(
+            Id: Guid.NewGuid(),
+            Key: "Registration:PublicEnabled",
+            Value: "true",
+            ValueType: "Boolean",
+            Description: "Controls whether public registration is enabled",
+            Category: "Authentication",
+            IsActive: true,
+            RequiresRestart: false,
+            Environment: environment,
+            Version: 1,
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Handlers/SetRegistrationModeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Handlers/SetRegistrationModeCommandHandlerTests.cs
@@ -48,7 +48,7 @@ public class SetRegistrationModeCommandHandlerTests
         _mockConfigService
             .Setup(c => c.GetConfigurationByKeyAsync(
                 "Registration:PublicEnabled",
-                It.IsAny<string?>(),
+                "Development",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((SystemConfigurationDto?)null);
         _mockMediator
@@ -60,6 +60,12 @@ public class SetRegistrationModeCommandHandlerTests
 
         await _handler.Handle(cmd, TestContext.Current.CancellationToken);
 
+        _mockConfigService.Verify(
+            c => c.GetConfigurationByKeyAsync(
+                "Registration:PublicEnabled",
+                "Development",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
         _mockMediator.Verify(
             m => m.Send(
                 It.Is<CreateConfigurationCommand>(c =>
@@ -80,7 +86,7 @@ public class SetRegistrationModeCommandHandlerTests
         _mockConfigService
             .Setup(c => c.GetConfigurationByKeyAsync(
                 "Registration:PublicEnabled",
-                It.IsAny<string?>(),
+                "Production",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((SystemConfigurationDto?)null);
         _mockMediator
@@ -92,6 +98,12 @@ public class SetRegistrationModeCommandHandlerTests
 
         await _handler.Handle(cmd, TestContext.Current.CancellationToken);
 
+        _mockConfigService.Verify(
+            c => c.GetConfigurationByKeyAsync(
+                "Registration:PublicEnabled",
+                "Production",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
         _mockMediator.Verify(
             m => m.Send(
                 It.Is<CreateConfigurationCommand>(c =>
@@ -130,7 +142,7 @@ public class SetRegistrationModeCommandHandlerTests
         _mockConfigService
             .Setup(c => c.GetConfigurationByKeyAsync(
                 "Registration:PublicEnabled",
-                It.IsAny<string?>(),
+                "Development",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingDto);
         _mockMediator
@@ -142,6 +154,12 @@ public class SetRegistrationModeCommandHandlerTests
 
         await _handler.Handle(cmd, TestContext.Current.CancellationToken);
 
+        _mockConfigService.Verify(
+            c => c.GetConfigurationByKeyAsync(
+                "Registration:PublicEnabled",
+                "Development",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
         _mockMediator.Verify(
             m => m.Send(
                 It.Is<UpdateConfigValueCommand>(c =>


### PR DESCRIPTION
## Summary
- Fix P0 user-facing 500 on `PUT /api/v1/admin/settings/registration-mode`: the lookup used `ConfigurationService` fallback (current env), but the Create branch hardcoded `Environment="Production"`. In any non-Production environment the two paths disagreed → `INSERT` collided with the seed row and raised `23505 duplicate key value violates unique constraint "IX_system_configurations_Key_Environment"`.
- Inject `IWebHostEnvironment` into `SetRegistrationModeCommandHandler` and use `_environment.EnvironmentName` in BOTH the lookup and the `CreateConfigurationCommand`, so they always stay consistent.
- Adds the first unit test class for this handler (zero coverage existed — root cause of the regression).

## Repro (before fix)
```
Given: existing row { Key:"Registration:PublicEnabled", Environment:"Production", Value:"false" }
And:   ASPNETCORE_ENVIRONMENT=Development
When:  superadmin POSTs { enabled: true }
Then:  500 + 23505 duplicate key (Key, Environment="Production")
```

## Acceptance (verified)
- [x] Development env + no existing config → `CreateConfigurationCommand.Environment == "Development"` (regression test).
- [x] Production env + no existing config → `CreateConfigurationCommand.Environment == "Production"` (guard against re-introducing a hardcoded literal).
- [x] Development env + existing config → `UpdateConfigValueCommand` only, no Create (idempotency guard for repeated toggles).
- [x] Lookup is verified to use the exact current env string (post-review tighten on mocks).

## Test results
- 388 Authentication BC unit tests pass / 0 fail
- 189 SystemConfiguration BC unit tests pass / 0 fail
- 3 new tests in `SetRegistrationModeCommandHandlerTests.cs` — both lookup-side AND create-side env arguments asserted exactly

## Design decision rationale
Per panel review (Fowler + Nygard), chose Option (a) — *use current env in both branches* — over Option (b) *hardcode "Production"*:
- Coherent with `IConfigurationService` contract that uses `(Key, Environment)` as composite key.
- Allows seed rows / overrides to diverge per environment (Development can toggle independently of Production).
- Removes the magic-string hardcode.

## ⚠️ Ops note — staging data orphan (post code review)
After this fix deploys to **staging**, the first toggle issued from a non-Production environment writes a new row `(Key, Environment="Staging")` (or whatever `ASPNETCORE_ENVIRONMENT` evaluates to). The pre-existing seed row `(Key, Environment="Production")` becomes **orphan** — never read again unless `ASPNETCORE_ENVIRONMENT=Production`.

**Consequence**: if the old "Production" seed row had `publicRegistrationEnabled=true`, the effective value on staging after the upgrade is the default (`false`) until a superadmin toggles it on via `/admin/config`. GET-side (`RequirePublicRegistrationFilter`, `GetRegistrationModeQueryHandler`) also resolves on `_environment.EnvironmentName`, so GET and SET stay symmetric — the orphan row is fully isolated, not a data loss risk, just a soft reset of the flag value.

**Action for ops post-merge**: confirm the desired value of `publicRegistrationEnabled` on staging immediately after deploy (toggle once via the admin UI). No SQL migration required.

## Files touched
- `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs` (handler: +ctor dep, +consistent env in lookup & create)
- `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Handlers/SetRegistrationModeCommandHandlerTests.cs` (NEW)

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SetRegistrationModeCommandHandlerTests"` → 3/3 green
- [x] `dotnet test --filter "BoundedContext=Authentication&Category=Unit"` → 388/388 green
- [x] `dotnet test --filter "BoundedContext=SystemConfiguration&Category=Unit"` → 189/189 green
- [ ] Post-deploy staging smoke: admin toggles registration mode without 500 + value persists across page reload

## Follow-ups (not blocking this PR)
- Integration test using Testcontainers for the full endpoint flow (catches actual SQL constraint, which mocked MediatR cannot see).
- Audit other config keys for similar lookup/write asymmetry patterns.

Closes #2116

🤖 Generated with [Claude Code](https://claude.com/claude-code)