### PR TITLE
feat(catalog): #1823 M12 admin trigger endpoint + IWikidataCoverEnrichmentRunner

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommand.cs
@@ -1,0 +1,59 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Wave 3 M12 — admin-triggered Wikidata cover enrichment for a
+/// single shared game. Delegates the actual enrich+record workflow to
+/// <see cref="Services.IWikidataCoverEnrichmentRunner"/> so the admin path
+/// produces the same audit trail (<c>WikidataCoverEnrichmentAttempt</c> row)
+/// as the M9 scheduler tick.
+/// </summary>
+/// <param name="GameId">Target shared-game id.</param>
+/// <param name="ForceRefresh">When <see langword="true"/>, the M8 90-day freshness window is bypassed.</param>
+/// <param name="TriggeredByUserId">Admin user id captured for audit logging.</param>
+internal sealed record AdminEnrichWikidataCoverCommand(
+    Guid GameId,
+    bool ForceRefresh,
+    Guid TriggeredByUserId) : ICommand<AdminEnrichWikidataCoverResult>;
+
+/// <summary>
+/// Flat DTO returned to the admin endpoint. Encodes the three terminal outcome
+/// categories produced by <see cref="EnrichCatalogCoverCommand"/> + the optional
+/// success payload.
+/// </summary>
+/// <param name="Outcome">Either <c>"success"</c>, <c>"skipped"</c>, or <c>"failed"</c>.</param>
+/// <param name="Reason">Skip / failure reason; <see langword="null"/> for success.</param>
+/// <param name="Details">Optional failure detail (typically an exception message).</param>
+/// <param name="R2Key">R2 key on success (WITHOUT <c>.webp</c> suffix); <see langword="null"/> otherwise.</param>
+/// <param name="License">Whitelisted license string on success.</param>
+/// <param name="Attribution">Optional Artist credit on success.</param>
+/// <param name="SourceUrl">Wikidata entity URL on success.</param>
+internal sealed record AdminEnrichWikidataCoverResult(
+    string Outcome,
+    string? Reason,
+    string? Details,
+    string? R2Key,
+    string? License,
+    string? Attribution,
+    string? SourceUrl)
+{
+    public const string OutcomeSuccess = "success";
+    public const string OutcomeSkipped = "skipped";
+    public const string OutcomeFailed = "failed";
+
+    public static AdminEnrichWikidataCoverResult FromSuccess(EnrichCatalogCoverResult.Success success) =>
+        new(OutcomeSuccess, Reason: null, Details: null,
+            R2Key: success.R2Key,
+            License: success.License,
+            Attribution: success.Attribution,
+            SourceUrl: success.SourceUrl);
+
+    public static AdminEnrichWikidataCoverResult FromSkipped(EnrichCatalogCoverResult.Skipped skipped) =>
+        new(OutcomeSkipped, Reason: skipped.Reason, Details: null,
+            R2Key: null, License: null, Attribution: null, SourceUrl: null);
+
+    public static AdminEnrichWikidataCoverResult FromFailed(EnrichCatalogCoverResult.Failed failed) =>
+        new(OutcomeFailed, Reason: failed.Reason, Details: failed.Details,
+            R2Key: null, License: null, Attribution: null, SourceUrl: null);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommand.cs
@@ -11,7 +11,18 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatal
 /// </summary>
 /// <param name="GameId">Target shared-game id.</param>
 /// <param name="ForceRefresh">When <see langword="true"/>, the M8 90-day freshness window is bypassed.</param>
-/// <param name="TriggeredByUserId">Admin user id captured for audit logging.</param>
+/// <param name="TriggeredByUserId">
+/// Admin user id captured ONLY in the structured log line emitted by the handler
+/// (<c>AdminEnrichWikidataCover: triggered by user {UserId} for game {GameId}</c>) —
+/// NOT persisted to the <c>WikidataCoverEnrichmentAttempt</c> row. This is by
+/// design for M12 scope: attempt rows are record-of-fact about the enrichment
+/// pipeline outcome (success / skipped / failed / dead-letter) and remain
+/// indistinguishable between scheduler-triggered and admin-triggered runs so
+/// the audit trail stays uniform. If the M13 admin dead-letter page needs to
+/// show "triggered by admin X", it must source that information from the
+/// structured log stream or a separate trigger-audit table introduced in M13,
+/// not from <c>WikidataCoverEnrichmentAttempt</c>.
+/// </param>
 internal sealed record AdminEnrichWikidataCoverCommand(
     Guid GameId,
     bool ForceRefresh,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandler.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Handler for <see cref="AdminEnrichWikidataCoverCommand"/>. Thin wrapper over
+/// <see cref="IWikidataCoverEnrichmentRunner"/>: runs the M8 pipeline + records
+/// a <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/> row, then
+/// flattens the result into a wire-friendly DTO for the admin endpoint.
+/// Issue #1823 Wave 3 M12.
+/// </summary>
+internal sealed class AdminEnrichWikidataCoverCommandHandler
+    : ICommandHandler<AdminEnrichWikidataCoverCommand, AdminEnrichWikidataCoverResult>
+{
+    private readonly IWikidataCoverEnrichmentRunner _runner;
+    private readonly ILogger<AdminEnrichWikidataCoverCommandHandler> _logger;
+
+    public AdminEnrichWikidataCoverCommandHandler(
+        IWikidataCoverEnrichmentRunner runner,
+        ILogger<AdminEnrichWikidataCoverCommandHandler> logger)
+    {
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AdminEnrichWikidataCoverResult> Handle(
+        AdminEnrichWikidataCoverCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        _logger.LogInformation(
+            "AdminEnrichWikidataCover: triggered by user {UserId} for game {GameId} (forceRefresh={ForceRefresh})",
+            request.TriggeredByUserId, request.GameId, request.ForceRefresh);
+
+        var result = await _runner
+            .EnrichAndRecordAsync(request.GameId, request.ForceRefresh, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result switch
+        {
+            EnrichCatalogCoverResult.Success success => AdminEnrichWikidataCoverResult.FromSuccess(success),
+            EnrichCatalogCoverResult.Skipped skipped => AdminEnrichWikidataCoverResult.FromSkipped(skipped),
+            EnrichCatalogCoverResult.Failed failed => AdminEnrichWikidataCoverResult.FromFailed(failed),
+            _ => AdminEnrichWikidataCoverResult.FromFailed(
+                new EnrichCatalogCoverResult.Failed("unexpected-result", result.GetType().Name)),
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommand.cs
@@ -27,6 +27,13 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatal
 /// Game-not-found surfaces as <see cref="Api.Middleware.Exceptions.NotFoundException"/>
 /// (HTTP 404 via the exception middleware).
 /// </para>
+/// <para>
+/// <see cref="ForceRefresh"/> (Wave 3 M12): when <see langword="true"/> the
+/// handler skips the 90-day freshness window check (ADR DEC-3i preparation) and
+/// always runs the full pipeline. Used by the admin trigger endpoint to force
+/// a re-enrichment for dogfood / edge-case testing. The default (<see langword="false"/>)
+/// preserves the scheduler's freshness skip semantics.
+/// </para>
 /// </remarks>
-internal sealed record EnrichCatalogCoverCommand(Guid GameId)
+internal sealed record EnrichCatalogCoverCommand(Guid GameId, bool ForceRefresh = false)
     : ICommand<EnrichCatalogCoverResult>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -111,8 +111,11 @@ internal sealed class EnrichCatalogCoverCommandHandler
 
         // 2. Freshness window (DEC-3i preparation). Both the column AND a non-null
         //    R2 key are required to short-circuit — a verified-but-cleared entry
-        //    must still re-enrich.
-        if (game.WikidataQidLastVerifiedAt is { } lastVerifiedAt
+        //    must still re-enrich. Wave 3 M12: callers (admin trigger) can pass
+        //    ForceRefresh=true to bypass the window for dogfood / edge-case
+        //    re-runs; the scheduler still passes the default false.
+        if (!request.ForceRefresh
+            && game.WikidataQidLastVerifiedAt is { } lastVerifiedAt
             && !string.IsNullOrWhiteSpace(game.WikidataCoverR2Key)
             && (nowUtc - lastVerifiedAt) < FreshnessWindow)
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs
@@ -1,9 +1,5 @@
-using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
-using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
-using Api.SharedKernel.Infrastructure.Persistence;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Quartz;
@@ -16,10 +12,10 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
 /// <list type="number">
 ///   <item>Queries up to <see cref="BatchSize"/> <c>SharedGame</c> IDs ready for
 ///   enrichment (never-attempted OR retry-eligible per
-///   <see cref="WikidataCoverEnrichmentAttempt.NextRetryAt"/>).</item>
-///   <item>Dispatches <see cref="EnrichCatalogCoverCommand"/> per game via MediatR.</item>
-///   <item>Records a <see cref="WikidataCoverEnrichmentAttempt"/> classified by
-///   <see cref="IWikidataCoverEnrichmentRetryPolicy"/> (DEC-3j semantics).</item>
+///   <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.WikidataCoverEnrichmentAttempt.NextRetryAt"/>).</item>
+///   <item>Delegates the per-game enrich+record workflow to
+///   <see cref="IWikidataCoverEnrichmentRunner"/> — the single source of truth
+///   shared with the M12 admin trigger endpoint.</item>
 ///   <item>Throttles 1s between games to respect the shared Wikimedia 5 RPS cap
 ///   (DEC-3e) alongside the in-process token bucket.</item>
 /// </list>
@@ -72,11 +68,9 @@ public sealed class WikidataCoverEnrichmentJob : IJob
         using var scope = _serviceProvider.CreateScope();
 
         var attempts = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentAttemptRepository>();
-        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-        var policy = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentRetryPolicy>();
+        var runner = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentRunner>();
 
-        await RunBatchAsync(attempts, uow, mediator, policy, ct).ConfigureAwait(false);
+        await RunBatchAsync(attempts, runner, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -85,9 +79,7 @@ public sealed class WikidataCoverEnrichmentJob : IJob
     /// </summary>
     internal async Task RunBatchAsync(
         IWikidataCoverEnrichmentAttemptRepository attempts,
-        IUnitOfWork uow,
-        IMediator mediator,
-        IWikidataCoverEnrichmentRetryPolicy policy,
+        IWikidataCoverEnrichmentRunner runner,
         CancellationToken ct)
     {
         var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
@@ -119,7 +111,10 @@ public sealed class WikidataCoverEnrichmentJob : IJob
 
             try
             {
-                await ProcessGameAsync(attempts, uow, mediator, policy, gameId, ct).ConfigureAwait(false);
+                // Scheduler always uses forceRefresh=false — freshness window
+                // honoured. The admin trigger endpoint uses forceRefresh=true
+                // for dogfood re-runs.
+                await runner.EnrichAndRecordAsync(gameId, forceRefresh: false, ct).ConfigureAwait(false);
                 processed++;
             }
             // OperationCanceledException is intentionally allowed to propagate
@@ -151,67 +146,5 @@ public sealed class WikidataCoverEnrichmentJob : IJob
         _logger.LogInformation(
             "WikidataCoverEnrichmentJob: tick complete — processed {Processed}/{Total} games.",
             processed, dueGameIds.Count);
-    }
-
-    private async Task ProcessGameAsync(
-        IWikidataCoverEnrichmentAttemptRepository attempts,
-        IUnitOfWork uow,
-        IMediator mediator,
-        IWikidataCoverEnrichmentRetryPolicy policy,
-        Guid gameId,
-        CancellationToken ct)
-    {
-        var previous = await attempts
-            .GetLatestBySharedGameIdAsync(gameId, ct)
-            .ConfigureAwait(false);
-
-        var previousRetryCount = previous?.RetryCount ?? 0;
-
-        var result = await mediator
-            .Send(new EnrichCatalogCoverCommand(gameId), ct)
-            .ConfigureAwait(false);
-
-        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
-        var decision = policy.Classify(result, previousRetryCount, nowUtc);
-
-        // RetryCount for the NEW attempt row:
-        // - Terminal/DeadLetter: preserve previous count (this attempt is the
-        //   nth retry that produced the terminal outcome).
-        // - ScheduleRetry: increment by 1 (this attempt counts towards the budget).
-        var nextRetryCount = decision switch
-        {
-            WikidataCoverEnrichmentRetryDecision.ScheduleRetry => previousRetryCount + 1,
-            _ => previousRetryCount,
-        };
-
-        WikidataCoverEnrichmentAttempt newAttempt = (decision, result) switch
-        {
-            (WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Success) =>
-                WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, nextRetryCount, nowUtc),
-
-            (WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Skipped skipped) =>
-                WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, skipped.Reason, nextRetryCount, nowUtc),
-
-            (WikidataCoverEnrichmentRetryDecision.ScheduleRetry retry, EnrichCatalogCoverResult.Failed failed) =>
-                WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
-                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, retry.NextRetryAt),
-
-            (WikidataCoverEnrichmentRetryDecision.DeadLetter, EnrichCatalogCoverResult.Failed failed) =>
-                WikidataCoverEnrichmentAttempt.RecordDeadLetter(
-                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc),
-
-            // Defensive: a mismatched (decision, result) pair shouldn't happen since
-            // the policy only emits ScheduleRetry/DeadLetter for Failed results, but
-            // record a DeadLetter rather than crash the batch.
-            _ => WikidataCoverEnrichmentAttempt.RecordDeadLetter(
-                gameId, "unexpected-decision", $"{decision.GetType().Name} for {result.GetType().Name}", nextRetryCount, nowUtc),
-        };
-
-        await attempts.AddAsync(newAttempt, ct).ConfigureAwait(false);
-        await uow.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        _logger.LogDebug(
-            "WikidataCoverEnrichmentJob: game {GameId} outcome={Outcome} reason={Reason} retry={RetryCount} nextRetryAt={NextRetryAt}",
-            gameId, newAttempt.Outcome, newAttempt.Reason, newAttempt.RetryCount, newAttempt.NextRetryAt);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataCoverEnrichmentRunner.cs
@@ -1,0 +1,31 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Encapsulates the "send <see cref="EnrichCatalogCoverCommand"/> + classify
+/// outcome via <see cref="IWikidataCoverEnrichmentRetryPolicy"/> + record the
+/// resulting <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.WikidataCoverEnrichmentAttempt"/>"
+/// workflow used both by the M9 scheduler tick and the M12 admin trigger
+/// endpoint. Single source of truth so the audit trail is identical regardless
+/// of who pulled the trigger. Issue #1823 Wave 3 M12.
+/// </summary>
+internal interface IWikidataCoverEnrichmentRunner
+{
+    /// <summary>
+    /// Runs the enrichment pipeline for one game and persists a new attempt
+    /// row reflecting the outcome.
+    /// </summary>
+    /// <param name="gameId">Target shared-game id.</param>
+    /// <param name="forceRefresh">
+    /// When <see langword="true"/>, the M8 handler bypasses the 90-day freshness
+    /// window (admin dogfood / edge-case re-runs); the scheduler always passes
+    /// <see langword="false"/>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token honoured by all downstream calls.</param>
+    /// <returns>The terminal outcome of the underlying <see cref="EnrichCatalogCoverCommand"/>.</returns>
+    Task<EnrichCatalogCoverResult> EnrichAndRecordAsync(
+        Guid gameId,
+        bool forceRefresh,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
@@ -1,0 +1,103 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IWikidataCoverEnrichmentRunner"/>.
+/// Single source of truth for the enrich+record workflow, consumed by
+/// the M9 <c>WikidataCoverEnrichmentJob</c> scheduler and the M12 admin
+/// trigger endpoint. Issue #1823 Wave 3 M12.
+/// </summary>
+internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRunner
+{
+    private readonly IMediator _mediator;
+    private readonly IWikidataCoverEnrichmentAttemptRepository _attempts;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IWikidataCoverEnrichmentRetryPolicy _policy;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WikidataCoverEnrichmentRunner> _logger;
+
+    public WikidataCoverEnrichmentRunner(
+        IMediator mediator,
+        IWikidataCoverEnrichmentAttemptRepository attempts,
+        IUnitOfWork unitOfWork,
+        IWikidataCoverEnrichmentRetryPolicy policy,
+        TimeProvider timeProvider,
+        ILogger<WikidataCoverEnrichmentRunner> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EnrichCatalogCoverResult> EnrichAndRecordAsync(
+        Guid gameId,
+        bool forceRefresh,
+        CancellationToken cancellationToken = default)
+    {
+        var previous = await _attempts
+            .GetLatestBySharedGameIdAsync(gameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var previousRetryCount = previous?.RetryCount ?? 0;
+
+        var result = await _mediator
+            .Send(new EnrichCatalogCoverCommand(gameId, forceRefresh), cancellationToken)
+            .ConfigureAwait(false);
+
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var decision = _policy.Classify(result, previousRetryCount, nowUtc);
+
+        // RetryCount for the NEW attempt row:
+        // - Terminal / DeadLetter: preserve previous count (this attempt is the
+        //   nth retry that produced the terminal outcome).
+        // - ScheduleRetry: increment by 1 (this attempt counts towards the budget).
+        var nextRetryCount = decision switch
+        {
+            WikidataCoverEnrichmentRetryDecision.ScheduleRetry => previousRetryCount + 1,
+            _ => previousRetryCount,
+        };
+
+        WikidataCoverEnrichmentAttempt newAttempt = (decision, result) switch
+        {
+            (WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Success) =>
+                WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, nextRetryCount, nowUtc),
+
+            (WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Skipped skipped) =>
+                WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, skipped.Reason, nextRetryCount, nowUtc),
+
+            (WikidataCoverEnrichmentRetryDecision.ScheduleRetry retry, EnrichCatalogCoverResult.Failed failed) =>
+                WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, retry.NextRetryAt),
+
+            (WikidataCoverEnrichmentRetryDecision.DeadLetter, EnrichCatalogCoverResult.Failed failed) =>
+                WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc),
+
+            // Defensive: a mismatched (decision, result) pair shouldn't happen
+            // because the policy only emits ScheduleRetry/DeadLetter for Failed
+            // results, but record a DeadLetter rather than crash the runner.
+            _ => WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+                gameId, "unexpected-decision",
+                $"{decision.GetType().Name} for {result.GetType().Name}",
+                nextRetryCount, nowUtc),
+        };
+
+        await _attempts.AddAsync(newAttempt, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "WikidataCoverEnrichmentRunner: game {GameId} outcome={Outcome} reason={Reason} retry={RetryCount} nextRetryAt={NextRetryAt} forceRefresh={ForceRefresh}",
+            gameId, newAttempt.Outcome, newAttempt.Reason, newAttempt.RetryCount, newAttempt.NextRetryAt, forceRefresh);
+
+        return result;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminEnrichWikidataCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminEnrichWikidataCoverCommandValidator.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="AdminEnrichWikidataCoverCommand"/>. Only enforces
+/// the minimal shape invariants — every business outcome (qid-missing, license
+/// not whitelisted, ...) is returned as part of the result DTO instead of
+/// becoming an HTTP 400. Issue #1823 Wave 3 M12.
+/// </summary>
+internal sealed class AdminEnrichWikidataCoverCommandValidator
+    : AbstractValidator<AdminEnrichWikidataCoverCommand>
+{
+    public AdminEnrichWikidataCoverCommandValidator()
+    {
+        RuleFor(x => x.GameId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("GameId must not be empty.");
+
+        RuleFor(x => x.TriggeredByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("TriggeredByUserId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -221,6 +221,11 @@ internal static class SharedGameCatalogServiceExtensions
         // singleton lifetime.
         services.AddSingleton<IWikidataCoverEnrichmentRetryPolicy, WikidataCoverEnrichmentRetryPolicy>();
 
+        // Issue #1823 Wave 3 M12: single source of truth for the enrich+record
+        // workflow (M9 scheduler + M12 admin trigger endpoint). Scoped — uses
+        // the request UoW + repository.
+        services.AddScoped<IWikidataCoverEnrichmentRunner, WikidataCoverEnrichmentRunner>();
+
         // Issue #1823 Wave 3 M9: Quartz scheduler for batch Wikidata cover
         // enrichment. Runs every 1 minute (HPA=1 per DEC-3e). [DisallowConcurrentExecution]
         // on the job class is the belt-and-braces guarantee that we never have

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -888,6 +888,7 @@ app.MapAdminBulkImportEndpoints();       // Issue #4354: Bulk import endpoint ro
 app.MapAdminProviderEndpoints();         // Issue #936: Provider token probe observability
 v1Api.MapGroup("/admin/catalog-ingestion").MapAdminCatalogIngestionEndpoints(); // Admin bulk Excel import + enrichment
 v1Api.MapGroup("/admin/catalog/seeds").MapAdminCatalogSeedEndpoints();          // Issue #1903 M6.2: admin catalog seed pipeline
+v1Api.MapGroup("/admin/wikidata/enrichment").MapAdminWikidataCoverEnrichmentEndpoints(); // Issue #1823 Wave 3 M12: admin Wikidata cover trigger
 v1Api.MapGroup("/admin/event-outbox").MapAdminDomainEventOutboxEndpoints();    // Issue #1535 T6: domain_event_outbox health surface
 
 // Issue #1928 Task B (DEC-B-1 + DEC-B-4) — E2E test seeding endpoints, triple-gated:

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -41,7 +41,7 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
     /// Request body for the trigger endpoint. <see cref="ForceRefresh"/> is
     /// optional — null is treated as <see langword="false"/>.
     /// </summary>
-    public sealed record AdminTriggerWikidataEnrichmentRequest(bool? ForceRefresh);
+    internal sealed record AdminTriggerWikidataEnrichmentRequest(bool? ForceRefresh);
 
     private static async Task<IResult> HandleTrigger(
         Guid gameId,

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.Extensions;
+using Api.Filters;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace Api.Routing.Admin;
+
+/// <summary>
+/// Issue #1823 Wave 3 M12 — admin endpoint for the Wikidata cover enrichment
+/// pipeline. Routes under <c>/api/v1/admin/wikidata/enrichment</c>. Admin-only
+/// (gated by <see cref="RequireAdminSessionFilter"/>).
+/// </summary>
+/// <remarks>
+/// <para>Endpoint summary:</para>
+/// <list type="bullet">
+///   <item><c>POST /{gameId:guid}</c> — manually trigger enrichment for one
+///   shared game. Body: <c>{ "forceRefresh": bool }</c>. Returns the flattened
+///   <see cref="AdminEnrichWikidataCoverResult"/> with outcome <c>"success"</c>
+///   / <c>"skipped"</c> / <c>"failed"</c>.</item>
+/// </list>
+/// <para>CQRS compliance: dispatches exclusively via <see cref="IMediator"/>.</para>
+/// </remarks>
+internal static class AdminWikidataCoverEnrichmentEndpoints
+{
+    public static RouteGroupBuilder MapAdminWikidataCoverEnrichmentEndpoints(this RouteGroupBuilder group)
+    {
+        // Mirror of AdminCatalogSeedEndpoints: group-level admin auth filter.
+        // Anonymous probes get 401; non-admin sessions get 403 BEFORE the
+        // route handler runs.
+        group.AddEndpointFilter<RequireAdminSessionFilter>();
+
+        group.MapPost("/{gameId:guid}", HandleTrigger)
+            .WithName("AdminWikidataCoverEnrichment_Trigger")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
+        return group;
+    }
+
+    /// <summary>
+    /// Request body for the trigger endpoint. <see cref="ForceRefresh"/> is
+    /// optional — null is treated as <see langword="false"/>.
+    /// </summary>
+    public sealed record AdminTriggerWikidataEnrichmentRequest(bool? ForceRefresh);
+
+    private static async Task<IResult> HandleTrigger(
+        Guid gameId,
+        AdminTriggerWikidataEnrichmentRequest? request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        // Auth already enforced at the group level via RequireAdminSessionFilter.
+        // GameId is parsed by the route constraint :guid — an invalid GUID
+        // returns 400 BEFORE this handler runs. The request body is optional;
+        // null body is treated as forceRefresh=false.
+        var command = new AdminEnrichWikidataCoverCommand(
+            GameId: gameId,
+            ForceRefresh: request?.ForceRefresh ?? false,
+            TriggeredByUserId: context.User.GetUserId());
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandlerTests.cs
@@ -1,0 +1,94 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Unit tests for <see cref="AdminEnrichWikidataCoverCommandHandler"/>.
+/// Issue #1823 Wave 3 M12.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class AdminEnrichWikidataCoverCommandHandlerTests
+{
+    private readonly Mock<IWikidataCoverEnrichmentRunner> _runner = new();
+
+    private AdminEnrichWikidataCoverCommandHandler Sut() =>
+        new(_runner.Object, NullLogger<AdminEnrichWikidataCoverCommandHandler>.Instance);
+
+    [Fact]
+    public async Task Handle_SuccessOutcome_FlattensToSuccessDto()
+    {
+        var gameId = Guid.NewGuid();
+        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("covers/abc/cover", "CC BY-SA 4.0", "John Doe", "https://wikidata.org/wiki/Q1"));
+
+        var result = await Sut().Handle(
+            new AdminEnrichWikidataCoverCommand(gameId, ForceRefresh: true, TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.Outcome.Should().Be(AdminEnrichWikidataCoverResult.OutcomeSuccess);
+        result.R2Key.Should().Be("covers/abc/cover");
+        result.License.Should().Be("CC BY-SA 4.0");
+        result.Attribution.Should().Be("John Doe");
+        result.SourceUrl.Should().Be("https://wikidata.org/wiki/Q1");
+        result.Reason.Should().BeNull();
+        result.Details.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_SkippedOutcome_FlattensToSkippedDto()
+    {
+        var gameId = Guid.NewGuid();
+        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Skipped(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing));
+
+        var result = await Sut().Handle(
+            new AdminEnrichWikidataCoverCommand(gameId, ForceRefresh: false, TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.Outcome.Should().Be(AdminEnrichWikidataCoverResult.OutcomeSkipped);
+        result.Reason.Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing);
+        result.R2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_FailedOutcome_FlattensToFailedDtoWithDetails()
+    {
+        var gameId = Guid.NewGuid();
+        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503 service unavailable"));
+
+        var result = await Sut().Handle(
+            new AdminEnrichWikidataCoverCommand(gameId, ForceRefresh: false, TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.Outcome.Should().Be(AdminEnrichWikidataCoverResult.OutcomeFailed);
+        result.Reason.Should().Be(EnrichCatalogCoverCommandHandler.FailReasonR2Upload);
+        result.Details.Should().Be("503 service unavailable");
+        result.R2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ForwardsForceRefreshAndUserToRunner()
+    {
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        _runner.Setup(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        await Sut().Handle(
+            new AdminEnrichWikidataCoverCommand(gameId, ForceRefresh: true, TriggeredByUserId: userId),
+            default);
+
+        _runner.Verify(r => r.EnrichAndRecordAsync(gameId, true, It.IsAny<CancellationToken>()), Times.Once,
+            "command MUST forward forceRefresh to the runner so the M8 freshness window is bypassed");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs
@@ -1,11 +1,8 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
 using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
-using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
-using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
-using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -14,23 +11,22 @@ using Xunit;
 namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Jobs;
 
 /// <summary>
-/// Unit tests for <see cref="WikidataCoverEnrichmentJob"/> — Issue #1823 Wave 3 M9.
-/// Drives <see cref="WikidataCoverEnrichmentJob.RunBatchAsync"/> directly with
-/// mocked dependencies so the Quartz scheduler is not needed. Uses the real
-/// <see cref="WikidataCoverEnrichmentRetryPolicy"/> to exercise the full DEC-3j
-/// classification flow.
+/// Unit tests for <see cref="WikidataCoverEnrichmentJob"/>. Post-M12 refactor:
+/// the job is a thin batch-loop wrapper around <see cref="IWikidataCoverEnrichmentRunner"/>.
+/// These tests verify the batch-loop semantics (no-op when nothing due, per-item
+/// exception isolation, throttle index logic, graceful cancellation). Outcome
+/// classification + attempt recording is tested in
+/// <c>WikidataCoverEnrichmentRunnerTests</c>.
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
 [Trait("Issue", "1823")]
 public class WikidataCoverEnrichmentJobTests
 {
-    private static readonly DateTime FixedNow = new(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime FixedNow = new(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
 
     private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _attempts = new();
-    private readonly Mock<IUnitOfWork> _uow = new();
-    private readonly Mock<IMediator> _mediator = new();
-    private readonly WikidataCoverEnrichmentRetryPolicy _policy = new();
+    private readonly Mock<IWikidataCoverEnrichmentRunner> _runner = new();
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(FixedNow, TimeSpan.Zero));
 
     private WikidataCoverEnrichmentJob Sut() => new(
@@ -45,153 +41,31 @@ public class WikidataCoverEnrichmentJobTests
                 It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Guid>());
 
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
+        await Sut().RunBatchAsync(_attempts.Object, _runner.Object, default);
 
-        _mediator.Verify(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()), Times.Never);
-        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _runner.Verify(
+            r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
-    public async Task RunBatchAsync_SuccessOutcome_RecordsSuccessAttempt()
+    public async Task RunBatchAsync_ForwardsForceRefreshFalseAlways()
     {
-        var gameId = Guid.NewGuid();
+        var game = Guid.NewGuid();
 
         _attempts.Setup(r => r.GetGameIdsDueForEnrichmentAsync(
                 It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { gameId });
+            .ReturnsAsync(new[] { game });
 
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+        _runner.Setup(r => r.EnrichAndRecordAsync(game, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
-        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EnrichCatalogCoverResult.Success("key", "CC0", null, "url"));
+        await Sut().RunBatchAsync(_attempts.Object, _runner.Object, default);
 
-        WikidataCoverEnrichmentAttempt? recorded = null;
-        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
-            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
-            .Returns(Task.CompletedTask);
-
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
-
-        recorded.Should().NotBeNull();
-        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Success);
-        recorded.Reason.Should().Be("success");
-        recorded.RetryCount.Should().Be(0, "first attempt, no previous retries");
-        recorded.NextRetryAt.Should().BeNull();
-        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task RunBatchAsync_SkippedOutcome_RecordsSkippedAttempt()
-    {
-        var gameId = Guid.NewGuid();
-
-        _attempts.Setup(r => r.GetGameIdsDueForEnrichmentAsync(
-                It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { gameId });
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
-
-        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EnrichCatalogCoverResult.Skipped(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing));
-
-        WikidataCoverEnrichmentAttempt? recorded = null;
-        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
-            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
-            .Returns(Task.CompletedTask);
-
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
-
-        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Skipped);
-        recorded.Reason.Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing);
-        recorded.NextRetryAt.Should().BeNull("skipped is terminal");
-    }
-
-    [Fact]
-    public async Task RunBatchAsync_FailedR2Upload_FirstAttempt_SchedulesRetryAt1m()
-    {
-        var gameId = Guid.NewGuid();
-
-        _attempts.Setup(r => r.GetGameIdsDueForEnrichmentAsync(
-                It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { gameId });
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
-
-        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
-                EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503"));
-
-        WikidataCoverEnrichmentAttempt? recorded = null;
-        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
-            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
-            .Returns(Task.CompletedTask);
-
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
-
-        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Failed);
-        recorded.RetryCount.Should().Be(1, "first retry");
-        recorded.NextRetryAt.Should().Be(FixedNow.AddMinutes(1), "DEC-3j: 1m for the first retry");
-    }
-
-    [Fact]
-    public async Task RunBatchAsync_FailedR2Upload_AfterMaxRetries_DeadLetters()
-    {
-        var gameId = Guid.NewGuid();
-
-        // Previous attempt: 3 retries already exhausted
-        var previous = WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
-            gameId, EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503",
-            retryCount: 3, attemptedAt: FixedNow.AddMinutes(-20), nextRetryAt: FixedNow.AddMinutes(-5));
-
-        _attempts.Setup(r => r.GetGameIdsDueForEnrichmentAsync(
-                It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { gameId });
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(previous);
-
-        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
-                EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503"));
-
-        WikidataCoverEnrichmentAttempt? recorded = null;
-        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
-            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
-            .Returns(Task.CompletedTask);
-
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
-
-        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.DeadLetter);
-        recorded.DeadLetteredAt.Should().Be(FixedNow);
-        recorded.NextRetryAt.Should().BeNull("dead-letter is terminal");
-        recorded.RetryCount.Should().Be(3, "preserve previous retry count on terminal");
-    }
-
-    [Fact]
-    public async Task RunBatchAsync_FailedImageProcessing_DeadLettersImmediately()
-    {
-        var gameId = Guid.NewGuid();
-
-        _attempts.Setup(r => r.GetGameIdsDueForEnrichmentAsync(
-                It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { gameId });
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
-
-        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
-                EnrichCatalogCoverCommandHandler.FailReasonImageProcessing, "corrupted bytes"));
-
-        WikidataCoverEnrichmentAttempt? recorded = null;
-        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
-            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
-            .Returns(Task.CompletedTask);
-
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
-
-        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.DeadLetter);
-        recorded.Reason.Should().Be(EnrichCatalogCoverCommandHandler.FailReasonImageProcessing);
-        recorded.RetryCount.Should().Be(0, "no retries attempted for corrupted-image failure");
+        _runner.Verify(
+            r => r.EnrichAndRecordAsync(game, false, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "scheduler MUST always pass forceRefresh=false — freshness window honoured");
     }
 
     [Fact]
@@ -204,34 +78,20 @@ public class WikidataCoverEnrichmentJobTests
                 It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { game1, game2 });
 
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
-
-        // game1 throws inside the mediator; game2 succeeds.
-        _mediator.Setup(m => m.Send(It.Is<EnrichCatalogCoverCommand>(c => c.GameId == game1), It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game1, false, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
-        _mediator.Setup(m => m.Send(It.Is<EnrichCatalogCoverCommand>(c => c.GameId == game2), It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
-        var recorded = new List<WikidataCoverEnrichmentAttempt>();
-        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
-            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded.Add(a))
-            .Returns(Task.CompletedTask);
+        await Sut().RunBatchAsync(_attempts.Object, _runner.Object, default);
 
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, default);
-
-        recorded.Should().HaveCount(1,
-            "game1 throw should be swallowed (no attempt recorded), game2 success records normally");
-        recorded[0].SharedGameId.Should().Be(game2);
+        _runner.Verify(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<CancellationToken>()), Times.Once,
+            "game1 throw should be swallowed (logged); the loop continues with game2");
     }
 
     [Fact]
     public async Task RunBatchAsync_TokenCancelledMidBatch_BreaksLoopGracefully()
     {
-        // Quartz semantics: when shutdown fires, the job's CT is signalled and
-        // the batch should drain the current game then stop on the next loop top
-        // check (NOT throw out). The test verifies that game2 is skipped after
-        // game1 cancels the token.
         var game1 = Guid.NewGuid();
         var game2 = Guid.NewGuid();
         var cts = new CancellationTokenSource();
@@ -240,18 +100,13 @@ public class WikidataCoverEnrichmentJobTests
                 It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { game1, game2 });
 
-        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
-
-        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game1, false, It.IsAny<CancellationToken>()))
             .Callback(() => cts.Cancel())
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
-        await Sut().RunBatchAsync(_attempts.Object, _uow.Object, _mediator.Object, _policy, cts.Token);
+        await Sut().RunBatchAsync(_attempts.Object, _runner.Object, cts.Token);
 
-        _mediator.Verify(
-            m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()),
-            Times.Once,
+        _runner.Verify(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<CancellationToken>()), Times.Never,
             "after game1 finishes (and cancels the token), the loop top check breaks before game2");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -1,0 +1,204 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="WikidataCoverEnrichmentRunner"/> — Issue #1823 Wave 3 M12.
+/// Single source of truth for the enrich+record workflow used by both the M9
+/// scheduler and the M12 admin trigger endpoint. Uses the real
+/// <see cref="WikidataCoverEnrichmentRetryPolicy"/> (no mock policy) per the
+/// <c>acceptance_tests_must_exercise_real_pipeline</c> feedback memory.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class WikidataCoverEnrichmentRunnerTests
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _attempts = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly WikidataCoverEnrichmentRetryPolicy _policy = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(FixedNow, TimeSpan.Zero));
+
+    private WikidataCoverEnrichmentRunner Sut() => new(
+        _mediator.Object, _attempts.Object, _uow.Object, _policy,
+        _time, NullLogger<WikidataCoverEnrichmentRunner>.Instance);
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_SuccessOutcome_RecordsSuccessAttempt()
+    {
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("key", "CC0", null, "url"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        var result = await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Success>();
+        recorded.Should().NotBeNull();
+        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Success);
+        recorded.RetryCount.Should().Be(0);
+        recorded.NextRetryAt.Should().BeNull();
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_SkippedOutcome_RecordsSkippedAttempt()
+    {
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Skipped(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Skipped);
+        recorded.Reason.Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing);
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_FailedR2Upload_FirstAttempt_SchedulesRetryAt1m()
+    {
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Failed);
+        recorded.RetryCount.Should().Be(1);
+        recorded.NextRetryAt.Should().Be(FixedNow.AddMinutes(1));
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_AfterMaxRetries_DeadLetters()
+    {
+        var gameId = Guid.NewGuid();
+        var previous = WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+            gameId, EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503",
+            retryCount: 3, attemptedAt: FixedNow.AddMinutes(-20), nextRetryAt: FixedNow.AddMinutes(-5));
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(previous);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.DeadLetter);
+        recorded.DeadLetteredAt.Should().Be(FixedNow);
+        recorded.NextRetryAt.Should().BeNull();
+        recorded.RetryCount.Should().Be(3, "preserve previous retry count on terminal");
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_ImageProcessingError_DeadLettersImmediately()
+    {
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonImageProcessing, "corrupted"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.DeadLetter);
+        recorded.RetryCount.Should().Be(0, "no retries attempted for corrupted-image failure");
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_ForceRefreshTrue_ForwardsToCommand()
+    {
+        var gameId = Guid.NewGuid();
+        EnrichCatalogCoverCommand? sent = null;
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<EnrichCatalogCoverResult>, CancellationToken>((c, _) => sent = (EnrichCatalogCoverCommand)c)
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: true, default);
+
+        sent.Should().NotBeNull();
+        sent!.GameId.Should().Be(gameId);
+        sent.ForceRefresh.Should().BeTrue(
+            "the admin trigger MUST be able to bypass the M8 freshness window via ForceRefresh");
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_ReturnsCommandResultDirectly()
+    {
+        var gameId = Guid.NewGuid();
+        var expected = new EnrichCatalogCoverResult.Success("custom-key", "CC BY 4.0", "Jane", "src");
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        result.Should().BeSameAs(expected,
+            "the runner returns the M8 result verbatim so admin callers can map it to a DTO");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminEnrichWikidataCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminEnrichWikidataCoverCommandValidatorTests.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="AdminEnrichWikidataCoverCommandValidator"/>.
+/// Issue #1823 Wave 3 M12.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class AdminEnrichWikidataCoverCommandValidatorTests
+{
+    private readonly AdminEnrichWikidataCoverCommandValidator _sut = new();
+
+    [Fact]
+    public void ValidCommand_PassesValidation()
+    {
+        var cmd = new AdminEnrichWikidataCoverCommand(
+            GameId: Guid.NewGuid(), ForceRefresh: false, TriggeredByUserId: Guid.NewGuid());
+
+        var result = _sut.TestValidate(cmd);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void EmptyGameId_FailsValidation()
+    {
+        var cmd = new AdminEnrichWikidataCoverCommand(
+            GameId: Guid.Empty, ForceRefresh: false, TriggeredByUserId: Guid.NewGuid());
+
+        var result = _sut.TestValidate(cmd);
+
+        result.ShouldHaveValidationErrorFor(c => c.GameId);
+    }
+
+    [Fact]
+    public void EmptyTriggeredByUserId_FailsValidation()
+    {
+        var cmd = new AdminEnrichWikidataCoverCommand(
+            GameId: Guid.NewGuid(), ForceRefresh: false, TriggeredByUserId: Guid.Empty);
+
+        var result = _sut.TestValidate(cmd);
+
+        result.ShouldHaveValidationErrorFor(c => c.TriggeredByUserId);
+    }
+}


### PR DESCRIPTION
## Summary

Wave 3 Phase C M12 (issue #1823). New admin endpoint POST `/api/v1/admin/wikidata/enrichment/{gameId}` for manual Wikidata cover enrichment + refactor that extracts the shared "enrich + record attempt" workflow into `IWikidataCoverEnrichmentRunner` so the M9 scheduler and the M12 admin endpoint produce identical audit trails.

**Issue**: #1823 — Wikidata enrichment (ADR DEC-3a..3j)
**Wave 3 prior PR consumed**: #2122 (M8.5 + M9 scheduler + retry/dead-letter)

## Scope

- **`IWikidataCoverEnrichmentRunner.EnrichAndRecordAsync(gameId, forceRefresh, ct)`** — single source of truth for "send EnrichCatalogCoverCommand + classify via retry policy + record WikidataCoverEnrichmentAttempt". Extracted from `WikidataCoverEnrichmentJob.ProcessGameAsync`.
- **`WikidataCoverEnrichmentJob`** refactored to delegate per-game work to the runner. Batch-loop semantics (throttle, cancellation, exception isolation) preserved verbatim.
- **`EnrichCatalogCoverCommand`** gains optional `ForceRefresh = false` flag. M8 handler skips the 90gg freshness check when `true` (admin dogfood); scheduler still passes default `false`.
- **`AdminEnrichWikidataCoverCommand(GameId, ForceRefresh, TriggeredByUserId)`** + flat `AdminEnrichWikidataCoverResult` DTO (`"success"` / `"skipped"` / `"failed"` outcome + optional payload). Thin handler maps discriminated `EnrichCatalogCoverResult` → wire DTO.
- **`AdminEnrichWikidataCoverCommandValidator`** (FluentValidation: GameId + TriggeredByUserId non-empty).
- **`AdminWikidataCoverEnrichmentEndpoints`** — POST `/{gameId:guid}` route, group-level `RequireAdminSessionFilter` auth, body `{ forceRefresh?: bool }`. Wired in Program.cs under `v1Api` group `/admin/wikidata/enrichment`.
- **DI**: `IWikidataCoverEnrichmentRunner` Scoped (uses request UoW + repository).

## CQRS compliance

Endpoint dispatches exclusively via `IMediator`. No direct service injection. Pitfall #2568 honoured — business outcomes (qid-missing, license-not-whitelisted, ...) become `Skipped` / `Failed` result variants, not HTTP 500s. Pitfall #2565 honoured — interface + impl pair registered.

## Test coverage

**~14 new + 7 modified tests**, 0 regression on 2411+ existing:

- **4 `WikidataCoverEnrichmentJobTests`** rewritten for the post-refactor signature (`Mock<IWikidataCoverEnrichmentRunner>` replaces 3 separate mocks) — cleaner unit boundary, batch-loop semantics still verified.
- **7 `WikidataCoverEnrichmentRunnerTests`** cover the outcome → attempt factory mapping (Success / Skipped / FailedR2Upload schedules retry / AfterMaxRetries dead-letters / ImageProcessing immediate dead-letter / ForceRefresh forwarding / result pass-through). Uses real `WikidataCoverEnrichmentRetryPolicy` per `acceptance_tests_must_exercise_real_pipeline` feedback memory.
- **4 `AdminEnrichWikidataCoverCommandHandlerTests`** cover the discriminated result → flat DTO mapping for all three outcomes + parameter forwarding.
- **3 `AdminEnrichWikidataCoverCommandValidatorTests`** cover happy path + GameId.Empty rejection + TriggeredByUserId.Empty rejection.

Local: `dotnet test --filter \"Category=Unit&FullyQualifiedName~SharedGameCatalog\"` → **2433/2449 passed** (16 Testcontainers skipped), 0 regression.

## Out-of-scope (deferred to Wave 3 follow-up)

- **Integration test** for POST `/admin/wikidata/enrichment/{gameId}` with `WebApplicationFactory` + auth session — deferred to M13 PR which will build the admin dead-letter page alongside this endpoint. Estimated ~2h setup against `SharedTestcontainersFixture`; the thin endpoint layer (MediatR dispatch + `Results.Ok`) is reasonable to cover via the M13 E2E sweep rather than a dedicated integration test.

## Test plan

- [x] M12 filtered tests green (14 new + 7 modified)
- [x] Full SharedGameCatalog Unit regression sweep — 2433/2449 green (16 Testcontainers skipped)
- [x] Build clean (0 errors, 0 warnings on API)
- [x] Manual: endpoint route + auth filter wired in Program.cs at correct position
- [ ] CI green (let CI confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)