### PR TITLE
feat(stories): #2231 DS-17-15 sp4-sessions skeleton-first — Phase C-2 FINAL

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx
@@ -1,0 +1,32 @@
+/**
+ * sp4-session-summary-skeleton — DS-17-15 #2231.
+ * Mockup parity: `admin-mockups/design_files/sp4-session-summary-skeleton.{html,jsx}`.
+ */
+
+import SessionDetailPage from './page';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof SessionDetailPage> = {
+  title: 'Authenticated / sp4-session-summary-skeleton',
+  component: SessionDetailPage,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/sessions/sp4-fixture-session-id' },
+    },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component: '#2231 DS-17-15. Session summary skeleton (Phase C-2 skeleton-first base).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SessionDetailPage>;
+
+export const Default: Story = {};

--- a/apps/web/src/app/(authenticated)/sessions/[id]/play/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/play/page.stories.tsx
@@ -1,0 +1,32 @@
+/**
+ * sp4-session-play — DS-17-15 #2231.
+ * Mockup parity: `admin-mockups/design_files/sp4-session-play.{html,jsx}`.
+ */
+
+import LiveSessionPlayPage from './page';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof LiveSessionPlayPage> = {
+  title: 'Authenticated / sp4-session-play',
+  component: LiveSessionPlayPage,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/sessions/sp4-fixture-session-id/play' },
+    },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component: '#2231 DS-17-15. Session play live view (Phase C-2 skeleton-first base).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LiveSessionPlayPage>;
+
+export const Default: Story = {};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/catan.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/catan.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * sp4-session-catan stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ *
+ * Full MSW handlers + Catan flavor components (HexBoard, RobberOverlay, DiceDisplay, TradePanel, DevCardsPanel, ResourceHandBar)
+ * DEFERRED a Phase C-3 follow-up.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-catan-live.html
+ * - admin-mockups/design_files/sp4-session-catan-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-catan',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Catan session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-catan-live (Stub)
+      </h2>
+      <p>Per-game Catan flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-catan-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-catan-summary (Stub)
+      </h2>
+      <p>Per-game Catan summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-catan-summary.html</p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/codenames.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/codenames.stories.tsx
@@ -1,0 +1,56 @@
+/**
+ * sp4-session-codenames stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ *
+ * Full MSW handlers + Codenames flavor components (WordGrid, WordCard 5 states, SpymasterKeyCardOverlay, TeamPanel, CurrentCluePanel, ClueHistoryTimeline, RoleAvatar)
+ * DEFERRED a Phase C-3 follow-up.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-codenames-live.html
+ * - admin-mockups/design_files/sp4-session-codenames-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-codenames',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Codenames session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-codenames-live (Stub)
+      </h2>
+      <p>Per-game Codenames flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-codenames-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-codenames-summary (Stub)
+      </h2>
+      <p>Per-game Codenames summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">
+        Mockup: admin-mockups/design_files/sp4-session-codenames-summary.html
+      </p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/paleo.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/paleo.stories.tsx
@@ -1,0 +1,52 @@
+/**
+ * sp4-session-paleo stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ * Full implementation deferred Phase C-3.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-paleo-live.html
+ * - admin-mockups/design_files/sp4-session-paleo-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-paleo',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Paleo session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-paleo-live (Stub)
+      </h2>
+      <p>Per-game Paleo flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-paleo-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-paleo-summary (Stub)
+      </h2>
+      <p>Per-game Paleo summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-paleo-summary.html</p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/power-grid.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/power-grid.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * sp4-session-power-grid stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ * Full implementation deferred Phase C-3.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-power-grid-live.html
+ * - admin-mockups/design_files/sp4-session-power-grid-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-power-grid',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Power Grid session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-power-grid-live (Stub)
+      </h2>
+      <p>Per-game Power Grid flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-power-grid-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-power-grid-summary (Stub)
+      </h2>
+      <p>Per-game Power Grid summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">
+        Mockup: admin-mockups/design_files/sp4-session-power-grid-summary.html
+      </p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/puerto-rico.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/puerto-rico.stories.tsx
@@ -1,0 +1,56 @@
+/**
+ * sp4-session-puerto-rico stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ * Full implementation deferred Phase C-3.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-puerto-rico-live.html
+ * - admin-mockups/design_files/sp4-session-puerto-rico-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-puerto-rico',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Puerto Rico session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-puerto-rico-live (Stub)
+      </h2>
+      <p>Per-game Puerto Rico flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">
+        Mockup: admin-mockups/design_files/sp4-session-puerto-rico-live.html
+      </p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-puerto-rico-summary (Stub)
+      </h2>
+      <p>Per-game Puerto Rico summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">
+        Mockup: admin-mockups/design_files/sp4-session-puerto-rico-summary.html
+      </p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/wingspan.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/wingspan.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * sp4-session-wingspan stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ * Full implementation deferred Phase C-3.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-wingspan-live.html
+ * - admin-mockups/design_files/sp4-session-wingspan-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-wingspan',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Wingspan session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-wingspan-live (Stub)
+      </h2>
+      <p>Per-game Wingspan flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-wingspan-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-wingspan-summary (Stub)
+      </h2>
+      <p>Per-game Wingspan summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">
+        Mockup: admin-mockups/design_files/sp4-session-wingspan-summary.html
+      </p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/zombicide.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_sp4-stubs/zombicide.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * sp4-session-zombicide stub — DS-17-15 #2231 Phase C-2 skeleton-first.
+ * Full implementation deferred Phase C-3.
+ *
+ * Mockup refs:
+ * - admin-mockups/design_files/sp4-session-zombicide-live.html
+ * - admin-mockups/design_files/sp4-session-zombicide-summary.html
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-zombicide',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2231 DS-17-15. Zombicide session stub. Live + Summary variants. Full implementation deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-zombicide-live (Stub)
+      </h2>
+      <p>Per-game Zombicide flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">Mockup: admin-mockups/design_files/sp4-session-zombicide-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-3xl font-bold text-foreground">
+        sp4-session-zombicide-summary (Stub)
+      </h2>
+      <p>Per-game Zombicide summary components deferred Phase C-3 follow-up.</p>
+      <p className="text-xs">
+        Mockup: admin-mockups/design_files/sp4-session-zombicide-summary.html
+      </p>
+    </div>
+  ),
+};

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.stories.tsx
@@ -1,0 +1,32 @@
+/**
+ * sp4-session-skeleton-live — DS-17-15 #2231.
+ * Mockup parity: `admin-mockups/design_files/sp4-session-skeleton-live.{html,jsx}`.
+ */
+
+import LiveSessionPage from './page';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof LiveSessionPage> = {
+  title: 'Authenticated / sp4-session-skeleton-live',
+  component: LiveSessionPage,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/sessions/live/sp4-fixture-session-id' },
+    },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component: '#2231 DS-17-15. Live session skeleton (Phase C-2 skeleton-first base).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LiveSessionPage>;
+
+export const Default: Story = {};

--- a/docs/superpowers/specs/2026-06-12-ds-17-15-sp4-sessions-skeleton-first-design.md
+++ b/docs/superpowers/specs/2026-06-12-ds-17-15-sp4-sessions-skeleton-first-design.md
@@ -1,0 +1,170 @@
+# DS-17-15 sp4-sessions skeleton-first cluster — Design + Plan
+
+**Status**: design approved 2026-06-12 sess.46p brainstorming
+**Owner**: badsworm@gmail.com
+**Sub-issue**: [#2231](https://github.com/meepleAi-app/meepleai-monorepo/issues/2231)
+**Parent umbrella**: [#2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063)
+**Phase C-2 META spec**: [`2026-06-11-ds-17-phase-c-2-sp4-split-and-ds-17-12-design.md`](2026-06-11-ds-17-phase-c-2-sp4-split-and-ds-17-12-design.md)
+**Predecessor**: DS-17-14 #2228 PR #2230 `46ade8cf3` sess.46p
+**Phase C-2 milestone**: Merge → **Phase C-2 4/4 COMPLETE**
+
+## 1. Context
+
+DS-17 Phase C-2 step 4/4 FINAL. Skeleton-first scope per META DEC-3: 3 base ship + 7 per-game stub files. Per-game full implementation (MSW + flavor components) deferred Phase C-3.
+
+Combined spec+plan doc per P259 (small cluster pattern, ≤3-4h effort).
+
+## 2. DEC (1 new + 3 inherited)
+
+| # | Decisione | Source |
+|---|---|---|
+| DEC-1 | 7 stub files (1 per game, 2 Stories: Live + Summary) | sess.46p new |
+| DEC-inherited-META-3 | Skeleton-first scope (3 base + per-game lazy) | Phase C-2 META |
+| DEC-inherited-BGG-0 | BGG Stage 0 SKIP (0 findings) | DS-17-12-14 precedent |
+| DEC-inherited-Phase-C-3 | Per-game full MSW + flavor deferred Phase C-3 | Phase C-2 META |
+
+## 3. Scope
+
+### 3a. 3 base ship stems
+
+| # | Stem | Route | Action |
+|---|---|---|---|
+| 1 | sp4-session-skeleton-live | `(authenticated)/sessions/live/[sessionId]/` | Ship full story |
+| 2 | sp4-session-summary-skeleton | `(authenticated)/sessions/[id]/` | Ship full story |
+| 3 | sp4-session-play | `(authenticated)/sessions/[id]/play/` | Ship full story |
+
+### 3b. 7 per-game stub files
+
+Path: `apps/web/src/app/(authenticated)/sessions/_sp4-stubs/<game>.stories.tsx`
+
+| # | Game | Stories | Mockups covered |
+|---|---|---|---|
+| 4 | catan | Live + Summary | sp4-session-catan-{live,summary} |
+| 5 | codenames | Live + Summary | sp4-session-codenames-{live,summary} |
+| 6 | paleo | Live + Summary | sp4-session-paleo-{live,summary} |
+| 7 | power-grid | Live + Summary | sp4-session-power-grid-{live,summary} |
+| 8 | puerto-rico | Live + Summary | sp4-session-puerto-rico-{live,summary} |
+| 9 | wingspan | Live + Summary | sp4-session-wingspan-{live,summary} |
+| 10 | zombicide | Live + Summary | sp4-session-zombicide-{live,summary} |
+
+## 4. Implementation
+
+### Stage 0: BGG cleanup SKIP (0 findings verified pre-execution)
+
+### Stage 1: Pre-flight routes verify
+
+```bash
+ls apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.tsx \
+   apps/web/src/app/(authenticated)/sessions/[id]/page.tsx \
+   apps/web/src/app/(authenticated)/sessions/[id]/play/page.tsx
+```
+
+If MISSING for any base stem, escalate or ship as stub pattern.
+
+### Stage 2: 3 base ship stories inline (~30 min)
+
+Standard P251 pattern (story imports existing page component).
+
+### Stage 3: 7 stub files inline (~70 min)
+
+Stub pattern (~30 LOC each):
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Authenticated / sp4-session-<game>',
+  parameters: {
+    docs: {
+      description: {
+        component: '#2231 DS-17-15. <Game> session stub (Phase C-2 skeleton-first). Live + Summary variants. Full MSW + flavor components deferred Phase C-3.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Live: Story = {
+  render: () => (
+    <div className="p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-2xl">sp4-session-<game>-live (Stub)</h2>
+      <p>Per-game flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-sm">Mockup ref: admin-mockups/design_files/sp4-session-<game>-live.html</p>
+    </div>
+  ),
+};
+
+export const Summary: Story = {
+  render: () => (
+    <div className="p-8 text-center text-muted-foreground">
+      <h2 className="font-quicksand text-2xl">sp4-session-<game>-summary (Stub)</h2>
+      <p>Per-game flavor components deferred Phase C-3 follow-up.</p>
+      <p className="text-sm">Mockup ref: admin-mockups/design_files/sp4-session-<game>-summary.html</p>
+    </div>
+  ),
+};
+```
+
+### Stage 4: Quality gates
+
+### Stage 5: Merge P145 42a + Phase C-2 4/4 COMPLETE milestone + memory
+
+## 5. Effort recap
+
+| Stage | Effort |
+|---|---|
+| Pre-flight + sub-issue + branch | ✅ done (~10 min) |
+| Stage 0 SKIP | 0 min |
+| Stage 1 routes verify | ~5 min |
+| Stage 2 3 base stories | ~30 min |
+| Stage 3 7 stub files | ~70 min |
+| Stage 4 gates | ~30 min |
+| Stage 5 merge + closure + Phase C-2 milestone | ~30 min |
+| **Total** | **~3-4h** |
+
+## 6. Acceptance criteria
+
+### Base ship
+- [ ] 3 base stories scaffolded (skeleton-live + summary + play)
+- [ ] Existing route verification documented
+
+### Per-game stubs
+- [ ] 7 stub files in `sessions/_sp4-stubs/` dir
+- [ ] Each stub exports Live + Summary Stories (14 Stories total)
+- [ ] Stub content references mockup HTML path
+
+### Quality gates
+- [ ] pnpm typecheck 0 errors
+- [ ] pnpm lint 0 errors
+- [ ] pnpm lint:tokens 0 violations
+- [ ] pnpm lint:bgg clean
+- [ ] pnpm lint:fidelity all PASS
+- [ ] pnpm mockup-annotations:audit ≥80% mappable
+
+### Phase C-2 milestone
+- [ ] Admin-squash merge P145 42a
+- [ ] Sub-issue #2231 closed
+- [ ] EPIC #2063 Phase C-2 4/4 COMPLETE comment
+- [ ] Memory entry `ds-17-15-sp4-sessions-shipped.md`
+- [ ] Phase C-3 NEXT trigger note
+
+## 7. Out of scope (deferred Phase C-3)
+
+- ❌ Per-game MSW handlers (Catan/Codenames/etc datasets)
+- ❌ Per-game flavor components rendering (HexBoard, WordGrid, etc.)
+- ❌ Real game mockup parity
+- ❌ Visual baseline (P252)
+- ❌ DS-17 Phase D + E
+
+## 8. References
+
+- Sub-issue: #2231
+- Phase C-2 META: parent spec
+- Predecessors: #2218 + #2225 + #2230 (Phase C-2 steps 1-3)
+- Memory: `ds-17-14-sp4-admin-shipped.md` (P259 + P260)
+
+---
+
+**End of combined spec+plan.**


### PR DESCRIPTION
## Summary

🎉 **Phase C-2 4/4 COMPLETE on merge.** DS-17-15 closes the final Phase C-2 step.

### 3 base ship stories
- sp4-session-skeleton-live → /sessions/live/[sessionId]
- sp4-session-summary-skeleton → /sessions/[id]
- sp4-session-play → /sessions/[id]/play

### 7 per-game stub files (1 per game, 14 Stories Live + Summary)
Catan + Codenames + Paleo + Power Grid + Puerto Rico + Wingspan + Zombicide

Location: `apps/web/src/app/(authenticated)/sessions/_sp4-stubs/<game>.stories.tsx` (underscore-prefix private dir, Storybook picked up).

**Per-game MSW + flavor components (HexBoard/WordGrid/etc) DEFERRED Phase C-3.**

## Stage 0 BGG cleanup

SKIP — 0 BGG references in 17 sp4-session stems.

## Test plan

- [x] pnpm typecheck → 0 errors
- [x] pnpm lint → 0 errors (12 warnings pre-existing unrelated)
- [ ] Designer review SKIPPED per Opzione C

## Phase C-2 closure milestone

| Step | Sub-issue | PR |
|---|---|---|
| 1 — catalog | #2214 | #2218 |
| 2 — content | #2220 | #2225 |
| 3 — admin | #2228 | #2230 |
| **4 — sessions skeleton** | **#2231** | **#NEW** |

**Phase C-2 ✅ COMPLETE on merge.** DS-17 umbrella next: Phase D (or Phase C-3 per-game implementation).

## Refs

- Closes #2231
- Phase C-2 4/4 COMPLETE milestone (#2063)
- Phase C-3 NEXT (deferred per-game MSW + flavor)
- Predecessors: #2218 + #2225 + #2230

🤖 Generated with [Claude Code](https://claude.com/claude-code)