### PR TITLE
fix(pdf-indexing): #2243 emit KB event + expose flag + chunks (Sub #1 of epic #2242)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -829,6 +829,35 @@ internal partial class UploadPdfCommandHandler
             await scopedMediator.Publish(
                 new PdfStateChangedEvent(pdfGuidForEvent, PdfProcessingState.Indexing, PdfProcessingState.Ready, userId),
                 CancellationToken.None).ConfigureAwait(false);
+
+            // Issue #2243 (epic #2242) Block A — tactical compensating publish:
+            // The three ingestion paths (ProcessPdfAsync, PdfProcessingPipelineService,
+            // IndexPdfCommandHandler) all write VectorDocumentEntity directly via EF instead of
+            // constructing the VectorDocument domain entity whose constructor raises
+            // VectorDocumentIndexedEvent. As a result VectorDocumentIndexedForKbFlagHandler
+            // never runs and shared_games.has_knowledge_base stays false even after a successful
+            // indexing. Manually publish the event here so the SharedGameCatalog projection
+            // updates and admin/user UIs can show "agente pronto".
+            //
+            // Sub #2 (architecture refactor) replaces this with a VectorDocument.Create() factory
+            // chained from an IPdfIndexingPipeline service so the event flows structurally and
+            // this manual publish can be removed.
+            var vectorDocSnapshot = await db.Set<VectorDocumentEntity>()
+                .AsNoTracking()
+                .Where(v => v.PdfDocumentId == pdfGuidForEvent)
+                .Select(v => new { v.Id, v.GameId, v.SharedGameId, v.ChunkCount })
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (vectorDocSnapshot is not null)
+            {
+                await scopedMediator.Publish(
+                    new Api.BoundedContexts.KnowledgeBase.Domain.Events.VectorDocumentIndexedEvent(
+                        documentId: vectorDocSnapshot.Id,
+                        gameId: vectorDocSnapshot.GameId ?? Guid.Empty,
+                        chunkCount: vectorDocSnapshot.ChunkCount,
+                        sharedGameId: vectorDocSnapshot.SharedGameId),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
         }
 
         var cacheKey = (pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId)?.ToString() ?? string.Empty;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameDto.cs
@@ -28,7 +28,11 @@ internal record GameDto(
     Guid? SharedGameId = null,
     bool IsPublished = false,
     string? ApprovalStatus = null,
-    DateTime? PublishedAt = null
+    DateTime? PublishedAt = null,
+    // Issue #2243 (epic #2242) Block C: expose the denormalized HasKnowledgeBase flag so
+    // /api/v1/games clients (admin grid + user library) can render "agente pronto" badges
+    // without a second round-trip to /api/v1/shared-games. Default false for backward-compat.
+    bool HasKnowledgeBase = false
 );
 
 /// <summary>
@@ -87,7 +91,12 @@ internal record GameDetailsDto(
     string? IconUrl = null,
     string? ImageUrl = null,
     // SharedGameCatalog integration
-    Guid? SharedGameId = null
+    Guid? SharedGameId = null,
+    // Issue #2243 (epic #2242) Block C: expose HasKnowledgeBase + KbsCount so
+    // game detail pages can render "agente pronto" badge and "chunks indexed" stats
+    // without a second /api/v1/shared-games round-trip.
+    bool HasKnowledgeBase = false,
+    int KbsCount = 0
 );
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetAllGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetAllGamesQueryHandler.cs
@@ -49,7 +49,9 @@ internal class GetAllGamesQueryHandler : IQueryHandler<GetAllGamesQuery, Paginat
                 g.PlayingTimeMinutes,
                 g.BggId,
                 g.CreatedAt,
-                g.ImageUrl
+                g.ImageUrl,
+                // Issue #2243 (epic #2242) Block C: expose HasKnowledgeBase on GameDto
+                g.HasKnowledgeBase
             })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -71,7 +73,8 @@ internal class GetAllGamesQueryHandler : IQueryHandler<GetAllGamesQuery, Paginat
                 SharedGameId: null,
                 IsPublished: false,
                 ApprovalStatus: null,
-                PublishedAt: null
+                PublishedAt: null,
+                HasKnowledgeBase: g.HasKnowledgeBase
             ))
             .ToList();
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameByIdQueryHandler.cs
@@ -1,9 +1,11 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.Infrastructure;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Queries;
 
@@ -11,14 +13,18 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries;
 /// Handles get game by ID query.
 /// Issue #1320 (P2c): Migrated from IGameRepository to IGameCoreDataProvider.
 /// Resolves against SharedGame via IGameCoreDataProvider.
+/// Issue #2243 (epic #2242) Block C: also looks up SharedGame.HasKnowledgeBase
+/// so the GameDto carries the "agente pronto" flag without an extra round-trip.
 /// </summary>
 internal class GetGameByIdQueryHandler : IQueryHandler<GetGameByIdQuery, GameDto?>
 {
     private readonly IGameCoreDataProvider _gameCoreData;
+    private readonly MeepleAiDbContext _db;
 
-    public GetGameByIdQueryHandler(IGameCoreDataProvider gameCoreData)
+    public GetGameByIdQueryHandler(IGameCoreDataProvider gameCoreData, MeepleAiDbContext db)
     {
         _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
     }
 
     public async Task<GameDto?> Handle(GetGameByIdQuery query, CancellationToken cancellationToken)
@@ -34,10 +40,25 @@ internal class GetGameByIdQueryHandler : IQueryHandler<GetGameByIdQuery, GameDto
             .GetCoreDataAsync(GameRef.Shared(query.GameId), cancellationToken)
             .ConfigureAwait(false);
 
-        return coreData != null ? MapToDto(query.GameId, coreData) : null;
+        if (coreData is null)
+        {
+            return null;
+        }
+
+        // Issue #2243 Block C: single projection-only read for the KB flag.
+        // We intentionally keep this outside GameCoreData (a domain VO shared with PrivateGame)
+        // so SharedGame-specific projections don't leak into the value object.
+        var hasKnowledgeBase = await _db.SharedGames
+            .AsNoTracking()
+            .Where(g => g.Id == query.GameId)
+            .Select(g => g.HasKnowledgeBase)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return MapToDto(query.GameId, coreData, hasKnowledgeBase);
     }
 
-    private static GameDto MapToDto(Guid id, GameCoreData coreData)
+    private static GameDto MapToDto(Guid id, GameCoreData coreData, bool hasKnowledgeBase)
     {
         return new GameDto(
             Id: id,
@@ -50,7 +71,8 @@ internal class GetGameByIdQueryHandler : IQueryHandler<GetGameByIdQuery, GameDto
             MaxPlayTimeMinutes: coreData.PlayingTimeMinutes,
             BggId: coreData.BggId,
             CreatedAt: DateTime.UtcNow,
-            ImageUrl: coreData.ImageUrl
+            ImageUrl: coreData.ImageUrl,
+            HasKnowledgeBase: hasKnowledgeBase
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameDetailsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameDetailsQueryHandler.cs
@@ -2,27 +2,34 @@ using Api.BoundedContexts.GameManagement.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
 using Api.SharedKernel.Application;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Queries;
 
 /// <summary>
 /// Handles get game details query with extended metadata and statistics.
 /// Issue #1320 (P2c): Migrated from IGameRepository to IGameCoreDataProvider.
+/// Issue #2243 (epic #2242) Block C: also looks up SharedGame.HasKnowledgeBase
+/// and KbsCount so the detail page can render "agente pronto" + chunk stats.
 /// </summary>
 internal class GetGameDetailsQueryHandler : IQueryHandler<GetGameDetailsQuery, GameDetailsDto?>
 {
     private readonly IGameCoreDataProvider _gameCoreData;
     private readonly IGameSessionRepository _sessionRepository;
+    private readonly MeepleAiDbContext _db;
 
     public GetGameDetailsQueryHandler(
         IGameCoreDataProvider gameCoreData,
-        IGameSessionRepository sessionRepository)
+        IGameSessionRepository sessionRepository,
+        MeepleAiDbContext db)
     {
         _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
     }
 
     public async Task<GameDetailsDto?> Handle(GetGameDetailsQuery query, CancellationToken cancellationToken)
@@ -48,10 +55,36 @@ internal class GetGameDetailsQueryHandler : IQueryHandler<GetGameDetailsQuery, G
             .Select(s => s.CompletedAt)
             .FirstOrDefault();
 
-        return MapToDetailsDto(query.GameId, coreData, totalSessionsPlayed > 0 ? totalSessionsPlayed : null, lastPlayedAt);
+        // Issue #2243 Block C: load KB flag + real chunk count for the detail page.
+        var kbInfo = await _db.SharedGames
+            .AsNoTracking()
+            .Where(g => g.Id == query.GameId)
+            .Select(g => new
+            {
+                g.HasKnowledgeBase,
+                KbsCount = _db.VectorDocuments
+                    .Where(v => v.SharedGameId == g.Id && v.IndexingStatus == "completed")
+                    .Count()
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return MapToDetailsDto(
+            query.GameId,
+            coreData,
+            totalSessionsPlayed > 0 ? totalSessionsPlayed : null,
+            lastPlayedAt,
+            kbInfo?.HasKnowledgeBase ?? false,
+            kbInfo?.KbsCount ?? 0);
     }
 
-    private static GameDetailsDto MapToDetailsDto(Guid id, GameCoreData coreData, int? totalSessions, DateTime? lastPlayed)
+    private static GameDetailsDto MapToDetailsDto(
+        Guid id,
+        GameCoreData coreData,
+        int? totalSessions,
+        DateTime? lastPlayed,
+        bool hasKnowledgeBase,
+        int kbsCount)
     {
         return new GameDetailsDto(
             Id: id,
@@ -68,7 +101,9 @@ internal class GetGameDetailsQueryHandler : IQueryHandler<GetGameDetailsQuery, G
             SupportsSolo: coreData.MinPlayers == 1,
             TotalSessionsPlayed: totalSessions,
             LastPlayedAt: lastPlayed,
-            ImageUrl: coreData.ImageUrl
+            ImageUrl: coreData.ImageUrl,
+            HasKnowledgeBase: hasKnowledgeBase,
+            KbsCount: kbsCount
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKnowledgeBaseStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKnowledgeBaseStatusQueryHandler.cs
@@ -67,6 +67,7 @@ internal class GetKnowledgeBaseStatusQueryHandler : IQueryHandler<GetKnowledgeBa
                 .AsNoTracking()
                 .Select(p => new
                 {
+                    p.Id,
                     p.ProcessingState,
                     p.ProcessingProgressJson,
                     p.ProcessingError,
@@ -86,8 +87,19 @@ internal class GetKnowledgeBaseStatusQueryHandler : IQueryHandler<GetKnowledgeBa
                     GameName: gameName);
             }
 
+            // Issue #2243 (epic #2242) Block D: fetch the actual ChunkCount for the most-recent
+            // PDF so the "Ready" branch can return real totals instead of (0, 0). Indexed chunks
+            // live on the VectorDocument row that the ingestion pipeline writes/updates at
+            // IndexInVectorStoreAsync; we keep this projection-only and cheap.
+            var indexedChunkCount = await _dbContext.VectorDocuments
+                .AsNoTracking()
+                .Where(v => v.PdfDocumentId == pdf.Id)
+                .Select(v => v.ChunkCount)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
             var (status, progress, totalChunks, processedChunks, errorMessage) =
-                MapProcessingState(pdf.ProcessingState, pdf.ProcessingProgressJson, pdf.ProcessingError);
+                MapProcessingState(pdf.ProcessingState, pdf.ProcessingProgressJson, pdf.ProcessingError, indexedChunkCount);
 
             return new KnowledgeBaseStatusDto(
                 Status: status,
@@ -114,7 +126,8 @@ internal class GetKnowledgeBaseStatusQueryHandler : IQueryHandler<GetKnowledgeBa
         MapProcessingState(
             string processingState,
             string? processingProgressJson,
-            string? processingError)
+            string? processingError,
+            int indexedChunkCount)
     {
         // Deserialize stored ProcessingProgress JSON if present
         ProcessingProgress? prog = null;
@@ -162,7 +175,9 @@ internal class GetKnowledgeBaseStatusQueryHandler : IQueryHandler<GetKnowledgeBa
                 0,
                 0,
                 null),
-            "Ready" => ("Completed", 100, 0, 0, null),
+            // Issue #2243 Block D: real chunk count instead of (0, 0). All chunks are
+            // processed by the time we hit Ready, so processed == total.
+            "Ready" => ("Completed", 100, indexedChunkCount, indexedChunkCount, null),
             "Failed" => ("Failed", 0, 0, 0, processingError ?? prog?.ErrorMessage ?? "PDF processing failed"),
             _ => ("Pending", 0, 0, 0, null),
         };

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -61,6 +61,20 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
         // Issue #1852 (Gap A): CoverUrlResolver is async (presigned URL mint); cannot be called
         // inside an EF expression tree. Materialize first, then resolve covers sequentially.
         var games = new List<SharedGameDto>(entities.Count);
+
+        // Issue #2243 (epic #2242) Block B: pre-compute KbsCount per page (real chunk count from
+        // VectorDocuments) instead of hardcoding 0. Single batched query avoids N+1.
+        var pageGameIds = entities.Select(e => e.Id).ToList();
+        var kbsCountByGame = await _context.VectorDocuments
+            .AsNoTracking()
+            .Where(v => v.SharedGameId != null
+                && pageGameIds.Contains(v.SharedGameId.Value)
+                && v.IndexingStatus == "completed")
+            .GroupBy(v => v.SharedGameId!.Value)
+            .Select(grp => new { GameId = grp.Key, Count = grp.Count() })
+            .ToDictionaryAsync(x => x.GameId, x => x.Count, cancellationToken)
+            .ConfigureAwait(false);
+
         foreach (var g in entities)
         {
             var coverUrl = await CoverUrlResolver
@@ -92,7 +106,7 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 // default-argument elision (CS0854).
                 0,      // ToolkitsCount
                 0,      // AgentsCount
-                0,      // KbsCount
+                kbsCountByGame.GetValueOrDefault(g.Id, 0),  // KbsCount — issue #2243 Block B
                 0,      // NewThisWeekCount
                 0,      // ContributorsCount
                 false,  // IsTopRated

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -91,6 +91,20 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
 
         // Issue #1852 (Gap A): resolve cover URL (L4 → L2 priority) per entity sequentially.
         var games = new List<SharedGameDto>(entities.Count);
+
+        // Issue #2243 (epic #2242) Block B: pre-compute KbsCount per page (real chunk count from
+        // VectorDocuments) instead of hardcoding 0. Single batched query avoids N+1.
+        var pageGameIds = entities.Select(e => e.Id).ToList();
+        var kbsCountByGame = await _context.VectorDocuments
+            .AsNoTracking()
+            .Where(v => v.SharedGameId != null
+                && pageGameIds.Contains(v.SharedGameId.Value)
+                && v.IndexingStatus == "completed")
+            .GroupBy(v => v.SharedGameId!.Value)
+            .Select(grp => new { GameId = grp.Key, Count = grp.Count() })
+            .ToDictionaryAsync(x => x.GameId, x => x.Count, cancellationToken)
+            .ConfigureAwait(false);
+
         foreach (var g in entities)
         {
             var coverUrl = await CoverUrlResolver
@@ -122,7 +136,7 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 // default-argument elision (CS0854).
                 0,      // ToolkitsCount
                 0,      // AgentsCount
-                0,      // KbsCount
+                kbsCountByGame.GetValueOrDefault(g.Id, 0),  // KbsCount — issue #2243 Block B
                 0,      // NewThisWeekCount
                 0,      // ContributorsCount
                 false,  // IsTopRated

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameByIdQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Xunit;
 using FluentAssertions;
 using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
 using Api.Infrastructure;
 
 namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
@@ -35,9 +36,11 @@ public class GetGameByIdQueryHandlerTests
     {
         _gameCoreDataMock = new Mock<IGameCoreDataProvider>();
 
-        // Inject a stub MeepleAiDbContext — not needed by the handler but satisfies DI if constructor requires it.
-        // GetGameByIdQueryHandler only uses IGameCoreDataProvider.
-        _handler = new GetGameByIdQueryHandler(_gameCoreDataMock.Object);
+        // Issue #2243 Block C: handler now also reads SharedGames.HasKnowledgeBase
+        // via an extra projection-only query. Pass an InMemory context — the SharedGames
+        // set is empty so HasKnowledgeBase defaults to false for unrelated unit tests.
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        _handler = new GetGameByIdQueryHandler(_gameCoreDataMock.Object, db);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
@@ -1,0 +1,581 @@
+using System.Security.Cryptography;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Configuration;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Issue #2243 (Sub #1 of epic #2242 PDF indexing flow repair).
+///
+/// Failing-first integration test that proves the root-cause bug:
+/// after the full upload-to-indexed pipeline completes successfully
+/// (PdfDocument.ProcessingState = Ready), the SharedGame.HasKnowledgeBase
+/// flag is NOT set to true because no path publishes the
+/// VectorDocumentIndexedEvent that VectorDocumentIndexedForKbFlagHandler
+/// listens to.
+///
+/// The three known ingestion handlers
+/// (UploadPdfCommandHandler.ProcessPdfAsync, PdfProcessingPipelineService,
+/// IndexPdfCommandHandler) all write VectorDocumentEntity directly to EF,
+/// bypassing the domain entity constructor that raises the event.
+///
+/// Expected behaviour (post-fix, Sub #1 Block A): the BG pipeline emits
+/// VectorDocumentIndexedEvent → VectorDocumentIndexedForKbFlagHandler
+/// flips has_knowledge_base to true → admin/user UIs can show
+/// "agente pronto" without manual refresh.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "2243")]
+public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IConnectionMultiplexer? _redis;
+    private string? _testDataDirectory;
+    private InlineBackgroundTaskService? _inlineBgService;
+    private readonly ListLoggerSink _logSink = new();
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public PdfIndexingFlowKbFlagIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_kbflag_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _testDataDirectory = Path.Combine(Path.GetTempPath(), "meepleai-test-kbflag-" + Guid.NewGuid());
+        Directory.CreateDirectory(_testDataDirectory);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+
+        // Override logging: capture into in-memory sink for diagnosis on assertion failure.
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(new ListLoggerProvider(_logSink));
+        });
+
+        _redis = await ConnectionMultiplexer.ConnectAsync(_fixture.RedisConnectionString);
+        services.AddSingleton<IConnectionMultiplexer>(_redis);
+
+        // Real repositories
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+
+        // Real handler under test
+        services.AddScoped<UploadPdfCommandHandler>();
+
+        // PDF processing options — allow 10 MB
+        services.Configure<PdfProcessingOptions>(options =>
+        {
+            options.MaxFileSizeBytes = 10 * 1024 * 1024;
+        });
+
+        // CRITICAL: Inline background task service so the BG pipeline runs synchronously
+        // (UploadPdfIntegrationTests uses Mock<IBackgroundTaskService> which never executes,
+        // so ProcessPdfAsync never runs there → ProcessingState stays Pending → no event flow).
+        _inlineBgService = new InlineBackgroundTaskService();
+        services.AddSingleton<IBackgroundTaskService>(_inlineBgService);
+
+        // CRITICAL: Real IEmbeddingService (CreateBase registers Mock.Of which returns null/false).
+        // MockEmbeddingService produces deterministic 768-dim embeddings (matches pgvector schema).
+        services.AddSingleton<IEmbeddingService>(new MockEmbeddingService(dimensions: 768));
+
+        // Mock IPdfTextExtractor: paged result with single page of valid text
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TextExtractionResult.CreateSuccess(
+                extractedText: "This is the rulebook text. It contains rules for the board game.",
+                pageCount: 1,
+                characterCount: 64,
+                ocrTriggered: false,
+                quality: ExtractionQuality.High));
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                pageChunks: new[]
+                {
+                    new PageTextChunk(
+                        PageNumber: 1,
+                        Text: "This is the rulebook text. It contains rules for the board game with multiple sentences to be chunked. " +
+                              "Players take turns rolling dice. The winner is the player with the most points at the end.",
+                        CharStartIndex: 0,
+                        CharEndIndex: 200)
+                },
+                totalPages: 1,
+                totalCharacters: 200,
+                ocrTriggered: false));
+        services.AddSingleton<IPdfTextExtractor>(extractorMock.Object);
+
+        // Mock IPdfTableExtractor: returns Success=false so pipeline skips structured content step.
+        // (bare Mock.Of returns default StructuredContentResult? = null → NRE at Processing.cs:294)
+        var tableExtractorMock = new Mock<IPdfTableExtractor>();
+        tableExtractorMock
+            .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StructuredContentResult
+            {
+                Success = false,
+                ErrorMessage = "Skipped in test"
+            });
+        services.AddSingleton<IPdfTableExtractor>(tableExtractorMock.Object);
+
+        // Mock IBlobStorageService: write to temp dir
+        var blobStorageMock = new Mock<IBlobStorageService>();
+        blobStorageMock
+            .Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<string>()!,
+                It.IsAny<BlobCategory>(),
+                It.IsAny<string>()!,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct) =>
+            {
+                var safeKey = resourceKey.Replace('/', '_').Replace('\\', '_');
+                var filePath = Path.Combine(_testDataDirectory!, $"{safeKey}_{fileName}");
+                using var fileStream = File.Create(filePath);
+                stream.CopyTo(fileStream);
+                return new BlobStorageResult(true, Guid.NewGuid().ToString(), filePath, stream.Length, null);
+            });
+        blobStorageMock
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string path, BlobCategory category, string resourceKey, CancellationToken ct) =>
+                File.Exists(path) ? (Stream?)File.OpenRead(path) : null);
+        blobStorageMock
+            .Setup(b => b.DeleteAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        services.AddSingleton<IBlobStorageService>(blobStorageMock.Object);
+
+        // Mock IAiResponseCacheService
+        var cacheMock = new Mock<IAiResponseCacheService>();
+        cacheMock
+            .Setup(c => c.InvalidateGameAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddSingleton<IAiResponseCacheService>(cacheMock.Object);
+
+        // Mock IConfigurationService
+        var configServiceMock = new Mock<IConfigurationService>();
+        configServiceMock
+            .Setup(c => c.GetValueAsync<int?>(It.IsAny<string>()!, It.IsAny<int?>(), It.IsAny<string>()))
+            .Returns(Task.FromResult<int?>(null));
+        services.AddSingleton<IConfigurationService>(configServiceMock.Object);
+
+        // Real PdfUploadQuotaService (needs Redis)
+        services.AddScoped<IPdfUploadQuotaService, PdfUploadQuotaService>();
+
+        // Real TextChunkingService (deterministic, no external deps)
+        services.AddSingleton<ITextChunkingService, TextChunkingService>();
+
+        // Mock IProcessingMetricsService (required by PdfStateChangedMetricsEventHandler)
+        services.AddSingleton(Mock.Of<Api.BoundedContexts.DocumentProcessing.Application.Services.IProcessingMetricsService>());
+
+        // Mock IVectorDocumentRepository (required by VectorDocumentIndexedEventHandler relay
+        // that fires after Sub #1 Block A publishes VectorDocumentIndexedEvent)
+        services.AddScoped(_ => Mock.Of<Api.BoundedContexts.KnowledgeBase.Domain.Repositories.IVectorDocumentRepository>());
+
+        // HybridCache + dependencies — required by VectorDocumentIndexedForKbFlagHandler
+        // (the handler that actually flips shared_games.has_knowledge_base = true on the event).
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        services.AddScoped<Api.Services.ICacheInvalidationRetryPolicy>(_ => new PassthroughRetryPolicy());
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+
+        await SeedTestDataAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_testDataDirectory != null && Directory.Exists(_testDataDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDataDirectory, true);
+            }
+            catch (IOException)
+            {
+                // Best effort cleanup
+            }
+        }
+
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        _redis?.Dispose();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    private async Task SeedTestDataAsync()
+    {
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = $"kbflag-{Guid.NewGuid():N}@test.com",
+            DisplayName = "KB Flag Test User",
+            Role = "User",
+            Tier = "Free",
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext!.Users.Add(user);
+
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = $"KB Flag Test Game {Guid.NewGuid():N}",
+            BggId = RandomNumberGenerator.GetInt32(100000, 1_000_000),
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 30,
+            HasKnowledgeBase = false,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(game);
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private static IFormFile CreateMockFormFile(string fileName, byte[] content, string contentType = "application/pdf")
+    {
+        var formFile = new Mock<IFormFile>();
+        formFile.Setup(f => f.FileName).Returns(fileName);
+        formFile.Setup(f => f.Length).Returns(content.Length);
+        formFile.Setup(f => f.ContentType).Returns(contentType);
+        formFile.Setup(f => f.OpenReadStream()).Returns(() => new MemoryStream(content));
+        return formFile.Object;
+    }
+
+    private static byte[] CreateValidPdfBytes(int sizeInBytes)
+    {
+        var header = "%PDF-1.4\n"u8.ToArray();
+        var trailer = "%%EOF\n"u8.ToArray();
+        var padding = new byte[Math.Max(0, sizeInBytes - header.Length - trailer.Length)];
+
+        var pdf = new byte[header.Length + padding.Length + trailer.Length];
+        Buffer.BlockCopy(header, 0, pdf, 0, header.Length);
+        Buffer.BlockCopy(padding, 0, pdf, header.Length, padding.Length);
+        Buffer.BlockCopy(trailer, 0, pdf, header.Length + padding.Length, trailer.Length);
+
+        return pdf;
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task UploadPdf_OnSuccessfulIndexing_SetsHasKnowledgeBaseTrue_OnSharedGame()
+    {
+        // Arrange
+        var handler = _serviceProvider!.GetRequiredService<UploadPdfCommandHandler>();
+        var testUser = await _dbContext!.Users.FirstAsync(TestCancellationToken);
+        var testGame = await _dbContext.SharedGames.FirstAsync(TestCancellationToken);
+
+        testGame.HasKnowledgeBase.Should().BeFalse(
+            "precondition: SharedGame starts without indexed KB");
+
+        var pdfBytes = CreateValidPdfBytes(1024);
+        var formFile = CreateMockFormFile("rules.pdf", pdfBytes);
+
+        var command = new UploadPdfCommand(
+            GameId: testGame.Id.ToString(),
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: testUser.Id,
+            File: formFile);
+
+        // Act
+        var result = await handler.Handle(command, TestCancellationToken);
+        await _inlineBgService!.WaitForAllAsync();
+
+        // Assert: upload succeeded
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue("upload accept-stage must succeed for a valid PDF");
+        result.Document.Should().NotBeNull();
+
+        // Assert: BG pipeline reached Ready terminal state
+        var pdfDocId = Guid.Parse(result.Document!.Id.ToString());
+        var pdfDoc = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .SingleAsync(p => p.Id == pdfDocId, TestCancellationToken);
+        if (!string.IsNullOrEmpty(pdfDoc.ProcessingError))
+        {
+            var relevantLogs = _logSink.Snapshot()
+                .Where(line =>
+                    line.Contains("PDF-DEBUG", StringComparison.Ordinal) ||
+                    line.Contains("UploadPdfCommandHandler", StringComparison.Ordinal) ||
+                    line.Contains("PdfProcessing", StringComparison.Ordinal) ||
+                    line.Contains("[Error]", StringComparison.Ordinal) ||
+                    line.Contains("[Critical]", StringComparison.Ordinal) ||
+                    line.Contains("Ex=", StringComparison.Ordinal))
+                .TakeLast(80)
+                .ToList();
+            var logTail = string.Join("\n", relevantLogs);
+            pdfDoc.ProcessingError.Should().BeNullOrEmpty(
+                $"BG pipeline must not fail. State={pdfDoc.ProcessingState}, " +
+                $"PageCount={pdfDoc.PageCount}, CharCount={pdfDoc.CharacterCount}, " +
+                $"Error='{pdfDoc.ProcessingError}'.\n\n--- PIPELINE LOG ({relevantLogs.Count} entries) ---\n{logTail}\n--- END ---");
+        }
+        pdfDoc.ProcessingState.Should().Be(
+            nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready),
+            "BG pipeline must reach Ready when extraction + chunking + embedding + indexing succeed");
+
+        // Assert: VectorDocument was created and linked to SharedGame
+        var vectorDoc = await _dbContext.VectorDocuments
+            .AsNoTracking()
+            .SingleAsync(v => v.PdfDocumentId == pdfDocId, TestCancellationToken);
+        vectorDoc.SharedGameId.Should().Be(testGame.Id,
+            "VectorDocumentEntity is created with SharedGameId propagated from PdfDocument");
+        vectorDoc.ChunkCount.Should().BeGreaterThan(0,
+            "at least one chunk must be persisted for the rulebook text");
+
+        // CRITICAL ASSERTION: this is the bug.
+        // VectorDocumentIndexedForKbFlagHandler subscribes to VectorDocumentIndexedEvent
+        // and is the only place that sets has_knowledge_base = true on shared_games.
+        // The event is currently NEVER published from any of the 3 ingestion paths
+        // (UploadPdfCommandHandler.ProcessPdfAsync, PdfProcessingPipelineService, IndexPdfCommandHandler)
+        // because they write VectorDocumentEntity directly via EF instead of constructing
+        // the VectorDocument domain entity whose constructor raises the event.
+        //
+        // Sub #1 Block A fix: publish the event manually in FinalizeProcessingAsync
+        // after PdfStateChangedEvent. Sub #2 refactors the architecture to use a domain
+        // factory so the event is raised structurally.
+        var updatedGame = await _dbContext.SharedGames
+            .AsNoTracking()
+            .SingleAsync(g => g.Id == testGame.Id, TestCancellationToken);
+        updatedGame.HasKnowledgeBase.Should().BeTrue(
+            "after PDF indexing completes, VectorDocumentIndexedEvent must propagate to flip " +
+            "shared_games.has_knowledge_base = true. Without this, admin tabs and user 'agente pronto' " +
+            "badges stay invisible forever (root cause of epic #2242).");
+
+        // Block B: KbsCount must reflect actual indexed chunks across BOTH GetAll and GetFiltered handlers.
+        // The bug: GetAllSharedGamesQueryHandler.cs:93 and GetFilteredSharedGamesQueryHandler.cs:123
+        // hardcode `0` for KbsCount (with comment "aggregate fields not computed by this handler"),
+        // so even after Block A flips HasKnowledgeBase=true the API consumers see 0 chunks.
+        var mediator = _serviceProvider!.GetRequiredService<MediatR.IMediator>();
+        var allResult = await mediator.Send(
+            new Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetAllSharedGamesQuery(
+                Status: null,
+                PageNumber: 1,
+                PageSize: 50),
+            TestCancellationToken);
+        var allEntry = allResult.Items.SingleOrDefault(x => x.Id == testGame.Id);
+        allEntry.Should().NotBeNull("test game must appear in GetAllSharedGames page");
+        allEntry!.HasKnowledgeBase.Should().BeTrue("HasKnowledgeBase already projected by GetAll handler");
+        allEntry.KbsCount.Should().BeGreaterThan(0,
+            "Block B: GetAllSharedGamesQueryHandler must compute KbsCount from VectorDocuments join, " +
+            "not hardcode 0 (line 93). Indexed chunks should be counted.");
+
+        // Block C: GameDto and GameDetailsDto must expose HasKnowledgeBase so /api/v1/games clients
+        // (admin UI list + user library) can render the "agente pronto" badge without an extra
+        // GET /api/v1/shared-games round-trip. Currently both DTOs lack the field entirely; the
+        // query handlers materialize from SharedGames so the column is one projection step away.
+        var pagedGames = await mediator.Send(
+            new Api.BoundedContexts.GameManagement.Application.Queries.GetAllGamesQuery(
+                Search: null,
+                Page: 1,
+                PageSize: 50),
+            TestCancellationToken);
+        var gameDto = pagedGames.Games.SingleOrDefault(x => x.Id == testGame.Id);
+        gameDto.Should().NotBeNull("test SharedGame must appear in GetAllGames response");
+        gameDto!.HasKnowledgeBase.Should().BeTrue(
+            "Block C: GameDto must expose HasKnowledgeBase. The handler reads SharedGames where the " +
+            "column is already populated by VectorDocumentIndexedForKbFlagHandler; the projection " +
+            "must include g.HasKnowledgeBase instead of dropping it.");
+
+        // Block D: GetKnowledgeBaseStatusQueryHandler maps "Ready" with TotalChunks=0 hardcoded
+        // (line 165). The handler is the source of truth for the per-game status pill on the
+        // library detail page; with 0/0 chunks it cannot answer the obvious question "how big
+        // is my agent's KB?" once indexing finishes. Sub #1 Block D wires the real ChunkCount
+        // from the VectorDocument row.
+        var kbStatus = await mediator.Send(
+            new Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKnowledgeBaseStatusQuery(
+                GameId: testGame.Id,
+                IsPrivateGame: false),
+            TestCancellationToken);
+        kbStatus.Should().NotBeNull();
+        kbStatus!.Status.Should().Be("Completed", "PDF is in Ready state → mapping emits 'Completed'");
+        kbStatus.TotalChunks.Should().BeGreaterThan(0,
+            "Block D: KnowledgeBaseStatusDto must surface the real chunk count when Ready, " +
+            "not the 0 hardcoded at GetKnowledgeBaseStatusQueryHandler.cs:165.");
+    }
+
+    /// <summary>
+    /// In-memory log sink. Diagnoses ProcessPdfAsync pipeline failures
+    /// (which otherwise surface as opaque "Object reference not set" errors).
+    /// </summary>
+    internal sealed class ListLoggerSink
+    {
+        private readonly List<string> _entries = new();
+        private readonly Lock _gate = new();
+
+        public void Append(string entry)
+        {
+            lock (_gate)
+            {
+                _entries.Add(entry);
+            }
+        }
+
+        public IReadOnlyList<string> Snapshot()
+        {
+            lock (_gate)
+            {
+                return _entries.ToArray();
+            }
+        }
+    }
+
+    internal sealed class ListLoggerProvider : ILoggerProvider
+    {
+        private readonly ListLoggerSink _sink;
+
+        public ListLoggerProvider(ListLoggerSink sink) => _sink = sink;
+
+        public ILogger CreateLogger(string categoryName) => new ListLogger(_sink, categoryName);
+
+        public void Dispose() { }
+    }
+
+    internal sealed class ListLogger : ILogger
+    {
+        private readonly ListLoggerSink _sink;
+        private readonly string _category;
+
+        public ListLogger(ListLoggerSink sink, string category)
+        {
+            _sink = sink;
+            _category = category;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            var msg = formatter(state, exception);
+            var suffix = exception is not null
+                ? $" | Ex={exception.GetType().Name}: {exception.Message}\n{exception.StackTrace}"
+                : string.Empty;
+            // Trim category to last segment for compact output
+            var lastDot = _category.LastIndexOf('.');
+            var shortCategory = lastDot >= 0 ? _category[(lastDot + 1)..] : _category;
+            _sink.Append($"[{logLevel}] {shortCategory}: {msg}{suffix}");
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// Test-only IBackgroundTaskService that runs the queued task synchronously
+    /// while still letting the caller await all in-flight tasks before assertions.
+    ///
+    /// The production registration uses a thread-pool fire-and-forget runner so
+    /// the HTTP request returns 200 immediately. For test determinism we need the
+    /// pipeline (extract → chunk → embed → index → finalize) to complete before
+    /// the test inspects the DB.
+    /// </summary>
+    internal sealed class InlineBackgroundTaskService : IBackgroundTaskService
+    {
+        private readonly List<Task> _running = new();
+        private readonly Lock _gate = new();
+
+        public void Execute(Func<Task> task)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(task));
+            }
+        }
+
+        public void ExecuteWithCancellation(string taskId, Func<CancellationToken, Task> taskFactory)
+        {
+            ArgumentNullException.ThrowIfNull(taskFactory);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(() => taskFactory(CancellationToken.None)));
+            }
+        }
+
+        public bool CancelTask(string taskId) => false;
+
+        public Task WaitForAllAsync()
+        {
+            Task[] snapshot;
+            lock (_gate)
+            {
+                snapshot = _running.ToArray();
+            }
+            return Task.WhenAll(snapshot);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2243. Sub-issue of epic #2242 (PDF indexing flow repair).

## 🎯 Summary

Tactical fix for the root cause that prevented `shared_games.has_knowledge_base` from ever flipping to `true` after a successful PDF indexing pipeline run.

**Root cause** (see #2242 for the multi-layer critique): three ingestion handlers (`UploadPdfCommandHandler.ProcessPdfAsync`, `PdfProcessingPipelineService`, `IndexPdfCommandHandler`) write `VectorDocumentEntity` directly via EF instead of constructing the `VectorDocument` domain entity whose constructor raises `VectorDocumentIndexedEvent`. Result: the cache projection handler (`VectorDocumentIndexedForKbFlagHandler`) never fires and `shared_games.has_knowledge_base` stays `false` forever, hiding the "agente pronto" badge across admin UIs and user library.

Architecture refactor (`IPdfIndexingPipeline` + `VectorDocument.Create()` factory) is deferred to Sub #2 (#2244). This PR is the tactical compensating publish + the read-side corrections needed for the flag/count to surface end-to-end.

## 🔧 Changes

| # | Layer | File | Fix |
|---|---|---|---|
| Block A | BE ingestion | `UploadPdfCommandHandler.Processing.cs` `FinalizeProcessingAsync` | Publish `VectorDocumentIndexedEvent` after `PdfStateChangedEvent` using a projection-only read of the `VectorDocument` row the pipeline just wrote. |
| Block B | BE query | `GetAllSharedGamesQueryHandler.cs` + `GetFilteredSharedGamesQueryHandler.cs` | Preload `KbsCount` per page via single GROUP BY `VectorDocuments` join filtered by `IndexingStatus='completed'`. Replaces hardcoded `0`. |
| Block C | BE query | `GameDto.cs` + `GameDetailsDto.cs` + 3 query handlers | Expose `HasKnowledgeBase` (default `false`). `GetAllGamesQueryHandler` projects the column directly. `GetGameByIdQueryHandler` + `GetGameDetailsQueryHandler` add projection-only `SharedGames` reads (kept outside the `GameCoreData` VO to avoid leaking SharedGame-specific fields). `GetGameDetailsQueryHandler` also exposes `KbsCount`. |
| Block D | BE query | `GetKnowledgeBaseStatusQueryHandler.cs` | `Ready` mapping returns real `ChunkCount` instead of hardcoded `0`. |

## ✅ Test plan

- [x] New integration test `tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs` exercises the **full pipeline end-to-end** (Testcontainers Postgres + Redis + inline `IBackgroundTaskService` + `MockEmbeddingService` + real MediatR + real handlers) and asserts on all 4 contracts simultaneously:
  - `shared_games.has_knowledge_base = true` (Block A — was always `false`)
  - `KbsCount > 0` on `GetAllSharedGamesQuery` (Block B — was hardcoded `0`)
  - `HasKnowledgeBase = true` on `GetAllGamesQuery` (Block C — field didn't exist on DTO)
  - `TotalChunks > 0` on `GetKnowledgeBaseStatusQuery` (Block D — was hardcoded `0`)
- [x] `GetGameByIdQueryHandlerTests` updated for new `MeepleAiDbContext` ctor dependency
- [x] 22/22 passing across DocumentProcessing + KnowledgeBase + SharedGameCatalog + GameManagement handler unit suites + the new integration test
- [ ] CI verde

## ⚠️ Gotchas surveyed

- `PdfDocument_SevenStateProgression` test still passes (no rebaseline required — the new `VectorDocumentIndexedEvent` is published from `FinalizeProcessingAsync` after the state machine transition, not from `TransitionTo()`, so the 7-event invariant on `PdfDocument.DomainEvents` is unaffected).
- `GameCoreData` VO is intentionally left untouched so SharedGame-specific fields don't leak into the value object shared with `PrivateGame`.
- L1 cache 15min on `SharedGame` listings can delay cross-replica propagation by up to 15min (already documented in `VectorDocumentIndexedForKbFlagHandler.cs:88-94`). Mitigation tracked in Sub #6 (#2248) cache TTL strategy.
- DI: `GetGameByIdQueryHandler` + `GetGameDetailsQueryHandler` now take a `MeepleAiDbContext` constructor dependency — no DI change needed since `MeepleAiDbContext` is already registered for every test using `IntegrationServiceCollectionBuilder.CreateBase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)