### PR TITLE
docs(mockups): flag auth-flow as forward-refactor for session_expired (#2170)

### DIFF
--- a/admin-mockups/design_files/auth-flow.fidelity.json
+++ b/admin-mockups/design_files/auth-flow.fidelity.json
@@ -26,7 +26,9 @@
     "designer_approved_on": "",
     "story_path": "apps/web/src/components/auth/auth-flow.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/auth/auth-flow.ts",
-    "design_intent": "current",
+    "design_intent": "forward-refactor",
+    "design_intent_tracking_issue": "2170",
+    "design_intent_notes": "Phase B reclassified `current` → `forward-refactor` per #2170: the live /login?reason=session_expired surface (warning banner on top of AuthCard) is NOT covered by any of the 6 phone screens in auth-flow.html. Designer signoff required to commission a 7th screen (SessionExpiredScreen) showing the banner + form. Bonus drift: OAuth providers — mockup shows Google + Discord (2), live shows Google + Discord + GitHub (3).",
     "viewports": [
       "desktop"
     ],

--- a/docs/for-developers/frontend/mockup-designer-review-queue.md
+++ b/docs/for-developers/frontend/mockup-designer-review-queue.md
@@ -89,6 +89,13 @@ Spec-panel critique with 4 experts (Cockburn lead · Adzic · Wiegers · Fowler)
 
 Second spec-panel critique on nav-chrome / BGG / naming consistency. Full report: [`audits/2026-06-10-nav-chrome-bgg-naming-audit.md`](../../../audits/2026-06-10-nav-chrome-bgg-naming-audit.md).
 
+## US-2 walkthrough addendum — auth-flow gap (2026-06-12, #2170)
+
+`auth-flow.fidelity.json` was reclassified `current` → `forward-refactor` to track a gap discovered during the US-2 Marco Socratic walkthrough.
+
+- [ ] **#2170 — `auth-flow.html`: add `SessionExpiredScreen`** — The live `/login?reason=session_expired` surface renders a warning banner above `AuthCard` (`t('auth.session.expired')` — yellow alert). The mockup ships 6 phone screens but none of them shows this state, so the design intent for "resume session" (central to US-2) is undocumented. Decision required: commission a 7th screen, or downgrade the live banner to match the mockup.
+- [ ] **OAuth provider drift (#2170 bonus)** — Mockup shows 2 OAuth providers (Google + Discord). Live shows 3 (Google + Discord + GitHub). Decision required: add GitHub to the mockup, or remove GitHub from the live UI.
+
 ### 3 follow-up decisions (Drafts 14/15/16 — created post designer sign-off)
 
 - [ ] **Draft 14 (Fowler, architecture)**: Nav-chrome 3-way drift — primitives never consumed by page-mocks or runtime. Decide deprecate-or-backfill.


### PR DESCRIPTION
Closes #2170. US-2 walkthrough surfaced two drifts: live `/login?reason=session_expired` warning banner has no matching phone screen + OAuth count is 2 (mockup) vs 3 (live). Reclassify `auth-flow.fidelity.json` design_intent current→forward-refactor + add Designer Review Queue entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)