### PR TITLE
refactor(pdf-indexing): #2284 complete state-machine migration (TD1+TD2+TD3 + outbox coverage)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -33,7 +33,7 @@ internal partial class UploadPdfCommandHandler
         try
         {
             _logger.LogInformation("🔍 [PDF-DEBUG] Calling ValidateAndPrepareProcessingAsync for {PdfId}", pdfId);
-            var pdfDoc = await ValidateAndPrepareProcessingAsync(pdfId, userId, db, quotaService, cancellationToken).ConfigureAwait(false);
+            var pdfDoc = await ValidateAndPrepareProcessingAsync(pdfId, userId, db, scope, quotaService, cancellationToken).ConfigureAwait(false);
             if (pdfDoc == null)
             {
                 _logger.LogWarning("⚠️ [PDF-DEBUG] ValidateAndPrepareProcessingAsync returned null for {PdfId} - EARLY EXIT", pdfId);
@@ -107,15 +107,15 @@ internal partial class UploadPdfCommandHandler
         }
         catch (OperationCanceledException)
         {
-            await HandleProcessingCancellationAsync(pdfId, userId, db, quotaService, startTime, cancellationToken).ConfigureAwait(false);
+            await HandleProcessingCancellationAsync(pdfId, userId, db, scope, quotaService, startTime, cancellationToken).ConfigureAwait(false);
         }
         catch (InvalidOperationException ex)
         {
-            await HandleProcessingErrorAsync(pdfId, userId, db, quotaService, startTime, ex, "Invalid operation", cancellationToken).ConfigureAwait(false);
+            await HandleProcessingErrorAsync(pdfId, userId, db, scope, quotaService, startTime, ex, "Invalid operation", cancellationToken).ConfigureAwait(false);
         }
         catch (DbUpdateException ex)
         {
-            await HandleProcessingErrorAsync(pdfId, userId, db, quotaService, startTime, ex, "Database error occurred", cancellationToken).ConfigureAwait(false);
+            await HandleProcessingErrorAsync(pdfId, userId, db, scope, quotaService, startTime, ex, "Database error occurred", cancellationToken).ConfigureAwait(false);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
 #pragma warning disable S125 // Sections of code should not be commented out
@@ -125,7 +125,7 @@ internal partial class UploadPdfCommandHandler
         catch (Exception ex)
 #pragma warning restore CA1031
         {
-            await HandleProcessingErrorAsync(pdfId, userId, db, quotaService, startTime, ex, ex.Message, cancellationToken).ConfigureAwait(false);
+            await HandleProcessingErrorAsync(pdfId, userId, db, scope, quotaService, startTime, ex, ex.Message, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -136,6 +136,7 @@ internal partial class UploadPdfCommandHandler
         string pdfId,
         Guid userId,
         MeepleAiDbContext db,
+        IServiceScope scope,
         IPdfUploadQuotaService quotaService,
         CancellationToken cancellationToken)
     {
@@ -183,25 +184,26 @@ internal partial class UploadPdfCommandHandler
             return null;
         }
 
-        // Mark as processing (optimistic locking)
-        _logger.LogInformation("🔄 [PDF-DEBUG-VALIDATE] Updating status from 'pending' to 'processing'");
-        pdfDoc.ProcessingState = nameof(PdfProcessingState.Uploading);
+        // Mark as processing — transition through the domain so PdfStateChangedEvent
+        // (Pending → Uploading) is raised structurally instead of via direct EF mutation.
+        // #2284 follow-up: closes TD3.
+        _logger.LogInformation("🔄 [PDF-DEBUG-VALIDATE] Updating status from 'pending' to 'uploading' via domain");
         try
         {
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await TransitionStateAsync(scope, db, pdfGuid, PdfProcessingState.Uploading, cancellationToken).ConfigureAwait(false);
         }
-        catch (DbUpdateConcurrencyException ex)
+        catch (DbUpdateConcurrencyException)
         {
-            MeepleAiMetrics.RecordPdfConcurrencyConflict(
-                nameof(UploadPdfCommandHandler),
-                MeepleAiMetrics.PdfConcurrencyCategories.B);
-            _logger.LogWarning(ex,
-                "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
-                pdfId, nameof(UploadPdfCommandHandler));
+            // TransitionStateAsync already recorded the metric + logged before throwing.
             return null; // Null signals to caller that preparation failed; pipeline will skip
         }
         _logger.LogInformation("✅ [PDF-DEBUG-VALIDATE] Status updated, proceeding with processing");
 
+        // Reload the EF snapshot the rest of ProcessPdfAsync uses — TransitionStateAsync
+        // persisted the new state via the repository (which detaches the existing tracked
+        // entity), so the local pdfDoc reference is stale w.r.t. ProcessingState.
+        pdfDoc = await db.PdfDocuments.AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken).ConfigureAwait(false);
         return pdfDoc;
     }
 
@@ -242,23 +244,12 @@ internal partial class UploadPdfCommandHandler
             {
                 RecordPipelineMetricSafely("extraction_error", 0);
                 await UpdateProgressAsync(db, pdfId, ProcessingStep.Failed, 0, 0, startTime, extractResult.ErrorMessage, cancellationToken).ConfigureAwait(false);
-                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
-                pdfDoc.ProcessingError = extractResult.ErrorMessage;
-                pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
-                try
-                {
-                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (DbUpdateConcurrencyException ex)
-                {
-                    MeepleAiMetrics.RecordPdfConcurrencyConflict(
-                        nameof(UploadPdfCommandHandler),
-                        MeepleAiMetrics.PdfConcurrencyCategories.B);
-                    _logger.LogWarning(ex,
-                        "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
-                        pdfId, nameof(UploadPdfCommandHandler));
-                    return (false, null, null);
-                }
+                // #2284 follow-up: TD2 — transition Failed via domain (raises
+                // PdfStateChangedEvent(Extracting → Failed) + PdfFailedEvent).
+                await TransitionToFailedAsync(
+                    scope, db, Guid.Parse(pdfId), extractResult.ErrorMessage ?? "Extraction failed",
+                    Api.BoundedContexts.DocumentProcessing.Domain.Enums.ErrorCategory.Parsing,
+                    PdfProcessingState.Extracting, cancellationToken).ConfigureAwait(false);
                 return (false, null, null);
             }
 
@@ -447,7 +438,7 @@ internal partial class UploadPdfCommandHandler
             {
                 _logger.LogError("❌ [BATCH-EMBED] Batch {Current}/{Total} FAILED: {Error}",
                     batchIndex + 1, batchCount, batchResult.ErrorMessage);
-                await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, quotaService, startTime,
+                await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, scope, quotaService, startTime,
                     $"Embedding generation failed at batch {batchIndex + 1}/{batchCount}: {batchResult.ErrorMessage}", cancellationToken).ConfigureAwait(false);
                 return (false, null);
             }
@@ -456,7 +447,7 @@ internal partial class UploadPdfCommandHandler
             {
                 var mismatch = $"Batch {batchIndex + 1} returned {batchResult.Embeddings?.Count ?? 0} embeddings for {batchTexts.Count} texts";
                 _logger.LogError("❌ [BATCH-EMBED] {Mismatch}", mismatch);
-                await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, quotaService, startTime, mismatch, cancellationToken).ConfigureAwait(false);
+                await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, scope, quotaService, startTime, mismatch, cancellationToken).ConfigureAwait(false);
                 return (false, null);
             }
 
@@ -467,7 +458,7 @@ internal partial class UploadPdfCommandHandler
                 {
                     var error = $"Invalid embedding detected in batch {batchIndex + 1}";
                     _logger.LogError("❌ [BATCH-EMBED] {Error}", error);
-                    await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, quotaService, startTime, error, cancellationToken).ConfigureAwait(false);
+                    await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, scope, quotaService, startTime, error, cancellationToken).ConfigureAwait(false);
                     return (false, null);
                 }
             }
@@ -506,7 +497,7 @@ internal partial class UploadPdfCommandHandler
         {
             var mismatch = $"Total embeddings {allEmbeddings.Count} != total chunks {allDocumentChunks.Count}";
             _logger.LogError("❌ [BATCH-EMBED] {Mismatch}", mismatch);
-            await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, quotaService, startTime, mismatch, cancellationToken).ConfigureAwait(false);
+            await HandleEmbeddingFailureAsync(pdfId, userId, pdfDoc, db, scope, quotaService, startTime, mismatch, cancellationToken).ConfigureAwait(false);
             return (false, null);
         }
 
@@ -521,6 +512,7 @@ internal partial class UploadPdfCommandHandler
         Guid userId,
         PdfDocumentEntity pdfDoc,
         MeepleAiDbContext db,
+        IServiceScope scope,
         IPdfUploadQuotaService quotaService,
         DateTime startTime,
         string errorMessage,
@@ -528,22 +520,13 @@ internal partial class UploadPdfCommandHandler
     {
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Failed, 0, 0, startTime, errorMessage, cancellationToken).ConfigureAwait(false);
         await quotaService.ReleaseQuotaAsync(userId, pdfId, CancellationToken.None).ConfigureAwait(false);
-        pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
-        pdfDoc.ProcessingError = errorMessage;
-        pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
-        try
-        {
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            MeepleAiMetrics.RecordPdfConcurrencyConflict(
-                nameof(UploadPdfCommandHandler),
-                MeepleAiMetrics.PdfConcurrencyCategories.B);
-            _logger.LogWarning(ex,
-                "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
-                pdfId, nameof(UploadPdfCommandHandler));
-        }
+        // #2284 follow-up: TD2 — transition Failed via domain. ErrorCategory.Service
+        // because embedding failure typically signals the embedding microservice is
+        // unreachable or returning malformed responses.
+        await TransitionToFailedAsync(
+            scope, db, Guid.Parse(pdfId), errorMessage,
+            Api.BoundedContexts.DocumentProcessing.Domain.Enums.ErrorCategory.Service,
+            PdfProcessingState.Embedding, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -816,6 +799,66 @@ internal partial class UploadPdfCommandHandler
     }
 
     /// <summary>
+    /// Marks the document as Failed via the domain aggregate (PdfDocument.MarkAsFailed)
+    /// so PdfStateChangedEvent(&lt;prev&gt; → Failed) + PdfFailedEvent are raised
+    /// structurally and dispatched through MediatR. Replaces the legacy pattern of
+    /// `pdfDoc.ProcessingState = "Failed"; pdfDoc.ProcessingError = ...;
+    /// pdfDoc.ProcessedAt = ...; db.SaveChangesAsync()` which raised no events.
+    ///
+    /// #2284 follow-up: closes TD2 across 4 error sites (line ~245, ~531, ~916, ~962
+    /// pre-refactor) so failure transitions are observable by downstream metric +
+    /// notification handlers, not silent.
+    ///
+    /// DbUpdateConcurrencyException is logged + swallowed (best-effort) because the
+    /// caller already returns to the error path — re-throwing would mask the original
+    /// failure reason.
+    /// </summary>
+    private async Task TransitionToFailedAsync(
+        IServiceScope scope,
+        MeepleAiDbContext db,
+        Guid pdfGuid,
+        string errorMessage,
+        Api.BoundedContexts.DocumentProcessing.Domain.Enums.ErrorCategory category,
+        PdfProcessingState? failedAtState,
+        CancellationToken cancellationToken)
+    {
+        var pdfRepo = scope.ServiceProvider.GetRequiredService<Api.BoundedContexts.DocumentProcessing.Domain.Repositories.IPdfDocumentRepository>();
+        var pdfDomain = await pdfRepo.GetByIdAsync(pdfGuid, cancellationToken).ConfigureAwait(false);
+        if (pdfDomain is null)
+        {
+            // Pdf may have been deleted by an admin mutation; nothing structurally to
+            // raise. The caller will still return its error path.
+            _logger.LogWarning(
+                "PdfDocument {PdfId} not found while transitioning to Failed (best-effort)",
+                pdfGuid);
+            return;
+        }
+
+        // failedAtState == null signals "I don't know which step failed — use the
+        // aggregate's current state". Used by generic catch blocks (cancellation,
+        // unexpected exception) where the upstream code can't pinpoint the step.
+        var resolvedFailedAtState = failedAtState ?? pdfDomain.ProcessingState;
+
+        try
+        {
+            pdfDomain.MarkAsFailed(errorMessage, category, resolvedFailedAtState);
+            await pdfRepo.UpdateAsync(pdfDomain, cancellationToken).ConfigureAwait(false);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            MeepleAiMetrics.RecordPdfConcurrencyConflict(
+                nameof(UploadPdfCommandHandler),
+                MeepleAiMetrics.PdfConcurrencyCategories.B);
+            _logger.LogWarning(ex,
+                "Concurrency conflict transitioning PdfDocument {PdfId} to Failed (Category B) — admin mutation wins, error path still completes",
+                pdfGuid);
+            // Swallow: the caller already records the upstream failure reason; the
+            // missing event is a tolerable observability gap relative to throwing here.
+        }
+    }
+
+    /// <summary>
     /// Finalizes PDF processing with completion status and quota confirmation.
     /// #2284 PR C: drives the final state transition through PdfDocument.TransitionTo(Ready)
     /// via IPdfDocumentRepository so PdfStateChangedEvent + KbDocIndexedEvent are raised
@@ -842,15 +885,14 @@ internal partial class UploadPdfCommandHandler
 
         var pdfGuid = Guid.Parse(pdfId);
 
-        // Set ProcessedAt on the EF entity so it survives the upcoming UpdateAsync (mapper
-        // round-trip preserves it). The state transition is handled by TransitionTo(Ready)
-        // below — no bridge save needed because the pipeline progressed through Indexing
-        // via TransitionStateAsync.
-        pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
-
-        // Load aggregate, call TransitionTo(Ready) so PdfStateChangedEvent + KbDocIndexedEvent
-        // are raised structurally, then persist via repository so IDomainEventCollector picks
-        // them up and the DbContext SaveChanges dispatcher publishes them through MediatR.
+        // Load aggregate, call TransitionTo(Ready) + MarkProcessed(now) so
+        // PdfStateChangedEvent + KbDocIndexedEvent are raised structurally and
+        // ProcessedAt is set via the domain (not via direct EF mutation). Persist
+        // via repository so IDomainEventCollector picks the events up and the
+        // DbContext SaveChanges dispatcher publishes them through MediatR.
+        //
+        // #2284 follow-up: closes TD1 — the legacy `pdfDoc.ProcessedAt = _timeProvider...`
+        // EF mutation that survived PR #2297 is replaced by pdfDomain.MarkProcessed(now).
         var pdfDomain = await pdfRepo.GetByIdAsync(pdfGuid, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException(
                 $"PdfDocument {pdfGuid} not found while finalizing processing");
@@ -858,6 +900,7 @@ internal partial class UploadPdfCommandHandler
         try
         {
             pdfDomain.TransitionTo(PdfProcessingState.Ready);
+            pdfDomain.MarkProcessed(_timeProvider.GetUtcNow().UtcDateTime);
             await pdfRepo.UpdateAsync(pdfDomain, cancellationToken).ConfigureAwait(false);
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -897,6 +940,7 @@ internal partial class UploadPdfCommandHandler
         string pdfId,
         Guid userId,
         MeepleAiDbContext db,
+        IServiceScope scope,
         IPdfUploadQuotaService quotaService,
         DateTime startTime,
         CancellationToken cancellationToken)
@@ -905,31 +949,16 @@ internal partial class UploadPdfCommandHandler
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Failed, 0, 0, startTime, "Processing cancelled by user", cancellationToken).ConfigureAwait(false);
         await quotaService.ReleaseQuotaAsync(userId, pdfId, CancellationToken.None).ConfigureAwait(false);
 
+        // #2284 follow-up: TD2 — transition Failed via domain. failedAtState=null →
+        // resolved to current pdfDomain.ProcessingState (whatever step the cancellation
+        // hit). Use CancellationToken.None because the cancellation token that triggered
+        // this branch is already signalled; we still want to persist the Failed state.
         if (Guid.TryParse(pdfId, out var cancelledPdfGuid))
         {
-            var pdfDoc = await db.PdfDocuments
-                .AsTracking()
-                .FirstOrDefaultAsync(p => p.Id == cancelledPdfGuid, CancellationToken.None)
-                .ConfigureAwait(false);
-            if (pdfDoc != null)
-            {
-                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
-                pdfDoc.ProcessingError = "Processing cancelled by user";
-                pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
-                try
-                {
-                    await db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
-                }
-                catch (DbUpdateConcurrencyException ex)
-                {
-                    MeepleAiMetrics.RecordPdfConcurrencyConflict(
-                        nameof(UploadPdfCommandHandler),
-                        MeepleAiMetrics.PdfConcurrencyCategories.B);
-                    _logger.LogWarning(ex,
-                        "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
-                        pdfId, nameof(UploadPdfCommandHandler));
-                }
-            }
+            await TransitionToFailedAsync(
+                scope, db, cancelledPdfGuid, "Processing cancelled by user",
+                Api.BoundedContexts.DocumentProcessing.Domain.Enums.ErrorCategory.Unknown,
+                failedAtState: null, CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -940,6 +969,7 @@ internal partial class UploadPdfCommandHandler
         string pdfId,
         Guid userId,
         MeepleAiDbContext db,
+        IServiceScope scope,
         IPdfUploadQuotaService quotaService,
         DateTime startTime,
         Exception ex,
@@ -951,31 +981,15 @@ internal partial class UploadPdfCommandHandler
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Failed, 0, 0, startTime, errorMessage, cancellationToken).ConfigureAwait(false);
         await quotaService.ReleaseQuotaAsync(userId, pdfId, cancellationToken).ConfigureAwait(false);
 
+        // #2284 follow-up: TD2 — transition Failed via domain. failedAtState=null →
+        // resolved to current pdfDomain.ProcessingState (the catch is generic, so the
+        // upstream step that threw is whatever pdfDomain currently observes).
         if (Guid.TryParse(pdfId, out var errorPdfGuid))
         {
-            var pdfDoc = await db.PdfDocuments
-                .AsTracking()
-                .FirstOrDefaultAsync(p => p.Id == errorPdfGuid, cancellationToken)
-                .ConfigureAwait(false);
-            if (pdfDoc != null)
-            {
-                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
-                pdfDoc.ProcessingError = errorMessage;
-                pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
-                try
-                {
-                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (DbUpdateConcurrencyException concEx)
-                {
-                    MeepleAiMetrics.RecordPdfConcurrencyConflict(
-                        nameof(UploadPdfCommandHandler),
-                        MeepleAiMetrics.PdfConcurrencyCategories.B);
-                    _logger.LogWarning(concEx,
-                        "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
-                        pdfId, nameof(UploadPdfCommandHandler));
-                }
-            }
+            await TransitionToFailedAsync(
+                scope, db, errorPdfGuid, errorMessage,
+                Api.BoundedContexts.DocumentProcessing.Domain.Enums.ErrorCategory.Unknown,
+                failedAtState: null, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -301,6 +301,31 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
         return document;
     }
 
+    /// <summary>
+    /// Records the moment when the document finished processing (transition to Ready).
+    /// Pure audit field setter — does NOT raise a domain event because:
+    /// (1) ProcessedAt is metadata, not a state-change consumers care about beyond the
+    ///     Ready transition itself; (2) TransitionTo(Ready) already raises
+    ///     PdfStateChangedEvent + KbDocIndexedEvent which carry the meaningful signal.
+    ///
+    /// Invariant: caller MUST call this only after the aggregate has transitioned to
+    /// Ready (i.e., the pipeline's structural finalization is complete). Throws if
+    /// called from any other state.
+    ///
+    /// #2284 follow-up: replaces the legacy `pdfDoc.ProcessedAt = now` EF mutation
+    /// that survived PR #2297 in FinalizeProcessingAsync.
+    /// </summary>
+    /// <param name="processedAt">The wall-clock time when processing completed.</param>
+    public void MarkProcessed(DateTime processedAt)
+    {
+        if (ProcessingState != PdfProcessingState.Ready)
+        {
+            throw new InvalidOperationException(
+                $"MarkProcessed can only be called after TransitionTo(Ready); current state is {ProcessingState}.");
+        }
+        ProcessedAt = processedAt;
+    }
+
     // Issue #4215: Deprecated methods - use TransitionTo() instead
     // Deprecated: Use TransitionTo() instead (remove in Issue #4216)
     public void MarkAsProcessing()

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentTests.cs
@@ -351,6 +351,63 @@ public class PdfDocumentTests
         document.ProcessingState.Should().Be(PdfProcessingState.Chunking);
     }
 
+    // #2284 follow-up: TD1 — MarkProcessed domain method
+    [Fact]
+    public void MarkProcessed_FromReadyState_SetsProcessedAt()
+    {
+        // Arrange — advance the document fully to Ready first.
+        var document = CreateTestDocument(LanguageCode.English);
+        document.TransitionTo(PdfProcessingState.Uploading);
+        document.TransitionTo(PdfProcessingState.Extracting);
+        document.TransitionTo(PdfProcessingState.Chunking);
+        document.TransitionTo(PdfProcessingState.Embedding);
+        document.TransitionTo(PdfProcessingState.Indexing);
+        document.TransitionTo(PdfProcessingState.Ready);
+        var expected = new DateTime(2026, 6, 13, 12, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        document.MarkProcessed(expected);
+
+        // Assert
+        document.ProcessedAt.Should().Be(expected);
+        document.ProcessingState.Should().Be(PdfProcessingState.Ready,
+            "MarkProcessed is a pure audit setter — state must remain Ready");
+    }
+
+    [Fact]
+    public void MarkProcessed_FromNonReadyState_Throws()
+    {
+        var document = CreateTestDocument(LanguageCode.English);
+        document.TransitionTo(PdfProcessingState.Uploading);
+
+        var act = () => document.MarkProcessed(DateTime.UtcNow);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Ready*");
+    }
+
+    [Fact]
+    public void MarkProcessed_DoesNotRaiseDomainEvent()
+    {
+        // MarkProcessed is intentionally a pure audit setter — no event raised.
+        // Consumers receive PdfStateChangedEvent + KbDocIndexedEvent from
+        // TransitionTo(Ready) instead.
+        var document = CreateTestDocument(LanguageCode.English);
+        document.TransitionTo(PdfProcessingState.Uploading);
+        document.TransitionTo(PdfProcessingState.Extracting);
+        document.TransitionTo(PdfProcessingState.Chunking);
+        document.TransitionTo(PdfProcessingState.Embedding);
+        document.TransitionTo(PdfProcessingState.Indexing);
+        document.TransitionTo(PdfProcessingState.Ready);
+
+        var eventsBeforeMark = document.DomainEvents.Count;
+
+        document.MarkProcessed(DateTime.UtcNow);
+
+        document.DomainEvents.Count.Should().Be(eventsBeforeMark,
+            "MarkProcessed must NOT add a new domain event");
+    }
+
     [Fact]
     public void MarkAsFailed_WithCategory_SetsAllFields()
     {

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
@@ -468,6 +468,38 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
         kbStatus.TotalChunks.Should().BeGreaterThan(0,
             "Block D: KnowledgeBaseStatusDto must surface the real chunk count when Ready, " +
             "not the 0 hardcoded at GetKnowledgeBaseStatusQueryHandler.cs:165.");
+
+        // #2284 follow-up coverage gap: assert the pipeline raises exactly 6
+        // PdfStateChangedEvent into the domain-event outbox (one per state transition:
+        // Pending→Uploading, Uploading→Extracting, Extracting→Chunking,
+        // Chunking→Embedding, Embedding→Indexing, Indexing→Ready) plus exactly 1
+        // KbDocIndexedEvent on the Ready transition. Pre-refactor the count was 1 due
+        // to the bridge-save shortcut (Uploading → Indexing via EF). The 6-event count
+        // matches the PdfDocument_SevenStateProgression baseline contract.
+        // Match outbox rows by checking the JSON payload contains the PdfDocumentId — the
+        // outbox row schema does not store an AggregateId column, so the test filters
+        // on the serialised event body. Acceptable in test scope because the only PDF in
+        // play is the one this test seeded.
+        var pdfIdString = pdfDocId.ToString();
+        var pdfStateChangedCount = await _dbContext.DomainEventOutbox
+            .AsNoTracking()
+            .CountAsync(
+                e => e.EventType.Contains("PdfStateChanged") && e.PayloadJson.Contains(pdfIdString),
+                TestCancellationToken);
+        pdfStateChangedCount.Should().Be(6,
+            "pipeline must raise PdfStateChangedEvent for EVERY state transition " +
+            "(Pending→Uploading + Uploading→Extracting + Extracting→Chunking + " +
+            "Chunking→Embedding + Embedding→Indexing + Indexing→Ready). " +
+            "If this counts 1, the bridge-save shortcut from PR #2295 has regressed.");
+
+        var kbDocIndexedCount = await _dbContext.DomainEventOutbox
+            .AsNoTracking()
+            .CountAsync(
+                e => e.EventType.Contains("KbDocIndexed") && e.PayloadJson.Contains(pdfIdString),
+                TestCancellationToken);
+        kbDocIndexedCount.Should().Be(1,
+            "KbDocIndexedEvent must fire exactly once per upload, raised by " +
+            "PdfDocument.TransitionTo(Ready) (PdfDocument.cs:435-442).");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes the 3 acknowledged tech debt items from the #2284 audit + the PdfStateChangedEvent coverage gap. EF state-mutation surface on PdfDocument is now **completely closed** in the upload pipeline.

| Item | Resolution |
|------|------------|
| **TD1** Drop `pdfDoc.ProcessedAt = ...` EF mutation | New `PdfDocument.MarkProcessed(DateTime)` domain method + replacement in `FinalizeProcessingAsync` |
| **TD2** Migrate 4 error-path Failed mutations to domain | New private helper `TransitionToFailedAsync(...)` using `MarkAsFailed` → 4 sites refactored |
| **TD3** Migrate initial Pending → Uploading mutation | `ValidateAndPrepareProcessingAsync` uses `TransitionStateAsync` |
| **Coverage gap** | Integration assertion: 6 `PdfStateChangedEvent` + 1 `KbDocIndexedEvent` in outbox per upload |

## Domain changes

### `PdfDocument.MarkProcessed(DateTime processedAt)` — new method
- Pure audit-field setter (no event raised)
- Invariant: `ProcessingState == Ready`; throws otherwise
- Pre-condition: caller has already called `TransitionTo(Ready)` (which raises `PdfStateChangedEvent` + `KbDocIndexedEvent`)

## Pipeline changes (UploadPdfCommandHandler.Processing.cs)

### TD1
```csharp
- pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
+ pdfDomain.TransitionTo(PdfProcessingState.Ready);
+ pdfDomain.MarkProcessed(_timeProvider.GetUtcNow().UtcDateTime);
```

### TD2 — new `TransitionToFailedAsync(...)` helper

```csharp
private async Task TransitionToFailedAsync(
    IServiceScope scope, MeepleAiDbContext db, Guid pdfGuid,
    string errorMessage, ErrorCategory category, PdfProcessingState? failedAtState,
    CancellationToken ct)
{
    var pdfRepo = scope.ServiceProvider.GetRequiredService<IPdfDocumentRepository>();
    var pdfDomain = await pdfRepo.GetByIdAsync(pdfGuid, ct);
    if (pdfDomain is null) { /* best-effort log + return */ }

    var resolvedFailedAtState = failedAtState ?? pdfDomain.ProcessingState;
    try
    {
        pdfDomain.MarkAsFailed(errorMessage, category, resolvedFailedAtState);
        await pdfRepo.UpdateAsync(pdfDomain, ct);
        await db.SaveChangesAsync(ct);
    }
    catch (DbUpdateConcurrencyException) { /* metric + log + swallow */ }
}
```

4 call sites migrated:
- Extraction failure → `Parsing` / `Extracting`
- `HandleEmbeddingFailureAsync` → `Service` / `Embedding`
- `HandleProcessingCancellationAsync` → `Unknown` / null (resolved from current state)
- `HandleProcessingErrorAsync` → `Unknown` / null (3 catch types: InvalidOperationException, DbUpdateException, generic Exception)

### TD3
```csharp
- pdfDoc.ProcessingState = nameof(PdfProcessingState.Uploading);
- await db.SaveChangesAsync(cancellationToken);
+ await TransitionStateAsync(scope, db, pdfGuid, PdfProcessingState.Uploading, ct);
+ // reload pdfDoc via AsNoTracking() because TransitionStateAsync detached it
```

## Integration test coverage gap

Added two assertions in `UploadPdf_OnSuccessfulIndexing_…`:

```csharp
// PdfStateChangedEvent: 6 per upload (one per state transition)
pdfStateChangedCount.Should().Be(6,
    "Pending→Uploading + Uploading→Extracting + Extracting→Chunking + " +
    "Chunking→Embedding + Embedding→Indexing + Indexing→Ready");

// KbDocIndexedEvent: 1 per upload (raised by TransitionTo(Ready))
kbDocIndexedCount.Should().Be(1);
```

Match by `PayloadJson.Contains(pdfDocId)` because `DomainEventOutboxEntity` has no `AggregateId` column.

## Behavior changes

- **Error path events**: 4 sites that previously raised 0 events on failure (silent state corruption) now raise 2 events per failure: `PdfStateChangedEvent(<prev> → Failed)` + `PdfFailedEvent`. Downstream metrics + notification handlers will start observing them.
- **Cancellation events**: 1 event per cancellation: `PdfStateChangedEvent(<prev> → Failed)` + `PdfFailedEvent`. Same as above.
- **No new HTTP API surface**.

## Test plan

- [x] 3 new unit tests for `MarkProcessed` (Ready→sets / non-Ready→throws / no event)
- [x] 55/55 PASS in slice (`PdfDocument_SevenStateProgression + PdfDocumentTests + UploadPdfCommandHandlerTests`)
- [x] Build: 0 errors / 0 warnings
- [x] Zero residual `pdfDoc.ProcessingState = ` / `pdfDoc.ProcessingError = ` / `pdfDoc.ProcessedAt = ` mutations in production code (3 hits remain — all in docstring text only)
- [ ] Integration test outbox count assertion (Testcontainers, CI exercises)

## Final state — #2284 follow-up arc complete

EF state mutation surface on `PdfDocument` is now **completely closed** in upload pipeline:

| Transition | Mechanism |
|------------|-----------|
| Pending → Uploading | `TransitionStateAsync` (TD3 ✅) |
| Uploading → Extracting → Chunking → Embedding → Indexing | `TransitionStateAsync` per step (PR #2297 ✅) |
| Indexing → Ready | `TransitionTo` + `MarkProcessed` (PR #2295 + TD1 ✅) |
| Any state → Failed | `TransitionToFailedAsync` (TD2 ✅) |

## Cross-refs

- Parent ticket: #2244 (closed by #2278)
- Residual tracker: #2284 (closed by PR C #2295)
- Audit: this session's audit message identified TD1+TD2+TD3 + coverage gap
- Memory: `P234 domain-event-bypass-via-ef-entity` (already references all PRs in arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)