### PR TITLE
fix(discover): dedupe search box, gate HubLayout top input via showSearch (#2193 sub#2)

### DIFF
--- a/apps/web/src/components/features/discover/DiscoverHub.tsx
+++ b/apps/web/src/components/features/discover/DiscoverHub.tsx
@@ -210,7 +210,7 @@ export function DiscoverHub({ pathnameOverride }: DiscoverHubProps = {}) {
   const trendingVisible = entity === 'all' || entity === 'games';
 
   return (
-    <HubLayout searchPlaceholder={t('pages.discover.search.placeholder')}>
+    <HubLayout searchPlaceholder={t('pages.discover.search.placeholder')} showSearch={false}>
       <DiscoverHero
         title={t('pages.discover.hero.title')}
         subtitle={t('pages.discover.hero.subtitle')}

--- a/apps/web/src/components/layout/HubLayout/HubLayout.tsx
+++ b/apps/web/src/components/layout/HubLayout/HubLayout.tsx
@@ -21,6 +21,17 @@ export interface HubLayoutProps {
   viewMode?: 'grid' | 'list' | 'carousel';
   onViewModeChange?: (mode: 'grid' | 'list' | 'carousel') => void;
   showViewToggle?: boolean;
+  /**
+   * When false the top search input is not rendered. Use this when the page
+   * provides its own contextual search in the hero (e.g. `DiscoverSearchBox`)
+   * so the user does not see two identical "Cerca giochi, agenti, toolkit…"
+   * inputs stacked on top of each other.
+   *
+   * Defaults to `true` for backward compatibility.
+   *
+   * Issue #2193 sub#2.
+   */
+  showSearch?: boolean;
   topActions?: React.ReactNode;
   children: React.ReactNode;
 }
@@ -41,6 +52,7 @@ export function HubLayout({
   viewMode = 'grid',
   onViewModeChange,
   showViewToggle = false,
+  showSearch = true,
   topActions,
   children,
 }: HubLayoutProps) {
@@ -50,29 +62,33 @@ export function HubLayout({
       <div className="flex flex-col gap-2 px-4 pt-3 pb-2">
         {/* Search bar + view toggle row */}
         <div className="flex items-center gap-2">
-          {/* Search bar */}
-          <div className="relative flex-1">
-            <Search
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted,#94a3b8)] pointer-events-none"
-              size={16}
-              aria-hidden="true"
-            />
-            <input
-              type="search"
-              placeholder={searchPlaceholder}
-              value={searchValue}
-              onChange={e => onSearchChange?.(e.target.value)}
-              aria-label={searchPlaceholder}
-              className={cn(
-                'w-full h-10 pl-10 pr-4',
-                'bg-card/90 border border-black/[0.07] rounded-2xl shadow-sm',
-                'text-sm text-[var(--text,#1a1a1a)]',
-                'placeholder:text-[var(--text-muted,#94a3b8)]',
-                'outline-none focus-visible:ring-2 focus-visible:ring-[var(--text,#1a1a1a)]/20',
-                'transition-shadow'
-              )}
-            />
-          </div>
+          {/* Search bar — opt-out via showSearch={false} when the page renders
+              its own contextual search box (e.g. DiscoverSearchBox). Issue
+              #2193 sub#2. */}
+          {showSearch && (
+            <div className="relative flex-1">
+              <Search
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted,#94a3b8)] pointer-events-none"
+                size={16}
+                aria-hidden="true"
+              />
+              <input
+                type="search"
+                placeholder={searchPlaceholder}
+                value={searchValue}
+                onChange={e => onSearchChange?.(e.target.value)}
+                aria-label={searchPlaceholder}
+                className={cn(
+                  'w-full h-10 pl-10 pr-4',
+                  'bg-card/90 border border-black/[0.07] rounded-2xl shadow-sm',
+                  'text-sm text-[var(--text,#1a1a1a)]',
+                  'placeholder:text-[var(--text-muted,#94a3b8)]',
+                  'outline-none focus-visible:ring-2 focus-visible:ring-[var(--text,#1a1a1a)]/20',
+                  'transition-shadow'
+                )}
+              />
+            </div>
+          )}
 
           {/* Optional top actions (e.g. "Nuova sessione" button) */}
           {topActions && <div className="flex items-center shrink-0">{topActions}</div>}

--- a/apps/web/src/components/layout/HubLayout/__tests__/HubLayout.test.tsx
+++ b/apps/web/src/components/layout/HubLayout/__tests__/HubLayout.test.tsx
@@ -28,6 +28,11 @@ describe('HubLayout', () => {
     expect(screen.getByRole('searchbox', { name: /cerca/i })).toBeInTheDocument();
   });
 
+  it('hides the search bar when showSearch={false} (#2193 sub#2)', () => {
+    render(<HubLayout showSearch={false}>child</HubLayout>);
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
   it('renders the search bar with a custom placeholder', () => {
     render(<HubLayout searchPlaceholder="Cerca giochi...">child</HubLayout>);
     expect(screen.getByRole('searchbox', { name: /cerca giochi/i })).toBeInTheDocument();


### PR DESCRIPTION
Closes #2193 (last sub-finding). /discover rendered two identical search boxes — HubLayout top (no onChange wired) + DiscoverSearchBox (in hero). New `showSearch` prop on HubLayout (default true for back-compat) + DiscoverHub opts out. Combined with #2250 (badge) and #2257 (RecentsBar link), this closes #2193 fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)