### PR TITLE
refactor(kb): #2284 Rehydrate + TotalCharacters + drop mutators (PR A — issues #1+#2+#3)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/PdfIndexingPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/PdfIndexingPipeline.cs
@@ -79,12 +79,15 @@ internal sealed class PdfIndexingPipeline : IPdfIndexingPipeline
             // Build the domain aggregate so the constructor raises
             // VectorDocumentIndexedEvent — this is the contract Sub #1's
             // tactical publish was emulating.
+            // #2284 issue 2: thread totalCharacters to the domain so it survives the
+            // mapper round-trip (mapper now writes domain.TotalCharacters instead of 0).
             newDomainAggregate = VectorDocument.Create(
                 pdfDocumentId: pdfDocumentId,
                 gameId: gameId ?? Guid.Empty,
                 totalChunks: chunkCount,
                 language: language,
-                sharedGameId: sharedGameId);
+                sharedGameId: sharedGameId,
+                totalCharacters: totalCharacters);
 
             existing = new VectorDocumentEntity
             {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/VectorDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/VectorDocument.cs
@@ -8,6 +8,13 @@ namespace Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 /// VectorDocument aggregate root.
 /// Represents a document that has been indexed in the vector database.
 /// Controls embeddings and search operations for the document.
+///
+/// Construction rules (#2284 / follow-up of #2244):
+/// - Use <see cref="Create"/> from ingestion pipelines — raises <see cref="VectorDocumentIndexedEvent"/>.
+/// - Use <see cref="Rehydrate"/> from the mapper (KnowledgeBaseMappers.ToDomain)
+///   and test fixtures — does NOT raise domain events (read-side, no phantom event on every DB read).
+/// - The public constructor is preserved for backward compatibility but is deprecated;
+///   prefer the factory methods so the call-site intent (write vs read) is explicit.
 /// </summary>
 internal sealed class VectorDocument : AggregateRoot<Guid>
 {
@@ -15,6 +22,7 @@ internal sealed class VectorDocument : AggregateRoot<Guid>
     public Guid PdfDocumentId { get; private set; }
     public string Language { get; private set; }
     public int TotalChunks { get; private set; }
+    public int TotalCharacters { get; private set; }
     public DateTime IndexedAt { get; private set; }
     public DateTime? LastSearchedAt { get; private set; }
     public int SearchCount { get; private set; }
@@ -26,18 +34,46 @@ internal sealed class VectorDocument : AggregateRoot<Guid>
     public string? Metadata { get; private set; }
 
     /// <summary>
-    /// Private constructor for EF Core.
+    /// Private parameterless constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
     private VectorDocument() : base()
 #pragma warning restore CS8618
     {
+        // EF Core only.
     }
 
     /// <summary>
-    /// Creates a new vector document. Constructor kept public for backward compatibility
-    /// with existing internal callers (KnowledgeBase mappers + ingest service). New code
-    /// SHOULD use <see cref="Create"/> to make the factory boundary explicit.
+    /// Private field-init constructor used by both the public ctor (event-raising) and
+    /// <see cref="Rehydrate"/> (no event). Performs no validation — callers must validate
+    /// (public ctor validates language + totalChunks; Rehydrate clamps to safe defaults).
+    /// </summary>
+    private VectorDocument(
+        Guid id,
+        Guid gameId,
+        Guid pdfDocumentId,
+        string language,
+        int totalChunks,
+        int totalCharacters,
+        DateTime indexedAt,
+        Guid? sharedGameId) : base(id)
+    {
+        GameId = gameId;
+        PdfDocumentId = pdfDocumentId;
+        Language = language;
+        TotalChunks = totalChunks;
+        TotalCharacters = totalCharacters;
+        IndexedAt = indexedAt;
+        SearchCount = 0;
+        SharedGameId = sharedGameId;
+    }
+
+    /// <summary>
+    /// Creates a new vector document and raises <see cref="VectorDocumentIndexedEvent"/>.
+    /// Constructor kept public for backward compatibility with existing internal callers
+    /// (KnowledgeBase mappers + ingest service). New code SHOULD use <see cref="Create"/>
+    /// to make the factory boundary explicit. Mapper read path SHOULD use <see cref="Rehydrate"/>
+    /// to avoid enqueueing phantom events on every DB read (#2284 issue 1).
     /// </summary>
     public VectorDocument(
         Guid id,
@@ -45,22 +81,18 @@ internal sealed class VectorDocument : AggregateRoot<Guid>
         Guid pdfDocumentId,
         string language,
         int totalChunks,
-        Guid? sharedGameId = null) : base(id)
+        Guid? sharedGameId = null,
+        int totalCharacters = 0)
+        : this(
+            id: id,
+            gameId: gameId,
+            pdfDocumentId: pdfDocumentId,
+            language: ValidateLanguage(language),
+            totalChunks: ValidatePositiveChunks(totalChunks),
+            totalCharacters: ValidateNonNegativeCharacters(totalCharacters),
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: sharedGameId)
     {
-        if (string.IsNullOrWhiteSpace(language))
-            throw new ArgumentException("Language cannot be empty", nameof(language));
-
-        if (totalChunks <= 0)
-            throw new ArgumentException("Total chunks must be positive", nameof(totalChunks));
-
-        GameId = gameId;
-        PdfDocumentId = pdfDocumentId;
-        Language = language.ToLowerInvariant();
-        TotalChunks = totalChunks;
-        IndexedAt = DateTime.UtcNow;
-        SearchCount = 0;
-        SharedGameId = sharedGameId;
-
         AddDomainEvent(new VectorDocumentIndexedEvent(id, gameId, totalChunks, sharedGameId));
     }
 
@@ -68,16 +100,15 @@ internal sealed class VectorDocument : AggregateRoot<Guid>
     /// Factory entry point for a freshly indexed vector document.
     /// Encapsulates Guid generation + parameter ordering so cross-BC callers
     /// (DocumentProcessing) don't have to know id-allocation semantics.
-    /// Raises <see cref="VectorDocumentIndexedEvent"/> via the constructor —
-    /// closes #2244 by ensuring the domain event always fires when a new
-    /// VectorDocument enters the aggregate.
+    /// Raises <see cref="VectorDocumentIndexedEvent"/> via the underlying constructor.
     /// </summary>
     public static VectorDocument Create(
         Guid pdfDocumentId,
         Guid gameId,
         int totalChunks,
         string language,
-        Guid? sharedGameId = null)
+        Guid? sharedGameId = null,
+        int totalCharacters = 0)
     {
         return new VectorDocument(
             id: Guid.NewGuid(),
@@ -85,7 +116,43 @@ internal sealed class VectorDocument : AggregateRoot<Guid>
             pdfDocumentId: pdfDocumentId,
             language: language,
             totalChunks: totalChunks,
+            sharedGameId: sharedGameId,
+            totalCharacters: totalCharacters);
+    }
+
+    /// <summary>
+    /// Rehydrates an EXISTING VectorDocument from persistence WITHOUT raising domain events.
+    /// Used by <c>KnowledgeBaseMappers.ToDomain</c> (fixes #2284 issue 1: every mapper read
+    /// previously called the public ctor which enqueued a fresh VectorDocumentIndexedEvent
+    /// into the outbox — phantom events on every DB read) and by test fixtures that need a
+    /// pre-built aggregate without polluting the event stream.
+    ///
+    /// Applies lenient defaults for malformed data (empty language → "en", zero chunks → 1,
+    /// negative totalCharacters → 0) — the public ctor + Create enforce strict validation
+    /// for the write path; Rehydrate trusts the DB row exists for a reason.
+    /// </summary>
+    internal static VectorDocument Rehydrate(
+        Guid id,
+        Guid gameId,
+        Guid pdfDocumentId,
+        string language,
+        int totalChunks,
+        DateTime indexedAt,
+        Guid? sharedGameId,
+        string? metadata = null,
+        int totalCharacters = 0)
+    {
+        var doc = new VectorDocument(
+            id: id,
+            gameId: gameId,
+            pdfDocumentId: pdfDocumentId,
+            language: string.IsNullOrWhiteSpace(language) ? "en" : language.ToLowerInvariant(),
+            totalChunks: totalChunks <= 0 ? 1 : totalChunks,
+            totalCharacters: totalCharacters < 0 ? 0 : totalCharacters,
+            indexedAt: indexedAt,
             sharedGameId: sharedGameId);
+        doc.Metadata = metadata;
+        return doc;
     }
 
     /// <summary>
@@ -108,19 +175,24 @@ internal sealed class VectorDocument : AggregateRoot<Guid>
         AddDomainEvent(new VectorDocumentMetadataUpdatedEvent(Id, metadata));
     }
 
-    /// <summary>
-    /// Sets metadata value (internal for mapper use only).
-    /// </summary>
-    internal void SetMetadata(string? metadata)
+    private static string ValidateLanguage(string language)
     {
-        Metadata = metadata;
+        if (string.IsNullOrWhiteSpace(language))
+            throw new ArgumentException("Language cannot be empty", nameof(language));
+        return language.ToLowerInvariant();
     }
 
-    /// <summary>
-    /// Sets shared game ID (internal for mapper use only).
-    /// </summary>
-    internal void SetSharedGameId(Guid? sharedGameId)
+    private static int ValidatePositiveChunks(int totalChunks)
     {
-        SharedGameId = sharedGameId;
+        if (totalChunks <= 0)
+            throw new ArgumentException("Total chunks must be positive", nameof(totalChunks));
+        return totalChunks;
+    }
+
+    private static int ValidateNonNegativeCharacters(int totalCharacters)
+    {
+        if (totalCharacters < 0)
+            throw new ArgumentException("Total characters must be non-negative", nameof(totalCharacters));
+        return totalCharacters;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Mappers/KnowledgeBaseMappers.cs
@@ -24,7 +24,9 @@ internal static class KnowledgeBaseMappers
             GameId = domain.GameId,
             PdfDocumentId = domain.PdfDocumentId,
             ChunkCount = domain.TotalChunks,
-            TotalCharacters = 0, // Not tracked in domain
+            // #2284 issue 2: thread TotalCharacters through the domain (was hardcoded 0,
+            // silently zeroing the audit field on every new ingestion).
+            TotalCharacters = domain.TotalCharacters,
             IndexingStatus = "completed", // Simplified status mapping
             IndexedAt = domain.IndexedAt,
             IndexingError = null,
@@ -41,22 +43,19 @@ internal static class KnowledgeBaseMappers
     public static VectorDocument ToDomain(this VectorDocumentEntity entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        var domain = new VectorDocument(
+        // #2284 issue 1: use Rehydrate (not the public ctor) so reading from DB does NOT
+        // enqueue a fresh VectorDocumentIndexedEvent into the outbox — that was a latent
+        // read-side bug introduced by PR #2278 (every mapper ToDomain raised an event).
+        return VectorDocument.Rehydrate(
             id: entity.Id,
             gameId: entity.GameId ?? Guid.Empty,
             pdfDocumentId: entity.PdfDocumentId,
-            language: "en", // Default language (not stored in entity)
+            language: "en", // Default language (not stored on entity)
             totalChunks: entity.ChunkCount,
-            sharedGameId: entity.SharedGameId // Issue #5185
-        );
-
-        // Restore metadata using internal method
-        if (!string.IsNullOrEmpty(entity.Metadata))
-        {
-            domain.SetMetadata(entity.Metadata);
-        }
-
-        return domain;
+            indexedAt: entity.IndexedAt ?? DateTime.UtcNow,
+            sharedGameId: entity.SharedGameId, // Issue #5185
+            metadata: entity.Metadata,
+            totalCharacters: entity.TotalCharacters);
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Entities/VectorDocumentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Entities/VectorDocumentTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Xunit;
 using FluentAssertions;
 using Api.Tests.Constants;
@@ -170,20 +171,6 @@ public class VectorDocumentTests
     }
 
     [Fact]
-    public void SetMetadata_NullValue_SetsToNull()
-    {
-        // Arrange
-        var document = CreateTestDocument();
-        document.UpdateMetadata("{\"test\": true}");
-
-        // Act
-        document.SetMetadata(null);
-
-        // Assert
-        document.Metadata.Should().BeNull();
-    }
-
-    [Fact]
     public void Constructor_SetsIndexedAtToCurrentTime()
     {
         // Arrange
@@ -223,45 +210,175 @@ public class VectorDocumentTests
         document.SharedGameId.Should().Be(sharedGameId);
     }
 
+    // ── #2284 factory / rehydrate / TotalCharacters tests ────────────────────
+
     [Fact]
-    public void SetSharedGameId_UpdatesValue()
+    public void Create_WithValidArgs_RaisesVectorDocumentIndexedEventOnce()
     {
-        var document = CreateTestDocument();
-        var sharedGameId = Guid.NewGuid();
+        var doc = VectorDocument.Create(
+            pdfDocumentId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            totalChunks: 42,
+            language: "en",
+            sharedGameId: Guid.NewGuid());
 
-        document.SetSharedGameId(sharedGameId);
-
-        document.SharedGameId.Should().Be(sharedGameId);
+        doc.DomainEvents.OfType<VectorDocumentIndexedEvent>().Should().HaveCount(1);
     }
 
     [Fact]
-    public void SetSharedGameId_WithNull_ClearsValue()
+    public void Create_WithTotalCharacters_SetsProperty()
     {
-        var sharedGameId = Guid.NewGuid();
-        var document = new VectorDocument(
+        var doc = VectorDocument.Create(
+            pdfDocumentId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            totalChunks: 5,
+            language: "en",
+            totalCharacters: 1234);
+
+        doc.TotalCharacters.Should().Be(1234);
+    }
+
+    [Fact]
+    public void Create_WithoutTotalCharacters_DefaultsToZero()
+    {
+        var doc = VectorDocument.Create(
+            pdfDocumentId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            totalChunks: 5,
+            language: "en");
+
+        doc.TotalCharacters.Should().Be(0);
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeTotalCharacters_Throws()
+    {
+        var act = () => new VectorDocument(
             id: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
             pdfDocumentId: Guid.NewGuid(),
             language: "en",
             totalChunks: 5,
-            sharedGameId: sharedGameId);
+            sharedGameId: null,
+            totalCharacters: -1);
 
-        document.SetSharedGameId(null);
-
-        document.SharedGameId.Should().BeNull();
+        act.Should().Throw<ArgumentException>().WithMessage("*characters*");
     }
 
-    // Helper method
+    [Fact]
+    public void Rehydrate_DoesNotRaiseDomainEvents()
+    {
+        // #2284 issue 1: read-side bug fix — Rehydrate must not enqueue phantom events.
+        // Without this fix, every KnowledgeBaseMappers.ToDomain call silently inserted
+        // a fresh VectorDocumentIndexedEvent into the outbox on every database read.
+        var doc = VectorDocument.Rehydrate(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            language: "en",
+            totalChunks: 5,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null);
+
+        doc.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Rehydrate_WithMetadata_SetsMetadataWithoutEvent()
+    {
+        // Replaces the dropped SetMetadata mutator. Metadata is now a single-phase
+        // construction concern via Rehydrate (mapper read path).
+        var metadata = "{\"quality\": 0.92}";
+
+        var doc = VectorDocument.Rehydrate(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            language: "en",
+            totalChunks: 5,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null,
+            metadata: metadata);
+
+        doc.Metadata.Should().Be(metadata);
+        doc.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Rehydrate_WithTotalCharacters_SetsValue()
+    {
+        var doc = VectorDocument.Rehydrate(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            language: "en",
+            totalChunks: 5,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null,
+            totalCharacters: 9876);
+
+        doc.TotalCharacters.Should().Be(9876);
+    }
+
+    [Fact]
+    public void Rehydrate_WithEmptyLanguage_DefaultsToEn()
+    {
+        // Lenient defaults on read-path: DB row may have empty/malformed language.
+        var doc = VectorDocument.Rehydrate(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            language: "",
+            totalChunks: 5,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null);
+
+        doc.Language.Should().Be("en");
+    }
+
+    [Fact]
+    public void Rehydrate_WithZeroChunks_DefaultsToOne()
+    {
+        var doc = VectorDocument.Rehydrate(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            language: "en",
+            totalChunks: 0,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null);
+
+        doc.TotalChunks.Should().Be(1);
+    }
+
+    [Fact]
+    public void Rehydrate_WithNegativeTotalCharacters_ClampsToZero()
+    {
+        var doc = VectorDocument.Rehydrate(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            language: "en",
+            totalChunks: 5,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null,
+            totalCharacters: -42);
+
+        doc.TotalCharacters.Should().Be(0);
+    }
+
+    // Helper method — uses Rehydrate for fixture construction (no event side-effects in tests)
     private static VectorDocument CreateTestDocument(
         string language = "en",
         int totalChunks = 10)
     {
-        return new VectorDocument(
+        return VectorDocument.Rehydrate(
             id: Guid.NewGuid(),
             gameId: Guid.NewGuid(),
             pdfDocumentId: Guid.NewGuid(),
             language: language,
-            totalChunks: totalChunks
-        );
+            totalChunks: totalChunks,
+            indexedAt: DateTime.UtcNow,
+            sharedGameId: null);
     }
 }


### PR DESCRIPTION
## Summary

PR A of 3 follow-ups to #2244 (closed by #2278). Closes residual items #1, #2, #3 of issue #2284. PR B (#4 mandatory pipeline injection) + PR C (#5 TransitionTo Ready + bridge-save) follow.

## Residual items addressed

### #1 — Read-side bug (HIGH impact)

`KnowledgeBaseMappers.ToDomain()` called the public `VectorDocument` ctor on every database read → enqueued `VectorDocumentIndexedEvent` into the outbox. Phantom events bloat the outbox + trigger handler dispatch on every entity read. Latent since #2278.

**Fix**: add `internal static VectorDocument.Rehydrate(...)` factory that bypasses event raising and applies lenient defaults for malformed DB rows (empty language → "en", zero chunks → 1, negative chars → 0). Mapper now uses Rehydrate, threading metadata + TotalCharacters through the factory signature.

### #2 — TotalCharacters data regression (MEDIUM-HIGH impact)

`KnowledgeBaseMappers.ToEntity` hardcoded `TotalCharacters = 0` because the domain didn't track the field. Every new ingestion via `PdfIndexingPipeline` silently zeroed the audit field that pre-#2244 paths populated from `pdfDoc.ExtractedText.Length`.

**Fix**: add `int TotalCharacters` property to `VectorDocument` (private set); thread through public ctor + `Create()` + `Rehydrate()` as optional param (default 0 preserves backward compat with 30+ existing callers); `KnowledgeBaseMappers.ToEntity` now writes `domain.TotalCharacters`; `PdfIndexingPipeline` passes `totalCharacters: totalCharacters` to `VectorDocument.Create`.

### #3 — Drop SetMetadata / SetSharedGameId mutators (LOW impact, code health)

Dead code after fix #1 (Rehydrate accepts both as constructor params). Removes post-construction mutator surface — step toward single-phase construction.

## Behavior changes

- **Outbox row pressure**: `VectorDocumentIndexedEvent` no longer enqueued on every `ToDomain()` read. Production outbox table growth should slow significantly post-merge.
- **`VectorDocumentEntity.TotalCharacters`** column now populated with `pdfDoc.ExtractedText.Length` for new ingestions via `PdfIndexingPipeline`. Existing rows (zeroed since #2278 merge) need a backfill if the audit data matters — opening separate issue if needed.
- No API surface changes. Public `VectorDocument` ctor preserved (backward compat with 30+ callers).

## Test plan

- [x] Unit: VectorDocumentTests (31/31 PASS) — 3 mutator tests dropped + 10 new tests:
  - `Create_WithValidArgs_RaisesVectorDocumentIndexedEventOnce`
  - `Create_WithTotalCharacters_SetsProperty`
  - `Create_WithoutTotalCharacters_DefaultsToZero`
  - `Constructor_WithNegativeTotalCharacters_Throws`
  - `Rehydrate_DoesNotRaiseDomainEvents` (#1 fix proof)
  - `Rehydrate_WithMetadata_SetsMetadataWithoutEvent`
  - `Rehydrate_WithTotalCharacters_SetsValue`
  - `Rehydrate_WithEmptyLanguage_DefaultsToEn`
  - `Rehydrate_WithZeroChunks_DefaultsToOne`
  - `Rehydrate_WithNegativeTotalCharacters_ClampsToZero`
- [x] Unit: 20/20 caller suites PASS (KnowledgeBaseIngestService, LinkExistingKbToGameCommandHandler, LinkUserAgentDocuments, RemoveDocumentFromKb, GetAdminGameKbDocuments, GetUserGameKbStatus)
- [x] Build: 0 errors, 0 warnings

## Out of scope (deferred to PR B / PR C per #2284)

- **#4**: mandatory non-nullable `IPdfIndexingPipeline` injection (Task 4 BLOCKER discipline)
- **#5**: `PdfDocument.TransitionTo(Ready)` via `IPdfDocumentRepository` + drop manual `PdfStateChangedEvent` publish
- **Make `VectorDocument` ctor private**: 25+ test fixtures + 2 production sites to migrate. Defer to dedicated cleanup PR once factory pattern is dominant convention.

## Cross-refs

- Original ticket: #2244 (closed by #2278)
- Residual tracker: #2284
- Memory pattern: \`P234 domain-event-bypass-via-ef-entity\` (\`~/.claude/projects/.../memory/p234-domain-event-bypass-via-ef-entity.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)