### PR TITLE
fix(agents): chat CTA redirects to /chat/new flow (#2199)

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
@@ -540,7 +540,13 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
           createdAt: safeAgent.createdAt,
         }}
         ctaBack={() => router.push('/agents')}
-        ctaPlay={variant === 'active' ? () => router.push(`/agents/${agentId}/chat`) : undefined}
+        // Issue #2199: /agents/[id]/chat was an orphan route (no page.tsx
+        // exists). Redirect to the chat creation flow with the agent
+        // pre-selected via query param. Pattern matches the chat slot in
+        // buildGameConnections (#2190 follow-up).
+        ctaPlay={
+          variant === 'active' ? () => router.push(`/chat/new?agentId=${agentId}`) : undefined
+        }
         ctaSetup={
           variant === 'draft' && safeAgent.gameId
             ? () => router.push(`/library/${safeAgent.gameId}/play/setup-wizard`)


### PR DESCRIPTION
Closes #2199. Agent detail 'Avvia chat' button (ctaPlay, active variant) was wired to `/agents/{id}/chat` which has no page.tsx → 404. Redirect to `/chat/new?agentId={id}` so users land in the chat creation flow with the agent pre-selected.

Pattern matches `buildGameConnections` chat slot redirect (#2190 post ADR-061 follow-up).

## Test plan
- [x] pnpm test -- AgentDetailView (25/25 pass)
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)