### PR TITLE
feat(catalog): #1823 M10 circuit breaker + DEC-3j 7gg retention sweep

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverDeadLetterRetentionJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverDeadLetterRetentionJob.cs
@@ -1,0 +1,90 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Issue #1823 Wave 3 retention sweep (ADR DEC-3j: dead-letter retention 7
+/// days). Quartz job that runs daily at 03:00 UTC and deletes
+/// <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/> rows whose
+/// <c>DeadLetteredAt</c> timestamp is older than
+/// <see cref="RetentionWindow"/>.
+/// </summary>
+/// <remarks>
+/// <para>Single-pod batch (HPA=1 per DEC-3e). <c>[DisallowConcurrentExecution]</c>
+/// belt-and-braces against overlapping ticks. Internal <see cref="RunOnceAsync"/>
+/// hook for unit tests so the Quartz scheduler does not need to spin up.</para>
+///
+/// <para>Idempotent: re-running the sweep on the same day deletes nothing new
+/// because previous rows with old <c>DeadLetteredAt</c> have already been
+/// removed.</para>
+///
+/// <para>Records the deleted count as a structured log line so ops can spot
+/// retention spikes. The M11 metric expansion will add a Prometheus counter
+/// for this signal.</para>
+/// </remarks>
+[DisallowConcurrentExecution]
+public sealed class WikidataCoverDeadLetterRetentionJob : IJob
+{
+    /// <summary>Dead-letter retention window per ADR DEC-3j.</summary>
+    public static readonly TimeSpan RetentionWindow = TimeSpan.FromDays(7);
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WikidataCoverDeadLetterRetentionJob> _logger;
+
+    public WikidataCoverDeadLetterRetentionJob(
+        IServiceProvider serviceProvider,
+        TimeProvider timeProvider,
+        ILogger<WikidataCoverDeadLetterRetentionJob> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+
+        using var scope = _serviceProvider.CreateScope();
+        var attempts = scope.ServiceProvider.GetRequiredService<IWikidataCoverEnrichmentAttemptRepository>();
+
+        await RunOnceAsync(attempts, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Internal sweep — extracted from <see cref="Execute"/> for unit tests.</summary>
+    internal async Task<int> RunOnceAsync(
+        IWikidataCoverEnrichmentAttemptRepository attempts,
+        CancellationToken ct)
+    {
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var cutoff = nowUtc - RetentionWindow;
+
+        _logger.LogDebug(
+            "WikidataCoverDeadLetterRetentionJob: sweeping dead-letter rows older than {Cutoff} (retention {Days}d).",
+            cutoff, RetentionWindow.TotalDays);
+
+        var deleted = await attempts
+            .DeleteDeadLetteredOlderThanAsync(cutoff, ct)
+            .ConfigureAwait(false);
+
+        if (deleted > 0)
+        {
+            _logger.LogInformation(
+                "WikidataCoverDeadLetterRetentionJob: deleted {Count} dead-letter row(s) older than {Cutoff}.",
+                deleted, cutoff);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "WikidataCoverDeadLetterRetentionJob: no dead-letter rows older than {Cutoff} — sweep idle.",
+                cutoff);
+        }
+
+        return deleted;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
@@ -30,4 +30,17 @@ public interface IWikidataCoverEnrichmentAttemptRepository
         int limit,
         DateTime nowUtc,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #1823 Wave 3 retention sweep (ADR DEC-3j: dead-letter retention 7
+    /// days). Deletes every attempt row whose <c>DeadLetteredAt</c> is non-null
+    /// AND strictly less than <paramref name="cutoffUtc"/>. Live attempt rows
+    /// (Success / Skipped / pending retries) are untouched.
+    /// </summary>
+    /// <param name="cutoffUtc">UTC threshold; rows older than this are deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of rows physically removed from the table.</returns>
+    Task<int> DeleteDeadLetteredOlderThanAsync(
+        DateTime cutoffUtc,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -8,6 +8,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -232,6 +233,10 @@ internal static class SharedGameCatalogServiceExtensions
         // two ticks executing simultaneously.
         RegisterWikidataCoverEnrichmentJob(services);
 
+        // Issue #1823 Wave 3 retention sweep (ADR DEC-3j): Quartz job that
+        // deletes dead-letter rows older than 7 days. Runs daily at 03:00 UTC.
+        RegisterWikidataCoverDeadLetterRetentionJob(services);
+
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 
         return services;
@@ -315,7 +320,13 @@ internal static class SharedGameCatalogServiceExtensions
             client.BaseAddress = new Uri(WikidataBaseUrl);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CatalogUserAgent);
             client.Timeout = TimeSpan.FromSeconds(30);
-        });
+        })
+        // Issue #1823 Wave 3 M10 (ADR DEC-3f): circuit breaker per-client.
+        // Wikidata SPARQL outage MUST NOT collapse Commons traffic and vice
+        // versa — separate handler instances per typed client.
+        .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
+            sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
+            clientName: "wikidata-sparql"));
 
         // Issue #1823 M4 (ADR DEC-3b/3c/3e): Wikimedia Commons license fetcher.
         // Consumed by the M8 orchestrator AFTER the Wikidata SPARQL pass resolves
@@ -341,7 +352,13 @@ internal static class SharedGameCatalogServiceExtensions
             client.BaseAddress = new Uri(CommonsBaseUrl);
             client.DefaultRequestHeaders.UserAgent.ParseAdd(CatalogUserAgent);
             client.Timeout = TimeSpan.FromSeconds(30);
-        });
+        })
+        // Issue #1823 Wave 3 M10 (ADR DEC-3f): separate circuit breaker instance
+        // from the Wikidata SPARQL client so a Commons CDN outage opens this
+        // breaker independently.
+        .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
+            sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
+            clientName: "commons-api"));
 
         services.AddHttpClient<BggCatalogProvider>(client =>
         {
@@ -363,6 +380,30 @@ internal static class SharedGameCatalogServiceExtensions
             var bgg = sp.GetRequiredKeyedService<ICatalogProvider>("bgg");
             var logger = sp.GetRequiredService<ILogger<CatalogSeedAggregator>>();
             return new CatalogSeedAggregator(wikidata, bgg, logger);
+        });
+    }
+
+    /// <summary>
+    /// Issue #1823 Wave 3 retention sweep (ADR DEC-3j) — registers
+    /// <see cref="WikidataCoverDeadLetterRetentionJob"/> with the Quartz
+    /// scheduler. Runs daily at 03:00 UTC. Idempotent: sweeping twice the same
+    /// day yields zero additional deletions.
+    /// </summary>
+    private static void RegisterWikidataCoverDeadLetterRetentionJob(IServiceCollection services)
+    {
+        services.AddQuartz(q =>
+        {
+            var jobKey = new JobKey("WikidataCoverDeadLetterRetentionJob", "SharedGameCatalog");
+
+            q.AddJob<WikidataCoverDeadLetterRetentionJob>(opts => opts
+                .WithIdentity(jobKey)
+                .StoreDurably(true));
+
+            q.AddTrigger(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("WikidataCoverDeadLetterRetentionTrigger", "SharedGameCatalog")
+                .WithCronSchedule("0 0 3 * * ?")
+                .WithDescription("Issue #1823 Wave 3 ADR DEC-3j: deletes wikidata_cover_enrichment_attempts rows whose dead_lettered_at is older than 7 days. Runs daily at 03:00 UTC."));
         });
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -123,8 +123,8 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
     {
         // EF Core ExecuteDeleteAsync translates to a single DELETE FROM ...
         // WHERE ... on PostgreSQL — no SELECT round-trip, no entity tracking
-        // overhead. Safe on the partial index ix_wikidata_cover_attempts_dead_letter
-        // (next_retry_at IS NOT NULL filter) which keeps the scan small.
+        // overhead. Covered by the partial index ix_wikidata_cover_attempts_dead_letter
+        // (dead_lettered_at IS NOT NULL filter) which keeps the scan small.
         return await DbContext.WikidataCoverEnrichmentAttempts
             .Where(a => a.DeadLetteredAt != null && a.DeadLetteredAt < cutoffUtc)
             .ExecuteDeleteAsync(cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -117,6 +117,20 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             .ConfigureAwait(false);
     }
 
+    public async Task<int> DeleteDeadLetteredOlderThanAsync(
+        DateTime cutoffUtc,
+        CancellationToken cancellationToken = default)
+    {
+        // EF Core ExecuteDeleteAsync translates to a single DELETE FROM ...
+        // WHERE ... on PostgreSQL — no SELECT round-trip, no entity tracking
+        // overhead. Safe on the partial index ix_wikidata_cover_attempts_dead_letter
+        // (next_retry_at IS NOT NULL filter) which keeps the scan small.
+        return await DbContext.WikidataCoverEnrichmentAttempts
+            .Where(a => a.DeadLetteredAt != null && a.DeadLetteredAt < cutoffUtc)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private static WikidataCoverEnrichmentAttempt Map(WikidataCoverEnrichmentAttemptEntity entity) =>
         WikidataCoverEnrichmentAttempt.Reconstitute(
             id: entity.Id,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/WikimediaCircuitBreakerHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/WikimediaCircuitBreakerHandler.cs
@@ -1,0 +1,120 @@
+using Polly;
+using Polly.CircuitBreaker;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+
+/// <summary>
+/// Issue #1823 Wave 3 M10 (ADR DEC-3f) — Polly v8 circuit-breaker delegating
+/// handler for the Wikidata + Commons HttpClients. OPEN the circuit when 3
+/// consecutive 5xx (or transient HttpRequestException) occur within a 60s
+/// window; remain OPEN for 5 minutes before half-opening.
+/// </summary>
+/// <remarks>
+/// <para>One handler instance is registered PER TYPED CLIENT (Wikidata SPARQL
+/// vs Commons API) so a SPARQL outage does NOT collapse Commons traffic and
+/// vice-versa. ADR DEC-3e keeps the rate-limiter shared; ADR DEC-3f keeps the
+/// circuit breaker per-endpoint.</para>
+///
+/// <para>Failure mapping:</para>
+/// <list type="bullet">
+///   <item><c>HttpRequestException</c> — transient network failure (DNS, TCP
+///   reset, TLS handshake). Counts towards the threshold.</item>
+///   <item><c>5xx HTTP status</c> — server-side outage signal. Counts.</item>
+///   <item><c>4xx HTTP status</c> — client-side. Does NOT count (the breaker
+///   is for upstream-health detection, not for app-logic errors).</item>
+///   <item><see cref="OperationCanceledException"/> — caller cancellation.
+///   Not handled by the breaker, propagates verbatim.</item>
+/// </list>
+///
+/// <para>While the circuit is OPEN, callers receive a
+/// <c>BrokenCircuitException</c> (Polly.CircuitBreaker namespace) immediately.
+/// The M8 client wrappers already catch <c>HttpRequestException</c> + return
+/// their "not available" sentinel; the broken-circuit exception derives from
+/// <c>ExecutionRejectedException</c>, not from <c>HttpRequestException</c>, so
+/// it propagates uncaught to the M9 scheduler which records the failure under
+/// the catch-all per-game exception handler in
+/// <c>WikidataCoverEnrichmentJob.RunBatchAsync</c>. A follow-up will add a
+/// dedicated <c>circuit-open</c> outcome reason as part of the M11 metric
+/// expansion.</para>
+/// </remarks>
+internal sealed class WikimediaCircuitBreakerHandler : DelegatingHandler
+{
+    /// <summary>Threshold for OPENing the circuit per DEC-3f.</summary>
+    internal const int ConsecutiveFailureThreshold = 3;
+
+    /// <summary>Sampling window per DEC-3f.</summary>
+    internal static readonly TimeSpan SamplingWindow = TimeSpan.FromSeconds(60);
+
+    /// <summary>OPEN-state duration per DEC-3f.</summary>
+    internal static readonly TimeSpan BreakDuration = TimeSpan.FromMinutes(5);
+
+    private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
+    private readonly ILogger<WikimediaCircuitBreakerHandler> _logger;
+    private readonly string _clientName;
+
+    public WikimediaCircuitBreakerHandler(
+        ILogger<WikimediaCircuitBreakerHandler> logger,
+        string clientName)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clientName = string.IsNullOrWhiteSpace(clientName)
+            ? throw new ArgumentException("Client name required.", nameof(clientName))
+            : clientName;
+
+        _pipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                // FailureRatio = 1.0 + MinimumThroughput = 3 + SamplingDuration = 60s
+                // = "open after 3 failures-in-a-row inside any rolling 60s window".
+                // This is the closest Polly-native equivalent to DEC-3f's
+                // "3 consecutive 5xx within 60s" — the breaker DOES require all
+                // 3 calls in the throughput window to be failures, which on small
+                // samples (3-5 calls/min during a batch) maps cleanly to the
+                // "consecutive" intent.
+                FailureRatio = 1.0,
+                MinimumThroughput = ConsecutiveFailureThreshold,
+                SamplingDuration = SamplingWindow,
+                BreakDuration = BreakDuration,
+                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                    .Handle<HttpRequestException>()
+                    .HandleResult(static r => (int)r.StatusCode >= 500),
+                OnOpened = args =>
+                {
+                    _logger.LogError(
+                        "Wikimedia circuit breaker OPENED for client '{Client}' after {Threshold} failures inside {Window}s. Breaking for {BreakSeconds}s.",
+                        _clientName,
+                        ConsecutiveFailureThreshold,
+                        SamplingWindow.TotalSeconds,
+                        args.BreakDuration.TotalSeconds);
+                    return ValueTask.CompletedTask;
+                },
+                OnClosed = args =>
+                {
+                    _logger.LogInformation(
+                        "Wikimedia circuit breaker CLOSED for client '{Client}' — upstream recovered.",
+                        _clientName);
+                    return ValueTask.CompletedTask;
+                },
+                OnHalfOpened = args =>
+                {
+                    _logger.LogInformation(
+                        "Wikimedia circuit breaker HALF-OPENED for client '{Client}' — probing upstream.",
+                        _clientName);
+                    return ValueTask.CompletedTask;
+                },
+            })
+            .Build();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Delegate the inner call inside the resilience pipeline. The pipeline
+        // catches HttpRequestException + 5xx responses to drive the breaker
+        // state machine; BrokenCircuitException is thrown on OPEN state.
+        return await _pipeline.ExecuteAsync(
+            async token => await base.SendAsync(request, token).ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverDeadLetterRetentionJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverDeadLetterRetentionJobTests.cs
@@ -1,0 +1,84 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Jobs;
+
+/// <summary>
+/// Unit tests for <see cref="WikidataCoverDeadLetterRetentionJob"/>. Issue #1823
+/// Wave 3 retention sweep (ADR DEC-3j).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class WikidataCoverDeadLetterRetentionJobTests
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 11, 3, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _attempts = new();
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(FixedNow, TimeSpan.Zero));
+
+    private WikidataCoverDeadLetterRetentionJob Sut() => new(
+        Mock.Of<IServiceProvider>(),
+        _time,
+        NullLogger<WikidataCoverDeadLetterRetentionJob>.Instance);
+
+    [Fact]
+    public async Task RunOnceAsync_PassesCutoff7DaysBeforeNow()
+    {
+        DateTime? captured = null;
+        _attempts.Setup(r => r.DeleteDeadLetteredOlderThanAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback<DateTime, CancellationToken>((c, _) => captured = c)
+            .ReturnsAsync(0);
+
+        await Sut().RunOnceAsync(_attempts.Object, default);
+
+        captured.Should().Be(FixedNow.AddDays(-7),
+            "DEC-3j retention window is exactly 7 days — the cutoff must be now-7d UTC");
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_ReturnsDeletedCountFromRepo()
+    {
+        _attempts.Setup(r => r.DeleteDeadLetteredOlderThanAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(42);
+
+        var deleted = await Sut().RunOnceAsync(_attempts.Object, default);
+
+        deleted.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_NoRowsDeleted_StillCompletesSuccessfully()
+    {
+        _attempts.Setup(r => r.DeleteDeadLetteredOlderThanAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var deleted = await Sut().RunOnceAsync(_attempts.Object, default);
+
+        deleted.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_HonoursCancellation()
+    {
+        _attempts.Setup(r => r.DeleteDeadLetteredOlderThanAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var act = async () => await Sut().RunOnceAsync(_attempts.Object, new CancellationToken(true));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void RetentionWindow_IsExactly7Days()
+    {
+        WikidataCoverDeadLetterRetentionJob.RetentionWindow
+            .Should().Be(TimeSpan.FromDays(7),
+                "DEC-3j locks the dead-letter retention window at 7 days — any change requires a deliberate ADR update");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/WikimediaCircuitBreakerHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/WikimediaCircuitBreakerHandlerTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly.CircuitBreaker;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="WikimediaCircuitBreakerHandler"/>. Issue #1823
+/// Wave 3 M10 (ADR DEC-3f).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class WikimediaCircuitBreakerHandlerTests
+{
+    private static HttpClient CreateClientWithInnerHandler(HttpMessageHandler inner, string clientName = "test")
+    {
+        var breaker = new WikimediaCircuitBreakerHandler(
+            NullLogger<WikimediaCircuitBreakerHandler>.Instance,
+            clientName)
+        {
+            InnerHandler = inner,
+        };
+
+        return new HttpClient(breaker)
+        {
+            BaseAddress = new Uri("https://test.example.com/")
+        };
+    }
+
+    [Fact]
+    public async Task Sends_3xxAnd2xxResponses_Pass_Through_WithoutOpeningCircuit()
+    {
+        // 4 successful responses → circuit must NOT open.
+        var inner = new SequencedResponseHandler(new[]
+        {
+            HttpStatusCode.OK,
+            HttpStatusCode.OK,
+            HttpStatusCode.OK,
+            HttpStatusCode.OK,
+        });
+        var client = CreateClientWithInnerHandler(inner);
+
+        for (var i = 0; i < 4; i++)
+        {
+            var resp = await client.GetAsync("/probe");
+            resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+
+    [Fact]
+    public async Task Sends_NonTransient4xx_DoesNotCountTowardsBreaker()
+    {
+        // Three consecutive 404s should NOT open the circuit (4xx is client-side
+        // and the breaker only handles transient upstream failures per DEC-3f).
+        var inner = new SequencedResponseHandler(new[]
+        {
+            HttpStatusCode.NotFound,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.NotFound,
+        });
+        var client = CreateClientWithInnerHandler(inner);
+
+        // The 4th call MUST hit the inner handler (no BrokenCircuitException).
+        for (var i = 0; i < 4; i++)
+        {
+            var resp = await client.GetAsync("/missing");
+            resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        inner.CallCount.Should().Be(4,
+            "404 is client-side — the breaker MUST forward every request to the inner handler");
+    }
+
+    [Fact]
+    public async Task After3Consecutive5xx_4thRequest_ThrowsBrokenCircuitException()
+    {
+        var inner = new SequencedResponseHandler(new[]
+        {
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.BadGateway,
+            HttpStatusCode.ServiceUnavailable,
+            // 4th call SHOULD be rejected by the breaker BEFORE reaching inner.
+            HttpStatusCode.OK,
+        });
+        var client = CreateClientWithInnerHandler(inner);
+
+        // First 3 calls return 5xx and tick the failure counter.
+        for (var i = 0; i < WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold; i++)
+        {
+            var resp = await client.GetAsync("/sparql");
+            ((int)resp.StatusCode).Should().BeGreaterThanOrEqualTo(500);
+        }
+
+        // 4th call is short-circuited by the open breaker.
+        var act = async () => await client.GetAsync("/sparql");
+        await act.Should().ThrowAsync<BrokenCircuitException>(
+            "after 3 consecutive 5xx within the sampling window the circuit OPENs and rejects subsequent calls without reaching the inner handler");
+
+        inner.CallCount.Should().Be(WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold,
+            "the 4th call MUST be rejected without dispatching to the inner handler");
+    }
+
+    [Fact]
+    public async Task HttpRequestException_CountsAsFailure_AndCanOpenCircuit()
+    {
+        // 3 consecutive network failures → 4th call short-circuited.
+        var inner = new ThrowingHandler(new HttpRequestException("simulated"));
+        var client = CreateClientWithInnerHandler(inner);
+
+        // Drive the breaker with 3 failures.
+        for (var i = 0; i < WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold; i++)
+        {
+            var act = async () => await client.GetAsync("/sparql");
+            await act.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        // 4th call: breaker is OPEN.
+        var openCall = async () => await client.GetAsync("/sparql");
+        await openCall.Should().ThrowAsync<BrokenCircuitException>();
+
+        inner.CallCount.Should().Be(WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold,
+            "HttpRequestException MUST count towards the failure threshold");
+    }
+
+    [Fact]
+    public void Constructor_RequiresClientName()
+    {
+        var act = () => new WikimediaCircuitBreakerHandler(
+            NullLogger<WikimediaCircuitBreakerHandler>.Instance,
+            clientName: "  ");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Client name required*");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Test helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private sealed class SequencedResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode[] _statuses;
+        public int CallCount { get; private set; }
+
+        public SequencedResponseHandler(HttpStatusCode[] statuses)
+        {
+            _statuses = statuses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var status = _statuses[Math.Min(CallCount, _statuses.Length - 1)];
+            CallCount++;
+            return Task.FromResult(new HttpResponseMessage(status));
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+        public int CallCount { get; private set; }
+
+        public ThrowingHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromException<HttpResponseMessage>(_exception);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wave 3 Phase C operational reliability primitives for the Wikidata cover enrichment pipeline (issue #1823).

**Issue**: #1823 — Wikidata enrichment (ADR DEC-3a..3j)
**Wave 3 prior PRs consumed**: #2122 (M9 scheduler) · #2165 (M12 admin endpoint) · #2167 (M12 smoke test)
**Spec-panel review**: M10+retention bundle confermato 2026-06-11 (Nygard reliability ordering)

## Scope

### M10 — Polly v8 circuit breaker (ADR DEC-3f)

- `WikimediaCircuitBreakerHandler` `DelegatingHandler` con `CircuitBreakerStrategyOptions<HttpResponseMessage>`:
  - OPEN dopo 3 consecutive failures (HttpRequestException OR 5xx response) in 60s window
  - BreakDuration 5 min prima di HALF-OPEN
  - **4xx responses NON contano** verso il threshold (client-side, non upstream infra failure)
- Registrato come **istanza separata per typed HttpClient** (WikidataCatalogProvider + IWikimediaCommonsClient) — un Wikidata SPARQL outage NON collassa Commons traffic e viceversa
- Preserva DEC-3e shared rate-limiter + isola DEC-3f breaker per-endpoint
- OnOpened/OnClosed/OnHalfOpened log lines per ops visibility

### Retention sweep — 7gg dead-letter (ADR DEC-3j)

- `IWikidataCoverEnrichmentAttemptRepository.DeleteDeadLetteredOlderThanAsync(cutoffUtc)` usa `ExecuteDeleteAsync` (single DELETE FROM, no tracking)
- Filtered su dead-letter rows; live attempts (Success/Skipped/pending retries) untouched
- `WikidataCoverDeadLetterRetentionJob` Quartz job `[DisallowConcurrentExecution]`, cron giornaliero 03:00 UTC
- Internal `RunOnceAsync` hook per unit test (mirror pattern M9)
- Idempotent re-runs: stesso-giorno invocations dopo il primo DELETE nothing new
- Structured log line per deleted count

## Test coverage

**10 nuovi unit test**, 2443/2459 SharedGameCatalog regression verdi (0 regression):

- **5 `WikimediaCircuitBreakerHandlerTests`** — happy-path passthrough · 4xx non-trigger · 3x 5xx → 4th call `BrokenCircuitException` · `HttpRequestException` counts towards threshold · ctor name validation
- **5 `WikidataCoverDeadLetterRetentionJobTests`** — cutoff=now-7d computation · deleted-count return · zero-row idempotent path · cancellation propagation · ADR-locked 7-day window guard

## Out-of-scope (deferred a M11)

- **`circuit-open` outcome reason** dedicato sull'attempt row. Oggi il `BrokenCircuitException` propaga uncaught al M9 scheduler catch-all per-game exception handler e NON produce attempt row → acceptable v1 perché lo stato OPEN è short-lived. Aggiunto nel handler comment block come follow-up M11.

## Test plan

- [x] 10 M10 + retention filtered tests verdi
- [x] Full SharedGameCatalog Unit regression — 2443/2459 verdi (16 Testcontainers skipped)
- [x] Build clean
- [x] EF migration unchanged (retention sweep usa solo ExecuteDeleteAsync su table esistente)
- [ ] CI green (let CI confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)