### PR TITLE
fix(library): remove 'Tipo entità' filter panel section (#2186 partial)

### DIFF
--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/AdvancedFiltersDrawer.test.tsx
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/AdvancedFiltersDrawer.test.tsx
@@ -204,9 +204,9 @@ describe('AdvancedFiltersDrawer — 7-section rendering', () => {
       />
     );
     const slots = screen.getAllByTestId(/^advanced-filters-section-/);
+    // Issue #2186: 'entities' removed (handled by LibraryTabs entity scope).
     expect(slots.map(el => el.getAttribute('data-slot'))).toEqual([
       'advanced-filters-section-statuses',
-      'advanced-filters-section-entities',
       'advanced-filters-section-games',
       'advanced-filters-section-period',
       'advanced-filters-section-tags',
@@ -215,7 +215,21 @@ describe('AdvancedFiltersDrawer — 7-section rendering', () => {
     ]);
   });
 
-  it('opens the first 3 sections by default (mockup parity)', () => {
+  it('does not render the legacy "entities" section (#2186)', () => {
+    renderWithIntl(
+      <AdvancedFiltersDrawer
+        open={true}
+        onOpenChange={noop}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    );
+    expect(screen.queryByTestId('advanced-filters-section-entities')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Tipo entità/ })).not.toBeInTheDocument();
+  });
+
+  it('opens the first 3 sections by default (Stato / Gioco / Periodo after #2186)', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
@@ -226,11 +240,11 @@ describe('AdvancedFiltersDrawer — 7-section rendering', () => {
       />
     );
     expect(screen.getByRole('button', { name: /Stato/, expanded: true })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Tipo entità/, expanded: true })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Gioco/, expanded: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Periodo/, expanded: true })).toBeInTheDocument();
   });
 
-  it('keeps sections at index >= 3 collapsed by default', () => {
+  it('keeps sections at index >= 3 collapsed by default (Tags / Rating / Complessità)', () => {
     renderWithIntl(
       <AdvancedFiltersDrawer
         open={true}
@@ -240,7 +254,8 @@ describe('AdvancedFiltersDrawer — 7-section rendering', () => {
         onClear={noop}
       />
     );
-    expect(screen.getByRole('button', { name: /Periodo/, expanded: false })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Tag/, expanded: false })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rating/, expanded: false })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Complessità/, expanded: false })
     ).toBeInTheDocument();
@@ -257,9 +272,11 @@ describe('AdvancedFiltersDrawer — 7-section rendering', () => {
         onClear={noop}
       />
     );
-    const periodToggle = screen.getByRole('button', { name: /Periodo/, expanded: false });
-    await user.click(periodToggle);
-    expect(screen.getByRole('button', { name: /Periodo/, expanded: true })).toBeInTheDocument();
+    // After #2186 'Periodo' is in the first 3 (default-open). Use a section
+    // from the collapsed tail (Tag is index 3) to exercise the expand toggle.
+    const tagToggle = screen.getByRole('button', { name: /Tag/, expanded: false });
+    await user.click(tagToggle);
+    expect(screen.getByRole('button', { name: /Tag/, expanded: true })).toBeInTheDocument();
   });
 });
 
@@ -374,8 +391,8 @@ describe('AdvancedFiltersDrawer — period-quick (period section)', () => {
         onClear={noop}
       />
     );
-    // Period collapses by default → expand first
-    await user.click(screen.getByRole('button', { name: /Periodo/ }));
+    // Period is now in the first 3 default-open sections (#2186 — entities
+    // was removed so Period moved from index 3 → index 2).
     const radiogroup = screen.getByRole('radiogroup', { name: /Periodo/ });
     const options = within(radiogroup).getAllByRole('radio');
     expect(options).toHaveLength(5);
@@ -393,7 +410,6 @@ describe('AdvancedFiltersDrawer — period-quick (period section)', () => {
         onClear={noop}
       />
     );
-    await user.click(screen.getByRole('button', { name: /Periodo/ }));
     await user.click(screen.getByRole('radio', { name: /Ultimi 30 giorni/ }));
     await user.click(screen.getByRole('button', { name: /^Applica/ }));
     expect(onApply).toHaveBeenCalledWith({ period: '30d' });

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/sections.test.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/sections.test.ts
@@ -2,9 +2,9 @@
  * AdvancedFiltersDrawer — DRAWER_SECTIONS configuration tests.
  *
  * SP4 mockup conformance (Issue #1585-followup, plan Task 3.3). The drawer
- * uses a static 7-section descriptor (no scope dispatch). Tests assert the
- * shape, ordering, kind variety, and default-open behaviour matches the
- * mockup (admin-mockups/design_files/sp4-library-desktop.jsx:319-388).
+ * originally shipped a 7-section descriptor; Issue #2186 dropped the
+ * `entities` chips-multi (it duplicated LibraryTabs entity scope) so the
+ * descriptor is now 6 sections.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -12,10 +12,9 @@ import { describe, expect, it } from 'vitest';
 import { DRAWER_SECTIONS, isDefaultOpen } from '../sections';
 
 describe('DRAWER_SECTIONS', () => {
-  it('exposes 7 sections matching the mockup order', () => {
+  it('exposes 6 sections after the #2186 entity-section removal', () => {
     expect(DRAWER_SECTIONS.map(s => s.key)).toEqual([
       'statuses',
-      'entities',
       'games',
       'period',
       'tags',
@@ -24,9 +23,13 @@ describe('DRAWER_SECTIONS', () => {
     ]);
   });
 
-  it('uses chips-multi for status / entity / tags / weights sections', () => {
+  it('does not register an "entities" chips-multi (#2186 — handled by LibraryTabs)', () => {
+    expect(DRAWER_SECTIONS.find(s => s.key === 'entities')).toBeUndefined();
+  });
+
+  it('uses chips-multi for status / tags / weights sections', () => {
     const chipsMultiKeys = DRAWER_SECTIONS.filter(s => s.kind === 'chips-multi').map(s => s.key);
-    expect(chipsMultiKeys).toEqual(['statuses', 'entities', 'tags', 'weights']);
+    expect(chipsMultiKeys).toEqual(['statuses', 'tags', 'weights']);
   });
 
   it('uses select-multi for games section', () => {
@@ -58,14 +61,6 @@ describe('DRAWER_SECTIONS', () => {
     expect(section?.kind).toBe('chips-multi');
     if (section && section.kind === 'chips-multi') {
       expect(section.options.map(o => o.value)).toEqual(['owned', 'wishlist', 'setup', 'archived']);
-    }
-  });
-
-  it('exposes 5 entity options (game/agent/kb/session/chat)', () => {
-    const section = DRAWER_SECTIONS.find(s => s.key === 'entities');
-    expect(section?.kind).toBe('chips-multi');
-    if (section && section.kind === 'chips-multi') {
-      expect(section.options.map(o => o.value)).toEqual(['game', 'agent', 'kb', 'session', 'chat']);
     }
   });
 
@@ -112,16 +107,11 @@ describe('DRAWER_SECTIONS', () => {
     }
   });
 
-  it('assigns icons to status / entity chip options (mockup affordance)', () => {
+  it('assigns icons to status chip options (mockup affordance)', () => {
     const statusSection = DRAWER_SECTIONS.find(s => s.key === 'statuses');
     if (statusSection && statusSection.kind === 'chips-multi') {
       expect(statusSection.options.find(o => o.value === 'owned')?.icon).toBe('✓');
       expect(statusSection.options.find(o => o.value === 'wishlist')?.icon).toBe('★');
-    }
-    const entitySection = DRAWER_SECTIONS.find(s => s.key === 'entities');
-    if (entitySection && entitySection.kind === 'chips-multi') {
-      expect(entitySection.options.find(o => o.value === 'game')?.icon).toBe('🎲');
-      expect(entitySection.options.find(o => o.value === 'agent')?.icon).toBe('🤖');
     }
   });
 
@@ -144,6 +134,5 @@ describe('isDefaultOpen', () => {
     expect(isDefaultOpen(3)).toBe(false);
     expect(isDefaultOpen(4)).toBe(false);
     expect(isDefaultOpen(5)).toBe(false);
-    expect(isDefaultOpen(6)).toBe(false);
   });
 });

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/sections.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/sections.ts
@@ -24,7 +24,6 @@
  */
 
 import type {
-  LibraryFilterEntity,
   LibraryFilterPeriod,
   LibraryFilterStatus,
   LibraryFilterTag,
@@ -96,7 +95,6 @@ export interface RangeSection {
 
 export type SectionConfig =
   | ChipsMultiSection<LibraryFilterStatus>
-  | ChipsMultiSection<LibraryFilterEntity>
   | ChipsMultiSection<LibraryFilterTag>
   | ChipsMultiSection<LibraryFilterWeight>
   | SelectMultiSection
@@ -130,38 +128,10 @@ const STATUS_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterStatus>> = [
   },
 ];
 
-const ENTITY_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterEntity>> = [
-  {
-    value: 'game',
-    i18nKey: 'pages.library.filters.section.entity.options.game',
-    icon: '🎲',
-    color: 'game',
-  },
-  {
-    value: 'agent',
-    i18nKey: 'pages.library.filters.section.entity.options.agent',
-    icon: '🤖',
-    color: 'agent',
-  },
-  {
-    value: 'kb',
-    i18nKey: 'pages.library.filters.section.entity.options.kb',
-    icon: '📚',
-    color: 'kb',
-  },
-  {
-    value: 'session',
-    i18nKey: 'pages.library.filters.section.entity.options.session',
-    icon: '🎯',
-    color: 'session',
-  },
-  {
-    value: 'chat',
-    i18nKey: 'pages.library.filters.section.entity.options.chat',
-    icon: '💬',
-    color: 'chat',
-  },
-];
+// Issue #2186: ENTITY_OPTIONS removed — entity scope is the responsibility
+// of LibraryTabs (Tutti / Giochi / Agenti / KB / Sessioni / Chat) and
+// duplicating it inside the AdvancedFiltersDrawer created two parallel
+// filter paths with overlapping semantics.
 
 const PERIOD_OPTIONS: ReadonlyArray<PeriodQuickOption<LibraryFilterPeriod>> = [
   { value: '7d', i18nKey: 'pages.library.filters.section.period.options.7d' },
@@ -230,9 +200,10 @@ const WEIGHT_OPTIONS: ReadonlyArray<ChipOption<LibraryFilterWeight>> = [
 ];
 
 /**
- * Static 7-section descriptor matching the mockup `DRAWER_SECTIONS` array.
- * Order is significant: first 3 sections are open by default (see drawer
- * `defaultOpen` logic), remaining 4 collapse on initial render.
+ * Static 6-section descriptor (#2186: 'entities' removed, was index 1 / 7-of-7
+ * in the original mockup). Order is significant: first 3 sections are open
+ * by default (see drawer `defaultOpen` logic), remaining 3 collapse on
+ * initial render.
  */
 export const DRAWER_SECTIONS: ReadonlyArray<SectionConfig> = [
   {
@@ -242,13 +213,7 @@ export const DRAWER_SECTIONS: ReadonlyArray<SectionConfig> = [
     icon: '●',
     options: STATUS_OPTIONS,
   },
-  {
-    kind: 'chips-multi',
-    key: 'entities',
-    i18nLabel: 'pages.library.filters.section.entity.title',
-    icon: '⌗',
-    options: ENTITY_OPTIONS,
-  },
+  // Issue #2186: 'entities' section removed — handled by LibraryTabs instead.
   {
     kind: 'select-multi',
     key: 'games',

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/types.ts
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/types.ts
@@ -22,6 +22,12 @@
 
 export type LibraryFilterStatus = 'owned' | 'wishlist' | 'setup' | 'archived';
 
+/**
+ * @deprecated Issue #2186 — the AdvancedFiltersDrawer no longer ships an
+ * entity-type filter section because it duplicated the LibraryTabs entity
+ * scope (Tutti / Giochi / Agenti / KB / Sessioni / Chat). The type is kept
+ * for one release so external consumers can migrate; remove in a follow-up.
+ */
 export type LibraryFilterEntity = 'game' | 'agent' | 'kb' | 'session' | 'chat';
 
 export type LibraryFilterPeriod = '7d' | '30d' | '1y' | 'all' | 'range';
@@ -40,6 +46,11 @@ export type LibraryFilterWeight = 'light' | 'medium' | 'heavy' | 'extra';
 
 export interface LibraryFilters {
   readonly statuses?: ReadonlyArray<LibraryFilterStatus>;
+  /**
+   * @deprecated Issue #2186 — removed in favor of the LibraryTabs entity
+   * scope. Field kept optional for one release so persisted user state can
+   * be migrated. Always undefined for new state.
+   */
   readonly entities?: ReadonlyArray<LibraryFilterEntity>;
   readonly games?: ReadonlyArray<string>;
   readonly period?: LibraryFilterPeriod;


### PR DESCRIPTION
Refs #2186 (partial — biggest of three sub-fixes). AdvancedFiltersDrawer 'Tipo entità' chips-multi duplicated the LibraryTabs entity scope; the section is now gone (DRAWER_SECTIONS 7→6). `LibraryFilterEntity` type + `LibraryFilters.entities` field kept one release with `@deprecated` markers for state migration. Sort/Ordina dedicated action bar + games-tab sub-status cleanup are tracked separately on #2186 as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)