### PR TITLE
feat(pdf-indexing): #2248 KB-flag drift audit + metric + cache ADR (Sub #6 of epic #2242)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ tests/Api.Tests/          # Backend test suite
 ## Known Flaky Tests
 
 Tests confirmed failing on `main-dev` baseline independently of any specific PR.
-Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale) → 2026-06-09 (#1887 PdfDocument_SevenStateProgression cleared via PR #2038, baseline now empty) → 2026-06-12 (#2270 cleared orphan `asse-b-axe.test.tsx` left behind by PR #2161 layout-shell dedupe; baseline clean again).
+Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale) → 2026-06-09 (#1887 PdfDocument_SevenStateProgression cleared via PR #2038, baseline now empty) → 2026-06-12 (#2270 cleared orphan `asse-b-axe.test.tsx` left behind by PR #2161 layout-shell dedupe; baseline clean again) → 2026-06-13 (#2266 cleared 2 nav-test follow-ups from PR #2279 #2190 cleanup — `AppTopBar.test.tsx` + `MobileBottomBar.test.tsx` still expecting label "Hub" after rename to "Games"; baseline clean again).
 
 | Test | File | First observed | Reason | Action |
 |---|---|---|---|---|

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJob.cs
@@ -1,0 +1,106 @@
+using Api.Infrastructure;
+using Api.Observability;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// Issue #2248 (epic #2242, Sub #6 Block B): periodic guard against the silent-failure
+/// mode that #2243 Block A fixed at the publish-event level.
+///
+/// The invariant: PdfDocument.ProcessingState == "Ready" ⇒
+/// SharedGame.HasKnowledgeBase == true.
+///
+/// If the tactical mediator.Publish(VectorDocumentIndexedEvent) inside
+/// FinalizeProcessingAsync is ever bypassed (regression, new ingestion path
+/// added without raising the event, swallowed exception in the projection
+/// handler, etc.) admin UIs silently revert to showing "no agent ready" while
+/// the catalog is otherwise healthy. This job catches the drift at most 10
+/// minutes after it appears so the SLO=0 alert fires.
+///
+/// Each detected row increments
+/// <see cref="MeepleAiMetrics.PdfIndexedNoKbFlagTotal"/> and logs the
+/// PdfDocumentId + SharedGameId at Warning. The job is idempotent and best
+/// effort — it does NOT try to repair the drift (that is the job of Sub #2
+/// architecture refactor — VectorDocument.Create factory — or a manual
+/// re-index for already-stuck docs).
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class KbFlagDriftAuditJob : IJob
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<KbFlagDriftAuditJob> _logger;
+
+    public KbFlagDriftAuditJob(
+        MeepleAiDbContext dbContext,
+        ILogger<KbFlagDriftAuditJob> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var cancellationToken = context.CancellationToken;
+
+        try
+        {
+            // Inner join PdfDocuments (Ready) with SharedGames (HasKnowledgeBase=false)
+            // via SharedGameId. Projection-only, no tracking, no entity materialization.
+            // Limited to 100 rows per run — if drift is widespread the SLO=0 alert fires
+            // on the first batch and the operator triages from the audit log.
+            var driftedRows = await _dbContext.PdfDocuments
+                .AsNoTracking()
+                .Where(p => p.ProcessingState == "Ready" && p.SharedGameId != null)
+                .Join(
+                    _dbContext.SharedGames.AsNoTracking().Where(g => !g.HasKnowledgeBase),
+                    p => p.SharedGameId,
+                    g => g.Id,
+                    (p, g) => new { PdfDocumentId = p.Id, SharedGameId = g.Id })
+                .Take(100)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (driftedRows.Count == 0)
+            {
+                _logger.LogDebug(
+                    "KbFlagDriftAuditJob: 0 drifted rows (FireTime={FireTime})",
+                    context.FireTimeUtc);
+                context.Result = new { DriftedRows = 0 };
+                return;
+            }
+
+            foreach (var row in driftedRows)
+            {
+                MeepleAiMetrics.RecordPdfIndexedNoKbFlagDrift();
+                _logger.LogWarning(
+                    "KbFlagDrift detected: PdfDocument {PdfDocumentId} is Ready but " +
+                    "SharedGame {SharedGameId} HasKnowledgeBase=false. " +
+                    "Root cause: VectorDocumentIndexedEvent was not published for this PDF " +
+                    "(#2243 Block A regression or new ingestion path bypassing the publish).",
+                    row.PdfDocumentId,
+                    row.SharedGameId);
+            }
+
+            _logger.LogError(
+                "KbFlagDriftAuditJob: {Count} drifted rows detected — SLO=0 violated. " +
+                "Investigate publish-event chain in UploadPdfCommandHandler.FinalizeProcessingAsync, " +
+                "PdfProcessingPipelineService and IndexPdfCommandHandler.",
+                driftedRows.Count);
+
+            context.Result = new { DriftedRows = driftedRows.Count };
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        // Background job — must not throw or Quartz suspends the trigger.
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "KbFlagDriftAuditJob: unexpected error during audit");
+            context.Result = new { Error = ex.Message };
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -187,6 +187,10 @@ internal static class DocumentProcessingServiceExtensions
         // Issue #1831 follow-up: Register Quartz job for orphan cover recovery (daily at 03:00 UTC)
         RegisterPdfCoverOrphanRecoveryJob(services);
 
+        // Issue #2248 (epic #2242, Sub #6 Block B): periodic audit for the
+        // "Ready ⇒ HasKnowledgeBase" invariant. Runs every 10 minutes.
+        RegisterKbFlagDriftAuditJob(services);
+
         return services;
     }
 
@@ -309,6 +313,33 @@ internal static class DocumentProcessingServiceExtensions
                     .WithIntervalInSeconds(10)
                     .RepeatForever())
                 .WithDescription("Picks up and processes the next queued PDF every 10 seconds")
+            );
+        });
+    }
+
+    /// <summary>
+    /// Issue #2248 (epic #2242 Sub #6 Block B): periodic guard against the
+    /// silent-failure mode where PdfDocument.ProcessingState=Ready but
+    /// SharedGame.HasKnowledgeBase=false. Increments
+    /// <c>meepleai.pdf.indexed.no.kb.flag.total</c> for each drifted row.
+    /// SLO=0; any increment is a P1 alert.
+    /// </summary>
+    private static void RegisterKbFlagDriftAuditJob(IServiceCollection services)
+    {
+        // Only register job definition here — AddQuartzHostedService is bootstrapped
+        // once in the Administration context.
+        services.AddQuartz(q =>
+        {
+            var jobKey = new Quartz.JobKey("KbFlagDriftAuditJob", "DocumentProcessing");
+
+            q.AddJob<Api.BoundedContexts.DocumentProcessing.Application.Jobs.KbFlagDriftAuditJob>(opts =>
+                opts.WithIdentity(jobKey));
+
+            q.AddTrigger(opts => opts
+                .ForJob(jobKey)
+                .WithIdentity("KbFlagDriftAuditTrigger", "DocumentProcessing")
+                .WithCronSchedule("0 */10 * * * ?") // Every 10 minutes
+                .WithDescription("Audits Ready PDFs against SharedGame.HasKnowledgeBase invariant (#2248)")
             );
         });
     }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -3,7 +3,6 @@ using Api.Infrastructure;
 using Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Hybrid;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
 
@@ -19,27 +18,34 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
 ///     SearchSharedGamesQueryHandler so catalog consumers see the new flag
 ///     immediately instead of waiting for the L1/L2 TTL (15 min / 1 h).
 ///
+/// Epic #2242 Sub #6 Block C (ADR-062, this PR):
+///   - Cache invalidation now uses <see cref="IHybridCacheService.RemoveByTagAcrossReplicasAsync"/>
+///     so the eviction propagates to other API replicas via Redis Pub/Sub within sub-second
+///     latency. Previously, only the calling replica's L1 cleared while other replicas kept
+///     serving stale entries until LocalCacheExpiration (15-30 min) — the bug ADR-062 closes.
+///
 /// Flow:
 ///   1. If notification.SharedGameId is null → noop.
 ///   2. Load the SharedGame row, flip HasKnowledgeBase to true if needed, save.
-///   3. Invalidate cache entries tagged "search-games".
+///   3. Invalidate cache entries tagged "search-games" + "shared-game:{id}" across all replicas.
 ///
 /// Idempotent: early-exit when already true. Single-row update.
 ///
 /// Reference: docs/superpowers/specs/2026-04-09-library-to-game-epic-design.md §4.2
 /// Plan: docs/superpowers/plans/2026-04-09-s2-kb-filter.md Task 7
+/// ADR: docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md
 /// </summary>
 internal sealed class VectorDocumentIndexedForKbFlagHandler
     : INotificationHandler<VectorDocumentIndexedEvent>
 {
     private readonly MeepleAiDbContext _context;
-    private readonly HybridCache _cache;
+    private readonly IHybridCacheService _cache;
     private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly ILogger<VectorDocumentIndexedForKbFlagHandler> _logger;
 
     public VectorDocumentIndexedForKbFlagHandler(
         MeepleAiDbContext context,
-        HybridCache cache,
+        IHybridCacheService cache,
         ICacheInvalidationRetryPolicy retryPolicy,
         ILogger<VectorDocumentIndexedForKbFlagHandler> logger)
     {
@@ -79,22 +85,24 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
 
         // Invalidate all cached catalog query results so the new AI-ready flag
         // appears immediately instead of waiting for the L1/L2 TTL to expire.
-        // RemoveByTagAsync with the "search-games" tag evicts every entry in the
-        // SearchSharedGamesQueryHandler cache namespace.
+        // RemoveByTagAcrossReplicasAsync with the "search-games" tag evicts every entry in the
+        // SearchSharedGamesQueryHandler cache namespace AND broadcasts the tag via Redis
+        // Pub/Sub so other API replicas evict their L1 entries within sub-second.
         //
-        // Multi-instance deployment caveat (epic library-to-game CR-I2):
-        // HybridCache tag invalidation evicts the L2 distributed entry
-        // (shared across nodes) but only the L1 MemoryCache of THIS instance.
-        // Other API replicas still serve their own L1 cached values until
-        // `LocalCacheExpiration` (15 min) expires. Worst case: a sticky-session
-        // user on another replica sees a stale AI-ready flag for up to 15 min.
-        // Acceptable for staging (single node); for multi-replica prod consider
-        // either shortening LocalCacheExpiration or publishing an integration
-        // event that each instance subscribes to for L1 cleanup.
+        // Cross-replica L1 invariant (ADR-062, epic #2242 Sub #6 Block C):
+        // The wrapper performs local L1+L2 eviction then publishes to channel
+        // "meepleai:cache-invalidate:tag". HybridCacheInvalidationSubscriber on
+        // each replica receives the tag and evicts L1 locally. Net latency for
+        // multi-replica propagation: ~1ms (Redis intra-DC Pub/Sub).
+        // Failure mode: if Redis Pub/Sub is unreachable, only the broadcast step
+        // is skipped — local eviction still completes; other replicas fall back to
+        // LocalCacheExpiration (15-30 min). Defence-in-depth: KbFlagDriftAuditJob
+        // (Block B) catches any residual drift within 10 minutes.
+        //
         // Issue #613: bounded retry guards against transient Redis failures
         // that would otherwise leave the read-model serving a stale flag.
         await _retryPolicy.ExecuteAsync(
-            token => _cache.RemoveByTagAsync("search-games", token),
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
             "shared-games.list",
             cancellationToken).ConfigureAwait(false);
 
@@ -102,7 +110,7 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
         // next /shared-games/{id} read sees the new HasKnowledgeBase flag and
         // refreshed KbsCount/Kbs preview list.
         await _retryPolicy.ExecuteAsync(
-            token => _cache.RemoveByTagAsync($"shared-game:{sharedGameId.Value}", token),
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId.Value}", token)),
             "shared-games.detail",
             cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -350,6 +350,13 @@ internal static class InfrastructureServiceExtensions
         // Required for ILlmTierRoutingService and other singleton services that depend on caching
         services.AddSingleton<IHybridCacheService, HybridCacheService>();
 
+        // ADR-062: Cross-replica L1 cache invalidation subscriber
+        // Subscribes to Redis Pub/Sub channel "meepleai:cache-invalidate:tag" on startup so
+        // that any tag-scoped invalidation broadcast by another replica evicts this replica's
+        // L1 entries within sub-second latency. Required for multi-replica deploys; on a
+        // single-replica setup it remains harmless (only self-broadcast messages received).
+        services.AddHostedService<HybridCacheInvalidationSubscriber>();
+
         // AI-10: Cache optimization services
         services.Configure<CacheOptimizationConfiguration>(
             configuration.GetSection("CacheOptimization"));

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.KbFlagDrift.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.KbFlagDrift.cs
@@ -1,0 +1,40 @@
+// Issue #2248 (epic #2242): Silent failure detector for the PDF→KB flag pipeline.
+// Counter is incremented by KbFlagDriftAuditJob when a row violates the invariant
+// "PdfDocument.ProcessingState == Ready ⇒ SharedGame.HasKnowledgeBase == true"
+// (the same root-cause #2243 Block A guards against at the publish-event level).
+//
+// SLO = 0. Any nonzero increment is a P1: the tactical Block A publish was bypassed
+// or a new ingestion path was introduced without raising VectorDocumentIndexedEvent.
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>
+    /// Total number of (PdfDocument, SharedGame) pairs detected by the periodic
+    /// audit where the PDF reached the Ready terminal state but the SharedGame's
+    /// HasKnowledgeBase flag is still false — proof that
+    /// VectorDocumentIndexedEvent was never published for that document.
+    /// </summary>
+    /// <remarks>
+    /// Cardinality: zero tags. Per-game labels were considered but rejected
+    /// (catalog can hold tens of thousands of SharedGames; an alert on the
+    /// aggregate counter is sufficient — operators inspect the audit job's
+    /// structured log for the offending IDs).
+    /// </remarks>
+    public static readonly Counter<long> PdfIndexedNoKbFlagTotal = Meter.CreateCounter<long>(
+        name: "meepleai.pdf.indexed.no.kb.flag.total",
+        unit: "rows",
+        description:
+            "Audit counter: PdfDocument.ProcessingState=Ready AND SharedGame.HasKnowledgeBase=false. " +
+            "SLO=0; any increment indicates the publish-event chain is broken (#2243 / #2244).");
+
+    /// <summary>
+    /// Records one drifted row found by KbFlagDriftAuditJob.
+    /// </summary>
+    public static void RecordPdfIndexedNoKbFlagDrift()
+    {
+        PdfIndexedNoKbFlagTotal.Add(1);
+    }
+}

--- a/apps/api/src/Api/Services/HybridCacheInvalidationSubscriber.cs
+++ b/apps/api/src/Api/Services/HybridCacheInvalidationSubscriber.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Caching.Hybrid;
+using StackExchange.Redis;
+
+namespace Api.Services;
+
+/// <summary>
+/// Background service that subscribes to the Redis channel
+/// <see cref="HybridCacheService.CrossReplicaInvalidationChannel"/> at startup.
+/// Each message carries a single tag (string). On receipt the service evicts every
+/// matching entry from its replica-local <see cref="HybridCache"/> L1 cache.
+///
+/// Cross-replica L1 invariant: when a writer on Replica A calls
+/// <see cref="IHybridCacheService.RemoveByTagAcrossReplicasAsync"/>, the local
+/// L1+L2 eviction is followed by a Redis Pub/Sub broadcast. Replicas B/C receive
+/// the tag here and evict their local L1 entries. Without this subscriber the
+/// non-publishing replicas would keep serving the L1 entry until its
+/// <c>LocalCacheExpiration</c> ticked (15-30 min) — the bug ADR-062 closes.
+///
+/// Idempotent: the publishing replica also receives its own broadcast and re-runs
+/// the eviction as a no-op (L1 entry already gone from Step 1 of the publish).
+///
+/// ADR-062 (KB-flag cache propagation strategy).
+/// </summary>
+internal sealed class HybridCacheInvalidationSubscriber : IHostedService
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly HybridCache _hybridCache;
+    private readonly ILogger<HybridCacheInvalidationSubscriber> _logger;
+    private ChannelMessageQueue? _queue;
+
+    public HybridCacheInvalidationSubscriber(
+        IConnectionMultiplexer redis,
+        HybridCache hybridCache,
+        ILogger<HybridCacheInvalidationSubscriber> logger)
+    {
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+        _hybridCache = hybridCache ?? throw new ArgumentNullException(nameof(hybridCache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var subscriber = _redis.GetSubscriber();
+        _queue = await subscriber
+            .SubscribeAsync(RedisChannel.Literal(HybridCacheService.CrossReplicaInvalidationChannel))
+            .ConfigureAwait(false);
+
+        _queue.OnMessage(async message =>
+        {
+            var tag = message.Message.ToString();
+            if (string.IsNullOrWhiteSpace(tag))
+            {
+                return;
+            }
+
+            try
+            {
+                // RemoveByTagAsync on the Microsoft HybridCache evicts BOTH L1 (local replica)
+                // and L2 (distributed). L2 is already empty when this fires (publisher cleared it)
+                // — the L1 eviction is the work that matters here.
+                await _hybridCache.RemoveByTagAsync(tag, CancellationToken.None).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Received cross-replica cache invalidation; evicted L1 entries for tag '{Tag}'",
+                    tag);
+            }
+#pragma warning disable CA1031 // Pub/sub callback must not throw — would break the channel queue
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to evict cache entries for tag '{Tag}' after Redis cross-replica invalidation",
+                    tag);
+            }
+        });
+
+        _logger.LogInformation(
+            "Subscribed to Redis channel '{Channel}' for cross-replica L1 cache invalidation",
+            HybridCacheService.CrossReplicaInvalidationChannel);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_queue is not null)
+        {
+            await _queue.UnsubscribeAsync().ConfigureAwait(false);
+            _queue = null;
+            _logger.LogInformation(
+                "Unsubscribed from Redis channel '{Channel}' for cross-replica L1 cache invalidation",
+                HybridCacheService.CrossReplicaInvalidationChannel);
+        }
+    }
+}

--- a/apps/api/src/Api/Services/HybridCacheService.cs
+++ b/apps/api/src/Api/Services/HybridCacheService.cs
@@ -219,6 +219,70 @@ internal class HybridCacheService : IHybridCacheService
         return keysToRemove.Count;
     }
 
+    /// <summary>
+    /// Redis Pub/Sub channel used for cross-replica L1 cache invalidation.
+    /// Subscribed by <see cref="HybridCacheInvalidationSubscriber"/>.
+    /// See ADR-062 (KB-flag cache propagation strategy).
+    /// </summary>
+    internal const string CrossReplicaInvalidationChannel = "meepleai:cache-invalidate:tag";
+
+    /// <inheritdoc />
+    public async Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+        {
+            throw new ArgumentException("Tag cannot be null or whitespace", nameof(tag));
+        }
+
+        // Step 1: local eviction (L1 of this replica + L2 distributed).
+        // RemoveByTagAsync already evicts L2 globally, so other replicas just need their L1 cleared.
+        var localCount = await RemoveByTagAsync(tag, ct).ConfigureAwait(false);
+
+        // Step 2: broadcast the tag to other replicas via Redis Pub/Sub.
+        // Each replica's HybridCacheInvalidationSubscriber receives the tag and evicts its L1.
+        // The publishing replica also receives its own message — no-op (already evicted in Step 1).
+        if (_redis is null)
+        {
+            _logger.LogWarning(
+                "Redis unavailable; cross-replica invalidation skipped for tag {Tag}. " +
+                "Behaviour degrades to single-replica L1 eviction.",
+                tag);
+            return localCount;
+        }
+
+        try
+        {
+            var subscriber = _redis.GetSubscriber();
+            var receivers = await subscriber
+                .PublishAsync(RedisChannel.Literal(CrossReplicaInvalidationChannel), tag)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Broadcast cross-replica invalidation: Tag={Tag}, LocalEvictedCount={LocalCount}, ReceivingReplicas={Receivers}",
+                tag,
+                localCount,
+                receivers);
+        }
+        catch (RedisConnectionException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Redis connection failed during cross-replica invalidation broadcast for tag {Tag}. " +
+                "Local eviction succeeded; other replicas will rely on LocalCacheExpiration.",
+                tag);
+        }
+        catch (RedisTimeoutException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Redis timeout during cross-replica invalidation broadcast for tag {Tag}. " +
+                "Local eviction succeeded; other replicas will rely on LocalCacheExpiration.",
+                tag);
+        }
+
+        return localCount;
+    }
+
     /// <inheritdoc />
     public async Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default)
     {

--- a/apps/api/src/Api/Services/IHybridCacheService.cs
+++ b/apps/api/src/Api/Services/IHybridCacheService.cs
@@ -94,6 +94,30 @@ internal interface IHybridCacheService
     /// <param name="ct">Cancellation token</param>
     /// <returns>Cache statistics (hit rate, entry count, memory usage)</returns>
     Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes cache entries by tag locally AND broadcasts an invalidation message
+    /// to all API replicas via Redis Pub/Sub. Each replica's
+    /// <see cref="HybridCacheInvalidationSubscriber"/> evicts matching L1 entries on receipt.
+    ///
+    /// Use this for cross-replica L1 invalidation when a domain event mutates a projection
+    /// that downstream readers consume from L1 cache (e.g. <c>HasKnowledgeBase</c> flip
+    /// post-PDF indexing). Without the broadcast, only the calling replica's L1 evicts;
+    /// other replicas keep serving stale L1 entries until <c>LocalCacheExpiration</c>.
+    ///
+    /// ADR-062 (KB-flag cache propagation strategy).
+    /// </summary>
+    /// <param name="tag">Tag to invalidate across replicas (e.g. "search-games", "shared-game:{id}")</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Number of L1+L2 cache entries removed on the calling replica.
+    /// Other replicas' eviction is asynchronous (sub-second typical) and not counted in the return.</returns>
+    /// <remarks>
+    /// Failure modes:
+    /// - Redis Pub/Sub unreachable → local <see cref="RemoveByTagAsync(string,CancellationToken)"/> still runs;
+    ///   only the broadcast step is skipped. Behaviour degrades to legacy single-replica eviction.
+    /// - Subscriber receiving its own publishing replica's message → no-op (L1 already evicted by Step 1).
+    /// </remarks>
+    Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/Services/ProviderQuotaServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/Services/ProviderQuotaServiceTests.cs
@@ -25,6 +25,7 @@ public sealed class ProviderQuotaServiceTests
         public Task RemoveAsync(string cacheKey, CancellationToken ct = default) => Task.CompletedTask;
         public Task<int> RemoveByTagAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
         public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
         public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new HybridCacheStats());
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJobTests.cs
@@ -1,0 +1,168 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// Issue #2248 (epic #2242, Sub #6 Block B): unit tests for the periodic audit
+/// that guards the "Ready ⇒ HasKnowledgeBase" invariant.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "2248")]
+public sealed class KbFlagDriftAuditJobTests
+{
+    private readonly Mock<ILogger<KbFlagDriftAuditJob>> _logger = new();
+
+    private static PdfDocumentEntity ReadyPdf(Guid id, Guid sharedGameId) =>
+        new()
+        {
+            Id = id,
+            SharedGameId = sharedGameId,
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow.AddMinutes(-30),
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow.AddMinutes(-25),
+            Language = "en",
+            Tags = new List<string>(),
+        };
+
+    private static SharedGameEntity Game(Guid id, bool hasKb) =>
+        new()
+        {
+            Id = id,
+            Title = "Test Game",
+            YearPublished = 2020,
+            Description = "Desc",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 30,
+            MinAge = 8,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Status = 1,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            HasKnowledgeBase = hasKb,
+        };
+
+    private static IJobExecutionContext FakeContext()
+    {
+        var ctx = new Mock<IJobExecutionContext>();
+        ctx.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        ctx.SetupProperty(c => c.Result);
+        return ctx.Object;
+    }
+
+    [Fact]
+    public async Task Execute_NoDriftedRows_LogsZeroAndReturns()
+    {
+        var sharedGameId = Guid.NewGuid();
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        // Healthy state: PDF Ready and SharedGame.HasKnowledgeBase=true (the invariant holds)
+        db.SharedGames.Add(Game(sharedGameId, hasKb: true));
+        db.PdfDocuments.Add(ReadyPdf(Guid.NewGuid(), sharedGameId));
+        await db.SaveChangesAsync();
+
+        var job = new KbFlagDriftAuditJob(db, _logger.Object);
+        var ctx = FakeContext();
+
+        await job.Execute(ctx);
+
+        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 0 });
+    }
+
+    [Fact]
+    public async Task Execute_DriftDetected_LogsWarningAndIncrementsCounter()
+    {
+        var sharedGameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        // Drifted state: PDF Ready but SharedGame.HasKnowledgeBase=false (the bug
+        // #2243 Block A patches and Sub #2 architecture refactor structurally fixes).
+        db.SharedGames.Add(Game(sharedGameId, hasKb: false));
+        db.PdfDocuments.Add(ReadyPdf(pdfId, sharedGameId));
+        await db.SaveChangesAsync();
+
+        var job = new KbFlagDriftAuditJob(db, _logger.Object);
+        var ctx = FakeContext();
+
+        await job.Execute(ctx);
+
+        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 1 });
+
+        // Warning per drifted row + 1 Error summary line.
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("KbFlagDrift detected", StringComparison.Ordinal)),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("SLO=0 violated", StringComparison.Ordinal)),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_PdfWithoutSharedGameId_DoesNotDrift()
+    {
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        // A PDF with null SharedGameId (private game / orphan) must not appear in the audit.
+        var orphan = ReadyPdf(Guid.NewGuid(), sharedGameId: Guid.NewGuid());
+        orphan.SharedGameId = null;
+        db.PdfDocuments.Add(orphan);
+        await db.SaveChangesAsync();
+
+        var job = new KbFlagDriftAuditJob(db, _logger.Object);
+        var ctx = FakeContext();
+
+        await job.Execute(ctx);
+
+        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 0 });
+    }
+
+    [Fact]
+    public async Task Execute_PdfNotReady_DoesNotDrift()
+    {
+        var sharedGameId = Guid.NewGuid();
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.SharedGames.Add(Game(sharedGameId, hasKb: false));
+        var indexing = ReadyPdf(Guid.NewGuid(), sharedGameId);
+        indexing.ProcessingState = "Indexing"; // in progress, not yet Ready
+        db.PdfDocuments.Add(indexing);
+        await db.SaveChangesAsync();
+
+        var job = new KbFlagDriftAuditJob(db, _logger.Object);
+        var ctx = FakeContext();
+
+        await job.Execute(ctx);
+
+        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 0 });
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
@@ -248,6 +248,7 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         public Task RemoveAsync(string cacheKey, CancellationToken ct = default) => Task.CompletedTask;
         public Task<int> RemoveByTagAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
         public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
         public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
             => Task.FromResult(new HybridCacheStats());
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandlerTests.cs
@@ -1,13 +1,10 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.Caching.Hybrid;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -23,6 +20,10 @@ namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
 /// Tech debt revision (CR-I1, CR-M4):
 ///   - Event carries SharedGameId directly (no cross-BC DB read).
 ///   - Handler invalidates the HybridCache tag "search-games" after updates.
+///
+/// Epic #2242 Sub #6 Block C (ADR-062):
+///   - Cache eviction now goes through IHybridCacheService.RemoveByTagAcrossReplicasAsync
+///     for cross-replica L1 invalidation via Redis Pub/Sub.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -30,14 +31,12 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
 {
     private readonly Mock<ILogger<VectorDocumentIndexedForKbFlagHandler>> _logger = new();
 
-    private static HybridCache CreateHybridCache()
+    private static Mock<IHybridCacheService> CreateCacheMock()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IMemoryCache, MemoryCache>();
-        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
-            Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions())));
-        services.AddHybridCache();
-        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+        var mock = new Mock<IHybridCacheService>(MockBehavior.Strict);
+        mock.Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        return mock;
     }
 
     private static SharedGameEntity CreateSharedGame(Guid id, bool hasKb = false) =>
@@ -71,7 +70,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateCacheMock().Object, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(documentId, gameId, chunkCount: 42, sharedGameId: sharedGameId);
 
         // Act
@@ -95,7 +94,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateCacheMock().Object, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(documentId, gameId, chunkCount: 42, sharedGameId: null);
 
         // Act
@@ -111,7 +110,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
     {
         // Arrange
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateCacheMock().Object, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(
             documentId: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
@@ -137,7 +136,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: true));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateCacheMock().Object, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(documentId, gameId, chunkCount: 42, sharedGameId: sharedGameId);
 
         // Act
@@ -153,7 +152,7 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
     {
         // Arrange
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateHybridCache(), new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, CreateCacheMock().Object, new PassthroughRetryPolicy(), _logger.Object);
 
         // Act
         var act = async () => await handler.Handle(null!, CancellationToken.None);
@@ -163,66 +162,47 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithValidUpdate_InvalidatesSearchGamesCache()
+    public async Task Handle_WithValidUpdate_InvokesCrossReplicaInvalidationForSearchGamesTag()
     {
-        // Arrange — prime the cache with a dummy entry under the "search-games" tag
-        var cache = CreateHybridCache();
-        var sentinelKey = $"search-games:{Guid.NewGuid()}";
-        var tags = new[] { "search-games" };
-        await cache.SetAsync(sentinelKey, "cached-value", tags: tags);
-
+        // Issue #2242 Sub #6 Block C (ADR-062): handler must invoke the cross-replica
+        // wrapper so other replicas evict their L1 entries via Redis Pub/Sub broadcast.
+        // The wrapper internally performs local RemoveByTagAsync (L1 + L2) before broadcasting.
+        var cacheMock = CreateCacheMock();
         var sharedGameId = Guid.NewGuid();
+
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cache, new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cacheMock.Object, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(
             documentId: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
             chunkCount: 42,
             sharedGameId: sharedGameId);
 
-        // Act
         await handler.Handle(evt, CancellationToken.None);
 
-        // Assert — SharedGame flag flipped and cache entry evicted
-        (await db.SharedGames.FindAsync(sharedGameId))!.HasKnowledgeBase.Should().BeTrue();
-        // The cached value should be gone now; GetOrCreateAsync would repopulate.
-        // We cannot read the internal HybridCache state directly, but a subsequent
-        // write with the same key should succeed and the factory should be invoked
-        // (indicating the prior entry was evicted).
-        var factoryInvoked = false;
-        await cache.GetOrCreateAsync(
-            sentinelKey,
-            _ =>
-            {
-                factoryInvoked = true;
-                return ValueTask.FromResult("fresh-value");
-            },
-            tags: tags);
-        factoryInvoked.Should().BeTrue("RemoveByTagAsync should have evicted the sentinel");
+        cacheMock.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "handler should evict the catalog list cache namespace across replicas after the flag flip");
     }
 
     [Fact]
-    public async Task Handle_WithValidUpdate_InvalidatesPerGameDetailCache()
+    public async Task Handle_WithValidUpdate_InvokesCrossReplicaInvalidationForPerGameDetailTag()
     {
         // Issue #603 (Wave A.4) — verify the handler also evicts the per-game
-        // detail cache `shared-game:{id}` so the next /shared-games/{id} read
-        // sees the refreshed HasKnowledgeBase flag and KB previews.
-        // Mirrors the search-games eviction test pattern above.
-        var cache = CreateHybridCache();
+        // detail cache `shared-game:{id}` across replicas so the next
+        // /shared-games/{id} read on ANY replica sees the refreshed HasKnowledgeBase flag.
+        var cacheMock = CreateCacheMock();
         var sharedGameId = Guid.NewGuid();
-        var perGameTag = $"shared-game:{sharedGameId}";
-        var detailKey = $"shared-game:{sharedGameId}";
-
-        await cache.SetAsync(detailKey, "seed-detail", tags: new[] { perGameTag });
 
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
         db.SharedGames.Add(CreateSharedGame(sharedGameId, hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cache, new PassthroughRetryPolicy(), _logger.Object);
+        var handler = new VectorDocumentIndexedForKbFlagHandler(db, cacheMock.Object, new PassthroughRetryPolicy(), _logger.Object);
         var evt = new VectorDocumentIndexedEvent(
             documentId: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
@@ -231,15 +211,9 @@ public sealed class VectorDocumentIndexedForKbFlagHandlerTests
 
         await handler.Handle(evt, CancellationToken.None);
 
-        var factoryInvoked = false;
-        await cache.GetOrCreateAsync(
-            detailKey,
-            _ =>
-            {
-                factoryInvoked = true;
-                return ValueTask.FromResult("fresh-detail");
-            },
-            tags: new[] { perGameTag });
-        factoryInvoked.Should().BeTrue("RemoveByTagAsync(\"shared-game:{id}\") should have evicted the detail entry");
+        cacheMock.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "handler should evict the per-game detail cache across replicas after the flag flip");
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
@@ -223,6 +223,8 @@ internal sealed class TestHybridCacheService : Api.Services.IHybridCacheService
 
     public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default) => Task.FromResult(0);
 
+    public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
+
     public Task<Api.Services.HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
         => Task.FromResult(new Api.Services.HybridCacheStats());
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/PassthroughHybridCache.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PassthroughHybridCache.cs
@@ -29,5 +29,7 @@ internal sealed class PassthroughHybridCache : IHybridCacheService
 
     public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default) => Task.FromResult(0);
 
+    public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
+
     public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new HybridCacheStats());
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
@@ -215,6 +215,19 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
         services.AddHybridCache();
         services.AddScoped<Api.Services.ICacheInvalidationRetryPolicy>(_ => new PassthroughRetryPolicy());
 
+        // ADR-062: IHybridCacheService wrapper used by VectorDocumentIndexedForKbFlagHandler
+        // for cross-replica L1 invalidation. Configuration mirrors production defaults; the
+        // wrapper still works in single-replica test mode (broadcast publish becomes no-op
+        // when only this Redis subscriber connects).
+        services.Configure<Api.Configuration.HybridCacheConfiguration>(opts =>
+        {
+            opts.EnableL2Cache = true;
+            opts.EnableTags = true;
+            opts.DefaultExpiration = TimeSpan.FromMinutes(5);
+            opts.MaxTagsPerEntry = 10;
+        });
+        services.AddSingleton<Api.Services.IHybridCacheService, Api.Services.HybridCacheService>();
+
         _serviceProvider = services.BuildServiceProvider();
         _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
 

--- a/apps/api/tests/Api.Tests/Integration/Infrastructure/HybridCacheServiceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Infrastructure/HybridCacheServiceIntegrationTests.cs
@@ -503,6 +503,106 @@ public sealed class HybridCacheServiceIntegrationTests : IAsyncLifetime
 
     #endregion
 
+    #region Cross-replica L1 invalidation (ADR-062 / Epic #2242 Sub #6 Block C)
+
+    /// <summary>
+    /// ADR-062: RemoveByTagAcrossReplicasAsync must perform local eviction (L1+L2) AND
+    /// publish the tag to the Redis Pub/Sub channel so other replicas can evict their L1.
+    /// </summary>
+    [Fact]
+    public async Task RemoveByTagAcrossReplicasAsync_BroadcastsTagViaRedisPubSub()
+    {
+        // Arrange — pre-populate cache with an entry tagged "test:cross-replica"
+        var key = _keyPrefix + "cross_replica_test";
+        var tag = _keyPrefix + "cross_replica_tag";
+        var factoryCalls = 0;
+
+        Func<CancellationToken, Task<TestCacheData>> factory = _ =>
+        {
+            factoryCalls++;
+            return Task.FromResult(new TestCacheData { Value = "v1", Timestamp = DateTime.UtcNow });
+        };
+
+        await _cacheService.GetOrCreateAsync(
+            key,
+            factory,
+            tags: new[] { tag },
+            ct: TestContext.Current.CancellationToken);
+
+        // Set up a parallel subscriber on the same Redis channel to capture the broadcast.
+        var subscriber = _redis.GetSubscriber();
+        var receivedTag = string.Empty;
+        var receivedSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var queue = await subscriber.SubscribeAsync(RedisChannel.Literal(HybridCacheService.CrossReplicaInvalidationChannel));
+        queue.OnMessage(msg =>
+        {
+            receivedTag = msg.Message.ToString();
+            receivedSignal.TrySetResult(true);
+        });
+
+        try
+        {
+            // Act
+            var localCount = await _cacheService.RemoveByTagAcrossReplicasAsync(tag, TestContext.Current.CancellationToken);
+
+            // Assert: broadcast received via Redis Pub/Sub
+            var received = await Task.WhenAny(receivedSignal.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            received.Should().Be(receivedSignal.Task, "broadcast should arrive at the subscriber within 5s");
+            receivedTag.Should().Be(tag);
+            localCount.Should().BeGreaterThanOrEqualTo(1, "the entry tagged before the call should have been evicted locally");
+        }
+        finally
+        {
+            await queue.UnsubscribeAsync();
+        }
+    }
+
+    /// <summary>
+    /// ADR-062: RemoveByTagAcrossReplicasAsync without Redis still performs local eviction.
+    /// Pub/Sub failure must not break the local invalidation path.
+    /// </summary>
+    [Fact]
+    public async Task RemoveByTagAcrossReplicasAsync_WithoutRedis_DegradesToLocalOnly()
+    {
+        // Arrange — service constructed without a Redis IConnectionMultiplexer
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisCache(options =>
+        {
+            options.Configuration = _fixture.RedisConnectionString;
+            options.InstanceName = _keyPrefix + "no_redis_pub:";
+        });
+        services.AddHybridCache();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var hybridCache = serviceProvider.GetRequiredService<HybridCache>();
+
+        var config = new HybridCacheConfiguration
+        {
+            EnableL2Cache = true,
+            EnableTags = true,
+            DefaultExpiration = TimeSpan.FromMinutes(5),
+            MaxTagsPerEntry = 10
+        };
+
+        var serviceNoRedis = new HybridCacheService(
+            hybridCache,
+            Options.Create(config),
+            _loggerMock.Object,
+            redis: null);
+
+        // Act
+        var act = async () => await serviceNoRedis.RemoveByTagAcrossReplicasAsync(
+            "missing_tag_" + Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        // Assert — does not throw despite missing pub/sub channel
+        await act.Should().NotThrowAsync();
+    }
+
+    #endregion
+
     #region Helper Classes
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -319,6 +319,9 @@ internal sealed class ContractTestHybridCacheService : IHybridCacheService
     public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default)
         => Task.FromResult(0);
 
+    public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default)
+        => Task.FromResult(0);
+
     public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
         => Task.FromResult(new HybridCacheStats());
 }

--- a/apps/web/e2e/pdf-indexing-flow.spec.ts
+++ b/apps/web/e2e/pdf-indexing-flow.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Epic #2242 — PDF indexing flow repair.
+ * Sub #6 (#2248) Block D — end-to-end Playwright skeleton.
+ *
+ * Walks the full journey the bug broke (#2243 root cause): admin uploads a PDF,
+ * the BG pipeline reaches Ready, the catalog DTOs surface HasKnowledgeBase=true,
+ * and the user-facing badge "agente pronto" appears on the library and the
+ * game-detail page.
+ *
+ * Tests are skipped by default — they rely on the backend running with the
+ * embedding-service mock + a staged admin/user fixture pair which is not yet
+ * wired into the e2e harness. Once `test-fixtures/auth/admin.json` and
+ * `test-fixtures/auth/user.json` storage states ship from the auth workstream,
+ * remove the `test.fixme` annotations and run via `pnpm test:e2e -- pdf-indexing-flow`.
+ *
+ * Until then this file acts as the executable BDD specification for the epic:
+ * the assertions below describe the contract every block of #2242 must honour
+ * end-to-end. Reviewers can use it as a checklist when validating Sub #4 / #5
+ * frontend changes.
+ */
+
+test.describe('Epic #2242 — PDF indexing flow end-to-end', () => {
+  test.fixme('admin uploads PDF, sees Ready, then user sees agente pronto on library + game-detail', async ({
+    browser,
+  }) => {
+    // ────────────────────────────────────────────────────────────────────
+    // ADMIN JOURNEY
+    // ────────────────────────────────────────────────────────────────────
+    const adminContext = await browser.newContext({
+      storageState: 'test-fixtures/auth/admin.json',
+    });
+    const adminPage = await adminContext.newPage();
+
+    await adminPage.goto('/admin/knowledge-base/upload');
+
+    // Pick the test SharedGame seeded by the fixture harness.
+    const gameTitle = 'Wingspan Test Fixture';
+    await adminPage.getByTestId('game-search').fill(gameTitle);
+    await adminPage.getByRole('option', { name: gameTitle }).click();
+
+    // Upload a small valid PDF.
+    await adminPage
+      .getByTestId('upload-zone')
+      .locator('input[type="file"]')
+      .setInputFiles('test-fixtures/pdfs/wingspan-rules-mock.pdf');
+
+    // Block A invariant: upload accepts and the per-doc status badge climbs
+    // through the 7-state pipeline (Pending → Uploading → … → Ready).
+    // The new admin queue page (Sub #4 cache invalidation) must reflect the
+    // change without a manual refresh.
+    await expect(
+      adminPage.getByTestId('upload-status'),
+      'upload zone must report completion within the BG pipeline window'
+    ).toContainText(/completed/i, { timeout: 60_000 });
+
+    // Block C invariant: navigating to the game-detail Documents tab shows
+    // the new doc in Ready state (the polling stage labels must match the
+    // backend enum — Sub #4 Block C in #2246 fixes the previous mismatch).
+    await adminPage.goto('/admin/shared-games/wingspan');
+    await expect(adminPage.getByTestId('pdf-row-wingspan-rules-mock')).toHaveAttribute(
+      'data-state',
+      'Ready',
+      { timeout: 30_000 }
+    );
+
+    // Sub #4 Block A invariant: the KB documents list refreshes without a
+    // manual navigation (cache invalidation post-upload).
+    await adminPage.goto('/admin/shared-games/wingspan/knowledge-base');
+    await expect(adminPage.getByTestId('kb-documents-list')).not.toBeEmpty();
+
+    await adminContext.close();
+
+    // ────────────────────────────────────────────────────────────────────
+    // USER JOURNEY
+    // ────────────────────────────────────────────────────────────────────
+    const userContext = await browser.newContext({
+      storageState: 'test-fixtures/auth/user.json',
+    });
+    const userPage = await userContext.newPage();
+
+    // Sub #1 Block A+C invariant: GET /api/v1/games returns HasKnowledgeBase
+    // and GET /api/v1/shared-games returns KbsCount>0, so the library grid
+    // can render the "📄 KB" chip via MeepleLibraryGameCard.
+    await userPage.goto('/library');
+    await expect(userPage.getByTestId('library-card-wingspan').getByTestId('kb-chip')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Sub #5 (#2247) Block A invariant: /games/[id] Documents tab is wired
+    // to safeDetail.kbs instead of the previous hardcoded `docs=[]`.
+    await userPage.goto('/games/wingspan');
+    await expect(
+      userPage.getByTestId('game-detail-kb-doc-list'),
+      'game-detail Documents tab must render the published KB list (not the empty hardcoded array)'
+    ).not.toBeEmpty();
+
+    // Sub #5 Block A invariant: the chat CTA is enabled because
+    // safeDetail.hasKnowledgeBase=true.
+    await expect(userPage.getByTestId('chat-cta')).toBeEnabled();
+
+    await userContext.close();
+  });
+
+  test.fixme('discover catalog shows AI Ready badge once HasKnowledgeBase=true', async ({
+    page,
+  }) => {
+    // Sub #5 Block B invariant — discover badge wired to SharedGame.hasKnowledgeBase.
+    await page.goto('/games?tab=discover');
+    await expect(
+      page.getByTestId('discover-card-wingspan').getByTestId('ai-ready-badge')
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test.fixme('GamesFilterPanel quick-link AI Ready navigates to /games?hasKb=true', async ({
+    page,
+  }) => {
+    // Sub #5 Block D invariant — fixes the URL pointing at /library?hasKb=true.
+    await page.goto('/games');
+    await page.getByRole('link', { name: /ai ready/i }).click();
+    await expect(page).toHaveURL(/\/games\?.*hasKb=true/);
+  });
+});

--- a/apps/web/src/components/layout/AppNav/__tests__/AppTopBar.test.tsx
+++ b/apps/web/src/components/layout/AppNav/__tests__/AppTopBar.test.tsx
@@ -44,7 +44,8 @@ describe('AppTopBar', () => {
     render(<AppTopBar />);
     expect(screen.getByText('Dashboard')).toBeDefined();
     expect(screen.getByText('Libreria')).toBeDefined();
-    expect(screen.getByText('Hub')).toBeDefined();
+    // PR #2279 (#2190 nav cleanup, 2026-06-13) renamed "Hub" → "Games".
+    expect(screen.getByText('Games')).toBeDefined();
     expect(screen.getByText('Sessioni')).toBeDefined();
     expect(screen.getByText('Toolkit')).toBeDefined();
   });

--- a/apps/web/src/components/layout/AppNav/__tests__/MobileBottomBar.test.tsx
+++ b/apps/web/src/components/layout/AppNav/__tests__/MobileBottomBar.test.tsx
@@ -26,7 +26,8 @@ describe('MobileBottomBar', () => {
     render(<MobileBottomBar />);
     expect(screen.getByText('Home')).toBeDefined();
     expect(screen.getByText('Libreria')).toBeDefined();
-    expect(screen.getByText('Hub')).toBeDefined();
+    // PR #2279 (#2190 nav cleanup, 2026-06-13) renamed "Hub" → "Games".
+    expect(screen.getByText('Games')).toBeDefined();
     expect(screen.getByText('Chat')).toBeDefined();
     expect(screen.getByText('Profilo')).toBeDefined();
     // The override means the dashboard tab does NOT show "Dashboard".

--- a/docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md
@@ -1,6 +1,6 @@
 # ADR-062 — KB-flag cache propagation strategy
 
-**Status**: Proposed (2026-06-12)
+**Status**: Accepted (2026-06-13, supersedes 2026-06-12 Proposed)
 **Context**: Epic [#2242](https://github.com/meepleAi-app/meepleai-monorepo/issues/2242) — PDF indexing flow repair.
 **Sub-issue**: [#2248](https://github.com/meepleAi-app/meepleai-monorepo/issues/2248) Sub #6 Block C (Quality Gates).
 **Authors**: KB pipeline workstream.
@@ -12,12 +12,12 @@
 1. Updates `shared_games.has_knowledge_base`.
 2. Invalidates the HybridCache tag `search-games` AND `shared-game:{id}`.
 
-Tag invalidation on HybridCache evicts the **L2 distributed entry** (Redis, shared across nodes) but only the **L1 in-memory entry of the local API replica**. Other replicas keep serving their L1 cached `SharedGameDto`s (with `HasKnowledgeBase=false`) for up to **15 minutes** — the configured `LocalCacheExpiration` on:
+Tag invalidation on HybridCache evicts the **L2 distributed entry** (Redis, shared across nodes) but only the **L1 in-memory entry of the local API replica**. Other replicas keep serving their L1 cached `SharedGameDto`s (with `HasKnowledgeBase=false`) for up to **15-30 minutes** — the configured `LocalCacheExpiration` on:
 
-- `SearchSharedGamesQueryHandler.cs` (the catalog list endpoint)
-- `GetSharedGameByIdQueryHandler.cs` (the catalog detail endpoint)
+- `SearchSharedGamesQueryHandler.cs` (the catalog list endpoint, 15 min)
+- `GetSharedGameByIdQueryHandler.cs` (the catalog detail endpoint, 30 min)
 
-For Wave A.4 (single-replica staging) this was acceptable. For multi-replica production (and the catalog Phase E F4 SSE event stream shipped in #2227) it produces a 15-minute window where:
+For Wave A.4 (single-replica staging) this was acceptable. For multi-replica production (and the catalog Phase E F4 SSE event stream shipped in #2227) it produces a multi-minute window where:
 
 - Replica A (where the upload happened) sees `HasKnowledgeBase=true` immediately.
 - Replicas B/C still serve `HasKnowledgeBase=false` until their L1 expires.
@@ -28,64 +28,90 @@ Documented at `VectorDocumentIndexedForKbFlagHandler.cs:88-94`; mitigation track
 
 ## Options considered
 
-### Option 1 — Reduce `LocalCacheExpiration` to 60 seconds (RECOMMENDED)
+### Option 1 — Reduce `LocalCacheExpiration` to 60 seconds
 
-Change `SearchSharedGamesQueryHandler` and `GetSharedGameByIdQueryHandler` to use a 60-second L1 TTL (was 15 min).
+Change `SearchSharedGamesQueryHandler` and `GetSharedGameByIdQueryHandler` to use a 60-second L1 TTL (was 15-30 min).
 
 **Pros**: trivial code change (2 numeric constants + their tests). Cache stampede is still bounded by the L2 layer. Operationally simple — no new infrastructure.
 
-**Cons**: 60-second blind window on multi-replica. Slightly higher Redis L2 hit rate (acceptable per the existing benchmarks).
+**Cons**: 60-second blind window on multi-replica. Slightly higher Redis L2 hit rate (acceptable per the existing benchmarks). Does not fundamentally solve the cross-replica propagation problem — it only narrows it.
 
 **Effort**: ~1h including a rebaseline test for the L1 expiry assertion if any exists.
 
-### Option 2 — Redis pub/sub L1 invalidation broadcast
+### Option 2 — Redis pub/sub L1 invalidation broadcast (without wrapper)
 
-Publish a "kb-flag-changed:{sharedGameId}" message on a Redis channel from `VectorDocumentIndexedForKbFlagHandler`. Each replica subscribes and evicts the L1 entry on receipt.
+Publish a "kb-flag-changed:{sharedGameId}" message on a Redis channel from `VectorDocumentIndexedForKbFlagHandler`. Each replica subscribes (directly via `IConnectionMultiplexer`) and evicts the L1 entry on receipt.
 
 **Pros**: sub-second propagation. No L1 TTL change needed.
 
-**Cons**: introduces new infra surface (pub/sub subscription on startup, reconnect logic), risk of missed messages during connection blips. Requires per-replica subscription manager. The HybridCache APIs do not expose a native L1 eviction primitive, so the subscriber has to invoke a private API or use a parallel `IMemoryCache`. Maintenance debt rises.
+**Cons**: introduces new infra surface (pub/sub subscription on startup, reconnect logic), risk of missed messages during connection blips. Requires per-replica subscription manager. The HybridCache APIs do not expose a native L1-only eviction primitive, so the subscriber has to invoke `RemoveByTagAsync` (idempotent but re-touches L2). Plumbing duplicated at every event handler that needs the broadcast.
 
 **Effort**: ~2-3 days (subscriber service + reconnect handling + integration test with Testcontainers Redis).
 
-### Option 3 — HybridCache stampede protection via `IHybridCacheService` wrapper
+### Option 3 — HybridCache wrapper with built-in cross-replica broadcast (CHOSEN)
 
-Wrap `HybridCache` calls in an `IHybridCacheService` (already exists per CLAUDE.md #2620) and centralise cache-stampede protection + invalidation. The wrapper publishes/subscribes to a per-key invalidation event internally.
+Extend the existing `IHybridCacheService` (CLAUDE.md #2620 — wrapper around `HybridCache` already used by `ProviderQuotaService`, `InvalidateCacheCommandHandler`) with a new method `RemoveByTagAcrossReplicasAsync(tag)` that:
 
-**Pros**: keeps the cache-stampede mitigation that Option 1 implicitly preserves; cleaner abstraction long-term.
+1. Performs the local `RemoveByTagAsync(tag)` (evicts L1 of the calling replica + L2 distributed).
+2. Publishes the tag to a Redis Pub/Sub channel `meepleai:cache-invalidate:tag`.
 
-**Cons**: cross-cutting refactor — touches every handler that reads `SharedGames`. Risk of accidental behaviour drift in unrelated query paths.
+A dedicated `BackgroundService` (`HybridCacheInvalidationSubscriber`) subscribes to that channel on every replica at startup. On receive it calls `_hybridCache.RemoveByTagAsync(tag)` locally — evicting the stale L1 entry on the receiving replica. Subscription is idempotent: the publishing replica also receives its own message and re-runs the eviction as a no-op.
 
-**Effort**: ~5+ days (refactor + regression test suite).
+**Pros**: sub-second propagation (Redis Pub/Sub latency ~1ms intra-DC). Cross-replica invalidation logic encapsulated in **one** place. Other event handlers that need the same pattern (toolkit, agent, mechanic-metrics) can adopt it incrementally without re-implementing pub/sub plumbing. Centralised observability (one subscriber → one log site → one Prometheus counter to add later if needed). Plays well with the existing `IHybridCacheService` consumers (ProviderQuotaService, InvalidateCacheCommandHandler) that benefit from the same wrapper.
+
+**Cons**: introduces a `BackgroundService` startup dependency (Redis must be reachable at boot or subscription retry kicks in). Cross-cutting refactor scope: the chosen event handler (`VectorDocumentIndexedForKbFlagHandler`) migrates from `HybridCache` direct to `IHybridCacheService`. Reader code paths (`SearchSharedGamesQueryHandler`, `GetSharedGameByIdQueryHandler`) keep their existing `HybridCache` direct usage — only **writers** of the invalidation event need to switch to the wrapper.
+
+**Effort**: ~1 day for the minimum-viable cross-replica broadcast (extension + subscriber + handler migration + unit tests). Future incremental adoption by other writer handlers is opt-in.
+
+### Variants explicitly rejected
+
+- **Wholesale wrapper migration of all SharedGameCatalog query handlers**: deferred. The reader-side wrapper migration has no functional value for this epic (HybridCache direct already works for reads). Scope creep risk too high — covered by a separate tracking issue if a cross-cutting policy emerges.
+- **Tag tracking via Microsoft.Extensions.Caching.Hybrid native API**: HybridCache 9.x does not expose a `GetKeysByTag` primitive, so the wrapper would have to maintain its own tag → key Redis Set tracking. The existing `HybridCacheService` already does this; we reuse it.
 
 ## Decision
 
-**Adopt Option 1** for this epic. Rationale:
+**Adopt Option 3** for this epic. Rationale:
 
-- Closes the UX gap reported in #2242 with the smallest code change and the lowest operational risk.
-- The Sub #6 audit job (`KbFlagDriftAuditJob` Block B, this same epic) catches any residual drift within 10 minutes regardless of the L1 TTL choice, so 60s is already over-engineered for the recovery window.
-- Option 2/3 remain on the table if the catalog SSE work (#2227) grows enough that 60s propagation becomes a UX issue — at that point pub/sub graduates from "nice to have" to "load-bearing", and the team has more signal to choose between Option 2 and Option 3 from production telemetry.
+- Cross-replica propagation drops from 15-30 min to sub-second — definitively closes the UX flake reported in #2242 across all read paths.
+- The Sub #6 audit job (`KbFlagDriftAuditJob` Block B, this same epic) keeps catching residual drift within 10 minutes regardless, providing defence-in-depth.
+- Encapsulating the broadcast in `IHybridCacheService` keeps the writer-side surface small: only `VectorDocumentIndexedForKbFlagHandler` changes in this epic. Future writers (toolkit, mechanic-metrics, BG Twin cache invalidation) can adopt incrementally without re-architecting.
+- Option 1 was rejected because narrowing the window from 15 min to 60 s leaves a fundamentally unresolved propagation gap; multi-tab users still observe the flake within the 60 s window. The audit job exists for a reason — to surface drift the cache layer itself failed to propagate. With Option 3 the audit job should remain perpetually at SLO=0 in healthy operation.
+- Option 2 was rejected because the same plumbing repeated across event handlers degrades long-term maintainability. The wrapper centralises it.
 
 ## Implementation
 
-To be shipped in a follow-up PR of #2248:
+Shipped in this PR (#2266):
 
-1. In `SearchSharedGamesQueryHandler.cs`, change the `HybridCacheEntryOptions.LocalCacheExpiration` (or equivalent constant) from `TimeSpan.FromMinutes(15)` to `TimeSpan.FromSeconds(60)`.
-2. Same change in `GetSharedGameByIdQueryHandler.cs`.
-3. Update the cross-instance behaviour comment in `VectorDocumentIndexedForKbFlagHandler.cs:88-94` to point at this ADR.
-4. Verify existing cache-related unit tests still pass; if any asserts on a >60s expiry, rebaseline.
-5. Manually verify in staging that flushing `meepleai_local_cache_evictions_total` (or equivalent gauge) follows the expected ~60-second cycle under load.
+1. **Extension** — `IHybridCacheService.RemoveByTagAcrossReplicasAsync(tag, ct)` interface + `HybridCacheService` impl (apps/api/src/Api/Services/HybridCacheService.cs):
+   - Step 1: `await this.RemoveByTagAsync(tag, ct)` — evicts L1 of this replica + L2 (Redis).
+   - Step 2: `await _redisDb.PublishAsync("meepleai:cache-invalidate:tag", tag)` — broadcast.
+2. **Subscriber** — `HybridCacheInvalidationSubscriber : BackgroundService` (apps/api/src/Api/Services/HybridCacheInvalidationSubscriber.cs):
+   - `ExecuteAsync`: subscribes to `meepleai:cache-invalidate:tag` channel.
+   - On message: `await _hybridCache.RemoveByTagAsync(tag)` to evict L1 locally.
+   - Registered via `AddHostedService<HybridCacheInvalidationSubscriber>()` in InfrastructureServiceExtensions.
+3. **Handler refactor** — `VectorDocumentIndexedForKbFlagHandler`:
+   - Replace `HybridCache _cache` dependency with `IHybridCacheService _cacheService`.
+   - Replace `_retryPolicy.ExecuteAsync(token => _cache.RemoveByTagAsync(...))` with `_retryPolicy.ExecuteAsync(token => _cacheService.RemoveByTagAcrossReplicasAsync(...))`.
+4. **Cross-instance behaviour comment** at `VectorDocumentIndexedForKbFlagHandler.cs:88-94`: updated to reference this ADR and the new cross-replica invariant ("sub-second propagation via cache-invalidate channel").
+5. **Unit tests** — `HybridCacheServiceTests` adds:
+   - `RemoveByTagAcrossReplicasAsync_InvokesLocalRemoveAndRedisPublish`.
+   - `HybridCacheInvalidationSubscriberTests` (new file): `OnMessage_InvokesLocalHybridCacheRemoveByTag`.
 
 ## Consequences
 
-- Multi-replica propagation window drops from 15 min to ≤60 sec.
-- Redis L2 read pressure on `search-games:*` rises modestly. The L2 layer is sized for catalog peak, so the increase is well within headroom (already verified during Wave A.3 sizing).
-- The SLO=0 on `meepleai.pdf.indexed.no.kb.flag.total` (Sub #6 Block B) keeps catching any residual drift if Block A regresses or a new ingestion path is added.
+- **Latency**: multi-replica HasKnowledgeBase flip surfaces within sub-second (Redis Pub/Sub typical 1ms intra-DC); SSE consumers (#2227) see the flip immediately on next polling tick.
+- **Operational footprint**: one new Redis subscription per API replica (constant overhead, negligible).
+- **Redis load**: Pub/Sub messages tag-sized (string ≤ 32 bytes per tag) — negligible vs existing tag tracking write load.
+- **Failure mode**: if Redis is unreachable at boot, subscriber retries (Polly-style backoff). Existing `ICacheInvalidationRetryPolicy` continues to guard the publish step. Both layers degrade independently; if both fail, behaviour falls back to existing L1 TTL expiry (15-30 min) — i.e. legacy Option 1 worst-case behaviour, never worse.
+- **SLO**: `meepleai.pdf.indexed.no.kb.flag.total` (Sub #6 Block B) remains the canary; it should stay at zero in healthy operation since the broadcast eliminates the cross-replica window. Any non-zero increment now signals either (a) a handler bypass regression (Block A pattern returns), (b) Redis Pub/Sub outage masking, or (c) a new ingestion path; all three are operational P1 signals.
+- **Forward extension**: other writer handlers (toolkit, mechanic-metrics, agent contributors) can adopt `RemoveByTagAcrossReplicasAsync` opportunistically. No epic-level migration required.
 
 ## References
 
 - Epic [#2242](https://github.com/meepleAi-app/meepleai-monorepo/issues/2242)
 - Sub #1 PR [#2263](https://github.com/meepleAi-app/meepleai-monorepo/pull/2263) (Block A shipped)
+- Sub #2 PR [#2278](https://github.com/meepleAi-app/meepleai-monorepo/pull/2278) (BE refactor factory + pipeline)
 - Sub #6 [#2248](https://github.com/meepleAi-app/meepleai-monorepo/issues/2248) (this Block C)
-- Existing 15-min limitation comment: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs:88-94`
+- IHybridCacheService reference: `apps/api/src/Api/Services/IHybridCacheService.cs`
 - HybridCache invalidation semantics: Microsoft .NET 9 `Microsoft.Extensions.Caching.Hybrid` docs.
+- CLAUDE.md known pitfall #2620 — HybridCache via IHybridCacheService for event handlers.

--- a/docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md
@@ -1,0 +1,91 @@
+# ADR-062 — KB-flag cache propagation strategy
+
+**Status**: Proposed (2026-06-12)
+**Context**: Epic [#2242](https://github.com/meepleAi-app/meepleai-monorepo/issues/2242) — PDF indexing flow repair.
+**Sub-issue**: [#2248](https://github.com/meepleAi-app/meepleai-monorepo/issues/2248) Sub #6 Block C (Quality Gates).
+**Authors**: KB pipeline workstream.
+
+## Context
+
+`#2243` Block A is the tactical fix that flips `shared_games.has_knowledge_base` to `true` after a successful PDF indexing pipeline run, by publishing `VectorDocumentIndexedEvent` from `FinalizeProcessingAsync`. `VectorDocumentIndexedForKbFlagHandler` consumes that event and:
+
+1. Updates `shared_games.has_knowledge_base`.
+2. Invalidates the HybridCache tag `search-games` AND `shared-game:{id}`.
+
+Tag invalidation on HybridCache evicts the **L2 distributed entry** (Redis, shared across nodes) but only the **L1 in-memory entry of the local API replica**. Other replicas keep serving their L1 cached `SharedGameDto`s (with `HasKnowledgeBase=false`) for up to **15 minutes** — the configured `LocalCacheExpiration` on:
+
+- `SearchSharedGamesQueryHandler.cs` (the catalog list endpoint)
+- `GetSharedGameByIdQueryHandler.cs` (the catalog detail endpoint)
+
+For Wave A.4 (single-replica staging) this was acceptable. For multi-replica production (and the catalog Phase E F4 SSE event stream shipped in #2227) it produces a 15-minute window where:
+
+- Replica A (where the upload happened) sees `HasKnowledgeBase=true` immediately.
+- Replicas B/C still serve `HasKnowledgeBase=false` until their L1 expires.
+
+Resulting UX: a sticky-session user on replica B reports "agente non pronto" while the same user, refreshing through replica A, sees "agente pronto". Hard to debug, surfaces as flaky behaviour.
+
+Documented at `VectorDocumentIndexedForKbFlagHandler.cs:88-94`; mitigation tracked here.
+
+## Options considered
+
+### Option 1 — Reduce `LocalCacheExpiration` to 60 seconds (RECOMMENDED)
+
+Change `SearchSharedGamesQueryHandler` and `GetSharedGameByIdQueryHandler` to use a 60-second L1 TTL (was 15 min).
+
+**Pros**: trivial code change (2 numeric constants + their tests). Cache stampede is still bounded by the L2 layer. Operationally simple — no new infrastructure.
+
+**Cons**: 60-second blind window on multi-replica. Slightly higher Redis L2 hit rate (acceptable per the existing benchmarks).
+
+**Effort**: ~1h including a rebaseline test for the L1 expiry assertion if any exists.
+
+### Option 2 — Redis pub/sub L1 invalidation broadcast
+
+Publish a "kb-flag-changed:{sharedGameId}" message on a Redis channel from `VectorDocumentIndexedForKbFlagHandler`. Each replica subscribes and evicts the L1 entry on receipt.
+
+**Pros**: sub-second propagation. No L1 TTL change needed.
+
+**Cons**: introduces new infra surface (pub/sub subscription on startup, reconnect logic), risk of missed messages during connection blips. Requires per-replica subscription manager. The HybridCache APIs do not expose a native L1 eviction primitive, so the subscriber has to invoke a private API or use a parallel `IMemoryCache`. Maintenance debt rises.
+
+**Effort**: ~2-3 days (subscriber service + reconnect handling + integration test with Testcontainers Redis).
+
+### Option 3 — HybridCache stampede protection via `IHybridCacheService` wrapper
+
+Wrap `HybridCache` calls in an `IHybridCacheService` (already exists per CLAUDE.md #2620) and centralise cache-stampede protection + invalidation. The wrapper publishes/subscribes to a per-key invalidation event internally.
+
+**Pros**: keeps the cache-stampede mitigation that Option 1 implicitly preserves; cleaner abstraction long-term.
+
+**Cons**: cross-cutting refactor — touches every handler that reads `SharedGames`. Risk of accidental behaviour drift in unrelated query paths.
+
+**Effort**: ~5+ days (refactor + regression test suite).
+
+## Decision
+
+**Adopt Option 1** for this epic. Rationale:
+
+- Closes the UX gap reported in #2242 with the smallest code change and the lowest operational risk.
+- The Sub #6 audit job (`KbFlagDriftAuditJob` Block B, this same epic) catches any residual drift within 10 minutes regardless of the L1 TTL choice, so 60s is already over-engineered for the recovery window.
+- Option 2/3 remain on the table if the catalog SSE work (#2227) grows enough that 60s propagation becomes a UX issue — at that point pub/sub graduates from "nice to have" to "load-bearing", and the team has more signal to choose between Option 2 and Option 3 from production telemetry.
+
+## Implementation
+
+To be shipped in a follow-up PR of #2248:
+
+1. In `SearchSharedGamesQueryHandler.cs`, change the `HybridCacheEntryOptions.LocalCacheExpiration` (or equivalent constant) from `TimeSpan.FromMinutes(15)` to `TimeSpan.FromSeconds(60)`.
+2. Same change in `GetSharedGameByIdQueryHandler.cs`.
+3. Update the cross-instance behaviour comment in `VectorDocumentIndexedForKbFlagHandler.cs:88-94` to point at this ADR.
+4. Verify existing cache-related unit tests still pass; if any asserts on a >60s expiry, rebaseline.
+5. Manually verify in staging that flushing `meepleai_local_cache_evictions_total` (or equivalent gauge) follows the expected ~60-second cycle under load.
+
+## Consequences
+
+- Multi-replica propagation window drops from 15 min to ≤60 sec.
+- Redis L2 read pressure on `search-games:*` rises modestly. The L2 layer is sized for catalog peak, so the increase is well within headroom (already verified during Wave A.3 sizing).
+- The SLO=0 on `meepleai.pdf.indexed.no.kb.flag.total` (Sub #6 Block B) keeps catching any residual drift if Block A regresses or a new ingestion path is added.
+
+## References
+
+- Epic [#2242](https://github.com/meepleAi-app/meepleai-monorepo/issues/2242)
+- Sub #1 PR [#2263](https://github.com/meepleAi-app/meepleai-monorepo/pull/2263) (Block A shipped)
+- Sub #6 [#2248](https://github.com/meepleAi-app/meepleai-monorepo/issues/2248) (this Block C)
+- Existing 15-min limitation comment: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs:88-94`
+- HybridCache invalidation semantics: Microsoft .NET 9 `Microsoft.Extensions.Caching.Hybrid` docs.


### PR DESCRIPTION
Closes #2248. Sub-issue of epic #2242 (PDF indexing flow repair, **Quality Gates**).

> **Updated 2026-06-13**: ADR-062 decision flipped from Option 1 (reduce-TTL 60s) to **Option 3** (HybridCache wrapper with built-in cross-replica broadcast). See "Updated Block C" section below. Frontend test failures from initial run resolved by rebase + Option 3 commit.

## 🎯 Summary

Observability + executable spec + cross-replica L1 invalidation for the PDF→KB flag pipeline that #2263 (Sub #1 Block A) patched. If a regression or a new ingestion path re-introduces the publish-event bypass, this PR catches it within 10 minutes instead of letting admin UIs go silently inconsistent — and now ALSO propagates the AI-ready flag flip to every API replica within sub-second.

Block A is intentionally **not** re-shipped here — the end-to-end integration test (`PdfIndexingFlowKbFlagIntegrationTests`) already landed with #2263.

## 🔧 Changes

| Block | Layer | File | Fix |
|---|---|---|---|
| B | BE observability | `MeepleAiMetrics.KbFlagDrift.cs` + `KbFlagDriftAuditJob.cs` + `DocumentProcessingServiceExtensions.cs` | Prometheus counter `meepleai.pdf.indexed.no.kb.flag.total` (zero tags, SLO=0). Quartz job runs every 10 min, joins Ready PDFs against `SharedGame.HasKnowledgeBase=false`, emits one Warning per drifted row + one Error summary. Triage signal for #2243 Block A regression or new ingestion paths bypassing the publish event. |
| C (UPDATED) | BE cache strategy | `IHybridCacheService.cs` + `HybridCacheService.cs` + `HybridCacheInvalidationSubscriber.cs` + `VectorDocumentIndexedForKbFlagHandler.cs` + `InfrastructureServiceExtensions.cs` | **ADR-062 Option 3**: New `RemoveByTagAcrossReplicasAsync` method publishes the tag to Redis Pub/Sub channel `meepleai:cache-invalidate:tag`. `HybridCacheInvalidationSubscriber : IHostedService` subscribes on every replica and evicts L1 entries locally on receipt. Handler refactored to use `IHybridCacheService` + the new method for both `search-games` and `shared-game:{id}` tags. Pattern mirrors `ProviderCacheInvalidationSubscriber` (#1859). |
| C (docs) | docs | `docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md` | ADR-062 rewritten: Status Proposed → Accepted, Decision Option 1 → Option 3. Documents the sub-second cross-replica propagation guarantee + degradation behaviour when Redis Pub/Sub is unreachable. |
| D | FE e2e | `apps/web/e2e/pdf-indexing-flow.spec.ts` | Playwright spec acts as the executable BDD specification for the full admin→user journey. 3 scenarios with `test.fixme` until the auth fixture pair lands; the assertions match the contracts every sub-issue of #2242 must honour end-to-end and serve as a reviewer checklist for Sub #4 / #5 frontend changes. |

## ✅ Test plan

- [x] 4/4 new unit tests in `KbFlagDriftAuditJobTests.cs` covering: no drift, single-row drift (with Warning + Error log verification), null `SharedGameId` PDF, not-yet-Ready PDF
- [x] 7/7 unit tests in `VectorDocumentIndexedForKbFlagHandlerTests` rewritten to mock `IHybridCacheService` (verifies cross-replica calls for both tags)
- [x] 2/2 new integration tests in `HybridCacheServiceIntegrationTests`:
  - `RemoveByTagAcrossReplicasAsync_BroadcastsTagViaRedisPubSub` — end-to-end broadcast verification with real Redis
  - `RemoveByTagAcrossReplicasAsync_WithoutRedis_DegradesToLocalOnly` — graceful failure verification
- [x] 5 stub fixtures across the test suite updated to implement the new `IHybridCacheService.RemoveByTagAcrossReplicasAsync` member
- [x] Backend build clean (0 errors)
- [ ] CI verde (post-rebase + Option 3 commit force-push)
- [ ] Operations manual addition (post-merge): add the alert rule under § PromQL alerts → `KbFlagDrift`

## ⚠️ Gotchas surveyed

- The new counter is intentionally untagged. Per-game labels were considered but rejected (catalog can hold tens of thousands of `SharedGames`; an alert on the aggregate counter is sufficient — operators inspect the audit job's structured log for the offending `PdfDocumentId` + `SharedGameId` pair).
- The audit batches at 100 rows per run. If drift is widespread (>100 simultaneous regressions, e.g. a botched migration), the first batch already trips the SLO; the operator triages from the log before subsequent batches finish.
- ADR-062 originally proposed Option 1 (reduce-TTL 60s) with the impl deferred. Updated 2026-06-13 to ship Option 3 in this same PR — sub-second propagation cleanly closes the cross-replica window for all read paths; the audit job remains as defence-in-depth.
- The Playwright spec is `test.fixme` everywhere. CI will not execute it. It is shipped as documentation + a reviewer aid; once the auth fixture pair lands the workstream that wires the e2e backend test ground flips the annotation.
- `HybridCacheInvalidationSubscriber` is registered as `IHostedService` and starts subscription at app boot. If Redis is unreachable at boot, StackExchange.Redis reconnect logic takes over; ongoing writers fall back to the legacy 15-30min LocalCacheExpiration window (i.e. Option 1 worst case).

## 🔗 Cross-references

- Epic #2242
- Sub #1 PR #2263 (Block A shipped, `8ef78a642`)
- Sub #2 PR #2278 (architecture refactor, merged)
- Sub #4 #2246, Sub #5 #2247 (frontend cache invalidation + game-detail wiring — the Playwright spec doubles as their acceptance checklist)
- ADR-062 (now Accepted Option 3) — `docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md`
- Pattern reference (similar pub/sub subscriber) — `ProviderCacheInvalidationSubscriber` (#1859)
- CLAUDE.md known pitfall #2620 (HybridCache via IHybridCacheService for event handlers) — addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)