### PR TITLE
fix(games): wire Trending tab to live /catalog/trending endpoint (#2191)

### DIFF
--- a/apps/web/src/app/(authenticated)/games/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/__tests__/page.test.tsx
@@ -56,6 +56,13 @@ vi.mock('@/components/features/discover/DiscoverHub', () => ({
   },
 }));
 
+// Issue #2191: TrendingTabContent now wires the live /catalog/trending hook.
+// Mock to a stub so this orchestrator test stays focused on tab routing — the
+// component itself is covered by TrendingTabContent.test.tsx.
+vi.mock('@/components/features/games/TrendingTabContent', () => ({
+  TrendingTabContent: () => <div data-testid="games-tab-trending">TrendingTabContent mock</div>,
+}));
+
 // ─── Import under test (after mocks) ──────────────────────────────────────
 
 import GamesHubPage from '../page';
@@ -139,14 +146,15 @@ describe('/games hub multi-tab page (Asse D P2)', () => {
       expect(screen.queryByTestId('discover-hub-mock')).not.toBeInTheDocument();
     });
 
-    it('renders Trending placeholder when ?tab=trending', () => {
+    it('renders live Trending content when ?tab=trending (#2191 wired)', () => {
       setQueryParam('tab', 'trending');
       render(<GamesHubPage />);
 
       const hub = screen.getByTestId('games-hub');
       expect(hub).toHaveAttribute('data-active-tab', 'trending');
-      expect(screen.getByTestId('games-tab-trending-coming-soon')).toBeInTheDocument();
-      expect(screen.getByText('Trending')).toBeInTheDocument();
+      // Issue #2191: Trending is wired to /catalog/trending — no longer ComingSoon.
+      expect(screen.getByTestId('games-tab-trending')).toBeInTheDocument();
+      expect(screen.queryByTestId('games-tab-trending-coming-soon')).not.toBeInTheDocument();
       expect(screen.queryByTestId('discover-hub-mock')).not.toBeInTheDocument();
     });
 

--- a/apps/web/src/app/(authenticated)/games/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/page.tsx
@@ -43,6 +43,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 
 import { DiscoverHub } from '@/components/features/discover/DiscoverHub';
+import { TrendingTabContent } from '@/components/features/games/TrendingTabContent';
 import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
 
 type GamesTab = 'discover' | 'catalogo' | 'trending' | 'community';
@@ -119,7 +120,11 @@ function GamesHubContent() {
     <div data-testid="games-hub" data-slot="games-hub" data-active-tab={activeTab}>
       {activeTab === 'discover' && <DiscoverHub pathnameOverride="/games" />}
       {activeTab === 'catalogo' && <ComingSoonTab label={TAB_LABEL.catalogo} />}
-      {activeTab === 'trending' && <ComingSoonTab label={TAB_LABEL.trending} />}
+      {/* Issue #2191: Trending tab is now wired to the live
+          /api/v1/catalog/trending endpoint (BE already shipped — the Discover
+          hub Row 1 has been consuming it since Asse D follow-up P2). The
+          Catalogo/Community placeholders remain ComingSoonTab. */}
+      {activeTab === 'trending' && <TrendingTabContent />}
       {activeTab === 'community' && <ComingSoonTab label={TAB_LABEL.community} />}
     </div>
   );

--- a/apps/web/src/components/features/games/TrendingTabContent.tsx
+++ b/apps/web/src/components/features/games/TrendingTabContent.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { HorizontalRow, type RowItemBase } from '@/components/features/discover';
+import { useCatalogTrending } from '@/hooks/queries/useCatalogTrending';
+import { useTranslation } from '@/hooks/useTranslation';
+import { trackEvent } from '@/lib/analytics/track-event';
+
+/**
+ * `TrendingTabContent` — `/games?tab=trending` body.
+ *
+ * Issue #2191: replaces the `ComingSoonTab` placeholder for the Trending tab.
+ * The backend endpoint `/api/v1/catalog/trending` ships and is already consumed
+ * by the Discover hub Row 1; this component wires the same hook
+ * (`useCatalogTrending`) into the Games hub Trending tab so users who follow
+ * the sidebar voice / deep-link finally see live data instead of a ComingSoon
+ * dead end.
+ *
+ * Render: `HorizontalRow` with `variant="grid"` so the tab body lays out the
+ * full trending list as a responsive grid (vs the carousel used on Discover).
+ * Loading/error/empty states are handled by `HorizontalRow` itself.
+ */
+export function TrendingTabContent({ limit = 20 }: { limit?: number } = {}) {
+  const { t } = useTranslation();
+  const trending = useCatalogTrending(limit);
+
+  const items = useMemo<ReadonlyArray<RowItemBase>>(
+    () =>
+      (trending.data ?? []).map(g => ({
+        id: g.gameId,
+        name: g.title,
+        imageUrl: g.thumbnailUrl,
+      })),
+    [trending.data]
+  );
+
+  const handleCardClick = (rowId: string, item: RowItemBase) => {
+    trackEvent('games_trending_tab_card_clicked', {
+      row: rowId,
+      entityId: item.id,
+    });
+  };
+
+  return (
+    <div
+      data-testid="games-tab-trending"
+      data-slot="games-tab-trending"
+      className="flex flex-col gap-6 py-6"
+    >
+      <HorizontalRow
+        rowId="trending"
+        variant="grid"
+        title={t('pages.discover.rows.trending.title')}
+        subtitle={t('pages.discover.rows.trending.subtitle')}
+        items={items}
+        isLoading={trending.isLoading}
+        isError={trending.isError}
+        onRetry={() => trending.refetch()}
+        onCardClick={handleCardClick}
+        retryLabel={t('pages.discover.common.retry')}
+        emptyLabel={t('pages.discover.common.empty')}
+        viewAllLabel={t('pages.discover.common.viewAll')}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/features/games/__tests__/TrendingTabContent.test.tsx
+++ b/apps/web/src/components/features/games/__tests__/TrendingTabContent.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * TrendingTabContent tests — Issue #2191
+ *
+ * Verifies that the `/games?tab=trending` tab body:
+ *  - Calls `useCatalogTrending(20)` (default limit)
+ *  - Renders the HorizontalRow grid with the returned items
+ *  - Surfaces loading / error / empty states from the hook
+ *  - Maps the catalog DTO → `RowItemBase` shape correctly
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useCatalogTrendingMock = vi.fn();
+vi.mock('@/hooks/queries/useCatalogTrending', () => ({
+  useCatalogTrending: (limit: number) => useCatalogTrendingMock(limit),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const horizontalRowSpy = vi.fn();
+vi.mock('@/components/features/discover', () => ({
+  HorizontalRow: (props: unknown) => {
+    horizontalRowSpy(props);
+    return <div data-testid="horizontal-row-mock">HorizontalRow mock</div>;
+  },
+}));
+
+vi.mock('@/lib/analytics/track-event', () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { TrendingTabContent } from '../TrendingTabContent';
+
+describe('TrendingTabContent (#2191)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls useCatalogTrending with default limit 20', () => {
+    useCatalogTrendingMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<TrendingTabContent />);
+
+    expect(useCatalogTrendingMock).toHaveBeenCalledWith(20);
+  });
+
+  it('passes loading flag through to HorizontalRow', () => {
+    useCatalogTrendingMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<TrendingTabContent />);
+
+    expect(horizontalRowSpy).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true }));
+  });
+
+  it('passes error flag through to HorizontalRow', () => {
+    useCatalogTrendingMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
+
+    render(<TrendingTabContent />);
+
+    expect(horizontalRowSpy).toHaveBeenCalledWith(expect.objectContaining({ isError: true }));
+  });
+
+  it('maps the catalog DTO to RowItemBase shape', () => {
+    useCatalogTrendingMock.mockReturnValue({
+      data: [
+        { gameId: 'g-1', title: 'Catan', thumbnailUrl: 'https://example.com/catan.jpg' },
+        { gameId: 'g-2', title: 'Carcassonne', thumbnailUrl: null },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<TrendingTabContent />);
+
+    expect(horizontalRowSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          { id: 'g-1', name: 'Catan', imageUrl: 'https://example.com/catan.jpg' },
+          { id: 'g-2', name: 'Carcassonne', imageUrl: null },
+        ],
+        variant: 'grid',
+        rowId: 'trending',
+      })
+    );
+  });
+
+  it('renders an outer container with data-testid="games-tab-trending"', () => {
+    useCatalogTrendingMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<TrendingTabContent />);
+
+    expect(screen.getByTestId('games-tab-trending')).toBeInTheDocument();
+  });
+
+  it('honors the limit prop when provided', () => {
+    useCatalogTrendingMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<TrendingTabContent limit={50} />);
+
+    expect(useCatalogTrendingMock).toHaveBeenCalledWith(50);
+  });
+});


### PR DESCRIPTION
Closes #2191. Shipping gap fix — BE `/api/v1/catalog/trending` was already consumed by Discover Row 1, but the dedicated Trending tab on `/games` rendered `ComingSoonTab`. New `TrendingTabContent` component uses the existing `useCatalogTrending` hook + `HorizontalRow` grid variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)