### PR TITLE
fix(ui-shell): convert RecentsBar pills from button to next/link (#2193 sub#3)

### DIFF
--- a/apps/web/src/components/layout/UserShell/RecentsBar.tsx
+++ b/apps/web/src/components/layout/UserShell/RecentsBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { entityHsl } from '@/components/ui/data-display/meeple-card';
 import { useRecentsStore } from '@/stores/use-recents';
@@ -9,11 +10,18 @@ import { useRecentsStore } from '@/stores/use-recents';
  * RecentsBar — shows recent entity pills in the MiniNav right area.
  * Max 3 pills visible (excludes current page).
  * Hidden on mobile (< md).
+ *
+ * Issue #2193 sub#3: pills used to be `<button onClick={router.push}>`. The
+ * US-8 walkthrough flagged the resulting "L"-style label as semantically
+ * ambiguous: Sara couldn't tell whether the affordance was a scope filter, a
+ * toggle, or a navigation shortcut. Conversion to `next/link` makes the
+ * destination obvious to assistive tech AND restores the native browser
+ * affordances (ctrl/middle-click → open in new tab, hover URL preview,
+ * right-click context menu) — the strongest signal that "this opens a page".
  */
 export function RecentsBar() {
   const items = useRecentsStore(s => s.items);
   const pathname = usePathname();
-  const router = useRouter();
 
   const visible = items.filter(i => i.href !== pathname).slice(0, 3);
 
@@ -27,13 +35,12 @@ export function RecentsBar() {
         const colorWithAlpha = entityHsl(item.entity, 0.1);
         const colorHover = entityHsl(item.entity, 0.4);
         return (
-          <button
+          <Link
             key={item.id}
-            type="button"
+            href={item.href}
             data-testid={`recent-pill-${item.id}`}
             title={item.title}
-            onClick={() => router.push(item.href)}
-            aria-label={item.title}
+            aria-label={`Apri ${item.title}`}
             className="flex h-7 w-7 items-center justify-center rounded-full text-[11px] font-bold transition-all duration-200 hover:scale-110 hover:shadow-md focus-visible:ring-2 focus-visible:ring-current focus-visible:outline-none"
             style={{
               backgroundColor: colorWithAlpha,
@@ -48,7 +55,7 @@ export function RecentsBar() {
             }}
           >
             {item.title.charAt(0).toUpperCase()}
-          </button>
+          </Link>
         );
       })}
     </div>

--- a/apps/web/src/components/layout/UserShell/__tests__/RecentsBar.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/RecentsBar.test.tsx
@@ -1,14 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { act } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { RecentsBar } from '../RecentsBar';
 import { useRecentsStore } from '@/stores/use-recents';
 
-// Mock next/navigation
-const mockPush = vi.fn();
+// Mock next/navigation — RecentsBar no longer needs useRouter after #2193
+// sub#3 (pills became next/link <a>), but the page mock still needs
+// usePathname for the "exclude current path" logic.
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
   usePathname: () => '/games/g1',
 }));
 
@@ -27,7 +26,6 @@ describe('RecentsBar', () => {
   beforeEach(() => {
     sessionStorage.clear();
     act(() => useRecentsStore.getState().clear());
-    mockPush.mockClear();
   });
 
   it('renders nothing when no recents', () => {
@@ -57,14 +55,22 @@ describe('RecentsBar', () => {
     expect(screen.getByTestId('recent-pill-g2')).toBeInTheDocument();
   });
 
-  it('navigates on click', async () => {
+  it('renders pills as next/link <a> with the destination href (#2193 sub#3)', () => {
     seedRecents();
     render(<RecentsBar />);
-    await userEvent.click(screen.getByTestId('recent-pill-g2'));
-    expect(mockPush).toHaveBeenCalledWith('/games/g2');
+    const pill = screen.getByTestId('recent-pill-g2');
+    expect(pill.tagName.toLowerCase()).toBe('a');
+    expect(pill).toHaveAttribute('href', '/games/g2');
   });
 
-  it('shows tooltip with title on hover', async () => {
+  it('exposes a descriptive aria-label so the single-letter content is not ambiguous (#2193 sub#3)', () => {
+    seedRecents();
+    render(<RecentsBar />);
+    const pill = screen.getByTestId('recent-pill-g2');
+    expect(pill).toHaveAttribute('aria-label', 'Apri Catan');
+  });
+
+  it('shows tooltip with title on hover', () => {
     seedRecents();
     render(<RecentsBar />);
     const pill = screen.getByTestId('recent-pill-g2');


### PR DESCRIPTION
Refs #2193 (sub-finding #3 only). US-8 walkthrough flagged single-letter pill labels ('L' for Library) as ambiguous. `next/link` makes destination obvious + restores native browser affordances (ctrl-click new tab, hover preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)