### PR TITLE
fix(feature-flags): #2162 FeatureFlagService environment asymmetry

### DIFF
--- a/apps/api/src/Api/Services/FeatureFlagService.cs
+++ b/apps/api/src/Api/Services/FeatureFlagService.cs
@@ -7,6 +7,7 @@ using Api.Helpers;
 using Api.Middleware;
 using Api.Models;
 using MediatR;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Api.Services;
@@ -35,6 +36,7 @@ internal class FeatureFlagService : IFeatureFlagService
 {
     private readonly IConfigurationService _configService;
     private readonly IMediator _mediator;
+    private readonly IWebHostEnvironment _environment;
     private readonly ILogger<FeatureFlagService> _logger;
     private const string FeatureFlagCategory = "FeatureFlags";
     private const string TierPrefix = "Tier";
@@ -42,10 +44,12 @@ internal class FeatureFlagService : IFeatureFlagService
     public FeatureFlagService(
         IConfigurationService configService,
         IMediator mediator,
+        IWebHostEnvironment environment,
         ILogger<FeatureFlagService> logger)
     {
         _configService = configService;
         _mediator = mediator;
+        _environment = environment;
         _logger = logger;
     }
 
@@ -177,8 +181,13 @@ internal class FeatureFlagService : IFeatureFlagService
     {
         var key = role.HasValue ? $"{featureName}.{role.Value}" : featureName;
 
-        // Check if configuration exists
-        var existing = await _configService.GetConfigurationByKeyAsync(key).ConfigureAwait(false);
+        // Bug #2162 (same pattern as #2116): pass the current environment to the
+        // lookup so it stays symmetric with the CREATE branch below. Without it
+        // the lookup falls back to _environment.EnvironmentName via the
+        // ConfigurationService default, while the CREATE used to hardcode
+        // "Production" — the asymmetry caused 23505 collisions in non-Production.
+        var environmentName = _environment.EnvironmentName;
+        var existing = await _configService.GetConfigurationByKeyAsync(key, environmentName).ConfigureAwait(false);
 
         var userGuid = userId != null && Guid.TryParse(userId, out var parsed) ? parsed : Guid.Empty;
 
@@ -210,7 +219,7 @@ internal class FeatureFlagService : IFeatureFlagService
                 CreatedByUserId: userGuid,
                 Description: $"Feature flag: {featureName}",
                 Category: FeatureFlagCategory,
-                Environment: "Production",
+                Environment: environmentName,
                 RequiresRestart: false);
 
             await _mediator.Send(command).ConfigureAwait(false);
@@ -227,8 +236,9 @@ internal class FeatureFlagService : IFeatureFlagService
     {
         var key = role.HasValue ? $"{featureName}.{role.Value}" : featureName;
 
-        // Check if configuration exists
-        var existing = await _configService.GetConfigurationByKeyAsync(key).ConfigureAwait(false);
+        // Bug #2162: symmetric lookup + CREATE per environment. See EnableFeatureAsync.
+        var environmentName = _environment.EnvironmentName;
+        var existing = await _configService.GetConfigurationByKeyAsync(key, environmentName).ConfigureAwait(false);
 
         var userGuid = userId != null && Guid.TryParse(userId, out var parsed) ? parsed : Guid.Empty;
 
@@ -260,7 +270,7 @@ internal class FeatureFlagService : IFeatureFlagService
                 CreatedByUserId: userGuid,
                 Description: $"Feature flag: {featureName}",
                 Category: FeatureFlagCategory,
-                Environment: "Production",
+                Environment: environmentName,
                 RequiresRestart: false);
 
             await _mediator.Send(command).ConfigureAwait(false);
@@ -278,8 +288,9 @@ internal class FeatureFlagService : IFeatureFlagService
         ArgumentNullException.ThrowIfNull(tier);
         var key = $"{featureName}.{TierPrefix}.{tier.Value}";
 
-        // Check if configuration exists
-        var existing = await _configService.GetConfigurationByKeyAsync(key).ConfigureAwait(false);
+        // Bug #2162: symmetric lookup + CREATE per environment. See EnableFeatureAsync.
+        var environmentName = _environment.EnvironmentName;
+        var existing = await _configService.GetConfigurationByKeyAsync(key, environmentName).ConfigureAwait(false);
 
         var userGuid = userId != null && Guid.TryParse(userId, out var parsed) ? parsed : Guid.Empty;
 
@@ -311,7 +322,7 @@ internal class FeatureFlagService : IFeatureFlagService
                 CreatedByUserId: userGuid,
                 Description: $"Feature flag: {featureName} (tier: {tier.Value})",
                 Category: FeatureFlagCategory,
-                Environment: "Production",
+                Environment: environmentName,
                 RequiresRestart: false);
 
             await _mediator.Send(command).ConfigureAwait(false);
@@ -329,8 +340,9 @@ internal class FeatureFlagService : IFeatureFlagService
         ArgumentNullException.ThrowIfNull(tier);
         var key = $"{featureName}.{TierPrefix}.{tier.Value}";
 
-        // Check if configuration exists
-        var existing = await _configService.GetConfigurationByKeyAsync(key).ConfigureAwait(false);
+        // Bug #2162: symmetric lookup + CREATE per environment. See EnableFeatureAsync.
+        var environmentName = _environment.EnvironmentName;
+        var existing = await _configService.GetConfigurationByKeyAsync(key, environmentName).ConfigureAwait(false);
 
         var userGuid = userId != null && Guid.TryParse(userId, out var parsed) ? parsed : Guid.Empty;
 
@@ -362,7 +374,7 @@ internal class FeatureFlagService : IFeatureFlagService
                 CreatedByUserId: userGuid,
                 Description: $"Feature flag: {featureName} (tier: {tier.Value})",
                 Category: FeatureFlagCategory,
-                Environment: "Production",
+                Environment: environmentName,
                 RequiresRestart: false);
 
             await _mediator.Send(command).ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Integration/FeatureFlagTierAccessIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Integration/FeatureFlagTierAccessIntegrationTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.Services;
 using Api.Tests.Constants;
 using MediatR;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -29,9 +30,14 @@ public class FeatureFlagTierAccessIntegrationTests
         _mockConfigService = new Mock<IConfigurationService>();
         _mockMediator = new Mock<IMediator>();
         _mockLogger = new Mock<ILogger<FeatureFlagService>>();
+
+        var environment = new Mock<IWebHostEnvironment>();
+        environment.Setup(e => e.EnvironmentName).Returns("Production");
+
         _featureFlagService = new FeatureFlagService(
             _mockConfigService.Object,
             _mockMediator.Object,
+            environment.Object,
             _mockLogger.Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Integration/FeatureFlagTierHierarchyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Integration/FeatureFlagTierHierarchyTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.Services;
 using Api.Tests.Constants;
 using MediatR;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -31,9 +32,13 @@ public class FeatureFlagTierHierarchyTests
         _mockMediator = new Mock<IMediator>();
         _mockLogger = new Mock<ILogger<FeatureFlagService>>();
 
+        var environment = new Mock<IWebHostEnvironment>();
+        environment.Setup(e => e.EnvironmentName).Returns("Production");
+
         _service = new FeatureFlagService(
             _mockConfigService.Object,
             _mockMediator.Object,
+            environment.Object,
             _mockLogger.Object);
     }
 

--- a/apps/api/tests/Api.Tests/Services/FeatureFlagServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Services/FeatureFlagServiceTests.cs
@@ -7,6 +7,7 @@ using Api.Models;
 using Api.Services;
 using Api.Tests.Constants;
 using MediatR;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -24,6 +25,7 @@ public class FeatureFlagServiceTests
 {
     private readonly Mock<IConfigurationService> _mockConfigService;
     private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<IWebHostEnvironment> _mockEnvironment;
     private readonly Mock<ILogger<FeatureFlagService>> _mockLogger;
     private readonly FeatureFlagService _service;
 
@@ -31,11 +33,14 @@ public class FeatureFlagServiceTests
     {
         _mockConfigService = new Mock<IConfigurationService>();
         _mockMediator = new Mock<IMediator>();
+        _mockEnvironment = new Mock<IWebHostEnvironment>();
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Production");
         _mockLogger = new Mock<ILogger<FeatureFlagService>>();
 
         _service = new FeatureFlagService(
             _mockConfigService.Object,
             _mockMediator.Object,
+            _mockEnvironment.Object,
             _mockLogger.Object);
     }
 
@@ -160,7 +165,7 @@ public class FeatureFlagServiceTests
         var expectedKey = $"{featureName}.Tier.{tier.Value}";
         var userId = Guid.NewGuid().ToString();
 
-        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, null, It.IsAny<CancellationToken>()))
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, "Production", It.IsAny<CancellationToken>()))
             .ReturnsAsync((SystemConfigurationDto?)null);
 
         // Act
@@ -188,7 +193,7 @@ public class FeatureFlagServiceTests
 
         var existingConfig = CreateSystemConfigDto(configId.ToString(), expectedKey, "false");
 
-        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, null, It.IsAny<CancellationToken>()))
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, "Production", It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingConfig);
 
         // Act
@@ -223,7 +228,7 @@ public class FeatureFlagServiceTests
         var expectedKey = $"{featureName}.Tier.{tier.Value}";
         var userId = Guid.NewGuid().ToString();
 
-        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, null, It.IsAny<CancellationToken>()))
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, "Production", It.IsAny<CancellationToken>()))
             .ReturnsAsync((SystemConfigurationDto?)null);
 
         // Act
@@ -250,7 +255,7 @@ public class FeatureFlagServiceTests
 
         var existingConfig = CreateSystemConfigDto(configId.ToString(), expectedKey, "true");
 
-        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, null, It.IsAny<CancellationToken>()))
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(expectedKey, "Production", It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingConfig);
 
         // Act
@@ -261,6 +266,226 @@ public class FeatureFlagServiceTests
             It.Is<UpdateConfigValueCommand>(cmd =>
                 cmd.ConfigId == configId &&
                 cmd.NewValue == "false"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region #2162 regression — Environment asymmetry (mirror of #2116 / PR #2159)
+
+    // For each of the 4 mutating methods, three regression tests guard against
+    // re-introducing the hardcoded Environment="Production" literal:
+    //   1. In Development env, the CREATE branch persists Environment="Development".
+    //   2. In Production env, the CREATE branch persists Environment="Production"
+    //      (derived from IWebHostEnvironment, NOT a literal).
+    //   3. The LOOKUP and the CREATE pass the SAME environment string (symmetric).
+
+    [Fact]
+    public async Task EnableFeatureAsync_InDevelopmentEnv_CreatesConfigWithDevelopmentEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Development");
+        const string featureName = "Features.NewFlag";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(featureName, "Development", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.EnableFeatureAsync(featureName, null, Guid.NewGuid().ToString());
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd =>
+                cmd.Key == featureName &&
+                cmd.Value == "true" &&
+                cmd.Environment == "Development"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnableFeatureAsync_InProductionEnv_PassesProductionDerivedFromIWebHostEnvironment()
+    {
+        // Regression guard: prevent re-introducing a hardcoded "Production" string literal.
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Production");
+        const string featureName = "Features.AnotherFlag";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(featureName, "Production", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.EnableFeatureAsync(featureName);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Production"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _mockEnvironment.Verify(e => e.EnvironmentName, Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task EnableFeatureAsync_LookupAndCreate_PassTheSameEnvironmentString()
+    {
+        // Symmetric lookup + create: any non-Production env exposes the asymmetry.
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Staging");
+        const string featureName = "Features.Symmetric";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(featureName, "Staging", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.EnableFeatureAsync(featureName);
+
+        _mockConfigService.Verify(c => c.GetConfigurationByKeyAsync(featureName, "Staging", It.IsAny<CancellationToken>()), Times.Once);
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Staging"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableFeatureAsync_InDevelopmentEnv_CreatesConfigWithDevelopmentEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Development");
+        const string featureName = "Features.OffFlag";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(featureName, "Development", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.DisableFeatureAsync(featureName);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd =>
+                cmd.Value == "false" &&
+                cmd.Environment == "Development"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableFeatureAsync_InProductionEnv_PassesProductionDerivedFromIWebHostEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Production");
+        const string featureName = "Features.ProdOff";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(featureName, "Production", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.DisableFeatureAsync(featureName);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Production"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableFeatureAsync_LookupAndCreate_PassTheSameEnvironmentString()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Staging");
+        const string featureName = "Features.SymOff";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(featureName, "Staging", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.DisableFeatureAsync(featureName);
+
+        _mockConfigService.Verify(c => c.GetConfigurationByKeyAsync(featureName, "Staging", It.IsAny<CancellationToken>()), Times.Once);
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Staging"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnableFeatureForTierAsync_InDevelopmentEnv_CreatesConfigWithDevelopmentEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Development");
+        const string featureName = "Features.TierOn";
+        var tier = UserTier.Premium;
+        var key = $"{featureName}.Tier.{tier.Value}";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(key, "Development", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.EnableFeatureForTierAsync(featureName, tier);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd =>
+                cmd.Key == key &&
+                cmd.Value == "true" &&
+                cmd.Environment == "Development"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnableFeatureForTierAsync_InProductionEnv_PassesProductionDerivedFromIWebHostEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Production");
+        const string featureName = "Features.TierProd";
+        var tier = UserTier.Normal;
+        var key = $"{featureName}.Tier.{tier.Value}";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(key, "Production", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.EnableFeatureForTierAsync(featureName, tier);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Production"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnableFeatureForTierAsync_LookupAndCreate_PassTheSameEnvironmentString()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Staging");
+        const string featureName = "Features.TierSym";
+        var tier = UserTier.Free;
+        var key = $"{featureName}.Tier.{tier.Value}";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(key, "Staging", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.EnableFeatureForTierAsync(featureName, tier);
+
+        _mockConfigService.Verify(c => c.GetConfigurationByKeyAsync(key, "Staging", It.IsAny<CancellationToken>()), Times.Once);
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Staging"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableFeatureForTierAsync_InDevelopmentEnv_CreatesConfigWithDevelopmentEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Development");
+        const string featureName = "Features.TierOff";
+        var tier = UserTier.Premium;
+        var key = $"{featureName}.Tier.{tier.Value}";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(key, "Development", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.DisableFeatureForTierAsync(featureName, tier);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd =>
+                cmd.Value == "false" &&
+                cmd.Environment == "Development"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableFeatureForTierAsync_InProductionEnv_PassesProductionDerivedFromIWebHostEnvironment()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Production");
+        const string featureName = "Features.TierProdOff";
+        var tier = UserTier.Normal;
+        var key = $"{featureName}.Tier.{tier.Value}";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(key, "Production", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.DisableFeatureForTierAsync(featureName, tier);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Production"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableFeatureForTierAsync_LookupAndCreate_PassTheSameEnvironmentString()
+    {
+        _mockEnvironment.Setup(e => e.EnvironmentName).Returns("Staging");
+        const string featureName = "Features.TierSymOff";
+        var tier = UserTier.Free;
+        var key = $"{featureName}.Tier.{tier.Value}";
+        _mockConfigService.Setup(c => c.GetConfigurationByKeyAsync(key, "Staging", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SystemConfigurationDto?)null);
+
+        await _service.DisableFeatureForTierAsync(featureName, tier);
+
+        _mockConfigService.Verify(c => c.GetConfigurationByKeyAsync(key, "Staging", It.IsAny<CancellationToken>()), Times.Once);
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateConfigurationCommand>(cmd => cmd.Environment == "Staging"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 


### PR DESCRIPTION
## Summary
Mirror of [#2116](https://github.com/meepleAi-app/meepleai-monorepo/issues/2116) / PR [#2159](https://github.com/meepleAi-app/meepleai-monorepo/pull/2159) fix, applied to the 4 mutating methods of \`FeatureFlagService\`:

- \`EnableFeatureAsync\`
- \`DisableFeatureAsync\`
- \`EnableFeatureForTierAsync\`
- \`DisableFeatureForTierAsync\`

Each had the same asymmetry: GET lookup left \`environment\` parameter null (falling back to current env via \`ConfigurationService\` default), but CREATE branch hardcoded \`Environment="Production"\` literal. In any non-Production env on a fresh DB this caused 23505 duplicate-key collisions with seed rows at \`Environment="Production"\`.

## Why this shape
- 1:1 follow of the SetRegistrationModeCommandHandler pattern from PR #2159 — same DI, same naming (\`environmentName\`), same comment placement.
- Default test mock returns \`"Production"\` so existing tests continue to compile with minimal churn (only the 4 lookup setups that explicitly passed \`null\` get updated to \`"Production"\`).
- 12 new regression unit tests (3 per method × 4 methods) lock the contract:
  - (a) Development env → CREATE persists \`"Development"\`
  - (b) Production env → CREATE persists \`"Production"\` derived from \`IWebHostEnvironment\` (NOT a literal)
  - (c) LOOKUP and CREATE pass the same string (symmetry verifier)

## Test plan
- [x] 85/85 \`FeatureFlag*\` unit tests pass
- [x] BE build verde (\`dotnet build\` Api + Api.Tests)
- [x] FE typecheck pulito (pre-existing stale \`.next/types/\` artifact cleaned)
- [x] 12 new regression tests cover all 4 methods + 3 contracts
- [ ] Smoke: invoke any of the 4 methods on a fresh dev DB (Environment=Development) — INSERT must land with Environment=Development, not Production. Manual.

## Files changed
- \`apps/api/src/Api/Services/FeatureFlagService.cs\` — inject \`IWebHostEnvironment\`, read \`environmentName\` once per method, pass to both lookup + create.
- \`apps/api/tests/Api.Tests/Services/FeatureFlagServiceTests.cs\` — +12 regression tests + \`IWebHostEnvironment\` mock with default \`"Production"\` + 4 setup updates (\`null\` → \`"Production"\`).
- \`apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Integration/FeatureFlagTierHierarchyTests.cs\` — ctor updated to pass \`IWebHostEnvironment\` mock.
- \`apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Integration/FeatureFlagTierAccessIntegrationTests.cs\` — same.

## Related
- #2116 (closed) root cause + fix pattern
- PR [#2159](https://github.com/meepleAi-app/meepleai-monorepo/pull/2159) (merged) reference fix
- Audit \`docs/for-developers/audits/2026-06-11-config-key-environment-asymmetry-audit.md\` — discovery doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)