### PR TITLE
chore(library): code-review #2270 follow-ups bundled (#2273 #2274 #2275 #2276)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
+++ b/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
@@ -150,10 +150,6 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
         side="right"
         className="w-full sm:max-w-xl flex flex-col p-0"
         data-testid="add-game-drawer"
-        // #2269 P0-3 (M4) — Radix Dialog primitive does not emit aria-modal
-        // on its own (see memory `radix-dialog-no-aria-modal`); we set it
-        // explicitly so screen readers announce the drawer as a modal.
-        aria-modal="true"
       >
         <SheetHeader className="px-6 py-4 border-b border-border/50">
           <SheetTitle data-testid="add-game-drawer-title">{drawerTitle}</SheetTitle>

--- a/apps/web/src/app/(authenticated)/library/CatalogSearchStep.tsx
+++ b/apps/web/src/app/(authenticated)/library/CatalogSearchStep.tsx
@@ -30,7 +30,8 @@ import Image from 'next/image';
 import { CatalogPagination } from '@/components/catalog/CatalogPagination';
 import { toast } from '@/components/layout';
 import { Button } from '@/components/ui/primitives/button';
-import { useGameInLibraryStatus, useSharedGames } from '@/hooks/queries';
+import { useSharedGames } from '@/hooks/queries';
+import { useBatchGameStatus } from '@/hooks/queries/useBatchGameStatus';
 import { useAddGameToLibrary } from '@/hooks/queries/useLibrary';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { SharedGame } from '@/lib/api';
@@ -46,6 +47,12 @@ interface SelectableGameCardProps {
   game: SharedGame;
   onSelect: (gameId: string, gameName: string) => void;
   isSelecting: boolean;
+  /**
+   * #2275 — Library status passed in from the parent's batched
+   * useBatchGameStatus call instead of a per-card useGameInLibraryStatus
+   * (avoids N+1 requests when the grid renders ≤9 cards per page).
+   */
+  inLibrary: boolean;
   labels: {
     noImage: string;
     inLibraryBadge: string;
@@ -64,11 +71,10 @@ function SelectableGameCard({
   game,
   onSelect,
   isSelecting,
+  inLibrary,
   labels,
   onBlocked,
 }: SelectableGameCardProps) {
-  const { data: status } = useGameInLibraryStatus(game.id);
-  const inLibrary = status?.inLibrary ?? false;
   const isBlockable = inLibrary && Boolean(onBlocked);
 
   return (
@@ -301,6 +307,13 @@ export function CatalogSearchStep({
     status: 2, // Published / Active
   });
 
+  // #2275 — Batched library-status lookup for all cards on the current
+  // page. Replaces the per-card useGameInLibraryStatus(gameId) that was
+  // firing N (≤9) HTTP requests per fresh search. The hook returns a
+  // results map keyed by gameId; cards read their own status from it.
+  const gameIds = data?.items.map(g => g.id) ?? [];
+  const { data: batchStatus } = useBatchGameStatus(gameIds);
+
   const addMutation = useAddGameToLibrary();
 
   const handleSelect = useCallback(
@@ -418,6 +431,7 @@ export function CatalogSearchStep({
                 game={game}
                 onSelect={handleSelect}
                 isSelecting={selectingId === game.id}
+                inLibrary={batchStatus?.results[game.id]?.inLibrary ?? false}
                 labels={cardLabels}
                 onBlocked={onNavigateToGame ? handleBlocked : undefined}
               />

--- a/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
@@ -286,6 +286,24 @@ describe('AddGameDrawer', () => {
       expect(screen.getByTestId('add-game-step-manual')).toBeInTheDocument();
       expect(screen.queryByTestId('add-game-step-catalog')).not.toBeInTheDocument();
     });
+
+    // #2269 P0-2 (M2 / review #2270 finding C1) — when the user clicks an
+    // already-in-library card, the blocked-alert CTA triggers
+    // onNavigateToGame, which the drawer wires to close + router.push to the
+    // game's detail page. Pre-fix the mock destructured only onSelect/onBack/
+    // onGoToManual so this wiring had no unit-level guard (only the live
+    // Playwright QA in PR #2270 exercised it).
+    it('closes drawer and pushes to /library/{id} when CatalogSearchStep invokes onNavigateToGame', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderDrawer({ open: true, onClose });
+
+      await user.click(screen.getByTestId('add-game-choice-catalog'));
+      await user.click(screen.getByTestId('catalog-navigate-to-game'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockRouter.push).toHaveBeenCalledWith('/library/game-456');
+    });
   });
 
   describe('Close behavior', () => {

--- a/apps/web/src/app/(authenticated)/library/__tests__/CatalogSearchStep.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/CatalogSearchStep.test.tsx
@@ -25,7 +25,10 @@ import { CatalogSearchStep } from '../CatalogSearchStep';
 
 vi.mock('@/hooks/queries', () => ({
   useSharedGames: vi.fn(),
-  useGameInLibraryStatus: vi.fn(),
+}));
+
+vi.mock('@/hooks/queries/useBatchGameStatus', () => ({
+  useBatchGameStatus: vi.fn(),
 }));
 
 vi.mock('@/hooks/queries/useLibrary', () => ({
@@ -65,13 +68,29 @@ vi.mock('next/image', () => ({
   ),
 }));
 
-import { useSharedGames, useGameInLibraryStatus } from '@/hooks/queries';
+import { useSharedGames } from '@/hooks/queries';
+import { useBatchGameStatus } from '@/hooks/queries/useBatchGameStatus';
 import { useAddGameToLibrary } from '@/hooks/queries/useLibrary';
 import { toast } from '@/components/layout';
 
 const mockUseSharedGames = useSharedGames as Mock;
-const mockUseGameInLibraryStatus = useGameInLibraryStatus as Mock;
+const mockUseBatchGameStatus = useBatchGameStatus as Mock;
 const mockUseAddGameToLibrary = useAddGameToLibrary as Mock;
+
+// #2275 helper — build the {results, totalChecked} shape returned by
+// useBatchGameStatus from a map of `{gameId: inLibrary?}`. Defaults
+// isFavorite/isOwned to false (tests don't currently exercise those).
+function makeBatchStatus(map: Record<string, boolean> = {}) {
+  const ids = Object.keys(map);
+  return {
+    data: {
+      results: Object.fromEntries(
+        ids.map(id => [id, { inLibrary: map[id], isFavorite: false, isOwned: false }])
+      ),
+      totalChecked: ids.length,
+    },
+  };
+}
 
 // ── Shared fixtures ────────────────────────────────────────────────────────────
 
@@ -154,7 +173,7 @@ describe('CatalogSearchStep', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseSharedGames.mockReturnValue({ data: makeGamesData(), isLoading: false });
-    mockUseGameInLibraryStatus.mockReturnValue({ data: { inLibrary: false } });
+    mockUseBatchGameStatus.mockReturnValue(makeBatchStatus());
     mockUseAddGameToLibrary.mockReturnValue({ mutateAsync });
   });
 
@@ -328,9 +347,7 @@ describe('CatalogSearchStep', () => {
 
   describe('Already in library', () => {
     it('disables Select button for games already in library', () => {
-      mockUseGameInLibraryStatus.mockImplementation((gameId: string) => ({
-        data: { inLibrary: gameId === 'g1' },
-      }));
+      mockUseBatchGameStatus.mockReturnValue(makeBatchStatus({ g1: true, g2: false }));
       renderStep();
 
       expect(screen.getByTestId('catalog-card-g1-select-btn')).toBeDisabled();
@@ -338,16 +355,14 @@ describe('CatalogSearchStep', () => {
     });
 
     it('shows "Already in library" button label for in-library games', () => {
-      mockUseGameInLibraryStatus.mockReturnValue({ data: { inLibrary: true } });
+      mockUseBatchGameStatus.mockReturnValue(makeBatchStatus({ g1: true, g2: true }));
       renderStep();
 
       expect(screen.getAllByText('Already in library').length).toBeGreaterThan(0);
     });
 
     it('shows "In library" badge on in-library cards', () => {
-      mockUseGameInLibraryStatus.mockImplementation((gameId: string) => ({
-        data: { inLibrary: gameId === 'g1' },
-      }));
+      mockUseBatchGameStatus.mockReturnValue(makeBatchStatus({ g1: true, g2: false }));
       renderStep();
 
       expect(screen.getByTestId('catalog-card-g1-in-library-badge')).toBeInTheDocument();
@@ -361,9 +376,7 @@ describe('CatalogSearchStep', () => {
     // admin-mockups/design_files/sp4-add-game-drawer.jsx:506-541.
     describe('Blocked: already in library', () => {
       beforeEach(() => {
-        mockUseGameInLibraryStatus.mockImplementation((gameId: string) => ({
-          data: { inLibrary: gameId === 'g1' },
-        }));
+        mockUseBatchGameStatus.mockReturnValue(makeBatchStatus({ g1: true, g2: false }));
       });
 
       it('does not show alert by default before any click', () => {

--- a/apps/web/src/components/ui/navigation/__tests__/sheet.test.tsx
+++ b/apps/web/src/components/ui/navigation/__tests__/sheet.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Sheet primitive — a11y regression guard.
+ *
+ * Closes #2273. Every Sheet consumer historically needed to add
+ * `aria-modal="true"` ad-hoc because Radix Dialog primitive does not emit
+ * it (memory `radix-dialog-no-aria-modal`). Pre-#2273 audit found 31
+ * consumers without the attribute — only AddGameDrawer (added in #2269)
+ * had it. This test pins the primitive-level default so the fragile
+ * per-consumer pattern cannot return.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '../sheet';
+
+describe('SheetContent — a11y primitive defaults', () => {
+  it('emits role="dialog" + aria-modal="true" + aria-labelledby tied to SheetTitle', () => {
+    render(
+      <Sheet open onOpenChange={() => undefined}>
+        <SheetContent data-testid="sheet">
+          <SheetHeader>
+            <SheetTitle data-testid="sheet-title">Title</SheetTitle>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    const title = screen.getByTestId('sheet-title');
+    expect(title.id).toBe(labelledBy);
+  });
+});

--- a/apps/web/src/components/ui/navigation/sheet.tsx
+++ b/apps/web/src/components/ui/navigation/sheet.tsx
@@ -59,7 +59,19 @@ const SheetContent = React.forwardRef<
 >(({ side = 'right', className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
-    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+    {/*
+      #2273 — Radix Dialog primitive does NOT emit `aria-modal` on its own
+      (see memory `radix-dialog-no-aria-modal`). Set it here so every Sheet
+      consumer inherits modal semantics for screen readers without having
+      to add the attribute ad-hoc. Consumers can still override (e.g. for
+      a future non-modal Sheet variant) by passing aria-modal={false}.
+    */}
+    <SheetPrimitive.Content
+      ref={ref}
+      aria-modal="true"
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring dark:focus:ring-accent focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>

--- a/apps/web/src/components/ui/wizard-modal/__tests__/wizard-modal-axe.test.tsx
+++ b/apps/web/src/components/ui/wizard-modal/__tests__/wizard-modal-axe.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * WizardModal — axe AA accessibility regression guard.
+ *
+ * Closes #2274. Restores the WizardModal axe scan that was previously the
+ * 3rd `it()` block of the deleted `apps/web/__tests__/asse-b-axe.test.tsx`
+ * (dropped in PR #2270 as orphan post-#2161 layout-shell dedupe). Without
+ * this file the codebase has zero jest-axe coverage on WizardModal — the
+ * e2e a11y suite skips authenticated routes including /onboarding where
+ * WizardModal is mounted.
+ *
+ * Sibling to `wizard-modal.test.tsx`; standalone so the axe scan stays
+ * isolated from the integration suite.
+ */
+
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { WizardModal } from '../wizard-modal';
+
+expect.extend(toHaveNoViolations);
+
+describe('WizardModal — axe AA gate', () => {
+  it('open state — no axe violations on step 1', async () => {
+    const { container } = render(
+      <WizardModal
+        steps={[
+          { title: 'Step 1', content: <p>Content 1</p> },
+          { title: 'Step 2', content: <p>Content 2</p> },
+        ]}
+        onComplete={async () => undefined}
+        onCancel={() => undefined}
+        open={true}
+        onOpenChange={() => undefined}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Summary

Bundle dei 4 follow-up emersi dal code review di PR #2270 (4 findings → 4 commit logici, un'unica PR per ridurre overhead CI/review). Tutte le 4 issue closed da questa PR.

## Commits

### `0dbe11d78` test: WizardModal jest-axe AA gate (#2274, verifier B1 CONFIRMED)
Nuovo `apps/web/src/components/ui/wizard-modal/__tests__/wizard-modal-axe.test.tsx` (1 `it()`: render WizardModal open → `axe()` → `toHaveNoViolations`). Ripristina la AA regression coverage per WizardModal persa quando PR #2270 ha eliminato l'orphan `asse-b-axe.test.tsx` (era l'unico scan jest-axe del primitive nel repo).

### `572fb1125` refactor: Sheet `aria-modal="true"` primitive hoist (#2273, verifier G1 CONFIRMED, 31 consumers)
`SheetContent` ora emette `aria-modal="true"` di default (settato prima di `{...props}` per consentire override consumer per future Sheet non-modali). Rimosso l'override ad-hoc da `AddGameDrawer.tsx`. Nuovo `sheet.test.tsx` come regression guard: assert `role=dialog` + `aria-modal=true` + `aria-labelledby` collegato a `SheetTitle.id`. L'assertion a11y esistente di AddGameDrawer continua a passare (ora per ereditarietà) — 34/34.

### `d0cec2bc5` perf: `useBatchGameStatus` wire-up in CatalogSearchStep (#2275, verifier F1 PLAUSIBLE)
Eliminato N+1 sulla catalog search: `useGameInLibraryStatus(gameId)` per-card (≤9 GET HTTP requests per fresh search) → singola call parent-level `useBatchGameStatus(gameIds)` (1 batch request). `inLibrary` ora passato come prop ai card. Test mock aggiornati con helper `makeBatchStatus(map)` che costruisce lo shape `{results, totalChecked}` da una mappa per-game. 32/32.

### `1c839c32e` test: assertion onNavigateToGame wiring + #2276 scope-narrowing
**C1 (verifier C1 CONFIRMED)** — assertion nuova in `AddGameDrawer.test.tsx`: click su `catalog-navigate-to-game` (button esposto dal mock nel commit quick-wins di PR #2270) → expect `onClose()` + `router.push('/library/game-456')`. 35/35.

**D1 (ErrorBanner refactor) deferred deliberatamente** — `apps/web/src/components/ui/invites/index.ts` dichiara policy esplicita "Do NOT import from other surfaces". Tutti i consumer cross-surface di ErrorBanner attuali (dashboard, kb-globale, join-form) già la rispettano implementando varianti locali. Riusare `invites/error-banner` da `library/` violerebbe la policy. Estrarre un nuovo primitive `InlineNotice` generico è scope creep per un singolo consumer (il blocked-alert è 28 righe). Deferred a quando emergono 2+ consumer. Rationale completo nel body del commit `1c839c32e`.

## Test plan

- [x] `pnpm typecheck` → 0 errori
- [x] `pnpm vitest run sheet|wizard-modal-axe|CatalogSearchStep|AddGameDrawer` → 1 + 1 + 32 + 35 = **69 test pass**, 0 fail
- [x] Lint clean sui file modificati

## Issue chiuse

- Closes #2273 (Sheet aria-modal primitive)
- Closes #2274 (WizardModal axe coverage)
- Closes #2275 (useBatchGameStatus wire-up)
- Closes #2276 (C1 shipped; D1 deferred con rationale)

## Riferimenti

- Code review di PR #2270 (Sonnet phase-1 finders + phase-2 verifiers, 8 findings totali, top 4 CONFIRMED/PLAUSIBLE in queste 4 issue)
- Pattern reference: `git show e25e434d4:apps/web/__tests__/asse-b-axe.test.tsx` (sorgente del WizardModal axe block)
- Memory `radix-dialog-no-aria-modal` (driver per #2273)
- `claudedocs/batch-game-status-api-spec.md` (driver per #2275)

🤖 Generated with [Claude Code](https://claude.com/claude-code)