### PR TITLE
fix(a11y): wrap (auth) route group in <main> landmark (#2169)

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -14,6 +14,13 @@
  * - Minimal footer (Privacy + Terms)
  * - Dark mode support
  * - Optimized for auth flows
+ *
+ * Issue #2169: wraps children in <main id="main-content"> so the WCAG 2.1
+ * § 1.3.1 landmark requirement is satisfied and the root-layout "Skip to
+ * main content" link has a valid target. Previously the (auth) tree
+ * mounted form content directly inside <body> with no landmark — axe-core
+ * flagged 11x "content not contained by landmarks" + 1x "no skip link
+ * target" on /login during the US-2 validation walkthrough.
  */
 
 'use client';
@@ -21,13 +28,13 @@
 import { ReactNode } from 'react';
 
 /**
- * Auth layout wrapper
+ * Auth layout wrapper.
  *
- * AuthLayout is applied directly by individual auth pages
- * with page-specific titles and subtitles.
- *
- * This wrapper just provides a consistent container.
+ * AuthLayout is applied directly by individual auth pages with page-
+ * specific titles and subtitles. This wrapper provides the WCAG-required
+ * <main> landmark + skip-link target shared across the (auth) route
+ * group.
  */
 export default function AuthRootLayout({ children }: { children: ReactNode }) {
-  return <>{children}</>;
+  return <main id="main-content">{children}</main>;
 }


### PR DESCRIPTION
Closes #2169. WCAG 2.1 § 1.3.1 fix — auth route layout now wraps children in `<main id='main-content'>` so axe-core landmark violations and the AccessibleSkipLink target are both satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)