### PR TITLE
fix(library): drop GIOCO visual-stub chip from CrossEntityFilters (#2186 closes)

### DIFF
--- a/apps/web/src/components/features/library/CrossEntityFilters.tsx
+++ b/apps/web/src/components/features/library/CrossEntityFilters.tsx
@@ -201,15 +201,16 @@ export function CrossEntityFilters({
 
       {/* Row 2 — Filter chips + advanced CTA + view toggle */}
       <div className="flex items-center gap-1.5 overflow-x-auto" style={{ scrollbarWidth: 'none' }}>
-        {/* 4 mockup-conformant filter chips (visual stubs).
-            STATO/GIOCO/DATA are non-interactive placeholders.
-            SORT reflects current sortKey label as a hook for a future popover. */}
+        {/* Mockup-conformant filter chips. STATO/DATA are non-interactive
+            placeholders; SORT reflects current sortKey label as a hook for a
+            future popover.
+            Issue #2186: the GIOCO chip was removed — it was a visual stub
+            duplicating the LibraryTabs entity scope (Tutti / Giochi / Agenti /
+            KB / Sessioni / Chat) and contributed to the triple-filter overlap
+            reported in the US-10 audit. Sort/Ordina now lives as its own
+            visual chip surface here, matching the locked decision A. */}
         <FilterChip
           label={t('pages.library.filters.chips.stato')}
-          value={t('pages.library.filters.chips.value.all')}
-        />
-        <FilterChip
-          label={t('pages.library.filters.chips.gioco')}
           value={t('pages.library.filters.chips.value.all')}
         />
         <FilterChip

--- a/apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx
@@ -211,7 +211,7 @@ describe('CrossEntityFilters', () => {
 
   // Task 1.4 — SP4 mockup conformance (jsx:218–310): search row + filter chips + view toggle.
 
-  it('renders the 4 cross-entity filter chips (STATO/GIOCO/DATA/SORT)', () => {
+  it('renders the 3 cross-entity filter chips after the #2186 GIOCO removal', () => {
     renderWithIntl(
       <CrossEntityFilters
         {...surfaceDefaults}
@@ -221,10 +221,12 @@ describe('CrossEntityFilters', () => {
         onMoreFilters={vi.fn()}
       />
     );
+    // STATO + DATA + SORT remain; GIOCO removed (#2186 — duplicated the
+    // LibraryTabs entity scope and contributed to triple-filter overlap).
     expect(screen.getByRole('button', { name: /STATO/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /GIOCO/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /DATA/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /SORT/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /GIOCO/ })).not.toBeInTheDocument();
   });
 
   it('renders search input with / keyboard hint badge', () => {


### PR DESCRIPTION
Closes #2186. Level-2 visual-stub GIOCO chip duplicated the LibraryTabs entity scope — third leg of the triple-filter overlap. Combined with #2260 (entity section dropped from drawer), this closes the locked decision A scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)