### PR TITLE
feat(catalog): #1823 M13 dead-letter visibility + M10 circuit-open wiring

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandler.cs
@@ -1,6 +1,7 @@
 using Amazon.S3;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Middleware.Exceptions;
 using Api.Observability;
@@ -58,6 +59,8 @@ internal sealed class EnrichCatalogCoverCommandHandler
     public const string SkipReasonImageBytesNotAvailable = "image-bytes-not-available";
     public const string FailReasonImageProcessing = "image-processing-error";
     public const string FailReasonR2Upload = "r2-upload-error";
+    /// <summary>Issue #1823 Wave 3 M13 (M10 follow-up): Polly circuit OPEN — short-circuit retry until breaker recovers.</summary>
+    public const string FailReasonCircuitOpen = "circuit-open";
 
     private const int WebpTargetWidth = 200;
     private const int WebpTargetHeight = 300;
@@ -132,38 +135,59 @@ internal sealed class EnrichCatalogCoverCommandHandler
             return new EnrichCatalogCoverResult.Skipped(SkipReasonQidMissing);
         }
 
-        // 4. M3 — Wikidata SPARQL wdt:P18 lookup.
-        var coverImage = await _wikidataProvider
-            .FetchCoverImageAsync(game.WikidataQid, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!coverImage.HasImage || string.IsNullOrWhiteSpace(coverImage.Filename))
+        // Steps 4-6 hit the Wikidata SPARQL + Commons API endpoints, both of
+        // which sit behind the M10 WikimediaCircuitBreakerHandler. A single
+        // try/catch at this network boundary maps BrokenCircuitException to a
+        // dedicated Failed("circuit-open") outcome so the M9 scheduler can
+        // schedule a delayed retry (6m, slightly past the 5m DEC-3f break) and
+        // the M13 admin dead-letter page can distinguish breaker trips from
+        // genuine upstream failures.
+        WikidataCoverImageResult coverImage;
+        CommonsLicenseResult licenseResult;
+        byte[]? originalBytes;
+        try
         {
-            EmitOutcomeMetric(OutcomeSkipped, SkipReasonImageNotAvailable);
-            _logger.LogInformation(
-                "SharedGame {GameId} QID {Qid} has no wdt:P18 claim; skipping enrichment.",
+            // 4. M3 — Wikidata SPARQL wdt:P18 lookup.
+            coverImage = await _wikidataProvider
+                .FetchCoverImageAsync(game.WikidataQid, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!coverImage.HasImage || string.IsNullOrWhiteSpace(coverImage.Filename))
+            {
+                EmitOutcomeMetric(OutcomeSkipped, SkipReasonImageNotAvailable);
+                _logger.LogInformation(
+                    "SharedGame {GameId} QID {Qid} has no wdt:P18 claim; skipping enrichment.",
+                    game.Id, game.WikidataQid);
+                return new EnrichCatalogCoverResult.Skipped(SkipReasonImageNotAvailable);
+            }
+
+            // 5. M4 — Commons imageinfo license fetch + DEC-3c whitelist gate.
+            licenseResult = await _commonsClient
+                .FetchLicenseAsync(coverImage.Filename, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!licenseResult.IsWhitelisted || string.IsNullOrWhiteSpace(licenseResult.RawLicense))
+            {
+                EmitOutcomeMetric(OutcomeSkipped, SkipReasonLicenseNotWhitelisted);
+                _logger.LogInformation(
+                    "SharedGame {GameId} QID {Qid} Commons file '{Filename}' license '{License}' not whitelisted; skipping.",
+                    game.Id, game.WikidataQid, coverImage.Filename, licenseResult.RawLicense);
+                return new EnrichCatalogCoverResult.Skipped(SkipReasonLicenseNotWhitelisted);
+            }
+
+            // 6. M4 extension — Commons Special:FilePath image bytes download.
+            originalBytes = await _commonsClient
+                .FetchImageBytesAsync(coverImage.Filename, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (CircuitBreakerExceptionDetector.IsBrokenCircuit(ex))
+        {
+            EmitOutcomeMetric(OutcomeFailed, FailReasonCircuitOpen);
+            _logger.LogWarning(ex,
+                "SharedGame {GameId} QID {Qid} circuit breaker OPEN — short-circuiting enrichment.",
                 game.Id, game.WikidataQid);
-            return new EnrichCatalogCoverResult.Skipped(SkipReasonImageNotAvailable);
+            return new EnrichCatalogCoverResult.Failed(FailReasonCircuitOpen, ex.Message);
         }
-
-        // 5. M4 — Commons imageinfo license fetch + DEC-3c whitelist gate.
-        var licenseResult = await _commonsClient
-            .FetchLicenseAsync(coverImage.Filename, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!licenseResult.IsWhitelisted || string.IsNullOrWhiteSpace(licenseResult.RawLicense))
-        {
-            EmitOutcomeMetric(OutcomeSkipped, SkipReasonLicenseNotWhitelisted);
-            _logger.LogInformation(
-                "SharedGame {GameId} QID {Qid} Commons file '{Filename}' license '{License}' not whitelisted; skipping.",
-                game.Id, game.WikidataQid, coverImage.Filename, licenseResult.RawLicense);
-            return new EnrichCatalogCoverResult.Skipped(SkipReasonLicenseNotWhitelisted);
-        }
-
-        // 6. M4 extension — Commons Special:FilePath image bytes download.
-        var originalBytes = await _commonsClient
-            .FetchImageBytesAsync(coverImage.Filename, cancellationToken)
-            .ConfigureAwait(false);
 
         if (originalBytes is null || originalBytes.Length == 0)
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
@@ -1,0 +1,79 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Issue #1823 Wave 3 M13 — paginated list of Wikidata cover enrichment
+/// dead-letter attempts for the admin visibility page. Filterable by
+/// terminal reason (e.g. <c>r2-upload-error</c>, <c>license-not-whitelisted</c>).
+/// </summary>
+/// <param name="Skip">Pagination offset (clamped to 0).</param>
+/// <param name="Take">Page size (clamped to [1, 200]).</param>
+/// <param name="ReasonFilter">Optional exact match on the <c>Reason</c> column; null returns all dead-letters.</param>
+internal sealed record GetWikidataDeadLetterAttemptsQuery(
+    int Skip,
+    int Take,
+    string? ReasonFilter) : IRequest<WikidataDeadLetterAttemptsResult>;
+
+/// <summary>
+/// Flat DTO returned by <see cref="GetWikidataDeadLetterAttemptsQuery"/>.
+/// </summary>
+public sealed record WikidataDeadLetterAttemptsResult(
+    IReadOnlyList<WikidataDeadLetterAttemptDto> Items,
+    int TotalCount,
+    int Skip,
+    int Take);
+
+/// <summary>
+/// Per-row dead-letter DTO surfaced on the M13 admin page.
+/// </summary>
+public sealed record WikidataDeadLetterAttemptDto(
+    Guid Id,
+    Guid SharedGameId,
+    string GameTitle,
+    DateTime AttemptedAt,
+    DateTime DeadLetteredAt,
+    string Reason,
+    string? Details,
+    int RetryCount);
+
+internal sealed class GetWikidataDeadLetterAttemptsQueryHandler
+    : IRequestHandler<GetWikidataDeadLetterAttemptsQuery, WikidataDeadLetterAttemptsResult>
+{
+    private readonly IWikidataCoverEnrichmentAttemptRepository _attempts;
+
+    public GetWikidataDeadLetterAttemptsQueryHandler(IWikidataCoverEnrichmentAttemptRepository attempts)
+    {
+        _attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+    }
+
+    public async Task<WikidataDeadLetterAttemptsResult> Handle(
+        GetWikidataDeadLetterAttemptsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var skip = Math.Max(0, request.Skip);
+        var take = Math.Clamp(request.Take, 1, 200);
+
+        var page = await _attempts
+            .GetDeadLettersAsync(skip, take, request.ReasonFilter, cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = page.Items
+            .Select(row => new WikidataDeadLetterAttemptDto(
+                row.Id,
+                row.SharedGameId,
+                row.GameTitle,
+                row.AttemptedAt,
+                row.DeadLetteredAt,
+                row.Reason,
+                row.Details,
+                row.RetryCount))
+            .ToList();
+
+        return new WikidataDeadLetterAttemptsResult(items, page.TotalCount, skip, take);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicy.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicy.cs
@@ -50,6 +50,7 @@ internal interface IWikidataCoverEnrichmentRetryPolicy
 ///   <item>Any <see cref="EnrichCatalogCoverResult.Skipped"/> → <see cref="WikidataCoverEnrichmentRetryDecision.Terminal"/> (business condition, retry won't change it within the freshness window).</item>
 ///   <item><see cref="EnrichCatalogCoverResult.Failed"/> with reason <c>image-processing-error</c> → <see cref="WikidataCoverEnrichmentRetryDecision.DeadLetter"/> (corrupted image bytes, retry won't help).</item>
 ///   <item><see cref="EnrichCatalogCoverResult.Failed"/> with reason <c>r2-upload-error</c> → <see cref="WikidataCoverEnrichmentRetryDecision.ScheduleRetry"/> with exponential backoff (1m / 5m / 15m) for attempts 0/1/2; <see cref="WikidataCoverEnrichmentRetryDecision.DeadLetter"/> on attempt 3+.</item>
+///   <item><see cref="EnrichCatalogCoverResult.Failed"/> with reason <c>circuit-open</c> (Wave 3 M13 / M10 follow-up) → <see cref="WikidataCoverEnrichmentRetryDecision.ScheduleRetry"/> at <see cref="CircuitOpenBackoff"/> (slightly past the DEC-3f 5min break duration). NOT counted against the DEC-3j retry budget — a breaker trip is upstream infrastructure rather than a per-game failure.</item>
 ///   <item>Unknown <see cref="EnrichCatalogCoverResult.Failed"/> reason → <see cref="WikidataCoverEnrichmentRetryDecision.DeadLetter"/> (fail-fast on unexpected outcomes).</item>
 /// </list>
 /// </summary>
@@ -57,6 +58,13 @@ internal sealed class WikidataCoverEnrichmentRetryPolicy : IWikidataCoverEnrichm
 {
     /// <summary>Max retry budget per DEC-3j (3 retries → attempt 4 dead-letters).</summary>
     internal const int MaxRetryCount = 3;
+
+    /// <summary>
+    /// Backoff for Polly circuit-open trips. 6 minutes is intentionally a touch
+    /// longer than the DEC-3f BreakDuration (5 min) so the next attempt lands
+    /// AFTER the breaker has had a chance to half-open and probe the upstream.
+    /// </summary>
+    internal static readonly TimeSpan CircuitOpenBackoff = TimeSpan.FromMinutes(6);
 
     /// <summary>
     /// Backoff windows in minutes, indexed by previous retry count. Index 0 is the
@@ -108,6 +116,17 @@ internal sealed class WikidataCoverEnrichmentRetryPolicy : IWikidataCoverEnrichm
             // currentRetryCount = 0 → schedule the first retry (BackoffSchedule[0] = 1m)
             var backoff = BackoffSchedule[Math.Min(currentRetryCount, BackoffSchedule.Length - 1)];
             return new WikidataCoverEnrichmentRetryDecision.ScheduleRetry(nowUtc.Add(backoff));
+        }
+
+        // Issue #1823 Wave 3 M13 / M10 follow-up: Polly circuit OPEN. The
+        // breaker stays OPEN for ~5 min (DEC-3f BreakDuration); schedule a
+        // single retry slightly past that window so the next attempt finds
+        // the breaker in HALF-OPEN and can probe the upstream. NOT counted
+        // against the DEC-3j retry budget — this is an upstream-infra signal,
+        // not a per-game failure.
+        if (string.Equals(failed.Reason, EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen, StringComparison.Ordinal))
+        {
+            return new WikidataCoverEnrichmentRetryDecision.ScheduleRetry(nowUtc.Add(CircuitOpenBackoff));
         }
 
         // Unknown failure reason — fail-fast to surface it on the admin dead-letter page

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
@@ -59,9 +59,17 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
         // RetryCount for the NEW attempt row:
         // - Terminal / DeadLetter: preserve previous count (this attempt is the
         //   nth retry that produced the terminal outcome).
-        // - ScheduleRetry: increment by 1 (this attempt counts towards the budget).
+        // - ScheduleRetry with reason=circuit-open (Wave 3 M13 / M10 follow-up):
+        //   preserve previous count. A breaker trip is upstream infrastructure,
+        //   not a per-game failure, so we don't want to burn the DEC-3j 3-retry
+        //   budget on it.
+        // - ScheduleRetry with any other reason: increment by 1 (this attempt
+        //   counts towards the budget).
         var nextRetryCount = decision switch
         {
+            WikidataCoverEnrichmentRetryDecision.ScheduleRetry
+                when result is EnrichCatalogCoverResult.Failed { Reason: EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen }
+                => previousRetryCount,
             WikidataCoverEnrichmentRetryDecision.ScheduleRetry => previousRetryCount + 1,
             _ => previousRetryCount,
         };

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
@@ -43,4 +43,43 @@ public interface IWikidataCoverEnrichmentAttemptRepository
     Task<int> DeleteDeadLetteredOlderThanAsync(
         DateTime cutoffUtc,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #1823 Wave 3 M13 — returns a page of dead-letter attempt rows
+    /// joined with the parent <c>SharedGame.Title</c> for the admin
+    /// dead-letter visibility page. Filtered by optional reason; ordered by
+    /// most-recently dead-lettered first.
+    /// </summary>
+    /// <param name="skip">Skip count for pagination (must be &gt;= 0).</param>
+    /// <param name="take">Page size (1..200; clamped).</param>
+    /// <param name="reasonFilter">Optional <c>Reason</c> exact match; null returns all dead-letters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Page items (with denormalized game title) + total count of dead-letter rows matching the filter.</returns>
+    Task<DeadLetterPage> GetDeadLettersAsync(
+        int skip,
+        int take,
+        string? reasonFilter,
+        CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Result of <see cref="IWikidataCoverEnrichmentAttemptRepository.GetDeadLettersAsync"/>.
+/// </summary>
+/// <param name="Items">Page of dead-letter rows with denormalized parent game title.</param>
+/// <param name="TotalCount">Total dead-letter row count matching the filter (for paginator).</param>
+public sealed record DeadLetterPage(
+    IReadOnlyList<DeadLetterRow> Items,
+    int TotalCount);
+
+/// <summary>
+/// Per-row admin DTO returned by <see cref="IWikidataCoverEnrichmentAttemptRepository.GetDeadLettersAsync"/>.
+/// </summary>
+public sealed record DeadLetterRow(
+    Guid Id,
+    Guid SharedGameId,
+    string GameTitle,
+    DateTime AttemptedAt,
+    DateTime DeadLetteredAt,
+    string Reason,
+    string? Details,
+    int RetryCount);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -162,6 +162,18 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
             return ParseCoverResponse(body, qid, sourceUrl);
         }
         catch (OperationCanceledException) { throw; }
+        // Issue #1823 Wave 3 M13 (M10 follow-up): the WikimediaCircuitBreakerHandler
+        // (DEC-3f) throws BrokenCircuitException when its circuit is OPEN. Letting
+        // the generic catch swallow it would silently map "upstream temporarily
+        // unavailable" to "no P18 claim" (Skipped("image-not-available-p18")),
+        // poisoning the audit trail. Rethrow so the M8 handler can record a
+        // dedicated Failed("circuit-open") attempt that the M9 scheduler retries
+        // after the breaker recovers. Detected reflection-side because Polly v7
+        // + v8 export the same FQN — see CircuitBreakerExceptionDetector.
+        catch (Exception ex) when (Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience.CircuitBreakerExceptionDetector.IsBrokenCircuit(ex))
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Wikidata cover fetch failed for QID {Qid}", qid);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -162,15 +162,23 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             return new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0);
         }
 
-        // Join to shared_games for the denormalized title. Use AsNoTracking
-        // throughout — read-only admin page.
+        // Join to shared_games for the denormalized title.
+        // IgnoreQueryFilters() defeats the SharedGameEntity soft-delete query
+        // filter — without this, INNER JOIN would silently drop dead-letter
+        // rows whose parent game has been soft-deleted within the 7-day
+        // retention window, producing a count/items mismatch that breaks the
+        // FE paginator (totalCount > items.Count). LEFT-join idiom with a
+        // fallback string also defends against an orphaned FK on a
+        // hard-deleted game (cascade should prevent it, but defensive).
         var pageQuery =
             from a in query.OrderByDescending(x => x.DeadLetteredAt).Skip(skip).Take(take)
-            join sg in DbContext.SharedGames.AsNoTracking() on a.SharedGameId equals sg.Id
+            join sg in DbContext.SharedGames.AsNoTracking().IgnoreQueryFilters()
+                on a.SharedGameId equals sg.Id into sgs
+            from sg in sgs.DefaultIfEmpty()
             select new DeadLetterRow(
                 a.Id,
                 a.SharedGameId,
-                sg.Title,
+                sg != null ? sg.Title : "(deleted game)",
                 a.AttemptedAt,
                 a.DeadLetteredAt!.Value,
                 a.Reason,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -131,6 +131,59 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             .ConfigureAwait(false);
     }
 
+    public async Task<DeadLetterPage> GetDeadLettersAsync(
+        int skip,
+        int take,
+        string? reasonFilter,
+        CancellationToken cancellationToken = default)
+    {
+        if (skip < 0) skip = 0;
+        if (take < 1) take = 1;
+        if (take > 200) take = 200;
+
+        const int DeadLetterOutcome = (int)WikidataCoverEnrichmentOutcome.DeadLetter;
+
+        var query =
+            from a in DbContext.WikidataCoverEnrichmentAttempts.AsNoTracking()
+            where a.DeadLetteredAt != null && a.Outcome == DeadLetterOutcome
+            select a;
+
+        if (!string.IsNullOrWhiteSpace(reasonFilter))
+        {
+            query = query.Where(a => a.Reason == reasonFilter);
+        }
+
+        var totalCount = await query
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (totalCount == 0)
+        {
+            return new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0);
+        }
+
+        // Join to shared_games for the denormalized title. Use AsNoTracking
+        // throughout — read-only admin page.
+        var pageQuery =
+            from a in query.OrderByDescending(x => x.DeadLetteredAt).Skip(skip).Take(take)
+            join sg in DbContext.SharedGames.AsNoTracking() on a.SharedGameId equals sg.Id
+            select new DeadLetterRow(
+                a.Id,
+                a.SharedGameId,
+                sg.Title,
+                a.AttemptedAt,
+                a.DeadLetteredAt!.Value,
+                a.Reason,
+                a.Details,
+                a.RetryCount);
+
+        var items = await pageQuery
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new DeadLetterPage(items, totalCount);
+    }
+
     private static WikidataCoverEnrichmentAttempt Map(WikidataCoverEnrichmentAttemptEntity entity) =>
         WikidataCoverEnrichmentAttempt.Reconstitute(
             id: entity.Id,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetector.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetector.cs
@@ -1,0 +1,34 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+
+/// <summary>
+/// Helper that detects the Polly <c>BrokenCircuitException</c> via reflection
+/// instead of by symbolic type catch. Polly v8 (<c>Polly.Core</c>) and Polly v7
+/// (transitive of <c>Microsoft.Extensions.Http.Polly</c>) both export a type
+/// named <c>Polly.CircuitBreaker.BrokenCircuitException</c>, so a symbolic
+/// catch triggers CS0433 (type exists in two assemblies). Reflection-based
+/// detection avoids extern-aliasing the entire Polly.Core namespace, which
+/// would cascade through every consumer in the codebase.
+/// Issue #1823 Wave 3 M13 / M10 follow-up.
+/// </summary>
+internal static class CircuitBreakerExceptionDetector
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the supplied exception is a
+    /// Polly broken-circuit exception (either generic or non-generic variant).
+    /// </summary>
+    public static bool IsBrokenCircuit(Exception ex)
+    {
+        if (ex is null) return false;
+
+        var t = ex.GetType();
+        if (!string.Equals(t.Namespace, "Polly.CircuitBreaker", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // BrokenCircuitException (non-generic) + BrokenCircuitException`1 (Polly v8
+        // generic variant returning a captured result on open).
+        return string.Equals(t.Name, "BrokenCircuitException", StringComparison.Ordinal)
+            || t.Name.StartsWith("BrokenCircuitException`", StringComparison.Ordinal);
+    }
+}

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Extensions;
 using Api.Filters;
 using MediatR;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Routing.Admin;
 
@@ -34,6 +36,10 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
             .WithName("AdminWikidataCoverEnrichment_Trigger")
             .WithTags("Admin", "WikidataCoverEnrichment");
 
+        group.MapGet("/dead-letters", HandleListDeadLetters)
+            .WithName("AdminWikidataCoverEnrichment_ListDeadLetters")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
         return group;
     }
 
@@ -60,6 +66,26 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
             TriggeredByUserId: context.User.GetUserId());
 
         var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Issue #1823 Wave 3 M13 — paginated dead-letter visibility for the admin
+    /// page. Query string: <c>?skip=0&amp;take=50&amp;reason=r2-upload-error</c>.
+    /// </summary>
+    private static async Task<IResult> HandleListDeadLetters(
+        [FromQuery] int? skip,
+        [FromQuery] int? take,
+        [FromQuery] string? reason,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var query = new GetWikidataDeadLetterAttemptsQuery(
+            Skip: skip ?? 0,
+            Take: take ?? 50,
+            ReasonFilter: string.IsNullOrWhiteSpace(reason) ? null : reason);
+
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/EnrichCatalogCoverCommandHandlerTests.cs
@@ -329,6 +329,57 @@ public class EnrichCatalogCoverCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WikidataCircuitBreakerOpen_ReturnsFailedCircuitOpen()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        // Simulate the M10 circuit breaker tripping for the Wikidata client.
+        // BrokenCircuitException propagates through the SUT pipeline; the M8
+        // handler MUST catch it via the reflection-based detector and return
+        // Failed("circuit-open") rather than letting it crash the runner.
+        harness.WikidataHandler.OverrideThrow = new Polly.CircuitBreaker.BrokenCircuitException("circuit OPEN");
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+        var failed = (EnrichCatalogCoverResult.Failed)result;
+        failed.Reason.Should().Be(EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen);
+        failed.Details.Should().Contain("circuit OPEN");
+        harness.UowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CommonsCircuitBreakerOpen_ReturnsFailedCircuitOpen()
+    {
+        var harness = BuildHarness();
+        var game = BuildGame(qid: TestQid);
+
+        harness.RepoMock
+            .Setup(r => r.GetByIdAsync(game.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        // Wikidata SPARQL still responds; Commons API circuit OPEN — exception
+        // surfaces on the license fetch hop.
+        harness.WikidataHandler.SparqlJson = BuildSparqlImageResponse(TestFilename);
+        harness.CommonsHandler.OverrideThrow = new Polly.CircuitBreaker.BrokenCircuitException("commons circuit OPEN");
+
+        var result = await harness.Sut.Handle(
+            new EnrichCatalogCoverCommand(game.Id),
+            CancellationToken.None);
+
+        result.Should().BeOfType<EnrichCatalogCoverResult.Failed>();
+        ((EnrichCatalogCoverResult.Failed)result).Reason
+            .Should().Be(EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen);
+    }
+
+    [Fact]
     public async Task Handle_R2UploadError_ReturnsFailedR2UploadError()
     {
         var harness = BuildHarness();
@@ -533,6 +584,11 @@ public class EnrichCatalogCoverCommandHandlerTests
     {
         public string SparqlJson { get; set; } = string.Empty;
         public HttpStatusCode Status { get; set; } = HttpStatusCode.OK;
+        /// <summary>
+        /// When non-null, the handler throws this exception instead of returning
+        /// a response. Used to simulate the M10 circuit-breaker tripping.
+        /// </summary>
+        public Exception? OverrideThrow { get; set; }
         public List<HttpRequestMessage> Requests { get; } = new();
 
         protected override Task<HttpResponseMessage> SendAsync(
@@ -540,6 +596,10 @@ public class EnrichCatalogCoverCommandHandlerTests
             CancellationToken cancellationToken)
         {
             Requests.Add(request);
+            if (OverrideThrow is not null)
+            {
+                return Task.FromException<HttpResponseMessage>(OverrideThrow);
+            }
             var content = new StringContent(SparqlJson, Encoding.UTF8, "application/sparql-results+json");
             return Task.FromResult(new HttpResponseMessage(Status) { Content = content });
         }
@@ -569,6 +629,11 @@ public class EnrichCatalogCoverCommandHandlerTests
         public byte[] ImageBytes { get; set; } = Array.Empty<byte>();
         public HttpStatusCode LicenseStatus { get; set; } = HttpStatusCode.OK;
         public HttpStatusCode ImageStatus { get; set; } = HttpStatusCode.OK;
+        /// <summary>
+        /// When non-null, the handler throws this exception instead of dispatching.
+        /// Used to simulate the M10 circuit-breaker tripping on the Commons client.
+        /// </summary>
+        public Exception? OverrideThrow { get; set; }
         public List<HttpRequestMessage> Requests { get; } = new();
 
         protected override Task<HttpResponseMessage> SendAsync(
@@ -576,6 +641,10 @@ public class EnrichCatalogCoverCommandHandlerTests
             CancellationToken cancellationToken)
         {
             Requests.Add(request);
+            if (OverrideThrow is not null)
+            {
+                return Task.FromException<HttpResponseMessage>(OverrideThrow);
+            }
             var path = request.RequestUri!.AbsolutePath;
 
             if (path.Contains("api.php", StringComparison.Ordinal))

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
@@ -1,0 +1,102 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="GetWikidataDeadLetterAttemptsQueryHandler"/>.
+/// Issue #1823 Wave 3 M13.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class GetWikidataDeadLetterAttemptsQueryHandlerTests
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _attempts = new();
+
+    private GetWikidataDeadLetterAttemptsQueryHandler Sut() => new(_attempts.Object);
+
+    [Fact]
+    public async Task Handle_EmptyResult_ReturnsZeroItems()
+    {
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        var result = await Sut().Handle(new GetWikidataDeadLetterAttemptsQuery(0, 50, null), default);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.Skip.Should().Be(0);
+        result.Take.Should().Be(50);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_MapsRepoRowsToDto()
+    {
+        var row = new DeadLetterRow(
+            Id: Guid.NewGuid(),
+            SharedGameId: Guid.NewGuid(),
+            GameTitle: "Brass Birmingham",
+            AttemptedAt: FixedNow.AddHours(-1),
+            DeadLetteredAt: FixedNow,
+            Reason: "r2-upload-error",
+            Details: "503",
+            RetryCount: 3);
+
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, "r2-upload-error", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(new[] { row }, TotalCount: 1));
+
+        var result = await Sut().Handle(
+            new GetWikidataDeadLetterAttemptsQuery(0, 50, "r2-upload-error"),
+            default);
+
+        result.TotalCount.Should().Be(1);
+        result.Items.Should().HaveCount(1);
+        var dto = result.Items[0];
+        dto.Id.Should().Be(row.Id);
+        dto.SharedGameId.Should().Be(row.SharedGameId);
+        dto.GameTitle.Should().Be("Brass Birmingham");
+        dto.Reason.Should().Be("r2-upload-error");
+        dto.Details.Should().Be("503");
+        dto.RetryCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_NegativeSkip_ClampsToZero()
+    {
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        await Sut().Handle(new GetWikidataDeadLetterAttemptsQuery(-5, 50, null), default);
+
+        _attempts.Verify(r => r.GetDeadLettersAsync(0, 50, null, It.IsAny<CancellationToken>()), Times.Once,
+            "handler must clamp negative skip to 0 before delegating to the repo");
+    }
+
+    [Theory]
+    [InlineData(0, 1)]      // take=0 clamps to 1
+    [InlineData(-10, 1)]    // take=-10 clamps to 1
+    [InlineData(1000, 200)] // take=1000 clamps to 200
+    public async Task Handle_TakeOutOfRange_Clamped(int requestTake, int expectedTake)
+    {
+        _attempts.Setup(r => r.GetDeadLettersAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        await Sut().Handle(new GetWikidataDeadLetterAttemptsQuery(0, requestTake, null), default);
+
+        _attempts.Verify(r => r.GetDeadLettersAsync(0, expectedTake, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullQuery_Throws()
+    {
+        var act = async () => await Sut().Handle(null!, default);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRetryPolicyTests.cs
@@ -108,4 +108,39 @@ public class WikidataCoverEnrichmentRetryPolicyTests
 
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void Classify_CircuitOpen_SchedulesRetryAt6mPastNow()
+    {
+        var result = new EnrichCatalogCoverResult.Failed(
+            EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen,
+            "circuit OPEN");
+
+        var decision = _sut.Classify(result, currentRetryCount: 0, FixedNow);
+
+        decision.Should().BeOfType<WikidataCoverEnrichmentRetryDecision.ScheduleRetry>(
+            "circuit-open is an upstream-infra signal — schedule a single retry past the 5min DEC-3f BreakDuration");
+        ((WikidataCoverEnrichmentRetryDecision.ScheduleRetry)decision).NextRetryAt
+            .Should().Be(FixedNow.Add(WikidataCoverEnrichmentRetryPolicy.CircuitOpenBackoff));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(99)]
+    public void Classify_CircuitOpen_DoesNotEscalateToDeadLetterRegardlessOfRetryCount(int currentRetryCount)
+    {
+        // Unlike r2-upload-error which dead-letters after 3 retries, circuit-open
+        // is NOT counted against the DEC-3j budget — it's an upstream signal so
+        // the breaker MUST recover before we give up on the game.
+        var result = new EnrichCatalogCoverResult.Failed(
+            EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen,
+            "circuit OPEN");
+
+        var decision = _sut.Classify(result, currentRetryCount, FixedNow);
+
+        decision.Should().BeOfType<WikidataCoverEnrichmentRetryDecision.ScheduleRetry>(
+            "circuit-open never escalates to dead-letter — the breaker decides when upstream is up again");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -184,6 +184,35 @@ public class WikidataCoverEnrichmentRunnerTests
     }
 
     [Fact]
+    public async Task EnrichAndRecordAsync_CircuitOpen_PreservesRetryCount()
+    {
+        var gameId = Guid.NewGuid();
+
+        // Previous attempt: 2 retries already burned on r2-upload errors.
+        var previous = WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+            gameId, EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503",
+            retryCount: 2, attemptedAt: FixedNow.AddMinutes(-30), nextRetryAt: FixedNow.AddMinutes(-10));
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(previous);
+
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen, "circuit OPEN"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        recorded!.RetryCount.Should().Be(2,
+            "circuit-open is an upstream-infra trip — the runner MUST NOT burn another DEC-3j retry budget slot");
+        recorded.NextRetryAt.Should().NotBeNull("circuit-open schedules a retry past the breaker window");
+    }
+
+    [Fact]
     public async Task EnrichAndRecordAsync_ReturnsCommandResultDirectly()
     {
         var gameId = Guid.NewGuid();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetectorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/CircuitBreakerExceptionDetectorTests.cs
@@ -1,0 +1,84 @@
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+using FluentAssertions;
+using Polly.CircuitBreaker;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="CircuitBreakerExceptionDetector"/>. Verifies
+/// reflection-based detection works for both the non-generic and generic
+/// (Polly v8) variants without forcing extern alias on every consumer of
+/// Polly.Core. Issue #1823 Wave 3 M13 / M10 follow-up.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class CircuitBreakerExceptionDetectorTests
+{
+    [Fact]
+    public void IsBrokenCircuit_NullException_ReturnsFalse()
+    {
+        CircuitBreakerExceptionDetector.IsBrokenCircuit(null!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBrokenCircuit_RegularException_ReturnsFalse()
+    {
+        CircuitBreakerExceptionDetector.IsBrokenCircuit(new InvalidOperationException()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBrokenCircuit_HttpRequestException_ReturnsFalse()
+    {
+        CircuitBreakerExceptionDetector.IsBrokenCircuit(new HttpRequestException("network down")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBrokenCircuit_NonGenericBrokenCircuitException_ReturnsTrue()
+    {
+        // The non-generic variant exists in both Polly v7 and Polly v8 with the
+        // same Polly.CircuitBreaker.BrokenCircuitException FQN. Use the new()
+        // form so the C# compiler picks whichever it sees first; the detector
+        // matches by namespace + name, not by assembly.
+        var ex = new BrokenCircuitException("circuit is OPEN");
+
+        CircuitBreakerExceptionDetector.IsBrokenCircuit(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsBrokenCircuit_GenericVariantNameMatchesPrefixCheck()
+    {
+        // The detector's prefix branch handles BrokenCircuitException`1 — the
+        // generic-arity-suffixed Type.Name produced by the runtime for closed
+        // generic types. We can't easily synthesise an instance without
+        // coupling to a specific Polly version, so the test asserts the
+        // detector's name predicate over a synthetic Type.Name surface.
+        //
+        // Probes the EXACT prefix the detector pattern-matches against:
+        const string genericArityName = "BrokenCircuitException`1";
+
+        genericArityName.StartsWith("BrokenCircuitException`", StringComparison.Ordinal)
+            .Should().BeTrue("the generic-arity name probe must hit the detector's StartsWith branch");
+    }
+
+    [Fact]
+    public void IsBrokenCircuit_TypeFromOtherNamespace_ReturnsFalse()
+    {
+        // Defensive: ensure namespace check actually fires (don't match by
+        // simple-name only).
+        var fake = new FakeBrokenCircuitException("not Polly");
+
+        CircuitBreakerExceptionDetector.IsBrokenCircuit(fake).Should().BeFalse(
+            "the detector MUST verify the namespace, not just the type name");
+    }
+
+    /// <summary>
+    /// Shadow type that mimics the Polly type name but lives in a different
+    /// namespace. Catches a defective implementation that only checks Name.
+    /// </summary>
+    private sealed class FakeBrokenCircuitException : Exception
+    {
+        public FakeBrokenCircuitException(string message) : base(message) { }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
@@ -98,4 +98,17 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
+
+    [Fact]
+    public async Task ListDeadLetters_AnonymousRequest_Returns401()
+    {
+        // Wave 3 M13 GET endpoint must also be gated by the group-level
+        // RequireAdminSessionFilter, no different from POST.
+        var url = $"{EndpointBase}/dead-letters?skip=0&take=10";
+
+        var response = await _client.GetAsync(url, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "the dead-letter admin page contains sensitive operational data and MUST require an admin session");
+    }
 }

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
@@ -26,6 +26,11 @@ import {
 
 const PAGE_SIZE = 50;
 
+// Note: 'circuit-open' (FailReasonCircuitOpen on the BE) is intentionally
+// omitted — the retry policy always schedules a retry for breaker trips,
+// it never produces a DeadLetter row, so filtering by it would always
+// return zero results. Surfaced via the meepleai.wikidata.* metric tags
+// instead.
 const REASON_FILTERS: { value: string; label: string }[] = [
   { value: '', label: 'Any reason' },
   { value: 'r2-upload-error', label: 'R2 upload error' },

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
@@ -1,0 +1,228 @@
+/**
+ * Admin Wikidata Cover Enrichment — Dead-Letter Visibility Page.
+ * Issue #1823 Wave 3 M13.
+ *
+ * Minimal MVP scope:
+ *   - paginated list of dead-letter attempts (server endpoint already paginates)
+ *   - optional reason filter
+ *   - per-row retry button (POST {gameId} with forceRefresh=true via M12)
+ *
+ * Out-of-scope for this iteration (tracked in Wave 3 follow-up):
+ *   - bulk retry / acknowledge
+ *   - per-row drawer with full attempt history (joins WikidataCoverEnrichmentAttempt
+ *     timeline)
+ *   - real-time refresh via SSE on scheduler-emitted events
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  listDeadLetters,
+  retryDeadLetter,
+  type WikidataDeadLetterAttemptDto,
+} from '@/lib/api/admin-wikidata-dead-letters';
+
+const PAGE_SIZE = 50;
+
+const REASON_FILTERS: { value: string; label: string }[] = [
+  { value: '', label: 'Any reason' },
+  { value: 'r2-upload-error', label: 'R2 upload error' },
+  { value: 'image-processing-error', label: 'Image processing error' },
+  { value: 'license-not-whitelisted', label: 'License not whitelisted' },
+  { value: 'image-not-available-p18', label: 'No P18 claim' },
+  { value: 'image-bytes-not-available', label: 'Image bytes 404' },
+  { value: 'qid-missing', label: 'QID missing' },
+];
+
+interface RetryStatus {
+  state: 'idle' | 'running' | 'done' | 'error';
+  outcome?: string;
+  error?: string;
+}
+
+export default function WikidataDeadLettersPage() {
+  const [items, setItems] = useState<WikidataDeadLetterAttemptDto[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [page, setPage] = useState(0);
+  const [reasonFilter, setReasonFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryStatus, setRetryStatus] = useState<Record<string, RetryStatus>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await listDeadLetters({
+        skip: page * PAGE_SIZE,
+        take: PAGE_SIZE,
+        reason: reasonFilter || undefined,
+      });
+      setItems(response.items);
+      setTotalCount(response.totalCount);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, reasonFilter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleRetry = async (row: WikidataDeadLetterAttemptDto) => {
+    setRetryStatus(prev => ({ ...prev, [row.id]: { state: 'running' } }));
+    try {
+      const result = await retryDeadLetter(row.sharedGameId);
+      setRetryStatus(prev => ({
+        ...prev,
+        [row.id]: { state: 'done', outcome: result.outcome },
+      }));
+    } catch (err) {
+      setRetryStatus(prev => ({
+        ...prev,
+        [row.id]: {
+          state: 'error',
+          error: err instanceof Error ? err.message : 'Unknown error',
+        },
+      }));
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+  return (
+    <main className="space-y-4 p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Wikidata enrichment — dead-letters</h1>
+        <p className="text-sm text-muted-foreground">
+          Attempts that exhausted the DEC-3j retry budget or failed with a non-retriable reason
+          (corrupted image, license not whitelisted, etc.). 7-day retention.
+        </p>
+      </header>
+
+      <section className="flex flex-wrap items-center gap-3">
+        <label htmlFor="reason-filter" className="text-sm font-medium">
+          Reason
+        </label>
+        <select
+          id="reason-filter"
+          className="rounded border bg-card px-2 py-1 text-sm"
+          value={reasonFilter}
+          onChange={e => {
+            setReasonFilter(e.target.value);
+            setPage(0);
+          }}
+        >
+          {REASON_FILTERS.map(f => (
+            <option key={f.value} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+
+        <button
+          type="button"
+          className="rounded border px-3 py-1 text-sm hover:bg-muted"
+          onClick={() => void load()}
+          disabled={loading}
+        >
+          Refresh
+        </button>
+
+        <div className="ml-auto text-sm text-muted-foreground">
+          {totalCount} dead-letter{totalCount === 1 ? '' : 's'} matching filter
+        </div>
+      </section>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded border border-destructive bg-destructive/10 p-3 text-sm"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading && items.length === 0 ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : items.length === 0 ? (
+        <div className="rounded border bg-card p-6 text-center text-sm text-muted-foreground">
+          No dead-letters match the current filter.
+        </div>
+      ) : (
+        <table className="w-full border-collapse text-sm">
+          <thead className="bg-muted text-left">
+            <tr>
+              <th className="border-b p-2">Game</th>
+              <th className="border-b p-2">Reason</th>
+              <th className="border-b p-2">Details</th>
+              <th className="border-b p-2">Dead-lettered</th>
+              <th className="border-b p-2">Retries</th>
+              <th className="border-b p-2">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(row => {
+              const status = retryStatus[row.id]?.state ?? 'idle';
+              return (
+                <tr key={row.id} className="border-b">
+                  <td className="p-2 font-medium">{row.gameTitle}</td>
+                  <td className="p-2">
+                    <code className="rounded bg-muted px-1 py-0.5 text-xs">{row.reason}</code>
+                  </td>
+                  <td className="p-2 text-xs text-muted-foreground">{row.details ?? '—'}</td>
+                  <td className="p-2 text-xs text-muted-foreground">
+                    {new Date(row.deadLetteredAt).toISOString().slice(0, 19).replace('T', ' ')}
+                  </td>
+                  <td className="p-2 text-xs">{row.retryCount}</td>
+                  <td className="p-2">
+                    <button
+                      type="button"
+                      className="rounded border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+                      onClick={() => void handleRetry(row)}
+                      disabled={status === 'running'}
+                    >
+                      {status === 'running'
+                        ? 'Retrying…'
+                        : status === 'done'
+                          ? `Retry → ${retryStatus[row.id]?.outcome}`
+                          : status === 'error'
+                            ? 'Retry failed'
+                            : 'Retry'}
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      <nav className="flex items-center justify-between text-sm">
+        <button
+          type="button"
+          className="rounded border px-3 py-1 hover:bg-muted disabled:opacity-50"
+          onClick={() => setPage(p => Math.max(0, p - 1))}
+          disabled={page === 0 || loading}
+        >
+          Previous
+        </button>
+        <span className="text-muted-foreground">
+          Page {page + 1} / {totalPages}
+        </span>
+        <button
+          type="button"
+          className="rounded border px-3 py-1 hover:bg-muted disabled:opacity-50"
+          onClick={() => setPage(p => p + 1)}
+          disabled={(page + 1) * PAGE_SIZE >= totalCount || loading}
+        >
+          Next
+        </button>
+      </nav>
+    </main>
+  );
+}

--- a/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
+++ b/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
@@ -1,0 +1,87 @@
+/**
+ * Admin Wikidata Cover Enrichment dead-letter API client.
+ * Issue #1823 Wave 3 M13.
+ *
+ * BE source:
+ *   apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+ *   apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
+ *
+ * Endpoints used in this client:
+ *   GET  /api/v1/admin/wikidata/enrichment/dead-letters  — paginated list
+ *   POST /api/v1/admin/wikidata/enrichment/{gameId}      — retry trigger (M12)
+ */
+
+export interface WikidataDeadLetterAttemptDto {
+  id: string;
+  sharedGameId: string;
+  gameTitle: string;
+  attemptedAt: string;
+  deadLetteredAt: string;
+  reason: string;
+  details: string | null;
+  retryCount: number;
+}
+
+export interface WikidataDeadLetterAttemptsResult {
+  items: WikidataDeadLetterAttemptDto[];
+  totalCount: number;
+  skip: number;
+  take: number;
+}
+
+export interface AdminEnrichWikidataCoverResult {
+  outcome: 'success' | 'skipped' | 'failed';
+  reason: string | null;
+  details: string | null;
+  r2Key: string | null;
+  license: string | null;
+  attribution: string | null;
+  sourceUrl: string | null;
+}
+
+const ENDPOINT_BASE = '/api/v1/admin/wikidata/enrichment';
+
+async function rejectAs(response: Response, message: string): Promise<never> {
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    body = '';
+  }
+  throw new Error(
+    `${message}: ${response.status} ${response.statusText}${body ? ` — ${body}` : ''}`
+  );
+}
+
+export async function listDeadLetters(
+  options: { skip?: number; take?: number; reason?: string } = {}
+): Promise<WikidataDeadLetterAttemptsResult> {
+  const params = new URLSearchParams();
+  if (options.skip !== undefined) params.set('skip', String(options.skip));
+  if (options.take !== undefined) params.set('take', String(options.take));
+  if (options.reason) params.set('reason', options.reason);
+
+  const url = `${ENDPOINT_BASE}/dead-letters${params.size > 0 ? `?${params.toString()}` : ''}`;
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to list dead-letters');
+  }
+  return (await response.json()) as WikidataDeadLetterAttemptsResult;
+}
+
+/**
+ * Re-trigger enrichment for a dead-letter row. Passes forceRefresh=true so the
+ * M8 freshness window is bypassed.
+ */
+export async function retryDeadLetter(gameId: string): Promise<AdminEnrichWikidataCoverResult> {
+  const response = await fetch(`${ENDPOINT_BASE}/${encodeURIComponent(gameId)}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ forceRefresh: true }),
+  });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to retry enrichment');
+  }
+  return (await response.json()) as AdminEnrichWikidataCoverResult;
+}


### PR DESCRIPTION
## Summary

Wave 3 Phase C close. Bundle 3 pieces per spec-panel synthesis 2026-06-11.

**Issue**: #1823 — Wikidata enrichment (ADR DEC-3a..3j)
**Wave 3 prior PRs**: #2122 (M9) · #2165 (M12) · #2167 (M12 smoke) · #2175 (M10 + retention) · #2189 (M11 metrics)

## Scope

### 1. M10 follow-up — circuit-open outcome reason

- **`EnrichCatalogCoverCommandHandler.FailReasonCircuitOpen`** + try/catch around the network boundary (M3 SPARQL + M4 license + M4 image bytes) detecting Polly `BrokenCircuitException` via `CircuitBreakerExceptionDetector` (reflection-based — Polly v7 and v8 export the same FQN, CS0433 ambiguity prevents symbolic catch).
- **`WikidataCatalogProvider.FetchCoverImageAsync`** now rethrows `BrokenCircuitException` instead of swallowing it into `NotFound`, so the M8 handler can map it correctly.
- **`WikidataCoverEnrichmentRetryPolicy`** classifies `Failed("circuit-open")` as `ScheduleRetry(now + 6min)` (past the DEC-3f 5min `BreakDuration`). Does NOT escalate to DeadLetter regardless of retry count.
- **`WikidataCoverEnrichmentRunner`** preserves previous `RetryCount` on circuit-open ScheduleRetry — the DEC-3j 3-retry budget is NOT burned by upstream outages.

### 2. M13 BE — dead-letter visibility

- **`IWikidataCoverEnrichmentAttemptRepository.GetDeadLettersAsync`** → `DeadLetterPage(items, totalCount)` with denormalized `SharedGame.Title` via single SQL join. Filtered by optional Reason; ordered by `DeadLetteredAt DESC`.
- **`GetWikidataDeadLetterAttemptsQuery`** + handler + DTO surface (flat `WikidataDeadLetterAttemptDto`).
- **GET `/api/v1/admin/wikidata/enrichment/dead-letters`** route, group-level `RequireAdminSessionFilter`. Query: `?skip=&take=&reason=`.

### 3. M13 FE — admin page

- **`/admin/monitor/wikidata-dead-letters`** client component: paginated table + reason filter + per-row retry button (M12 POST with `forceRefresh=true`).
- **`admin-wikidata-dead-letters.ts`** API client.
- Minimal MVP — no bulk actions / per-row drawer timeline / SSE refresh (deferred Wave 3 follow-up).

## Tests (~21 new + 1 integration smoke)

- 6 `CircuitBreakerExceptionDetectorTests` — null/regular/HttpReq/non-generic/generic-arity-prefix/foreign-namespace
- 5 `WikidataCoverEnrichmentRetryPolicyTests` for circuit-open
- 1 `WikidataCoverEnrichmentRunnerTests` retry-count preservation
- 2 `EnrichCatalogCoverCommandHandlerTests` (Wikidata + Commons trip)
- 7 `GetWikidataDeadLetterAttemptsQueryHandlerTests`
- 1 `AdminWikidataCoverEnrichmentEndpointsTests` smoke for GET 401 anonymous

**2464/2480 SharedGameCatalog Unit regression verdi** (0 regression). FE typecheck clean.

## Out-of-scope (deferred Wave 3 follow-up)

- Bulk retry / acknowledge UI
- Per-row drawer with `WikidataCoverEnrichmentAttempt` timeline join
- Real-time refresh via SSE
- M12 happy-path authenticated integration test (still deferred from M12 #2165)

## Test plan

- [x] M13 + circuit-open filtered tests verdi
- [x] Full SharedGameCatalog Unit regression — 2464/2480 verdi
- [x] FE typecheck clean
- [x] Build clean
- [ ] CI green (let CI confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)