### PR TITLE
test(auth)+docs(ops): #2116 follow-up — IT testcontainers + audit + smoke checklist

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/Authentication/SetRegistrationModeIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/SetRegistrationModeIntegrationTests.cs
@@ -175,6 +175,7 @@ public sealed class SetRegistrationModeIntegrationTests : IAsyncLifetime
 
         var devRow = rows.Should().ContainSingle(r => r.Environment == DevelopmentEnv).Subject;
         devRow.Value.Should().Be("true");
+        devRow.Version.Should().Be(1, "the Create path must produce a brand-new row at Version=1 — symmetric guard with Scenario 2's Version=2 assertion on the Update path");
         devRow.CreatedByUserId.Should().Be(AdminUserId);
 
         var prodRow = rows.Should().ContainSingle(r => r.Environment == ProductionEnv).Subject;

--- a/apps/api/tests/Api.Tests/Integration/Authentication/SetRegistrationModeIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/SetRegistrationModeIntegrationTests.cs
@@ -1,0 +1,294 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.SystemConfiguration.Domain.Repositories;
+using Api.BoundedContexts.SystemConfiguration.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.Authentication;
+
+/// <summary>
+/// Integration tests for SetRegistrationModeCommandHandler against real PostgreSQL.
+/// Issue #2116 follow-up: a real DB exercise (Testcontainers) is the only way to catch
+/// the actual 23505 duplicate-key violation that the unit-test mocks cannot see.
+///
+/// Scenario covered:
+///   - Pre-existing seed row at Environment="Production" + current env = "Development"
+///     → handler must NOT raise 23505, must write a new row at Environment="Development".
+///   - Idempotency: second call in the same env must hit the Update path, no duplicate row.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Authentication")]
+[Trait("Issue", "2116")]
+public sealed class SetRegistrationModeIntegrationTests : IAsyncLifetime
+{
+    private const string RegistrationKey = "Registration:PublicEnabled";
+    private const string DevelopmentEnv = "Development";
+    private const string ProductionEnv = "Production";
+
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private FakeTimeProvider _timeProvider = null!;
+    private readonly Action<string> _output;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    private static readonly Guid AdminUserId = new("a0000000-0000-0000-0000-000000002116");
+
+    public SetRegistrationModeIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _output = Console.WriteLine;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_setregmode_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var enforcedBuilder = new NpgsqlConnectionStringBuilder(_isolatedDbConnectionString)
+        {
+            SslMode = SslMode.Disable,
+            KeepAlive = 30,
+            Pooling = false,
+            Timeout = 15,
+            CommandTimeout = 30
+        };
+
+        _timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(enforcedBuilder.ConnectionString);
+
+        services.RemoveAll<TimeProvider>();
+        services.AddSingleton<TimeProvider>(_timeProvider);
+
+        // Auth repos needed to seed the admin user (FK target for system_configurations.CreatedByUserId).
+        services.AddScoped<IUserRepository, UserRepository>();
+
+        // SystemConfiguration repos + service required by SetRegistrationModeCommandHandler
+        // and the CreateConfigurationCommandHandler / UpdateConfigValueCommandHandler it dispatches.
+        services.AddScoped<IConfigurationRepository, ConfigurationRepository>();
+        services.AddScoped<IConfigurationService, ConfigurationService>();
+
+        // IWebHostEnvironment stub — pretend ASPNETCORE_ENVIRONMENT="Development" to reproduce the bug.
+        var environmentMock = new Mock<IWebHostEnvironment>();
+        environmentMock.Setup(e => e.EnvironmentName).Returns(DevelopmentEnv);
+        services.AddSingleton(environmentMock.Object);
+
+        // Override the default Mock.Of<IHybridCacheService>() from CreateBase: it returns
+        // null without invoking the factory, so ConfigurationService.GetConfigurationByKeyAsync
+        // can never observe the row written by a previous call → the second toggle re-enters
+        // the Create branch and triggers a real 23505 inside the test. Use a passthrough impl.
+        services.RemoveAll<IHybridCacheService>();
+        services.AddScoped<IHybridCacheService, PassthroughHybridCache>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await MigrateWithRetry(_dbContext);
+
+        // Seed admin user (FK target).
+        var userRepo = _serviceProvider.GetRequiredService<IUserRepository>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var adminUser = new User(
+            AdminUserId,
+            new Email("admin-2116@test.meepleai.dev"),
+            "Test Admin 2116",
+            PasswordHash.Create("AdminUnusualPwd123!"),
+            Role.Admin);
+        await userRepo.AddAsync(adminUser, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        else
+            (_serviceProvider as IDisposable)?.Dispose();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch (Exception ex)
+            {
+                _output($"Warning: Failed to drop database {_databaseName}: {ex.Message}");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SetRegistrationMode_WithSeedRowAtProduction_AndCurrentEnvIsDevelopment_DoesNotRaiseDuplicateKey()
+    {
+        // Arrange: seed the "Production" row that triggered the original 500.
+        // Mirrors the row produced by Migration 20260... InitialCreate seed for Registration:PublicEnabled.
+        await SeedSystemConfigurationRowAsync(ProductionEnv, "false", version: 1);
+
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+
+        // Act: superadmin toggles registration mode → handler enters Create branch
+        // (no row exists for Environment="Development" yet). Pre-fix this raised 23505
+        // because the Create branch hardcoded Environment="Production".
+        var act = async () => await mediator.Send(
+            new SetRegistrationModeCommand(Enabled: true, AdminId: AdminUserId),
+            TestCancellationToken);
+
+        await act.Should().NotThrowAsync();
+
+        // Assert: there are now TWO independent rows — the original Production seed (unchanged)
+        // and the new Development row carrying the toggled value.
+        var rows = await _dbContext!.Set<SystemConfigurationEntity>()
+            .Where(c => c.Key == RegistrationKey)
+            .OrderBy(c => c.Environment)
+            .ToListAsync(TestCancellationToken);
+
+        rows.Should().HaveCount(2, "the handler must keep the Production seed and add a Development row, never overwrite");
+
+        var devRow = rows.Should().ContainSingle(r => r.Environment == DevelopmentEnv).Subject;
+        devRow.Value.Should().Be("true");
+        devRow.CreatedByUserId.Should().Be(AdminUserId);
+
+        var prodRow = rows.Should().ContainSingle(r => r.Environment == ProductionEnv).Subject;
+        prodRow.Value.Should().Be("false", "the original Production seed must remain untouched");
+    }
+
+    [Fact]
+    public async Task SetRegistrationMode_TwoConsecutiveTogglesInDevelopment_HitUpdatePath_NoDuplicateRow()
+    {
+        // Arrange: seed Production row (the original bug condition). Each MediatR send happens
+        // in a fresh DI scope to mirror the production behavior: every HTTP request gets its own
+        // scoped DbContext + scoped ConfigurationService. Sharing a single scope across both
+        // toggles would let the EF Core change tracker see a tracked Get-side entity and a
+        // detached Update-side entity with the same Id — a tracker conflict unrelated to #2116
+        // and not reproducible from a real HTTP path.
+        await SeedSystemConfigurationRowAsync(ProductionEnv, "false", version: 1);
+
+        var scopeFactory = _serviceProvider!.GetRequiredService<IServiceScopeFactory>();
+
+        await using (var scope1 = scopeFactory.CreateAsyncScope())
+        {
+            var mediator1 = scope1.ServiceProvider.GetRequiredService<IMediator>();
+            await mediator1.Send(
+                new SetRegistrationModeCommand(Enabled: true, AdminId: AdminUserId),
+                TestCancellationToken);
+        }
+
+        // Act: second toggle flipping the value, in a fresh scope.
+        await using var scope2 = scopeFactory.CreateAsyncScope();
+        var mediator2 = scope2.ServiceProvider.GetRequiredService<IMediator>();
+
+        var act = async () => await mediator2.Send(
+            new SetRegistrationModeCommand(Enabled: false, AdminId: AdminUserId),
+            TestCancellationToken);
+
+        await act.Should().NotThrowAsync(
+            "the second call must take the Update path; entering Create again would violate IX_system_configurations_Key_Environment");
+
+        // Assert: still exactly ONE Development row (updated, not duplicated). Production row untouched.
+        // Use a fresh DbContext scope to bypass any change-tracker state held by the assertion fixture's _dbContext.
+        await using var assertScope = scopeFactory.CreateAsyncScope();
+        var assertContext = assertScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var devRows = await assertContext.Set<SystemConfigurationEntity>()
+            .AsNoTracking()
+            .Where(c => c.Key == RegistrationKey && c.Environment == DevelopmentEnv)
+            .ToListAsync(TestCancellationToken);
+        devRows.Should().HaveCount(1);
+        devRows[0].Value.Should().Be("false", "the second toggle flipped the value back to false");
+        devRows[0].Version.Should().Be(2, "the Update path must bump Version");
+    }
+
+    private async Task SeedSystemConfigurationRowAsync(string environment, string value, int version)
+    {
+        var entity = new SystemConfigurationEntity
+        {
+            Id = Guid.NewGuid(),
+            Key = RegistrationKey,
+            Value = value,
+            ValueType = "Boolean",
+            Description = "Controls whether public registration is enabled",
+            Category = "Authentication",
+            IsActive = true,
+            RequiresRestart = false,
+            Environment = environment,
+            Version = version,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            CreatedByUserId = AdminUserId,
+            UpdatedByUserId = null,
+        };
+
+        _dbContext!.Set<SystemConfigurationEntity>().Add(entity);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private async Task MigrateWithRetry(MeepleAiDbContext context, int maxRetries = 3)
+    {
+        for (int i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                await context.Database.MigrateAsync(TestCancellationToken);
+                return;
+            }
+            catch (Exception ex) when (i < maxRetries - 1)
+            {
+                _output($"Migration attempt {i + 1} failed: {ex.Message}. Retrying...");
+                await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Always invoke the factory — needed for end-to-end tests where the same DbContext
+    /// must see writes performed by earlier MediatR sends. The default
+    /// Mock.Of&lt;IHybridCacheService&gt;() returns null without calling the factory and
+    /// the lookup is permanently stuck on a cache miss.
+    /// </summary>
+    private sealed class PassthroughHybridCache : IHybridCacheService
+    {
+        public Task<T> GetOrCreateAsync<T>(
+            string cacheKey,
+            Func<CancellationToken, Task<T>> factory,
+            string[]? tags = null,
+            TimeSpan? expiration = null,
+            CancellationToken ct = default) where T : class
+            => factory(ct);
+
+        public Task RemoveAsync(string cacheKey, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<int> RemoveByTagAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
+
+        public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default) => Task.FromResult(0);
+
+        public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new HybridCacheStats());
+    }
+}

--- a/docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md
+++ b/docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md
@@ -31,7 +31,7 @@ grep -rn "new CreateConfigurationCommand" apps/api/src --include="*.cs"
 
 | Method | GET (line) | CREATE (line) | GET env | CREATE env |
 |---|---|---|---|---|
-| `EnableFeatureAsync` | 181 | 206–214 | null → `_environment.EnvironmentName` (via `ConfigurationService.cs:79`) | `"Production"` literal |
+| `EnableFeatureAsync` | 181 | 206–214 | omits `environment` argument (defaults to null → current env via `ConfigurationService.cs:79`) | `"Production"` literal |
 | `DisableFeatureAsync` | 231 | 256–264 | same | `"Production"` literal |
 | `EnableFeatureForTierAsync` | 282 | 307–315 | same | `"Production"` literal |
 | `DisableFeatureForTierAsync` | 333 | 358–366 | same | `"Production"` literal |

--- a/docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md
+++ b/docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md
@@ -1,0 +1,107 @@
+# Config Key Environment Asymmetry Audit — 2026-06-11
+
+**Trigger**: post-#2116 fix code review (PR #2159) → follow-up "audit other config keys for similar lookup/write asymmetry patterns".
+
+**Scope**: all call sites of `IConfigurationService.GetConfigurationByKeyAsync` (the GET side) paired with `CreateConfigurationCommand` (the CREATE side). Look for handlers that read with current-environment fallback but write with a hardcoded environment string — the exact pattern that produced the `23505` duplicate-key 500 on `PUT /api/v1/admin/settings/registration-mode`.
+
+## TL;DR
+
+- **1 HIGH-severity finding** (same bug pattern as #2116, not yet reported as user-facing 500):
+  - `FeatureFlagService.cs` — 4 methods (`EnableFeatureAsync`, `DisableFeatureAsync`, `EnableFeatureForTierAsync`, `DisableFeatureForTierAsync`) read with `_configService.GetConfigurationByKeyAsync(key)` (null env → current-env fallback) and write with `Environment: "Production"` hardcoded.
+- **0 other findings**. The 6 `Update*LimitsCommandHandler` instances use `Environment = "All"` (constant), which is intentional `(Key, "All")` wildcard rows; the `FeatureFlagEndpoints.cs` POST resolves `request.Environment ?? "All"`; `ConfigurationEndpoints.cs` propagates `request.Environment` (user-provided).
+
+## Method
+
+```bash
+# 1. All GET-side calls
+grep -rn "GetConfigurationByKeyAsync" apps/api/src --include="*.cs"
+
+# 2. All CREATE-side calls
+grep -rn "new CreateConfigurationCommand" apps/api/src --include="*.cs"
+
+# 3. For every CREATE call, inspect the `Environment` named argument:
+#    - literal "Production" → suspect
+#    - literal "All"        → wildcard, intentional
+#    - variable/parameter   → trace source
+```
+
+## Findings
+
+### HIGH-1 — `FeatureFlagService` 4-method asymmetry
+
+| Method | GET (line) | CREATE (line) | GET env | CREATE env |
+|---|---|---|---|---|
+| `EnableFeatureAsync` | 181 | 206–214 | null → `_environment.EnvironmentName` (via `ConfigurationService.cs:79`) | `"Production"` literal |
+| `DisableFeatureAsync` | 231 | 256–264 | same | `"Production"` literal |
+| `EnableFeatureForTierAsync` | 282 | 307–315 | same | `"Production"` literal |
+| `DisableFeatureForTierAsync` | 333 | 358–366 | same | `"Production"` literal |
+
+**Reproduces the #2116 pattern verbatim**: in any non-Production environment (Development, Staging), the GET returns null on a fresh DB, the CREATE inserts `(Key, Environment="Production")` — and if a `"Production"` seed row already exists for that feature flag, the INSERT collides with `IX_system_configurations_Key_Environment`.
+
+**Why not yet a P0 user-facing 500?**
+- These four methods are not exposed via a public admin endpoint that toggles feature flags one at a time. The user-facing toggle path goes through `FeatureFlagEndpoints.cs` (which already uses `request.Environment ?? "All"` correctly).
+- These four methods are used by **internal callers** (programmatic flag mutations, likely from seed/migration code or admin tooling). The 23505 has not been reported because the code path may rarely hit a pre-existing "Production" row in dev/staging — but the design fault is present.
+
+**Recommended fix** (same as #2116):
+1. Inject `IWebHostEnvironment` into `FeatureFlagService` constructor.
+2. Replace `Environment: "Production"` in all four `CreateConfigurationCommand` blocks with `_environment.EnvironmentName`.
+3. Pass `_environment.EnvironmentName` explicitly to the four `GetConfigurationByKeyAsync(key)` calls (currently null → relies on internal fallback; explicit makes the symmetry self-evident).
+4. Existing `FeatureFlagServiceTests.cs` needs `IWebHostEnvironment` mock (additive — no test rewrite required).
+
+**Severity rationale**: same root cause as a P0, but no current user-facing exploit path identified → classify as **P1**.
+
+## Non-findings (verified safe)
+
+### "All" wildcard handlers (6× — intentional, symmetric)
+
+These 6 handlers use the `Environment = "All"` (or `EnvironmentValue = "All"`) class-level constant in BOTH the implicit `Update*Command` write path AND the matched read path that knows how to resolve "All" via `ConfigurationRepository.GetByKeyAsync` (per the reviewer's note in PR #2159 — the SQL `WHERE` clause supports the "All" wildcard).
+
+| Handler | Constant |
+|---|---|
+| `UpdateChatHistoryLimitsCommandHandler.cs:21` | `Environment = "All"` |
+| `UpdateGameLibraryLimitsCommandHandler.cs:24` | `Environment = "All"` |
+| `UpdatePdfLimitsCommandHandler.cs:23` | `EnvironmentValue = "All"` |
+| `UpdatePdfTierUploadLimitsCommandHandler.cs:29` | `Environment = "All"` |
+| `UpdatePdfUploadLimitsCommandHandler.cs:25` | `Environment = "All"` |
+| `UpdateSessionLimitsCommandHandler.cs:24` | `Environment = "All"` |
+
+These are NOT affected — the "All" string means "env-agnostic config row" and the read side handles the wildcard.
+
+### Variable-source environment (2× — intentional, user-controlled)
+
+| Call site | Source |
+|---|---|
+| `FeatureFlagEndpoints.cs:191–200` | `request.Environment ?? "All"` (admin caller controls env) |
+| `ConfigurationEndpoints.cs:176–184` | `request.Environment` (admin caller controls env) |
+
+These are admin endpoints where the caller explicitly chooses the target environment. No symmetry violation.
+
+### Query handlers reading current-env config (12× — read-only, no write path)
+
+All `Get*LimitsQueryHandler` files in `BoundedContexts/SystemConfiguration/Application/Queries/` call `GetConfigurationByKeyAsync(key, null, ct)` to read a config value. They never write. No symmetry to violate.
+
+## Recommendations
+
+1. **Track HIGH-1 as a separate P1 issue** with the same playbook as #2116:
+   - Failing unit test that asserts `CreateConfigurationCommand.Environment == "Development"` (or current env, not `"Production"`) — RED before fix, GREEN after.
+   - Inject `IWebHostEnvironment` constructor dep.
+   - Apply 4× line edit.
+   - Add `IWebHostEnvironment` mock to existing `FeatureFlagServiceTests` setup.
+
+2. **Architectural follow-up (P3, design discussion)**: standardise the "what does `Environment` mean for this Key?" decision tree. Today the codebase mixes three idioms:
+   - **`"All"` wildcard** — env-agnostic config, used by `Update*LimitsCommandHandler`.
+   - **Caller-provided** — used by `ConfigurationEndpoints` and `FeatureFlagEndpoints`.
+   - **Current-env per-row** — used by `SetRegistrationMode` (post-#2116) and (incorrectly) by `FeatureFlagService` literal `"Production"`.
+
+   Without a contract, future handlers will pick at random and the next 23505 is a matter of time. Either:
+   - Document a convention (e.g. "global flags → `"All"`; per-env settings → current env"); or
+   - Refactor `ConfigurationRepository.GetByKeyAsync` so that the "All" wildcard absorbs concrete env hits (then concrete env writes become equivalent to "All" reads, removing the asymmetry surface entirely).
+
+   This is a docs / design RFC task, not a bugfix.
+
+3. **Test-side**: when the IT Testcontainers test for `/admin/settings/registration-mode` lands (sibling follow-up), consider adding one IT that exercises `FeatureFlagService.EnableFeatureAsync` against a real DB with a seed `"Production"` row. Would catch HIGH-1 end-to-end.
+
+## Out of scope
+
+- The HIGH-1 fix itself — tracked as separate issue.
+- Migration / data backfill of orphan `"Production"` rows produced by past calls of the four `FeatureFlagService` methods on dev/staging databases. If HIGH-1 is fixed and there are orphan rows, ops would need to either reconcile or accept the same "soft reset" semantics noted in PR #2159 for #2116.

--- a/docs/for-developers/operations/2026-06-11-issue-2116-post-deploy-smoke.md
+++ b/docs/for-developers/operations/2026-06-11-issue-2116-post-deploy-smoke.md
@@ -1,0 +1,75 @@
+# Post-Deploy Smoke Checklist — Issue #2116 (registration-mode env asymmetry fix)
+
+**When to run**: immediately after the first deploy that carries [PR #2159](https://github.com/meepleAi-app/meepleai-monorepo/pull/2159) (commit `ebdf63fb7` on `main-dev`) reaches an environment other than Production.
+
+**Why this is needed**: PR #2159 fixed a P0 500 on `PUT /api/v1/admin/settings/registration-mode` but it changed the `(Key, Environment)` row that `Registration:PublicEnabled` writes to. On a database that already carried the seeded row at `Environment="Production"`, the first toggle on a non-Production deploy writes a NEW row at the current environment name (`"Staging"`, `"Development"`, …) and the old `"Production"` row becomes orphan. The effective `publicRegistrationEnabled` value resets to its boolean default (`false`) until a superadmin sets it again.
+
+**Risk if skipped**: silent regression on the public-registration flag — users on staging may not be able to register (or may be able to register when they shouldn't) for one full refresh cycle.
+
+## Pre-deploy
+
+- [ ] Note the current value of `publicRegistrationEnabled` in staging (login as superadmin → `/admin/config` → General → Registration Mode → record `Public registration enabled: true/false`).
+
+## Post-deploy smoke (≤ 5 min)
+
+### 1. The endpoint no longer 500s (the original bug)
+
+- [ ] Login as superadmin at the staging URL.
+- [ ] Navigate to `/admin/config` → General → Registration Mode.
+- [ ] Toggle the switch (either direction).
+- [ ] Confirm the page returns successfully (HTTP 200, no toast/banner error).
+
+If you see HTTP 500 or `23505 duplicate key`, **STOP** — the fix did not deploy. Rollback per `./rollback-runbook.md`.
+
+### 2. The new env-specific row is created
+
+- [ ] In a DB console connected to the staging Postgres, run:
+
+  ```sql
+  SELECT environment, value, version, created_at, updated_at
+  FROM system_configurations
+  WHERE key = 'Registration:PublicEnabled'
+  ORDER BY environment;
+  ```
+
+- [ ] Expect **2 rows**:
+  - `Environment='Production'` → the original seed row (unchanged `version=1`, original value).
+  - `Environment='Staging'` (or whatever `ASPNETCORE_ENVIRONMENT` evaluates to on the staging deploy) → freshly created at the moment of step 1.
+
+### 3. Restore the pre-deploy intent
+
+- [ ] Compare the new env-specific row value to the pre-deploy value you recorded.
+- [ ] If they differ, toggle once more so the new env-specific row matches the pre-deploy intent.
+- [ ] Re-verify by toggling **twice** (on→off→on, or off→on→off). Both clicks must return HTTP 200 and the row's `version` must increment each time. No 500.
+
+### 4. Confirm GET endpoint reads the new row
+
+- [ ] `curl https://<staging>/api/v1/auth/registration-mode` — should return the value matching the env-specific row you just confirmed in step 2.
+- [ ] Test the public path: open an incognito window, visit `/register`. The page must reflect the current `publicRegistrationEnabled` state (form vs. `RequestAccessForm` popup).
+
+### 5. Idempotency under repeat-toggle (regression of `IX_system_configurations_Key_Environment`)
+
+- [ ] Toggle 3 more times rapidly in the admin UI. All must return HTTP 200. The DB row count for `key='Registration:PublicEnabled'` must remain exactly 2 (never more).
+
+## What to do if any step fails
+
+| Failure | Likely cause | Action |
+|---|---|---|
+| Step 1: HTTP 500 + `23505` | Fix did not deploy / migration applied to wrong env | Verify commit on staging: `ssh meepleai@staging "docker ps --format '{{.Image}}'"`, check api image SHA. If old, redeploy. |
+| Step 2: only 1 row, missing env-specific | Lookup-side env override (env var, K8s pod) is overriding `ASPNETCORE_ENVIRONMENT` | `printenv ASPNETCORE_ENVIRONMENT` on the api container — must match expected staging value (`"Staging"` or `"Production"` depending on infra convention). |
+| Step 2: > 2 rows for same key | Another writer (FeatureFlagService, see #2162) created an extra row | Capture all rows and attach to a comment on #2162. Pick one row to be the active one. |
+| Step 4: GET returns wrong value | Cache stale (HybridCache 5 min TTL) | Wait 5 min OR restart the api container OR call `POST /admin/cache/invalidate` if exposed. |
+| Step 5: row count grows past 2 | Race condition between concurrent toggles or another asymmetric writer | Lock the admin UI from accepting toggles, file a P1 issue, attach DB dump of the table. |
+
+## Out of scope
+
+- **Production deploy**: on Production `ASPNETCORE_ENVIRONMENT="Production"` so the existing seed row IS the row the new code touches. No orphan, no checklist needed. Just verify step 1 (no 500) once after rollout.
+- **#2162 FeatureFlagService follow-up**: the same env asymmetry exists in `FeatureFlagService.cs` (4 methods) but is NOT exposed via the admin UI toggle path. Out of scope for this smoke; tracked separately.
+
+## Related
+
+- Issue #2116 (closed) — root cause.
+- PR #2159 (merged) — the fix.
+- Issue #2162 — same-pattern bug in `FeatureFlagService` (P1, not blocking).
+- Audit: `docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md`.
+- IT regression test (catches 23505 end-to-end): `apps/api/tests/Api.Tests/Integration/Authentication/SetRegistrationModeIntegrationTests.cs`.

--- a/docs/for-developers/operations/2026-06-11-issue-2116-post-deploy-smoke.md
+++ b/docs/for-developers/operations/2026-06-11-issue-2116-post-deploy-smoke.md
@@ -33,8 +33,8 @@ If you see HTTP 500 or `23505 duplicate key`, **STOP** — the fix did not deplo
   ```
 
 - [ ] Expect **2 rows**:
-  - `Environment='Production'` → the original seed row (unchanged `version=1`, original value).
-  - `Environment='Staging'` (or whatever `ASPNETCORE_ENVIRONMENT` evaluates to on the staging deploy) → freshly created at the moment of step 1.
+  - `Environment='Production'` → the original seed row (unchanged value, `version=1` if untouched by prior deploys to this DB).
+  - `Environment='Staging'` (or whatever `ASPNETCORE_ENVIRONMENT` evaluates to on the staging deploy) → the env-specific row, **any `version >= 1`**. If this is the very first deploy of the fix to this DB it will be `version=1` and the row was created by step 1; on a re-deploy or if dev/staging shared a DB, it may be `version > 1` and pre-exist — that is OK as long as the row exists.
 
 ### 3. Restore the pre-deploy intent
 
@@ -56,7 +56,7 @@ If you see HTTP 500 or `23505 duplicate key`, **STOP** — the fix did not deplo
 | Failure | Likely cause | Action |
 |---|---|---|
 | Step 1: HTTP 500 + `23505` | Fix did not deploy / migration applied to wrong env | Verify commit on staging: `ssh meepleai@staging "docker ps --format '{{.Image}}'"`, check api image SHA. If old, redeploy. |
-| Step 2: only 1 row, missing env-specific | Lookup-side env override (env var, K8s pod) is overriding `ASPNETCORE_ENVIRONMENT` | `printenv ASPNETCORE_ENVIRONMENT` on the api container — must match expected staging value (`"Staging"` or `"Production"` depending on infra convention). |
+| Step 2: only 1 row, missing env-specific | Lookup-side env override (env var, K8s pod) is overriding `ASPNETCORE_ENVIRONMENT`, OR the toggle in step 1 silently no-op'd | First: `printenv ASPNETCORE_ENVIRONMENT` on the api container — must match the expected staging value (`"Staging"` or `"Production"` depending on infra convention). If env var is correct, capture the api container logs around the toggle time and look for a non-200 response that wasn't surfaced to the UI. |
 | Step 2: > 2 rows for same key | Another writer (FeatureFlagService, see #2162) created an extra row | Capture all rows and attach to a comment on #2162. Pick one row to be the active one. |
 | Step 4: GET returns wrong value | Cache stale (HybridCache 5 min TTL) | Wait 5 min OR restart the api container OR call `POST /admin/cache/invalidate` if exposed. |
 | Step 5: row count grows past 2 | Race condition between concurrent toggles or another asymmetric writer | Lock the admin UI from accepting toggles, file a P1 issue, attach DB dump of the table. |


### PR DESCRIPTION
## Summary

Three deliverables from the #2116 / PR #2159 code-review follow-up list:

1. **IT Testcontainers** for `SetRegistrationModeCommandHandler` — catches the real `23505` end-to-end (unit-test mocks can't see SQL constraints).
2. **Audit report** sweeping every `GetConfigurationByKeyAsync` ↔ `CreateConfigurationCommand` pair for the same lookup/write env asymmetry.
3. **Post-deploy smoke checklist** for the next non-Production deploy (the old `\"Production\"` seed row becomes orphan and the effective `publicRegistrationEnabled` value resets to default).

## What's in the PR

### IT Testcontainers (`SetRegistrationModeIntegrationTests.cs`)

Two scenarios on real Postgres:

| Test | Setup | Acts | Asserts |
|---|---|---|---|
| `WithSeedRowAtProduction_AndCurrentEnvIsDevelopment_DoesNotRaiseDuplicateKey` | Seed `(Key, Environment=\"Production\")` row + admin user; `IWebHostEnvironment.EnvironmentName=\"Development\"` | Send `SetRegistrationModeCommand(true)` | No exception; DB has 2 rows: `Production` seed untouched + new `Development` row |
| `TwoConsecutiveTogglesInDevelopment_HitUpdatePath_NoDuplicateRow` | Same seed + two `mediator.Send` calls in **separate DI scopes** (mirrors two HTTP requests) | Toggle on, then off | Exactly 1 `Development` row, `Version==2`, `Value==\"false\"` |

**Implementation note**: ships an in-test `PassthroughHybridCache` because the default `Mock.Of<IHybridCacheService>()` registered by `IntegrationServiceCollectionBuilder.CreateBase()` never invokes the factory, which masks the Update path. Scope-separated calls in test 2 mirror production HTTP request boundaries.

### Audit report

`docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md`

- **1 HIGH-severity finding**: `FeatureFlagService` 4 methods (`EnableFeatureAsync`, `DisableFeatureAsync`, `EnableFeatureForTierAsync`, `DisableFeatureForTierAsync`) reproduce the #2116 pattern verbatim. Tracked as #2162.
- **0 other findings**: 6 `Update*LimitsCommandHandler` use `Environment=\"All\"` wildcard (symmetric); 2 endpoint handlers accept caller-provided env (symmetric).
- Architectural RFC recommendation: standardise the 3 idioms currently in use (`\"All\"` wildcard / caller-provided / current-env per-row).

### Ops smoke checklist

`docs/for-developers/operations/2026-06-11-issue-2116-post-deploy-smoke.md`

5-step playbook for the first deploy carrying PR #2159 to a non-Production env:

1. Confirm 500 is gone.
2. Verify the new env-specific row is created.
3. Restore pre-deploy intent of `publicRegistrationEnabled` (old Production seed becomes orphan).
4. Confirm GET reads the new row.
5. Repeat-toggle idempotency.

Includes a failure → action table for the 5 most likely deviations.

## Test plan
- [x] `dotnet test --filter \"FullyQualifiedName~SetRegistrationModeIntegrationTests\"` → 2/2 green (~13s, Testcontainers Postgres)
- [x] Audit doc lints clean (no Lychee broken links)
- [x] Ops checklist tested manually for readability against the runbook conventions in `docs/for-developers/operations/`

## Related

- Issue #2116 (closed) — root cause + P0 fix.
- PR #2159 (merged) — the SetRegistrationModeCommandHandler fix.
- Issue #2162 (open, P1) — same-pattern bug in `FeatureFlagService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)