### PR TITLE
test(catalog): #1823 M16 IT Testcontainers expansion

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
@@ -239,7 +239,7 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
             DeadLetteredAt = DateTime.UtcNow.AddHours(-1),
         };
         dbContext.WikidataCoverEnrichmentAttempts.Add(attempt);
-        await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         return game.Id;
     }

--- a/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
@@ -1,8 +1,13 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -38,6 +43,14 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
     private readonly string _testDbName;
     private WebApplicationFactory<Program> _factory = null!;
     private HttpClient _client = null!;
+    private string _adminSessionToken = null!;
+    private static readonly Guid TestAdminId = Guid.NewGuid();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
 
     public AdminWikidataCoverEnrichmentEndpointsTests(SharedTestcontainersFixture fixture)
     {
@@ -54,6 +67,9 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
             await dbContext.Database.MigrateAsync(TestContext.Current.CancellationToken);
+
+            var (_, token) = await TestSessionHelper.CreateAdminSessionAsync(dbContext, TestAdminId);
+            _adminSessionToken = token;
         }
 
         _client = _factory.CreateClient();
@@ -110,5 +126,121 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
             "the dead-letter admin page contains sensitive operational data and MUST require an admin session");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Wave 3 M16 — authenticated admin happy-path coverage.
+    //
+    // These tests close the deferred-integration gap flagged on PR #2165
+    // (M12) + #2206 (M13). They use TestSessionHelper.CreateAdminSessionAsync
+    // to fabricate a valid admin session token, then send requests via
+    // CreateAuthenticatedRequest (mirror of AdminDomainEventOutboxEndpoints
+    // test pattern from #1535 T6).
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListDeadLetters_Admin_EmptyTable_Returns200WithZeroItems()
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"{EndpointBase}/dead-letters?skip=0&take=10",
+            _adminSessionToken);
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<WikidataDeadLetterAttemptsResult>(body, JsonOptions);
+        result.Should().NotBeNull();
+        result!.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.Skip.Should().Be(0);
+        result.Take.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ListDeadLetters_Admin_PopulatedTable_ReturnsRows()
+    {
+        var gameId = await SeedDeadLetterAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"{EndpointBase}/dead-letters?skip=0&take=10",
+            _adminSessionToken);
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<WikidataDeadLetterAttemptsResult>(body, JsonOptions);
+
+        result!.TotalCount.Should().Be(1);
+        result.Items.Should().ContainSingle();
+        result.Items[0].SharedGameId.Should().Be(gameId);
+        result.Items[0].Reason.Should().Be("r2-upload-error");
+        result.Items[0].GameTitle.Should().Be("M16 Test Game");
+    }
+
+    [Fact]
+    public async Task ListDeadLetters_Admin_ReasonFilter_Applied()
+    {
+        await SeedDeadLetterAsync("M16 r2-upload Game", reason: "r2-upload-error");
+        await SeedDeadLetterAsync("M16 image-processing Game", reason: "image-processing-error");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"{EndpointBase}/dead-letters?reason=image-processing-error",
+            _adminSessionToken);
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<WikidataDeadLetterAttemptsResult>(body, JsonOptions);
+
+        result!.TotalCount.Should().Be(1);
+        result.Items[0].Reason.Should().Be("image-processing-error");
+    }
+
+    private async Task<Guid> SeedDeadLetterAsync(
+        string gameTitle = "M16 Test Game",
+        string reason = "r2-upload-error")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = gameTitle,
+            YearPublished = 2020,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Description = string.Empty,
+            CreatedBy = TestAdminId,
+            CreatedAt = DateTime.UtcNow,
+            WikidataQid = "Q1",
+        };
+        dbContext.SharedGames.Add(game);
+
+        var attempt = new WikidataCoverEnrichmentAttemptEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = game.Id,
+            AttemptedAt = DateTime.UtcNow.AddHours(-1),
+            Outcome = 3, // DeadLetter
+            Reason = reason,
+            Details = "503 service unavailable",
+            RetryCount = 3,
+            DeadLetteredAt = DateTime.UtcNow.AddHours(-1),
+        };
+        dbContext.WikidataCoverEnrichmentAttempts.Add(attempt);
+        await dbContext.SaveChangesAsync();
+
+        return game.Id;
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs
@@ -1,0 +1,393 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Integration tests for <see cref="WikidataCoverEnrichmentAttemptRepository"/>
+/// against a real PostgreSQL via Testcontainers. Validates the LINQ → SQL
+/// translation that the unit tests cannot exercise (correlated EXISTS sub-query
+/// for due-for-enrichment, LEFT JOIN with IgnoreQueryFilters for dead-letter
+/// page, partial-index-covered DELETE for retention).
+///
+/// Issue #1823 Wave 3 M16 (per Lisa Crispin spec-panel recommendation).
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+[Collection("Integration-GroupC")]
+public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext? _dbContext;
+    private string? _connectionString;
+    private readonly string _databaseName = $"test_wcea_repo_{Guid.NewGuid():N}";
+    private WikidataCoverEnrichmentAttemptRepository _sut = null!;
+
+    private static readonly DateTime FixedNow = new(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    public WikidataCoverEnrichmentAttemptRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(_connectionString);
+        _dbContext = await Api.Tests.Infrastructure.TestHelpers.CreateDbContextAndMigrateAsync(_connectionString);
+        _sut = new WikidataCoverEnrichmentAttemptRepository(_dbContext, new Mock<IDomainEventCollector>().Object);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // GetGameIdsDueForEnrichmentAsync — correlated EXISTS sub-query
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_NeverAttempted_ReturnsGame()
+    {
+        var game = SeedGame(qid: "Q1");
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 10, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().ContainSingle().Which.Should().Be(game.Id);
+    }
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_GameWithoutQid_NotDue()
+    {
+        SeedGame(qid: null);
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 10, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().BeEmpty("games without WikidataQid are NOT enrichment targets");
+    }
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_TerminalSuccess_ExcludesGame()
+    {
+        var game = SeedGame(qid: "Q1");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Success, reason: "success",
+            attemptedAt: FixedNow.AddMinutes(-10));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 10, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().BeEmpty("terminal Success keeps the game out of the rerun queue");
+    }
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_TerminalDeadLetter_ExcludesGame()
+    {
+        var game = SeedGame(qid: "Q1");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.DeadLetter, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddMinutes(-10), deadLetteredAt: FixedNow.AddMinutes(-10));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 10, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_FailedDueForRetry_IncludesGame()
+    {
+        var game = SeedGame(qid: "Q1");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Failed, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddMinutes(-10), nextRetryAt: FixedNow.AddMinutes(-1));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 10, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().ContainSingle().Which.Should().Be(game.Id);
+    }
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_FailedNotYetDue_ExcludesGame()
+    {
+        var game = SeedGame(qid: "Q1");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Failed, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddMinutes(-2), nextRetryAt: FixedNow.AddMinutes(10));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 10, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().BeEmpty("NextRetryAt > now keeps the game in cooldown");
+    }
+
+    [Fact]
+    public async Task GetGameIdsDueForEnrichmentAsync_LimitBatchSize()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            SeedGame(qid: $"Q{i}");
+        }
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var due = await _sut.GetGameIdsDueForEnrichmentAsync(
+            limit: 3, nowUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        due.Should().HaveCount(3, "limit clamps the batch size");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // GetDeadLettersAsync — LEFT JOIN with IgnoreQueryFilters
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDeadLettersAsync_HappyPath_ReturnsRowsWithTitle()
+    {
+        var game = SeedGame(qid: "Q1", title: "Brass Birmingham");
+        var attempt = SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.DeadLetter,
+            reason: "r2-upload-error", attemptedAt: FixedNow.AddDays(-1),
+            deadLetteredAt: FixedNow.AddDays(-1), details: "503");
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.TotalCount.Should().Be(1);
+        page.Items.Should().ContainSingle();
+        var row = page.Items[0];
+        row.Id.Should().Be(attempt.Id);
+        row.GameTitle.Should().Be("Brass Birmingham");
+        row.Reason.Should().Be("r2-upload-error");
+        row.Details.Should().Be("503");
+    }
+
+    [Fact]
+    public async Task GetDeadLettersAsync_SoftDeletedGame_StillShowsRowWithFallbackTitle()
+    {
+        var game = SeedGame(qid: "Q1", title: "Lost Cities");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.DeadLetter,
+            reason: "license-not-whitelisted", attemptedAt: FixedNow.AddDays(-1),
+            deadLetteredAt: FixedNow.AddDays(-1));
+        // Soft-delete the parent game.
+        game.IsDeleted = true;
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.TotalCount.Should().Be(1, "soft-deleting the game MUST NOT drop the attempt from the count");
+        page.Items.Should().ContainSingle();
+        page.Items[0].GameTitle.Should().Be("Lost Cities",
+            "IgnoreQueryFilters() on the SharedGames join surfaces the soft-deleted title rather than producing the fallback '(deleted game)'");
+    }
+
+    [Fact]
+    public async Task GetDeadLettersAsync_FilterByReason_ReturnsMatchingOnly()
+    {
+        var g1 = SeedGame(qid: "Q1");
+        var g2 = SeedGame(qid: "Q2");
+        SeedAttempt(g1.Id, WikidataCoverEnrichmentOutcome.DeadLetter, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddDays(-1), deadLetteredAt: FixedNow.AddDays(-1));
+        SeedAttempt(g2.Id, WikidataCoverEnrichmentOutcome.DeadLetter, reason: "image-processing-error",
+            attemptedAt: FixedNow.AddDays(-1), deadLetteredAt: FixedNow.AddDays(-1));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: "image-processing-error",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.TotalCount.Should().Be(1);
+        page.Items[0].SharedGameId.Should().Be(g2.Id);
+    }
+
+    [Fact]
+    public async Task GetDeadLettersAsync_OrdersByDeadLetteredAtDesc()
+    {
+        var g1 = SeedGame(qid: "Q1");
+        var g2 = SeedGame(qid: "Q2");
+        SeedAttempt(g1.Id, WikidataCoverEnrichmentOutcome.DeadLetter, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddDays(-3), deadLetteredAt: FixedNow.AddDays(-3));
+        SeedAttempt(g2.Id, WikidataCoverEnrichmentOutcome.DeadLetter, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddDays(-1), deadLetteredAt: FixedNow.AddDays(-1));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.Items.Should().HaveCount(2);
+        page.Items[0].SharedGameId.Should().Be(g2.Id, "most-recently dead-lettered comes first");
+        page.Items[1].SharedGameId.Should().Be(g1.Id);
+    }
+
+    [Fact]
+    public async Task GetDeadLettersAsync_ExcludesLiveAttempts()
+    {
+        var game = SeedGame(qid: "Q1");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Failed, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddMinutes(-5), nextRetryAt: FixedNow.AddMinutes(5));
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Skipped, reason: "qid-missing",
+            attemptedAt: FixedNow.AddDays(-1));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.TotalCount.Should().Be(0,
+            "only DeadLetter outcomes appear on the visibility page");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // DeleteDeadLetteredOlderThanAsync — ExecuteDeleteAsync on partial index
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteDeadLetteredOlderThanAsync_DeletesOldDeadLettersOnly()
+    {
+        var g1 = SeedGame(qid: "Q1");
+        var g2 = SeedGame(qid: "Q2");
+        var oldDl = SeedAttempt(g1.Id, WikidataCoverEnrichmentOutcome.DeadLetter,
+            reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddDays(-10), deadLetteredAt: FixedNow.AddDays(-10));
+        var freshDl = SeedAttempt(g2.Id, WikidataCoverEnrichmentOutcome.DeadLetter,
+            reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddDays(-2), deadLetteredAt: FixedNow.AddDays(-2));
+        var successRow = SeedAttempt(g1.Id, WikidataCoverEnrichmentOutcome.Success,
+            reason: "success",
+            attemptedAt: FixedNow.AddDays(-30));
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Cutoff = now - 7 days. oldDl (10 days) gets swept; freshDl (2 days) stays;
+        // successRow (30 days) is untouched because DeadLetteredAt is null.
+        var deleted = await _sut.DeleteDeadLetteredOlderThanAsync(
+            cutoffUtc: FixedNow.AddDays(-7),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        deleted.Should().Be(1);
+
+        var remaining = await _dbContext.WikidataCoverEnrichmentAttempts
+            .AsNoTracking()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        remaining.Should().HaveCount(2);
+        remaining.Should().NotContain(a => a.Id == oldDl.Id);
+        remaining.Should().Contain(a => a.Id == freshDl.Id);
+        remaining.Should().Contain(a => a.Id == successRow.Id,
+            "Success rows must survive the dead-letter sweep regardless of age");
+    }
+
+    [Fact]
+    public async Task DeleteDeadLetteredOlderThanAsync_EmptyTable_ReturnsZero()
+    {
+        var deleted = await _sut.DeleteDeadLetteredOlderThanAsync(
+            cutoffUtc: FixedNow,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        deleted.Should().Be(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // GetLatestBySharedGameIdAsync — single-game lookup
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLatestBySharedGameIdAsync_ReturnsMostRecentAttempt()
+    {
+        var game = SeedGame(qid: "Q1");
+        SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Failed, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddMinutes(-30), nextRetryAt: FixedNow.AddMinutes(-15));
+        var latest = SeedAttempt(game.Id, WikidataCoverEnrichmentOutcome.Failed, reason: "r2-upload-error",
+            attemptedAt: FixedNow.AddMinutes(-5), nextRetryAt: FixedNow.AddMinutes(1),
+            retryCount: 1);
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _sut.GetLatestBySharedGameIdAsync(
+            game.Id, TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(latest.Id);
+        result.RetryCount.Should().Be(1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private SharedGameEntity SeedGame(string? qid, string? title = null)
+    {
+        var entity = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = title ?? $"Game {qid ?? Guid.NewGuid().ToString("N")}",
+            YearPublished = 2020,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Description = string.Empty,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            WikidataQid = qid,
+        };
+        _dbContext!.SharedGames.Add(entity);
+        return entity;
+    }
+
+    private WikidataCoverEnrichmentAttemptEntity SeedAttempt(
+        Guid sharedGameId,
+        WikidataCoverEnrichmentOutcome outcome,
+        string reason,
+        DateTime attemptedAt,
+        DateTime? nextRetryAt = null,
+        DateTime? deadLetteredAt = null,
+        string? details = null,
+        int retryCount = 0)
+    {
+        var entity = new WikidataCoverEnrichmentAttemptEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            AttemptedAt = attemptedAt,
+            Outcome = (int)outcome,
+            Reason = reason,
+            Details = details,
+            RetryCount = retryCount,
+            NextRetryAt = nextRetryAt,
+            DeadLetteredAt = deadLetteredAt,
+        };
+        _dbContext!.WikidataCoverEnrichmentAttempts.Add(entity);
+        return entity;
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
@@ -66,7 +66,10 @@ public class WikimediaCircuitBreakerIntegrationTests
         public FixedResponseHandler(Func<HttpResponseMessage> factory)
         {
             _factory = factory;
-            InnerHandler = new HttpClientHandler();
+            // No InnerHandler assignment — when this handler sits in the
+            // ConfigurePrimaryHttpMessageHandler slot, the HttpClientFactory
+            // pipeline builder injects the chain end for us. Assigning a
+            // dummy HttpClientHandler here would only be a dead-code leak.
         }
 
         protected override Task<HttpResponseMessage> SendAsync(

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikimediaCircuitBreakerIntegrationTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Polly.CircuitBreaker;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Integration tests for the M10 <see cref="WikimediaCircuitBreakerHandler"/>
+/// when registered via the standard <c>AddHttpClient(...).AddHttpMessageHandler(...)</c>
+/// DI extension. Validates that:
+/// <list type="bullet">
+///   <item>A typed HttpClient resolved from <see cref="IServiceProvider"/> gets a
+///   functional circuit breaker — the unit tests only assert behavior on a
+///   hand-wired DelegatingHandler chain.</item>
+///   <item>Two distinct typed clients (Wikidata SPARQL vs Commons API) get
+///   independent breaker instances — a SPARQL outage MUST NOT collapse Commons
+///   traffic (ADR DEC-3f per-client isolation).</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// Does not need Testcontainers — exercises the in-process DI + HttpClient
+/// factory pipeline with a fake inner handler. Issue #1823 Wave 3 M16 per
+/// Lisa Crispin spec-panel recommendation.
+/// </remarks>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class WikimediaCircuitBreakerIntegrationTests
+{
+    private interface IFakeWikidataClient
+    {
+        Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct);
+    }
+
+    private interface IFakeCommonsClient
+    {
+        Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct);
+    }
+
+    private sealed class FakeWikidataClient : IFakeWikidataClient
+    {
+        private readonly HttpClient _client;
+        public FakeWikidataClient(HttpClient client) => _client = client;
+        public Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct) =>
+            _client.GetAsync(path, ct);
+    }
+
+    private sealed class FakeCommonsClient : IFakeCommonsClient
+    {
+        private readonly HttpClient _client;
+        public FakeCommonsClient(HttpClient client) => _client = client;
+        public Task<HttpResponseMessage> GetAsync(string path, CancellationToken ct) =>
+            _client.GetAsync(path, ct);
+    }
+
+    private sealed class FixedResponseHandler : DelegatingHandler
+    {
+        private readonly Func<HttpResponseMessage> _factory;
+        public int CallCount { get; private set; }
+
+        public FixedResponseHandler(Func<HttpResponseMessage> factory)
+        {
+            _factory = factory;
+            InnerHandler = new HttpClientHandler();
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(_factory());
+        }
+    }
+
+    private static ServiceProvider BuildHost(
+        out FixedResponseHandler wikidataInner,
+        out FixedResponseHandler commonsInner,
+        Func<HttpResponseMessage>? wikidataFactory = null,
+        Func<HttpResponseMessage>? commonsFactory = null)
+    {
+        var wikidata = new FixedResponseHandler(wikidataFactory
+            ?? (() => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        var commons = new FixedResponseHandler(commonsFactory
+            ?? (() => new HttpResponseMessage(HttpStatusCode.OK)));
+        wikidataInner = wikidata;
+        commonsInner = commons;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddHttpClient<IFakeWikidataClient, FakeWikidataClient>(client =>
+            client.BaseAddress = new Uri("https://wikidata.test/"))
+            .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
+                sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
+                clientName: "wikidata-sparql"))
+            .ConfigurePrimaryHttpMessageHandler(() => wikidata);
+
+        services.AddHttpClient<IFakeCommonsClient, FakeCommonsClient>(client =>
+            client.BaseAddress = new Uri("https://commons.test/"))
+            .AddHttpMessageHandler(sp => new WikimediaCircuitBreakerHandler(
+                sp.GetRequiredService<ILogger<WikimediaCircuitBreakerHandler>>(),
+                clientName: "commons-api"))
+            .ConfigurePrimaryHttpMessageHandler(() => commons);
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task Wikidata5xxBurst_OpensCircuit_OnFourthCall_BrokenCircuit()
+    {
+        using var sp = BuildHost(out var wikidata, out _);
+        var client = sp.GetRequiredService<IFakeWikidataClient>();
+
+        // 3 consecutive 5xx ticks the breaker open.
+        for (var i = 0; i < WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold; i++)
+        {
+            var resp = await client.GetAsync("/probe", default);
+            ((int)resp.StatusCode).Should().BeGreaterThanOrEqualTo(500);
+        }
+
+        // 4th call is short-circuited before reaching the inner handler.
+        var act = async () => await client.GetAsync("/probe", default);
+        await act.Should().ThrowAsync<BrokenCircuitException>();
+
+        wikidata.CallCount.Should().Be(WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold);
+    }
+
+    [Fact]
+    public async Task WikidataCircuitOpen_DoesNotAffectCommonsClient()
+    {
+        using var sp = BuildHost(out _, out var commons);
+        var wikidataClient = sp.GetRequiredService<IFakeWikidataClient>();
+        var commonsClient = sp.GetRequiredService<IFakeCommonsClient>();
+
+        // Trip the Wikidata breaker open.
+        for (var i = 0; i < WikimediaCircuitBreakerHandler.ConsecutiveFailureThreshold; i++)
+        {
+            await wikidataClient.GetAsync("/probe", default);
+        }
+        await wikidataClient.Invoking(c => c.GetAsync("/probe", default))
+            .Should().ThrowAsync<BrokenCircuitException>();
+
+        // Commons remains usable — ADR DEC-3f per-client isolation.
+        var commonsResp = await commonsClient.GetAsync("/api", default);
+        commonsResp.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a SPARQL outage MUST NOT collapse Commons traffic — independent breaker instances");
+        commons.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NonTransient4xx_DoesNotTickBreaker()
+    {
+        using var sp = BuildHost(out var wikidata, out _,
+            wikidataFactory: () => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var client = sp.GetRequiredService<IFakeWikidataClient>();
+
+        // 4 consecutive 404 — breaker stays CLOSED, inner handler still hit.
+        for (var i = 0; i < 4; i++)
+        {
+            var resp = await client.GetAsync("/probe", default);
+            resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        wikidata.CallCount.Should().Be(4,
+            "4xx is client-side — the breaker MUST forward every request to the inner handler");
+    }
+}


### PR DESCRIPTION
## Summary

Wave 3 Phase D M16 — Integration test expansion per Lisa Crispin spec-panel sess.2026-06-11. Locks in behavior that the Wave 3 unit tests cannot verify (LINQ-to-SQL translation, real DI breaker registration, authenticated admin happy-path).

**Issue**: #1823 — Wikidata enrichment
**Phase D context**: Closes the M12 (#2165) + M13 (#2206) deferred-integration-test gap.

## Scope (3 IT classes, 24 tests, ~5min wall-clock)

### 1. `WikidataCoverEnrichmentAttemptRepositoryIntegrationTests` (15 tests)

Testcontainers Postgres + real EF Core LINQ-to-SQL translation:
- **`GetGameIdsDueForEnrichmentAsync`** — never-attempted, no-QID, terminal-Success/DeadLetter, Failed-due-for-retry, Failed-cooldown, limit-clamping
- **`GetDeadLettersAsync`** — happy-path with title denorm join, soft-deleted parent with `IgnoreQueryFilters` (M13 code-review fix), reason filter, ORDER BY DESC, excludes live attempts
- **`DeleteDeadLetteredOlderThanAsync`** — selective cutoff sweep, leaves Success rows + young dead-letters untouched
- **`GetLatestBySharedGameIdAsync`** — returns most-recent by `AttemptedAt DESC`

### 2. `WikimediaCircuitBreakerIntegrationTests` (3 tests)

Real DI host + `AddHttpClient().AddHttpMessageHandler()` chain, no Testcontainers:
- **5xx burst opens circuit** via `IServiceProvider`-resolved typed client
- **Per-client isolation**: Wikidata circuit OPEN does NOT collapse Commons traffic (ADR DEC-3f verified end-to-end)
- **4xx do not tick** the breaker (forwards every call to inner)

### 3. `AdminWikidataCoverEnrichmentEndpointsTests` extended (3 new authenticated tests)

Auth via `TestSessionHelper.CreateAdminSessionAsync` (mirror #1535 T6 pattern):
- **GET `/dead-letters` admin** empty result → 200
- **GET `/dead-letters` admin** seeded data → row + title denorm
- **GET `/dead-letters` admin** `?reason=` filter narrows correctly

## Test plan

- [x] 15 repo IT verdi (31s with Testcontainers Postgres startup)
- [x] 3 circuit-breaker IT verdi (271ms in-process)
- [x] 6 admin endpoint IT verdi (3.5min with WebApplicationFactory cold starts)
- [x] Build clean
- [ ] CI green (let CI confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)