### PR TITLE
feat(catalog): #1823 Phase E F2+F3 — bulk retry + per-row timeline drawer

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommand.cs
@@ -1,0 +1,50 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Phase E F2 — admin bulk re-trigger of Wikidata cover enrichment
+/// for a set of dead-letter attempts. Each input id is resolved to the parent
+/// <c>SharedGameId</c> and re-dispatched through
+/// <see cref="Services.IWikidataCoverEnrichmentRunner"/> with
+/// <c>forceRefresh=true</c>, producing a fresh
+/// <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/> row per
+/// invocation. The previous dead-letter row is retained for the 7-day DEC-3j
+/// retention window so the audit trail is preserved.
+/// </summary>
+/// <param name="AttemptIds">Dead-letter attempt ids selected on the admin page (max 50 enforced by the validator).</param>
+/// <param name="TriggeredByUserId">
+/// Admin user id captured ONLY in the structured log line; not persisted on the
+/// new attempt rows. Same intent as <see cref="AdminEnrichWikidataCoverCommand.TriggeredByUserId"/>.
+/// </param>
+internal sealed record AdminBulkRetryWikidataCoverCommand(
+    IReadOnlyList<Guid> AttemptIds,
+    Guid TriggeredByUserId) : ICommand<AdminBulkRetryWikidataCoverResult>;
+
+/// <summary>
+/// Per-row outcome on the bulk-retry result envelope.
+/// </summary>
+public sealed record AdminBulkRetryRow(
+    Guid AttemptId,
+    Guid? GameId,
+    string Outcome,
+    string? Reason)
+{
+    /// <summary>Re-dispatched and the runner produced a Success / Skipped / Failed-with-retry row.</summary>
+    public const string OutcomeTriggered = "triggered";
+
+    /// <summary>The supplied attempt id was not found (already swept, or typo).</summary>
+    public const string OutcomeNotFound = "not-found";
+
+    /// <summary>The runner threw before completing — the attempt was NOT re-dispatched.</summary>
+    public const string OutcomeFailed = "failed";
+}
+
+/// <summary>
+/// Result envelope for <see cref="AdminBulkRetryWikidataCoverCommand"/>.
+/// </summary>
+public sealed record AdminBulkRetryWikidataCoverResult(
+    int TriggeredCount,
+    int NotFoundCount,
+    int FailedCount,
+    IReadOnlyList<AdminBulkRetryRow> Rows);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs
@@ -1,0 +1,117 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Handler for <see cref="AdminBulkRetryWikidataCoverCommand"/>. Resolves each
+/// attempt id to its parent <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt.SharedGameId"/>,
+/// then re-dispatches via <see cref="IWikidataCoverEnrichmentRunner"/> with
+/// <c>forceRefresh=true</c>. Per-row failures are caught and converted into a
+/// <c>failed</c> envelope so a single broken game never breaks the batch.
+/// Issue #1823 Phase E F2.
+/// </summary>
+/// <remarks>
+/// <para>Sequential dispatch (no parallel fan-out): the runner ultimately calls
+/// the DEC-3e shared rate-limiter (5rps across SPARQL + Commons); parallel
+/// dispatch would burn rate-limit budget without speeding the batch up.</para>
+///
+/// <para>The per-row <c>try/catch</c> swallows exceptions intentionally — the
+/// handler MUST always return a result envelope so the admin UI can render the
+/// partial success/failure table. Background runner errors are still logged
+/// via <see cref="ILogger"/> for ops triage.</para>
+/// </remarks>
+internal sealed class AdminBulkRetryWikidataCoverCommandHandler
+    : ICommandHandler<AdminBulkRetryWikidataCoverCommand, AdminBulkRetryWikidataCoverResult>
+{
+    private readonly IWikidataCoverEnrichmentAttemptRepository _attempts;
+    private readonly IWikidataCoverEnrichmentRunner _runner;
+    private readonly ILogger<AdminBulkRetryWikidataCoverCommandHandler> _logger;
+
+    public AdminBulkRetryWikidataCoverCommandHandler(
+        IWikidataCoverEnrichmentAttemptRepository attempts,
+        IWikidataCoverEnrichmentRunner runner,
+        ILogger<AdminBulkRetryWikidataCoverCommandHandler> logger)
+    {
+        _attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AdminBulkRetryWikidataCoverResult> Handle(
+        AdminBulkRetryWikidataCoverCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        _logger.LogInformation(
+            "AdminBulkRetryWikidataCover: user {UserId} requested bulk retry of {Count} attempt(s)",
+            request.TriggeredByUserId, request.AttemptIds.Count);
+
+        var gameIdMap = await _attempts
+            .GetSharedGameIdsByAttemptIdsAsync(request.AttemptIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        var rows = new List<AdminBulkRetryRow>(request.AttemptIds.Count);
+        var triggered = 0;
+        var notFound = 0;
+        var failed = 0;
+
+        foreach (var attemptId in request.AttemptIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!gameIdMap.TryGetValue(attemptId, out var gameId))
+            {
+                rows.Add(new AdminBulkRetryRow(
+                    AttemptId: attemptId,
+                    GameId: null,
+                    Outcome: AdminBulkRetryRow.OutcomeNotFound,
+                    Reason: "attempt-id-not-found"));
+                notFound++;
+                continue;
+            }
+
+            try
+            {
+                await _runner
+                    .EnrichAndRecordAsync(gameId, forceRefresh: true, cancellationToken)
+                    .ConfigureAwait(false);
+
+                rows.Add(new AdminBulkRetryRow(
+                    AttemptId: attemptId,
+                    GameId: gameId,
+                    Outcome: AdminBulkRetryRow.OutcomeTriggered,
+                    Reason: null));
+                triggered++;
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation propagates — let the outer pipeline handle it
+                // so the partial batch is not silently truncated into a
+                // misleading result envelope.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "AdminBulkRetryWikidataCover: runner threw for attempt {AttemptId} (game {GameId})",
+                    attemptId, gameId);
+                rows.Add(new AdminBulkRetryRow(
+                    AttemptId: attemptId,
+                    GameId: gameId,
+                    Outcome: AdminBulkRetryRow.OutcomeFailed,
+                    Reason: ex.GetType().Name));
+                failed++;
+            }
+        }
+
+        return new AdminBulkRetryWikidataCoverResult(
+            TriggeredCount: triggered,
+            NotFoundCount: notFound,
+            FailedCount: failed,
+            Rows: rows);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Issue #1823 Phase E F3 — full attempt timeline for one shared game, used by
+/// the per-row drawer on the admin dead-letter visibility page.
+/// </summary>
+/// <param name="GameId">Shared game to inspect.</param>
+/// <param name="Limit">Max attempts (clamped to [1, 200]).</param>
+internal sealed record GetWikidataAttemptTimelineQuery(
+    Guid GameId,
+    int Limit) : IRequest<WikidataAttemptTimelineResult>;
+
+/// <summary>
+/// Result envelope; empty <see cref="Items"/> when the game has never been processed.
+/// </summary>
+public sealed record WikidataAttemptTimelineResult(
+    Guid GameId,
+    IReadOnlyList<WikidataAttemptTimelineNode> Items);
+
+/// <summary>
+/// Per-node payload on the timeline. Each maps 1:1 to a
+/// <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/> row.
+/// </summary>
+public sealed record WikidataAttemptTimelineNode(
+    Guid Id,
+    DateTime AttemptedAt,
+    string Outcome,
+    string? Reason,
+    string? Details,
+    int RetryCount,
+    DateTime? NextRetryAt,
+    DateTime? DeadLetteredAt);
+
+internal sealed class GetWikidataAttemptTimelineQueryHandler
+    : IRequestHandler<GetWikidataAttemptTimelineQuery, WikidataAttemptTimelineResult>
+{
+    private readonly IWikidataCoverEnrichmentAttemptRepository _attempts;
+
+    public GetWikidataAttemptTimelineQueryHandler(IWikidataCoverEnrichmentAttemptRepository attempts)
+    {
+        _attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+    }
+
+    public async Task<WikidataAttemptTimelineResult> Handle(
+        GetWikidataAttemptTimelineQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var attempts = await _attempts
+            .GetAttemptsByGameIdAsync(request.GameId, request.Limit, cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = attempts
+            .Select(a => new WikidataAttemptTimelineNode(
+                a.Id,
+                a.AttemptedAt,
+                a.Outcome.ToString(),
+                a.Reason,
+                a.Details,
+                a.RetryCount,
+                a.NextRetryAt,
+                a.DeadLetteredAt))
+            .ToList();
+
+        return new WikidataAttemptTimelineResult(request.GameId, items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkRetryWikidataCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkRetryWikidataCoverCommandValidator.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="AdminBulkRetryWikidataCoverCommand"/>. Caps the
+/// batch at 50 so a runaway click cannot deluge the M9 rate-limiter (DEC-3e
+/// shared limiter is 5 rps shared across SPARQL+Commons; 50 enrichments at
+/// worst-case ~6s/game = 5 minutes of inline admin-request work, which is the
+/// outer bound of acceptable HTTP timeout). Issue #1823 Phase E F2.
+/// </summary>
+internal sealed class AdminBulkRetryWikidataCoverCommandValidator
+    : AbstractValidator<AdminBulkRetryWikidataCoverCommand>
+{
+    /// <summary>
+    /// Maximum number of attempts that can be re-dispatched in a single
+    /// admin click. Larger batches must be split across multiple requests.
+    /// </summary>
+    public const int MaxBatchSize = 50;
+
+    public AdminBulkRetryWikidataCoverCommandValidator()
+    {
+        RuleFor(x => x.AttemptIds)
+            .Cascade(CascadeMode.Stop)
+            .NotNull()
+            .NotEmpty()
+            .WithMessage("AttemptIds must contain at least one id.")
+            .Must(ids => ids.Count <= MaxBatchSize)
+            .WithMessage($"AttemptIds cannot exceed {MaxBatchSize} per request.")
+            .Must(ids => ids.All(id => id != Guid.Empty))
+            .WithMessage("AttemptIds must not contain Guid.Empty.")
+            .Must(ids => ids.Distinct().Count() == ids.Count)
+            .WithMessage("AttemptIds must not contain duplicates.");
+
+        RuleFor(x => x.TriggeredByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("TriggeredByUserId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
@@ -68,6 +68,33 @@ public interface IWikidataCoverEnrichmentAttemptRepository
         int take,
         string? reasonFilter,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #1823 Phase E F2 — resolves the supplied attempt ids to their
+    /// parent <c>SharedGameId</c> in a single round-trip. Missing ids are
+    /// simply absent from the dictionary so the caller can report
+    /// <c>not-found</c> to the admin UI.
+    /// </summary>
+    /// <param name="attemptIds">Set of attempt ids to resolve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Map <c>attemptId → SharedGameId</c>; absent keys = attempt not found.</returns>
+    Task<IReadOnlyDictionary<Guid, Guid>> GetSharedGameIdsByAttemptIdsAsync(
+        IReadOnlyCollection<Guid> attemptIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #1823 Phase E F3 — returns the full attempt timeline for a single
+    /// game, ordered by <c>AttemptedAt</c> DESC. Bounded by <paramref name="limit"/>
+    /// (clamped to a sane upper bound by the impl) so the admin drawer never
+    /// pulls thousands of rows.
+    /// </summary>
+    /// <param name="sharedGameId">Target game id.</param>
+    /// <param name="limit">Max rows to return (clamped to [1, 200]).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<WikidataCoverEnrichmentAttempt>> GetAttemptsByGameIdAsync(
+        Guid sharedGameId,
+        int limit,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -200,6 +200,50 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
         return new DeadLetterPage(items, totalCount);
     }
 
+    public async Task<IReadOnlyDictionary<Guid, Guid>> GetSharedGameIdsByAttemptIdsAsync(
+        IReadOnlyCollection<Guid> attemptIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(attemptIds);
+
+        if (attemptIds.Count == 0)
+        {
+            return new Dictionary<Guid, Guid>();
+        }
+
+        // Defensive cap mirroring the F2 validator MaxBatchSize (50). EF Core
+        // translates a Contains() against a parameterized list into a single
+        // SARGable WHERE id = ANY(@p) on PostgreSQL.
+        var ids = attemptIds.Distinct().Take(50).ToArray();
+
+        var rows = await DbContext.WikidataCoverEnrichmentAttempts
+            .AsNoTracking()
+            .Where(a => ids.Contains(a.Id))
+            .Select(a => new { a.Id, a.SharedGameId })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows.ToDictionary(r => r.Id, r => r.SharedGameId);
+    }
+
+    public async Task<IReadOnlyList<WikidataCoverEnrichmentAttempt>> GetAttemptsByGameIdAsync(
+        Guid sharedGameId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        limit = Math.Clamp(limit, 1, 200);
+
+        var entities = await DbContext.WikidataCoverEnrichmentAttempts
+            .AsNoTracking()
+            .Where(a => a.SharedGameId == sharedGameId)
+            .OrderByDescending(a => a.AttemptedAt)
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.Select(Map).ToList();
+    }
+
     private static WikidataCoverEnrichmentAttempt Map(WikidataCoverEnrichmentAttemptEntity entity) =>
         WikidataCoverEnrichmentAttempt.Reconstitute(
             id: entity.Id,

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -40,6 +40,16 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
             .WithName("AdminWikidataCoverEnrichment_ListDeadLetters")
             .WithTags("Admin", "WikidataCoverEnrichment");
 
+        // Phase E F2 — bulk-retry endpoint.
+        group.MapPost("/bulk-retry", HandleBulkRetry)
+            .WithName("AdminWikidataCoverEnrichment_BulkRetry")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
+        // Phase E F3 — per-game attempt timeline (drawer payload).
+        group.MapGet("/games/{gameId:guid}/attempts", HandleGetAttemptTimeline)
+            .WithName("AdminWikidataCoverEnrichment_GetAttemptTimeline")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
         return group;
     }
 
@@ -84,6 +94,47 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
             Skip: skip ?? 0,
             Take: take ?? 50,
             ReasonFilter: string.IsNullOrWhiteSpace(reason) ? null : reason);
+
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>Body for the F2 bulk-retry endpoint.</summary>
+    internal sealed record AdminBulkRetryWikidataRequest(IReadOnlyList<Guid>? AttemptIds);
+
+    /// <summary>
+    /// Issue #1823 Phase E F2 — bulk re-trigger of one or more dead-letter
+    /// attempts. Each id is resolved to its parent SharedGameId and dispatched
+    /// via the M9 runner with <c>forceRefresh=true</c>. Returns a per-row
+    /// envelope so the admin UI can render partial success/failure.
+    /// </summary>
+    private static async Task<IResult> HandleBulkRetry(
+        AdminBulkRetryWikidataRequest? request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var command = new AdminBulkRetryWikidataCoverCommand(
+            AttemptIds: request?.AttemptIds ?? Array.Empty<Guid>(),
+            TriggeredByUserId: context.User.GetUserId());
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Issue #1823 Phase E F3 — per-game attempt timeline. Query string:
+    /// <c>?limit=20</c> (default 50, max 200).
+    /// </summary>
+    private static async Task<IResult> HandleGetAttemptTimeline(
+        Guid gameId,
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var query = new GetWikidataAttemptTimelineQuery(
+            GameId: gameId,
+            Limit: limit ?? 50);
 
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandlerTests.cs
@@ -1,0 +1,164 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Unit tests for <see cref="AdminBulkRetryWikidataCoverCommandHandler"/>.
+/// Issue #1823 Phase E F2.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class AdminBulkRetryWikidataCoverCommandHandlerTests
+{
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _attempts = new();
+    private readonly Mock<IWikidataCoverEnrichmentRunner> _runner = new();
+
+    private AdminBulkRetryWikidataCoverCommandHandler Sut() => new(
+        _attempts.Object,
+        _runner.Object,
+        NullLogger<AdminBulkRetryWikidataCoverCommandHandler>.Instance);
+
+    [Fact]
+    public async Task Handle_AllIdsResolved_DispatchesEachWithForceRefreshTrue()
+    {
+        var a1 = Guid.NewGuid();
+        var a2 = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetSharedGameIdsByAttemptIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, Guid> { [a1] = g1, [a2] = g2 });
+
+        _runner.Setup(r => r.EnrichAndRecordAsync(
+                It.IsAny<Guid>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        var result = await Sut().Handle(
+            new AdminBulkRetryWikidataCoverCommand(
+                AttemptIds: new[] { a1, a2 },
+                TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.TriggeredCount.Should().Be(2);
+        result.NotFoundCount.Should().Be(0);
+        result.FailedCount.Should().Be(0);
+        result.Rows.Should().HaveCount(2);
+        result.Rows.Should().AllSatisfy(row => row.Outcome.Should().Be(AdminBulkRetryRow.OutcomeTriggered));
+        _runner.Verify(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<CancellationToken>()), Times.Once);
+        _runner.Verify(r => r.EnrichAndRecordAsync(g2, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownAttemptId_ProducesNotFoundRowWithoutInvokingRunner()
+    {
+        var known = Guid.NewGuid();
+        var unknown = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetSharedGameIdsByAttemptIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, Guid> { [known] = gameId });
+
+        _runner.Setup(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        var result = await Sut().Handle(
+            new AdminBulkRetryWikidataCoverCommand(
+                AttemptIds: new[] { known, unknown },
+                TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.TriggeredCount.Should().Be(1);
+        result.NotFoundCount.Should().Be(1);
+        result.FailedCount.Should().Be(0);
+        result.Rows.Single(r => r.AttemptId == unknown).Outcome.Should().Be(AdminBulkRetryRow.OutcomeNotFound);
+        result.Rows.Single(r => r.AttemptId == unknown).GameId.Should().BeNull();
+        _runner.Verify(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>()), Times.Once,
+            "the unknown id must NOT invoke the runner");
+    }
+
+    [Fact]
+    public async Task Handle_RunnerThrowsForOneRow_ContinuesBatchAndReportsFailed()
+    {
+        var a1 = Guid.NewGuid();
+        var a2 = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetSharedGameIdsByAttemptIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, Guid> { [a1] = g1, [a2] = g2 });
+
+        _runner.Setup(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("simulated runner failure"));
+        _runner.Setup(r => r.EnrichAndRecordAsync(g2, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        var result = await Sut().Handle(
+            new AdminBulkRetryWikidataCoverCommand(
+                AttemptIds: new[] { a1, a2 },
+                TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.TriggeredCount.Should().Be(1);
+        result.NotFoundCount.Should().Be(0);
+        result.FailedCount.Should().Be(1, "the per-row try/catch MUST not break the batch");
+        result.Rows.Single(r => r.AttemptId == a1).Outcome.Should().Be(AdminBulkRetryRow.OutcomeFailed);
+        result.Rows.Single(r => r.AttemptId == a1).Reason.Should().Be("InvalidOperationException");
+        result.Rows.Single(r => r.AttemptId == a2).Outcome.Should().Be(AdminBulkRetryRow.OutcomeTriggered);
+    }
+
+    [Fact]
+    public async Task Handle_CancellationRequested_PropagatesAndDoesNotSwallow()
+    {
+        var a1 = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetSharedGameIdsByAttemptIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, Guid> { [a1] = g1 });
+
+        _runner.Setup(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var act = async () => await Sut().Handle(
+            new AdminBulkRetryWikidataCoverCommand(
+                AttemptIds: new[] { a1 },
+                TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "cancellation MUST propagate so partial batches aren't silently truncated");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyMap_ReturnsAllNotFound()
+    {
+        _attempts.Setup(r => r.GetSharedGameIdsByAttemptIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, Guid>());
+
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+        var result = await Sut().Handle(
+            new AdminBulkRetryWikidataCoverCommand(
+                AttemptIds: ids,
+                TriggeredByUserId: Guid.NewGuid()),
+            default);
+
+        result.TriggeredCount.Should().Be(0);
+        result.NotFoundCount.Should().Be(3);
+        result.FailedCount.Should().Be(0);
+        result.Rows.Should().HaveCount(3);
+        _runner.Verify(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
@@ -1,0 +1,94 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="GetWikidataAttemptTimelineQueryHandler"/>.
+/// Issue #1823 Phase E F3.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class GetWikidataAttemptTimelineQueryHandlerTests
+{
+    private static readonly DateTime FixedNow = new(2026, 6, 12, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _attempts = new();
+
+    private GetWikidataAttemptTimelineQueryHandler Sut() => new(_attempts.Object);
+
+    [Fact]
+    public async Task Handle_NoAttempts_ReturnsEmptyTimeline()
+    {
+        var gameId = Guid.NewGuid();
+        _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WikidataCoverEnrichmentAttempt>());
+
+        var result = await Sut().Handle(new GetWikidataAttemptTimelineQuery(gameId, 50), default);
+
+        result.GameId.Should().Be(gameId);
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_MixedAttempts_MapsAllFieldsAndOutcomes()
+    {
+        var gameId = Guid.NewGuid();
+        var success = WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, retryCount: 0, attemptedAt: FixedNow);
+        var skipped = WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, "qid-missing",
+            retryCount: 0, attemptedAt: FixedNow.AddMinutes(-5));
+        var failedWithRetry = WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+            gameId, "r2-upload-error", "503",
+            retryCount: 1, attemptedAt: FixedNow.AddMinutes(-10), nextRetryAt: FixedNow.AddMinutes(-5));
+        var deadLetter = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            gameId, "image-processing-error", "corrupted",
+            retryCount: 0, attemptedAt: FixedNow.AddMinutes(-15));
+
+        _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { success, skipped, failedWithRetry, deadLetter });
+
+        var result = await Sut().Handle(new GetWikidataAttemptTimelineQuery(gameId, 50), default);
+
+        result.Items.Should().HaveCount(4);
+        result.Items.Should().Contain(n => n.Outcome == "Success");
+        result.Items.Should().Contain(n => n.Outcome == "Skipped" && n.Reason == "qid-missing");
+        result.Items.Should().Contain(n => n.Outcome == "Failed" && n.NextRetryAt.HasValue && n.RetryCount == 1);
+        result.Items.Should().Contain(n => n.Outcome == "DeadLetter" && n.DeadLetteredAt.HasValue);
+    }
+
+    [Fact]
+    public async Task Handle_PreservesRepoOrdering()
+    {
+        // Repo guarantees DESC AttemptedAt; the handler MUST NOT re-order so
+        // the drawer renders the most-recent attempt at the top of the timeline.
+        var gameId = Guid.NewGuid();
+        var newer = WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, 0, FixedNow);
+        var older = WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, "qid-missing", 0, FixedNow.AddDays(-1));
+
+        _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { newer, older });
+
+        var result = await Sut().Handle(new GetWikidataAttemptTimelineQuery(gameId, 50), default);
+
+        result.Items[0].Id.Should().Be(newer.Id);
+        result.Items[1].Id.Should().Be(older.Id);
+    }
+
+    [Fact]
+    public async Task Handle_LimitForwardedToRepo()
+    {
+        var gameId = Guid.NewGuid();
+        _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, 7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WikidataCoverEnrichmentAttempt>())
+            .Verifiable();
+
+        await Sut().Handle(new GetWikidataAttemptTimelineQuery(gameId, 7), default);
+
+        _attempts.Verify();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkRetryWikidataCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkRetryWikidataCoverCommandValidatorTests.cs
@@ -1,0 +1,92 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class AdminBulkRetryWikidataCoverCommandValidatorTests
+{
+    private readonly AdminBulkRetryWikidataCoverCommandValidator _sut = new();
+
+    [Fact]
+    public async Task ValidCommand_PassesValidation()
+    {
+        var cmd = new AdminBulkRetryWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid(), Guid.NewGuid() },
+            TriggeredByUserId: Guid.NewGuid());
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task EmptyAttemptIds_Fails()
+    {
+        var cmd = new AdminBulkRetryWikidataCoverCommand(
+            AttemptIds: Array.Empty<Guid>(),
+            TriggeredByUserId: Guid.NewGuid());
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds);
+    }
+
+    [Fact]
+    public async Task OverMaxBatchSize_Fails()
+    {
+        var ids = Enumerable.Range(0, AdminBulkRetryWikidataCoverCommandValidator.MaxBatchSize + 1)
+            .Select(_ => Guid.NewGuid()).ToArray();
+        var cmd = new AdminBulkRetryWikidataCoverCommand(ids, Guid.NewGuid());
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds)
+            .WithErrorMessage($"AttemptIds cannot exceed {AdminBulkRetryWikidataCoverCommandValidator.MaxBatchSize} per request.");
+    }
+
+    [Fact]
+    public async Task ContainsGuidEmpty_Fails()
+    {
+        var cmd = new AdminBulkRetryWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid(), Guid.Empty },
+            TriggeredByUserId: Guid.NewGuid());
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds);
+    }
+
+    [Fact]
+    public async Task ContainsDuplicates_Fails()
+    {
+        var dup = Guid.NewGuid();
+        var cmd = new AdminBulkRetryWikidataCoverCommand(
+            AttemptIds: new[] { dup, dup },
+            TriggeredByUserId: Guid.NewGuid());
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds);
+    }
+
+    [Fact]
+    public async Task EmptyTriggeredBy_Fails()
+    {
+        var cmd = new AdminBulkRetryWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid() },
+            TriggeredByUserId: Guid.Empty);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.TriggeredByUserId);
+    }
+
+    [Fact]
+    public void MaxBatchSize_Is50()
+    {
+        // ADR-driven cap; if this changes the operations runbook + the FE
+        // multi-select limit MUST update too.
+        AdminBulkRetryWikidataCoverCommandValidator.MaxBatchSize
+            .Should().Be(50, "DEC-3e rate-limiter budget caps each bulk click at 50 enrichments");
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx
@@ -31,9 +31,13 @@ interface AttemptTimelineDrawerProps {
   readonly onClose: () => void;
 }
 
+// Neutral outcome (Skipped) uses semantic tokens to honor the
+// DS-15 no-hardcoded-color-utility ESLint rule (`slate-*` etc. are banned).
+// Hue-based palettes (emerald/amber) remain whitelisted by that rule because
+// they convey terminal-state signal that has no canonical semantic token yet.
 const OUTCOME_TONE: Record<AttemptTimelineOutcome, string> = {
   Success: 'border-emerald-500 bg-emerald-500/10',
-  Skipped: 'border-slate-500 bg-slate-500/10',
+  Skipped: 'border-border bg-muted',
   Failed: 'border-amber-500 bg-amber-500/10',
   DeadLetter: 'border-destructive bg-destructive/10',
 };
@@ -67,7 +71,10 @@ export function AttemptTimelineDrawer({
         setError(err instanceof Error ? err.message : 'Unknown error');
       })
       .finally(() => {
-        if (cancelled) return;
+        // Always flip loading off even if the unmount/re-open cancellation
+        // flag is set — otherwise a future persistent-portal wrapper could
+        // leave the component stuck on the loading spinner indefinitely
+        // (latent bug noted in the F3 code review).
         setLoading(false);
       });
     return () => {

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx
@@ -1,0 +1,143 @@
+/**
+ * Issue #1823 Phase E F3 — per-game WikidataCoverEnrichmentAttempt timeline
+ * surfaced as a slide-over drawer on the admin dead-letter visibility page.
+ *
+ * Each node maps 1:1 to an attempt row (Success / Skipped / Failed-with-retry /
+ * DeadLetter) so operators can reconstruct the full enrichment history without
+ * leaving the page.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import {
+  getAttemptTimeline,
+  type AttemptTimelineOutcome,
+  type WikidataAttemptTimelineNode,
+} from '@/lib/api/admin-wikidata-dead-letters';
+
+interface AttemptTimelineDrawerProps {
+  readonly gameId: string;
+  readonly gameTitle: string;
+  readonly open: boolean;
+  readonly onClose: () => void;
+}
+
+const OUTCOME_TONE: Record<AttemptTimelineOutcome, string> = {
+  Success: 'border-emerald-500 bg-emerald-500/10',
+  Skipped: 'border-slate-500 bg-slate-500/10',
+  Failed: 'border-amber-500 bg-amber-500/10',
+  DeadLetter: 'border-destructive bg-destructive/10',
+};
+
+function formatUtc(iso: string): string {
+  return new Date(iso).toISOString().slice(0, 19).replace('T', ' ');
+}
+
+export function AttemptTimelineDrawer({
+  gameId,
+  gameTitle,
+  open,
+  onClose,
+}: AttemptTimelineDrawerProps): React.JSX.Element {
+  const [items, setItems] = useState<WikidataAttemptTimelineNode[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getAttemptTimeline(gameId, 50)
+      .then(result => {
+        if (cancelled) return;
+        setItems(result.items);
+      })
+      .catch(err => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [gameId, open]);
+
+  return (
+    <Drawer open={open} onOpenChange={next => (next ? null : onClose())} direction="right">
+      <DrawerContent className="flex max-h-screen w-full max-w-xl flex-col">
+        <DrawerHeader>
+          <DrawerTitle>Attempt timeline — {gameTitle}</DrawerTitle>
+          <DrawerDescription>
+            Most recent attempt at the top. Rows are bounded at 50; older history is pruned by the
+            7-day retention sweep.
+          </DrawerDescription>
+        </DrawerHeader>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {loading && <p className="text-sm text-muted-foreground">Loading timeline…</p>}
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          {!loading && !error && items.length === 0 && (
+            <p className="text-sm text-muted-foreground">No attempt history for this game.</p>
+          )}
+          {!loading && !error && items.length > 0 && (
+            <ol className="space-y-3" aria-label="Attempt history">
+              {items.map(node => (
+                <li
+                  key={node.id}
+                  className={`rounded-l-md border-l-4 p-3 ${OUTCOME_TONE[node.outcome]}`}
+                  data-outcome={node.outcome}
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="text-sm font-semibold">{node.outcome}</span>
+                    <time className="text-xs text-muted-foreground" dateTime={node.attemptedAt}>
+                      {formatUtc(node.attemptedAt)}
+                    </time>
+                  </div>
+                  {node.reason && (
+                    <p className="mt-1 text-xs">
+                      <span className="text-muted-foreground">reason: </span>
+                      <code className="rounded bg-muted px-1 py-0.5 text-xs">{node.reason}</code>
+                    </p>
+                  )}
+                  {node.details && (
+                    <p className="mt-1 text-xs text-muted-foreground">{node.details}</p>
+                  )}
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    retries: <span className="font-medium text-foreground">{node.retryCount}</span>
+                    {node.nextRetryAt && (
+                      <>
+                        {' · '}next retry: <time>{formatUtc(node.nextRetryAt)}</time>
+                      </>
+                    )}
+                    {node.deadLetteredAt && (
+                      <>
+                        {' · '}dead-lettered: <time>{formatUtc(node.deadLetteredAt)}</time>
+                      </>
+                    )}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
@@ -1,17 +1,16 @@
 /**
  * Admin Wikidata Cover Enrichment — Dead-Letter Visibility Page.
- * Issue #1823 Wave 3 M13.
+ * Issue #1823 Wave 3 M13 + Phase E F2 (bulk-retry) + F3 (per-row timeline drawer).
  *
- * Minimal MVP scope:
+ * In-scope:
  *   - paginated list of dead-letter attempts (server endpoint already paginates)
  *   - optional reason filter
  *   - per-row retry button (POST {gameId} with forceRefresh=true via M12)
+ *   - F2: checkbox column + bulk retry toolbar (max 50 per batch)
+ *   - F3: click on game title → drawer with WikidataCoverEnrichmentAttempt timeline
  *
- * Out-of-scope for this iteration (tracked in Wave 3 follow-up):
- *   - bulk retry / acknowledge
- *   - per-row drawer with full attempt history (joins WikidataCoverEnrichmentAttempt
- *     timeline)
- *   - real-time refresh via SSE on scheduler-emitted events
+ * Out-of-scope for this iteration:
+ *   - real-time refresh via SSE on scheduler-emitted events (Phase E F4 candidate)
  */
 
 'use client';
@@ -19,10 +18,15 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import {
+  BULK_RETRY_MAX_BATCH,
+  bulkRetryDeadLetters,
   listDeadLetters,
   retryDeadLetter,
+  type AdminBulkRetryWikidataCoverResult,
   type WikidataDeadLetterAttemptDto,
 } from '@/lib/api/admin-wikidata-dead-letters';
+
+import { AttemptTimelineDrawer } from './AttemptTimelineDrawer';
 
 const PAGE_SIZE = 50;
 
@@ -47,6 +51,11 @@ interface RetryStatus {
   error?: string;
 }
 
+interface DrawerState {
+  gameId: string;
+  gameTitle: string;
+}
+
 export default function WikidataDeadLettersPage() {
   const [items, setItems] = useState<WikidataDeadLetterAttemptDto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -55,6 +64,14 @@ export default function WikidataDeadLettersPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [retryStatus, setRetryStatus] = useState<Record<string, RetryStatus>>({});
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkState, setBulkState] = useState<
+    | { state: 'idle' }
+    | { state: 'running' }
+    | { state: 'done'; result: AdminBulkRetryWikidataCoverResult }
+    | { state: 'error'; error: string }
+  >({ state: 'idle' });
+  const [drawer, setDrawer] = useState<DrawerState | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -67,6 +84,10 @@ export default function WikidataDeadLettersPage() {
       });
       setItems(response.items);
       setTotalCount(response.totalCount);
+      // Reset selection on every page/filter change — the previously selected
+      // rows may no longer be visible, and bulk-retrying invisible rows would
+      // be a surprising UX violation.
+      setSelectedIds(new Set());
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {
@@ -97,7 +118,51 @@ export default function WikidataDeadLettersPage() {
     }
   };
 
+  const toggleSelect = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else if (next.size < BULK_RETRY_MAX_BATCH) {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const togglePageSelection = () => {
+    setSelectedIds(prev => {
+      const allSelected = items.every(i => prev.has(i.id));
+      if (allSelected) return new Set();
+      const next = new Set(prev);
+      for (const item of items) {
+        if (next.size >= BULK_RETRY_MAX_BATCH) break;
+        next.add(item.id);
+      }
+      return next;
+    });
+  };
+
+  const handleBulkRetry = async () => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    setBulkState({ state: 'running' });
+    try {
+      const result = await bulkRetryDeadLetters(ids);
+      setBulkState({ state: 'done', result });
+      // After a bulk run, reload to reflect new attempt rows.
+      void load();
+    } catch (err) {
+      setBulkState({
+        state: 'error',
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  };
+
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+  const selectionAtCap = selectedIds.size >= BULK_RETRY_MAX_BATCH;
+  const allOnPageSelected = items.length > 0 && items.every(i => selectedIds.has(i.id));
 
   return (
     <main className="space-y-4 p-6">
@@ -143,6 +208,50 @@ export default function WikidataDeadLettersPage() {
         </div>
       </section>
 
+      {/* Phase E F2 — bulk-retry toolbar. Sticky so it stays visible while
+          scrolling a long table. */}
+      <section
+        aria-label="Bulk actions"
+        className="sticky top-0 z-10 flex flex-wrap items-center gap-3 rounded border bg-card p-3 shadow-sm"
+      >
+        <span className="text-sm font-medium">
+          {selectedIds.size} selected
+          {selectionAtCap && (
+            <span className="ml-1 text-xs text-amber-700">(max {BULK_RETRY_MAX_BATCH})</span>
+          )}
+        </span>
+
+        <button
+          type="button"
+          className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          onClick={() => void handleBulkRetry()}
+          disabled={selectedIds.size === 0 || bulkState.state === 'running'}
+        >
+          {bulkState.state === 'running' ? 'Retrying…' : 'Retry selected'}
+        </button>
+
+        <button
+          type="button"
+          className="rounded border px-3 py-1 text-sm hover:bg-muted disabled:opacity-50"
+          onClick={() => setSelectedIds(new Set())}
+          disabled={selectedIds.size === 0 || bulkState.state === 'running'}
+        >
+          Clear selection
+        </button>
+
+        {bulkState.state === 'done' && (
+          <span className="text-xs text-muted-foreground">
+            ✔ {bulkState.result.triggeredCount} triggered · {bulkState.result.notFoundCount}{' '}
+            not-found · {bulkState.result.failedCount} failed
+          </span>
+        )}
+        {bulkState.state === 'error' && (
+          <span className="text-xs text-destructive" role="alert">
+            ✗ {bulkState.error}
+          </span>
+        )}
+      </section>
+
       {error && (
         <div
           role="alert"
@@ -162,6 +271,14 @@ export default function WikidataDeadLettersPage() {
         <table className="w-full border-collapse text-sm">
           <thead className="bg-muted text-left">
             <tr>
+              <th className="border-b p-2">
+                <input
+                  type="checkbox"
+                  aria-label="Select all rows on this page"
+                  checked={allOnPageSelected}
+                  onChange={togglePageSelection}
+                />
+              </th>
               <th className="border-b p-2">Game</th>
               <th className="border-b p-2">Reason</th>
               <th className="border-b p-2">Details</th>
@@ -173,9 +290,30 @@ export default function WikidataDeadLettersPage() {
           <tbody>
             {items.map(row => {
               const status = retryStatus[row.id]?.state ?? 'idle';
+              const checked = selectedIds.has(row.id);
               return (
                 <tr key={row.id} className="border-b">
-                  <td className="p-2 font-medium">{row.gameTitle}</td>
+                  <td className="p-2">
+                    <input
+                      type="checkbox"
+                      aria-label={`Select ${row.gameTitle}`}
+                      checked={checked}
+                      onChange={() => toggleSelect(row.id)}
+                      disabled={!checked && selectionAtCap}
+                    />
+                  </td>
+                  <td className="p-2 font-medium">
+                    <button
+                      type="button"
+                      className="text-left underline-offset-2 hover:underline"
+                      onClick={() =>
+                        setDrawer({ gameId: row.sharedGameId, gameTitle: row.gameTitle })
+                      }
+                      aria-label={`Open timeline for ${row.gameTitle}`}
+                    >
+                      {row.gameTitle}
+                    </button>
+                  </td>
                   <td className="p-2">
                     <code className="rounded bg-muted px-1 py-0.5 text-xs">{row.reason}</code>
                   </td>
@@ -228,6 +366,15 @@ export default function WikidataDeadLettersPage() {
           Next
         </button>
       </nav>
+
+      {drawer && (
+        <AttemptTimelineDrawer
+          gameId={drawer.gameId}
+          gameTitle={drawer.gameTitle}
+          open={drawer !== null}
+          onClose={() => setDrawer(null)}
+        />
+      )}
     </main>
   );
 }

--- a/apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-e.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-e.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Phase E F2 + F3 client coverage for admin-wikidata-dead-letters.
+ * Issue #1823.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BULK_RETRY_MAX_BATCH,
+  bulkRetryDeadLetters,
+  getAttemptTimeline,
+} from '../admin-wikidata-dead-letters';
+
+const ENDPOINT_BASE = '/api/v1/admin/wikidata/enrichment';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('bulkRetryDeadLetters (F2 client)', () => {
+  it('POSTs JSON body { attemptIds } to /bulk-retry with credentials', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          triggeredCount: 1,
+          notFoundCount: 0,
+          failedCount: 0,
+          rows: [{ attemptId: 'a1', gameId: 'g1', outcome: 'triggered', reason: null }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await bulkRetryDeadLetters(['a1']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ENDPOINT_BASE}/bulk-retry`);
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(JSON.parse(init.body as string)).toEqual({ attemptIds: ['a1'] });
+    expect(result.triggeredCount).toBe(1);
+  });
+
+  it('rejects with status + body when the server returns non-OK', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('forbidden', { status: 403, statusText: 'Forbidden' }))
+    );
+
+    await expect(bulkRetryDeadLetters(['a1'])).rejects.toThrow(/403.*forbidden/i);
+  });
+
+  it('exposes the MaxBatchSize cap matching the BE validator', () => {
+    expect(BULK_RETRY_MAX_BATCH).toBe(50);
+  });
+});
+
+describe('getAttemptTimeline (F3 client)', () => {
+  it('GETs /games/{gameId}/attempts?limit=N with credentials', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          gameId: 'g1',
+          items: [
+            {
+              id: 'a1',
+              attemptedAt: '2026-06-12T10:00:00Z',
+              outcome: 'DeadLetter',
+              reason: 'r2-upload-error',
+              details: '503',
+              retryCount: 3,
+              nextRetryAt: null,
+              deadLetteredAt: '2026-06-12T10:00:00Z',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getAttemptTimeline('g1', 7);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ENDPOINT_BASE}/games/g1/attempts?limit=7`);
+    expect(init.credentials).toBe('include');
+    expect(result.items[0]?.outcome).toBe('DeadLetter');
+  });
+
+  it('defaults the limit to 50 when omitted', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ gameId: 'g1', items: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getAttemptTimeline('g1');
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ENDPOINT_BASE}/games/g1/attempts?limit=50`);
+  });
+
+  it('rejects with status + body when the server returns non-OK', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('not found', { status: 404, statusText: 'Not Found' }))
+    );
+
+    await expect(getAttemptTimeline('g1')).rejects.toThrow(/404.*not found/i);
+  });
+});

--- a/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
+++ b/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
@@ -85,3 +85,85 @@ export async function retryDeadLetter(gameId: string): Promise<AdminEnrichWikida
   }
   return (await response.json()) as AdminEnrichWikidataCoverResult;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase E F2 — bulk retry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * BE-side cap (mirrors AdminBulkRetryWikidataCoverCommandValidator.MaxBatchSize).
+ * Larger client-side selections MUST be chunked before invoking the endpoint.
+ */
+export const BULK_RETRY_MAX_BATCH = 50;
+
+export type BulkRetryRowOutcome = 'triggered' | 'not-found' | 'failed';
+
+export interface BulkRetryRow {
+  attemptId: string;
+  gameId: string | null;
+  outcome: BulkRetryRowOutcome;
+  reason: string | null;
+}
+
+export interface AdminBulkRetryWikidataCoverResult {
+  triggeredCount: number;
+  notFoundCount: number;
+  failedCount: number;
+  rows: BulkRetryRow[];
+}
+
+export async function bulkRetryDeadLetters(
+  attemptIds: string[]
+): Promise<AdminBulkRetryWikidataCoverResult> {
+  const response = await fetch(`${ENDPOINT_BASE}/bulk-retry`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ attemptIds }),
+  });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to bulk-retry enrichments');
+  }
+  return (await response.json()) as AdminBulkRetryWikidataCoverResult;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase E F3 — per-row attempt timeline
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Outcome surfaced by the BE on each timeline node — mirrors the
+ * <c>WikidataCoverEnrichmentOutcome</c> enum on the aggregate.
+ */
+export type AttemptTimelineOutcome = 'Success' | 'Skipped' | 'Failed' | 'DeadLetter';
+
+export interface WikidataAttemptTimelineNode {
+  id: string;
+  attemptedAt: string;
+  outcome: AttemptTimelineOutcome;
+  reason: string | null;
+  details: string | null;
+  retryCount: number;
+  nextRetryAt: string | null;
+  deadLetteredAt: string | null;
+}
+
+export interface WikidataAttemptTimelineResult {
+  gameId: string;
+  items: WikidataAttemptTimelineNode[];
+}
+
+export async function getAttemptTimeline(
+  gameId: string,
+  limit = 50
+): Promise<WikidataAttemptTimelineResult> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  const response = await fetch(
+    `${ENDPOINT_BASE}/games/${encodeURIComponent(gameId)}/attempts?${params.toString()}`,
+    { credentials: 'include' }
+  );
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to load attempt timeline');
+  }
+  return (await response.json()) as WikidataAttemptTimelineResult;
+}


### PR DESCRIPTION
## Summary
Phase E mid-bundle for issue [#1823](https://github.com/meepleAi-app/meepleai-monorepo/issues/1823) Wikidata L2 cover enrichment — admin UX polish on top of the M13 dead-letter visibility page.

- **F2** — admin bulk-retry (BE command + handler + endpoint + FE checkbox column + sticky toolbar)
- **F3** — per-row `WikidataCoverEnrichmentAttempt` timeline drawer (BE query + endpoint + FE Drawer with color-coded outcome border)

## Why this shape
- F2 caps the batch at 50 in the validator because the DEC-3e rate-limiter is 5rps shared across SPARQL+Commons; larger batches would spend more than 5 minutes inside a single HTTP request. Per-row `try/catch` in the handler converts runner exceptions to a `failed` envelope entry instead of breaking the whole batch — the admin can re-trigger only the genuinely broken rows.
- F3 reuses the existing `Drawer` primitive (`direction="right"`) so the admin shell keeps a single drawer pattern. The timeline is bounded at 50 nodes (clamped repo-side to [1, 200]) so the 7-day retention window can't blow up the payload.
- BE leverages existing `IWikidataCoverEnrichmentRunner.EnrichAndRecordAsync(gameId, forceRefresh: true)` — both new entry points stay decoupled from the M9 pipeline implementation, mirroring the M12 admin trigger pattern.

## Endpoints
- `POST /api/v1/admin/wikidata/enrichment/bulk-retry` — body `{ attemptIds: Guid[] }` (max 50), returns `{ triggeredCount, notFoundCount, failedCount, rows[] }`
- `GET  /api/v1/admin/wikidata/enrichment/games/{gameId}/attempts?limit=N` — returns `{ gameId, items[] }` ordered DESC `AttemptedAt`

## Test plan
- [x] 125 BE unit pass (`dotnet test --filter "Category=Unit&FullyQualifiedName~Wikidata"`)
- [x] 16 nuovi unit (5 bulk-retry handler + 7 validator + 4 timeline query)
- [x] 6 FE Vitest client tests on `bulkRetryDeadLetters` + `getAttemptTimeline`
- [x] FE typecheck pulito (`pnpm typecheck`)
- [x] BE build verde (`dotnet build`)
- [ ] Browser smoke (visual UX on `/admin/(dashboard)/monitor/wikidata-dead-letters`) — manual

## Files changed
- BE F2:
  - `Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommand.cs` (new)
  - `Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs` (new)
  - `Application/Validators/AdminBulkRetryWikidataCoverCommandValidator.cs` (new, `MaxBatchSize = 50`)
- BE F3:
  - `Application/Queries/GetWikidataAttemptTimelineQuery.cs` (new, query + handler + DTOs)
- BE shared:
  - `Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs` (+ `GetSharedGameIdsByAttemptIdsAsync` + `GetAttemptsByGameIdAsync`)
  - `Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs` (impl)
  - `Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs` (+ `MapPost("/bulk-retry")` + `MapGet("/games/{gameId:guid}/attempts")`)
- BE tests: 3 new test classes (handler / validator / timeline query)
- FE F2+F3:
  - `lib/api/admin-wikidata-dead-letters.ts` (+ `bulkRetryDeadLetters` + `getAttemptTimeline` + `BULK_RETRY_MAX_BATCH`)
  - `app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx` (checkbox column + sticky toolbar + click-title-opens-drawer)
  - `app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx` (new)
  - `lib/api/__tests__/admin-wikidata-dead-letters-phase-e.test.ts` (new, 6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)