### PR TITLE
fix(discover): make DiscoverHero badge pathname dynamic (#2193 sub#1)

### DIFF
--- a/apps/web/src/components/features/discover/DiscoverHero.tsx
+++ b/apps/web/src/components/features/discover/DiscoverHero.tsx
@@ -11,6 +11,14 @@ export interface DiscoverHeroProps {
   readonly searchSlot?: ReactNode;
   /** FilterPillBar slot (rendered below search). */
   readonly filterSlot?: ReactNode;
+  /**
+   * Pathname displayed in the eyebrow badge (e.g. `/discover` or `/games`).
+   * Defaults to `/discover` for backward compatibility. Issue #2193: the
+   * standalone `/discover` route and the `/games?tab=discover` hub mount
+   * the same Discover surface, so the badge must reflect the actual route
+   * the user is on, not a hardcoded label.
+   */
+  readonly pathLabel?: string;
 }
 
 /**
@@ -20,7 +28,13 @@ export interface DiscoverHeroProps {
  * (entity event → toolkit → agent). Mockup-faithful pattern; not coupled to
  * DiscoverSearchBox or EntityFilterPillBar (both passed via slot props).
  */
-export function DiscoverHero({ title, subtitle, searchSlot, filterSlot }: DiscoverHeroProps) {
+export function DiscoverHero({
+  title,
+  subtitle,
+  searchSlot,
+  filterSlot,
+  pathLabel = '/discover',
+}: DiscoverHeroProps) {
   return (
     <header
       data-slot="discover-hero"
@@ -37,7 +51,7 @@ export function DiscoverHero({ title, subtitle, searchSlot, filterSlot }: Discov
             className="inline-flex w-fit items-center gap-1 rounded-full bg-muted/60 px-2 py-0.5 font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground"
             aria-hidden="true"
           >
-            <span>🔍</span>Hub · /discover
+            <span>🔍</span>Hub · {pathLabel}
           </span>
           <h1
             className="font-bold font-[Quicksand] text-2xl sm:text-3xl tracking-tight text-foreground"

--- a/apps/web/src/components/features/discover/DiscoverHub.tsx
+++ b/apps/web/src/components/features/discover/DiscoverHub.tsx
@@ -214,6 +214,7 @@ export function DiscoverHub({ pathnameOverride }: DiscoverHubProps = {}) {
       <DiscoverHero
         title={t('pages.discover.hero.title')}
         subtitle={t('pages.discover.hero.subtitle')}
+        pathLabel={effectivePathname}
         searchSlot={
           <DiscoverSearchBox
             value={q}

--- a/apps/web/src/components/features/discover/__tests__/DiscoverHero.test.tsx
+++ b/apps/web/src/components/features/discover/__tests__/DiscoverHero.test.tsx
@@ -71,6 +71,21 @@ describe('DiscoverHero', () => {
     expect(container.querySelector('[data-slot="discover-hero-filters"]')).toBeNull();
   });
 
+  describe('Hub badge pathLabel (#2193)', () => {
+    it('defaults the eyebrow badge to "Hub · /discover" when no pathLabel is provided', () => {
+      const { container } = render(<DiscoverHero title="Scopri" />);
+      const badge = container.querySelector('[data-slot="discover-hero"] span[aria-hidden="true"]');
+      expect(badge?.textContent).toContain('Hub · /discover');
+    });
+
+    it('overrides the badge pathname when pathLabel="/games" is provided', () => {
+      const { container } = render(<DiscoverHero title="Scopri" pathLabel="/games" />);
+      const badge = container.querySelector('[data-slot="discover-hero"] span[aria-hidden="true"]');
+      expect(badge?.textContent).toContain('Hub · /games');
+      expect(badge?.textContent).not.toContain('/discover');
+    });
+  });
+
   it('renders both slots when both are provided', () => {
     const { container } = render(
       <DiscoverHero


### PR DESCRIPTION
Refs #2193 (partial — sub-finding #1 only). Eyebrow badge 'Hub · /discover' was hardcoded, so users on `/games?tab=discover` saw the wrong path. New optional `pathLabel` prop on `DiscoverHero` defaults to `/discover` and DiscoverHub passes the effective pathname through.

Sub-findings #2 (duplicate search) and #3 (Library button intent) remain on #2193 for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)