### PR TITLE
fix: 3 quick-win post-audit cleanup (#2171 #2178 #2190)

### DIFF
--- a/apps/web/src/app/(authenticated)/dashboard/_components/sections/FriendsActivitySection.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/_components/sections/FriendsActivitySection.tsx
@@ -34,7 +34,8 @@ const VERB_LABEL_IT: Record<FriendActivityVerb, string> = {
 };
 
 const SECTION_ICON = '🎉';
-const SECTION_TITLE = 'Cosa fanno i tuoi';
+// Issue #2178: previously 'Cosa fanno i tuoi' truncated mid-sentence.
+const SECTION_TITLE = 'Cosa fanno i tuoi amici';
 const SECTION_ID = 'friends-activity';
 
 export type FriendsActivitySectionState = 'default' | 'empty' | 'loading' | 'error';

--- a/apps/web/src/config/__tests__/navigation.test.ts
+++ b/apps/web/src/config/__tests__/navigation.test.ts
@@ -281,14 +281,18 @@ describe('sp4 navbar placement', () => {
   it('includes hub and toolkit items', () => {
     const hub = UNIFIED_NAV_ITEMS.find(item => item.id === 'hub');
     const toolkit = UNIFIED_NAV_ITEMS.find(item => item.id === 'toolkit');
-    expect(hub?.href).toBe('/hub/games');
+    // Issue #2190: hub now points to /games multi-tab hub (Asse D P2 #1899)
+    expect(hub?.href).toBe('/games');
     expect(hub?.visibility?.authOnly).toBe(true);
     expect(toolkit?.href).toBe('/toolkit');
     expect(toolkit?.group).toBe('strumenti');
   });
 
-  it('hub activePattern matches any /hub route', () => {
+  it('hub activePattern matches /games or /hub routes', () => {
     const hub = UNIFIED_NAV_ITEMS.find(item => item.id === 'hub')!;
+    // Issue #2190: /games is the canonical hub; /hub/* preserved for legacy bookmarks.
+    expect(isUnifiedNavItemActive(hub, '/games')).toBe(true);
+    expect(isUnifiedNavItemActive(hub, '/games?tab=discover')).toBe(true);
     expect(isUnifiedNavItemActive(hub, '/hub/games')).toBe(true);
     expect(isUnifiedNavItemActive(hub, '/hub/agents')).toBe(true);
     expect(isUnifiedNavItemActive(hub, '/library')).toBe(false);

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -231,14 +231,18 @@ export const UNIFIED_NAV_ITEMS: UnifiedNavItem[] = [
   },
   {
     id: 'hub',
-    href: '/hub/games',
+    // Issue #2190: /hub/games was retired by Stage 3 #1026 + superseded by
+    // /games multi-tab hub (Asse D P2 #1899, default tab=discover). Redirect
+    // to the canonical surface so top-nav + bottom-tab Hub voice lands
+    // somewhere live instead of an obsolete hub page.
+    href: '/games',
     icon: Globe,
     iconName: 'globe',
     label: 'Hub',
     ariaLabel: 'Esplora il catalogo community',
     priority: 13,
     testId: 'nav-hub',
-    activePattern: /^\/hub/,
+    activePattern: /^\/(games|hub)/,
     visibility: { authOnly: true },
   },
   {

--- a/apps/web/src/lib/api/core/retryPolicy.ts
+++ b/apps/web/src/lib/api/core/retryPolicy.ts
@@ -22,7 +22,10 @@ import { API_CONFIG } from '@/config';
 import { sanitizeError } from '@/lib/errors';
 
 import { ApiError, NetworkError, ServerError } from './errors';
-import { logApiError, logger } from './logger';
+// Issue #2171: logApiError import removed — retry layer no longer
+// duplicates HttpClient + caller error logging. `logger.warn` is still
+// used for retry attempt telemetry.
+import { logger } from './logger';
 
 export interface RetryConfig {
   /** Maximum number of retry attempts (default: 3) */
@@ -216,19 +219,16 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
 
       // Check if we should retry this error
       if (!isRetryableError(error)) {
-        // Log non-retryable error and throw immediately
-        if (error instanceof ApiError) {
-          logApiError(error);
-        }
+        // Issue #2171: HttpClient catch handlers + caller already invoke
+        // logApiError. Don't double-log from the retry layer — only
+        // record the retry attempt count for telemetry.
         throw error;
       }
 
       // Check if we have retries left
       if (attempt >= config.maxAttempts) {
-        // All retries exhausted, log and throw
-        if (error instanceof ApiError) {
-          logApiError(error);
-        }
+        // Issue #2171: all retries exhausted — let HttpClient's catch logging
+        // and the caller surface the error once. No duplicate log here.
         throw error;
       }
 


### PR DESCRIPTION
Batch of 3 small post-audit fixes from US validation sweep follow-up.

## Changes

### #2178 fix(dashboard): FriendsActivitySection title truncated
`SECTION_TITLE` was 'Cosa fanno i tuoi' (truncated mid-sentence). Completed to 'Cosa fanno i tuoi amici'.

### #2190 fix(routing): Hub voice points to retired /hub/games
Top-nav (desktop) + bottom-tab (mobile) Hub voice was wired to `/hub/games`, which Stage 3 #1026 retired. Updated to `/games` (Asse D P2 #1899 multi-tab hub default tab=discover). `activePattern` widened to `/^\/(games|hub)/` so the Hub stays highlighted when users hit either the canonical surface or any legacy `/hub/*` bookmark.

### #2171 fix(api): retry layer no longer duplicates error logging
A single login failure previously fired 3 `[API Error]` console.error calls (HttpClient catch + 2 retry-policy catches at lines 221+230). `retryPolicy.ts` no longer calls `logApiError` — HttpClient catch handlers + callers (e.g. `_content.tsx`) already log once. Retry telemetry (`logger.warn` for retry attempts) preserved.

## Test plan

- [x] `pnpm test -- navigation` 202/202 pass
- [x] `pnpm test -- FriendsActivity` 11/11 pass
- [x] `pnpm test -- retryPolicy` 31/31 pass
- [x] Pre-commit hooks passed

## Closes

- #2171
- #2178
- #2190

🤖 Generated with [Claude Code](https://claude.com/claude-code)