### PR TITLE
fix(security): reject unsafe redirect targets via shared url-safety helper (#2168, #2182)

### DIFF
--- a/apps/web/e2e/auth-redirect-safety.spec.ts
+++ b/apps/web/e2e/auth-redirect-safety.spec.ts
@@ -13,8 +13,11 @@
  *   – 1 × valid relative ?from=/sessions → preserved
  *   – 1 × Referrer-Policy header check on /login
  *
- * Credentials: test@meepleai.com / Meeple1280!! (verified dev-seed user).
- * If login fails, update TEST_USER to a known-good seed from admin.secret.
+ * Credentials: sourced from PLAYWRIGHT_TEST_USER_EMAIL +
+ * PLAYWRIGHT_TEST_USER_PASSWORD env vars (CI provides via secrets store;
+ * local devs source `infra/secrets/admin.secret` before running).
+ * Falls back to placeholder strings so the spec compiles without env
+ * configured — tests will fail-fast at login if credentials are missing.
  *
  * @see apps/web/src/lib/url-safety.ts — isSafeRelativeLink helper
  * @see apps/web/src/middleware.ts — Referrer-Policy injection
@@ -23,9 +26,12 @@
 import { test, expect, type Page } from '@playwright/test';
 
 // ---------------------------------------------------------------------------
-// Credentials — dev-seed user verified during Gate 0 (issue #2168)
+// Credentials — sourced from env (CI secrets / local infra/secrets/admin.secret)
 // ---------------------------------------------------------------------------
-const TEST_USER = { email: 'test@meepleai.com', password: 'Meeple1280!!' };
+const TEST_USER = {
+  email: process.env.PLAYWRIGHT_TEST_USER_EMAIL ?? 'test@meepleai.com',
+  password: process.env.PLAYWRIGHT_TEST_USER_PASSWORD ?? '',
+};
 
 // ---------------------------------------------------------------------------
 // Attack vectors — representative subset of isSafeRelativeLink coverage

--- a/apps/web/e2e/auth-redirect-safety.spec.ts
+++ b/apps/web/e2e/auth-redirect-safety.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Auth Redirect Safety E2E Tests — Issue #2168
+ *
+ * Verifies that the `?from=` redirect parameter on /login is sanitised
+ * by `isSafeRelativeLink` so open-redirect attack vectors are silently
+ * dropped in favour of the safe fallback (/library).
+ *
+ * Also verifies that the Referrer-Policy: strict-origin header is present
+ * on /login responses (Task E middleware).
+ *
+ * Tests (8 total):
+ *   – 6 × unsafe ?from= vectors → fallback to /library
+ *   – 1 × valid relative ?from=/sessions → preserved
+ *   – 1 × Referrer-Policy header check on /login
+ *
+ * Credentials: test@meepleai.com / Meeple1280!! (verified dev-seed user).
+ * If login fails, update TEST_USER to a known-good seed from admin.secret.
+ *
+ * @see apps/web/src/lib/url-safety.ts — isSafeRelativeLink helper
+ * @see apps/web/src/middleware.ts — Referrer-Policy injection
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Credentials — dev-seed user verified during Gate 0 (issue #2168)
+// ---------------------------------------------------------------------------
+const TEST_USER = { email: 'test@meepleai.com', password: 'Meeple1280!!' };
+
+// ---------------------------------------------------------------------------
+// Attack vectors — representative subset of isSafeRelativeLink coverage
+// ---------------------------------------------------------------------------
+const UNSAFE_FROM_INPUTS = [
+  'https://evil.com',
+  'http://evil.com/path',
+  '//evil.com',
+  'javascript:alert(1)',
+  'data:text/html,<script>',
+  '%2F%2Fevil.com',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Helper: dismiss cookie-consent banner if present (best-effort, non-fatal)
+// ---------------------------------------------------------------------------
+async function dismissCookieBanner(page: Page): Promise<void> {
+  try {
+    await page.getByRole('button', { name: 'Solo essenziali' }).click({ timeout: 1500 });
+  } catch {
+    // Banner not present — continue normally
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: fill and submit login form, wait for navigation to settle
+// ---------------------------------------------------------------------------
+async function loginAs(page: Page, email: string, password: string): Promise<void> {
+  // Use data-testid on the form to scope selectors precisely
+  const form = page.locator('[data-testid="login-form"]');
+
+  // Fill email — label is "Email" (same in it/en locale)
+  await form.getByLabel(/^email$/i).fill(email);
+
+  // Fill password — label is "Password"
+  await form.getByLabel(/^password$/i).fill(password);
+
+  // Submit — the Btn renders as type="submit"; text is "Accedi" (it) / "Login" (en)
+  // We match any submit button inside the form to be locale-independent
+  await form.locator('button[type="submit"]').click();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Auth redirect safety (#2168)', () => {
+  test.beforeEach(async ({ context }) => {
+    // Start every test with a clean, unauthenticated state
+    await context.clearCookies();
+  });
+
+  // -- Unsafe ?from= vectors -------------------------------------------------
+
+  for (const unsafeFrom of UNSAFE_FROM_INPUTS) {
+    test(`rejects ?from=${unsafeFrom.slice(0, 40)} and falls back to /library`, async ({
+      page,
+    }) => {
+      await page.goto(`/login?from=${encodeURIComponent(unsafeFrom)}`);
+
+      await dismissCookieBanner(page);
+
+      await loginAs(page, TEST_USER.email, TEST_USER.password);
+
+      // Should land on /library (the safe fallback), NOT on the attacker domain
+      await expect(page).toHaveURL(/\/library(\?.*)?$/, { timeout: 5000 });
+
+      // Negative assertions
+      expect(page.url()).not.toContain('evil.com');
+      expect(page.url()).not.toContain('javascript:');
+      expect(page.url()).not.toContain('data:');
+    });
+  }
+
+  // -- Valid relative path ---------------------------------------------------
+
+  test('preserves valid relative ?from path on successful login', async ({ page }) => {
+    await page.goto('/login?from=/sessions');
+
+    await dismissCookieBanner(page);
+
+    await loginAs(page, TEST_USER.email, TEST_USER.password);
+
+    // Should land on /sessions (the allowed relative path)
+    await expect(page).toHaveURL(/\/sessions(\?.*)?$/, { timeout: 5000 });
+  });
+
+  // -- Referrer-Policy header ------------------------------------------------
+
+  test('Referrer-Policy: strict-origin header present on /login response', async ({ page }) => {
+    const response = await page.goto('/login');
+
+    // HTTP/2 header names are lower-cased; Playwright normalises them too
+    expect(response?.headers()['referrer-policy']).toBe('strict-origin');
+  });
+});

--- a/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
@@ -63,6 +63,7 @@ vi.mock('@/components/auth/oauth-url', () => ({
 
 // Import AFTER mocks
 import { LoginPageContent, LoginFallback } from '../_content';
+import { logger } from '@/lib/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -254,6 +255,67 @@ describe('LoginPageContent (v2 AuthCard)', () => {
     await waitFor(() => {
       expect(pushMock).toHaveBeenCalledWith('/library');
     });
+  });
+});
+
+describe('LoginPageContent — open redirect protection (#2168)', () => {
+  it('falls back to /library when ?from= is external URL', async () => {
+    setSearchParams({ from: 'https://evil.com' });
+    loginMock.mockResolvedValueOnce({
+      user: { id: 'u1', email: 't@e.com', role: 'User' },
+      requiresTwoFactor: false,
+    });
+
+    render(<LoginPageContent />);
+
+    fireEvent.change(screen.getByLabelText(/auth\.login\.emailLabel/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/auth\.login\.passwordLabel/i), {
+      target: { value: 'StrongPassword1' },
+    });
+    fireEvent.submit(screen.getByTestId('login-form'));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/library');
+    });
+    expect(pushMock).not.toHaveBeenCalledWith('https://evil.com');
+
+    // Unsafe input must trigger a warn log
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Rejected unsafe ?from= redirect target on login',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ fromMasked: expect.any(String) }),
+      })
+    );
+  });
+
+  it('preserves valid relative ?from= path', async () => {
+    setSearchParams({ from: '/sessions/abc-123' });
+    loginMock.mockResolvedValueOnce({
+      user: { id: 'u1', email: 't@e.com', role: 'User' },
+      requiresTwoFactor: false,
+    });
+
+    render(<LoginPageContent />);
+
+    fireEvent.change(screen.getByLabelText(/auth\.login\.emailLabel/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/auth\.login\.passwordLabel/i), {
+      target: { value: 'StrongPassword1' },
+    });
+    fireEvent.submit(screen.getByTestId('login-form'));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/sessions/abc-123');
+    });
+
+    // Safe input must NOT trigger a warn log
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'Rejected unsafe ?from= redirect target on login',
+      expect.anything()
+    );
   });
 });
 

--- a/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
@@ -312,10 +312,27 @@ describe('LoginPageContent — open redirect protection (#2168)', () => {
     });
 
     // Safe input must NOT trigger a warn log
-    expect(logger.warn).not.toHaveBeenCalledWith(
-      'Rejected unsafe ?from= redirect target on login',
-      expect.anything()
-    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs unsafe ?from= attempt on initial render (before any user action)', async () => {
+    setSearchParams({ from: 'https://evil.com' });
+
+    render(<LoginPageContent />);
+
+    // useEffect fires after render commit — wait for it
+    await waitFor(() => {
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Rejected unsafe ?from= redirect target on login',
+        expect.objectContaining({
+          metadata: expect.objectContaining({ fromMasked: expect.any(String) }),
+        })
+      );
+    });
+
+    // No form submission — warn fires on mount only, not tied to login action
+    expect(loginMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/(auth)/login/_content.tsx
+++ b/apps/web/src/app/(auth)/login/_content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -50,11 +50,16 @@ export function LoginPageContent() {
   const isSessionExpired = searchParams?.get('reason') === 'session_expired';
 
   // Log when the input was unsafe so we can detect attack attempts.
-  if (typeof rawFrom === 'string' && rawFrom.length > 0 && rawFrom !== from) {
-    logger.warn('Rejected unsafe ?from= redirect target on login', {
-      metadata: { fromMasked: rawFrom.slice(0, 32) },
-    });
-  }
+  // Wrapped in useEffect to fire once on mount (not on every re-render).
+  // State cycles during login (setIsAuthenticating) would otherwise emit
+  // 3+ warns per login attempt, polluting the remote log queue.
+  useEffect(() => {
+    if (typeof rawFrom === 'string' && rawFrom.length > 0 && rawFrom !== from) {
+      logger.warn('Rejected unsafe ?from= redirect target on login', {
+        metadata: { fromMasked: rawFrom.slice(0, 32) },
+      });
+    }
+  }, [rawFrom, from]);
 
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string>('');

--- a/apps/web/src/app/(auth)/login/_content.tsx
+++ b/apps/web/src/app/(auth)/login/_content.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
 import { logger } from '@/lib/logger';
+import { assertSafeRelativeOrFallback } from '@/lib/url-safety';
 
 // ============================================================================
 // Fallback (Suspense boundary)
@@ -42,8 +43,18 @@ export function LoginPageContent() {
   const { t } = useTranslation();
   const { loadCurrentUser } = useAuth();
 
-  const from = searchParams?.get('from') ?? '/library';
+  // Issue #2168: validate ?from= against open-redirect attack vectors.
+  // `assertSafeRelativeOrFallback` rejects 8 attack vectors and falls back to /library.
+  const rawFrom = searchParams?.get('from');
+  const from = assertSafeRelativeOrFallback(rawFrom, '/library');
   const isSessionExpired = searchParams?.get('reason') === 'session_expired';
+
+  // Log when the input was unsafe so we can detect attack attempts.
+  if (typeof rawFrom === 'string' && rawFrom.length > 0 && rawFrom !== from) {
+    logger.warn('Rejected unsafe ?from= redirect target on login', {
+      metadata: { fromMasked: rawFrom.slice(0, 32) },
+    });
+  }
 
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string>('');

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -98,6 +98,7 @@ export function RegisterPageContent() {
         // (matches AuthModal.handleRegister behavior)
         await new Promise(resolve => setTimeout(resolve, 100));
 
+        // #2168 audit: hardcoded redirect target — see header comment.
         await router.push(`/verification-pending?email=${encodeURIComponent(data.email)}`);
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : t('auth.register.genericError');

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -53,6 +53,10 @@ export function RegisterPageContent() {
   const [error, setError] = useState<string>('');
 
   const oauthDisabled = searchParams?.get('oauth_disabled') === 'true';
+  // Audit (#2168): register does NOT read ?from=. Post-registration redirect is
+  // hardcoded to /verification-pending (line below in handleRegister). If a
+  // ?from= param is ever introduced here, use assertSafeRelativeOrFallback from
+  // @/lib/url-safety before passing it to router.push().
 
   // Fetch registration mode on mount
   useEffect(() => {

--- a/apps/web/src/app/(auth)/reset-password/_content.tsx
+++ b/apps/web/src/app/(auth)/reset-password/_content.tsx
@@ -85,6 +85,10 @@ export function ResetPasswordPageContent(): JSX.Element | null {
 
   const token = searchParams?.get('token') ?? null;
   const mode: 'request' | 'reset' = token ? 'reset' : 'request';
+  // Note (#2168): all redirect targets in this file are hardcoded (/chat, /, /reset-password).
+  // Do NOT introduce ?from= here without using assertSafeRelativeOrFallback
+  // from @/lib/url-safety — open-redirect guard is mandatory for any
+  // query-param-driven navigation.
 
   // Auth state
   const [authUser, setAuthUser] = useState<AuthUser | null>(null);

--- a/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
@@ -80,6 +80,7 @@ describe('WelcomeContent — auto redirect', () => {
     await advancePastRedirect();
 
     expect(pushMock).toHaveBeenCalledWith('/library');
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('redirects immediately when the "Vai alla Dashboard" button is clicked', async () => {
@@ -95,6 +96,7 @@ describe('WelcomeContent — auto redirect', () => {
     fireEvent.click(btn);
 
     expect(pushMock).toHaveBeenCalledWith('/library');
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Welcome page (_content.tsx) tests.
+ *
+ * Verifies:
+ * - Auto-redirect fires after REDIRECT_DELAY_MS via setTimeout
+ * - Manual "Vai alla Dashboard" button triggers redirect immediately
+ * - Open-redirect protection (#2168): ?redirectTo= sanitization
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be registered before component import)
+// ---------------------------------------------------------------------------
+
+const pushMock = vi.fn().mockResolvedValue(undefined);
+const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => searchParamsMock,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+// Import AFTER mocks
+import { WelcomeContent } from '../_content';
+import { logger } from '@/lib/logger';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setSearchParams(params: Record<string, string | null>) {
+  searchParamsMock.get.mockImplementation((key: string) =>
+    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  setSearchParams({});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for timer-driven redirect
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance fake timers far enough to trigger the auto-redirect (REDIRECT_DELAY_MS = 2000).
+ * Uses advanceTimersByTime instead of runAllTimers to avoid the infinite-loop
+ * from the setInterval progress bar that keeps re-registering inside setState.
+ */
+async function advancePastRedirect() {
+  await act(async () => {
+    vi.advanceTimersByTime(2100);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Basic redirect behaviour
+// ---------------------------------------------------------------------------
+
+describe('WelcomeContent — auto redirect', () => {
+  it('redirects to /library after 2000ms when no ?redirectTo= param', async () => {
+    setSearchParams({});
+
+    await act(async () => {
+      render(<WelcomeContent />);
+    });
+
+    await advancePastRedirect();
+
+    expect(pushMock).toHaveBeenCalledWith('/library');
+  });
+
+  it('redirects immediately when the "Vai alla Dashboard" button is clicked', async () => {
+    setSearchParams({});
+
+    await act(async () => {
+      render(<WelcomeContent />);
+      // Flush the setMounted(true) useEffect so the component renders the button
+      vi.advanceTimersByTime(0);
+    });
+
+    const btn = screen.getByTestId('welcome-go-dashboard');
+    fireEvent.click(btn);
+
+    expect(pushMock).toHaveBeenCalledWith('/library');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Open redirect protection (#2168)
+// ---------------------------------------------------------------------------
+
+describe('WelcomeContent — open redirect protection (#2168)', () => {
+  it('falls back to /library when ?redirectTo= is external URL', async () => {
+    setSearchParams({ redirectTo: 'https://evil.com' });
+
+    await act(async () => {
+      render(<WelcomeContent />);
+    });
+
+    await advancePastRedirect();
+
+    expect(pushMock).toHaveBeenCalledWith('/library');
+    expect(pushMock).not.toHaveBeenCalledWith('https://evil.com');
+
+    // Unsafe input must trigger a warn log
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Rejected unsafe ?redirectTo= redirect target on welcome',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ redirectToMasked: expect.any(String) }),
+      })
+    );
+  });
+
+  it('preserves valid relative ?redirectTo= path', async () => {
+    setSearchParams({ redirectTo: '/sessions/abc-123' });
+
+    await act(async () => {
+      render(<WelcomeContent />);
+    });
+
+    await advancePastRedirect();
+
+    expect(pushMock).toHaveBeenCalledWith('/sessions/abc-123');
+
+    // Safe input must NOT trigger a warn log
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs unsafe ?redirectTo= attempt on initial render (before redirect)', async () => {
+    setSearchParams({ redirectTo: 'https://evil.com' });
+
+    await act(async () => {
+      render(<WelcomeContent />);
+      // Flush microtasks so the warn useEffect commits, but do NOT advance
+      // past the 2000ms redirect timer — push must not have been called yet
+    });
+
+    // The warn useEffect fires on mount (rawRedirectTo !== redirectTo)
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Rejected unsafe ?redirectTo= redirect target on welcome',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ redirectToMasked: expect.any(String) }),
+      })
+    );
+
+    // The redirect has NOT fired yet (timer not advanced to 2000ms)
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(auth)/welcome/_content.tsx
+++ b/apps/web/src/app/(auth)/welcome/_content.tsx
@@ -45,7 +45,7 @@ export function WelcomeContent() {
       rawRedirectTo !== redirectTo
     ) {
       logger.warn('Rejected unsafe ?redirectTo= redirect target on welcome', {
-        metadata: { fromMasked: rawRedirectTo.slice(0, 32) },
+        metadata: { redirectToMasked: rawRedirectTo.slice(0, 32) },
       });
     }
   }, [rawRedirectTo, redirectTo]);

--- a/apps/web/src/app/(auth)/welcome/_content.tsx
+++ b/apps/web/src/app/(auth)/welcome/_content.tsx
@@ -7,6 +7,8 @@ import { PartyPopper, ArrowRight, Sparkles } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { Btn } from '@/components/ui/btn';
+import { logger } from '@/lib/logger';
+import { assertSafeRelativeOrFallback } from '@/lib/url-safety';
 
 const REDIRECT_DELAY_MS = 2000;
 const PROGRESS_INTERVAL_MS = 50;
@@ -27,10 +29,26 @@ export function WelcomeFallback() {
 export function WelcomeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams?.get('redirectTo') ?? '/library';
+  const rawRedirectTo = searchParams?.get('redirectTo');
+  // Audit (#2168): ?redirectTo= is user-controlled; guard against open-redirect
+  // via assertSafeRelativeOrFallback before passing to router.push().
+  const redirectTo = assertSafeRelativeOrFallback(rawRedirectTo, '/library');
 
   const [progress, setProgress] = useState(0);
   const [mounted, setMounted] = useState(false);
+
+  // Fire-once-per-mount: warn if the raw param was rejected by the helper
+  useEffect(() => {
+    if (
+      typeof rawRedirectTo === 'string' &&
+      rawRedirectTo.length > 0 &&
+      rawRedirectTo !== redirectTo
+    ) {
+      logger.warn('Rejected unsafe ?redirectTo= redirect target on welcome', {
+        metadata: { fromMasked: rawRedirectTo.slice(0, 32) },
+      });
+    }
+  }, [rawRedirectTo, redirectTo]);
 
   const handleRedirect = useCallback(() => {
     router.push(redirectTo);
@@ -139,9 +157,7 @@ export function WelcomeContent() {
 
         {/* Features Preview */}
         <div className="pt-4 border-t border-border">
-          <p className="text-sm text-muted-foreground mb-3">
-            Cosa puoi fare con MeepleAI:
-          </p>
+          <p className="text-sm text-muted-foreground mb-3">Cosa puoi fare con MeepleAI:</p>
           <div className="flex flex-wrap justify-center gap-2 text-xs">
             <span className="px-3 py-1 bg-card rounded-full text-muted-foreground shadow-sm">
               📚 Regole dei giochi

--- a/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
@@ -18,6 +18,7 @@ import userEvent from '@testing-library/user-event';
 
 import NotificationsPage from '../page';
 import type { NotificationDto } from '@/lib/api';
+import { logger } from '@/lib/logger';
 import { EMPTY } from '../../../../__tests__/fixtures/test-strings';
 // #1816 P3-i18n: CatalogPagination (rendered when notifications > 20) calls
 // useTranslation which requires IntlProvider in the tree. Use renderWithIntl
@@ -392,5 +393,98 @@ describe('NotificationsPage', () => {
     expect(screen.getByRole('heading', { name: /oggi/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /ieri/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /precedenti/i })).toBeInTheDocument();
+  });
+
+  // ── detail.link safety (#2182) ───────────────────────────────────
+  describe('Notifications detail.link click handler (#2182)', () => {
+    it('calls window.location.assign for safe relative path', async () => {
+      const user = userEvent.setup();
+      const assignMock = vi.fn();
+      const originalLocation = window.location;
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: { ...originalLocation, assign: assignMock },
+      });
+
+      try {
+        const notifications = [
+          createNotification({
+            title: 'Safe link notification',
+            link: '/games/abc-123',
+            isRead: true,
+          }),
+        ];
+        setupStore({ notifications, unreadCount: 0 });
+
+        render(<NotificationsPage />);
+
+        // Open the detail drawer by clicking the card
+        const card = screen.getByRole('button', { name: /safe link notification/i });
+        await user.click(card);
+
+        // The "Apri" button should now be rendered inside the open drawer
+        const apriBtn = await screen.findByRole('button', { name: /^apri$/i });
+        await user.click(apriBtn);
+
+        expect(assignMock).toHaveBeenCalledWith('/games/abc-123');
+      } finally {
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          writable: true,
+          value: originalLocation,
+        });
+      }
+    });
+
+    it('does NOT call window.location.assign for external URL', async () => {
+      const user = userEvent.setup();
+      const assignMock = vi.fn();
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const originalLocation = window.location;
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: { ...originalLocation, assign: assignMock },
+      });
+
+      try {
+        const notifications = [
+          createNotification({
+            title: 'Unsafe link notification',
+            link: 'https://evil.com',
+            isRead: true,
+          }),
+        ];
+        setupStore({ notifications, unreadCount: 0 });
+
+        render(<NotificationsPage />);
+
+        // Open detail drawer
+        const card = screen.getByRole('button', { name: /unsafe link notification/i });
+        await user.click(card);
+
+        // The "Apri" button renders because detail.link is truthy
+        const apriBtn = await screen.findByRole('button', { name: /^apri$/i });
+        await user.click(apriBtn);
+
+        // window.location.assign must NOT be called for an external URL
+        expect(assignMock).not.toHaveBeenCalled();
+        // Rejection must be logged via logger.warn
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Rejected unsafe detail.link in notification',
+          expect.objectContaining({
+            metadata: expect.objectContaining({ linkMasked: 'https://evil.com' }),
+          })
+        );
+      } finally {
+        warnSpy.mockRestore();
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          writable: true,
+          value: originalLocation,
+        });
+      }
+    });
   });
 });

--- a/apps/web/src/app/(authenticated)/notifications/__tests__/redirect-safety.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/redirect-safety.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeRelativeLink } from '@/lib/url-safety';
+
+describe('Notifications detail link safety (#2182)', () => {
+  it('rejects external link in detail.link', () => {
+    expect(isSafeRelativeLink('https://evil.com')).toBe(false);
+  });
+
+  it('accepts safe deep link', () => {
+    expect(isSafeRelativeLink('/library/private/abc-123/toolkit')).toBe(true);
+  });
+});

--- a/apps/web/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/page.tsx
@@ -41,6 +41,8 @@ import {
 import type { EntityType } from '@/components/ui/entity-tokens';
 import { NotificationCard } from '@/components/ui/notification-card';
 import type { NotificationDto, NotificationType } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import { isSafeRelativeLink } from '@/lib/url-safety';
 import { cn } from '@/lib/utils';
 import { useNotificationStore, selectNotifications } from '@/stores/notification/store';
 
@@ -393,7 +395,18 @@ export default function NotificationsPage() {
                     entity={mapTypeToEntity(detail.type)}
                     fullWidth
                     onClick={() => {
-                      if (detail.link) window.location.assign(detail.link);
+                      // Issue #2182: defensive validation even though backend currently
+                      // produces only relative paths (Notification.cs:17 audit 2026-06-11).
+                      if (isSafeRelativeLink(detail.link)) {
+                        window.location.assign(detail.link!);
+                      } else {
+                        logger.warn('Rejected unsafe detail.link in notification', {
+                          metadata: {
+                            linkMasked: detail.link?.slice(0, 32),
+                            notificationId: detail.id,
+                          },
+                        });
+                      }
                     }}
                   >
                     Apri

--- a/apps/web/src/components/notifications/NotificationCenter.tsx
+++ b/apps/web/src/components/notifications/NotificationCenter.tsx
@@ -42,6 +42,8 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/na
 import { Button } from '@/components/ui/primitives/button';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { NotificationDto } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import { isSafeRelativeLink, assertSafeRelativeOrFallback } from '@/lib/url-safety';
 import { cn } from '@/lib/utils';
 import { useNotificationStore, selectNotifications } from '@/stores/notification/store';
 
@@ -228,9 +230,16 @@ function NotificationCenterItem({ notification, isUnread, onClose }: Notificatio
     if (!notification.isRead) {
       void markAsRead(notification.id);
     }
-    if (notification.link) {
-      router.push(notification.link);
+    if (isSafeRelativeLink(notification.link)) {
+      router.push(notification.link!);
       onClose();
+    } else if (notification.link) {
+      logger.warn('Rejected unsafe notification.link in NotificationCenter handleClick', {
+        metadata: {
+          linkMasked: notification.link.slice(0, 32),
+          notificationId: notification.id,
+        },
+      });
     }
   };
 
@@ -282,7 +291,7 @@ function NotificationCenterItem({ notification, isUnread, onClose }: Notificatio
       {isKbReady && notification.link && (
         <div className="mt-2 ml-7">
           <Link
-            href={notification.link}
+            href={assertSafeRelativeOrFallback(notification.link, '/notifications')}
             onClick={() => {
               if (!notification.isRead) void markAsRead(notification.id);
               onClose();

--- a/apps/web/src/components/notifications/NotificationItem.tsx
+++ b/apps/web/src/components/notifications/NotificationItem.tsx
@@ -28,6 +28,8 @@ import { useRouter } from 'next/navigation';
 
 import { PdfStatusBadge } from '@/components/pdf';
 import type { NotificationDto } from '@/lib/api';
+import { logger } from '@/lib/logger';
+import { isSafeRelativeLink } from '@/lib/url-safety';
 import { cn } from '@/lib/utils';
 import { useNotificationStore } from '@/stores/notification/store';
 
@@ -45,10 +47,20 @@ export function NotificationItem({ notification }: NotificationItemProps) {
       void markAsRead(notification.id);
     }
 
-    // Navigate to link if exists, otherwise resolve deep link from metadata
+    // Navigate to link if exists, otherwise resolve deep link from metadata.
+    // Issue #2182: guard against open-redirect via untrusted notification.link.
+    // getNotificationDeepLink() always returns relative paths (safe); only
+    // notification.link is the untrusted surface.
     const target = notification.link ?? getNotificationDeepLink(notification);
-    if (target) {
-      router.push(target);
+    if (isSafeRelativeLink(target)) {
+      router.push(target!);
+    } else if (target) {
+      logger.warn('Rejected unsafe target in NotificationItem', {
+        metadata: {
+          linkMasked: target?.slice(0, 32),
+          notificationId: notification.id,
+        },
+      });
     }
   };
 

--- a/apps/web/src/lib/__tests__/url-safety.test.ts
+++ b/apps/web/src/lib/__tests__/url-safety.test.ts
@@ -24,7 +24,27 @@ describe('isSafeRelativeLink', () => {
       ['data:text/html,<script>', 'data URI'],
       ['%2F%2Fevil.com', 'encoded protocol-relative'],
       ['  //evil.com', 'whitespace bypass'],
-    ])('rejects %s (%s)', input => {
+    ])('rejects %s (%s)', (input, _label) => {
+      expect(isSafeRelativeLink(input)).toBe(false);
+    });
+  });
+
+  describe('UNSAFE inputs — control character bypass (CVE-class)', () => {
+    it.each([
+      ['/\t//evil.com', 'tab-before-protocol-relative bypass'],
+      ['/\n//evil.com', 'newline-before-protocol-relative bypass'],
+      ['/\r//evil.com', 'CR-before-protocol-relative bypass'],
+      ['/library\x00//evil.com', 'NUL byte injection'],
+    ])('rejects %s (%s)', (input, _label) => {
+      expect(isSafeRelativeLink(input)).toBe(false);
+    });
+  });
+
+  describe('UNSAFE inputs — double-encoding bypass', () => {
+    it.each([
+      ['/%252F%252Fevil.com', 'double-encoded protocol-relative'],
+      ['/%252F%255Cevil.com', 'double-encoded slash-backslash'],
+    ])('rejects %s (%s)', (input, _label) => {
       expect(isSafeRelativeLink(input)).toBe(false);
     });
   });
@@ -39,6 +59,10 @@ describe('isSafeRelativeLink', () => {
 describe('assertSafeRelativeOrFallback', () => {
   it('returns input when safe', () => {
     expect(assertSafeRelativeOrFallback('/library', '/dashboard')).toBe('/library');
+  });
+
+  it('preserves root / path', () => {
+    expect(assertSafeRelativeOrFallback('/', '/dashboard')).toBe('/');
   });
 
   it('returns fallback when unsafe', () => {

--- a/apps/web/src/lib/__tests__/url-safety.test.ts
+++ b/apps/web/src/lib/__tests__/url-safety.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeRelativeLink, assertSafeRelativeOrFallback } from '@/lib/url-safety';
+
+describe('isSafeRelativeLink', () => {
+  describe('SAFE inputs (return true)', () => {
+    it.each([
+      ['/library'],
+      ['/sessions/abc-123/scores'],
+      ['/games?tab=discover'],
+      ['/profile#settings'],
+      ['/'],
+    ])('accepts safe relative path: %s', input => {
+      expect(isSafeRelativeLink(input)).toBe(true);
+    });
+  });
+
+  describe('UNSAFE inputs (return false) — 8 attack vectors', () => {
+    it.each([
+      ['https://evil.com', 'absolute external'],
+      ['http://evil.com/path', 'absolute external http'],
+      ['//evil.com', 'protocol-relative'],
+      ['\\\\evil.com', 'Windows path'],
+      ['javascript:alert(1)', 'scheme injection'],
+      ['data:text/html,<script>', 'data URI'],
+      ['%2F%2Fevil.com', 'encoded protocol-relative'],
+      ['  //evil.com', 'whitespace bypass'],
+    ])('rejects %s (%s)', input => {
+      expect(isSafeRelativeLink(input)).toBe(false);
+    });
+  });
+
+  describe('EDGE inputs (return false defensively)', () => {
+    it.each([[''], ['null'], ['undefined']])('rejects edge input: %s', input => {
+      expect(isSafeRelativeLink(input)).toBe(false);
+    });
+  });
+});
+
+describe('assertSafeRelativeOrFallback', () => {
+  it('returns input when safe', () => {
+    expect(assertSafeRelativeOrFallback('/library', '/dashboard')).toBe('/library');
+  });
+
+  it('returns fallback when unsafe', () => {
+    expect(assertSafeRelativeOrFallback('https://evil.com', '/dashboard')).toBe('/dashboard');
+  });
+
+  it('returns fallback when null/undefined', () => {
+    expect(assertSafeRelativeOrFallback(null, '/dashboard')).toBe('/dashboard');
+    expect(assertSafeRelativeOrFallback(undefined, '/dashboard')).toBe('/dashboard');
+  });
+
+  it('returns fallback when empty string', () => {
+    expect(assertSafeRelativeOrFallback('', '/dashboard')).toBe('/dashboard');
+  });
+});

--- a/apps/web/src/lib/url-safety.ts
+++ b/apps/web/src/lib/url-safety.ts
@@ -1,0 +1,72 @@
+/**
+ * URL safety validation for client-side redirects.
+ *
+ * Prevents open redirect attacks by ensuring `?from=` query params and
+ * notification deep links are restricted to same-origin relative paths.
+ *
+ * Closes #2168 (login open redirect) + #2182 (notifications defensive validation).
+ *
+ * Attack vectors rejected:
+ *   1. absolute external (https://evil.com)
+ *   2. absolute external http (http://evil.com)
+ *   3. protocol-relative (//evil.com)
+ *   4. Windows path (\\evil.com)
+ *   5. scheme injection (javascript:, data:)
+ *   6. data URI (data:text/html,...)
+ *   7. encoded protocol-relative (%2F%2Fevil.com)
+ *   8. whitespace bypass ("  //evil.com")
+ */
+
+/**
+ * Returns true only for safe same-origin relative URL paths.
+ *
+ * Safe: starts with `/`, does NOT start with `//`, does NOT contain `\\`,
+ * does NOT contain `:` before the first `/`, does NOT start with whitespace.
+ */
+export function isSafeRelativeLink(link: string | null | undefined): boolean {
+  if (typeof link !== 'string' || link.length === 0) return false;
+
+  // No leading whitespace
+  if (link[0] === ' ' || link[0] === '\t') return false;
+
+  // Must start with a single `/`
+  if (link[0] !== '/') return false;
+
+  // Reject protocol-relative `//evil.com`
+  if (link[1] === '/') return false;
+
+  // Reject Windows path `\\evil.com` (after the leading `/` it's `/\\evil.com`)
+  if (link[1] === '\\') return false;
+
+  // Reject encoded protocol-relative `%2F%2F`
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(link);
+    } catch {
+      return link;
+    }
+  })();
+  if (decoded.startsWith('//')) return false;
+  if (decoded.startsWith('/\\\\')) return false;
+
+  // Reject scheme injection: any `:` before first `/` is suspicious
+  const firstSlash = link.indexOf('/', 1);
+  const firstColon = link.indexOf(':');
+  if (firstColon !== -1 && (firstSlash === -1 || firstColon < firstSlash)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns input when safe, otherwise fallback.
+ *
+ * Use this at every consumer site so the validation policy is consistent.
+ */
+export function assertSafeRelativeOrFallback(
+  link: string | null | undefined,
+  fallback: string
+): string {
+  return isSafeRelativeLink(link) ? (link as string) : fallback;
+}

--- a/apps/web/src/lib/url-safety.ts
+++ b/apps/web/src/lib/url-safety.ts
@@ -15,19 +15,26 @@
  *   6. data URI (data:text/html,...)
  *   7. encoded protocol-relative (%2F%2Fevil.com)
  *   8. whitespace bypass ("  //evil.com")
+ *   9. control character bypass (/\t//evil.com — browsers silently strip U+0000-U+001F)
+ *  10. double-encoded protocol-relative (/%252F%252Fevil.com)
  */
 
 /**
  * Returns true only for safe same-origin relative URL paths.
  *
  * Safe: starts with `/`, does NOT start with `//`, does NOT contain `\\`,
- * does NOT contain `:` before the first `/`, does NOT start with whitespace.
+ * does NOT contain `:` before the first `/`, does NOT start with whitespace,
+ * does NOT contain ASCII control characters, does NOT double-encode to `//`.
  */
 export function isSafeRelativeLink(link: string | null | undefined): boolean {
   if (typeof link !== 'string' || link.length === 0) return false;
 
-  // No leading whitespace
-  if (link[0] === ' ' || link[0] === '\t') return false;
+  // Reject any input containing ASCII control characters (U+0000-U+001F)
+  // or DEL (U+007F). Browsers silently strip these during URL normalization,
+  // which can expose a following "//evil.com" to the redirect engine.
+  // e.g. new URL('/\t//evil.com', 'http://localhost') → href: "http://evil.com/"
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1F\x7F]/.test(link)) return false;
 
   // Must start with a single `/`
   if (link[0] !== '/') return false;
@@ -38,16 +45,23 @@ export function isSafeRelativeLink(link: string | null | undefined): boolean {
   // Reject Windows path `\\evil.com` (after the leading `/` it's `/\\evil.com`)
   if (link[1] === '\\') return false;
 
-  // Reject encoded protocol-relative `%2F%2F`
-  const decoded = (() => {
+  // Decode iteratively to defeat double-encoding (e.g. %252F%252F → %2F%2F → //).
+  // Max 3 passes is sufficient — anything pathological enough to need more is rejected.
+  // Note: window.location.assign() does NOT pre-decode like URLSearchParams does,
+  // so /%252F%252Fevil.com is exploitable from notification detail.link consumers.
+  let decoded = link;
+  for (let i = 0; i < 3; i++) {
+    let next: string;
     try {
-      return decodeURIComponent(link);
+      next = decodeURIComponent(decoded);
     } catch {
-      return link;
+      break;
     }
-  })();
+    if (next === decoded) break;
+    decoded = next;
+  }
   if (decoded.startsWith('//')) return false;
-  if (decoded.startsWith('/\\\\')) return false;
+  if (decoded.startsWith('/\\')) return false;
 
   // Reject scheme injection: any `:` before first `/` is suspicious
   const firstSlash = link.indexOf('/', 1);
@@ -63,6 +77,8 @@ export function isSafeRelativeLink(link: string | null | undefined): boolean {
  * Returns input when safe, otherwise fallback.
  *
  * Use this at every consumer site so the validation policy is consistent.
+ *
+ * @param fallback Must be a pre-validated safe path (not validated by this function).
  */
 export function assertSafeRelativeOrFallback(
   link: string | null | undefined,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -342,8 +342,11 @@ function getSecurityHeaders(requestOrigin?: string) {
     // XSS filter for legacy browsers
     'X-XSS-Protection': '1; mode=block',
 
-    // Referrer policy
-    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    // Referrer policy — Issue #2168 defense in depth: `strict-origin` sends
+    // only the origin (no path/query) on ALL requests (same- and cross-origin),
+    // preventing query-param exfiltration (e.g. `?from=` or session tokens)
+    // via the Referer header. Stricter than `strict-origin-when-cross-origin`.
+    'Referrer-Policy': 'strict-origin',
 
     // Permissions policy
     'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
@@ -381,7 +384,10 @@ export async function proxy(request: NextRequest) {
   if (hostname === '127.0.0.1') {
     const normalizedUrl = new URL(request.url);
     normalizedUrl.hostname = 'localhost';
-    return NextResponse.redirect(normalizedUrl);
+    // Issue #2168: apply security headers (including Referrer-Policy) on this
+    // early-exit redirect path, same as all other return sites below.
+    const normalizeResponse = NextResponse.redirect(normalizedUrl);
+    return addSecurityHeaders(normalizeResponse, requestOrigin);
   }
 
   // Check if user has a session cookie

--- a/audits/us-verification-log.md
+++ b/audits/us-verification-log.md
@@ -19,21 +19,505 @@
 
 | # | US | Persona | Title | Mockup | Status |
 |---|---|---|---|---|---|
-| 1 | US-2 | Marco | Log in + resume session | `auth-flow.html` | ⏳ pending |
-| 2 | US-6 | Marco | Dashboard priority-driven | `sp4-dashboard.html` (📐 obsolete — verifico vs Asse C live) | ⏳ pending |
-| 3 | US-25 | Sara | Notifications inbox | `notifications.html` | ⏳ pending |
-| 4 | US-10 | Sara | Library hybrid hub | `sp4-library-desktop.html` | ⏳ pending |
-| 5 | US-8 | Marco | Games hub multi-tab (Discover default) | `sp4-discover.html` | ⏳ pending |
-| 6 | US-9 | Giulia | Game detail tabs | `sp4-game-detail.html` (+ 5 tab mockups missing) | ⏳ pending |
-| 7 | US-27 | Sara | AI agent chat | `chat-fullscreen.html` + `sp4-agents-index.html` | ⏳ pending |
-| 8 | US-26 | Giulia | Profile + achievements | `settings.html` / `sp5-profile-settings.html` | ⏳ pending |
-| 9 | US-13 | Marco | GameNight create wizard | `sp7-game-night-create.html` | ⏳ pending |
-| 10 | US-15 | Marco | GameNight detail | `sp7-game-night-detail-rsvp.html` | ⏳ pending |
+| 1 | US-2 | Marco | Log in + resume session | `auth-flow.html` | 🔧 FUNCTIONAL_BUG (2026-06-11) |
+| 2 | US-6 | Marco | Dashboard priority-driven | `sp4-dashboard.html` (📐 obsolete — verificato vs Asse C live) | 🔧 FUNCTIONAL_BUG (2026-06-11) |
+| 3 | US-25 | Sara | Notifications inbox | `notifications.html` | ⚠️ VISUAL_DRIFT (2026-06-11) |
+| 4 | US-10 | Sara | Library hybrid hub | `sp4-library-desktop.html` | ⚠️ VISUAL_DRIFT (2026-06-11) — finding #1 retracted via Gate 0 |
+| 5 | US-8 | Marco | Games hub multi-tab (Discover default) | `sp4-discover.html` | ⚠️ VISUAL_DRIFT + 🔧 routing (2026-06-11) |
+| 6 | US-9 | Giulia | Game detail tabs | `sp4-game-detail.html` (+ 5 tab mockups missing) | 🔧 FUNCTIONAL_BUG (MULTIPLE) (2026-06-11) |
+| 7 | US-27 | Sara | AI agent chat | `chat-fullscreen.html` + `sp4-agents-index.html` | ⚠️ VISUAL_DRIFT + 🔧 nav gap (2026-06-11) |
+| 8 | US-26 | Giulia | Profile + achievements | `settings.html` / `sp5-profile-settings.html` | ⚠️ VISUAL_DRIFT (i18n + BGG mention) (2026-06-11) |
+| 9 | US-13 | Marco | GameNight create wizard | `sp7-game-night-create.html` | ✅ PASS (2026-06-11) |
+| 10 | US-15 | Marco | GameNight detail | `sp7-game-night-detail-rsvp.html` | ✅ PASS (not-found path) (2026-06-11) |
 
 (More US below queue, added on demand.)
 
 ## Verification log entries
 
 (Each US gets a `### US-N — verdict — date` heading appended below.)
+
+---
+
+### US-2 — 🔧 FUNCTIONAL_BUG — 2026-06-11
+
+**Persona / scope**: Marco · Log in + resume session
+**Mockup**: `admin-mockups/design_files/auth-flow.html` + `auth-flow.jsx` (6 phone screens)
+**Routes verificate**: `/login` (desktop 1280px), `/login` (mobile 375×812), `/login?reason=session_expired&from=...`, `/login?from=https://example.com/evil`
+**Modalità**: Socratic — panel Cockburn · Adzic · Wiegers · Crispin · Fowler
+**Tool**: Playwright MCP + backend code inspection
+**Credenziali**: admin (per validare success path + open redirect)
+
+**TTL / criteri misurabili (estratti dal backend)**
+- `Session.DefaultLifetime` = **30 giorni** (`Session.cs:57`)
+- `SessionManagementConfiguration.InactivityTimeoutDays` = **30 giorni** (`appsettings.json:109`)
+- Temp 2FA session = **5 min, single-use** (`LoginCommandHandler.cs:126`)
+- Account lockout = **15 min** dopo N failed (`LoginCommandHandler.cs:111`)
+- Device limit = **max 5 unique device** (`LoginCommandHandler.cs:199`)
+- Cookie session = HttpOnly (memoria: non accessibile da `document.cookie`)
+- Audit: `LoginFailure` (unknown_email / invalid_password / account_locked) + `LoginSuccess` con email PII masked (`al***@example.com`)
+
+**Edge case (Crispin)**
+| # | Scenario | Esito |
+|---|---|---|
+| E1 | Bad credentials → submit | ✅ alert "Invalid email or password" reso; banner session_expired persistente sopra; form non resettato |
+| E2 | `?from=https://example.com/evil` + login success | 🚨 **OPEN REDIRECT** — browser navigato a `https://example.com/evil` dopo cookie session settato |
+| E3 | Cookie consent dialog presente | Dialog modale all'arrivo; va dismissato manualmente prima del form (backdrop intercetta) — non testata interazione con dialog aperto |
+| E4 | 2FA timeout durante session_expired resume | Non testato (admin non ha 2FA attivo) — flag come gap di copertura |
+| E5 | OAuth in-flight + session_expired race | Non testato — richiede flusso OAuth completo |
+
+**Verdetto**: 🔧 **FUNCTIONAL_BUG** (HIGH severity — open redirect)
+
+**Findings prioritized**
+
+| # | Severity | Area | Finding | File:line | Recommendation |
+|---|---|---|---|---|---|
+| 1 | 🚨 **HIGH** | Security | Open redirect: `redirectAfterAuth(targetUrl=from)` accetta URL esterni; navigazione fuori dominio dopo login success | `apps/web/src/app/(auth)/login/_content.tsx:62` | Validare `from` con allowlist relativi (es. `from.startsWith('/') && !from.startsWith('//')`); fallback a `/library` |
+| 2 | 🚨 **HIGH** | A11y (WCAG) | 11× "Some page content is not contained by landmarks" su `/login` (manca `<main>` wrapper) — viola WCAG 2.1 1.3.1 | `AuthCard` component (renderizza fuori `<main>`) | Wrappare AuthCard in `<main id="main-content">` |
+| 3 | ⚠️ MED | A11y | "No skip link target" — link `#main-content` non risolve | stesso component | Aggiungere `id="main-content"` al landmark `<main>` |
+| 4 | ⚠️ MED | Logging | 1 evento errore login → 4 console.error (HTTP 400 + 2× "API request failed" + 1× Logger ERROR `Login failed`) | `apps/web/src/lib/api.ts` + `_content.tsx:97` | Logger ERROR unico in catch; rimuovere duplicate API Error |
+| 5 | ⚠️ MED | UX/Drift | Mockup mostra **2 OAuth** (Google+Discord); dev rende **3** (Google+Discord+GitHub) | `_content.tsx:213-217` | Designer decide: aggiungere GitHub in mockup o togliere da dev |
+| 6 | ⚠️ MED | UX/Drift | Mockup non mostra banner `session_expired` — concetto "resume session" non visualizzato | `auth-flow.jsx` | Designer aggiunga screen mockup con banner giallo "sessione scaduta" |
+| 7 | ⚠️ MED | Architecture | `LoginPageContent` legge `?reason=session_expired` ma non lo pulisce dopo render → al refresh il banner riappare anche se utente l'ha già visto | `_content.tsx:46` | Cleanup query param con `router.replace()` post-mount, o spostare reason in store ephemeral |
+| 8 | ⏳ LOW | UX | Cookie consent dialog aperto al 1° arrivo su `/login` intercetta input form (backdrop modale) | `apps/web/src/components/CookieConsent.tsx` | Decisione UX: dialog blocking pre-login (legal compliance) o anchor non-modal? Da audit GDPR/privacy |
+| 9 | ⏳ LOW | Test gap | Edge case E4 (2FA durante resume) + E5 (OAuth race) non coperti automatizzati | E2E suite | Aggiungere scenari in `apps/web/e2e/auth-flow.spec.ts` |
+
+**Mockup vs dev — scoreboard**
+- Brand mark + AuthCard layout: ✅ match
+- Form (Email + Password + Show toggle + Accedi): ✅ match
+- OAuth providers count: ⚠️ 2 mockup vs 3 dev (GitHub aggiunto)
+- Banner session_expired: 🆕 presente in dev, **assente nel mockup** (gap mockup)
+- "Password dimenticata" link: ✅ match (→ `/reset-password`)
+- "Registrati" footer link: ✅ match (→ `/register`)
+- StrengthMeter (registrazione): N/A per login screen
+- Mobile responsive (375×812): ✅ AuthCard si adatta correttamente
+
+**Mockup status update**: `auth-flow.html` rimane `current` ma è **incompleto** — manca screen "session expired banner". Suggerimento Phase B follow-up: aggiornare mockup o fidelity.json `design_intent: forward-refactor` con tracking.
+
+**Tracking issues aperte** (2026-06-11)
+- 🚨 **#2168 — P0 Security**: `[SECURITY] Login open redirect via ?from= query param`
+- 🚨 **#2169 — P1 A11y**: `[a11y] /login viola WCAG 2.1 1.3.1 — content fuori landmark + skip link rotto`
+- ⚠️ **#2170 — P2 Mockup**: `[mockup] auth-flow.html — add session_expired banner screen`
+- ⚠️ **#2171 — P2 DX**: `[login] duplicate console.error su credenziali errate (4× per 1 evento)`
+- ⏳ **#2172 — P3 Test**: `[e2e] auth-flow — coprire 2FA-during-resume + OAuth race`
+
+**Console errors triage** (15 al peak, 11 baseline, 1 atteso): 11 a11y + 1 HTTP 401 `/auth/me` (atteso non loggato) + 3 duplicate logging su failure (ridondanti).
+
+**Note Socratic** (dominio Marco — da chiarire con product)
+- Marco è "mobile-first quick access" oppure cross-device? Mockup è phone, dev è responsive desktop+mobile → testato entrambi.
+- "Resume" definito come "session TTL scaduto" (30gg inattività). UI rende il banner. **Manca documentazione user-facing** su quando scatta (es. tooltip o link "perché?").
+
+**Next**: US-6 (Marco · Dashboard priority-driven · `sp4-dashboard.html` obsolete per #2114).
+
+---
+
+### US-6 — 🔧 FUNCTIONAL_BUG — 2026-06-11
+
+**Persona / scope**: Marco · Dashboard priority-driven (Asse C #1898)
+**Mockup**: `admin-mockups/design_files/sp4-dashboard.html` → 📐 **MOCKUP_OBSOLETE** (Pre-Stage-3 forward-design, superseded da Asse C, già tracked #2114)
+**Routes verificate**: `/dashboard` (admin loggato, desktop + mobile 375×812)
+**Modalità**: Socratic manuale — panel Cockburn · Adzic · Wiegers · Crispin · Fowler
+**Tool**: utente fornisce screenshot + descrizione, Claude legge codice + screenshots
+**Screenshot raccolti**: `_dashboard.png`, `_dashboardMobile.png`, `_sidebarMobile.png`
+
+**Scoperta principale**
+SuggestedSection è montata in `DashboardClient.tsx:236-242` ma renderizza `null` quando `gamesQuery.data?.games.length === 0` (silent fallback MAJ-6, vedi `SuggestedSection.tsx:82-84`). Lo screenshot mostra KPI "GIOCHI: 3" (da `useLibraryStats`) ma SuggestedSection assente fra Recenti e FriendsActivity → **`useGames` query restituisce 0 mentre `useLibraryStats` dice 3**. Inconsistenza fra 2 endpoint paralleli.
+
+**Risposte panel da utente**
+- (Cockburn primary goal): N/A — utente non ha risposto esplicitamente
+- (Adzic concrete scenario): **"Giochi da aggiungere alla libreria che hanno il KB indicizzato (ossia un agent è utilizzabile)"** — chiarisce che Marco cerca DISCOVERY di nuovi giochi agent-ready, non recommendation di giochi già posseduti
+- (mobile screenshots forniti): conferma 3 sezioni visibili anche mobile (no SuggestedSection)
+- (privacy edge): 0 friends activity nel dataset corrente → test E5 non valutabile
+
+**Edge case (Crispin)**
+| # | Scenario | Esito |
+|---|---|---|
+| E1 | 0 GameNight pianificate | ✅ ProssimiSection rende empty state con CTA "Crea la tua prima Game Night" (corretto) |
+| E2 | Live session in-progress (StartedAt non null) | ⏳ Non testato — filtro `Status === 'Published'` strict (DashboardClient.tsx:96) potrebbe escludere `InProgress` |
+| E3 | Cascade drawer (asse-B) | Non verificato nel walkthrough — richiede click su card |
+| E4 | Mobile responsive 375px | ✅ Layout colonna single, KPI 2×2 grid, bottom-tab bar attiva |
+| E5 | Privacy friends | ⏳ Non valutabile (0 amici nel dataset) |
+
+**Verdetto**: 🔧 **FUNCTIONAL_BUG** (HIGH — SuggestedSection mismatch data) + 💡 **PRODUCT GAP** (Marco goal != algoritmo MVP)
+
+**Findings prioritized**
+
+| # | Severity | Area | Finding | File:line | Recommendation |
+|---|---|---|---|---|---|
+| 1 | 🔧 **HIGH** | Bug | SuggestedSection nascosta nonostante 3 giochi in libreria. `useGames` returna 0/error, `useLibraryStats` returna 3 → silent fallback maschera bug | `DashboardClient.tsx:145-167` + `useGames` | Riconciliare i 2 endpoint o investigare perché `useGames(undefined,undefined,1,20)` non restituisce gli stessi 3 giochi |
+| 2 | 💡 **P1** | Product | Marco goal mismatched: cerca "giochi agent-ready DA AGGIUNGERE", MVP rende "giochi già posseduti" | `DashboardClient.tsx:142-167` (MVP fixture) | Decidere: (a) ridefinire SuggestedSection come "discover agent-ready" (filtri `inLibrary=false AND kbIndexed=true`), oppure (b) aggiungere 5ª section "Espandi la libreria" (rompe DEC-1) |
+| 3 | ⚠️ P2 | i18n | Label "Cosa fanno i tuoi" troncato (atteso "...amici") | `FriendsActivitySection` i18n key | Verificare i18n string + adattare width header card per copy completo |
+| 4 | ⚠️ P2 | Navigation | 3 sistemi nav incongruenti: desktop top-nav (6) vs mobile sidebar (8) vs mobile bottom-tab (4) | `MainSidebar.tsx` mount in `DesktopShell.tsx` | Asse B MainSidebar 8-voce non rendered su desktop /dashboard. Verificare DesktopShell.tsx lg+ breakpoint condition |
+| 5 | 📐 P2 | Mockup | `sp4-dashboard.html` confermato obsolete | tracked #2114 | Nessuna nuova issue, conferma reclassificazione |
+| 6 | ⏳ P3 | Test gap | Live session in-progress non testato (filtro `Status === 'Published'` strict) | `DashboardClient.tsx:96` | Integration test con GN `Status === 'InProgress'` (post asse A WP1 #15) |
+| 7 | ⏳ P3 | Privacy | FriendsActivity privacy edge non valutabile | endpoint friends-activity | Dataset di test con amici privati per validation futura |
+
+**Mockup vs dev — scoreboard**
+- DashboardHero + KPI grid: ✅ preserved come da spec Asse C
+- 4 priority sections fixed order: 🔧 **3 rendered, 1 hidden** (Suggested silent fallback)
+- DEC-1 (refactor in-place /dashboard): ✅
+- Hero greeting per ora del giorno: ✅ "Buon pomeriggio"
+- Cascade drawer asse-B: ✅ montato (`CascadeDrawerHost`)
+- Mobile responsive: ✅ KPI 2×2 + bottom tab + hamburger sidebar
+
+**Mockup status update**: `sp4-dashboard.html` rimane 📐 forward-refactor-obsolete (già tracked #2114).
+
+**Console errors triage**: 4 issues (Next.js dev tools badge) — non triagated nel walkthrough manuale.
+
+**Tracking issues aperte** (2026-06-11)
+- 🔧 **#2176 — P0 Bug**: `[dashboard] SuggestedSection nascosta nonostante library > 0`
+- 💡 **#2177 — P1 Product**: `[dashboard] Marco goal mismatched: discover agent-ready vs recommendation owned games`
+- ⚠️ **#2178 — P2 i18n**: `[dashboard] FriendsActivitySection label troncato 'Cosa fanno i tuoi'`
+- ⚠️ **#2179 — P2 Nav**: `[ui-shell] MainSidebar 8-voce assente da desktop /dashboard`
+
+**Next**: US-25 Sara · Notifications inbox · `notifications.html`.
+
+---
+
+### US-25 — ⚠️ VISUAL_DRIFT — 2026-06-11
+
+**Persona / scope**: Sara · Notifications inbox
+**Mockup**: `admin-mockups/design_files/notifications.html` + `.jsx` — `design_intent: current`, `viewports: [desktop]`, **MA codice JSX è phone-mobile-first** (5 phone screens 380px con PhoneTopBar) → discrepanza fra fidelity claim e content reale
+**Routes verificate**: `/notifications` (admin loggato, desktop)
+**Modalità**: Socratic manuale — panel Cockburn · Adzic · Wiegers · Crispin · Fowler
+**Tool**: utente fornisce screenshot, Claude legge mockup + dev + backend
+**Screenshot**: `_notifications.png` (desktop, empty state)
+
+**User input chiave (US-25)**
+- Sara form factor: **Desktop + mobile responsive** → mockup va espanso a variant desktop
+- Filter UX: **Rimuovi tab legacy** `Tutte/Non lette` → mantieni solo i 5 pill + toggle "Solo non lette" separato
+- Open redirect: investigato backend → **risk LOW** (Notification.Link sempre path relativo hardcoded server-side)
+
+**Backend audit (Fowler request)**
+\`Notification.Link\` (`Notification.cs:17`) è sempre costruito server-side da codice trusted:
+- Hardcoded: `"/admin/share-requests?sort=oldest"`, `"/settings/notifications"`, `"/library"`
+- GUID-interpolated: \`$"/library/private/{notification.PrivateGameId}/toolkit"\`, \`$"/library/games/{evt.GameId}/agent"\`
+- **Nessun user input arbitrario** accettato come link
+
+→ Open redirect risk attuale BASSO. Defensive frontend validation comunque consigliata (P3) per resilience futura.
+
+**Edge case (Crispin)**
+| # | Scenario | Esito |
+|---|---|---|
+| E1 | 0 notifications | ✅ Empty state rendered (Bell icon + "Nessuna notifica") |
+| E2 | 100+ pagination + filter combo | ⏳ Untested (no data) — URL state NON observato (`useState` puro, no `?page=`) |
+| E3 | Detail drawer asse-B open | ⏳ Untested (no data) |
+| E4 | Race SSE notifica arriva | ⏳ Untested (no SSE producer in dev) |
+| E5 | Filter+tab combo 0 result | ⏳ Untested |
+| E6 | Open redirect via `detail.link` | ✅ Backend safe (path relativi only); defensive FE validation MISSING (P3) |
+| E7 | Mobile 375×812 | ⏳ Untested (screenshot solo desktop) |
+
+**Verdetto**: ⚠️ **VISUAL_DRIFT** (dev funzionale ma con multiple divergenze UI/UX da mockup)
+
+**Findings prioritized**
+
+| # | Severity | Area | Finding | File:line | Recommendation |
+|---|---|---|---|---|---|
+| 1 | 💡 **P1** | Mockup | `notifications.html`/`.jsx` è phone-mobile-only mentre Sara è desktop+mobile responsive. `fidelity.json` claim `viewports: [desktop]` ma il content non è desktop | `admin-mockups/design_files/notifications.{html,jsx,fidelity.json}` | Commission variant desktop mockup; correggere fidelity.json a `forward-refactor` fino a delivery |
+| 2 | ⚠️ **P2** | UX | Dual filter system: tab `Tutte/Non lette` legacy SOPRA i 5 pill duplicano "Tutte" semantica | `notifications/page.tsx:255-273` | Rimuovi tab legacy; aggiungi toggle "Solo non lette" come switch separato (entity counter sull'header). User input lockato |
+| 3 | ⚠️ P2 | UX | Empty state minimale (Bell icon + 1 riga copy) vs mockup ha EmptyState con illustration + CTA | `notifications/page.tsx:313-329` | Aggiornare empty state con illustration (BellOff o custom SVG) + copy contestuale + CTA "Configura preferenze" → `/notifications/preferences` |
+| 4 | ⚠️ P2 | UX | "Segna tutte come lette" CTA conditional su `hasUnread` → invisibile quando vuoto, vs mockup ⋯ menu sempre presente | `notifications/page.tsx:242-253` | Sempre visibile (disabled state quando 0 unread), oppure menu ⋯ con quick actions |
+| 5 | ⚠️ P2 | UX | Detail Drawer asse-B vs mockup NotificationDetail (phone screen separato) | `notifications/page.tsx:371-406` | Drift di paradigma accettabile (mobile→drawer è pattern moderno); aggiornare mockup quando arriva variant desktop |
+| 6 | ⏳ P3 | Security | `window.location.assign(detail.link)` senza validazione path relativo (defensive) | `notifications/page.tsx:396` | Aggiungere check `link?.startsWith('/') && !link.startsWith('//')` fallback `'/'` — anche se BE è safe ora |
+| 7 | ⏳ P3 | UX | Pagination URL state assente — Sara non può share link con filter+page | `notifications/page.tsx:161` | Migrare `currentPage` + `filter` + `activeTab` a `useSearchParams` |
+| 8 | ⏳ P3 | Test gap | E2-E5+E7 non testati (no data + no mobile screenshot) | E2E suite | Generare seed data + Playwright tests + mobile responsive snapshot |
+| 9 | 📐 *No new issue* | Nav | Top-nav 6-voce desktop confermata anche su /notifications — duplicate gap di US-6 #2179 | — | Vedi #2179 (no duplicate) |
+
+**Mockup vs dev — scoreboard**
+- 5 filter categories + entity colors: ✅ match
+- Group ordering oggi/ieri/settimana/precedenti: ✅ match
+- Group startOfDay logic: ✅ match
+- NotificationCard rendering: ✅ presumibile (no data per verifica)
+- Phone-mobile vs desktop responsive: 🔧 mockup phone-only, dev desktop+mobile responsive (Sara goal "entrambi")
+- Tab `Tutte/Non lette` extra in dev: ⚠️ va rimosso
+- Empty state: ⚠️ troppo minimale vs mockup
+- ⋯ menu mockup: ⚠️ assente in dev
+- @mockup DS-17-1 annotation: ✅ presente
+
+**Tracking issues aperte** (2026-06-11)
+- 💡 **#2180 — P1 Mockup**: `[mockup] notifications.html: commission variant desktop (Sara è desktop+mobile)`
+- ⚠️ **#2181 — P2 UX**: `[notifications] Rimuovi tab legacy 'Tutte/Non lette', aggiungi toggle 'Solo non lette'`
+- ⏳ **#2182 — P3 Security**: `[notifications] Defensive validation window.location.assign(detail.link)`
+- ⚠️ **#2183 — P2 UX**: `[notifications] Empty state minimale + CTA preferences mancante`
+
+**Next**: US-10 Sara · Library hybrid hub · `sp4-library-desktop.html`.
+
+---
+
+### US-10 — 🔧 FUNCTIONAL_BUG — 2026-06-11
+
+**Persona / scope**: Sara · Library hybrid hub
+**Mockup**: `admin-mockups/design_files/sp4-library-desktop.html` + `.jsx` (canonical) + variant mobile + wishlist
+**Routes verificate**: `/library` (admin loggato, desktop)
+**Modalità**: Socratic manuale — panel Cockburn · Adzic · Wiegers · Crispin · Fowler
+**Tool**: utente fornisce 3 screenshot
+**Screenshot**: `_libraryFiltrGames.png` (main view), `_libreriaAddGameDrawer.png` (add game drawer), `_libraryFiltrAvanzati.png` (filter panel)
+
+**Scoperta principale**
+Hero CTA **"↓ Importa BGG" LIVE in dev** → **viola freeze #2123 + ADR #1903** (BGG user-side banned 2026-06-10). Surface confermata da memoria CLAUDE.md (spec-panel addendum #2 aveva pre-flaggato `sp4-library-desktop.{html,jsx}` come BGG forbidden). Il drawer Add Game è invece **conforme** (no BGG step, vedi `_libreriaAddGameDrawer.png`).
+
+**Edge case (Crispin)**
+| # | Scenario | Esito |
+|---|---|---|
+| E1 | 0 giochi new user | ✅ Empty state rendered: meeple icon + "Aggiungi il tuo primo gioco" + CTA (no BGG fallback) |
+| E2 | 500+ giochi pagination | ⏳ Untested (no data) |
+| E3 | Filter combo 0 results | ⏳ Untested |
+| E4 | MeepleCard click → detail | ⏳ Untested (no data) |
+| E5 | Mobile 375px | ⏳ Untested (solo desktop screenshot) |
+
+**Verdetto**: 🔧 **FUNCTIONAL_BUG** (P0 — BGG ToS LIVE violation) + ⚠️ **VISUAL_DRIFT** secondario
+
+**Findings prioritized**
+
+| # | Severity | Area | Finding | File:line | Recommendation |
+|---|---|---|---|---|---|
+| 1 | 🚨 **P0** | Compliance | Hero CTA "↓ Importa BGG" LIVE viola ADR #1903 + freeze #2123 | `apps/web/src/app/(authenticated)/library/page.tsx` hero | Rimuovere il CTA "Importa BGG" o sostituirlo con "Importa da catalogo condiviso" |
+| 2 | 🔧 **P1** | Data | KPI counter inconsistency: hero "0 Giochi totali" vs /dashboard "GIOCHI 3" | useGames vs useLibraryStats | Same root cause di **#2176** — link cross-issue |
+| 3 | ⚠️ **P2** | UX | Triple filter overlap: tab entity + sub-tab status + filter panel "Tipo entità" | `library/page.tsx` filter components | Decidere single source of truth per filter type — eco #2181 |
+| 4 | ⚠️ **P2** | UX | "Più filtri" panel full-screen invasive con "Applica" full-width orange bar | `library/page.tsx` filter modal | Refactor a side-drawer asse-B oppure action bar fixed compatto |
+| 5 | 📐 **P2** | Mockup | `sp4-library-desktop.html` ha 2 BGG forbidden surfaces (hero + empty CTA) — già flagged spec-panel addendum #2 | `admin-mockups/design_files/sp4-library-desktop.{html,jsx,fidelity.json}` | Reclassificazione `forward-refactor-obsolete` per BGG ToS + tracking issue |
+| 6 | ✅ | UX | Add Game drawer 2 opzioni "Manualmente" + "Catalogo condiviso" — NO BGG step | `_libreriaAddGameDrawer.png` | Mantieni — match ADR #1903 |
+| 7 | 💡 P3 | Naming | "La tua libreria" multi-entity (giochi/agenti/documenti/chat) vs route `/library` semanticamente library = solo giochi | route naming | Considerare rename a `/hub` semantico o documentare hybrid hub concept |
+| 8 | ⏳ P3 | Test gap | Mobile 375px responsive non testato | E2E suite | Aggiungere snapshot test mobile |
+| 9 | 📐 *No new issue* | Nav | Top-nav 6-voce desktop duplicate da US-6 #2179 | — | Vedi #2179 |
+| 10 | 📐 *No new issue* | Data | Stesso useGames/useLibraryStats inconsistency di US-6 | — | Vedi #2176 |
+
+**Mockup vs dev — scoreboard**
+- Hero "La tua libreria" + 4 KPI pill: ✅ presumibile match struttura
+- "↓ Importa BGG" CTA: 🚨 entrambi (mockup + dev) hanno il bug BGG ToS
+- Tab entity (Tutti/Giochi/Agenti/KB/Sessioni/Chat): ✅ presente sia mockup che dev
+- Sub-tab status (Posseduti/Wishlist): ✅ presumibile match
+- Filter panel "Più filtri": ⚠️ pattern UX invasive — verifica match mockup
+- Add Game drawer: ✅ NO BGG step (dev) — corretto
+
+**Tracking issues** (2026-06-11)
+- ❌ **#2184 — CLOSED INVALID** (Gate 0 verification 2026-06-11): button role-gated correttamente, mio falso positivo (testato come admin). #1975 fix valido.
+- 📐 **#2185 — P3 Mockup** (downgrade post Gate 0): mockup drift minor, designer review optional
+- ⚠️ **#2186 — P2 UX**: `[library] Triple filter overlap: entity-tab + status-subtab + 'Più filtri' panel 'Tipo entità'`
+- ⚠️ **#2187 — P2 UX**: `[library] 'Più filtri' panel full-screen invasive — refactor a side-drawer`
+
+**Next**: US-8 Marco · Games hub multi-tab (Discover default) · `sp4-discover.html`.
+
+---
+
+### US-8 — ⚠️ VISUAL_DRIFT + 🔧 ROUTING — 2026-06-11
+
+**Persona / scope**: Marco · Games hub multi-tab (Discover default per invariante #20)
+**Mockup**: `sp4-discover.html` (queue) ↔ `sp4-games-index.html` (annotation dev) — 2 mockup ambigui per /games
+**Routes verificate**: `/games` (default), `/games?tab=discover`, `/games?tab=catalogo`, `/games?tab=trending`, `/games?tab=community`, `/games?tab=invalid_tab_xyz` (fallback test), `/discover` (standalone backward compat)
+**Modalità**: Playwright walkthrough automatico (utente ha delegato)
+**Tool**: Playwright MCP login admin + snapshot + screenshot + network audit BGG
+**Screenshot raccolti**: `us-8-games-default-desktop.png`, `us-8-games-catalogo-coming-soon.png`, `us-8-discover-standalone.png`, `us-8-games-tab-discover.png`, `us-8-games-mobile-375.png`
+
+**Edge case (Crispin)**
+| # | Scenario | Esito |
+|---|---|---|
+| E1 | `?tab=invalid_tab_xyz` | ✅ Fallback Discover content (graceful, URL preservato) |
+| E2 | `?tab=catalogo` bookmark direct | ⚠️ Vede ComingSoon, **nessuna CTA fallback** (no "Torna a Discover" / "Vai a Libreria") |
+| E3 | MiniNavSlot conformance | ✅ Mini-nav slot presente con breadcrumb "› Games" + 4 tab; ⚠️ button "Library" extra (ref=e38) intent unclear |
+| E4 | Mobile 375px | ✅ Hamburger + tab horizontal scroll + bottom tab bar 5-voce |
+| E5 | BGG ToS su Discover | ✅ **0 hit a host BGG** (network audit: 91 requests, 0 verso `cf.geekdo-images.com`/`boardgamegeek.com`/`geekdo-images.com`) |
+
+**Network audit (Fowler request)**
+- 91 requests totali
+- 0 BGG hits ✅
+- Endpoint chiamati: `/auth/me`, `/status-banner`, `/catalog/trending?limit=10`, `/sessions/active`, `/sessions/current`, `/users/<id>/chat-sessions/recent`, `/games`
+- **Anomalia**: `/api/v1/catalog/trending?limit=10` viene chiamato (BE pronto) ma tab Trending in FE è ComingSoon placeholder → **shipping gap** (BE pronto, FE non wireato)
+
+**Verdetto**: ⚠️ **VISUAL_DRIFT + 🔧 routing bug** (Hub link top-nav/bottom-tab → route obsoleta)
+
+**Findings prioritized**
+
+| # | Severity | Area | Finding | File:line | Recommendation |
+|---|---|---|---|---|---|
+| 1 | 🔧 **P1** | Routing | Top-nav desktop + bottom-tab mobile entrambi "Hub" link → `/hub/games` (route Stage 3 #1026 obsoleta) | header nav config | Aggiornare link "Hub" a `/games` (multi-tab hub) o rimuovere voce ridondante |
+| 2 | 🔧 **P1** | Shipping | `/api/v1/catalog/trending` BE pronto, FE tab Trending è ComingSoon placeholder | `games/page.tsx:69 ComingSoonTab` per `trending` | Wire FE tab Trending all'endpoint BE esistente |
+| 3 | ⚠️ **P2** | UX | 3 ComingSoon tabs senza CTA fallback (Catalogo/Trending/Community) — Marco dead-end | `games/page.tsx:68-82 ComingSoonTab` | Aggiungere CTA "↳ Torna a Discover" + "Vai a Libreria" in ComingSoon component |
+| 4 | ⚠️ **P2** | UX | Badge "Hub · /discover" hardcoded — appare anche su `/games?tab=discover` | `DiscoverHub` component | Usare `pathnameOverride` prop o `usePathname()` per badge dinamico |
+| 5 | ⚠️ P2 | UX | Search box duplicato: top (enabled) + section (disabled) | `DiscoverHub` rendering | Decidere single search; rimuovere disabled duplicate |
+| 6 | ⚠️ P2 | UX | Button "Library" (L) extra in mini-nav slot accanto a tab Discover/Catalogo/Trending/Community | mini-nav config | Investigare intent; rimuovere o documentare semantica |
+| 7 | ⏳ P3 | Data | 6 sezioni Discover tutte vuote ("Nessun elemento disponibile") — dataset insufficiente o endpoint silenti | endpoint backend | Seed dataset community + verificare endpoint render |
+| 8 | ✅ Security | BGG ToS PASS | 0 hit ai host BGG | — | Pass — mantenere ESLint `local/no-bgg-host` gate verde |
+| 9 | 📐 *No new* | Nav | Top-nav 6-voce duplicate da US-6 #2179 | — | Vedi #2179 |
+
+**Mockup vs dev — scoreboard**
+- Default tab Discover: ✅ match invariante #20
+- 4 tab (Discover/Catalogo/Trending/Community): ✅ presenti
+- 3 ComingSoon tabs: ⚠️ no CTA fallback
+- Backward compat `/discover` standalone: ✅ preservato
+- DiscoverHub shared component: ✅ stesso content fra `/discover` e `/games?tab=discover`
+- BGG-free: ✅ confermato
+- Mobile responsive: ✅ hamburger + bottom tab bar
+- @mockup annotation: ⚠️ punta a `sp4-games-index.html` ma queue cita `sp4-discover.html` — 2 mockup per stessa route (da chiarire)
+
+**Tracking issues aperte** (2026-06-11)
+- 🔧 **#2190 — P1 Routing**: `[routing] Top-nav 'Hub' link punta a /hub/games (Stage 3 obsoleto)`
+- 🔧 **#2191 — P1 Shipping**: `[games] Tab Trending placeholder ma backend già pronto`
+- ⚠️ **#2192 — P2 UX**: `[games] ComingSoon tabs senza CTA fallback — dead-end UX`
+- ⚠️ **#2193 — P2 UX**: `[discover] DiscoverHub UX cleanup: badge hardcoded + search duplicato + Library button extra`
+
+**Next**: US-9 Giulia · Game detail tabs · `sp4-game-detail.html` (5 sub-tab mockup mancanti — Draft 11).
+
+---
+
+### US-9 — 🔧 FUNCTIONAL_BUG (MULTIPLE) — 2026-06-11
+
+**Persona / scope**: Giulia · Game detail tabs (7 pages: main + 6 sub-routes)
+**Mockup**: `sp4-game-detail.html` (canonical) + **5 sub-tab mockups missing** (Draft 11 spec-panel 2026-06-10)
+**Routes verificate**: `/games/{id}` (Info default), `/games/{id}/reviews`, `/games/{id}/strategies`, `/games/{id}/chat`
+**Test game**: 7 Wonders (id `eefcd3a3-f6f0-4fdd-9233-7c21f2b59d3a`)
+**Modalità**: Playwright walkthrough automatico
+**Tool**: Playwright MCP login admin + snapshot + screenshot
+
+**Scoperta principale — TAB NAV INCOMPLETA + 3 ROUTES ORPHAN**
+UI tab list su `/games/{id}`:
+\`\`\`
+Info | Regole | FAQ | Partite (🔒) | pages.gameDetail.tabs.stats (🔒) | Agenti | Documenti
+\`\`\`
+
+Route directory:
+\`\`\`
+/games/[id]/page.tsx                ← Info (selected default)
+/games/[id]/rules/page.tsx          ← Regole tab
+/games/[id]/faqs/page.tsx           ← FAQ tab
+/games/[id]/sessions/page.tsx       ← Partite tab (disabled UI)
+/games/[id]/reviews/page.tsx        ← ⚠️ NO TAB
+/games/[id]/strategies/page.tsx     ← ⚠️ NO TAB
+/games/[id]/chat/page.tsx           ← ⚠️ NO TAB (also redirect bug)
+\`\`\`
+
+→ **3 routes (`/reviews`, `/strategies`, `/chat`) sono ORPHAN** dalla navigazione UI. Giulia può raggiungerle solo via URL diretto.
+
+**Backend 404**:
+- \`GET /api/v1/games/{id}/reviews?pageNumber=1&pageSize=10\` → **404**
+- \`GET /api/v1/games/{id}/strategies?pageNumber=1&pageSize=10\` → **404**
+
+→ Anche se Giulia raggiunge le orphan pages, vede error alert.
+
+**i18n broken**:
+- Tab label raw \`pages.gameDetail.tabs.stats\` (key non risolta)
+- Reviews/Strategies orphan rendono form in EN ("Write a Review", "Your Name", "Rating", "Submit Review", "Back to Game") mentre H1 + altro è IT
+
+**Edge case (Crispin)**
+| # | Scenario | Esito |
+|---|---|---|
+| E1 | Tab "Info" default | ✅ Rendered (KPI list + 2 generic blocks depth-truncated) |
+| E2 | Tab disabled 🔒 (Partite, Stats) | ⚠️ Nessuna documentazione/tooltip su lock reason |
+| E3 | Tab i18n broken | 🔧 \`pages.gameDetail.tabs.stats\` raw string |
+| E4 | Orphan `/reviews` direct | 🔧 BE 404 + form EN mixed IT |
+| E5 | Orphan `/strategies` direct | 🔧 BE 404 + back link EN mixed IT |
+| E6 | `/chat` direct | ⚠️ Redirect a `/games/{id}` (wrapper trivial) |
+| E7 | Back link da orphan | 🔧 Va a `/library/{id}` invece di `/games/{id}` |
+| E8 | Console warnings | ⚠️ 58 warnings su game detail main + 59 dopo re-snapshot |
+| E9 | Mobile responsive | ⏳ Untested |
+
+**Verdetto**: 🔧 **FUNCTIONAL_BUG (MULTIPLE)** — tab nav incompleta + BE 404 + i18n broken + routing inconsistency
+
+**Findings prioritized** (vedi sopra)
+
+**Mockup vs dev — scoreboard**
+- Hero "7 Wonders" + cover placeholder 🎲: ✅ rendered
+- Tab list: 🔧 incompleta (3 routes orphan)
+- 5 sub-tab mockups: 📐 **MISSING** (Draft 11 P1 unblock backlog)
+- CTAs hero ("Torna al catalogo", "+ Aggiungi a libreria", "Condividi"): ✅ rendered
+- i18n consistency: 🔧 multiple breaks
+
+**Tracking issues aperte** (2026-06-11)
+- 🚨 **#2194 — P0 Architecture**: `[game-detail] Tab nav incompleta: 3 routes orphan (/reviews /strategies /chat)`
+- 🔧 **#2195 — P1 Backend**: `[backend] /api/v1/games/{id}/reviews + /strategies ritornano 404`
+- 🔧 **#2196 — P1 i18n**: `[i18n] tab label 'pages.gameDetail.tabs.stats' unresolved + form EN mixed IT`
+- ⚠️ **#2197 — P2 UX**: `[game-detail] Back link mismatch + tab 🔒 senza tooltip + /chat redirect`
+- 💡 **#2198 — P1 Mockup**: `[mockup] Commission 5 sub-tab mockups (Draft 11)`
+
+**Next**: US-27 Sara · AI agent chat · `chat-fullscreen.html` + `sp4-agents-index.html`.
+
+---
+
+### US-27 — ⚠️ VISUAL_DRIFT + 🔧 NAV GAP — 2026-06-11
+
+**Persona / scope**: Sara · AI agent chat
+**Mockup**: `chat-fullscreen.html` + `sp4-agents-index.html` (coverage 2/3 per gap report)
+**Routes verificate**: `/agents`, `/agents/{id}`, `/chat`, `/chat/new`
+**Test agent**: "Rules Expert" (id `d39d68ee-1cee-4ea9-9b90-68d26bebe2d0`, status archived)
+**Modalità**: Playwright walkthrough automatico
+
+**Verdetto**: ⚠️ **VISUAL_DRIFT** + 🔧 navigation gap
+
+**Findings prioritized**
+
+| # | Severity | Area | Finding | Recommendation |
+|---|---|---|---|---|
+| 1 | 🔧 P1 | UX | Agent detail manca tab Chat / CTA "Avvia chat" — Sara forced reverse navigation | Aggiungere tab Chat o sticky CTA "Avvia chat con questo agente" → `/chat/new?agentId={id}` |
+| 2 | ⚠️ P2 | Test gap | Solo 1 agent archived nel dataset | Seed dataset agent attivo per E2E |
+| 3 | ⚠️ P2 | UX | "↻ Riattiva" agent archived — flow post-reattivazione non chiaro | Documentare expected flow + redirect (auto-redirect a /chat/new o resta detail) |
+| 4 | ✅ | UX | `/chat` 3-panel desktop layout | OK |
+| 5 | ✅ | UX | `/chat/new` flow + empty state | OK |
+| 6 | 📐 *No new* | Nav | Top-nav legacy duplicate da #2179, #2190 | — |
+
+**Tracking issues**: 1 nuova (vedi sotto). Gap mockup `sp4-agent-detail` per detail (Draft 12 implicit) lasciato per Phase B follow-up dedicato.
+
+**Next**: US-26 Giulia · Profile + achievements · `settings.html` / `sp5-profile-settings.html`.
+
+---
+
+### US-26 — ⚠️ VISUAL_DRIFT (i18n + BGG mention) — 2026-06-11
+
+**Persona / scope**: Giulia · Profile + achievements
+**Mockup**: `settings.html` / `sp5-profile-settings.html` (BGG forbidden flagged) + `sp4-profile-achievements.html` MISSING
+**Routes verificate**: `/profile`, `/profile/achievements` (redirect wrapper), `/profile?tab=settings&section=profile`
+**Modalità**: Playwright walkthrough automatico
+
+**Finding chiave**
+- Span text-only \"Connected services **BGG, Discord**\" live in profile Settings → text mention senza CTA (no network call BGG-host) MA brand esposto a user-side. **Review ADR #1903 scope** (text vs asset).
+- 4 tab labels in EN (Overview/Achievements/Activity/Settings) mentre content IT
+- `/profile/achievements` direct → redirect a `/profile?tab=achievements` (pattern wrapper, eco US-9 /chat)
+- Link \"Tutti →\" in achievements panel punta a route redirect → loop minore
+
+**Verdetto**: ⚠️ **VISUAL_DRIFT** (i18n + compliance review)
+
+**Tracking issues**: 3 nuove + 1 mockup gap (sp4-profile-achievements absent).
+
+**Next**: US-13 Marco · GameNight create wizard · `sp7-game-night-create.html`.
+
+---
+
+### US-13 — ✅ PASS — 2026-06-11
+
+**Persona / scope**: Marco · GameNight create wizard (4-step)
+**Mockup**: `sp7-game-night-create.html` (coverage 4/4 100% per gap report)
+**Routes verificate**: `/game-nights/new?step=1`, `/game-nights/new?step=2` (step 2 visited)
+**Modalità**: Playwright walkthrough automatico
+
+**Findings**: ✅ Tutto IT consistent · ✅ wizard 4-step (Quando/Dove/Chi/Cosa) · ✅ validation funzionale (Avanti disabled fino a datetime valido) · ✅ live preview "Anteprima invito" aggiornata in real-time ("ven 12 giu, 19:00") · ✅ step URL `?step={N}` shareable · ✅ CTA RSVP preview disabled coerentemente (preview, no live action)
+
+**Tracking issues**: 0 nuove. Top-nav legacy duplicate copre da #2179/#2190.
+
+---
+
+### US-15 — ✅ PASS (not-found path) — 2026-06-11
+
+**Persona / scope**: Marco · GameNight detail + RSVP
+**Mockup**: `sp7-game-night-detail-rsvp.html`
+**Routes verificate**: `/game-nights/00000000-0000-0000-0000-000000000000` (fake ID, error path)
+**Modalità**: Playwright walkthrough automatico
+**Test gap**: 0 game-night reali nel dataset → happy path (con RSVP) untested
+
+**Findings**:
+- ✅ Not found handling: h2 "Serata non trovata" + paragraph "La serata che cerchi non esiste o è stata rimossa." + CTA "Torna al calendario" → `/game-nights`
+- ✅ IT consistent
+- ⏳ Happy path RSVP cycle (Crispin) untested — richiede seed game-night
+
+**Tracking issues**: 0 nuove. Test gap RSVP cycle restituito al backlog.
+
+---
+
+---
+
+---
+
+---
+
+---
+
+---
 
 ---

--- a/docs/superpowers/plans/2026-06-11-p0-delivery-plan.md
+++ b/docs/superpowers/plans/2026-06-11-p0-delivery-plan.md
@@ -1,0 +1,319 @@
+# P0 Delivery Plan — US Validation Sweep 2026-06-11
+
+**Status**: Draft for execution (UPDATED post Gate 0 — 1 P0 retired)
+**Created**: 2026-06-11
+**Updated**: 2026-06-11 (Gate 0 outcome)
+**Origin**: `/sc:spec-panel` triage post US validation sweep (10/10 US, 30 issue, 4 P0 → **3 P0**)
+**Owner suggestion**: Tech lead + product owner co-pilot
+
+## 🎯 Gate 0 outcome (2026-06-11)
+
+**#2184 closed as INVALID** post empirical verification with non-admin user (`test@meepleai.com`):
+- Code review: `LibraryHub.tsx:485,546` role-gates `onImportBgg` via `isAdminOrAbove`; `LibraryHeroDesktop.tsx:231` conditional render → button NOT rendered for non-admins
+- Empirical: DOM scan `/import.*bgg/i` returns 0 elements for User role
+- Falso positive during US-10 validation (tested as admin@meepleai.app — admin BGG access is LEGIT per ADR-059)
+- **#1975 fix (closed 2026-06-07) is valid and shipped**
+
+### Impact on this plan
+
+| Track | Before Gate 0 | After Gate 0 |
+|---|---|---|
+| Track B (Compliance) | Active, paired PR + Gate 0 + E2E | **RETIRED** — no live bug |
+| #2185 (mockup) | P2 reclassification | Downgrade to P3 — mockup drift minor (mockup shows "admin view" implicit) |
+| Total P0 | 4 | **3** (#2168, #2176, #2194 umbrella) |
+| Timeline parallel | 7gg | **~5-6gg** |
+| Owner Track B (frontend-architect + designer) | Allocated | Reassigned to support Track C (#2176 fix) |
+
+**Lesson learned (added to mistakes log)**: validate role-based UI variations BEFORE opening P0 compliance issues. Fowler's spec-panel warning ("Don't conflate label drift with feature drift") was prescient.
+
+---
+
+## Executive summary
+
+4 P0 issue identificati durante la validazione US (vedi `audits/us-verification-log.md`). Spec-panel critique ha refined severity e DoD per ciascuna + decomposed #2194 in 3 sub-issue. **Parallel execution riduce ETA da ~15gg sequenziali a ~7gg con 4 track concorrenti** + 1 cross-cutting observability stream.
+
+### Priority ranking (locked post spec-panel)
+
+| # | Issue | Refined sev | Effort | Order | Track |
+|---|---|---|---|---|---|
+| 1 | #2168 — Login open redirect | P0 CRITICAL | S (1-2gg) | 1st | A — Security |
+| 2 | #2184 — `/library` BGG ToS LIVE | P0 CRITICAL+LEGAL | S-M (½-2gg) | 2nd | B — Compliance |
+| 3 | #2176 — Dashboard data inconsistency | P1 surface / P0 substrate | M (3-5gg) | 3rd | C — Data integrity |
+| 4 | #2203/2204/2205 — Game detail tab orphan | P0 BLOCKING decision | L (5-10gg) | 4th | D — Architecture |
+| Cross | Observability hooks (Nygard) | P1 | S parallel | — | E — Cross-cutting |
+
+---
+
+## Dependencies & blockers
+
+```
+Track A (Security)         : #2168 ─┐
+                                    ├─► shared helper url-safety.ts ──► #2182 (P3 sister)
+Track B (Compliance)       : Gate 0 (15min prod check)
+                              ├─► IF prod-affected: rollback + IR escalation
+                              └─► IF dev-only: paired PR #2184 + #2185 (mockup)
+Track C (Data integrity)   : #2176 instrument ──► root cause ──► fix + contract test
+                                                                  │
+                                                                  └─► sister echo: #2184 hero counter
+Track D (Architecture)     : #2203 (decision meeting + ADR) ──┬──► #2204 (impl, M-L)
+                                                              │
+                              #2205 (i18n) ──parallel──────────┘
+                                                              ▼
+                                                       #2195 BE 404 + #2197 UX + #2198 mockup
+                                                       (resolution depends on decision A/B/C)
+Track E (Observability)    : Prometheus metrics for silent failures
+                              ├─► #2168: meepleai_auth_redirect_rejected_total
+                              ├─► #2184: meepleai_bgg_url_attempted_render_total (existing, SLO=0)
+                              ├─► #2176: meepleai_dashboard_section_hidden_total
+                              └─► #2204: meepleai_api_404_total{expected}
+```
+
+---
+
+## Track-by-track plan
+
+### Track A — Security (1-2gg)
+
+**Owner**: security-engineer + frontend-architect
+**Blocks**: nothing (start immediately)
+**Unblocks**: #2182 (notifications defensive validation)
+
+**Tasks**:
+1. **A.1** — Extract `apps/web/src/lib/url-safety.ts` shared helper (½gg)
+   - `isSafeRelativeLink(link: string): boolean`
+   - Reject 8 attack vectors enumerated by Wiegers
+   - Unit test parametrized su 8 vectors
+2. **A.2** — Apply helper in #2168 (½gg)
+   - `(auth)/login/_content.tsx:62`: replace inline `targetUrl = from` with `targetUrl = isSafeRelativeLink(from) ? from : '/library'`
+   - Replicate in `/register`, `/reset-password`, OAuth callback
+3. **A.3** — Audit log entry (Nygard) (¼gg)
+   - Backend endpoint logs `{event: 'LoginRedirectRejected', reason, fromMasked}`
+4. **A.4** — Defense in depth: `Referrer-Policy: strict-origin` middleware (¼gg)
+5. **A.5** — E2E test `auth-redirect-safety.spec.ts` con 8 vectors (½gg)
+6. **A.6** — Apply helper in #2182 (notifications) — closes sister (¼gg)
+
+**DoD gate**: 8 attack vectors green in CI + audit log entry visible in Seq + 1 PR closes #2168 + #2182
+
+### Track B — Compliance (½-2gg)
+
+**Owner**: frontend-architect + designer (paired PR)
+**Blocks**: Gate 0 (15min) BEFORE any code
+**Unblocks**: #2185 (mockup reclassification)
+
+**Tasks**:
+1. **B.0** — Gate 0 prod/staging check (15min)
+   - `gh search code "Importa BGG" --owner=meepleAi-app --branch=main`
+   - `gh search code "Importa BGG" --owner=meepleAi-app --branch=main-staging`
+   - If LIVE on prod: SECURITY-INCIDENT triggered → rollback IR + freeze track B until cleared
+   - If dev-only: proceed B.1
+2. **B.1** — Disambiguate label vs feature (Fowler) (½gg)
+   - Read click handler → label-only or feature-active?
+   - If label-only: B.2 (rename)
+   - If feature-active: B.3 (full removal + telemetry)
+3. **B.2** — Paired PR: dev + mockup (Newman) — label-only path (1gg)
+   - `apps/web/src/app/(authenticated)/library/page.tsx`: rename CTA
+   - `admin-mockups/design_files/sp4-library-desktop.{html,jsx}`: rename CTA
+   - `sp4-library-desktop.fidelity.json`: reclassify if button structurally changed
+4. **B.3** — Full removal path (1-2gg) — only if feature-active
+   - Telemetry: confirm 0 historical user clicks (search Seq logs)
+   - Same as B.2 + remove handler + reverse code path
+5. **B.4** — ESLint extension (Wiegers) (¼gg)
+   - Rule `local/no-bgg-host` deve catturare button TEXT `/import.*bgg/i` non solo URL
+   - Aggiungere a `pnpm lint:bgg` gate
+6. **B.5** — E2E + Prometheus SLO assertion (Adzic) (½gg)
+   - `apps/web/e2e/library-bgg-compliance.spec.ts`:
+     - No DOM `/import.*bgg/i` text
+     - No network call a `*.geekdo.com|*.boardgamegeek.com`
+   - Prometheus `meepleai_bgg_url_attempted_render_total` SLO=0
+
+**DoD gate**: Gate 0 cleared + paired PR merged + ESLint extension green + E2E + Prometheus SLO=0
+
+### Track C — Data integrity (3-5gg)
+
+**Owner**: backend-architect + frontend
+**Blocks**: nothing (start parallel with A)
+**Unblocks**: #2184 hero counter consistency (cross-eco)
+
+**Tasks**:
+1. **C.1** — Instrumentation first (Fowler) (1gg)
+   - React Query DevTools dump per `useGames` + `useLibraryStats`
+   - EF Core query log enable: `Microsoft.EntityFrameworkCore.Database.Command` → Information
+   - Compare SQL output (filter, joins, soft-delete predicates)
+2. **C.2** — Hypothesis confirmation (Fowler) (1-2gg)
+   - Test H1: `useGames` queries shared catalog vs `useLibraryStats` queries personal UserLibrary
+   - Test H2: EF Core soft-delete filter disparità
+   - Test H3: TanStack Query cache key collision
+3. **C.3** — CQRS read-model audit (Newman) (½gg)
+   - Cross-context: GameManagement vs UserLibrary 'totalGames' ownership
+   - MediatR event flow validation
+   - Document in CLAUDE.md § DDD bounded contexts
+4. **C.4** — Fix + observability (1gg)
+   - Apply fix per root cause confirmed
+   - Add dev warning: `console.warn('[SuggestedSection] hidden because gamesQuery returned 0 items, but useLibraryStats reports {totalGames}.')`
+   - Add Prometheus metric: `meepleai_dashboard_section_hidden_total{section, reason}`
+5. **C.5** — Cross-endpoint contract test (Adzic) (½gg)
+   - `Api.Tests.Integration.DashboardConsistencyTests`
+   - Given user 3 games → both endpoints + SuggestedSection ≥1 card
+
+**DoD gate**: Root cause documented + fix shipped + contract test green + Prometheus SLO defined
+
+### Track D — Architecture (5-10gg)
+
+**Owner**: product owner (D.1) + tech lead (D.2) + frontend-architect (D.3)
+**Blocks**: D.1 BLOCKS D.2; D.3 PARALLEL
+**Unblocks**: #2195 BE 404 + #2197 UX + #2198 mockup commission
+
+#### D.1 — #2203 Product decision (1gg)
+1. **D.1.1** — Pull analytics: orphan URL hits last 30gg
+2. **D.1.2** — Sync decision meeting (1h):
+   - Opzione A (route-driven 7 tab): Info/Regole/FAQ/Recensioni/Sessioni/Strategie/Chat → backend wire required, breaks muscle memory
+   - Opzione B (UI-driven 7 tab, remove orphan): Info/Regole/FAQ/Partite/Statistiche/Agenti/Documenti → simpler, removes features
+   - Opzione C (hybrid 5+dropdown): preserves all, complex
+3. **D.1.3** — ADR commit `docs/for-claude/architecture/adr/adr-{N}-game-detail-tab-canonical.md` (2h)
+4. **D.1.4** — Decision communicated to designer (for #2198 mockup commission alignment)
+
+#### D.2 — #2204 Implementation (3-7gg, depends on D.1)
+1. **D.2.1** — Tab nav config aligned (Opzione A/B/C-specific)
+2. **D.2.2** — Routes orphan handled (kept w/ BE wire OR removed OR moved to dropdown)
+3. **D.2.3** — Lint rule (Fowler): file-system route vs nav entry parity (½gg)
+4. **D.2.4** — E2E test ogni tab navigation
+5. **D.2.5** — Visual conformance to #2198 mockup (post-delivery)
+6. **D.2.6** — Sister issue resolution: #2195 (close or update), #2197 (coordinated)
+
+#### D.3 — #2205 i18n cleanup (½gg PARALLEL)
+1. **D.3.1** — Grep audit: `grep -r 'pages.gameDetail' apps/web/messages/`
+2. **D.3.2** — Add missing keys (it.json/en.json)
+3. **D.3.3** — Unit test no-missing-key fallback
+
+**DoD gate**: ADR committed + tab nav allineata + lint rule CI gate + sister issues coordinated + i18n keys green
+
+### Track E — Cross-cutting observability (Nygard)
+
+**Owner**: backend-architect (parallel with A/B/C/D)
+**Blocks**: nothing (additive)
+
+**Recurring theme spotted dal panel**: 4 P0 share **silent failure modes**. Leverage point = observability hooks at failure boundary.
+
+**Tasks**:
+1. **E.1** — Prometheus metrics catalog (½gg)
+   - `meepleai_auth_redirect_rejected_total{reason}` (Track A)
+   - `meepleai_bgg_url_attempted_render_total` (existing, SLO=0)
+   - `meepleai_dashboard_section_hidden_total{section, reason}` (Track C)
+   - `meepleai_api_404_total{endpoint, expected}` (Track D)
+2. **E.2** — Grafana dashboard `Silent failure monitor` (½gg)
+3. **E.3** — Alertmanager rules: SLO breach on any metric (½gg)
+4. **E.4** — Documentation: CLAUDE.md § Observability conventions
+
+**DoD gate**: All 4 metrics emitting in dev + Grafana panel + alert rules → silent failures NOT silent anymore
+
+---
+
+## Timeline (parallel execution)
+
+```
+Day 0 (today):
+  ├─ Track B: Gate 0 prod check (15min) ⚠️
+  ├─ Track A: A.1 helper extraction starts
+  ├─ Track C: C.1 instrumentation starts
+  ├─ Track D: D.1.1 analytics pull + D.1.2 meeting scheduled, D.3 starts parallel
+  └─ Track E: E.1 metrics catalog drafted
+
+Day 1:
+  ├─ Track A: A.2-A.5 (helper applied + audit log + E2E)
+  ├─ Track B: B.1 disambiguate + B.2/B.3 paired PR drafted
+  ├─ Track C: C.2 hypothesis confirmation
+  ├─ Track D: D.1.2 meeting → D.1.3 ADR drafted
+  └─ Track E: E.2 Grafana panel
+
+Day 2:
+  ├─ Track A: A.6 (#2182) + PR merge ✅
+  ├─ Track B: PR merge + ESLint + E2E ✅
+  ├─ Track C: C.3 CQRS audit + C.4 fix start
+  ├─ Track D: D.1.3 ADR commit → D.2.1 impl starts
+  └─ Track E: E.3 alerts
+
+Day 3-4:
+  ├─ Track C: C.4 fix + C.5 contract test ✅
+  ├─ Track D: D.2.2-D.2.4 implementation continues
+  └─ Track E: E.4 docs + validation
+
+Day 5-7:
+  ├─ Track D: D.2.5 visual conformance (post #2198 mockup) + D.2.6 sister resolution ✅
+  └─ Final integration + observability verification
+
+Day 7: All 4 P0 closed + 13 sub-issue resolution path clear
+```
+
+**Critical path**: Track D (5-10gg post decision) — biggest tail risk.
+
+**Compression vs sequential**: ~7gg parallel vs ~15gg sequential = **53% saving**.
+
+---
+
+## Risk register
+
+| ID | Risk | Probability | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | Gate 0 reveals BGG button LIVE on prod | LOW | CRITICAL | IR playbook ready; rollback procedure documented; track B frozen until cleared |
+| R2 | #2176 hypothesis H1/H2 wrong (deeper CQRS bug) | MED | MED | Budget +2gg for additional investigation; escalate to backend architect |
+| R3 | Product decision #2203 delayed | MED | HIGH | Schedule meeting Day 0; tech lead empowered to lock decision if PM unavailable |
+| R4 | #2168 8 attack vectors expose deeper auth weakness | LOW | HIGH | Adversarial testing parametrized; security-engineer review before merge |
+| R5 | #2184 paired PR uncoordinated (mockup vs dev drift) | LOW | MED | Single PR enforces atomic delivery |
+| R6 | Track A helper extraction breaks existing redirects | LOW | MED | Parametrized regression suite on all redirect entry points |
+| R7 | Prometheus metric naming drift vs existing conventions | LOW | LOW | Validate against existing `meepleai_*` metrics naming convention |
+
+---
+
+## Cross-cutting recommendations (Meadows systems pattern)
+
+> Spec-panel rilevò che 4 P0 condividono root cause sistemico: **silent failure modes**. Fixing one-by-one tratta sintomi. Track E è la **leverage intervention**.
+
+1. **Observability-first culture**: ogni nuovo silent fallback DEVE emettere metrica + log.
+2. **Architecture review per pattern simili**: identificare altri silent fallback in monorepo (`grep -rn 'return null' apps/web/src/`) — backlog item.
+3. **CI gate: silent failure SLO**: nuove regressioni P0 dovrebbero triggerare SLO breach prima del bug report umano.
+4. **Spec-panel come quality gate ricorrente**: dopo ogni US validation sweep, refine i P0 con spec-panel critique (pattern validato in questa sessione).
+
+---
+
+## Owner suggestions
+
+| Track | Lead | Support |
+|---|---|---|
+| A — Security | security-engineer | frontend-architect |
+| B — Compliance | frontend-architect | designer |
+| C — Data integrity | backend-architect | frontend |
+| D.1 — Product decision | product owner | tech lead |
+| D.2 — Implementation | frontend-architect | backend-architect |
+| D.3 — i18n | i18n-specialist | — |
+| E — Observability | backend-architect | platform team |
+
+---
+
+## DoD finale (sign-off criteria)
+
+P0 delivery batch considered complete when:
+
+- [ ] 4 P0 issue marked closed (#2168 #2184 #2176 + #2204 closes #2194 umbrella)
+- [ ] 6 sub/sister issue resolution path documented (#2182 #2185 #2195 #2197 #2198 #2205)
+- [ ] 4 Prometheus metrics emitting + Grafana panel + alert rules
+- [ ] CLAUDE.md updated:
+  - § Observability conventions (Track E)
+  - § Game detail tab canonical (post #2203 ADR)
+  - § BGG enforcement rule extension (Track B)
+- [ ] ESLint `local/no-bgg-host` extended con button text rule
+- [ ] E2E suite: auth redirect safety + library BGG compliance + dashboard consistency + game detail tab nav
+- [ ] All sister P3/P2 issues either closed (defensive fix shipped) or backlog-tagged
+
+---
+
+## Refs
+
+- US verification log: `audits/us-verification-log.md`
+- Spec-panel critique (this conversation, 2026-06-11)
+- ADR-001 ↔ ADR-010 (DDD bounded contexts)
+- CLAUDE.md § Active Freezes (BGG asset ban #2123 + ADR #1903)
+- Memory: A11y baseline #1094 (a11y patterns informing #2169)
+
+---
+
+**Sign-off pending**: tech lead + product owner review.

--- a/docs/superpowers/plans/2026-06-11-track-a-url-safety.md
+++ b/docs/superpowers/plans/2026-06-11-track-a-url-safety.md
@@ -1,0 +1,720 @@
+# Track A — URL Safety Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #2168 (login open redirect) + #2182 (notifications defensive validation) by extracting a shared `url-safety.ts` helper that validates `?from=` query params and `detail.link` values against 8 attack vectors.
+
+**Architecture:** Single helper module `apps/web/src/lib/url-safety.ts` exports `isSafeRelativeLink(link: string): boolean`. All redirect consumers (login content, register content, notifications page, OAuth callback) call the helper before passing to `router.push()` / `window.location.assign()`. Failure mode: log via existing `logger` + fallback to safe default (`/library`). Defense in depth: `Referrer-Policy: strict-origin` header added to `proxy.ts` middleware.
+
+**Tech Stack:** TypeScript · Next.js 16 App Router (`useSearchParams` + `useRouter`) · Vitest (unit) · Playwright (E2E) · existing logger pattern (`apps/web/src/lib/logger.ts`)
+
+**Branch:** `feature/issue-2168-url-safety` from `main-dev` parent
+
+**Closes:** #2168, #2182
+
+---
+
+## File Structure
+
+| File | Role | Action |
+|---|---|---|
+| `apps/web/src/lib/url-safety.ts` | Exports `isSafeRelativeLink(link)` + `assertSafeRelativeOrFallback(link, fallback)` | **CREATE** |
+| `apps/web/src/lib/__tests__/url-safety.test.ts` | Vitest unit tests, 8 attack vectors parametrized + happy path | **CREATE** |
+| `apps/web/src/app/(auth)/login/_content.tsx` | `redirectAfterAuth` uses helper | **MODIFY** L45-69 |
+| `apps/web/src/app/(authenticated)/notifications/page.tsx` | `Apri` CTA uses helper before `window.location.assign(detail.link)` | **MODIFY** L389-401 |
+| `apps/web/src/app/(auth)/register/_content.tsx` | Verify whether `searchParams.get('from')` used post-register; apply helper if yes | **VERIFY + MODIFY** (line 45 reads searchParams) |
+| `apps/web/src/proxy.ts` | Add `Referrer-Policy: strict-origin` header to all responses | **MODIFY** middleware response builder |
+| `apps/web/e2e/auth-redirect-safety.spec.ts` | E2E 8 attack vectors against `/login?from=...` | **CREATE** |
+| `apps/web/src/app/(auth)/login/__tests__/_content.test.tsx` | Existing unit tests — verify still pass after change | **VERIFY** |
+
+---
+
+## Task 1: Helper module — write failing test
+
+**Files:**
+- Create: `apps/web/src/lib/__tests__/url-safety.test.ts`
+
+- [ ] **Step 1.1: Write the failing test**
+
+```typescript
+// apps/web/src/lib/__tests__/url-safety.test.ts
+import { describe, it, expect } from 'vitest';
+import { isSafeRelativeLink, assertSafeRelativeOrFallback } from '@/lib/url-safety';
+
+describe('isSafeRelativeLink', () => {
+  describe('SAFE inputs (return true)', () => {
+    it.each([
+      ['/library'],
+      ['/sessions/abc-123/scores'],
+      ['/games?tab=discover'],
+      ['/profile#settings'],
+      ['/'],
+    ])('accepts safe relative path: %s', (input) => {
+      expect(isSafeRelativeLink(input)).toBe(true);
+    });
+  });
+
+  describe('UNSAFE inputs (return false) — 8 attack vectors', () => {
+    it.each([
+      ['https://evil.com',         'absolute external'],
+      ['http://evil.com/path',     'absolute external http'],
+      ['//evil.com',               'protocol-relative'],
+      ['\\\\evil.com',             'Windows path'],
+      ['javascript:alert(1)',      'scheme injection'],
+      ['data:text/html,<script>',  'data URI'],
+      ['%2F%2Fevil.com',           'encoded protocol-relative'],
+      ['  //evil.com',             'whitespace bypass'],
+    ])('rejects %s (%s)', (input) => {
+      expect(isSafeRelativeLink(input)).toBe(false);
+    });
+  });
+
+  describe('EDGE inputs (return false defensively)', () => {
+    it.each([
+      [''],
+      ['null'],
+      ['undefined'],
+    ])('rejects edge input: %s', (input) => {
+      expect(isSafeRelativeLink(input)).toBe(false);
+    });
+  });
+});
+
+describe('assertSafeRelativeOrFallback', () => {
+  it('returns input when safe', () => {
+    expect(assertSafeRelativeOrFallback('/library', '/dashboard')).toBe('/library');
+  });
+
+  it('returns fallback when unsafe', () => {
+    expect(assertSafeRelativeOrFallback('https://evil.com', '/dashboard')).toBe('/dashboard');
+  });
+
+  it('returns fallback when null/undefined', () => {
+    expect(assertSafeRelativeOrFallback(null, '/dashboard')).toBe('/dashboard');
+    expect(assertSafeRelativeOrFallback(undefined, '/dashboard')).toBe('/dashboard');
+  });
+
+  it('returns fallback when empty string', () => {
+    expect(assertSafeRelativeOrFallback('', '/dashboard')).toBe('/dashboard');
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm test -- url-safety`
+Expected: FAIL with `Cannot find module '@/lib/url-safety'` or equivalent module-not-found error.
+
+## Task 2: Helper module — implement minimal
+
+**Files:**
+- Create: `apps/web/src/lib/url-safety.ts`
+
+- [ ] **Step 2.1: Write minimal implementation**
+
+```typescript
+// apps/web/src/lib/url-safety.ts
+/**
+ * URL safety validation for client-side redirects.
+ *
+ * Prevents open redirect attacks by ensuring `?from=` query params and
+ * notification deep links are restricted to same-origin relative paths.
+ *
+ * Closes #2168 (login open redirect) + #2182 (notifications defensive validation).
+ *
+ * Attack vectors rejected:
+ *   1. absolute external (https://evil.com)
+ *   2. absolute external http (http://evil.com)
+ *   3. protocol-relative (//evil.com)
+ *   4. Windows path (\\evil.com)
+ *   5. scheme injection (javascript:, data:)
+ *   6. data URI (data:text/html,...)
+ *   7. encoded protocol-relative (%2F%2Fevil.com)
+ *   8. whitespace bypass ("  //evil.com")
+ */
+
+/**
+ * Returns true only for safe same-origin relative URL paths.
+ *
+ * Safe: starts with `/`, does NOT start with `//`, does NOT contain `\\`,
+ * does NOT contain `:` before the first `/`, does NOT start with whitespace.
+ */
+export function isSafeRelativeLink(link: string | null | undefined): boolean {
+  if (typeof link !== 'string' || link.length === 0) return false;
+
+  // No leading whitespace
+  if (link[0] === ' ' || link[0] === '\t') return false;
+
+  // Must start with a single `/`
+  if (link[0] !== '/') return false;
+
+  // Reject protocol-relative `//evil.com`
+  if (link[1] === '/') return false;
+
+  // Reject Windows path `\\evil.com` (after the leading `/` it's `/\\evil.com`)
+  if (link[1] === '\\') return false;
+
+  // Reject encoded protocol-relative `%2F%2F`
+  const decoded = (() => {
+    try { return decodeURIComponent(link); }
+    catch { return link; }
+  })();
+  if (decoded.startsWith('//')) return false;
+  if (decoded.startsWith('/\\\\')) return false;
+
+  // Reject scheme injection: any `:` before first `/` is suspicious
+  const firstSlash = link.indexOf('/', 1);
+  const firstColon = link.indexOf(':');
+  if (firstColon !== -1 && (firstSlash === -1 || firstColon < firstSlash)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns input when safe, otherwise fallback.
+ *
+ * Use this at every consumer site so the validation policy is consistent.
+ */
+export function assertSafeRelativeOrFallback(
+  link: string | null | undefined,
+  fallback: string
+): string {
+  return isSafeRelativeLink(link) ? (link as string) : fallback;
+}
+```
+
+- [ ] **Step 2.2: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm test -- url-safety`
+Expected: PASS — all `describe` blocks green, including 8 attack vectors + 5 safe paths + 4 edge cases.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git checkout -b feature/issue-2168-url-safety
+git add apps/web/src/lib/url-safety.ts apps/web/src/lib/__tests__/url-safety.test.ts
+git commit -m "feat(security): add url-safety helper for relative-link validation (#2168)"
+```
+
+---
+
+## Task 3: Apply helper to login `_content.tsx`
+
+**Files:**
+- Modify: `apps/web/src/app/(auth)/login/_content.tsx:45-69`
+
+- [ ] **Step 3.1: Verify existing tests pass first**
+
+Run: `cd apps/web && pnpm test -- login/_content`
+Expected: PASS (baseline) — note any test names for use in 3.4.
+
+- [ ] **Step 3.2: Modify `redirectAfterAuth` to use helper**
+
+Find current code (line 45 + line 56-69):
+
+```typescript
+const from = searchParams?.get('from') ?? '/library';
+// ...
+const redirectAfterAuth = useCallback(
+  async (_role: string | null | undefined) => {
+    const targetUrl = from;
+    await new Promise(resolve => setTimeout(resolve, 100));
+    router.refresh();
+    await router.push(targetUrl);
+  },
+  [from, router]
+);
+```
+
+Replace with:
+
+```typescript
+import { assertSafeRelativeOrFallback } from '@/lib/url-safety';
+// ... (keep other imports)
+
+// Issue #2168: validate ?from= against open-redirect attack vectors.
+// `assertSafeRelativeOrFallback` rejects 8 attack vectors and falls back to /library.
+const rawFrom = searchParams?.get('from');
+const from = assertSafeRelativeOrFallback(rawFrom, '/library');
+const isSessionExpired = searchParams?.get('reason') === 'session_expired';
+
+// Log when the input was unsafe so we can detect attack attempts.
+if (typeof rawFrom === 'string' && rawFrom.length > 0 && rawFrom !== from) {
+  logger.warn('Rejected unsafe ?from= redirect target on login', {
+    fromMasked: rawFrom.slice(0, 32),
+  });
+}
+```
+
+Keep `redirectAfterAuth` unchanged (the `from` variable now holds the validated value).
+
+- [ ] **Step 3.3: Write/update test for login open redirect rejection**
+
+In `apps/web/src/app/(auth)/login/__tests__/_content.test.tsx` (or create if missing — verify file existence first with `ls apps/web/src/app/\(auth\)/login/__tests__/`), add:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { LoginPageContent } from '../_content';
+import * as nav from 'next/navigation';
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn(),
+  useRouter: vi.fn(),
+}));
+
+describe('LoginPageContent — open redirect protection (#2168)', () => {
+  it('falls back to /library when ?from= is external URL', async () => {
+    const push = vi.fn();
+    vi.mocked(nav.useRouter).mockReturnValue({ push, refresh: vi.fn() } as any);
+    vi.mocked(nav.useSearchParams).mockReturnValue({
+      get: (key: string) => (key === 'from' ? 'https://evil.com' : null),
+    } as any);
+
+    // ... (render + simulate successful login; mock api.auth.login if needed)
+    // Assert: push called with '/library', NOT 'https://evil.com'
+  });
+
+  it('preserves valid relative ?from= path', async () => {
+    const push = vi.fn();
+    vi.mocked(nav.useRouter).mockReturnValue({ push, refresh: vi.fn() } as any);
+    vi.mocked(nav.useSearchParams).mockReturnValue({
+      get: (key: string) => (key === 'from' ? '/sessions/abc-123' : null),
+    } as any);
+
+    // Assert: push called with '/sessions/abc-123' on successful login
+  });
+});
+```
+
+NOTE: if the existing test file already mocks `next/navigation` and login flow, extend those mocks rather than rewriting. The shape above is for a fresh file.
+
+- [ ] **Step 3.4: Run all login tests**
+
+Run: `cd apps/web && pnpm test -- login`
+Expected: PASS — including baseline tests from 3.1 + new open-redirect tests from 3.3.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/web/src/app/\(auth\)/login/_content.tsx apps/web/src/app/\(auth\)/login/__tests__/_content.test.tsx
+git commit -m "fix(auth): reject unsafe ?from= redirect targets on login (#2168)"
+```
+
+---
+
+## Task 4: Verify register and reset-password redirects
+
+**Files:**
+- Verify: `apps/web/src/app/(auth)/register/_content.tsx:45` (uses `useSearchParams`)
+- Verify: `apps/web/src/app/(auth)/reset-password/_content.tsx` (uses `useSearchParams`, hardcoded `/chat` — likely safe)
+
+- [ ] **Step 4.1: Read register `_content.tsx` and check for `?from=` usage**
+
+Run: `grep -n "searchParams" apps/web/src/app/\(auth\)/register/_content.tsx`
+
+If the file reads `?from=` and uses it for redirect (similar pattern to login), apply helper. Otherwise document no-change.
+
+- [ ] **Step 4.2: If register uses `?from=`, apply helper**
+
+Same pattern as Task 3.2:
+
+```typescript
+import { assertSafeRelativeOrFallback } from '@/lib/url-safety';
+// ...
+const rawFrom = searchParams?.get('from');
+const from = assertSafeRelativeOrFallback(rawFrom, '/library');
+// ... log unsafe input via logger.warn ...
+```
+
+If register does NOT redirect to `?from=` post-registration, skip the modification but add a comment explaining no change is needed.
+
+- [ ] **Step 4.3: Reset-password — verify hardcoded route**
+
+The `reset-password/_content.tsx` already uses `router.push('/chat')` hardcoded (no `?from=`). NO change needed. Add an inline comment to lock the policy:
+
+```typescript
+// Note (#2168): redirect target is hardcoded; do NOT introduce ?from= here
+// without using assertSafeRelativeOrFallback from @/lib/url-safety.
+```
+
+- [ ] **Step 4.4: Run all auth tests**
+
+Run: `cd apps/web && pnpm test -- "(auth)"`
+Expected: PASS — no regressions in register, reset-password, login.
+
+- [ ] **Step 4.5: Commit (only if 4.2 applied)**
+
+```bash
+git add apps/web/src/app/\(auth\)/register/_content.tsx apps/web/src/app/\(auth\)/reset-password/_content.tsx
+git commit -m "chore(auth): apply url-safety helper to register; document reset-password policy (#2168)"
+```
+
+If only documentation comments were added, single commit is fine.
+
+---
+
+## Task 5: Apply helper to notifications (#2182 sister)
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/notifications/page.tsx:389-401`
+
+- [ ] **Step 5.1: Locate the unsafe redirect**
+
+Run: `grep -n "window.location.assign" apps/web/src/app/\(authenticated\)/notifications/page.tsx`
+Expected output: line ~396 with `window.location.assign(detail.link)`.
+
+- [ ] **Step 5.2: Write failing test**
+
+Create `apps/web/src/app/(authenticated)/notifications/__tests__/redirect-safety.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { isSafeRelativeLink } from '@/lib/url-safety';
+
+describe('Notifications detail link safety (#2182)', () => {
+  it('rejects external link in detail.link', () => {
+    expect(isSafeRelativeLink('https://evil.com')).toBe(false);
+  });
+
+  it('accepts safe deep link', () => {
+    expect(isSafeRelativeLink('/library/private/abc-123/toolkit')).toBe(true);
+  });
+});
+```
+
+Run: `cd apps/web && pnpm test -- notifications/redirect-safety`
+Expected: PASS (helper already exists from Task 2 — this test verifies contract is honored).
+
+- [ ] **Step 5.3: Modify notifications page detail link handler**
+
+Find current code:
+
+```typescript
+{detail.link && (
+  <div className="px-4 pb-6">
+    <Btn
+      variant="primary"
+      entity={mapTypeToEntity(detail.type)}
+      fullWidth
+      onClick={() => {
+        if (detail.link) window.location.assign(detail.link);
+      }}
+    >
+      Apri
+    </Btn>
+  </div>
+)}
+```
+
+Replace with:
+
+```typescript
+{detail.link && (
+  <div className="px-4 pb-6">
+    <Btn
+      variant="primary"
+      entity={mapTypeToEntity(detail.type)}
+      fullWidth
+      onClick={() => {
+        // Issue #2182: defensive validation even though backend currently
+        // produces only relative paths (Notification.cs:17 audit 2026-06-11).
+        if (isSafeRelativeLink(detail.link)) {
+          window.location.assign(detail.link!);
+        } else {
+          logger.warn('Rejected unsafe detail.link in notification', {
+            linkMasked: detail.link?.slice(0, 32),
+            notificationId: detail.id,
+          });
+        }
+      }}
+    >
+      Apri
+    </Btn>
+  </div>
+)}
+```
+
+Add to imports at top of file:
+
+```typescript
+import { isSafeRelativeLink } from '@/lib/url-safety';
+import { logger } from '@/lib/logger';
+```
+
+(verify `logger` import — `apps/web/src/lib/logger.ts` exports `logger` as named export.)
+
+- [ ] **Step 5.4: Run notifications tests**
+
+Run: `cd apps/web && pnpm test -- notifications`
+Expected: PASS — including new redirect-safety test + existing notification tests.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/notifications/page.tsx apps/web/src/app/\(authenticated\)/notifications/__tests__/redirect-safety.test.tsx
+git commit -m "fix(notifications): defensive validation on detail.link before window.location.assign (#2182)"
+```
+
+---
+
+## Task 6: Defense in depth — Referrer-Policy header
+
+**Files:**
+- Modify: `apps/web/src/proxy.ts` (Next.js middleware)
+
+- [ ] **Step 6.1: Read current proxy.ts response building**
+
+Run: `grep -n "NextResponse" apps/web/src/proxy.ts`
+
+Identify where responses are returned (likely `NextResponse.next()` and `NextResponse.redirect()`). The header must be added to ALL response paths.
+
+- [ ] **Step 6.2: Add Referrer-Policy helper**
+
+At the top of `proxy.ts` (after imports, before main `middleware` export), add:
+
+```typescript
+/**
+ * Issue #2168 defense in depth: limit referrer leakage on cross-origin
+ * navigations. `strict-origin` sends only the origin (no path) on
+ * cross-origin requests, preventing query-param exfiltration (including
+ * any session-bound tokens in URL) via Referer header.
+ */
+function withSecurityHeaders<T extends NextResponse>(response: T): T {
+  response.headers.set('Referrer-Policy', 'strict-origin');
+  return response;
+}
+```
+
+- [ ] **Step 6.3: Wrap all NextResponse return sites**
+
+For every `return NextResponse.next()` change to `return withSecurityHeaders(NextResponse.next())`.
+For every `return NextResponse.redirect(...)` change to `return withSecurityHeaders(NextResponse.redirect(...))`.
+
+Search-and-verify:
+
+Run: `grep -n "return NextResponse" apps/web/src/proxy.ts`
+
+Replace each occurrence individually with an Edit operation to preserve surrounding logic.
+
+- [ ] **Step 6.4: Write integration test for header presence**
+
+Verify there are existing middleware tests under `apps/web/src/__tests__/` or `apps/web/__tests__/`. If yes, extend; if no, defer to E2E in Task 7.
+
+Search: `find apps/web -name "proxy.test.*" -o -name "middleware.test.*"`
+
+If proxy.test exists, add:
+
+```typescript
+it('adds Referrer-Policy: strict-origin to authenticated route responses', async () => {
+  const response = await middleware(mockRequest('/library', { auth: true }));
+  expect(response.headers.get('Referrer-Policy')).toBe('strict-origin');
+});
+
+it('adds Referrer-Policy: strict-origin to redirect responses', async () => {
+  const response = await middleware(mockRequest('/library', { auth: false }));
+  expect(response.headers.get('Referrer-Policy')).toBe('strict-origin');
+  // (response should also be a 302 to /login)
+});
+```
+
+If no test file, add comment in proxy.ts and rely on E2E (Task 7).
+
+- [ ] **Step 6.5: Run middleware tests**
+
+Run: `cd apps/web && pnpm test -- proxy` (or `middleware` if file is named differently)
+Expected: PASS (if test exists). Else skip — covered by E2E.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add apps/web/src/proxy.ts apps/web/src/__tests__/proxy.test.ts
+git commit -m "feat(security): add Referrer-Policy: strict-origin header in middleware (#2168 defense-in-depth)"
+```
+
+(Only include the test file if you actually wrote one.)
+
+---
+
+## Task 7: E2E Playwright test
+
+**Files:**
+- Create: `apps/web/e2e/auth-redirect-safety.spec.ts`
+
+- [ ] **Step 7.1: Write Playwright spec**
+
+```typescript
+// apps/web/e2e/auth-redirect-safety.spec.ts
+import { test, expect } from '@playwright/test';
+
+const TEST_USER = { email: 'test@meepleai.com', password: 'Meeple1280!!' };
+
+const UNSAFE_FROM_INPUTS = [
+  'https://evil.com',
+  'http://evil.com/path',
+  '//evil.com',
+  'javascript:alert(1)',
+  'data:text/html,<script>',
+  '%2F%2Fevil.com',
+];
+
+test.describe('Auth redirect safety (#2168)', () => {
+  test.beforeEach(async ({ context }) => {
+    // Start clean: no session
+    await context.clearCookies();
+  });
+
+  for (const unsafeFrom of UNSAFE_FROM_INPUTS) {
+    test(`rejects ?from=${unsafeFrom.slice(0, 40)} and falls back to /library`, async ({ page }) => {
+      await page.goto(`/login?from=${encodeURIComponent(unsafeFrom)}`);
+
+      // Dismiss cookie banner if shown (best-effort, do not fail if absent)
+      try {
+        await page.getByRole('button', { name: 'Solo essenziali' }).click({ timeout: 1500 });
+      } catch { /* banner not present, continue */ }
+
+      await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
+      await page.getByRole('textbox', { name: 'Password' }).fill(TEST_USER.password);
+      await page.getByRole('button', { name: 'Accedi' }).click();
+
+      // Should land on /library, NOT on the unsafe target
+      await expect(page).toHaveURL(/\/library(\?.*)?$/, { timeout: 5000 });
+
+      // Negative assertion: must not be on the attacker domain
+      expect(page.url()).not.toContain('evil.com');
+      expect(page.url()).not.toContain('javascript:');
+      expect(page.url()).not.toContain('data:');
+    });
+  }
+
+  test('preserves valid relative ?from path on successful login', async ({ page }) => {
+    await page.goto('/login?from=/sessions');
+
+    try { await page.getByRole('button', { name: 'Solo essenziali' }).click({ timeout: 1500 }); }
+    catch { /* skip */ }
+
+    await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
+    await page.getByRole('textbox', { name: 'Password' }).fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Accedi' }).click();
+
+    await expect(page).toHaveURL(/\/sessions(\?.*)?$/, { timeout: 5000 });
+  });
+
+  test('Referrer-Policy: strict-origin header present on /login response', async ({ page }) => {
+    const response = await page.goto('/login');
+    expect(response?.headers()['referrer-policy']).toBe('strict-origin');
+  });
+});
+```
+
+- [ ] **Step 7.2: Run Playwright test locally**
+
+Prerequisite: dev server up on `localhost:3000`.
+
+Run: `cd apps/web && pnpm test:e2e -- auth-redirect-safety`
+Expected: 8 tests PASS (6 unsafe vectors + 1 valid + 1 header check).
+
+If `test@meepleai.com` is not seeded in dev, replace with an existing seed user verified during Gate 0 (vedi `infra/secrets/admin.secret` for credentials).
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add apps/web/e2e/auth-redirect-safety.spec.ts
+git commit -m "test(e2e): auth redirect safety — 6 attack vectors + valid path + Referrer-Policy (#2168)"
+```
+
+---
+
+## Task 8: Open PR + close issues
+
+**Files:**
+- Push branch to remote, open PR targeting `main-dev`
+
+- [ ] **Step 8.1: Push branch**
+
+```bash
+git push -u origin feature/issue-2168-url-safety
+```
+
+- [ ] **Step 8.2: Open PR**
+
+```bash
+gh pr create --base main-dev --title "fix(security): reject unsafe redirect targets via shared url-safety helper (#2168, #2182)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #2168 (login open redirect P0) and #2182 (notifications defensive validation P3) by extracting a shared `isSafeRelativeLink` helper.
+
+## Changes
+
+- **New helper** `apps/web/src/lib/url-safety.ts` with `isSafeRelativeLink()` + `assertSafeRelativeOrFallback()`
+- **Login** `_content.tsx` validates `?from=` before redirect, falls back to `/library`, logs unsafe attempts via `logger.warn`
+- **Notifications** `page.tsx` validates `detail.link` before `window.location.assign`, logs unsafe attempts
+- **Middleware** `proxy.ts` adds `Referrer-Policy: strict-origin` (defense in depth)
+- **8 attack vectors** covered by unit + E2E tests
+
+## Attack vectors rejected
+
+1. `https://evil.com` (absolute external)
+2. `http://evil.com/path` (absolute external http)
+3. `//evil.com` (protocol-relative)
+4. `\\evil.com` (Windows path)
+5. `javascript:alert(1)` (scheme injection)
+6. `data:text/html,...` (data URI)
+7. `%2F%2Fevil.com` (encoded protocol-relative)
+8. `  //evil.com` (whitespace bypass)
+
+## Test plan
+
+- [x] Unit tests pass: `pnpm test -- url-safety` (8 attack + 5 safe + 4 edge)
+- [x] Unit tests pass: `pnpm test -- "(auth)"` (login + register + reset-password)
+- [x] Unit tests pass: `pnpm test -- notifications`
+- [x] E2E pass: `pnpm test:e2e -- auth-redirect-safety` (6 vectors + valid + header)
+- [x] Manual smoke: login with `?from=https://example.com/evil` → lands on `/library` ✅
+- [x] Manual smoke: login with `?from=/sessions` → lands on `/sessions` ✅
+
+## Refs
+
+- Audit: `audits/us-verification-log.md` § US-2
+- Spec-panel critique: this conversation, 2026-06-11
+- Delivery plan: `docs/superpowers/plans/2026-06-11-p0-delivery-plan.md` Track A
+- Sister issue: #2182 (closed by this PR)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8.3: Verify PR checks and merge readiness**
+
+Run: `gh pr checks`
+Expected: all CI checks green (lint, unit, build, type-check, E2E if configured).
+
+- [ ] **Step 8.4: Manual review checkpoint**
+
+Before merge, request review and verify the helper is consumed by ALL `?from=` consumers (use `grep`):
+
+Run: `grep -rn "searchParams.*get..'from'" apps/web/src/`
+
+Each result should either (a) use `assertSafeRelativeOrFallback` or (b) have a comment explaining why no validation is needed.
+
+---
+
+## Self-Review Checklist (post-plan)
+
+- [x] **Spec coverage**: 8 attack vectors → unit Task 1 + E2E Task 7 covers 6 of 8 (whitespace bypass + edge inputs are unit-only — acceptable since they're caught before reaching browser)
+- [x] **Shared helper**: extracted in Task 2, applied in Tasks 3, 4, 5
+- [x] **Defense in depth**: Referrer-Policy in Task 6
+- [x] **No placeholders**: all code blocks complete, no "TBD" or "TODO"
+- [x] **Type consistency**: `isSafeRelativeLink` used identically in helper + login + notifications + E2E
+- [x] **Commit cadence**: 1 commit per task, ~6 commits total → matches "frequent commits" principle
+- [x] **Closes #2168 + #2182** declared in PR body
+- [x] **TDD discipline**: every implementation task starts with a failing test
+
+## Refs
+
+- Issue: #2168 (P0 CRITICAL) + #2182 (P3 sister)
+- Spec-panel refinement: see #2168 comment 4682302774
+- Delivery plan: `docs/superpowers/plans/2026-06-11-p0-delivery-plan.md`
+- Audit log: `audits/us-verification-log.md` § US-2

--- a/docs/superpowers/plans/2026-06-11-track-a-url-safety.md
+++ b/docs/superpowers/plans/2026-06-11-track-a-url-safety.md
@@ -549,7 +549,10 @@ git commit -m "feat(security): add Referrer-Policy: strict-origin header in midd
 // apps/web/e2e/auth-redirect-safety.spec.ts
 import { test, expect } from '@playwright/test';
 
-const TEST_USER = { email: 'test@meepleai.com', password: 'Meeple1280!!' };
+const TEST_USER = {
+  email: process.env.PLAYWRIGHT_TEST_USER_EMAIL ?? 'test@meepleai.com',
+  password: process.env.PLAYWRIGHT_TEST_USER_PASSWORD ?? '',
+};
 
 const UNSAFE_FROM_INPUTS = [
   'https://evil.com',
@@ -616,7 +619,7 @@ Prerequisite: dev server up on `localhost:3000`.
 Run: `cd apps/web && pnpm test:e2e -- auth-redirect-safety`
 Expected: 8 tests PASS (6 unsafe vectors + 1 valid + 1 header check).
 
-If `test@meepleai.com` is not seeded in dev, replace with an existing seed user verified during Gate 0 (vedi `infra/secrets/admin.secret` for credentials).
+Credentials must be passed via env vars `PLAYWRIGHT_TEST_USER_EMAIL` + `PLAYWRIGHT_TEST_USER_PASSWORD`. CI provides them via secrets store; local devs source from `infra/secrets/admin.secret`. Do NOT hardcode passwords in the spec — see commit `e333e6991` for the original violation and the env-var refactor.
 
 - [ ] **Step 7.3: Commit**
 


### PR DESCRIPTION
## Summary

Closes #2168 (login open redirect, P0 CRITICAL) and #2182 (notifications defensive validation, P3 sister) by extracting a shared `isSafeRelativeLink` / `assertSafeRelativeOrFallback` helper applied across all `(auth)` and notification redirect surfaces, plus `Referrer-Policy: strict-origin` header in middleware for defense in depth.

## Scope (broader than original plan)

Spec-panel code review on each task uncovered additional unguarded redirect consumers beyond the original 2 issues. All consumers in the user-facing redirect surface are now guarded by the same helper.

**Guarded surfaces:**
- `login/_content.tsx` — `?from=` query param (Task B, useEffect-wrapped warn)
- `register/_content.tsx` — audit comment (no `?from=` consumer, hardcoded redirect)
- `reset-password/_content.tsx` — policy comment (hardcoded redirects, do not introduce `?from=`)
- `welcome/_content.tsx` — `?redirectTo=` query param (Task C unplanned security fix)
- `notifications/page.tsx` — `detail.link` in `window.location.assign` (Task D)
- `NotificationCenter.tsx` — `notification.link` in `router.push` + `<Link href>` (Task D follow-up)
- `NotificationItem.tsx` — `target` from `notification.link ?? deepLink` (Task D follow-up)
- `proxy.ts` middleware — `Referrer-Policy: strict-origin` on all response paths (Task E)

**Deferred (tracking issues):**
- `VerificationSuccess.tsx` `redirectUrl` prop — latent risk, no active exposure, tracked in #2217

## Attack vectors rejected by the helper

The helper `isSafeRelativeLink` rejects 10+ attack vectors enumerated through TDD + spec-panel critique iterations:

1. `https://evil.com` (absolute external)
2. `http://evil.com/path` (absolute external http)
3. `//evil.com` (protocol-relative)
4. `\evil.com` (Windows path)
5. `javascript:alert(1)` (scheme injection)
6. `data:text/html,...` (data URI)
7. `%2F%2Fevil.com` (encoded protocol-relative)
8. `  //evil.com` (whitespace bypass)
9. `/\t//evil.com` (control character bypass, browser URL normalization strips and exposes following `//`)
10. `/%252F%252Fevil.com` (double-encoded protocol-relative, iteratively decoded)

## Test plan

- [x] Unit: `cd apps/web && pnpm test -- url-safety` (27 tests covering all vectors + safe paths + edge cases)
- [x] Unit: `cd apps/web && pnpm test -- "(auth)"` (62 tests: login + register + reset-password + welcome + verify-email + verification-pending)
- [x] Unit: `cd apps/web && pnpm test -- notifications` (62 tests including handler-level + helper contract)
- [x] E2E: `cd apps/web && pnpm test:e2e -- auth-redirect-safety` (6 attack vectors + valid path + Referrer-Policy header — 8 tests, CI will execute)
- [x] TypeScript: `pnpm typecheck` clean across all touched files
- [x] Pre-commit hooks (lint-staged + prettier + tsc --noEmit) passed on all 11 commits

## Commits

11 commits structured by TDD red→green cycle per task, all with co-author trailer:

```
e333e6991 test(e2e): auth redirect safety — attack vectors + Referrer-Policy (#2168)
137a4b80a feat(security): Referrer-Policy strict-origin in middleware (#2168)
d7914b54a fix(notifications): guard NotificationCenter + NotificationItem links (#2182)
fb63789c4 fix(notifications): guard detail.link against open redirect (#2182)
5622ea291 test(welcome)+chore(register): warn-not-called assertions + audit comment (#2168)
22acf58d5 test(auth): welcome redirect sanitization tests + redirectToMasked (#2168)
536730f84 chore(auth): url-safety audit + fix welcome ?redirectTo= (#2168)
592045824 fix(auth): move login open-redirect warn into useEffect (#2168 follow-up)
a11426325 fix(auth): reject unsafe ?from= redirect targets on login (#2168)
8ea6367cb fix(security): defend url-safety against control chars + double-encoding (#2168)
19f215f98 feat(security): add url-safety helper for relative-link validation (#2168)
```

## Refs

- Audit: `audits/us-verification-log.md` § US-2 (US validation sweep 2026-06-11)
- Spec-panel critique: spec-panel iterations on Tasks A→F (this conversation 2026-06-11/12)
- Delivery plan: `docs/superpowers/plans/2026-06-11-p0-delivery-plan.md` Track A
- Implementation plan: `docs/superpowers/plans/2026-06-11-track-a-url-safety.md`
- Sister PR-deferred issue: #2217 (VerificationSuccess unvalidated prop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)