### PR TITLE
feat(catalog): #1823 Phase E F4 — SSE real-time event stream

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataEnrichmentEventBroadcaster.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataEnrichmentEventBroadcaster.cs
@@ -1,0 +1,54 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #1823 Phase E F4 — in-process pub/sub for Wikidata cover enrichment
+/// outcomes. The M9 <see cref="IWikidataCoverEnrichmentRunner"/> publishes one
+/// event per persisted <c>WikidataCoverEnrichmentAttempt</c>; the admin
+/// dead-letter visibility page subscribes via SSE for live row updates.
+/// </summary>
+/// <remarks>
+/// <para><b>Topology assumption</b>: single-pod (HPA=1, per DEC-3e rate-limiter
+/// contract). A multi-pod deployment would need a fan-out backplane (Redis
+/// pub/sub or NATS) — explicitly out of scope until DEC-3e is revisited.</para>
+///
+/// <para><b>Delivery semantics</b>: at-most-once, best-effort. Slow / paused
+/// subscribers do NOT back-pressure the publisher — the implementation drops
+/// the event for that subscriber and continues. This preserves the M9
+/// scheduler tick budget; the dead-letter table remains the source of truth.</para>
+/// </remarks>
+public interface IWikidataEnrichmentEventBroadcaster
+{
+    /// <summary>
+    /// Fire-and-forget publish. Returns immediately; per-subscriber delivery
+    /// happens on a background continuation.
+    /// </summary>
+    void Publish(WikidataEnrichmentEvent payload);
+
+    /// <summary>
+    /// Subscribe to the live event stream. The returned async-enumerable
+    /// completes when <paramref name="cancellationToken"/> is signalled
+    /// (typically the SSE client disconnecting).
+    /// </summary>
+    IAsyncEnumerable<WikidataEnrichmentEvent> SubscribeAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Current number of subscribers — surfaced as an admin diagnostic and used
+    /// by unit tests to assert subscribe / unsubscribe behaviour.
+    /// </summary>
+    int SubscriberCount { get; }
+}
+
+/// <summary>
+/// Wire payload for a single attempt-recorded SSE event. Mirrors the slim
+/// projection of <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/>
+/// needed to refresh the admin dead-letter row inline.
+/// </summary>
+public sealed record WikidataEnrichmentEvent(
+    Guid AttemptId,
+    Guid SharedGameId,
+    string Outcome,
+    string? Reason,
+    DateTime AttemptedAt,
+    int RetryCount,
+    DateTime? NextRetryAt,
+    DateTime? DeadLetteredAt);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs
@@ -76,9 +76,16 @@ internal sealed class InMemoryWikidataEnrichmentEventBroadcaster : IWikidataEnri
 
         try
         {
+            // NOTE: never use `yield break` from inside a nested catch — the
+            // C# async-iterator state machine guarantees `finally` runs on
+            // `yield break`, but the inversion via a `break` flag is the safer
+            // pattern for a long-running subscriber loop (avoids any future
+            // refactor accidentally moving `yield break` to a position that
+            // skips the outer finally cleanup of the subscriber map entry).
             while (!cancellationToken.IsCancellationRequested)
             {
-                WikidataEnrichmentEvent payload;
+                WikidataEnrichmentEvent? payload = null;
+                var shouldBreak = false;
                 try
                 {
                     payload = await channel.Reader
@@ -87,14 +94,15 @@ internal sealed class InMemoryWikidataEnrichmentEventBroadcaster : IWikidataEnri
                 }
                 catch (OperationCanceledException)
                 {
-                    yield break;
+                    shouldBreak = true;
                 }
                 catch (ChannelClosedException)
                 {
-                    yield break;
+                    shouldBreak = true;
                 }
 
-                yield return payload;
+                if (shouldBreak) break;
+                yield return payload!;
             }
         }
         finally

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs
@@ -1,0 +1,109 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Singleton in-process implementation of
+/// <see cref="IWikidataEnrichmentEventBroadcaster"/>. Each subscriber gets a
+/// dedicated bounded <see cref="Channel{T}"/>; publish writes to all channels
+/// with <see cref="BoundedChannelFullMode.DropOldest"/> drop policy so a slow
+/// SSE client never blocks the M9 scheduler tick.
+/// </summary>
+/// <remarks>
+/// Capacity per-subscriber is intentionally small (128) — the FE only renders
+/// the last N events on the page anyway, and a deep queue would just amplify
+/// delivery latency without changing the steady-state UX.
+/// </remarks>
+internal sealed class InMemoryWikidataEnrichmentEventBroadcaster : IWikidataEnrichmentEventBroadcaster
+{
+    private const int PerSubscriberCapacity = 128;
+
+    private readonly ConcurrentDictionary<Guid, Channel<WikidataEnrichmentEvent>> _subscribers = new();
+    private readonly ILogger<InMemoryWikidataEnrichmentEventBroadcaster> _logger;
+
+    public InMemoryWikidataEnrichmentEventBroadcaster(
+        ILogger<InMemoryWikidataEnrichmentEventBroadcaster> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public int SubscriberCount => _subscribers.Count;
+
+    public void Publish(WikidataEnrichmentEvent payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (_subscribers.IsEmpty)
+        {
+            return;
+        }
+
+        foreach (var (_, channel) in _subscribers)
+        {
+            // DropOldest channel — TryWrite never blocks. If the subscriber's
+            // queue is full, the channel quietly evicts the oldest pending
+            // event before accepting the new one. Either way TryWrite returns
+            // true on a healthy channel; false only when the writer has
+            // already completed, which we treat as a sign the subscriber is
+            // being torn down and the next iteration will clean it up.
+            if (!channel.Writer.TryWrite(payload))
+            {
+                _logger.LogDebug(
+                    "InMemoryWikidataEnrichmentEventBroadcaster: dropped event {AttemptId} for a completed subscriber",
+                    payload.AttemptId);
+            }
+        }
+    }
+
+    public async IAsyncEnumerable<WikidataEnrichmentEvent> SubscribeAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var subscriberId = Guid.NewGuid();
+        var channel = Channel.CreateBounded<WikidataEnrichmentEvent>(
+            new BoundedChannelOptions(PerSubscriberCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.DropOldest,
+            });
+
+        _subscribers.TryAdd(subscriberId, channel);
+        _logger.LogDebug(
+            "InMemoryWikidataEnrichmentEventBroadcaster: subscriber {SubscriberId} added (now {Total})",
+            subscriberId, _subscribers.Count);
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                WikidataEnrichmentEvent payload;
+                try
+                {
+                    payload = await channel.Reader
+                        .ReadAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    yield break;
+                }
+                catch (ChannelClosedException)
+                {
+                    yield break;
+                }
+
+                yield return payload;
+            }
+        }
+        finally
+        {
+            _subscribers.TryRemove(subscriberId, out _);
+            channel.Writer.TryComplete();
+            _logger.LogDebug(
+                "InMemoryWikidataEnrichmentEventBroadcaster: subscriber {SubscriberId} removed (now {Total})",
+                subscriberId, _subscribers.Count);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
@@ -21,6 +21,7 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
     private readonly IUnitOfWork _unitOfWork;
     private readonly IWikidataCoverEnrichmentRetryPolicy _policy;
     private readonly TimeProvider _timeProvider;
+    private readonly IWikidataEnrichmentEventBroadcaster _broadcaster;
     private readonly ILogger<WikidataCoverEnrichmentRunner> _logger;
 
     public WikidataCoverEnrichmentRunner(
@@ -29,6 +30,7 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
         IUnitOfWork unitOfWork,
         IWikidataCoverEnrichmentRetryPolicy policy,
         TimeProvider timeProvider,
+        IWikidataEnrichmentEventBroadcaster broadcaster,
         ILogger<WikidataCoverEnrichmentRunner> logger)
     {
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
@@ -36,6 +38,7 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _policy = policy ?? throw new ArgumentNullException(nameof(policy));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _broadcaster = broadcaster ?? throw new ArgumentNullException(nameof(broadcaster));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -111,6 +114,22 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
         {
             MeepleAiMetrics.IncrementWikidataDeadLetterCount();
         }
+
+        // Issue #1823 Phase E F4: SSE broadcast for live admin dead-letter
+        // page updates. Same post-SaveChanges placement as the F1 gauge — a
+        // pre-commit publish would leak phantom rows if the DB write fails.
+        // The broadcaster is fire-and-forget; a slow SSE subscriber is
+        // dropped rather than back-pressured (per its DropOldest channel
+        // policy) so the M9 scheduler tick budget is preserved.
+        _broadcaster.Publish(new WikidataEnrichmentEvent(
+            AttemptId: newAttempt.Id,
+            SharedGameId: newAttempt.SharedGameId,
+            Outcome: newAttempt.Outcome.ToString(),
+            Reason: newAttempt.Reason,
+            AttemptedAt: newAttempt.AttemptedAt,
+            RetryCount: newAttempt.RetryCount,
+            NextRetryAt: newAttempt.NextRetryAt,
+            DeadLetteredAt: newAttempt.DeadLetteredAt));
 
         _logger.LogDebug(
             "WikidataCoverEnrichmentRunner: game {GameId} outcome={Outcome} reason={Reason} retry={RetryCount} nextRetryAt={NextRetryAt} forceRefresh={ForceRefresh}",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -227,6 +227,13 @@ internal static class SharedGameCatalogServiceExtensions
         // the request UoW + repository.
         services.AddScoped<IWikidataCoverEnrichmentRunner, WikidataCoverEnrichmentRunner>();
 
+        // Issue #1823 Phase E F4: in-process SSE pub/sub for live admin
+        // dead-letter row updates. Singleton — the channel registry persists
+        // across requests so subscribers don't lose events between scheduler
+        // ticks. Single-pod assumption per DEC-3e (HPA=1); multi-pod fan-out
+        // would need a Redis/NATS backplane, explicitly out of scope.
+        services.AddSingleton<IWikidataEnrichmentEventBroadcaster, InMemoryWikidataEnrichmentEventBroadcaster>();
+
         // Issue #1823 Wave 3 M9: Quartz scheduler for batch Wikidata cover
         // enrichment. Runs every 1 minute (HPA=1 per DEC-3e). [DisallowConcurrentExecution]
         // on the job class is the belt-and-braces guarantee that we never have

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.Extensions;
 using Api.Filters;
 using MediatR;
@@ -48,6 +50,12 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
         // Phase E F3 — per-game attempt timeline (drawer payload).
         group.MapGet("/games/{gameId:guid}/attempts", HandleGetAttemptTimeline)
             .WithName("AdminWikidataCoverEnrichment_GetAttemptTimeline")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
+        // Phase E F4 — SSE stream of attempt-recorded events for live admin
+        // dead-letter row updates.
+        group.MapGet("/events", HandleEventsStream)
+            .WithName("AdminWikidataCoverEnrichment_EventsStream")
             .WithTags("Admin", "WikidataCoverEnrichment");
 
         return group;
@@ -138,5 +146,92 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
 
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
+    }
+
+    private static readonly TimeSpan SseHeartbeatInterval = TimeSpan.FromSeconds(15);
+
+    private static readonly JsonSerializerOptions SseJsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Issue #1823 Phase E F4 — SSE stream of attempt-recorded events. Each
+    /// event is a single JSON-serialised <see cref="WikidataEnrichmentEvent"/>.
+    /// </summary>
+    /// <remarks>
+    /// Mirror of the <see cref="Api.Routing.AdminEventsEndpoints"/> pattern:
+    /// 15s <c>:hb\n\n</c> heartbeat keeps proxies / load balancers from
+    /// closing the connection, <c>X-Accel-Buffering: no</c> defeats nginx
+    /// buffering if it ever lands in the stack, the body is committed
+    /// immediately with <c>:ok\n\n</c> so the client sees headers without
+    /// waiting for the first event.
+    /// </remarks>
+    private static async Task HandleEventsStream(
+        HttpContext context,
+        IWikidataEnrichmentEventBroadcaster broadcaster,
+        CancellationToken ct)
+    {
+        // Group-level RequireAdminSessionFilter has already authorised the
+        // request — SSE handlers can't return IResult once the body has
+        // started, so any auth failure would have happened before we got
+        // here.
+
+        context.Response.Headers.ContentType = "text/event-stream";
+        context.Response.Headers.CacheControl = "no-cache";
+        context.Response.Headers.Connection = "keep-alive";
+        context.Response.Headers["X-Accel-Buffering"] = "no";
+
+        // Commit headers + flush so the client sees the open stream
+        // immediately (and so TestServer's ResponseHeadersRead mode unblocks).
+        await context.Response.WriteAsync(":ok\n\n", ct).ConfigureAwait(false);
+        await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+
+        var heartbeatTask = Task.Run(async () =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(SseHeartbeatInterval, ct).ConfigureAwait(false);
+                    if (ct.IsCancellationRequested) break;
+                    await context.Response.WriteAsync(":hb\n\n", ct).ConfigureAwait(false);
+                    await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception)
+                {
+                    // Client disconnected — stop heartbeat silently.
+                    break;
+                }
+            }
+        }, ct);
+
+        try
+        {
+            await foreach (var payload in broadcaster.SubscribeAsync(ct).ConfigureAwait(false))
+            {
+                var json = JsonSerializer.Serialize(payload, SseJsonOptions);
+                await context.Response.WriteAsync($"event: attempt-recorded\ndata: {json}\n\n", ct)
+                    .ConfigureAwait(false);
+                await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: client disconnected or server shutting down.
+        }
+        finally
+        {
+            try
+            {
+                await heartbeatTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Heartbeat task swallows its own errors; rethrowing here would
+                // mask the cancellation that triggered the finally.
+            }
+        }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterTests.cs
@@ -1,0 +1,160 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryWikidataEnrichmentEventBroadcaster"/>.
+/// Issue #1823 Phase E F4.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class InMemoryWikidataEnrichmentEventBroadcasterTests
+{
+    private static WikidataEnrichmentEvent SampleEvent(Guid? attemptId = null) => new(
+        AttemptId: attemptId ?? Guid.NewGuid(),
+        SharedGameId: Guid.NewGuid(),
+        Outcome: "DeadLetter",
+        Reason: "r2-upload-error",
+        AttemptedAt: new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc),
+        RetryCount: 3,
+        NextRetryAt: null,
+        DeadLetteredAt: new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc));
+
+    private static InMemoryWikidataEnrichmentEventBroadcaster CreateSut() => new(
+        NullLogger<InMemoryWikidataEnrichmentEventBroadcaster>.Instance);
+
+    [Fact]
+    public void SubscriberCount_StartsAtZero()
+    {
+        CreateSut().SubscriberCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Publish_NoSubscribers_DoesNotThrow()
+    {
+        var sut = CreateSut();
+        var act = () => sut.Publish(SampleEvent());
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task Publish_OneSubscriber_DeliversPayload()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var payload = SampleEvent();
+        var subscribed = new TaskCompletionSource();
+        WikidataEnrichmentEvent? received = null;
+
+        var consumerTask = Task.Run(async () =>
+        {
+            await foreach (var ev in sut.SubscribeAsync(cts.Token))
+            {
+                received = ev;
+                cts.Cancel();
+            }
+        }, cts.Token);
+
+        // Wait until the subscriber registers — the SubscriberCount counter is
+        // the cheapest signal we have. Yield briefly so the consumer task runs.
+        for (var i = 0; i < 50 && sut.SubscriberCount == 0; i++)
+        {
+            await Task.Delay(10);
+        }
+
+        sut.SubscriberCount.Should().Be(1);
+        sut.Publish(payload);
+
+        try
+        {
+            await consumerTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: consumer cancelled itself after receiving the payload.
+        }
+
+        received.Should().BeEquivalentTo(payload);
+        sut.SubscriberCount.Should().Be(0, "the consumer's finally MUST remove the subscriber on exit");
+    }
+
+    [Fact]
+    public async Task Publish_MultipleSubscribers_FanOutsToAll()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var payload = SampleEvent();
+        var receivedA = 0;
+        var receivedB = 0;
+
+        var taskA = Task.Run(async () =>
+        {
+            await foreach (var _ in sut.SubscribeAsync(cts.Token))
+            {
+                Interlocked.Increment(ref receivedA);
+                break;
+            }
+        }, cts.Token);
+
+        var taskB = Task.Run(async () =>
+        {
+            await foreach (var _ in sut.SubscribeAsync(cts.Token))
+            {
+                Interlocked.Increment(ref receivedB);
+                break;
+            }
+        }, cts.Token);
+
+        for (var i = 0; i < 50 && sut.SubscriberCount < 2; i++)
+        {
+            await Task.Delay(10);
+        }
+        sut.SubscriberCount.Should().Be(2);
+
+        sut.Publish(payload);
+
+        await Task.WhenAll(taskA, taskB).WaitAsync(TimeSpan.FromSeconds(5));
+
+        receivedA.Should().Be(1);
+        receivedB.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_CancellationCleansUpSubscriber()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = Task.Run(async () =>
+        {
+            await foreach (var _ in sut.SubscribeAsync(cts.Token))
+            {
+                // Never receives anything — cancel below kicks it out.
+            }
+        }, cts.Token);
+
+        for (var i = 0; i < 50 && sut.SubscriberCount == 0; i++)
+        {
+            await Task.Delay(10);
+        }
+        sut.SubscriberCount.Should().Be(1);
+
+        cts.Cancel();
+        try
+        {
+            await consumerTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected.
+        }
+
+        sut.SubscriberCount.Should().Be(0,
+            "the consumer's finally block MUST remove the subscriber on cancellation");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -260,6 +260,33 @@ public class WikidataCoverEnrichmentRunnerTests
     }
 
     [Fact]
+    public async Task EnrichAndRecordAsync_PostSaveChanges_PublishesBroadcastEvent()
+    {
+        // F4 #1823 Phase E: every persisted attempt MUST be broadcast on the
+        // SSE pub/sub so the admin dead-letter page updates inline. The
+        // publish call MUST happen AFTER SaveChangesAsync — same placement as
+        // the F1 dead-letter gauge increment — so a DB write failure cannot
+        // leak phantom rows to subscribers.
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonImageProcessing, "corrupted"));
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+
+        _broadcaster.Verify(b => b.Publish(It.Is<WikidataEnrichmentEvent>(
+                e => e.SharedGameId == gameId
+                    && e.Outcome == nameof(WikidataCoverEnrichmentOutcome.DeadLetter)
+                    && e.Reason == EnrichCatalogCoverCommandHandler.FailReasonImageProcessing)),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task EnrichAndRecordAsync_FailedRetryOutcome_DoesNotIncrementDeadLetterGauge()
     {
         // F1 #1823 Wave 3: only DeadLetter terminal counts towards the gauge —

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -32,10 +32,12 @@ public class WikidataCoverEnrichmentRunnerTests
     private readonly Mock<IUnitOfWork> _uow = new();
     private readonly WikidataCoverEnrichmentRetryPolicy _policy = new();
     private readonly FakeTimeProvider _time = new(new DateTimeOffset(FixedNow, TimeSpan.Zero));
+    private readonly Mock<IWikidataEnrichmentEventBroadcaster> _broadcaster = new();
 
     private WikidataCoverEnrichmentRunner Sut() => new(
         _mediator.Object, _attempts.Object, _uow.Object, _policy,
-        _time, NullLogger<WikidataCoverEnrichmentRunner>.Instance);
+        _time, _broadcaster.Object,
+        NullLogger<WikidataCoverEnrichmentRunner>.Instance);
 
     [Fact]
     public async Task EnrichAndRecordAsync_SuccessOutcome_RecordsSuccessAttempt()

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/useWikidataEnrichmentEvents.test.ts
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/useWikidataEnrichmentEvents.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Phase E F4 — useWikidataEnrichmentEvents hook unit tests. Issue #1823.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWikidataEnrichmentEvents } from '../useWikidataEnrichmentEvents';
+
+type EventListener = (event: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  readyState = 0; // CONNECTING
+  onopen: ((e: Event) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  private listeners: Record<string, EventListener[]> = {};
+
+  constructor(url: string, init?: EventSourceInit) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    (this.listeners[type] ??= []).push(listener);
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    const arr = this.listeners[type];
+    if (!arr) return;
+    const idx = arr.indexOf(listener);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  emitEvent(type: string, data: string) {
+    const msg = { data, type } as MessageEvent;
+    for (const l of this.listeners[type] ?? []) l(msg);
+  }
+
+  emitOpen() {
+    this.readyState = 1;
+    this.onopen?.(new Event('open'));
+  }
+
+  emitError() {
+    this.onerror?.(new Event('error'));
+  }
+
+  close() {
+    this.readyState = 2;
+  }
+}
+
+describe('useWikidataEnrichmentEvents (Phase E F4)', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource as unknown as typeof EventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens an EventSource against the BE SSE endpoint with credentials', () => {
+    renderHook(() => useWikidataEnrichmentEvents());
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]!.url).toBe('/api/v1/admin/wikidata/enrichment/events');
+    expect(MockEventSource.instances[0]!.withCredentials).toBe(true);
+  });
+
+  it('transitions to open on `onopen` and exposes the last attempt-recorded payload', () => {
+    const { result } = renderHook(() => useWikidataEnrichmentEvents());
+    const source = MockEventSource.instances[0]!;
+
+    expect(result.current.state).toBe('connecting');
+
+    act(() => source.emitOpen());
+    expect(result.current.state).toBe('open');
+
+    const payload = {
+      attemptId: 'a1',
+      sharedGameId: 'g1',
+      outcome: 'DeadLetter',
+      reason: 'r2-upload-error',
+      attemptedAt: '2026-06-12T10:00:00Z',
+      retryCount: 3,
+      nextRetryAt: null,
+      deadLetteredAt: '2026-06-12T10:00:00Z',
+    };
+    act(() => source.emitEvent('attempt-recorded', JSON.stringify(payload)));
+
+    expect(result.current.lastEvent).toEqual(payload);
+  });
+
+  it('flips state back to connecting on `onerror` (UA auto-reconnect)', () => {
+    const { result } = renderHook(() => useWikidataEnrichmentEvents());
+    const source = MockEventSource.instances[0]!;
+    act(() => source.emitOpen());
+    expect(result.current.state).toBe('open');
+
+    act(() => source.emitError());
+    expect(result.current.state).toBe('connecting');
+  });
+
+  it('silently ignores malformed `attempt-recorded` payloads', () => {
+    const { result } = renderHook(() => useWikidataEnrichmentEvents());
+    const source = MockEventSource.instances[0]!;
+
+    act(() => source.emitEvent('attempt-recorded', '{not valid json'));
+
+    expect(result.current.lastEvent).toBeNull();
+  });
+
+  it('closes the EventSource on unmount', () => {
+    const { unmount } = renderHook(() => useWikidataEnrichmentEvents());
+    const source = MockEventSource.instances[0]!;
+    const closeSpy = vi.spyOn(source, 'close');
+
+    unmount();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/lib/api/admin-wikidata-dead-letters';
 
 import { AttemptTimelineDrawer } from './AttemptTimelineDrawer';
+import { useWikidataEnrichmentEvents } from './useWikidataEnrichmentEvents';
 
 const PAGE_SIZE = 50;
 
@@ -73,6 +74,10 @@ export default function WikidataDeadLettersPage() {
   >({ state: 'idle' });
   const [drawer, setDrawer] = useState<DrawerState | null>(null);
 
+  // Phase E F4 — live attempt-recorded SSE feed. Each new event triggers a
+  // page reload (cheap: same paginated endpoint already used by Refresh).
+  const sse = useWikidataEnrichmentEvents();
+
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -98,6 +103,16 @@ export default function WikidataDeadLettersPage() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // F4: refresh the list when the BE broadcasts a new attempt event.
+  // load() is stable across renders thanks to useCallback, so the deps array
+  // intentionally pins to lastEvent.attemptId — replaying the same event
+  // never re-loads, but a new event always does.
+  const lastEventAttemptId = sse.lastEvent?.attemptId ?? null;
+  useEffect(() => {
+    if (!lastEventAttemptId) return;
+    void load();
+  }, [lastEventAttemptId, load]);
 
   const handleRetry = async (row: WikidataDeadLetterAttemptDto) => {
     setRetryStatus(prev => ({ ...prev, [row.id]: { state: 'running' } }));
@@ -203,8 +218,27 @@ export default function WikidataDeadLettersPage() {
           Refresh
         </button>
 
-        <div className="ml-auto text-sm text-muted-foreground">
-          {totalCount} dead-letter{totalCount === 1 ? '' : 's'} matching filter
+        <div className="ml-auto flex items-center gap-3 text-sm text-muted-foreground">
+          <span
+            className="flex items-center gap-1"
+            aria-live="polite"
+            title={`Live event stream: ${sse.state}`}
+          >
+            <span
+              className={`inline-block size-2 rounded-full ${
+                sse.state === 'open'
+                  ? 'bg-emerald-500'
+                  : sse.state === 'connecting'
+                    ? 'bg-amber-500 motion-safe:animate-pulse'
+                    : 'bg-destructive'
+              }`}
+              aria-hidden="true"
+            />
+            <span className="text-xs">{sse.state}</span>
+          </span>
+          <span>
+            {totalCount} dead-letter{totalCount === 1 ? '' : 's'} matching filter
+          </span>
         </div>
       </section>
 

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/useWikidataEnrichmentEvents.ts
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/useWikidataEnrichmentEvents.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #1823 Phase E F4 — EventSource hook for live attempt-recorded events
+ * on the admin Wikidata dead-letter visibility page.
+ *
+ * Native browser EventSource auto-reconnects with a UA-default backoff
+ * (typically 3s) on transient network errors. We layer a slim wrapper that
+ *   - normalises connection state for UI badges (`connecting | open | closed`)
+ *   - exposes a `lastEvent` payload for inline row patches
+ *   - hard-closes the connection on unmount so React 19 strict-mode dev
+ *     re-mounts don't leak persistent SSE sockets
+ */
+
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export type AttemptTimelineOutcome = 'Success' | 'Skipped' | 'Failed' | 'DeadLetter';
+
+export interface WikidataEnrichmentEventPayload {
+  attemptId: string;
+  sharedGameId: string;
+  outcome: AttemptTimelineOutcome;
+  reason: string | null;
+  attemptedAt: string;
+  retryCount: number;
+  nextRetryAt: string | null;
+  deadLetteredAt: string | null;
+}
+
+export type SseConnectionState = 'connecting' | 'open' | 'closed';
+
+export interface UseWikidataEnrichmentEventsResult {
+  readonly state: SseConnectionState;
+  readonly lastEvent: WikidataEnrichmentEventPayload | null;
+}
+
+const SSE_ENDPOINT = '/api/v1/admin/wikidata/enrichment/events';
+
+/**
+ * Subscribes to the BE SSE stream and exposes the most-recent event for
+ * call-site consumption. Reconnection is delegated to the browser's native
+ * EventSource implementation; the only manual close is the unmount cleanup.
+ */
+export function useWikidataEnrichmentEvents(): UseWikidataEnrichmentEventsResult {
+  const [state, setState] = useState<SseConnectionState>('connecting');
+  const [lastEvent, setLastEvent] = useState<WikidataEnrichmentEventPayload | null>(null);
+  const sourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    const source = new EventSource(SSE_ENDPOINT, { withCredentials: true });
+    sourceRef.current = source;
+
+    source.onopen = () => setState('open');
+    source.onerror = () => {
+      // EventSource silently reconnects on error; surface 'connecting' so the
+      // UI badge reflects the transient state.
+      setState('connecting');
+    };
+    source.addEventListener('attempt-recorded', e => {
+      try {
+        const data = JSON.parse((e as MessageEvent).data) as WikidataEnrichmentEventPayload;
+        setLastEvent(data);
+      } catch {
+        // Ignore malformed payloads — the BE serializer guarantees well-formed
+        // JSON, so a parse error indicates an out-of-band proxy / heartbeat
+        // collision and is safe to skip.
+      }
+    });
+
+    return () => {
+      source.close();
+      sourceRef.current = null;
+      setState('closed');
+    };
+  }, []);
+
+  return { state, lastEvent };
+}


### PR DESCRIPTION
## Summary
Phase E **F4 SSE real-time** for issue [#1823](https://github.com/meepleAi-app/meepleai-monorepo/issues/1823) Wikidata L2 cover enrichment — live attempt-recorded events surfaced on the admin dead-letter visibility page.

- BE: in-process `IWikidataEnrichmentEventBroadcaster` (singleton, per-subscriber bounded `Channel<T>` with `DropOldest`) + SSE endpoint mirroring the existing `AdminEventsEndpoints` pattern
- FE: native `EventSource` hook (`useWikidataEnrichmentEvents`) with connection-state badge and auto-reload on every new attempt event

## Why this shape
- Single-pod assumption (HPA=1 per DEC-3e shared rate-limiter). Multi-pod fan-out would need a Redis/NATS backplane — explicitly out of scope until DEC-3e is revisited.
- `DropOldest` channel policy means a slow SSE subscriber never back-pressures the M9 scheduler tick. The dead-letter table remains the source of truth; SSE is a transient UX accelerator.
- `Publish(...)` placed POST-`SaveChangesAsync` (mirror of the F1 dead-letter gauge increment), so a DB write failure doesn't leak phantom events to subscribers.
- FE delegates reconnection to the browser's native `EventSource` (UA default ~3s backoff) — no custom backoff logic needed. Manual close only on unmount to defeat React 19 strict-mode dev re-mount leaks.

## Endpoint
- `GET /api/v1/admin/wikidata/enrichment/events` — `Content-Type: text/event-stream`, 15s `:hb\n\n` heartbeat, `X-Accel-Buffering: no` for nginx parity. Events arrive as `event: attempt-recorded\ndata: { ...JSON }\n\n`.

## Test plan
- [x] 130 BE unit (5 nuovi broadcaster: fan-out, cancellation cleanup, no-subscriber publish, single-subscriber delivery, subscriber-count guard) pass
- [x] 5 FE Vitest hook tests with custom `MockEventSource` (connect, open transition, attempt-recorded payload, error → connecting, malformed JSON safe, unmount close)
- [x] FE typecheck pulito (`pnpm typecheck`)
- [x] BE build verde (`dotnet build`)
- [x] ESLint pulito su tutti i nuovi file
- [ ] Browser smoke (SSE live update on real BE) — manual

## Files changed
- BE (4 files):
  - `Application/Services/IWikidataEnrichmentEventBroadcaster.cs` (new, interface + DTO)
  - `Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs` (new, singleton impl)
  - `Application/Services/WikidataCoverEnrichmentRunner.cs` (inject + publish POST-SaveChanges)
  - `Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs` (singleton registration)
  - `Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs` (+ `MapGet("/events")` + `HandleEventsStream`)
- BE tests (2 files):
  - `InMemoryWikidataEnrichmentEventBroadcasterTests.cs` (new, 5 tests)
  - `WikidataCoverEnrichmentRunnerTests.cs` (+ `_broadcaster` mock in Sut() ctor)
- FE (3 files):
  - `useWikidataEnrichmentEvents.ts` (new, hook)
  - `page.tsx` (wire hook + SSE state badge + auto-reload effect)
  - `__tests__/useWikidataEnrichmentEvents.test.ts` (new, 5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)