### PR TITLE
test(pdf-indexing): #2284 tripwire on TransitionTo(Ready) event count

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentTests.cs
@@ -435,6 +435,36 @@ public class PdfDocumentTests
         document.CanRetry().Should().BeFalse(); // Can't retry completed document
     }
 
+    [Fact]
+    public void TransitionTo_Ready_FromIndexing_RaisesExactlyTwoDomainEvents_Tripwire()
+    {
+        // TRIPWIRE (#2284): pins the event count raised by PdfDocument.TransitionTo(Ready) at 2.
+        // The Ready transition raises BOTH PdfStateChangedEvent (consumed by 4 handlers:
+        // cache-invalidation, notification, metrics, auto-agent-creation) AND KbDocIndexedEvent
+        // (activity rail milestone, BE-3 #1590 B2).
+        //
+        // If a future change adds a third event to TransitionTo(Ready), this test fails and
+        // forces the developer to wire the new event into the appropriate downstream handlers
+        // before merging — preventing silent drift between domain emission and handler coverage.
+        var document = CreateDefaultDocument();
+        document.TransitionTo(PdfProcessingState.Uploading);
+        document.TransitionTo(PdfProcessingState.Extracting);
+        document.TransitionTo(PdfProcessingState.Chunking);
+        document.TransitionTo(PdfProcessingState.Embedding);
+        document.TransitionTo(PdfProcessingState.Indexing);
+        document.ClearDomainEvents();
+
+        document.TransitionTo(PdfProcessingState.Ready);
+
+        document.DomainEvents.Should().HaveCount(2,
+            because: "PdfDocument.TransitionTo(Ready) is documented to raise exactly " +
+                     "PdfStateChangedEvent + KbDocIndexedEvent. Adding a third event without " +
+                     "wiring its handlers breaks the structural-dispatch contract used by " +
+                     "FinalizeProcessingAsync (#2284 PR C and follow-ups).");
+        document.DomainEvents.Should().ContainSingle(e => e is PdfStateChangedEvent);
+        document.DomainEvents.Should().ContainSingle(e => e is KbDocIndexedEvent);
+    }
+
     #region BaseDocumentId Tests (Issue #5444)
 
     [Fact]


### PR DESCRIPTION
## Summary

**Hardening complement to the #2284 closure series** (#2288, #2292, #2295, #2297, #2298). Issue #2284 already closed by PR #2295 merge — this PR is test-only.

Adds a single tripwire test pinning the event count raised by `PdfDocument.TransitionTo(Ready)` at exactly **2**:

- `PdfStateChangedEvent` — feeds 4 handlers (`PdfStateChangedCacheInvalidationHandler`, `PdfNotificationEventHandler`, `PdfStateChangedMetricsEventHandler`, `AutoCreateAgentOnPdfReadyHandler`).
- `KbDocIndexedEvent` — feeds the activity rail (BE-3 #1590 B2).

Both must propagate through the structural-dispatch flow established by #2295 (PR C) and refined by #2297 (option-b bridge-save cleanup).

## Why this test matters

If a future change adds a third event to `TransitionTo(Ready)`, this test fails — forcing the developer to wire the new event into the appropriate downstream handlers before merging. Prevents silent drift between domain emission and handler coverage.

```csharp
document.TransitionTo(PdfProcessingState.Ready);

document.DomainEvents.Should().HaveCount(2,
    because: "PdfDocument.TransitionTo(Ready) is documented to raise exactly " +
             "PdfStateChangedEvent + KbDocIndexedEvent. Adding a third event without " +
             "wiring its handlers breaks the structural-dispatch contract used by " +
             "FinalizeProcessingAsync (#2284 PR C and follow-ups).");
document.DomainEvents.Should().ContainSingle(e => e is PdfStateChangedEvent);
document.DomainEvents.Should().ContainSingle(e => e is KbDocIndexedEvent);
```

## Context

Original PR #2294 scope (which included `PdfDocument.CompleteProcessing(DateTime)` domain method + `pdf_finalize_split_brain_total` metric + `ReleaseQuotaAsync` on `DomainNotFound`) became obsolete after PR #2297 removed the bridge-save tech debt entirely. The split-brain failure window no longer exists because the pipeline now progresses through every state via `TransitionStateAsync` per step.

The tripwire is the one valuable delta that survives — it's orthogonal to the bridge-save concern and protects all current and future `TransitionTo(Ready)` code paths.

## Tests

1 new test, 30 LOC. Local: passes in 153ms.

## Test plan

- [ ] CI green on `Backend Fast`.
- [ ] Verify the test catches a synthetic 3rd-event regression locally (add a stub event to `TransitionTo(Ready)`, confirm `HaveCount(2)` fails with a clear message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)