### PR TITLE
fix(notifications): contextual empty states + Configura preferenze CTA (#2183)

### DIFF
--- a/apps/web/src/__tests__/fixtures/test-strings.ts
+++ b/apps/web/src/__tests__/fixtures/test-strings.ts
@@ -17,6 +17,10 @@ export const EMPTY = {
   notifications: 'Nessuna notifica',
   notificationsOfType: 'Nessuna notifica di questo tipo',
   notificationsUnread: 'Nessuna notifica non letta',
+  // Issue #2183: contextual empty-state copy variants
+  notificationsEmptyDefault: 'Nessuna notifica per ora',
+  notificationsEmptyCategory: 'Nessuna notifica in questa categoria',
+  notificationsEmptyAllRead: 'Sei in pari',
   sessions: 'Nessuna partita',
   sessionsActive: 'Nessuna partita in corso',
   proposals: 'Nessuna Proposta',

--- a/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
@@ -261,12 +261,16 @@ describe('NotificationsPage', () => {
     expect(markAllButton).toBeDisabled();
   });
 
-  it('should show empty state when no notifications', () => {
+  it('should show empty state when no notifications (#2183)', () => {
     setupStore({ notifications: [], unreadCount: 0, isFetching: false });
 
     render(<NotificationsPage />);
 
-    expect(screen.getByText(EMPTY.notifications)).toBeInTheDocument();
+    // Heading: explicit "no notifications yet" headline (#2183 contextual copy)
+    expect(screen.getByText(EMPTY.notificationsEmptyDefault)).toBeInTheDocument();
+    // CTA to /notifications/preferences must always render
+    const cta = screen.getByTestId('notifications-empty-preferences-cta');
+    expect(cta).toHaveAttribute('href', '/notifications/preferences');
   });
 
   it('should show empty state with unread message when unread-only toggle is on (#2181)', async () => {
@@ -298,8 +302,9 @@ describe('NotificationsPage', () => {
     });
     render(<NotificationsPage />);
     const newToggle = screen.getAllByTestId('notifications-unread-toggle').at(-1)!;
-    // Toggle is disabled (unreadCount === 0), so the "all-read" message lives
-    // both in the toggle label and in the empty-state copy.
+    // Toggle is disabled (unreadCount === 0), so the "all-read" message
+    // lives both in the toggle label and in the empty-state copy (#2181
+    // toggle + #2183 contextual empty-state heading).
     expect(newToggle).toBeDisabled();
     expect(screen.getAllByText(EMPTY.notificationsUnread).length).toBeGreaterThanOrEqual(1);
   });
@@ -344,7 +349,7 @@ describe('NotificationsPage', () => {
     expect(screen.getByText('2 non lette')).toBeInTheDocument();
   });
 
-  it('should show type-specific empty state when filter has no results', async () => {
+  it('should show type-specific empty state when filter has no results (#2183)', async () => {
     const user = userEvent.setup();
     const notifications = [createNotification({ type: 'document_ready' })];
     setupStore({ notifications, unreadCount: 1 });
@@ -354,7 +359,7 @@ describe('NotificationsPage', () => {
     // Click a filter category that has no matching notifications
     await user.click(screen.getByRole('button', { name: /serate/i }));
 
-    expect(screen.getByText(EMPTY.notificationsOfType)).toBeInTheDocument();
+    expect(screen.getByText(EMPTY.notificationsEmptyCategory)).toBeInTheDocument();
   });
 
   it('should display all filter category pills', () => {

--- a/apps/web/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/page.tsx
@@ -27,7 +27,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { formatDistanceToNow } from 'date-fns';
 import { it } from 'date-fns/locale';
-import { Bell, CheckCheck, Loader2 } from 'lucide-react';
+import { Bell, BellOff, CheckCheck, Loader2, Settings } from 'lucide-react';
+import Link from 'next/link';
 
 import { CatalogPagination } from '@/components/catalog/CatalogPagination';
 import { Btn } from '@/components/ui/btn';
@@ -314,20 +315,50 @@ export default function NotificationsPage() {
       )}
 
       {!isFetching && !error && filtered.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+        <div
+          className="flex flex-col items-center justify-center py-16 text-center gap-4"
+          data-testid="notifications-empty-state"
+        >
           <div
             className="flex h-24 w-24 items-center justify-center rounded-full bg-muted/60"
             aria-hidden="true"
           >
-            <Bell className="h-10 w-10 text-muted-foreground/60" />
+            {/* Issue #2183: BellOff communicates "you're all caught up" much
+                more clearly than Bell — the latter looked identical to the
+                inbox header, leaving Sara wondering if the page had failed
+                to load. Bell is kept for the broader "no notifications yet"
+                state because the inbox is genuinely awaiting its first
+                arrival, not muted. */}
+            {unreadOnly || notifications.length > 0 ? (
+              <BellOff className="h-10 w-10 text-muted-foreground/60" />
+            ) : (
+              <Bell className="h-10 w-10 text-muted-foreground/60" />
+            )}
           </div>
-          <p className="text-sm text-muted-foreground">
-            {unreadOnly
-              ? 'Nessuna notifica non letta'
-              : filter !== 'all'
-                ? 'Nessuna notifica di questo tipo'
-                : 'Nessuna notifica'}
-          </p>
+          <div className="flex flex-col items-center gap-1">
+            <p className="text-base font-semibold text-foreground">
+              {unreadOnly
+                ? 'Sei in pari'
+                : filter !== 'all'
+                  ? 'Nessuna notifica in questa categoria'
+                  : 'Nessuna notifica per ora'}
+            </p>
+            <p className="text-sm text-muted-foreground max-w-sm">
+              {unreadOnly
+                ? 'Tutte le notifiche sono state lette. Configura le preferenze per scegliere cosa ricevere in futuro.'
+                : filter !== 'all'
+                  ? 'Cambia categoria oppure modifica le preferenze per ricevere questo tipo di notifiche.'
+                  : 'Non hai ancora ricevuto notifiche. Configura le preferenze per personalizzare quando avvisarti.'}
+            </p>
+          </div>
+          <Link
+            href="/notifications/preferences"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted/50 transition-colors"
+            data-testid="notifications-empty-preferences-cta"
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+            Configura preferenze
+          </Link>
         </div>
       )}
 


### PR DESCRIPTION
Closes #2183 (quick-win parziale — custom design-team illustration deferred). Empty state was a single grey line with no action. Now renders one of three contextual messages (new user / all-read / filter-combo) plus a persistent /notifications/preferences link, and switches the icon to BellOff when filtering or clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)