### PR TITLE
refactor(pdf-indexing): #2284 TransitionTo Ready via domain (PR C — item #5, closes #2284)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -85,7 +85,11 @@ internal partial class UploadPdfCommandHandler
             // belongs to the original HTTP request scope, which has long since been disposed
             // by the time this background task reaches finalize for a multi-MB PDF.
             var scopedMediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-            await FinalizeProcessingAsync(pdfId, pdfDoc, userId, db, quotaService, scopedMediator, startTime, cancellationToken).ConfigureAwait(false);
+            // #2284 PR C: resolve IPdfDocumentRepository from scope (ADR-063 pattern) so
+            // FinalizeProcessingAsync can load the domain aggregate + TransitionTo(Ready)
+            // structurally instead of the legacy direct EF mutation + manual mediator publish.
+            var pdfRepo = scope.ServiceProvider.GetRequiredService<Api.BoundedContexts.DocumentProcessing.Domain.Repositories.IPdfDocumentRepository>();
+            await FinalizeProcessingAsync(pdfId, pdfDoc, userId, db, quotaService, scopedMediator, pdfRepo, startTime, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("✅ [PDF-DEBUG] ProcessPdfAsync COMPLETE for {PdfId}", pdfId);
         }
         catch (OperationCanceledException)
@@ -760,6 +764,10 @@ internal partial class UploadPdfCommandHandler
 
     /// <summary>
     /// Finalizes PDF processing with completion status and quota confirmation.
+    /// #2284 PR C: drives the final state transition through PdfDocument.TransitionTo(Ready)
+    /// via IPdfDocumentRepository so PdfStateChangedEvent + KbDocIndexedEvent are raised
+    /// structurally (via IDomainEventCollector → DbContext SaveChanges dispatcher) instead
+    /// of the legacy direct EF mutation + manual scopedMediator.Publish.
     /// </summary>
     private async Task FinalizeProcessingAsync(
         string pdfId,
@@ -768,13 +776,29 @@ internal partial class UploadPdfCommandHandler
         MeepleAiDbContext db,
         IPdfUploadQuotaService quotaService,
         IMediator scopedMediator,
+        Api.BoundedContexts.DocumentProcessing.Domain.Repositories.IPdfDocumentRepository pdfRepo,
         DateTime startTime,
         CancellationToken cancellationToken)
     {
         var totalPages = pdfDoc.PageCount ?? 0;
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Completed, totalPages, totalPages, startTime, null, cancellationToken).ConfigureAwait(false);
 
-        pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready);
+        var pdfGuid = Guid.Parse(pdfId);
+
+        // BRIDGE-SAVE (#2284 PR C tech debt): the pipeline steps
+        // (Extracting/Chunking/Embedding/Indexing) never advance pdfDoc.ProcessingState in
+        // the DB — they only update progress tracking. As a result the DB row is still in
+        // Uploading when we reach this point, but the domain state-machine guard requires
+        // Indexing → Ready as the only valid predecessor.
+        //
+        // Bridge-save Uploading → Indexing via direct EF mutation so the domain
+        // reconstitution gives us an aggregate in the valid pre-Ready state. ProcessedAt
+        // is set here so it survives the subsequent UpdateAsync round-trip.
+        //
+        // FOLLOW-UP: migrate the pipeline's intermediate state transitions to
+        // pdfDomain.TransitionTo(<State>) calls one-by-one so this bridge becomes
+        // unnecessary and FinalizeProcessingAsync becomes a pure domain operation.
+        pdfDoc.ProcessingState = nameof(PdfProcessingState.Indexing);
         pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
         try
         {
@@ -786,27 +810,43 @@ internal partial class UploadPdfCommandHandler
                 nameof(UploadPdfCommandHandler),
                 MeepleAiMetrics.PdfConcurrencyCategories.B);
             _logger.LogWarning(ex,
-                "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
+                "Concurrency conflict on PdfDocument {PdfId} (bridge save to Indexing) in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                 pdfId, nameof(UploadPdfCommandHandler));
             return; // CRITICAL: do not throw — background task must see success
         }
 
-        // Publish PdfStateChangedEvent so downstream handlers fire:
-        // AutoCreateAgentOnPdfReadyHandler (admin PDFs), PdfNotificationEventHandler, PdfStateChangedMetricsEventHandler.
-        // Must be published after SaveChanges so handlers can query the updated entity.
-        // Use scopedMediator (resolved from the live async scope), not the handler's _mediator
-        // field which references the disposed HTTP request scope.
-        if (Guid.TryParse(pdfId, out var pdfGuidForEvent))
-        {
-            await scopedMediator.Publish(
-                new PdfStateChangedEvent(pdfGuidForEvent, PdfProcessingState.Indexing, PdfProcessingState.Ready, userId),
-                CancellationToken.None).ConfigureAwait(false);
+        // Load aggregate, call TransitionTo(Ready) so PdfStateChangedEvent + KbDocIndexedEvent
+        // are raised structurally, then persist via repository so IDomainEventCollector picks
+        // them up and the DbContext SaveChanges dispatcher publishes them through MediatR.
+        var pdfDomain = await pdfRepo.GetByIdAsync(pdfGuid, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"PdfDocument {pdfGuid} not found while finalizing processing");
 
-            // Sub #1 (#2243) tactical compensating publish of VectorDocumentIndexedEvent
-            // removed by #2244: IPdfIndexingPipeline.IndexAsync now raises the event
-            // structurally through the VectorDocument domain aggregate. See
-            // UpdateVectorDocumentAsync above + IPdfIndexingPipeline.cs.
+        try
+        {
+            pdfDomain.TransitionTo(PdfProcessingState.Ready);
+            await pdfRepo.UpdateAsync(pdfDomain, cancellationToken).ConfigureAwait(false);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            MeepleAiMetrics.RecordPdfConcurrencyConflict(
+                nameof(UploadPdfCommandHandler),
+                MeepleAiMetrics.PdfConcurrencyCategories.B);
+            _logger.LogWarning(ex,
+                "Concurrency conflict on PdfDocument {PdfId} (TransitionTo Ready) in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
+                pdfId, nameof(UploadPdfCommandHandler));
+            return;
+        }
+
+        // #2284 PR C: tactical scopedMediator.Publish(PdfStateChangedEvent) deleted.
+        // PdfDocument.TransitionTo(Ready) raises BOTH PdfStateChangedEvent AND
+        // KbDocIndexedEvent structurally; the repository's UpdateAsync collects them via
+        // CollectDomainEvents and the SaveChanges dispatcher publishes them through MediatR.
+        // Downstream handlers (AutoCreateAgentOnPdfReadyHandler, PdfNotificationEventHandler,
+        // PdfStateChangedMetricsEventHandler, activity-rail KbDocIndexedEventHandler) fire
+        // via the same MediatR pipeline as before — no behavioural change at the handler
+        // level, just the source of the event is now the domain aggregate.
 
         var cacheKey = (pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId)?.ToString() ?? string.Empty;
         await InvalidateCacheSafelyAsync(cacheKey, "PDF processing", cancellationToken).ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/Integration/FinalValidation/Week12SimpleValidationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/FinalValidation/Week12SimpleValidationTests.cs
@@ -83,7 +83,7 @@ public sealed class Week12SimpleValidationTests : IAsyncLifetime
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 30,
-                        CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow
         };
 
         // Act
@@ -109,7 +109,7 @@ public sealed class Week12SimpleValidationTests : IAsyncLifetime
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 30,
-                        CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow
         }).ToList();
 
         // Act

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/CreateRuleCommentIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/CreateRuleCommentIntegrationTests.cs
@@ -145,7 +145,7 @@ public sealed class CreateRuleCommentIntegrationTests : IAsyncLifetime
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 60,
-                        CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow
         };
         _dbContext.SharedGames.Add(game);
 

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbAskStreamEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbAskStreamEndpointTests.cs
@@ -362,9 +362,9 @@ public sealed class GlobalKbAskStreamEndpointTests : IAsyncLifetime
         });
 
         // Seed three games
-        _gamePublicId    = Guid.NewGuid();
+        _gamePublicId = Guid.NewGuid();
         _gameAliceOwnedId = Guid.NewGuid();
-        _gameBobOwnedId  = Guid.NewGuid();
+        _gameBobOwnedId = Guid.NewGuid();
 
         db.SharedGames.AddRange(
             new SharedGameEntity
@@ -373,10 +373,13 @@ public sealed class GlobalKbAskStreamEndpointTests : IAsyncLifetime
                 Title = "Public Ask Game",
                 Description = "Publicly indexed",
                 YearPublished = 2022,
-                MinPlayers = 2, MaxPlayers = 4,
-                PlayingTimeMinutes = 60, MinAge = 10,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 10,
                 IsRagPublic = true,
-                CreatedBy = seedUserId, CreatedAt = DateTime.UtcNow
+                CreatedBy = seedUserId,
+                CreatedAt = DateTime.UtcNow
             },
             new SharedGameEntity
             {
@@ -384,10 +387,13 @@ public sealed class GlobalKbAskStreamEndpointTests : IAsyncLifetime
                 Title = "Alice Ask Private Game",
                 Description = "Private to Alice",
                 YearPublished = 2022,
-                MinPlayers = 2, MaxPlayers = 4,
-                PlayingTimeMinutes = 60, MinAge = 10,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 10,
                 IsRagPublic = false,
-                CreatedBy = seedUserId, CreatedAt = DateTime.UtcNow
+                CreatedBy = seedUserId,
+                CreatedAt = DateTime.UtcNow
             },
             new SharedGameEntity
             {
@@ -395,10 +401,13 @@ public sealed class GlobalKbAskStreamEndpointTests : IAsyncLifetime
                 Title = "Bob Ask Private Game",
                 Description = "Private to Bob",
                 YearPublished = 2022,
-                MinPlayers = 2, MaxPlayers = 4,
-                PlayingTimeMinutes = 60, MinAge = 10,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 10,
                 IsRagPublic = false,
-                CreatedBy = seedUserId, CreatedAt = DateTime.UtcNow
+                CreatedBy = seedUserId,
+                CreatedAt = DateTime.UtcNow
             }
         );
 
@@ -493,13 +502,13 @@ public sealed class GlobalKbAskStreamEndpointTests : IAsyncLifetime
                 {
                     results.Add(new MultiGameSearchResultItem
                     {
-                        GameId      = gameId,
-                        ChunkId     = $"{Guid.NewGuid():N}_0",
+                        GameId = gameId,
+                        ChunkId = $"{Guid.NewGuid():N}_0",
                         PdfDocumentId = Guid.NewGuid().ToString(),
-                        ChunkIndex  = 0,
-                        Content     = $"Movement rule: move up to 3 spaces per turn (game {gameId}).",
+                        ChunkIndex = 0,
+                        Content = $"Movement rule: move up to 3 spaces per turn (game {gameId}).",
                         HybridScore = 0.90f,
-                        Mode        = mode
+                        Mode = mode
                     });
                 }
                 return (IReadOnlyList<MultiGameSearchResultItem>)results.AsReadOnly();

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs
@@ -873,10 +873,13 @@ public sealed class GlobalKbSearchEndpointTests : IAsyncLifetime
                 Title = "Public RAG Game",
                 Description = "Publicly indexed",
                 YearPublished = 2022,
-                MinPlayers = 2, MaxPlayers = 4,
-                PlayingTimeMinutes = 60, MinAge = 10,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 10,
                 IsRagPublic = true,
-                CreatedBy = seedUserId, CreatedAt = DateTime.UtcNow
+                CreatedBy = seedUserId,
+                CreatedAt = DateTime.UtcNow
             },
             new SharedGameEntity
             {
@@ -884,10 +887,13 @@ public sealed class GlobalKbSearchEndpointTests : IAsyncLifetime
                 Title = "Alice Private Game",
                 Description = "Alice-owned private game",
                 YearPublished = 2022,
-                MinPlayers = 2, MaxPlayers = 4,
-                PlayingTimeMinutes = 60, MinAge = 10,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 10,
                 IsRagPublic = false,
-                CreatedBy = seedUserId, CreatedAt = DateTime.UtcNow
+                CreatedBy = seedUserId,
+                CreatedAt = DateTime.UtcNow
             },
             new SharedGameEntity
             {
@@ -895,10 +901,13 @@ public sealed class GlobalKbSearchEndpointTests : IAsyncLifetime
                 Title = "Bob Private Game",
                 Description = "Bob-owned private game",
                 YearPublished = 2022,
-                MinPlayers = 2, MaxPlayers = 4,
-                PlayingTimeMinutes = 60, MinAge = 10,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                MinAge = 10,
                 IsRagPublic = false,
-                CreatedBy = seedUserId, CreatedAt = DateTime.UtcNow
+                CreatedBy = seedUserId,
+                CreatedAt = DateTime.UtcNow
             }
         );
 

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
@@ -181,8 +181,8 @@ public sealed class SearchDocumentChunksQueryHandlerIntegrationTests : IAsyncLif
         // emb1 query-aligned: [1, 0, 0, ... ] → cosine similarity with query ≈ 1.0
         // emb2 orthogonal:    [0, 1, 0, ... ] → cosine similarity with query ≈ 0.0
         var queryVector = MakeVector(Dims, firstComponent: 1f);
-        var embVector1  = MakeVector(Dims, firstComponent: 1f);   // identical → sim ~1
-        var embVector2  = MakeVector(Dims, secondComponent: 1f);  // orthogonal → sim ~0
+        var embVector1 = MakeVector(Dims, firstComponent: 1f);   // identical → sim ~1
+        var embVector2 = MakeVector(Dims, secondComponent: 1f);  // orthogonal → sim ~0
 
         // Configure mock to return the query vector when asked.
         _embeddingServiceMock

--- a/apps/api/tests/Api.Tests/Integration/PdfUploadTestHelpers.cs
+++ b/apps/api/tests/Api.Tests/Integration/PdfUploadTestHelpers.cs
@@ -210,7 +210,7 @@ internal static class PdfUploadTestHelpers
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 30,
-                        CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow
         };
         context.SharedGames.Add(game);
         await context.SaveChangesAsync(ct);

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
@@ -303,7 +303,7 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 30,
-                        CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow
         };
         _dbContext.SharedGames.Add(testGame);
 
@@ -401,7 +401,7 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
             MinPlayers = 2,
             MaxPlayers = 4,
             PlayingTimeMinutes = 30,
-                        CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow
         };
         context.SharedGames.Add(game);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
## Summary

PR C of #2284. Closes residual item **#5** (PdfDocument.TransitionTo(Ready) via IPdfDocumentRepository + drop manual PdfStateChangedEvent publish). **Completes the #2244 follow-up arc** (PR A #2288 + PR B #2292 + PR C this).

## Background

Pre-PR-C the `FinalizeProcessingAsync` method in `UploadPdfCommandHandler.Processing.cs` finalized the PDF lifecycle with two anti-patterns left over from #2243's tactical hotfix:

1. **Direct EF mutation**: `pdfDoc.ProcessingState = nameof(PdfProcessingState.Ready)` + `pdfDoc.ProcessedAt = now` + `db.SaveChangesAsync()`. Bypassed the `PdfDocument` domain aggregate's state machine + event raising.
2. **Manual publish**: `scopedMediator.Publish(new PdfStateChangedEvent(Indexing → Ready, userId))`. Required because the EF mutation didn't trigger the domain event. Downstream handlers (`AutoCreateAgentOnPdfReadyHandler`, `PdfNotificationEventHandler`, `PdfStateChangedMetricsEventHandler`, activity-rail `KbDocIndexedEventHandler`) all depended on it.

Same anti-pattern P234 closed for `VectorDocument` in #2244: EF entity writes bypass the domain aggregate, tactical `mediator.Publish` compensates post-hoc.

## Refactor

```csharp
// 1. Resolve repository from background-task scope (ADR-063)
var pdfRepo = scope.ServiceProvider.GetRequiredService<IPdfDocumentRepository>();

// 2. Bridge-save: pipeline never advances state in DB; state machine needs Indexing → Ready
pdfDoc.ProcessingState = nameof(PdfProcessingState.Indexing);
pdfDoc.ProcessedAt = now;
await db.SaveChangesAsync(ct);

// 3. Load aggregate, TransitionTo, persist via repository
var pdfDomain = await pdfRepo.GetByIdAsync(pdfGuid, ct)
    ?? throw new InvalidOperationException(...);
pdfDomain.TransitionTo(PdfProcessingState.Ready);  // raises PdfStateChangedEvent + KbDocIndexedEvent
await pdfRepo.UpdateAsync(pdfDomain, ct);          // collects events via IDomainEventCollector
await db.SaveChangesAsync(ct);                      // dispatches through MediatR

// 4. Manual scopedMediator.Publish(PdfStateChangedEvent) block DELETED
```

`DbUpdateConcurrencyException` caught + metric Category B + log + return on BOTH bridge save AND structural save, preserving the Quartz semantic.

## Behavior changes

- **`PdfStateChangedEvent`**: still raised exactly once per Ready transition, now from the domain aggregate. Downstream handlers receive the same payload via the same MediatR pipeline.
- **`KbDocIndexedEvent`**: now raised from `FinalizeProcessingAsync` (was only raised from `IndexInVectorStoreAsync` path via `VectorDocumentIndexedEvent`). Activity-rail handler is already idempotent.
- **Tech debt acknowledged in code comment**: bridge-save (`Uploading → Indexing` via EF) is required because the pipeline steps (Extracting/Chunking/Embedding/Indexing) never advance `pdfDoc.ProcessingState` in DB. Follow-up should migrate those to `pdfDomain.TransitionTo(<State>)` calls so the bridge becomes unnecessary.

## Test plan

- [x] **`PdfDocument_SevenStateProgression_ShouldAdvanceThroughAllStates`** (CLAUDE.md baseline) — still emits exactly 7 events (6 `PdfStateChangedEvent` + 1 `KbDocIndexedEvent` on Ready). Proves the structural flow matches the original baseline.
- [x] **51/51 PASS** in affected slice (`UploadPdfCommandHandlerTests` + `PdfDocumentTests` + baseline)
- [x] Build: 0 errors, 0 warnings

## Co-located whitespace fixes

`dotnet format` pre-commit hook flagged 8 pre-existing whitespace drift sites across the test slice (not caused by PR C). Folded into this commit to unblock — no semantic change. Files: GlobalKbAskStreamEndpointTests, GlobalKbSearchEndpointTests, SearchDocumentChunksQueryHandlerIntegrationTests, PdfUploadTestHelpers, UploadPdfIntegrationTests, Week12SimpleValidationTests, CreateRuleCommentIntegrationTests.

**NOTE**: `--no-verify` used on commit (user-authorized). Pre-commit hook continues to discover drift across the repo each iteration; a separate global format PR would address the full surface.

## Out of scope (deferred — follow-up issues if needed)

- Migrate pipeline's intermediate state transitions (`Uploading → Extracting → ... → Indexing`) to `pdfDomain.TransitionTo(<State>)` calls so the bridge-save becomes unnecessary. Effort ~4-5h across 5 transition points.
- Repo-wide `dotnet format` chore PR to fix all pre-existing whitespace drift.
- Roslyn analyzer flagging `IPdfIndexingPipeline? = null` + `new VectorDocumentEntity {` outside mapper.

## Cross-refs

- Original ticket: #2244 (closed by #2278)
- Residual tracker: #2284 (this PR closes the umbrella)
- PR A: #2288 (items #1+#2+#3)
- PR B: #2292 (item #4 via ADR-063)
- Memory pattern: \`P234 domain-event-bypass-via-ef-entity\`

Closes #2284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)