### PR TITLE
fix(dashboard): SuggestedSection reads UserLibrary (not SharedGames) (#2176)

### DIFF
--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -25,14 +25,13 @@
 
 'use client';
 
-import { useMemo, type ReactElement } from 'react';
+import { useEffect, useMemo, type ReactElement } from 'react';
 
 import { useAuth } from '@/components/auth/AuthProvider';
 import { CascadeDrawerHost } from '@/components/dashboard/CascadeDrawerHost';
 import { useActiveSessions } from '@/hooks/queries/useActiveSessions';
 import { useCompletedGameNights, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
-import { useGames } from '@/hooks/queries/useGames';
-import { useLibraryStats } from '@/hooks/queries/useLibrary';
+import { useLibrary, useLibraryStats } from '@/hooks/queries/useLibrary';
 import { useFriendsActivity } from '@/hooks/use-friends-activity';
 import { useTranslation } from '@/hooks/useTranslation';
 
@@ -76,7 +75,15 @@ export function DashboardClient(): ReactElement {
   // F20 #1974: dashboard "Recenti" slot — recently completed game nights.
   const completedGNQuery = useCompletedGameNights({ limit: 5 });
   const sessionsQuery = useActiveSessions(10);
-  const gamesQuery = useGames(undefined, undefined, 1, 20);
+  // Issue #2176: SuggestedSection renders "Potresti giocare" cards from the
+  // user's OWN library (UserLibrary), NOT from the shared catalog (SharedGames).
+  // The previous useGames(undefined,…,20) call read SharedGames system-wide,
+  // which created a silent inconsistency: KPI "GIOCHI N" (useLibraryStats →
+  // UserLibrary) and the suggested cards (useGames → SharedGames) drew from
+  // different sources, so the section could render community catalog items
+  // even when the user owned 0 games, or hide when the user owned N games
+  // but the catalog query was throttled.
+  const libraryQuery = useLibrary({ page: 1, pageSize: 20 });
   const statsQuery = useLibraryStats();
   const friendsActivityQuery = useFriendsActivity();
 
@@ -139,38 +146,67 @@ export function DashboardClient(): ReactElement {
   );
 
   // ── Slot #3: Suggested ("Potresti giocare") ──────────────────────────────
-  // MVP algorithm: surface up to 6 owned games. Future BE endpoint
-  // `GET /dashboard/suggestions` will refine to "owned NOT played last 30d
-  // sorted by play count DESC" + collaborative filtering (plan §"MIN-2").
+  // MVP algorithm: surface up to 6 OWNED games from the user's UserLibrary.
+  // Future BE endpoint `GET /dashboard/suggestions` will refine to
+  // "owned NOT played last 30d sorted by play count DESC" + collaborative
+  // filtering (plan §"MIN-2"). Source is UserLibrary (not SharedGames) —
+  // see #2176 for why this matters.
   const suggestedCards = useMemo<ReadonlyArray<SuggestedGameCard>>(() => {
-    const games = gamesQuery.data?.games ?? [];
-    return games.slice(0, 6).map<SuggestedGameCard>(g => {
-      const min = g.minPlayers ?? 0;
-      const max = g.maxPlayers ?? 0;
-      const playerCount =
-        min > 0 && max > 0 && min !== max
-          ? `${min}-${max}`
-          : min > 0
-            ? `${min}`
-            : max > 0
-              ? `${max}`
-              : '—';
-      const durationMin = g.maxPlayTimeMinutes ?? g.minPlayTimeMinutes ?? 60;
-      return {
-        id: g.id,
-        title: g.title,
-        coverImageUrl: g.imageUrl ?? undefined,
-        playerCount,
-        durationMin,
-      };
-    });
-  }, [gamesQuery.data]);
+    const entries = libraryQuery.data?.items ?? [];
+    return entries
+      .filter(entry => entry.currentState === 'Owned' || entry.currentState === 'Nuovo')
+      .slice(0, 6)
+      .map<SuggestedGameCard>(entry => {
+        const min = entry.minPlayers ?? 0;
+        const max = entry.maxPlayers ?? 0;
+        const playerCount =
+          min > 0 && max > 0 && min !== max
+            ? `${min}-${max}`
+            : min > 0
+              ? `${min}`
+              : max > 0
+                ? `${max}`
+                : '—';
+        const durationMin = entry.playingTimeMinutes ?? 60;
+        return {
+          id: entry.gameId,
+          title: entry.gameTitle,
+          coverImageUrl: entry.coverUrl ?? entry.gameImageUrl ?? undefined,
+          playerCount,
+          durationMin,
+        };
+      });
+  }, [libraryQuery.data]);
 
   const suggestedState: SuggestedSectionState = deriveSectionState(
-    gamesQuery.isLoading,
-    gamesQuery.isError,
+    libraryQuery.isLoading,
+    libraryQuery.isError,
     suggestedCards.length
   );
+
+  // Issue #2176 observability: detect cross-endpoint drift when stats reports
+  // owned games but the library list returned 0 mappable entries. Fires once
+  // per state transition (React StrictMode double-mount produces 2 warns in
+  // dev, expected). Logged via console.warn in non-production builds —
+  // production emits this as a Prometheus counter from the backend audit
+  // layer instead.
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    if (!statsQuery.data || libraryQuery.isLoading || libraryQuery.isError) return;
+    if (statsQuery.data.totalGames > 0 && suggestedCards.length === 0) {
+      console.warn(
+        '[Dashboard] cross-endpoint drift: useLibraryStats.totalGames > 0 but SuggestedSection rendered 0 cards. ' +
+          `stats=${statsQuery.data.totalGames}, libraryItems=${libraryQuery.data?.items.length ?? 0}, ` +
+          'check filter (Owned/Nuovo) or useLibrary pagination.'
+      );
+    }
+  }, [
+    statsQuery.data,
+    libraryQuery.isLoading,
+    libraryQuery.isError,
+    libraryQuery.data,
+    suggestedCards.length,
+  ]);
 
   // ── Slot #4: Friends Activity ────────────────────────────────────────────
   const friendsActivities = friendsActivityQuery.data ?? [];
@@ -237,7 +273,7 @@ export function DashboardClient(): ReactElement {
           state={suggestedState}
           games={suggestedCards}
           onRetry={() => {
-            void gamesQuery.refetch();
+            void libraryQuery.refetch();
           }}
         />
 

--- a/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
@@ -30,16 +30,11 @@ vi.mock('@/hooks/useTranslation', () => ({
 }));
 
 const refetchUpcoming = vi.fn();
-const refetchGames = vi.fn();
+const refetchLibrary = vi.fn();
 
-vi.mock('@/hooks/queries/useGames', () => ({
-  useGames: vi.fn(() => ({
-    data: { games: [], total: 0, page: 1, pageSize: 20, totalPages: 0 },
-    isLoading: false,
-    isError: false,
-    refetch: refetchGames,
-  })),
-}));
+// Issue #2176: SuggestedSection now reads from useLibrary (UserLibrary entries)
+// instead of useGames (SharedGames catalog). Mock useLibrary in the useLibrary
+// block below instead of mocking useGames here.
 
 vi.mock('@/hooks/queries/useActiveSessions', () => ({
   useActiveSessions: vi.fn(() => ({
@@ -66,6 +61,20 @@ vi.mock('@/hooks/queries/useGameNights', () => ({
 }));
 
 vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: vi.fn(() => ({
+    data: {
+      items: [],
+      page: 1,
+      pageSize: 20,
+      totalCount: 0,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+    isLoading: false,
+    isError: false,
+    refetch: refetchLibrary,
+  })),
   useLibraryStats: vi.fn(() => ({
     data: { totalGames: 0, favoriteGames: 0, privatePdfs: 0 },
     isLoading: false,
@@ -147,7 +156,8 @@ describe('DashboardClient (Asse C priority cluster)', () => {
 
   it('renders 4 priority sections in fixed order (when all have data)', async () => {
     // Override mocks to provide data so all 4 sections render.
-    const useGamesMock = vi.mocked(await import('@/hooks/queries/useGames')).useGames;
+    // Issue #2176: SuggestedSection reads UserLibrary entries (not SharedGames).
+    const useLibraryMock = vi.mocked(await import('@/hooks/queries/useLibrary')).useLibrary;
     const useGameNightsMock = vi.mocked(
       await import('@/hooks/queries/useGameNights')
     ).useUpcomingGameNights;
@@ -155,35 +165,57 @@ describe('DashboardClient (Asse C priority cluster)', () => {
       await import('@/hooks/use-friends-activity')
     ).useFriendsActivity;
 
-    useGamesMock.mockReturnValueOnce({
+    useLibraryMock.mockReturnValueOnce({
       data: {
-        games: [
+        items: [
           {
-            id: '00000000-0000-0000-0000-000000000001',
-            title: 'Catan',
-            publisher: 'Kosmos',
-            yearPublished: 1995,
+            id: '00000000-0000-0000-0000-000000000099',
+            userId: 'u1',
+            gameId: '00000000-0000-0000-0000-000000000001',
+            gameTitle: 'Catan',
+            gamePublisher: 'Kosmos',
+            gameYearPublished: 1995,
+            gameIconUrl: null,
+            gameImageUrl: null,
+            coverUrl: null,
+            addedAt: '2024-01-01T00:00:00Z',
+            notes: null,
+            isFavorite: false,
+            currentState: 'Owned' as const,
+            stateChangedAt: null,
+            stateNotes: null,
+            hasKb: false,
+            kbCardCount: 0,
+            kbIndexedCount: 0,
+            kbProcessingCount: 0,
+            ownershipDeclaredAt: null,
+            hasRagAccess: false,
+            agentIsOwned: true,
             minPlayers: 3,
             maxPlayers: 4,
-            minPlayTimeMinutes: 60,
-            maxPlayTimeMinutes: 120,
-            bggId: 13,
-            createdAt: '2024-01-01T00:00:00Z',
-            imageUrl: null,
-            iconUrl: null,
+            playingTimeMinutes: 90,
+            complexityRating: null,
+            averageRating: null,
+            timesPlayed: 0,
+            lastPlayed: null,
+            privateGameId: null,
+            isPrivateGame: false,
+            canProposeToCatalog: false,
           },
         ],
-        total: 1,
         page: 1,
         pageSize: 20,
+        totalCount: 1,
         totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
       },
       isLoading: false,
       isError: false,
-      refetch: refetchGames,
+      refetch: refetchLibrary,
       // The cast is intentional — TanStack returns a much wider type;
       // we only assert the fields the component actually reads.
-    } as unknown as ReturnType<typeof useGamesMock>);
+    } as unknown as ReturnType<typeof useLibraryMock>);
 
     useGameNightsMock.mockReturnValueOnce({
       data: [
@@ -275,5 +307,46 @@ describe('DashboardClient (Asse C priority cluster)', () => {
 
     const { container } = render(<DashboardClient />);
     expect(container.querySelector('[data-testid="prossimi-error"]')).not.toBeNull();
+  });
+
+  // Issue #2176 contract: cross-endpoint drift detection.
+  it('emits dev console.warn when stats reports owned games but library returns 0 items', async () => {
+    const useLibraryModule = await import('@/hooks/queries/useLibrary');
+    const useLibraryMock = vi.mocked(useLibraryModule.useLibrary);
+    const useLibraryStatsMock = vi.mocked(useLibraryModule.useLibraryStats);
+
+    // Stats reports 3 owned games (UserLibrary aggregated count)
+    useLibraryStatsMock.mockReturnValueOnce({
+      data: { totalGames: 3, favoriteGames: 0, privatePdfs: 0 },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useLibraryStatsMock>);
+
+    // But useLibrary list returns 0 items — simulates a drift scenario
+    // (e.g. backend pagination throttle, soft-delete filter mismatch).
+    useLibraryMock.mockReturnValueOnce({
+      data: {
+        items: [],
+        page: 1,
+        pageSize: 20,
+        totalCount: 0,
+        totalPages: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+      isLoading: false,
+      isError: false,
+      refetch: refetchLibrary,
+    } as unknown as ReturnType<typeof useLibraryMock>);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(<DashboardClient />);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[Dashboard] cross-endpoint drift')
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes **#2176** (P0 substrate — dashboard data inconsistency).

\`DashboardClient.tsx\` previously used \`useGames\` (= \`/api/v1/games\` = \`SharedGames\` catalog) to populate the SuggestedSection \"Potresti giocare\" cards. But the KPI counter source (\`useLibraryStats\`) reads from \`UserLibrary\`. Two different data sources for the same conceptual surface produced silent cross-endpoint drift:

- Section could render community catalog items even when the user owned 0 games
- Section could hide (silent fallback) when the user owned N games but the catalog query was throttled
- KPI \"GIOCHI N\" and Suggested cards drew from different tables — KPI showed N, cards showed catalog total

## Root cause

\`apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetAllGamesQueryHandler.cs:28\` queries \`_context.SharedGames.AsNoTracking()\` — system-wide catalog.
\`apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryStatsQueryHandler.cs:28\` calls \`_libraryRepository.GetUserLibraryCountAsync(query.UserId)\` — per-user entries.

The frontend \`DashboardClient.tsx:79\` mismatch was: \`useGames(undefined, undefined, 1, 20)\` for suggestion source, despite the inline comment intending \"surface up to 6 owned games\".

## Fix

- Swap \`useGames\` → \`useLibrary({ page: 1, pageSize: 20 })\` in \`DashboardClient.tsx\`
- Project \`UserLibraryEntry\` → \`SuggestedGameCard\` (entry-level fields: \`gameId\`, \`gameTitle\`, \`coverUrl\`, \`playingTimeMinutes\`)
- Filter to \`currentState === 'Owned' || 'Nuovo'\` so only games the user actually plays surface
- Add observability \`useEffect\` warn in non-production builds when stats > 0 but suggestedCards = 0 (catches drift before users see hidden sections)

## Test plan

- [x] Unit: \`cd apps/web && pnpm test -- DashboardClient\` — 8/8 pass (was 7, +1 cross-endpoint contract test)
- [x] TypeScript: \`pnpm typecheck\` clean
- [x] Pre-commit hooks (lint-staged + prettier + tsc --noEmit) passed

## Refs

- Audit: \`audits/us-verification-log.md\` § US-6 (US validation sweep 2026-06-11)
- Spec-panel refinement: comment 4682305975 on #2176 (Wiegers/Nygard/Fowler/Newman/Adzic)
- Delivery plan: \`docs/superpowers/plans/2026-06-11-p0-delivery-plan.md\` Track C

🤖 Generated with [Claude Code](https://claude.com/claude-code)