### PR TITLE
fix: profile tabs IT + ComingSoon CTA fallbacks (#2201 #2192)

### DIFF
--- a/apps/web/src/app/(authenticated)/games/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/page.tsx
@@ -39,6 +39,7 @@
 
 import { Suspense } from 'react';
 
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 
 import { DiscoverHub } from '@/components/features/discover/DiscoverHub';
@@ -77,6 +78,24 @@ function ComingSoonTab({ label }: { label: string }) {
       <p className="text-sm text-muted-foreground">
         Funzionalità in arrivo. Disponibile in una release futura.
       </p>
+      {/* Issue #2192: dead-end UX fix — provide fallback CTAs so users who
+          land on a ComingSoon tab from a deep link have a clear next step
+          instead of bouncing. */}
+      <div
+        className="mt-4 flex flex-col items-center gap-2 text-sm"
+        data-slot="games-coming-soon-fallbacks"
+      >
+        <p className="text-xs text-muted-foreground">Nel frattempo, puoi:</p>
+        <Link
+          href="/games?tab=discover"
+          className="text-foreground underline-offset-2 hover:underline"
+        >
+          ↳ Esplora i giochi con Discover
+        </Link>
+        <Link href="/library" className="text-foreground underline-offset-2 hover:underline">
+          ↳ Vai alla tua libreria
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/profile/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/profile/__tests__/page.test.tsx
@@ -176,10 +176,11 @@ describe('ProfilePage', () => {
     renderWithQuery(<ProfilePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Overview/i })).toBeInTheDocument();
+      // Issue #2201: tab labels translated to IT (Achievement kept as anglicism)
+      expect(screen.getByRole('tab', { name: /Panoramica/i })).toBeInTheDocument();
     });
 
-    ['Overview', 'Achievements', 'Activity', 'Settings'].forEach(name =>
+    ['Panoramica', 'Achievement', 'Attività', 'Impostazioni'].forEach(name =>
       expect(screen.getByRole('tab', { name })).toBeInTheDocument()
     );
   });
@@ -211,7 +212,7 @@ describe('ProfilePage', () => {
     renderWithQuery(<ProfilePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Achievements/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Achievement/i })).toBeInTheDocument();
     });
 
     expect(screen.getByTestId('achievements-grid')).toBeInTheDocument();
@@ -222,7 +223,7 @@ describe('ProfilePage', () => {
     renderWithQuery(<ProfilePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Activity/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Attività/i })).toBeInTheDocument();
     });
 
     expect(screen.getByTestId('activity-feed')).toBeInTheDocument();
@@ -256,10 +257,10 @@ describe('ProfilePage', () => {
       renderWithQuery(<ProfilePage />);
 
       await waitFor(() => {
-        expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Impostazioni' })).toBeInTheDocument();
       });
 
-      expect(screen.getByRole('tab', { name: 'Settings' })).toHaveAttribute(
+      expect(screen.getByRole('tab', { name: 'Impostazioni' })).toHaveAttribute(
         'aria-selected',
         'true'
       );

--- a/apps/web/src/app/(authenticated)/profile/_components/ProfilePageContent.tsx
+++ b/apps/web/src/app/(authenticated)/profile/_components/ProfilePageContent.tsx
@@ -49,11 +49,14 @@ const VALID_TABS = new Set<Tab>(['overview', 'achievements', 'activity', 'settin
 // ─── TabBar ───────────────────────────────────────────────────────────────────
 
 function TabBar({ active, onChange }: { active: Tab; onChange: (t: Tab) => void }) {
+  // Issue #2201: tab labels were hardcoded EN; panel content is IT. Translate
+  // 3 of the 4 to match panel language. 'Achievement' kept as accepted Italian
+  // gaming anglicism (matches in-product usage in achievements panel).
   const tabs: { id: Tab; label: string; icon: React.ElementType }[] = [
-    { id: 'overview', label: 'Overview', icon: LayoutDashboard },
-    { id: 'achievements', label: 'Achievements', icon: Trophy },
-    { id: 'activity', label: 'Activity', icon: Activity },
-    { id: 'settings', label: 'Settings', icon: Settings },
+    { id: 'overview', label: 'Panoramica', icon: LayoutDashboard },
+    { id: 'achievements', label: 'Achievement', icon: Trophy },
+    { id: 'activity', label: 'Attività', icon: Activity },
+    { id: 'settings', label: 'Impostazioni', icon: Settings },
   ];
 
   return (


### PR DESCRIPTION
Closes #2201 + #2192. Two unrelated quick-wins batched.

## #2201 fix(profile): tab labels IT
ProfilePageContent tab labels were hardcoded EN (Overview / Achievements / Activity / Settings) while panel content rendered IT. Translated 3/4 (Panoramica / Attività / Impostazioni); Achievement kept as accepted Italian gaming anglicism (matches in-product usage in achievements panel).

## #2192 fix(games): ComingSoon CTA fallbacks
Catalogo/Trending/Community placeholder tabs were dead-end UX — users landing from a deep link bounced. Added 2 fallback CTAs (Esplora Discover + Vai alla libreria) inside the placeholder so existing tests still find the heading.

## Test plan
- [x] pnpm test -- profile (13/13 pass)
- [x] pnpm typecheck clean
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)