### PR TITLE
feat(pdf-indexing): #2245 SSE + AutoCreateAgent (Sub #3 of #2242)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/PdfStateChangedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/PdfStateChangedEvent.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.SharedKernel.Domain.Events;
 
@@ -6,6 +7,10 @@ namespace Api.BoundedContexts.DocumentProcessing.Domain.Events;
 /// <summary>
 /// Domain event raised when a PDF document transitions between processing states.
 /// Issue #4215: Enables real-time status updates and notification triggers.
+/// Issue #2245 (epic #2242 Sub #3): registered in
+/// <see cref="Api.Infrastructure.DomainEventLog.EventTypeRegistry"/> with alias
+/// <c>"pdf.state.changed"</c> so the admin LiveEventLog SSE stream can render real-time
+/// pipeline progress and the FE can drop polling.
 /// </summary>
 internal sealed class PdfStateChangedEvent : DomainEventBase
 {
@@ -28,6 +33,26 @@ internal sealed class PdfStateChangedEvent : DomainEventBase
     /// Gets the user who uploaded the document (for notification routing).
     /// </summary>
     public Guid UploadedByUserId { get; }
+
+    /// <summary>
+    /// Mirror of <see cref="PdfDocumentId"/> following the convention required by
+    /// <see cref="Api.Infrastructure.DomainEventLog.DomainEventLogMapper"/>: the mapper
+    /// reflects on a property named <c>AggregateId</c> to populate
+    /// <c>domain_event_logs.aggregate_id</c> without a custom override. Issue #2245.
+    /// <c>[JsonIgnore]</c> keeps the SSE payload schema clean
+    /// (<c>pdfDocumentId</c> remains the canonical wire-format field).
+    /// </summary>
+    [JsonIgnore]
+    public Guid AggregateId => PdfDocumentId;
+
+    /// <summary>
+    /// Mirror of <see cref="UploadedByUserId"/> for the
+    /// <see cref="Api.Infrastructure.DomainEventLog.DomainEventLogMapper"/> reflection
+    /// extraction of <c>domain_event_logs.user_id</c>. Issue #2245. <c>[JsonIgnore]</c>
+    /// keeps the SSE payload schema clean (<c>uploadedByUserId</c> remains canonical).
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId => UploadedByUserId;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PdfStateChangedEvent"/> class.

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs
@@ -11,8 +11,11 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
 
 /// <summary>
 /// Automatically creates an AI agent when a PDF finishes processing (state == Ready).
-/// Only triggers for admin-priority PDFs to avoid auto-creating agents for all user uploads.
 /// Uses the first active system definition with "Balanced" strategy as defaults.
+///
+/// Issue #2245 (epic #2242 Sub #3): the previous <c>ProcessingPriority == "Admin"</c> guard was
+/// removed so user-side uploads (Newman flow NW1) also trigger agent auto-creation. Tier quotas
+/// (handled by <c>CreateGameAgentCommand</c>) remain the only gate on user uploads.
 /// </summary>
 internal sealed class AutoCreateAgentOnPdfReadyHandler : INotificationHandler<PdfStateChangedEvent>
 {
@@ -41,10 +44,12 @@ internal sealed class AutoCreateAgentOnPdfReadyHandler : INotificationHandler<Pd
 
         try
         {
-            // Get the PDF entity to check priority (ProcessingPriority is on EF entity, not domain)
+            // Get the PDF entity to resolve game id (private > shared > empty).
+            // Issue #2245: the previous ProcessingPriority guard was dropped — user uploads also
+            // get an auto-created agent. Tier quotas inside CreateGameAgentCommand remain the gate.
             var pdfEntity = await _dbContext.PdfDocuments
                 .Where(p => p.Id == notification.PdfDocumentId)
-                .Select(p => new { p.SharedGameId, p.PrivateGameId, p.ProcessingPriority })
+                .Select(p => new { p.SharedGameId, p.PrivateGameId })
                 .FirstOrDefaultAsync(cancellationToken)
                 .ConfigureAwait(false);
 
@@ -52,15 +57,6 @@ internal sealed class AutoCreateAgentOnPdfReadyHandler : INotificationHandler<Pd
             {
                 _logger.LogWarning(
                     "AutoCreateAgent: PDF {PdfId} not found, skipping auto-agent creation",
-                    notification.PdfDocumentId);
-                return;
-            }
-
-            // Only auto-create for admin-priority PDFs (wizard flow)
-            if (!string.Equals(pdfEntity.ProcessingPriority, "Admin", StringComparison.Ordinal))
-            {
-                _logger.LogDebug(
-                    "AutoCreateAgent: PDF {PdfId} is not admin priority, skipping",
                     notification.PdfDocumentId);
                 return;
             }

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -48,9 +48,22 @@ public static class EventTypeRegistry
         [typeof(ChatSessionCreatedEvent)] = "chat.session.created",
 
         // H3: kb.doc.indexed fires ONLY when PdfDocument.TransitionTo(Ready) succeeds.
-        //     PdfStateChangedEvent (fires on every transition) remains UNREGISTERED to avoid
-        //     log explosion (one row per pipeline step). Decision B3 from #1590 spec panel.
+        //     KbDocIndexedEvent stays as the user-meaningful "doc indexed" milestone for the
+        //     activity rail / Activity Feed.
         [typeof(KbDocIndexedEvent)] = "kb.doc.indexed",
+
+        // Issue #2245 (epic #2242 Sub #3) — register every PDF state transition so the
+        // admin LiveEventLog SSE stream can render real-time pipeline progress without
+        // the FE polling /api/v1/pdfs/{id} on a 2s tick.
+        //
+        // NOTE — revisits B3 (#1590 spec panel): the original decision left this UNREGISTERED
+        // to avoid log explosion (one row per pipeline step × 6 transitions per PDF).
+        // The trade-off is now accepted because: (a) the SSE consumer eliminates polling
+        // load, (b) the activity-feed query path already filters by event_type, and
+        // (c) DomainEventOutboxRetentionService prunes old rows beyond the retention window.
+        // If the row volume becomes a problem, the mitigation is to add an EventBroadcastFilter
+        // entry that drops the persistence step for this alias while keeping the SSE fanout.
+        [typeof(PdfStateChangedEvent)] = "pdf.state.changed",
 
         // SessionTracking lifecycle. session.created is orthogonal to the session_events diary
         // "session_created" row (#1590 C3 — different consumers). session.finalized also (re)wires

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
@@ -121,6 +121,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests : IDisposable
             FileName = "rulebook.pdf",
             FilePath = "/uploads/rulebook.pdf",
             UploadedByUserId = UserId,
+            SharedGameId = GameId,
             ProcessingPriority = "Normal",
         });
         await _dbContext.SaveChangesAsync();
@@ -205,22 +206,73 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests : IDisposable
     }
 
     // ────────────────────────────────────────────────────────────────────────
-    // Guard: non-admin processing priority
+    // Issue #2245 (epic #2242 Sub #3): the ProcessingPriority="Admin" guard was REMOVED so user
+    // uploads (Newman flow NW1) trigger agent auto-creation too. The next two tests pin this
+    // behavior so a regression of the guard would surface immediately.
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Handle_WhenPdfIsNormalPriority_SkipsAutoAgentCreation()
+    [Trait("Issue", "2245")]
+    public async Task Handle_WhenPdfIsNormalPriority_AlsoTriggersAgentCreation()
     {
-        // Arrange
+        // Arrange — user upload (ProcessingPriority="Normal")
         var pdfId = await AddNormalPdfAsync();
+        await AddUserAsync();
+        SetupActiveDefinition();
+
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<CreateGameAgentCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateFakeAgentResult());
+
         var evt = CreateReadyEvent(pdfId);
 
         // Act
         await _handler.Handle(evt, CancellationToken.None);
 
-        // Assert — definition lookup never reached
-        _mockDefinitionRepo.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Never);
-        _mockMediator.Verify(m => m.Send(It.IsAny<CreateGameAgentCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Assert — Issue #2245: even Normal priority must reach CreateGameAgent now
+        _mockDefinitionRepo.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockMediator.Verify(
+            m => m.Send(It.Is<CreateGameAgentCommand>(c => c.GameId == GameId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [Trait("Issue", "2245")]
+    [InlineData("Normal")]
+    [InlineData("Admin")]
+    [InlineData("UserUpload")]
+    [InlineData("")]
+    public async Task Handle_AnyProcessingPriority_TriggersAgentCreation(string priority)
+    {
+        // Issue #2245: priority must be IGNORED for the auto-create decision.
+        // Arrange
+        var pdfId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "rulebook.pdf",
+            FilePath = "/uploads/rulebook.pdf",
+            UploadedByUserId = UserId,
+            SharedGameId = GameId,
+            ProcessingPriority = priority,
+        });
+        await _dbContext.SaveChangesAsync();
+        await AddUserAsync();
+        SetupActiveDefinition();
+
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<CreateGameAgentCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateFakeAgentResult());
+
+        var evt = CreateReadyEvent(pdfId);
+
+        // Act
+        await _handler.Handle(evt, CancellationToken.None);
+
+        // Assert — regardless of priority value, CreateGameAgent must be dispatched
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<CreateGameAgentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/apps/api/tests/Api.Tests/Infrastructure/DomainEventLog/EventTypeRegistryTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/DomainEventLog/EventTypeRegistryTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Api.BoundedContexts.Administration.Domain.Events;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.Infrastructure.DomainEventLog;
 using Api.SharedKernel.Domain.Interfaces;
@@ -158,5 +159,51 @@ public sealed class EventTypeRegistryTests
             IsTest: false);
 
         EventTypeRegistry.TryResolve(ev).Should().Be("alert.resolved");
+    }
+
+    /// <summary>
+    /// Issue #2245 (epic #2242 Sub #3) — PdfStateChangedEvent must resolve so the admin
+    /// LiveEventLog SSE stream renders real-time PDF pipeline transitions and the FE
+    /// can drop polling. Revisits B3 (#1590 spec panel) — see EventTypeRegistry rationale.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "2245")]
+    public void Registry_resolves_pdf_state_changed_alias()
+    {
+        var ev = new PdfStateChangedEvent(
+            pdfDocumentId: Guid.NewGuid(),
+            previousState: PdfProcessingState.Indexing,
+            newState: PdfProcessingState.Ready,
+            uploadedByUserId: Guid.NewGuid());
+
+        EventTypeRegistry.TryResolve(ev).Should().Be("pdf.state.changed");
+    }
+
+    /// <summary>
+    /// Issue #2245 — the mapper must populate <c>AggregateId</c> and <c>UserId</c> for the
+    /// SSE event. <see cref="PdfStateChangedEvent"/> exposes computed
+    /// <c>AggregateId</c>/<c>UserId</c> properties (mirrors of <c>PdfDocumentId</c>/<c>UploadedByUserId</c>)
+    /// so <see cref="DomainEventLogMapper.Map"/> reflection picks them up. If a future refactor drops
+    /// those mirror properties, this test will fail.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "2245")]
+    public void Mapper_PdfStateChangedEvent_populates_aggregate_id_and_user_id()
+    {
+        var pdfId = Guid.NewGuid();
+        var uploaderId = Guid.NewGuid();
+        var ev = new PdfStateChangedEvent(
+            pdfDocumentId: pdfId,
+            previousState: PdfProcessingState.Indexing,
+            newState: PdfProcessingState.Ready,
+            uploadedByUserId: uploaderId);
+
+        var row = DomainEventLogMapper.Map(ev);
+
+        row.Should().NotBeNull("the event is registered for log persistence");
+        row!.EventType.Should().Be("pdf.state.changed");
+        row.AggregateId.Should().Be(pdfId, "AggregateId mirrors PdfDocumentId so the mapper can populate domain_event_logs.aggregate_id");
+        row.UserId.Should().Be(uploaderId, "UserId mirrors UploadedByUserId so the mapper can populate domain_event_logs.user_id");
+        row.AggregateType.Should().Be("PdfStateChanged", "class name minus 'Event' suffix → aggregate type");
     }
 }


### PR DESCRIPTION
Closes #2245 (epic #2242 Sub #3 P2).

## Summary

### Block A — Ungate AutoCreateAgent
- Drop `ProcessingPriority='Admin'` guard in `KnowledgeBase/AutoCreateAgentOnPdfReadyHandler` so user-side uploads (Newman flow NW1) also trigger agent auto-creation.
- Tier quotas inside `CreateGameAgentCommand` remain the only gate on user uploads.

### Block B — Extend SSE `pdf-state-changed` events
- Register `PdfStateChangedEvent` in `EventTypeRegistry` with alias `pdf.state.changed` — every PDF state transition now flows through `DomainEventBroadcastInterceptor` → `IEventBroadcaster` → the admin SSE stream at `GET /api/v1/admin/events/stream` (PR #2227 infrastructure, no endpoint changes needed).
- Revisits #1590 B3 decision (avoid log explosion): trade-off now accepted because SSE consumer eliminates polling load + `DomainEventOutboxRetentionService` prunes old rows. Documented in registry + event XML.
- Add `AggregateId` + `UserId` computed mirror properties on `PdfStateChangedEvent` so `DomainEventLogMapper` reflection populates `aggregate_id` / `user_id` columns. `[JsonIgnore]` keeps the SSE wire payload schema clean (`pdfDocumentId`, `uploadedByUserId` remain canonical).

### Block C — Orphan handler audit
- `VectorDocumentReadyStateHandler` + `VectorDocumentIndexedEventHandler` are NOT orphan post Sub #1+#2. Chain: `VectorDocumentIndexedEvent` → relay handler publishes `VectorDocumentReadyIntegrationEvent` → 3 consumers (state compensating update, user notifications, GameManagement auto-agent). Documented in existing handler XML docs.

## Test plan

- [x] Unit: `Registry_resolves_pdf_state_changed_alias` (EventTypeRegistry)
- [x] Unit: `Mapper_PdfStateChangedEvent_populates_aggregate_id_and_user_id` (DomainEventLogMapper)
- [x] Unit: `Handle_WhenPdfIsNormalPriority_AlsoTriggersAgentCreation` (AutoCreateAgent)
- [x] Unit: `Handle_AnyProcessingPriority_TriggersAgentCreation` Theory across `Admin`/`Normal`/`UserUpload`/`""` (AutoCreateAgent)
- [x] All affected: 54 tests pass (AutoCreateAgent + EventTypeRegistry + PdfStateChanged + PdfDocument_SevenStateProgression)
- [x] DocumentProcessing Unit: 365 tests pass (no regression from the mirror property addition)
- [x] KnowledgeBase Unit: 2233 tests pass (no regression from guard removal)
- [x] GameManagement Unit: 1321 tests pass
- [x] Administration Unit: 588 tests pass
- [x] Backend build clean: 0 errors

## Notes

- `AdminEventsEndpointsIntegrationTests.Get_All_RequireAdminSession_401_403_200` fails on baseline `main-dev` independently of this PR (verified via stash) — not introduced by these changes.
- `EventTypeRegistryTests.AliasByType_AllEntriesResolveToLoadedIDomainEvent` shows test-pollution behavior on baseline when run together with `DomainEventLogPersistenceTests` (pre-existing reflection-mutation issue, NOT new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)