### PR TITLE
feat(catalog): #2254+#2255 Phase F bundle — F5 bulk acknowledge + F6 attempt-source

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommand.cs
@@ -61,9 +61,17 @@ public sealed record AdminBulkAcknowledgeRow(
 /// <param name="AckedCount">Rows newly transitioned to acknowledged.</param>
 /// <param name="IdempotentNoOpCount">Rows already acknowledged before this request.</param>
 /// <param name="NotFoundCount">Ids that did not resolve to an existing attempt row.</param>
+/// <param name="WrongStateCount">
+/// Ids resolved to an attempt that is NOT in the dead-letter state (e.g. a fresh
+/// Success / Skipped / Failed-with-retry row) — reachable under a race with the
+/// 7-day retention sweep (DEC-3j) that deletes + re-creates rows. Surfaced so
+/// the admin chip can report "K skipped (wrong state)" instead of silently
+/// dropping these rows from the operator-visible count.
+/// </param>
 /// <param name="Rows">Per-input-id outcome detail in the order received.</param>
 public sealed record AdminBulkAcknowledgeResult(
     int AckedCount,
     int IdempotentNoOpCount,
     int NotFoundCount,
+    int WrongStateCount,
     IReadOnlyList<AdminBulkAcknowledgeRow> Rows);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommand.cs
@@ -1,0 +1,69 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Phase F F5 — admin bulk-acknowledge of one or more dead-letter
+/// attempts. Operator marks a row as "not actionable" so it disappears from
+/// the default list view without waiting for the DEC-3j 7-day retention sweep.
+/// Idempotent: re-acknowledging an already-acked row is a no-op
+/// (<see cref="AdminBulkAcknowledgeRow.OutcomeAlreadyAcked"/>).
+/// </summary>
+/// <param name="AttemptIds">
+/// Dead-letter attempt ids selected on the admin page. Capped at
+/// <see cref="Validators.AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxBatchSize"/>
+/// to mirror the F2 bulk-retry budget.
+/// </param>
+/// <param name="Note">
+/// Optional free-text note (DEC-F-4 log-only, max
+/// <see cref="Validators.AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxNoteLength"/>
+/// chars). Shown in the confirmation modal; surfaced in the structured log
+/// line but NOT persisted on the attempt row.
+/// </param>
+/// <param name="TriggeredByUserId">
+/// Acknowledging admin user id. Captured on the attempt row via the F5
+/// <c>Acknowledge(by, at)</c> mutator so the timeline drawer (F6) can render
+/// the "acked by &lt;admin&gt;" badge.
+/// </param>
+internal sealed record AdminBulkAcknowledgeWikidataCoverCommand(
+    IReadOnlyList<Guid> AttemptIds,
+    string? Note,
+    Guid TriggeredByUserId) : ICommand<AdminBulkAcknowledgeResult>;
+
+/// <summary>
+/// Per-row outcome on the bulk-acknowledge result envelope.
+/// </summary>
+public sealed record AdminBulkAcknowledgeRow(
+    Guid AttemptId,
+    Guid? GameId,
+    string Outcome,
+    string? Reason)
+{
+    /// <summary>Row was in dead-letter state and got freshly acknowledged.</summary>
+    public const string OutcomeAcked = "acked";
+
+    /// <summary>Row was already acknowledged previously; the operation is a no-op.</summary>
+    public const string OutcomeAlreadyAcked = "already-acked";
+
+    /// <summary>The supplied attempt id was not found (already swept, or typo).</summary>
+    public const string OutcomeNotFound = "not-found";
+
+    /// <summary>
+    /// The attempt exists but is NOT in the dead-letter state, so it cannot be
+    /// acknowledged (e.g. it is a fresh Success / Skipped / Failed-with-retry row).
+    /// </summary>
+    public const string OutcomeWrongState = "wrong-state";
+}
+
+/// <summary>
+/// Result envelope for <see cref="AdminBulkAcknowledgeWikidataCoverCommand"/>.
+/// </summary>
+/// <param name="AckedCount">Rows newly transitioned to acknowledged.</param>
+/// <param name="IdempotentNoOpCount">Rows already acknowledged before this request.</param>
+/// <param name="NotFoundCount">Ids that did not resolve to an existing attempt row.</param>
+/// <param name="Rows">Per-input-id outcome detail in the order received.</param>
+public sealed record AdminBulkAcknowledgeResult(
+    int AckedCount,
+    int IdempotentNoOpCount,
+    int NotFoundCount,
+    IReadOnlyList<AdminBulkAcknowledgeRow> Rows);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandler.cs
@@ -1,0 +1,137 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Phase F F5 (sub-issue #2254) — bulk-acknowledge dead-letter
+/// attempts. Hydrates each id via <see cref="IWikidataCoverEnrichmentAttemptRepository.GetByIdsAsync"/>,
+/// invokes the in-domain <see cref="WikidataCoverEnrichmentAttempt.Acknowledge"/>
+/// mutator (idempotent on re-call) and persists via <see cref="IUnitOfWork"/>.
+/// Per-row outcomes are bucketed into the result envelope (acked /
+/// already-acked / not-found / wrong-state) so the admin UI can render the
+/// partial success/failure table.
+/// </summary>
+/// <remarks>
+/// <para>Sequential per-row processing: each row mutation runs in-memory + a
+/// single repo <c>UpdateAsync</c> call (EF change-tracking attach); the
+/// batch-final <c>SaveChangesAsync</c> commits everything atomically. No
+/// per-row transaction overhead.</para>
+///
+/// <para><see cref="IUnitOfWork.SaveChangesAsync"/> is skipped entirely when
+/// no row was mutated (the all-idempotent-or-not-found path) to avoid an
+/// unnecessary round-trip — mirrors the EF Core convention that a no-op
+/// <c>SaveChanges</c> still costs a DB hit for the change-tracker scan.</para>
+///
+/// <para>Cancellation propagates via <see cref="CancellationToken.ThrowIfCancellationRequested"/>
+/// inside the per-row loop so a partially-applied batch fails fast rather than
+/// silently truncating the result envelope. Pre-loop bulk fetch already honors
+/// the token via the repository contract.</para>
+///
+/// <para>The optional <see cref="AdminBulkAcknowledgeWikidataCoverCommand.Note"/>
+/// is DEC-F-4 log-only — surfaced in the structured log line but NOT persisted
+/// on the attempt rows.</para>
+/// </remarks>
+internal sealed class AdminBulkAcknowledgeWikidataCoverCommandHandler
+    : ICommandHandler<AdminBulkAcknowledgeWikidataCoverCommand, AdminBulkAcknowledgeResult>
+{
+    private readonly IWikidataCoverEnrichmentAttemptRepository _attempts;
+    private readonly IUnitOfWork _uow;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<AdminBulkAcknowledgeWikidataCoverCommandHandler> _logger;
+
+    public AdminBulkAcknowledgeWikidataCoverCommandHandler(
+        IWikidataCoverEnrichmentAttemptRepository attempts,
+        IUnitOfWork uow,
+        TimeProvider timeProvider,
+        ILogger<AdminBulkAcknowledgeWikidataCoverCommandHandler> logger)
+    {
+        _attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+        _uow = uow ?? throw new ArgumentNullException(nameof(uow));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AdminBulkAcknowledgeResult> Handle(
+        AdminBulkAcknowledgeWikidataCoverCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        _logger.LogInformation(
+            "AdminBulkAcknowledgeWikidataCover: user {UserId} acking {Count} attempt(s); note={Note}",
+            request.TriggeredByUserId, request.AttemptIds.Count, request.Note ?? "<none>");
+
+        var loaded = await _attempts
+            .GetByIdsAsync(request.AttemptIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        var rows = new List<AdminBulkAcknowledgeRow>(request.AttemptIds.Count);
+        var acked = 0;
+        var alreadyAcked = 0;
+        var notFound = 0;
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var anyUpdated = false;
+
+        foreach (var id in request.AttemptIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!loaded.TryGetValue(id, out var attempt))
+            {
+                rows.Add(new AdminBulkAcknowledgeRow(
+                    AttemptId: id,
+                    GameId: null,
+                    Outcome: AdminBulkAcknowledgeRow.OutcomeNotFound,
+                    Reason: "attempt-id-not-found"));
+                notFound++;
+                continue;
+            }
+
+            if (attempt.Outcome != WikidataCoverEnrichmentOutcome.DeadLetter)
+            {
+                rows.Add(new AdminBulkAcknowledgeRow(
+                    AttemptId: id,
+                    GameId: attempt.SharedGameId,
+                    Outcome: AdminBulkAcknowledgeRow.OutcomeWrongState,
+                    Reason: $"current-outcome:{attempt.Outcome}"));
+                continue;
+            }
+
+            if (attempt.AcknowledgedAt is not null)
+            {
+                rows.Add(new AdminBulkAcknowledgeRow(
+                    AttemptId: id,
+                    GameId: attempt.SharedGameId,
+                    Outcome: AdminBulkAcknowledgeRow.OutcomeAlreadyAcked,
+                    Reason: null));
+                alreadyAcked++;
+                continue;
+            }
+
+            attempt.Acknowledge(request.TriggeredByUserId, nowUtc);
+            await _attempts.UpdateAsync(attempt, cancellationToken).ConfigureAwait(false);
+            rows.Add(new AdminBulkAcknowledgeRow(
+                AttemptId: id,
+                GameId: attempt.SharedGameId,
+                Outcome: AdminBulkAcknowledgeRow.OutcomeAcked,
+                Reason: null));
+            acked++;
+            anyUpdated = true;
+        }
+
+        if (anyUpdated)
+        {
+            await _uow.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new AdminBulkAcknowledgeResult(
+            AckedCount: acked,
+            IdempotentNoOpCount: alreadyAcked,
+            NotFoundCount: notFound,
+            Rows: rows);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandler.cs
@@ -73,6 +73,7 @@ internal sealed class AdminBulkAcknowledgeWikidataCoverCommandHandler
         var acked = 0;
         var alreadyAcked = 0;
         var notFound = 0;
+        var wrongState = 0;
         var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
         var anyUpdated = false;
 
@@ -98,6 +99,7 @@ internal sealed class AdminBulkAcknowledgeWikidataCoverCommandHandler
                     GameId: attempt.SharedGameId,
                     Outcome: AdminBulkAcknowledgeRow.OutcomeWrongState,
                     Reason: $"current-outcome:{attempt.Outcome}"));
+                wrongState++;
                 continue;
             }
 
@@ -132,6 +134,7 @@ internal sealed class AdminBulkAcknowledgeWikidataCoverCommandHandler
             AckedCount: acked,
             IdempotentNoOpCount: alreadyAcked,
             NotFoundCount: notFound,
+            WrongStateCount: wrongState,
             Rows: rows);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommand.cs
@@ -14,8 +14,11 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatal
 /// </summary>
 /// <param name="AttemptIds">Dead-letter attempt ids selected on the admin page (max 50 enforced by the validator).</param>
 /// <param name="TriggeredByUserId">
-/// Admin user id captured ONLY in the structured log line; not persisted on the
-/// new attempt rows. Same intent as <see cref="AdminEnrichWikidataCoverCommand.TriggeredByUserId"/>.
+/// Admin user id of the operator who initiated the bulk-retry. Captured in the
+/// structured log line AND threaded into each per-row runner invocation so the
+/// new attempt rows persist <c>TriggeredByAdminUserId</c>. Same semantics as
+/// <see cref="AdminEnrichWikidataCoverCommand.TriggeredByUserId"/>; surfaces on
+/// the F6 timeline drawer + F4 SSE payload. Issue #1823 Phase F F6.
 /// </param>
 internal sealed record AdminBulkRetryWikidataCoverCommand(
     IReadOnlyList<Guid> AttemptIds,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs
@@ -76,8 +76,15 @@ internal sealed class AdminBulkRetryWikidataCoverCommandHandler
 
             try
             {
+                // Issue #1823 Phase F F6: pass the bulk-retry initiator id to
+                // the runner so each re-dispatched attempt row records the
+                // admin who pressed the button (mirror of M12 single-trigger).
                 await _runner
-                    .EnrichAndRecordAsync(gameId, forceRefresh: true, cancellationToken)
+                    .EnrichAndRecordAsync(
+                        gameId,
+                        forceRefresh: true,
+                        triggeredByAdminUserId: request.TriggeredByUserId,
+                        cancellationToken)
                     .ConfigureAwait(false);
 
                 rows.Add(new AdminBulkRetryRow(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommand.cs
@@ -12,16 +12,14 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatal
 /// <param name="GameId">Target shared-game id.</param>
 /// <param name="ForceRefresh">When <see langword="true"/>, the M8 90-day freshness window is bypassed.</param>
 /// <param name="TriggeredByUserId">
-/// Admin user id captured ONLY in the structured log line emitted by the handler
-/// (<c>AdminEnrichWikidataCover: triggered by user {UserId} for game {GameId}</c>) —
-/// NOT persisted to the <c>WikidataCoverEnrichmentAttempt</c> row. This is by
-/// design for M12 scope: attempt rows are record-of-fact about the enrichment
-/// pipeline outcome (success / skipped / failed / dead-letter) and remain
-/// indistinguishable between scheduler-triggered and admin-triggered runs so
-/// the audit trail stays uniform. If the M13 admin dead-letter page needs to
-/// show "triggered by admin X", it must source that information from the
-/// structured log stream or a separate trigger-audit table introduced in M13,
-/// not from <c>WikidataCoverEnrichmentAttempt</c>.
+/// Admin user id of the operator pressing the trigger button. Captured in the
+/// structured log line emitted by the handler (<c>AdminEnrichWikidataCover:
+/// triggered by user {UserId} for game {GameId}</c>) AND threaded into the
+/// runner so it is persisted on the new
+/// <c>WikidataCoverEnrichmentAttempt.TriggeredByAdminUserId</c> column —
+/// surfacing "triggered by admin X" on the F6 timeline drawer + F4 SSE payload
+/// without a separate audit table. Issue #1823 Phase F F6 (was log-only in M12,
+/// promoted to persisted in F6 per #2255 carry-forward).
 /// </param>
 internal sealed record AdminEnrichWikidataCoverCommand(
     Guid GameId,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandler.cs
@@ -35,8 +35,16 @@ internal sealed class AdminEnrichWikidataCoverCommandHandler
             "AdminEnrichWikidataCover: triggered by user {UserId} for game {GameId} (forceRefresh={ForceRefresh})",
             request.TriggeredByUserId, request.GameId, request.ForceRefresh);
 
+        // Issue #1823 Phase F F6: thread the admin user id into the runner so
+        // it is persisted on the attempt row + broadcast on the SSE payload —
+        // surfacing "triggered by admin X" in the admin timeline drawer + dead-letter
+        // page without a separate audit table.
         var result = await _runner
-            .EnrichAndRecordAsync(request.GameId, request.ForceRefresh, cancellationToken)
+            .EnrichAndRecordAsync(
+                request.GameId,
+                request.ForceRefresh,
+                triggeredByAdminUserId: request.TriggeredByUserId,
+                cancellationToken)
             .ConfigureAwait(false);
 
         return result switch

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs
@@ -141,7 +141,16 @@ public sealed class WikidataCoverEnrichmentJob : IJob
                 // Scheduler always uses forceRefresh=false — freshness window
                 // honoured. The admin trigger endpoint uses forceRefresh=true
                 // for dogfood re-runs.
-                await runner.EnrichAndRecordAsync(gameId, forceRefresh: false, ct).ConfigureAwait(false);
+                //
+                // Issue #1823 Phase F F6: the scheduler tick has no admin actor,
+                // so triggeredByAdminUserId stays at its default null — attempt
+                // rows authored by the cron are persisted with a null trigger
+                // source so the admin UI can distinguish them from manual M12/F2
+                // dispatches. Named arg avoids silent positional drift if the
+                // runner signature grows in future.
+                await runner
+                    .EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: ct)
+                    .ConfigureAwait(false);
                 processed++;
             }
             // OperationCanceledException is intentionally allowed to propagate

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs
@@ -22,7 +22,12 @@ public sealed record WikidataAttemptTimelineResult(
 
 /// <summary>
 /// Per-node payload on the timeline. Each maps 1:1 to a
-/// <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/> row.
+/// <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/> row,
+/// enriched with the F6 admin attribution (<see cref="TriggeredByAdminUserId"/>
+/// and <see cref="TriggeredByAdminFullName"/>) when the attempt was kicked off
+/// from the admin bulk-retry path (Phase F #2255). Both attribution fields are
+/// null for system/cron-triggered attempts so the FE can decide whether to
+/// render the badge.
 /// </summary>
 public sealed record WikidataAttemptTimelineNode(
     Guid Id,
@@ -32,7 +37,9 @@ public sealed record WikidataAttemptTimelineNode(
     string? Details,
     int RetryCount,
     DateTime? NextRetryAt,
-    DateTime? DeadLetteredAt);
+    DateTime? DeadLetteredAt,
+    Guid? TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
 
 internal sealed class GetWikidataAttemptTimelineQueryHandler
     : IRequestHandler<GetWikidataAttemptTimelineQuery, WikidataAttemptTimelineResult>
@@ -54,11 +61,9 @@ internal sealed class GetWikidataAttemptTimelineQueryHandler
             .GetAttemptsByGameIdAsync(request.GameId, request.Limit, cancellationToken)
             .ConfigureAwait(false);
 
-        // Task 2.3 bridge — Task 3.4 will extend WikidataAttemptTimelineNode
-        // with the F6 admin attribution (TriggeredByAdminUserId +
-        // TriggeredByAdminFullName) so the FE drawer can render the badge.
-        // For now the row exposes the new repo fields but the DTO ignores
-        // them to keep the FE contract stable in this commit.
+        // Task 3.4 (#2255 F6) — bridge lifted. The repo row already carries the
+        // admin LEFT JOIN result so we pass `TriggeredByAdminUserId` and
+        // `TriggeredByAdminFullName` straight through to the FE drawer badge.
         var items = rows
             .Select(r => new WikidataAttemptTimelineNode(
                 r.Id,
@@ -68,7 +73,9 @@ internal sealed class GetWikidataAttemptTimelineQueryHandler
                 r.Details,
                 r.RetryCount,
                 r.NextRetryAt,
-                r.DeadLetteredAt))
+                r.DeadLetteredAt,
+                r.TriggeredByAdminUserId,
+                r.TriggeredByAdminFullName))
             .ToList();
 
         return new WikidataAttemptTimelineResult(request.GameId, items);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs
@@ -1,4 +1,3 @@
-using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using MediatR;
 
@@ -51,20 +50,25 @@ internal sealed class GetWikidataAttemptTimelineQueryHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var attempts = await _attempts
+        var rows = await _attempts
             .GetAttemptsByGameIdAsync(request.GameId, request.Limit, cancellationToken)
             .ConfigureAwait(false);
 
-        var items = attempts
-            .Select(a => new WikidataAttemptTimelineNode(
-                a.Id,
-                a.AttemptedAt,
-                a.Outcome.ToString(),
-                a.Reason,
-                a.Details,
-                a.RetryCount,
-                a.NextRetryAt,
-                a.DeadLetteredAt))
+        // Task 2.3 bridge — Task 3.4 will extend WikidataAttemptTimelineNode
+        // with the F6 admin attribution (TriggeredByAdminUserId +
+        // TriggeredByAdminFullName) so the FE drawer can render the badge.
+        // For now the row exposes the new repo fields but the DTO ignores
+        // them to keep the FE contract stable in this commit.
+        var items = rows
+            .Select(r => new WikidataAttemptTimelineNode(
+                r.Id,
+                r.AttemptedAt,
+                r.Outcome.ToString(),
+                r.Reason,
+                r.Details,
+                r.RetryCount,
+                r.NextRetryAt,
+                r.DeadLetteredAt))
             .ToList();
 
         return new WikidataAttemptTimelineResult(request.GameId, items);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
@@ -8,14 +8,23 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 /// Issue #1823 Wave 3 M13 — paginated list of Wikidata cover enrichment
 /// dead-letter attempts for the admin visibility page. Filterable by
 /// terminal reason (e.g. <c>r2-upload-error</c>, <c>license-not-whitelisted</c>).
+/// Phase F (#2254) added <see cref="IncludeAcknowledged"/> so the admin UI can
+/// toggle between the default open-work view (hide acknowledged rows) and the
+/// historical audit view (show everything).
 /// </summary>
 /// <param name="Skip">Pagination offset (clamped to 0).</param>
 /// <param name="Take">Page size (clamped to [1, 200]).</param>
 /// <param name="ReasonFilter">Optional exact match on the <c>Reason</c> column; null returns all dead-letters.</param>
+/// <param name="IncludeAcknowledged">
+/// When <see langword="false"/> (default), rows whose <c>AcknowledgedAt</c> is
+/// non-null are hidden so operators only see open-work items. When
+/// <see langword="true"/>, all dead-letters are returned for the audit view.
+/// </param>
 internal sealed record GetWikidataDeadLetterAttemptsQuery(
     int Skip,
     int Take,
-    string? ReasonFilter) : IRequest<WikidataDeadLetterAttemptsResult>;
+    string? ReasonFilter,
+    bool IncludeAcknowledged = false) : IRequest<WikidataDeadLetterAttemptsResult>;
 
 /// <summary>
 /// Flat DTO returned by <see cref="GetWikidataDeadLetterAttemptsQuery"/>.
@@ -27,8 +36,23 @@ public sealed record WikidataDeadLetterAttemptsResult(
     int Take);
 
 /// <summary>
-/// Per-row dead-letter DTO surfaced on the M13 admin page.
+/// Per-row dead-letter DTO surfaced on the M13 admin page. Phase F extended
+/// the shape with F5 ack metadata and F6 admin attribution surfaced via the
+/// repository LEFT JOIN on Users.
 /// </summary>
+/// <param name="Id">Attempt id.</param>
+/// <param name="SharedGameId">Parent shared game id.</param>
+/// <param name="GameTitle">Denormalized parent title (fallback "(deleted game)").</param>
+/// <param name="AttemptedAt">UTC attempt timestamp.</param>
+/// <param name="DeadLetteredAt">UTC dead-letter timestamp.</param>
+/// <param name="Reason">Stable machine-readable reason.</param>
+/// <param name="Details">Optional human-readable detail.</param>
+/// <param name="RetryCount">0..N counter from the original pipeline.</param>
+/// <param name="AcknowledgedAt">F5 — UTC ack timestamp (null if not acknowledged).</param>
+/// <param name="AcknowledgedBy">F5 — user id who acknowledged (null if not acknowledged).</param>
+/// <param name="AcknowledgedByFullName">F5 — display name of the acknowledging user (null if not acknowledged or user deleted).</param>
+/// <param name="TriggeredByAdminUserId">F6 — admin user id that triggered this attempt via M12/F2 (null for M9 scheduler).</param>
+/// <param name="TriggeredByAdminFullName">F6 — display name of the triggering admin (null when M9 scheduler or user deleted).</param>
 public sealed record WikidataDeadLetterAttemptDto(
     Guid Id,
     Guid SharedGameId,
@@ -37,7 +61,12 @@ public sealed record WikidataDeadLetterAttemptDto(
     DateTime DeadLetteredAt,
     string Reason,
     string? Details,
-    int RetryCount);
+    int RetryCount,
+    DateTime? AcknowledgedAt,
+    Guid? AcknowledgedBy,
+    string? AcknowledgedByFullName,
+    Guid? TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
 
 internal sealed class GetWikidataDeadLetterAttemptsQueryHandler
     : IRequestHandler<GetWikidataDeadLetterAttemptsQuery, WikidataDeadLetterAttemptsResult>
@@ -58,12 +87,8 @@ internal sealed class GetWikidataDeadLetterAttemptsQueryHandler
         var skip = Math.Max(0, request.Skip);
         var take = Math.Clamp(request.Take, 1, 200);
 
-        // Task 2.3 bridge — Task 3.3 will propagate an optional
-        // IncludeAcknowledged param through the query DTO. For now retain the
-        // existing semantics (hide acknowledged rows on the default open-work
-        // view) by hard-coding includeAcknowledged: false.
         var page = await _attempts
-            .GetDeadLettersAsync(skip, take, request.ReasonFilter, includeAcknowledged: false, cancellationToken)
+            .GetDeadLettersAsync(skip, take, request.ReasonFilter, request.IncludeAcknowledged, cancellationToken)
             .ConfigureAwait(false);
 
         var items = page.Items
@@ -75,7 +100,12 @@ internal sealed class GetWikidataDeadLetterAttemptsQueryHandler
                 row.DeadLetteredAt,
                 row.Reason,
                 row.Details,
-                row.RetryCount))
+                row.RetryCount,
+                row.AcknowledgedAt,
+                row.AcknowledgedBy,
+                row.AcknowledgedByFullName,
+                row.TriggeredByAdminUserId,
+                row.TriggeredByAdminFullName))
             .ToList();
 
         return new WikidataDeadLetterAttemptsResult(items, page.TotalCount, skip, take);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs
@@ -58,8 +58,12 @@ internal sealed class GetWikidataDeadLetterAttemptsQueryHandler
         var skip = Math.Max(0, request.Skip);
         var take = Math.Clamp(request.Take, 1, 200);
 
+        // Task 2.3 bridge — Task 3.3 will propagate an optional
+        // IncludeAcknowledged param through the query DTO. For now retain the
+        // existing semantics (hide acknowledged rows on the default open-work
+        // view) by hard-coding includeAcknowledged: false.
         var page = await _attempts
-            .GetDeadLettersAsync(skip, take, request.ReasonFilter, cancellationToken)
+            .GetDeadLettersAsync(skip, take, request.ReasonFilter, includeAcknowledged: false, cancellationToken)
             .ConfigureAwait(false);
 
         var items = page.Items

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataCoverEnrichmentRunner.cs
@@ -22,10 +22,20 @@ internal interface IWikidataCoverEnrichmentRunner
     /// window (admin dogfood / edge-case re-runs); the scheduler always passes
     /// <see langword="false"/>.
     /// </param>
+    /// <param name="triggeredByAdminUserId">
+    /// Issue #1823 Phase F F6 — user id of the admin who triggered this attempt
+    /// (M12 single trigger or F2 bulk retry). Stamped onto the persisted
+    /// <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.WikidataCoverEnrichmentAttempt.TriggeredByAdminUserId"/>
+    /// and on the SSE broadcast payload so the admin timeline drawer + dead-letter
+    /// page can show "triggered by admin X" without a separate audit table.
+    /// Defaults to <see langword="null"/> for the M9 scheduler tick (the dominant
+    /// caller); admin callers MUST pass their user id explicitly.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token honoured by all downstream calls.</param>
     /// <returns>The terminal outcome of the underlying <see cref="EnrichCatalogCoverCommand"/>.</returns>
     Task<EnrichCatalogCoverResult> EnrichAndRecordAsync(
         Guid gameId,
         bool forceRefresh,
+        Guid? triggeredByAdminUserId = null,
         CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataEnrichmentEventBroadcaster.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataEnrichmentEventBroadcaster.cs
@@ -43,6 +43,28 @@ public interface IWikidataEnrichmentEventBroadcaster
 /// projection of <see cref="Domain.Aggregates.WikidataCoverEnrichmentAttempt"/>
 /// needed to refresh the admin dead-letter row inline.
 /// </summary>
+/// <param name="AttemptId">Stable id of the persisted attempt row.</param>
+/// <param name="SharedGameId">Target shared-game aggregate id.</param>
+/// <param name="Outcome">Stringified <see cref="Domain.Aggregates.WikidataCoverEnrichmentOutcome"/> name.</param>
+/// <param name="Reason">Stable machine-readable reason; <see langword="null"/> on success.</param>
+/// <param name="AttemptedAt">UTC timestamp when the attempt ran.</param>
+/// <param name="RetryCount">0-based retry count for this attempt row.</param>
+/// <param name="NextRetryAt">UTC retry schedule; <see langword="null"/> on terminal outcomes.</param>
+/// <param name="DeadLetteredAt">UTC dead-letter timestamp; <see langword="null"/> unless <see cref="Outcome"/> is <c>DeadLetter</c>.</param>
+/// <param name="TriggeredByAdminUserId">
+/// Issue #1823 Phase F F6 — user id of the admin who triggered this attempt via
+/// M12 or F2; <see langword="null"/> when the M9 scheduler authored it. The
+/// broadcaster only knows the id (resolving to a full name would require a DB
+/// LEFT JOIN per publish, which is incompatible with the synchronous fire-and-forget
+/// contract and the DEC-3e scheduler tick budget). Subscribers that need the
+/// display name fetch it via the F6 timeline query path.
+/// </param>
+/// <param name="TriggeredByAdminFullName">
+/// Always <see langword="null"/> on the broadcast payload — resolved server-side
+/// in the F6 timeline query via LEFT JOIN. Retained on the wire schema so
+/// subscribers see a stable shape and can degrade gracefully when the FullName
+/// is unknown.
+/// </param>
 public sealed record WikidataEnrichmentEvent(
     Guid AttemptId,
     Guid SharedGameId,
@@ -51,4 +73,6 @@ public sealed record WikidataEnrichmentEvent(
     DateTime AttemptedAt,
     int RetryCount,
     DateTime? NextRetryAt,
-    DateTime? DeadLetteredAt);
+    DateTime? DeadLetteredAt,
+    Guid? TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs
@@ -45,6 +45,7 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
     public async Task<EnrichCatalogCoverResult> EnrichAndRecordAsync(
         Guid gameId,
         bool forceRefresh,
+        Guid? triggeredByAdminUserId = null,
         CancellationToken cancellationToken = default)
     {
         var previous = await _attempts
@@ -78,21 +79,26 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
             _ => previousRetryCount,
         };
 
+        // Issue #1823 Phase F F6: thread the triggering admin id into every
+        // factory variant so attempt rows persist the trigger source (M9 cron =
+        // null, M12 admin = id, F2 bulk-retry = id). The default null on the
+        // factory signatures keeps existing callers backward-compatible.
         WikidataCoverEnrichmentAttempt newAttempt = (decision, result) switch
         {
             (WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Success) =>
-                WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, nextRetryCount, nowUtc),
+                WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, nextRetryCount, nowUtc, triggeredByAdminUserId),
 
             (WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Skipped skipped) =>
-                WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, skipped.Reason, nextRetryCount, nowUtc),
+                WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, skipped.Reason, nextRetryCount, nowUtc, triggeredByAdminUserId),
 
             (WikidataCoverEnrichmentRetryDecision.ScheduleRetry retry, EnrichCatalogCoverResult.Failed failed) =>
                 WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
-                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, retry.NextRetryAt),
+                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, retry.NextRetryAt,
+                    triggeredByAdminUserId),
 
             (WikidataCoverEnrichmentRetryDecision.DeadLetter, EnrichCatalogCoverResult.Failed failed) =>
                 WikidataCoverEnrichmentAttempt.RecordDeadLetter(
-                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc),
+                    gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, triggeredByAdminUserId),
 
             // Defensive: a mismatched (decision, result) pair shouldn't happen
             // because the policy only emits ScheduleRetry/DeadLetter for Failed
@@ -100,7 +106,7 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
             _ => WikidataCoverEnrichmentAttempt.RecordDeadLetter(
                 gameId, "unexpected-decision",
                 $"{decision.GetType().Name} for {result.GetType().Name}",
-                nextRetryCount, nowUtc),
+                nextRetryCount, nowUtc, triggeredByAdminUserId),
         };
 
         await _attempts.AddAsync(newAttempt, cancellationToken).ConfigureAwait(false);
@@ -121,6 +127,12 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
         // The broadcaster is fire-and-forget; a slow SSE subscriber is
         // dropped rather than back-pressured (per its DropOldest channel
         // policy) so the M9 scheduler tick budget is preserved.
+        //
+        // F6 (Phase F): the payload includes TriggeredByAdminUserId so the
+        // admin SSE consumer can update the row inline; TriggeredByAdminFullName
+        // is intentionally null here (resolved in the F6 timeline query path
+        // via LEFT JOIN — the broadcaster cannot afford a per-publish DB lookup
+        // without breaking the DEC-3e scheduler tick budget).
         _broadcaster.Publish(new WikidataEnrichmentEvent(
             AttemptId: newAttempt.Id,
             SharedGameId: newAttempt.SharedGameId,
@@ -129,11 +141,13 @@ internal sealed class WikidataCoverEnrichmentRunner : IWikidataCoverEnrichmentRu
             AttemptedAt: newAttempt.AttemptedAt,
             RetryCount: newAttempt.RetryCount,
             NextRetryAt: newAttempt.NextRetryAt,
-            DeadLetteredAt: newAttempt.DeadLetteredAt));
+            DeadLetteredAt: newAttempt.DeadLetteredAt,
+            TriggeredByAdminUserId: newAttempt.TriggeredByAdminUserId,
+            TriggeredByAdminFullName: null));
 
         _logger.LogDebug(
-            "WikidataCoverEnrichmentRunner: game {GameId} outcome={Outcome} reason={Reason} retry={RetryCount} nextRetryAt={NextRetryAt} forceRefresh={ForceRefresh}",
-            gameId, newAttempt.Outcome, newAttempt.Reason, newAttempt.RetryCount, newAttempt.NextRetryAt, forceRefresh);
+            "WikidataCoverEnrichmentRunner: game {GameId} outcome={Outcome} reason={Reason} retry={RetryCount} nextRetryAt={NextRetryAt} forceRefresh={ForceRefresh} triggeredByAdmin={TriggeredByAdminUserId}",
+            gameId, newAttempt.Outcome, newAttempt.Reason, newAttempt.RetryCount, newAttempt.NextRetryAt, forceRefresh, newAttempt.TriggeredByAdminUserId);
 
         return result;
     }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidator.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+/// <summary>
+/// Validator for <see cref="AdminBulkAcknowledgeWikidataCoverCommand"/>. Caps
+/// the batch at <see cref="MaxBatchSize"/> (DEC-3e shared rate-limiter budget,
+/// mirror of F2 bulk-retry) and the optional note at <see cref="MaxNoteLength"/>
+/// (DEC-F-4 log-only payload). Issue #1823 Phase F F5.
+/// </summary>
+internal sealed class AdminBulkAcknowledgeWikidataCoverCommandValidator
+    : AbstractValidator<AdminBulkAcknowledgeWikidataCoverCommand>
+{
+    /// <summary>
+    /// Maximum number of attempts that can be acknowledged in a single admin
+    /// click. Larger batches must be split across multiple requests. Mirrors
+    /// <c>AdminBulkRetryWikidataCoverCommandValidator.MaxBatchSize</c>.
+    /// </summary>
+    public const int MaxBatchSize = 50;
+
+    /// <summary>
+    /// Maximum length of the optional acknowledgement note. The note is
+    /// log-only (not persisted on the attempt row) but we still cap it so the
+    /// audit-log payload stays small.
+    /// </summary>
+    public const int MaxNoteLength = 500;
+
+    public AdminBulkAcknowledgeWikidataCoverCommandValidator()
+    {
+        RuleFor(x => x.AttemptIds)
+            .Cascade(CascadeMode.Stop)
+            .NotNull()
+            .NotEmpty()
+            .WithMessage("AttemptIds must contain at least one id.")
+            .Must(ids => ids.Count <= MaxBatchSize)
+            .WithMessage($"AttemptIds cannot exceed {MaxBatchSize} per request.")
+            .Must(ids => ids.All(id => id != Guid.Empty))
+            .WithMessage("AttemptIds must not contain Guid.Empty.")
+            .Must(ids => ids.Distinct().Count() == ids.Count)
+            .WithMessage("AttemptIds must not contain duplicates.");
+
+        RuleFor(x => x.Note)
+            .MaximumLength(MaxNoteLength)
+            .When(x => x.Note is not null)
+            .WithMessage($"Note must be {MaxNoteLength} characters or fewer.");
+
+        RuleFor(x => x.TriggeredByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("TriggeredByUserId must not be empty.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs
@@ -71,6 +71,12 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
     /// <summary>UTC timestamp at which the attempt was dead-lettered. Non-null only when <see cref="Outcome"/> is <see cref="WikidataCoverEnrichmentOutcome.DeadLetter"/>.</summary>
     public DateTime? DeadLetteredAt { get; private set; }
 
+    /// <summary>UTC timestamp when an operator acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged or not a dead-letter.</summary>
+    public DateTime? AcknowledgedAt { get; private set; }
+
+    /// <summary>User id of the operator who acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged.</summary>
+    public Guid? AcknowledgedBy { get; private set; }
+
     /// <summary>EF Core / repository reconstitution — do not call directly.</summary>
     private WikidataCoverEnrichmentAttempt() : base() { }
 
@@ -190,5 +196,34 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
             retryCount: retryCount,
             nextRetryAt: nextRetryAt,
             deadLetteredAt: deadLetteredAt);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Mutators
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Issue #1823 Phase F F5 — operator marks a dead-letter as "not actionable".
+    /// EXCEPTION to the record-of-fact pattern documented on the type: ack is
+    /// operational metadata orthogonal to the pipeline (parallel to
+    /// <see cref="DeadLetteredAt"/>), not a new pipeline event. Idempotent on
+    /// re-call: the first ack is preserved and subsequent calls are no-ops so
+    /// repeated bulk-acknowledge clicks cannot rewrite the audit trail.
+    /// </summary>
+    /// <param name="userId">Acknowledging admin user id; must not be <see cref="Guid.Empty"/>.</param>
+    /// <param name="ackedAt">UTC acknowledgement timestamp.</param>
+    public void Acknowledge(Guid userId, DateTime ackedAt)
+    {
+        if (Outcome != WikidataCoverEnrichmentOutcome.DeadLetter)
+            throw new InvalidOperationException(
+                $"Only DeadLetter attempts can be acknowledged; current Outcome={Outcome}.");
+
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId cannot be Guid.Empty.", nameof(userId));
+
+        if (AcknowledgedAt is not null) return; // idempotent
+
+        AcknowledgedAt = ackedAt;
+        AcknowledgedBy = userId;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs
@@ -74,8 +74,19 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
     /// <summary>UTC timestamp when an operator acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged or not a dead-letter.</summary>
     public DateTime? AcknowledgedAt { get; private set; }
 
-    /// <summary>User id of the operator who acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged.</summary>
+    /// <summary>
+    /// User id of the operator who acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged.
+    /// Invariant pair with <see cref="AcknowledgedAt"/>: both fields are non-null iff the row has been acknowledged
+    /// (they are written atomically in <see cref="Acknowledge"/> and must be reconstituted together).
+    /// </summary>
     public Guid? AcknowledgedBy { get; private set; }
+
+    /// <summary>
+    /// Issue #1823 Phase F F6 — user id of the admin who manually triggered this
+    /// attempt via M12 (single trigger) or F2 (bulk retry). <see langword="null"/>
+    /// when invoked by the M9 scheduler (the default path).
+    /// </summary>
+    public Guid? TriggeredByAdminUserId { get; private set; }
 
     /// <summary>EF Core / repository reconstitution — do not call directly.</summary>
     private WikidataCoverEnrichmentAttempt() : base() { }
@@ -89,7 +100,10 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
         string? details,
         int retryCount,
         DateTime? nextRetryAt,
-        DateTime? deadLetteredAt) : base(id)
+        DateTime? deadLetteredAt,
+        DateTime? acknowledgedAt,
+        Guid? acknowledgedBy,
+        Guid? triggeredByAdminUserId) : base(id)
     {
         SharedGameId = sharedGameId;
         AttemptedAt = attemptedAt;
@@ -99,6 +113,9 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
         RetryCount = retryCount;
         NextRetryAt = nextRetryAt;
         DeadLetteredAt = deadLetteredAt;
+        AcknowledgedAt = acknowledgedAt;
+        AcknowledgedBy = acknowledgedBy;
+        TriggeredByAdminUserId = triggeredByAdminUserId;
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -109,20 +126,24 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
     public static WikidataCoverEnrichmentAttempt RecordSuccess(
         Guid sharedGameId,
         int retryCount,
-        DateTime attemptedAt) =>
+        DateTime attemptedAt,
+        Guid? triggeredByAdminUserId = null) =>
         Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.Success,
             reason: "success", details: null, retryCount: retryCount,
-            nextRetryAt: null, deadLetteredAt: null);
+            nextRetryAt: null, deadLetteredAt: null,
+            triggeredByAdminUserId: triggeredByAdminUserId);
 
     /// <summary>Records a business skip (qid-missing, license-not-whitelisted, etc.). Terminal — no retry.</summary>
     public static WikidataCoverEnrichmentAttempt RecordSkipped(
         Guid sharedGameId,
         string reason,
         int retryCount,
-        DateTime attemptedAt) =>
+        DateTime attemptedAt,
+        Guid? triggeredByAdminUserId = null) =>
         Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.Skipped,
             reason: reason, details: null, retryCount: retryCount,
-            nextRetryAt: null, deadLetteredAt: null);
+            nextRetryAt: null, deadLetteredAt: null,
+            triggeredByAdminUserId: triggeredByAdminUserId);
 
     /// <summary>Records a technical failure with a retry scheduled.</summary>
     public static WikidataCoverEnrichmentAttempt RecordFailedWithRetry(
@@ -131,10 +152,12 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
         string? details,
         int retryCount,
         DateTime attemptedAt,
-        DateTime nextRetryAt) =>
+        DateTime nextRetryAt,
+        Guid? triggeredByAdminUserId = null) =>
         Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.Failed,
             reason: reason, details: details, retryCount: retryCount,
-            nextRetryAt: nextRetryAt, deadLetteredAt: null);
+            nextRetryAt: nextRetryAt, deadLetteredAt: null,
+            triggeredByAdminUserId: triggeredByAdminUserId);
 
     /// <summary>Records a dead-letter — terminal failure after max retries OR unrecoverable error.</summary>
     public static WikidataCoverEnrichmentAttempt RecordDeadLetter(
@@ -142,10 +165,12 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
         string reason,
         string? details,
         int retryCount,
-        DateTime attemptedAt) =>
+        DateTime attemptedAt,
+        Guid? triggeredByAdminUserId = null) =>
         Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.DeadLetter,
             reason: reason, details: details, retryCount: retryCount,
-            nextRetryAt: null, deadLetteredAt: attemptedAt);
+            nextRetryAt: null, deadLetteredAt: attemptedAt,
+            triggeredByAdminUserId: triggeredByAdminUserId);
 
     /// <summary>Repository hydration — bypasses invariants. Caller guarantees state validity.</summary>
     public static WikidataCoverEnrichmentAttempt Reconstitute(
@@ -157,9 +182,13 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
         string? details,
         int retryCount,
         DateTime? nextRetryAt,
-        DateTime? deadLetteredAt) =>
+        DateTime? deadLetteredAt,
+        DateTime? acknowledgedAt,
+        Guid? acknowledgedBy,
+        Guid? triggeredByAdminUserId) =>
         new(id, sharedGameId, attemptedAt, outcome, reason, details,
-            retryCount, nextRetryAt, deadLetteredAt);
+            retryCount, nextRetryAt, deadLetteredAt,
+            acknowledgedAt, acknowledgedBy, triggeredByAdminUserId);
 
     private static WikidataCoverEnrichmentAttempt Create(
         Guid sharedGameId,
@@ -169,7 +198,8 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
         string? details,
         int retryCount,
         DateTime? nextRetryAt,
-        DateTime? deadLetteredAt)
+        DateTime? deadLetteredAt,
+        Guid? triggeredByAdminUserId)
     {
         if (sharedGameId == Guid.Empty)
             throw new ArgumentException("SharedGameId cannot be Guid.Empty.", nameof(sharedGameId));
@@ -195,7 +225,10 @@ public sealed class WikidataCoverEnrichmentAttempt : AggregateRoot<Guid>
             details: details,
             retryCount: retryCount,
             nextRetryAt: nextRetryAt,
-            deadLetteredAt: deadLetteredAt);
+            deadLetteredAt: deadLetteredAt,
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+            triggeredByAdminUserId: triggeredByAdminUserId);
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs
@@ -58,15 +58,25 @@ public interface IWikidataCoverEnrichmentAttemptRepository
     /// dead-letter visibility page. Filtered by optional reason; ordered by
     /// most-recently dead-lettered first.
     /// </summary>
+    /// <remarks>
+    /// Phase F (#2254) added <paramref name="includeAcknowledged"/>: when
+    /// <see langword="false"/> (the default behavior for the open-work view),
+    /// rows whose <c>AcknowledgedAt</c> is non-null are filtered out so
+    /// operators don't see already-triaged dead-letters. The partial index
+    /// <c>ix_wikidata_cover_attempts_acknowledged_at</c> (defined in the EF
+    /// config) keeps this filter cheap.
+    /// </remarks>
     /// <param name="skip">Skip count for pagination (must be &gt;= 0).</param>
     /// <param name="take">Page size (1..200; clamped).</param>
     /// <param name="reasonFilter">Optional <c>Reason</c> exact match; null returns all dead-letters.</param>
+    /// <param name="includeAcknowledged">When false, hide rows with <c>AcknowledgedAt</c> set.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Page items (with denormalized game title) + total count of dead-letter rows matching the filter.</returns>
+    /// <returns>Page items (with denormalized game title + ack/trigger admin names) + total count matching the filter.</returns>
     Task<DeadLetterPage> GetDeadLettersAsync(
         int skip,
         int take,
         string? reasonFilter,
+        bool includeAcknowledged,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -86,14 +96,40 @@ public interface IWikidataCoverEnrichmentAttemptRepository
     /// Issue #1823 Phase E F3 — returns the full attempt timeline for a single
     /// game, ordered by <c>AttemptedAt</c> DESC. Bounded by <paramref name="limit"/>
     /// (clamped to a sane upper bound by the impl) so the admin drawer never
-    /// pulls thousands of rows.
+    /// pulls thousands of rows. Phase F (#2255) extended the row shape to
+    /// include F6 admin attribution via a LEFT JOIN on Users.
     /// </summary>
     /// <param name="sharedGameId">Target game id.</param>
     /// <param name="limit">Max rows to return (clamped to [1, 200]).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<IReadOnlyList<WikidataCoverEnrichmentAttempt>> GetAttemptsByGameIdAsync(
+    Task<IReadOnlyList<WikidataAttemptTimelineRow>> GetAttemptsByGameIdAsync(
         Guid sharedGameId,
         int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #2254 (Phase F F5) — bulk-loads aggregates by id for the
+    /// bulk-acknowledge handler. Missing ids are simply absent from the result
+    /// dictionary so the caller can report not-found rows to the admin UI.
+    /// Caller must invoke <c>IUnitOfWork.SaveChangesAsync</c> after mutating
+    /// the returned aggregates (see <see cref="UpdateAsync"/>).
+    /// </summary>
+    /// <param name="attemptIds">Set of attempt ids to resolve (defensive cap of 50).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Map <c>attemptId → aggregate</c>; absent keys = attempt not found.</returns>
+    Task<IReadOnlyDictionary<Guid, WikidataCoverEnrichmentAttempt>> GetByIdsAsync(
+        IReadOnlyCollection<Guid> attemptIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #2254 (Phase F F5) — persists mutations performed on a previously
+    /// hydrated aggregate. Per the record-of-fact pattern only the ack metadata
+    /// pair (<c>AcknowledgedAt</c>, <c>AcknowledgedBy</c>) is mutable; other
+    /// fields are intentionally not copied back. Caller must invoke
+    /// <c>IUnitOfWork.SaveChangesAsync</c>.
+    /// </summary>
+    Task UpdateAsync(
+        WikidataCoverEnrichmentAttempt attempt,
         CancellationToken cancellationToken = default);
 }
 
@@ -108,7 +144,21 @@ public sealed record DeadLetterPage(
 
 /// <summary>
 /// Per-row admin DTO returned by <see cref="IWikidataCoverEnrichmentAttemptRepository.GetDeadLettersAsync"/>.
+/// Phase F extended with F5 ack metadata and F6 admin attribution.
 /// </summary>
+/// <param name="Id">Attempt id.</param>
+/// <param name="SharedGameId">Parent shared game id.</param>
+/// <param name="GameTitle">Denormalized parent title (fallback "(deleted game)").</param>
+/// <param name="AttemptedAt">UTC attempt timestamp.</param>
+/// <param name="DeadLetteredAt">UTC dead-letter timestamp (guaranteed non-null on this row).</param>
+/// <param name="Reason">Stable machine-readable reason.</param>
+/// <param name="Details">Optional human-readable detail.</param>
+/// <param name="RetryCount">0..N counter from the original pipeline.</param>
+/// <param name="AcknowledgedAt">F5 — UTC ack timestamp (null if not acknowledged).</param>
+/// <param name="AcknowledgedBy">F5 — User id who acknowledged (null if not acknowledged).</param>
+/// <param name="AcknowledgedByFullName">F5 — display name of the acknowledging user (null if not acknowledged or user deleted).</param>
+/// <param name="TriggeredByAdminUserId">F6 — admin user id that triggered this attempt via M12/F2 (null for M9 scheduler).</param>
+/// <param name="TriggeredByAdminFullName">F6 — display name of the triggering admin (null when M9 scheduler or user deleted).</param>
 public sealed record DeadLetterRow(
     Guid Id,
     Guid SharedGameId,
@@ -117,4 +167,37 @@ public sealed record DeadLetterRow(
     DateTime DeadLetteredAt,
     string Reason,
     string? Details,
-    int RetryCount);
+    int RetryCount,
+    DateTime? AcknowledgedAt,
+    Guid? AcknowledgedBy,
+    string? AcknowledgedByFullName,
+    Guid? TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
+
+/// <summary>
+/// Issue #1823 Phase E F3 timeline row returned by
+/// <see cref="IWikidataCoverEnrichmentAttemptRepository.GetAttemptsByGameIdAsync"/>.
+/// Mirrors the aggregate shape but adds the F6 admin LEFT JOIN result so the
+/// admin drawer can render attribution without a second round-trip.
+/// </summary>
+/// <param name="Id">Attempt id.</param>
+/// <param name="AttemptedAt">UTC attempt timestamp.</param>
+/// <param name="Outcome">Outcome category.</param>
+/// <param name="Reason">Stable machine-readable reason.</param>
+/// <param name="Details">Optional human-readable detail.</param>
+/// <param name="RetryCount">Counter from the original pipeline iteration.</param>
+/// <param name="NextRetryAt">UTC retry schedule (null for terminal outcomes).</param>
+/// <param name="DeadLetteredAt">UTC dead-letter timestamp (null unless DeadLetter outcome).</param>
+/// <param name="TriggeredByAdminUserId">F6 — admin user id that triggered the attempt (null for M9 scheduler).</param>
+/// <param name="TriggeredByAdminFullName">F6 — display name of the triggering admin (null when M9 scheduler or user deleted).</param>
+public sealed record WikidataAttemptTimelineRow(
+    Guid Id,
+    DateTime AttemptedAt,
+    WikidataCoverEnrichmentOutcome Outcome,
+    string Reason,
+    string? Details,
+    int RetryCount,
+    DateTime? NextRetryAt,
+    DateTime? DeadLetteredAt,
+    Guid? TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -37,6 +37,9 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             RetryCount = attempt.RetryCount,
             NextRetryAt = attempt.NextRetryAt,
             DeadLetteredAt = attempt.DeadLetteredAt,
+            // Task 2.3 will add: AcknowledgedAt = attempt.AcknowledgedAt
+            // Task 2.3 will add: AcknowledgedBy = attempt.AcknowledgedBy
+            // Task 2.3 will add: TriggeredByAdminUserId = attempt.TriggeredByAdminUserId
         }, cancellationToken).ConfigureAwait(false);
 
         CollectDomainEvents(attempt);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -327,7 +327,15 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
     {
         ArgumentNullException.ThrowIfNull(attempt);
 
+        // AsTracking() override: DbContext default is QueryTrackingBehavior.NoTracking
+        // (PERF-06 — see InfrastructureServiceExtensions). Without an explicit
+        // .AsTracking() the loaded entity is NOT registered with the change
+        // tracker, so the subsequent property assignment silently no-ops and
+        // SaveChangesAsync emits no UPDATE. Caught by F5 integration tests
+        // (handler-only mock tests cannot reproduce the global tracking
+        // default).
         var entity = await DbContext.WikidataCoverEnrichmentAttempts
+            .AsTracking()
             .FirstOrDefaultAsync(e => e.Id == attempt.Id, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new InvalidOperationException(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -37,9 +37,9 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             RetryCount = attempt.RetryCount,
             NextRetryAt = attempt.NextRetryAt,
             DeadLetteredAt = attempt.DeadLetteredAt,
-            // Task 2.3 will add: AcknowledgedAt = attempt.AcknowledgedAt
-            // Task 2.3 will add: AcknowledgedBy = attempt.AcknowledgedBy
-            // Task 2.3 will add: TriggeredByAdminUserId = attempt.TriggeredByAdminUserId
+            AcknowledgedAt = attempt.AcknowledgedAt,
+            AcknowledgedBy = attempt.AcknowledgedBy,
+            TriggeredByAdminUserId = attempt.TriggeredByAdminUserId,
         }, cancellationToken).ConfigureAwait(false);
 
         CollectDomainEvents(attempt);
@@ -146,6 +146,7 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
         int skip,
         int take,
         string? reasonFilter,
+        bool includeAcknowledged,
         CancellationToken cancellationToken = default)
     {
         if (skip < 0) skip = 0;
@@ -158,6 +159,16 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             from a in DbContext.WikidataCoverEnrichmentAttempts.AsNoTracking()
             where a.DeadLetteredAt != null && a.Outcome == DeadLetterOutcome
             select a;
+
+        // Phase F (#2254) — default view hides acknowledged rows so operators
+        // see only open work. Partial index ix_wikidata_cover_attempts_acknowledged_at
+        // (acknowledged_at IS NOT NULL) is the inverse predicate used by the
+        // "show acked" toggle; the default !includeAcknowledged path uses the
+        // existing ix_wikidata_cover_attempts_dead_letter for the scan.
+        if (!includeAcknowledged)
+        {
+            query = query.Where(a => a.AcknowledgedAt == null);
+        }
 
         if (!string.IsNullOrWhiteSpace(reasonFilter))
         {
@@ -181,11 +192,22 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
         // FE paginator (totalCount > items.Count). LEFT-join idiom with a
         // fallback string also defends against an orphaned FK on a
         // hard-deleted game (cascade should prevent it, but defensive).
+        //
+        // Phase F adds two further LEFT JOINs on Users to surface DisplayName
+        // for the ack admin (F5) and the trigger admin (F6). LEFT JOIN (vs
+        // INNER) defends against a hard-deleted user account: row survives,
+        // FullName field is null.
         var pageQuery =
             from a in query.OrderByDescending(x => x.DeadLetteredAt).Skip(skip).Take(take)
             join sg in DbContext.SharedGames.AsNoTracking().IgnoreQueryFilters()
                 on a.SharedGameId equals sg.Id into sgs
             from sg in sgs.DefaultIfEmpty()
+            join ackUser in DbContext.Users.AsNoTracking()
+                on a.AcknowledgedBy equals ackUser.Id into ackUsers
+            from ackUser in ackUsers.DefaultIfEmpty()
+            join trgUser in DbContext.Users.AsNoTracking()
+                on a.TriggeredByAdminUserId equals trgUser.Id into trgUsers
+            from trgUser in trgUsers.DefaultIfEmpty()
             select new DeadLetterRow(
                 a.Id,
                 a.SharedGameId,
@@ -194,7 +216,12 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
                 a.DeadLetteredAt!.Value,
                 a.Reason,
                 a.Details,
-                a.RetryCount);
+                a.RetryCount,
+                a.AcknowledgedAt,
+                a.AcknowledgedBy,
+                ackUser != null ? ackUser.DisplayName : null,
+                a.TriggeredByAdminUserId,
+                trgUser != null ? trgUser.DisplayName : null);
 
         var items = await pageQuery
             .ToListAsync(cancellationToken)
@@ -229,22 +256,91 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
         return rows.ToDictionary(r => r.Id, r => r.SharedGameId);
     }
 
-    public async Task<IReadOnlyList<WikidataCoverEnrichmentAttempt>> GetAttemptsByGameIdAsync(
+    public async Task<IReadOnlyList<WikidataAttemptTimelineRow>> GetAttemptsByGameIdAsync(
         Guid sharedGameId,
         int limit,
         CancellationToken cancellationToken = default)
     {
         limit = Math.Clamp(limit, 1, 200);
 
-        var entities = await DbContext.WikidataCoverEnrichmentAttempts
-            .AsNoTracking()
-            .Where(a => a.SharedGameId == sharedGameId)
-            .OrderByDescending(a => a.AttemptedAt)
+        // Phase F (#2255) — LEFT JOIN on Users surfaces the F6 admin
+        // attribution alongside the existing pipeline fields. The ORDER BY
+        // sits BEFORE the JOIN clause in the LINQ tree so EF translates it as
+        // a SELECT ... ORDER BY ... LIMIT subquery feeding the join, which
+        // keeps the ix_wikidata_cover_attempts_game_latest composite index
+        // covering. The .Take() applied at the very end of the chain caps the
+        // post-join row count.
+        var query =
+            from a in DbContext.WikidataCoverEnrichmentAttempts.AsNoTracking()
+            where a.SharedGameId == sharedGameId
+            orderby a.AttemptedAt descending
+            join u in DbContext.Users.AsNoTracking()
+                on a.TriggeredByAdminUserId equals u.Id into us
+            from u in us.DefaultIfEmpty()
+            select new WikidataAttemptTimelineRow(
+                a.Id,
+                a.AttemptedAt,
+                (WikidataCoverEnrichmentOutcome)a.Outcome,
+                a.Reason,
+                a.Details,
+                a.RetryCount,
+                a.NextRetryAt,
+                a.DeadLetteredAt,
+                a.TriggeredByAdminUserId,
+                u != null ? u.DisplayName : null);
+
+        return await query
             .Take(limit)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
+    }
 
-        return entities.Select(Map).ToList();
+    public async Task<IReadOnlyDictionary<Guid, WikidataCoverEnrichmentAttempt>> GetByIdsAsync(
+        IReadOnlyCollection<Guid> attemptIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(attemptIds);
+
+        if (attemptIds.Count == 0)
+        {
+            return new Dictionary<Guid, WikidataCoverEnrichmentAttempt>();
+        }
+
+        // Defensive cap mirroring the F5 validator MaxBatchSize (50) — same
+        // budget as the F2 bulk-retry endpoint. EF Core translates a Contains
+        // against a parameterized list into a SARGable WHERE id = ANY(@p) on
+        // PostgreSQL. NOT AsNoTracking() because the caller will mutate the
+        // hydrated aggregate via Acknowledge() and persist via UpdateAsync().
+        var ids = attemptIds.Distinct().Take(50).ToArray();
+
+        var entities = await DbContext.WikidataCoverEnrichmentAttempts
+            .Where(a => ids.Contains(a.Id))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.ToDictionary(e => e.Id, Map);
+    }
+
+    public async Task UpdateAsync(
+        WikidataCoverEnrichmentAttempt attempt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+
+        var entity = await DbContext.WikidataCoverEnrichmentAttempts
+            .FirstOrDefaultAsync(e => e.Id == attempt.Id, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"WikidataCoverEnrichmentAttempt {attempt.Id} not found for update.");
+
+        // Only ack metadata is mutable per the record-of-fact pattern on the
+        // aggregate (Acknowledge is the single mutator). Other fields stay
+        // frozen — if a caller hands us a divergent aggregate it's a bug, not
+        // a silent overwrite we want to perform.
+        entity.AcknowledgedAt = attempt.AcknowledgedAt;
+        entity.AcknowledgedBy = attempt.AcknowledgedBy;
+
+        CollectDomainEvents(attempt);
     }
 
     private static WikidataCoverEnrichmentAttempt Map(WikidataCoverEnrichmentAttemptEntity entity) =>
@@ -258,7 +354,7 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             retryCount: entity.RetryCount,
             nextRetryAt: entity.NextRetryAt,
             deadLetteredAt: entity.DeadLetteredAt,
-            acknowledgedAt: null,            // Task 2.3 will replace with entity.AcknowledgedAt
-            acknowledgedBy: null,            // Task 2.3 will replace with entity.AcknowledgedBy
-            triggeredByAdminUserId: null);   // Task 2.3 will replace with entity.TriggeredByAdminUserId
+            acknowledgedAt: entity.AcknowledgedAt,
+            acknowledgedBy: entity.AcknowledgedBy,
+            triggeredByAdminUserId: entity.TriggeredByAdminUserId);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
@@ -254,5 +254,8 @@ internal sealed class WikidataCoverEnrichmentAttemptRepository
             details: entity.Details,
             retryCount: entity.RetryCount,
             nextRetryAt: entity.NextRetryAt,
-            deadLetteredAt: entity.DeadLetteredAt);
+            deadLetteredAt: entity.DeadLetteredAt,
+            acknowledgedAt: null,            // Task 2.3 will replace with entity.AcknowledgedAt
+            acknowledgedBy: null,            // Task 2.3 will replace with entity.AcknowledgedBy
+            triggeredByAdminUserId: null);   // Task 2.3 will replace with entity.TriggeredByAdminUserId
 }

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntity.cs
@@ -26,4 +26,13 @@ public class WikidataCoverEnrichmentAttemptEntity
 
     /// <summary>UTC timestamp when the attempt was dead-lettered; null otherwise.</summary>
     public DateTime? DeadLetteredAt { get; set; }
+
+    /// <summary>F5 — UTC timestamp when an operator acknowledged the dead-letter; null otherwise.</summary>
+    public DateTime? AcknowledgedAt { get; set; }
+
+    /// <summary>F5 — User id of the operator who acknowledged; null otherwise.</summary>
+    public Guid? AcknowledgedBy { get; set; }
+
+    /// <summary>F6 — Admin user id when triggered via M12 or F2; null for M9 scheduler.</summary>
+    public Guid? TriggeredByAdminUserId { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfiguration.cs
@@ -76,5 +76,24 @@ internal sealed class WikidataCoverEnrichmentAttemptEntityConfiguration
         builder.HasIndex(e => e.DeadLetteredAt)
             .HasDatabaseName("ix_wikidata_cover_attempts_dead_letter")
             .HasFilter("dead_lettered_at IS NOT NULL");
+
+        // Issue #2254 (F5) — bulk acknowledge metadata.
+        builder.Property(e => e.AcknowledgedAt)
+            .HasColumnName("acknowledged_at")
+            .IsRequired(false);
+
+        builder.Property(e => e.AcknowledgedBy)
+            .HasColumnName("acknowledged_by")
+            .IsRequired(false);
+
+        // Issue #2255 (F6) — admin-triggered attribution (null for M9 scheduler).
+        builder.Property(e => e.TriggeredByAdminUserId)
+            .HasColumnName("triggered_by_admin_user_id")
+            .IsRequired(false);
+
+        // F5 partial index: speeds up default list view (exclude acked = WHERE acknowledged_at IS NULL).
+        builder.HasIndex(e => e.AcknowledgedAt)
+            .HasDatabaseName("ix_wikidata_cover_attempts_acknowledged_at")
+            .HasFilter("acknowledged_at IS NOT NULL");
     }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260613175905_AddAcknowledgeAndTriggerSourceToWikidataAttempts.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260613175905_AddAcknowledgeAndTriggerSourceToWikidataAttempts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613175905_AddAcknowledgeAndTriggerSourceToWikidataAttempts")]
+    partial class AddAcknowledgeAndTriggerSourceToWikidataAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260613175905_AddAcknowledgeAndTriggerSourceToWikidataAttempts.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260613175905_AddAcknowledgeAndTriggerSourceToWikidataAttempts.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAcknowledgeAndTriggerSourceToWikidataAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "acknowledged_at",
+                table: "wikidata_cover_enrichment_attempts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "acknowledged_by",
+                table: "wikidata_cover_enrichment_attempts",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "triggered_by_admin_user_id",
+                table: "wikidata_cover_enrichment_attempts",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_wikidata_cover_attempts_acknowledged_at",
+                table: "wikidata_cover_enrichment_attempts",
+                column: "acknowledged_at",
+                filter: "acknowledged_at IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_wikidata_cover_attempts_acknowledged_at",
+                table: "wikidata_cover_enrichment_attempts");
+
+            migrationBuilder.DropColumn(
+                name: "acknowledged_at",
+                table: "wikidata_cover_enrichment_attempts");
+
+            migrationBuilder.DropColumn(
+                name: "acknowledged_by",
+                table: "wikidata_cover_enrichment_attempts");
+
+            migrationBuilder.DropColumn(
+                name: "triggered_by_admin_user_id",
+                table: "wikidata_cover_enrichment_attempts");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -47,6 +47,11 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
             .WithName("AdminWikidataCoverEnrichment_BulkRetry")
             .WithTags("Admin", "WikidataCoverEnrichment");
 
+        // Phase F F5 (#2254) — bulk-acknowledge endpoint.
+        group.MapPost("/bulk-acknowledge", HandleBulkAcknowledge)
+            .WithName("AdminWikidataCoverEnrichment_BulkAcknowledge")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
         // Phase E F3 — per-game attempt timeline (drawer payload).
         group.MapGet("/games/{gameId:guid}/attempts", HandleGetAttemptTimeline)
             .WithName("AdminWikidataCoverEnrichment_GetAttemptTimeline")
@@ -89,19 +94,24 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
 
     /// <summary>
     /// Issue #1823 Wave 3 M13 — paginated dead-letter visibility for the admin
-    /// page. Query string: <c>?skip=0&amp;take=50&amp;reason=r2-upload-error</c>.
+    /// page. Query string: <c>?skip=0&amp;take=50&amp;reason=r2-upload-error&amp;includeAcknowledged=true</c>.
+    /// Phase F (#2254) added the optional <c>includeAcknowledged</c> toggle so
+    /// the admin UI can switch between the default open-work view (hide acked
+    /// rows) and the historical audit view (show everything).
     /// </summary>
     private static async Task<IResult> HandleListDeadLetters(
         [FromQuery] int? skip,
         [FromQuery] int? take,
         [FromQuery] string? reason,
+        [FromQuery] bool? includeAcknowledged,
         IMediator mediator,
         CancellationToken ct)
     {
         var query = new GetWikidataDeadLetterAttemptsQuery(
             Skip: skip ?? 0,
             Take: take ?? 50,
-            ReasonFilter: string.IsNullOrWhiteSpace(reason) ? null : reason);
+            ReasonFilter: string.IsNullOrWhiteSpace(reason) ? null : reason,
+            IncludeAcknowledged: includeAcknowledged ?? false);
 
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
@@ -124,6 +134,40 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
     {
         var command = new AdminBulkRetryWikidataCoverCommand(
             AttemptIds: request?.AttemptIds ?? Array.Empty<Guid>(),
+            TriggeredByUserId: context.User.GetUserId());
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>Body for the F5 bulk-acknowledge endpoint.</summary>
+    internal sealed record AdminBulkAcknowledgeWikidataRequest(
+        IReadOnlyList<Guid>? AttemptIds,
+        string? Note);
+
+    /// <summary>
+    /// Issue #1823 Phase F F5 (#2254) — bulk-acknowledge one or more dead-letter
+    /// attempts. Each id is hydrated by the handler, mutated via
+    /// <c>WikidataCoverEnrichmentAttempt.Acknowledge(by, at)</c> (idempotent on
+    /// re-call) and persisted via the unit of work. Returns a per-row envelope
+    /// so the admin UI can render partial success/failure (acked /
+    /// already-acked / not-found / wrong-state).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <see cref="HandleBulkRetry"/> in shape: nullable body, defensive
+    /// fallback to <see cref="Array.Empty{T}"/>, dispatch via MediatR (CQRS —
+    /// zero direct service injection). The optional <c>Note</c> is DEC-F-4
+    /// log-only (not persisted on the attempt row).
+    /// </remarks>
+    private static async Task<IResult> HandleBulkAcknowledge(
+        AdminBulkAcknowledgeWikidataRequest? request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var command = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: request?.AttemptIds ?? Array.Empty<Guid>(),
+            Note: request?.Note,
             TriggeredByUserId: context.User.GetUserId());
 
         var result = await mediator.Send(command, ct).ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandlerTests.cs
@@ -128,6 +128,7 @@ public class AdminBulkAcknowledgeWikidataCoverCommandHandlerTests
             TriggeredByUserId: _user), CancellationToken.None);
 
         result.AckedCount.Should().Be(0);
+        result.WrongStateCount.Should().Be(1);
         result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeWrongState);
         _repo.Verify(r => r.UpdateAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()), Times.Never);
         _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -155,6 +156,7 @@ public class AdminBulkAcknowledgeWikidataCoverCommandHandlerTests
         result.AckedCount.Should().Be(1);
         result.IdempotentNoOpCount.Should().Be(1);
         result.NotFoundCount.Should().Be(1);
+        result.WrongStateCount.Should().Be(0);
         result.Rows.Should().HaveCount(3);
         // SaveChanges invoked exactly once for the batch because exactly one row was mutated.
         _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandlerTests.cs
@@ -1,0 +1,178 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Unit tests for <see cref="AdminBulkAcknowledgeWikidataCoverCommandHandler"/>.
+/// Issue #1823 Phase F F5 (sub-issue #2254).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2254")]
+public class AdminBulkAcknowledgeWikidataCoverCommandHandlerTests
+{
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly TimeProvider _time = TimeProvider.System;
+    private readonly Guid _user = Guid.NewGuid();
+
+    private AdminBulkAcknowledgeWikidataCoverCommandHandler Build() =>
+        new(_repo.Object, _uow.Object, _time, NullLogger<AdminBulkAcknowledgeWikidataCoverCommandHandler>.Instance);
+
+    private static WikidataCoverEnrichmentAttempt MakeDeadLetter(Guid? id = null) =>
+        WikidataCoverEnrichmentAttempt.Reconstitute(
+            id: id ?? Guid.NewGuid(),
+            sharedGameId: Guid.NewGuid(),
+            attemptedAt: DateTime.UtcNow,
+            outcome: WikidataCoverEnrichmentOutcome.DeadLetter,
+            reason: "r2-upload-error",
+            details: null,
+            retryCount: 3,
+            nextRetryAt: null,
+            deadLetteredAt: DateTime.UtcNow,
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+            triggeredByAdminUserId: null);
+
+    [Fact]
+    public async Task SingleDeadLetter_Acked_ReturnsAckedCountOne()
+    {
+        var dl = MakeDeadLetter();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt> { [dl.Id] = dl });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { dl.Id },
+            Note: null,
+            TriggeredByUserId: _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(1);
+        result.IdempotentNoOpCount.Should().Be(0);
+        result.NotFoundCount.Should().Be(0);
+        result.Rows.Should().ContainSingle(r =>
+            r.AttemptId == dl.Id && r.Outcome == AdminBulkAcknowledgeRow.OutcomeAcked);
+        dl.AcknowledgedAt.Should().NotBeNull();
+        dl.AcknowledgedBy.Should().Be(_user);
+        _repo.Verify(r => r.UpdateAsync(dl, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AlreadyAcked_Idempotent_NotPersistedAgain()
+    {
+        var dl = MakeDeadLetter();
+        dl.Acknowledge(Guid.NewGuid(), DateTime.UtcNow);
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt> { [dl.Id] = dl });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { dl.Id },
+            Note: null,
+            TriggeredByUserId: _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(0);
+        result.IdempotentNoOpCount.Should().Be(1);
+        result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeAlreadyAcked);
+        _repo.Verify(r => r.UpdateAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "no mutation occurred so SaveChanges must NOT be invoked");
+    }
+
+    [Fact]
+    public async Task NotFoundId_ReportedAsNotFound()
+    {
+        var missing = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt>());
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { missing },
+            Note: null,
+            TriggeredByUserId: _user), CancellationToken.None);
+
+        result.NotFoundCount.Should().Be(1);
+        result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeNotFound);
+        _repo.Verify(r => r.UpdateAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NonDeadLetterRow_ReportedAsWrongState()
+    {
+        var success = WikidataCoverEnrichmentAttempt.Reconstitute(
+            id: Guid.NewGuid(),
+            sharedGameId: Guid.NewGuid(),
+            attemptedAt: DateTime.UtcNow,
+            outcome: WikidataCoverEnrichmentOutcome.Success,
+            reason: "success",
+            details: null,
+            retryCount: 0,
+            nextRetryAt: null,
+            deadLetteredAt: null,
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+            triggeredByAdminUserId: null);
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt> { [success.Id] = success });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { success.Id },
+            Note: null,
+            TriggeredByUserId: _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(0);
+        result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeWrongState);
+        _repo.Verify(r => r.UpdateAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BatchMixedOutcomes_CountsAreAggregated()
+    {
+        var dl1 = MakeDeadLetter();
+        var dl2Already = MakeDeadLetter();
+        dl2Already.Acknowledge(Guid.NewGuid(), DateTime.UtcNow);
+        var missing = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt>
+            {
+                [dl1.Id] = dl1,
+                [dl2Already.Id] = dl2Already,
+            });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { dl1.Id, dl2Already.Id, missing },
+            Note: "operator note",
+            TriggeredByUserId: _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(1);
+        result.IdempotentNoOpCount.Should().Be(1);
+        result.NotFoundCount.Should().Be(1);
+        result.Rows.Should().HaveCount(3);
+        // SaveChanges invoked exactly once for the batch because exactly one row was mutated.
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CancellationToken_Propagated()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), cts.Token))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = () => Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid() },
+            Note: null,
+            TriggeredByUserId: _user), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandlerTests.cs
@@ -38,7 +38,7 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
             .ReturnsAsync(new Dictionary<Guid, Guid> { [a1] = g1, [a2] = g2 });
 
         _runner.Setup(r => r.EnrichAndRecordAsync(
-                It.IsAny<Guid>(), true, It.IsAny<CancellationToken>()))
+                It.IsAny<Guid>(), true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         var result = await Sut().Handle(
@@ -52,8 +52,8 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
         result.FailedCount.Should().Be(0);
         result.Rows.Should().HaveCount(2);
         result.Rows.Should().AllSatisfy(row => row.Outcome.Should().Be(AdminBulkRetryRow.OutcomeTriggered));
-        _runner.Verify(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<CancellationToken>()), Times.Once);
-        _runner.Verify(r => r.EnrichAndRecordAsync(g2, true, It.IsAny<CancellationToken>()), Times.Once);
+        _runner.Verify(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
+        _runner.Verify(r => r.EnrichAndRecordAsync(g2, true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
                 It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<Guid, Guid> { [known] = gameId });
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         var result = await Sut().Handle(
@@ -81,7 +81,7 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
         result.FailedCount.Should().Be(0);
         result.Rows.Single(r => r.AttemptId == unknown).Outcome.Should().Be(AdminBulkRetryRow.OutcomeNotFound);
         result.Rows.Single(r => r.AttemptId == unknown).GameId.Should().BeNull();
-        _runner.Verify(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>()), Times.Once,
+        _runner.Verify(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once,
             "the unknown id must NOT invoke the runner");
     }
 
@@ -97,9 +97,9 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
                 It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<Guid, Guid> { [a1] = g1, [a2] = g2 });
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("simulated runner failure"));
-        _runner.Setup(r => r.EnrichAndRecordAsync(g2, true, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(g2, true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         var result = await Sut().Handle(
@@ -126,7 +126,7 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
                 It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<Guid, Guid> { [a1] = g1 });
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(g1, true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException());
 
         var act = async () => await Sut().Handle(
@@ -158,7 +158,38 @@ public class AdminBulkRetryWikidataCoverCommandHandlerTests
         result.NotFoundCount.Should().Be(3);
         result.FailedCount.Should().Be(0);
         result.Rows.Should().HaveCount(3);
-        _runner.Verify(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+        _runner.Verify(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ForwardsTriggeringAdminIdToRunnerPerRow()
+    {
+        // F6 #1823 Phase F: every per-row runner invocation MUST receive the
+        // command's TriggeredByUserId so the persisted attempt rows can record
+        // which admin pressed the bulk-retry button — mirror of M12 single-trigger.
+        var attemptId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetSharedGameIdsByAttemptIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, Guid> { [attemptId] = gameId });
+
+        _runner.Setup(r => r.EnrichAndRecordAsync(
+                gameId, true, (Guid?)adminId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        var result = await Sut().Handle(
+            new AdminBulkRetryWikidataCoverCommand(
+                AttemptIds: new[] { attemptId },
+                TriggeredByUserId: adminId),
+            default);
+
+        result.TriggeredCount.Should().Be(1);
+        _runner.Verify(r => r.EnrichAndRecordAsync(
+                gameId, true, (Guid?)adminId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "F6: per-row dispatch MUST forward the command's TriggeredByUserId so each new attempt row records the operator");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandlerTests.cs
@@ -25,7 +25,7 @@ public class AdminEnrichWikidataCoverCommandHandlerTests
     public async Task Handle_SuccessOutcome_FlattensToSuccessDto()
     {
         var gameId = Guid.NewGuid();
-        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, true, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, true, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("covers/abc/cover", "CC BY-SA 4.0", "John Doe", "https://wikidata.org/wiki/Q1"));
 
         var result = await Sut().Handle(
@@ -45,7 +45,7 @@ public class AdminEnrichWikidataCoverCommandHandlerTests
     public async Task Handle_SkippedOutcome_FlattensToSkippedDto()
     {
         var gameId = Guid.NewGuid();
-        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, false, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Skipped(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing));
 
         var result = await Sut().Handle(
@@ -61,7 +61,7 @@ public class AdminEnrichWikidataCoverCommandHandlerTests
     public async Task Handle_FailedOutcome_FlattensToFailedDtoWithDetails()
     {
         var gameId = Guid.NewGuid();
-        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, false, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(gameId, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
                 EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503 service unavailable"));
 
@@ -78,17 +78,22 @@ public class AdminEnrichWikidataCoverCommandHandlerTests
     [Fact]
     public async Task Handle_ForwardsForceRefreshAndUserToRunner()
     {
+        // F6 #1823 Phase F: command must forward both forceRefresh and the
+        // admin user id (Guid? in the runner signature, non-nullable Guid on
+        // the command) — the runner stamps it onto the persisted attempt row.
         var gameId = Guid.NewGuid();
         var userId = Guid.NewGuid();
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(
+                It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         await Sut().Handle(
             new AdminEnrichWikidataCoverCommand(gameId, ForceRefresh: true, TriggeredByUserId: userId),
             default);
 
-        _runner.Verify(r => r.EnrichAndRecordAsync(gameId, true, It.IsAny<CancellationToken>()), Times.Once,
-            "command MUST forward forceRefresh to the runner so the M8 freshness window is bypassed");
+        _runner.Verify(r => r.EnrichAndRecordAsync(gameId, true, (Guid?)userId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "command MUST forward forceRefresh AND TriggeredByUserId so the M8 freshness window is bypassed AND the admin trigger is persisted on the F6 attempt row");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJobTests.cs
@@ -44,7 +44,7 @@ public class WikidataCoverEnrichmentJobTests
         await Sut().RunBatchAsync(_attempts.Object, _runner.Object, default);
 
         _runner.Verify(
-            r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            r => r.EnrichAndRecordAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -57,15 +57,19 @@ public class WikidataCoverEnrichmentJobTests
                 It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { game });
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(game, false, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         await Sut().RunBatchAsync(_attempts.Object, _runner.Object, default);
 
+        // F6 #1823 Phase F: scheduler passes triggeredByAdminUserId=null (default
+        // value) because the cron has no admin actor — the runner stamps null
+        // on the attempt row so the F6 timeline drawer can distinguish
+        // scheduler-authored attempts from manual admin dispatches.
         _runner.Verify(
-            r => r.EnrichAndRecordAsync(game, false, It.IsAny<CancellationToken>()),
+            r => r.EnrichAndRecordAsync(game, false, (Guid?)null, It.IsAny<CancellationToken>()),
             Times.Once,
-            "scheduler MUST always pass forceRefresh=false — freshness window honoured");
+            "scheduler MUST always pass forceRefresh=false AND triggeredByAdminUserId=null");
     }
 
     [Fact]
@@ -78,14 +82,14 @@ public class WikidataCoverEnrichmentJobTests
                 It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { game1, game2 });
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(game1, false, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game1, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
-        _runner.Setup(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         await Sut().RunBatchAsync(_attempts.Object, _runner.Object, default);
 
-        _runner.Verify(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<CancellationToken>()), Times.Once,
+        _runner.Verify(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once,
             "game1 throw should be swallowed (logged); the loop continues with game2");
     }
 
@@ -100,13 +104,13 @@ public class WikidataCoverEnrichmentJobTests
                 It.IsAny<int>(), FixedNow, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { game1, game2 });
 
-        _runner.Setup(r => r.EnrichAndRecordAsync(game1, false, It.IsAny<CancellationToken>()))
+        _runner.Setup(r => r.EnrichAndRecordAsync(game1, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .Callback(() => cts.Cancel())
             .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
 
         await Sut().RunBatchAsync(_attempts.Object, _runner.Object, cts.Token);
 
-        _runner.Verify(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<CancellationToken>()), Times.Never,
+        _runner.Verify(r => r.EnrichAndRecordAsync(game2, false, It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Never,
             "after game1 finishes (and cancels the token), the loop top check breaks before game2");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
@@ -114,4 +114,24 @@ public class GetWikidataAttemptTimelineQueryHandlerTests
 
         _attempts.Verify();
     }
+
+    [Fact]
+    public async Task Handler_MapsTriggeredByAdminFullName_FromRepoRow()
+    {
+        var repo = new Mock<IWikidataCoverEnrichmentAttemptRepository>();
+        var adminId = Guid.NewGuid();
+        var row = new WikidataAttemptTimelineRow(
+            Id: Guid.NewGuid(), AttemptedAt: DateTime.UtcNow,
+            Outcome: WikidataCoverEnrichmentOutcome.Success, Reason: "success", Details: null,
+            RetryCount: 0, NextRetryAt: null, DeadLetteredAt: null,
+            TriggeredByAdminUserId: adminId, TriggeredByAdminFullName: "Carol");
+        repo.Setup(r => r.GetAttemptsByGameIdAsync(It.IsAny<Guid>(), 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { row });
+
+        var handler = new GetWikidataAttemptTimelineQueryHandler(repo.Object);
+        var result = await handler.Handle(new GetWikidataAttemptTimelineQuery(Guid.NewGuid(), 50), default);
+
+        result.Items.Single().TriggeredByAdminUserId.Should().Be(adminId);
+        result.Items.Single().TriggeredByAdminFullName.Should().Be("Carol");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
@@ -22,12 +22,32 @@ public class GetWikidataAttemptTimelineQueryHandlerTests
 
     private GetWikidataAttemptTimelineQueryHandler Sut() => new(_attempts.Object);
 
+    // Phase F (#2255) note — Task 2.3 changed the repo return type from
+    // WikidataCoverEnrichmentAttempt[] to WikidataAttemptTimelineRow[] so the
+    // F6 admin LEFT JOIN result is included in a single round-trip. Mocks
+    // updated accordingly; the F6 admin DTO surface (TriggeredByAdminUserId +
+    // TriggeredByAdminFullName) lands on the timeline node in Task 3.4.
+
+    private static WikidataAttemptTimelineRow Row(
+        Guid attemptId,
+        DateTime attemptedAt,
+        WikidataCoverEnrichmentOutcome outcome,
+        string reason,
+        string? details = null,
+        int retryCount = 0,
+        DateTime? nextRetryAt = null,
+        DateTime? deadLetteredAt = null,
+        Guid? triggeredByAdminUserId = null,
+        string? triggeredByAdminFullName = null) =>
+        new(attemptId, attemptedAt, outcome, reason, details, retryCount,
+            nextRetryAt, deadLetteredAt, triggeredByAdminUserId, triggeredByAdminFullName);
+
     [Fact]
     public async Task Handle_NoAttempts_ReturnsEmptyTimeline()
     {
         var gameId = Guid.NewGuid();
         _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<WikidataCoverEnrichmentAttempt>());
+            .ReturnsAsync(Array.Empty<WikidataAttemptTimelineRow>());
 
         var result = await Sut().Handle(new GetWikidataAttemptTimelineQuery(gameId, 50), default);
 
@@ -39,15 +59,16 @@ public class GetWikidataAttemptTimelineQueryHandlerTests
     public async Task Handle_MixedAttempts_MapsAllFieldsAndOutcomes()
     {
         var gameId = Guid.NewGuid();
-        var success = WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, retryCount: 0, attemptedAt: FixedNow);
-        var skipped = WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, "qid-missing",
-            retryCount: 0, attemptedAt: FixedNow.AddMinutes(-5));
-        var failedWithRetry = WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
-            gameId, "r2-upload-error", "503",
-            retryCount: 1, attemptedAt: FixedNow.AddMinutes(-10), nextRetryAt: FixedNow.AddMinutes(-5));
-        var deadLetter = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
-            gameId, "image-processing-error", "corrupted",
-            retryCount: 0, attemptedAt: FixedNow.AddMinutes(-15));
+        var success = Row(Guid.NewGuid(), FixedNow,
+            WikidataCoverEnrichmentOutcome.Success, "success");
+        var skipped = Row(Guid.NewGuid(), FixedNow.AddMinutes(-5),
+            WikidataCoverEnrichmentOutcome.Skipped, "qid-missing");
+        var failedWithRetry = Row(Guid.NewGuid(), FixedNow.AddMinutes(-10),
+            WikidataCoverEnrichmentOutcome.Failed, "r2-upload-error",
+            details: "503", retryCount: 1, nextRetryAt: FixedNow.AddMinutes(-5));
+        var deadLetter = Row(Guid.NewGuid(), FixedNow.AddMinutes(-15),
+            WikidataCoverEnrichmentOutcome.DeadLetter, "image-processing-error",
+            details: "corrupted", deadLetteredAt: FixedNow.AddMinutes(-15));
 
         _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { success, skipped, failedWithRetry, deadLetter });
@@ -67,8 +88,10 @@ public class GetWikidataAttemptTimelineQueryHandlerTests
         // Repo guarantees DESC AttemptedAt; the handler MUST NOT re-order so
         // the drawer renders the most-recent attempt at the top of the timeline.
         var gameId = Guid.NewGuid();
-        var newer = WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, 0, FixedNow);
-        var older = WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, "qid-missing", 0, FixedNow.AddDays(-1));
+        var newer = Row(Guid.NewGuid(), FixedNow,
+            WikidataCoverEnrichmentOutcome.Success, "success");
+        var older = Row(Guid.NewGuid(), FixedNow.AddDays(-1),
+            WikidataCoverEnrichmentOutcome.Skipped, "qid-missing");
 
         _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, 50, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { newer, older });
@@ -84,7 +107,7 @@ public class GetWikidataAttemptTimelineQueryHandlerTests
     {
         var gameId = Guid.NewGuid();
         _attempts.Setup(r => r.GetAttemptsByGameIdAsync(gameId, 7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<WikidataCoverEnrichmentAttempt>())
+            .ReturnsAsync(Array.Empty<WikidataAttemptTimelineRow>())
             .Verifiable();
 
         await Sut().Handle(new GetWikidataAttemptTimelineQuery(gameId, 7), default);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
@@ -21,9 +21,10 @@ public class GetWikidataDeadLetterAttemptsQueryHandlerTests
 
     private GetWikidataDeadLetterAttemptsQueryHandler Sut() => new(_attempts.Object);
 
-    // Task 2.3 (#2254) bridge note — the handler hard-codes
-    // includeAcknowledged: false because Task 3.3 will expose it on the query
-    // DTO. The mocks pin the false value to lock the current bridge in place.
+    // Task 3.3 (#2254/#2255) — IncludeAcknowledged now lives on the query DTO
+    // (default false) and propagates straight to the repo. The DTO also carries
+    // the F5 ack metadata + F6 admin attribution fields surfaced via the repo
+    // LEFT JOIN on Users.
 
     [Fact]
     public async Task Handle_EmptyResult_ReturnsZeroItems()
@@ -107,5 +108,72 @@ public class GetWikidataDeadLetterAttemptsQueryHandlerTests
         var act = async () => await Sut().Handle(null!, default);
 
         await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // Task 3.3 — IncludeAcknowledged exposed on query DTO -------------------
+
+    [Fact]
+    public async Task DefaultIncludeAcknowledgedFalse_PassedToRepo()
+    {
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        var query = new GetWikidataDeadLetterAttemptsQuery(0, 50, null, IncludeAcknowledged: false);
+        await Sut().Handle(query, CancellationToken.None);
+
+        _attempts.Verify(
+            r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "default IncludeAcknowledged=false must propagate straight to the repo");
+    }
+
+    [Fact]
+    public async Task IncludeAcknowledgedTrue_PassedThrough()
+    {
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        var query = new GetWikidataDeadLetterAttemptsQuery(0, 50, null, IncludeAcknowledged: true);
+        await Sut().Handle(query, CancellationToken.None);
+
+        _attempts.Verify(
+            r => r.GetDeadLettersAsync(0, 50, null, true, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "IncludeAcknowledged=true must reach the repo so the audit view sees ack'd rows");
+    }
+
+    [Fact]
+    public async Task DtoIncludesAckAndAdminFields()
+    {
+        var ackAt = FixedNow.AddMinutes(-15);
+        var ackBy = Guid.NewGuid();
+        var triggeredBy = Guid.NewGuid();
+        var row = new DeadLetterRow(
+            Id: Guid.NewGuid(),
+            SharedGameId: Guid.NewGuid(),
+            GameTitle: "Game",
+            AttemptedAt: FixedNow.AddHours(-1),
+            DeadLetteredAt: FixedNow,
+            Reason: "r2-upload-error",
+            Details: null,
+            RetryCount: 3,
+            AcknowledgedAt: ackAt,
+            AcknowledgedBy: ackBy,
+            AcknowledgedByFullName: "Alice",
+            TriggeredByAdminUserId: triggeredBy,
+            TriggeredByAdminFullName: "Bob");
+
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(new[] { row }, 1));
+
+        var query = new GetWikidataDeadLetterAttemptsQuery(0, 50, null, IncludeAcknowledged: true);
+        var result = await Sut().Handle(query, CancellationToken.None);
+
+        var dto = result.Items.Single();
+        dto.AcknowledgedAt.Should().Be(ackAt);
+        dto.AcknowledgedBy.Should().Be(ackBy);
+        dto.AcknowledgedByFullName.Should().Be("Alice");
+        dto.TriggeredByAdminUserId.Should().Be(triggeredBy);
+        dto.TriggeredByAdminFullName.Should().Be("Bob");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
@@ -21,10 +21,14 @@ public class GetWikidataDeadLetterAttemptsQueryHandlerTests
 
     private GetWikidataDeadLetterAttemptsQueryHandler Sut() => new(_attempts.Object);
 
+    // Task 2.3 (#2254) bridge note — the handler hard-codes
+    // includeAcknowledged: false because Task 3.3 will expose it on the query
+    // DTO. The mocks pin the false value to lock the current bridge in place.
+
     [Fact]
     public async Task Handle_EmptyResult_ReturnsZeroItems()
     {
-        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, It.IsAny<CancellationToken>()))
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
 
         var result = await Sut().Handle(new GetWikidataDeadLetterAttemptsQuery(0, 50, null), default);
@@ -46,9 +50,14 @@ public class GetWikidataDeadLetterAttemptsQueryHandlerTests
             DeadLetteredAt: FixedNow,
             Reason: "r2-upload-error",
             Details: "503",
-            RetryCount: 3);
+            RetryCount: 3,
+            AcknowledgedAt: null,
+            AcknowledgedBy: null,
+            AcknowledgedByFullName: null,
+            TriggeredByAdminUserId: null,
+            TriggeredByAdminFullName: null);
 
-        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, "r2-upload-error", It.IsAny<CancellationToken>()))
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, "r2-upload-error", false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeadLetterPage(new[] { row }, TotalCount: 1));
 
         var result = await Sut().Handle(
@@ -69,12 +78,12 @@ public class GetWikidataDeadLetterAttemptsQueryHandlerTests
     [Fact]
     public async Task Handle_NegativeSkip_ClampsToZero()
     {
-        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, It.IsAny<CancellationToken>()))
+        _attempts.Setup(r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
 
         await Sut().Handle(new GetWikidataDeadLetterAttemptsQuery(-5, 50, null), default);
 
-        _attempts.Verify(r => r.GetDeadLettersAsync(0, 50, null, It.IsAny<CancellationToken>()), Times.Once,
+        _attempts.Verify(r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()), Times.Once,
             "handler must clamp negative skip to 0 before delegating to the repo");
     }
 
@@ -84,12 +93,12 @@ public class GetWikidataDeadLetterAttemptsQueryHandlerTests
     [InlineData(1000, 200)] // take=1000 clamps to 200
     public async Task Handle_TakeOutOfRange_Clamped(int requestTake, int expectedTake)
     {
-        _attempts.Setup(r => r.GetDeadLettersAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+        _attempts.Setup(r => r.GetDeadLettersAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
 
         await Sut().Handle(new GetWikidataDeadLetterAttemptsQuery(0, requestTake, null), default);
 
-        _attempts.Verify(r => r.GetDeadLettersAsync(0, expectedTake, null, It.IsAny<CancellationToken>()), Times.Once);
+        _attempts.Verify(r => r.GetDeadLettersAsync(0, expectedTake, null, false, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterTests.cs
@@ -22,7 +22,11 @@ public class InMemoryWikidataEnrichmentEventBroadcasterTests
         AttemptedAt: new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc),
         RetryCount: 3,
         NextRetryAt: null,
-        DeadLetteredAt: new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc));
+        DeadLetteredAt: new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc),
+        // F6 #1823 Phase F: broadcaster fan-out exercise is trigger-source
+        // agnostic; sample defaults to scheduler-authored (null).
+        TriggeredByAdminUserId: null,
+        TriggeredByAdminFullName: null);
 
     private static InMemoryWikidataEnrichmentEventBroadcaster CreateSut() => new(
         NullLogger<InMemoryWikidataEnrichmentEventBroadcaster>.Instance);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
@@ -55,7 +55,7 @@ public class WikidataCoverEnrichmentRunnerTests
             .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
             .Returns(Task.CompletedTask);
 
-        var result = await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        var result = await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         result.Should().BeOfType<EnrichCatalogCoverResult.Success>();
         recorded.Should().NotBeNull();
@@ -81,7 +81,7 @@ public class WikidataCoverEnrichmentRunnerTests
             .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Skipped);
         recorded.Reason.Should().Be(EnrichCatalogCoverCommandHandler.SkipReasonQidMissing);
@@ -104,7 +104,7 @@ public class WikidataCoverEnrichmentRunnerTests
             .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.Failed);
         recorded.RetryCount.Should().Be(1);
@@ -131,7 +131,7 @@ public class WikidataCoverEnrichmentRunnerTests
             .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.DeadLetter);
         recorded.DeadLetteredAt.Should().Be(FixedNow);
@@ -156,7 +156,7 @@ public class WikidataCoverEnrichmentRunnerTests
             .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         recorded!.Outcome.Should().Be(WikidataCoverEnrichmentOutcome.DeadLetter);
         recorded.RetryCount.Should().Be(0, "no retries attempted for corrupted-image failure");
@@ -178,7 +178,7 @@ public class WikidataCoverEnrichmentRunnerTests
         _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: true, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: true, cancellationToken: default);
 
         sent.Should().NotBeNull();
         sent!.GameId.Should().Be(gameId);
@@ -208,7 +208,7 @@ public class WikidataCoverEnrichmentRunnerTests
             .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         recorded!.RetryCount.Should().Be(2,
             "circuit-open is an upstream-infra trip — the runner MUST NOT burn another DEC-3j retry budget slot");
@@ -228,7 +228,7 @@ public class WikidataCoverEnrichmentRunnerTests
         _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var result = await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        var result = await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         result.Should().BeSameAs(expected,
             "the runner returns the M8 result verbatim so admin callers can map it to a DTO");
@@ -253,7 +253,7 @@ public class WikidataCoverEnrichmentRunnerTests
         // Anchor the gauge so the assertion is independent of cross-test leakage.
         MeepleAiMetrics.SetWikidataDeadLetterCount(5);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         ReadGauge(MeepleAiMetrics.WikidataDeadLetterCount).Should().Be(6,
             "F1 hybrid update: runner increments by 1 per persisted DeadLetter attempt");
@@ -277,7 +277,7 @@ public class WikidataCoverEnrichmentRunnerTests
         _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         _broadcaster.Verify(b => b.Publish(It.Is<WikidataEnrichmentEvent>(
                 e => e.SharedGameId == gameId
@@ -304,10 +304,100 @@ public class WikidataCoverEnrichmentRunnerTests
 
         MeepleAiMetrics.SetWikidataDeadLetterCount(7);
 
-        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, default);
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, cancellationToken: default);
 
         ReadGauge(MeepleAiMetrics.WikidataDeadLetterCount).Should().Be(7,
             "F1: Failed-with-retry is not a terminal — gauge MUST stay anchored at the previous value");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // F6 — TriggeredByAdminUserId persistence + SSE payload (#1823 Phase F / #2255)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_NullAdminId_PersistsNullOnAttempt()
+    {
+        // F6 #1823 Phase F: the M9 scheduler path passes a null trigger id;
+        // the runner MUST forward that null down to the factory so the attempt
+        // row preserves the "scheduler-authored" trigger source.
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, triggeredByAdminUserId: null, default);
+
+        recorded.Should().NotBeNull();
+        recorded!.TriggeredByAdminUserId.Should().BeNull(
+            "scheduler-authored attempts MUST persist a null trigger source so the F6 timeline drawer can distinguish them from manual admin dispatches");
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_AdminTriggered_PersistsAdminIdOnAttempt()
+    {
+        // F6 #1823 Phase F: M12 single-trigger + F2 bulk-retry paths thread the
+        // admin user id into the runner. The runner MUST stamp it onto the
+        // attempt row via the new factory parameter (which has a default null
+        // for backward compatibility with non-admin paths).
+        var adminId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "u"));
+
+        WikidataCoverEnrichmentAttempt? recorded = null;
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Callback<WikidataCoverEnrichmentAttempt, CancellationToken>((a, _) => recorded = a)
+            .Returns(Task.CompletedTask);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, triggeredByAdminUserId: adminId, default);
+
+        recorded.Should().NotBeNull();
+        recorded!.TriggeredByAdminUserId.Should().Be(adminId,
+            "admin-triggered attempts MUST persist the operator id so the F6 timeline drawer can show 'triggered by admin X'");
+    }
+
+    [Fact]
+    public async Task EnrichAndRecordAsync_PublishesEventWithTriggeredByAdmin()
+    {
+        // F6 #1823 Phase F: the SSE broadcaster payload MUST include the new
+        // TriggeredByAdminUserId field so subscribers can update the row inline
+        // without a round-trip to the timeline query. The full name is NOT
+        // resolved here (would require a DB LEFT JOIN per publish, incompatible
+        // with the DEC-3e scheduler tick budget) — it is filled in by the F6
+        // query path. Asserting null guards against accidental future eager
+        // resolution that could regress the broadcast latency contract.
+        var adminId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _attempts.Setup(r => r.GetLatestBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WikidataCoverEnrichmentAttempt?)null);
+        _mediator.Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Failed(
+                EnrichCatalogCoverCommandHandler.FailReasonR2Upload, "503"));
+        _attempts.Setup(r => r.AddAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        WikidataEnrichmentEvent? published = null;
+        _broadcaster.Setup(b => b.Publish(It.IsAny<WikidataEnrichmentEvent>()))
+            .Callback<WikidataEnrichmentEvent>(e => published = e);
+
+        await Sut().EnrichAndRecordAsync(gameId, forceRefresh: false, triggeredByAdminUserId: adminId, default);
+
+        published.Should().NotBeNull();
+        published!.TriggeredByAdminUserId.Should().Be(adminId,
+            "F6: the SSE payload MUST carry the trigger id so the admin page can update the row inline");
+        published.TriggeredByAdminFullName.Should().BeNull(
+            "F6: the broadcaster MUST NOT resolve the full name — that is the responsibility of the F6 timeline query (LEFT JOIN per row)");
     }
 
     private static int ReadGauge(System.Diagnostics.Metrics.ObservableGauge<int> gauge)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidatorTests.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "1823")]
+public class AdminBulkAcknowledgeWikidataCoverCommandValidatorTests
+{
+    private readonly AdminBulkAcknowledgeWikidataCoverCommandValidator _sut = new();
+    private readonly Guid _userId = Guid.NewGuid();
+
+    [Fact]
+    public async Task EmptyAttemptIds_Fails()
+    {
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: Array.Empty<Guid>(),
+            Note: null,
+            TriggeredByUserId: _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds);
+    }
+
+    [Fact]
+    public async Task OverMaxBatchSize_Fails()
+    {
+        var ids = Enumerable.Range(0, AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxBatchSize + 1)
+            .Select(_ => Guid.NewGuid()).ToList();
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(ids, null, _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds)
+            .WithErrorMessage($"AttemptIds cannot exceed {AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxBatchSize} per request.");
+    }
+
+    [Fact]
+    public async Task ContainsGuidEmpty_Fails()
+    {
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid(), Guid.Empty },
+            Note: null,
+            TriggeredByUserId: _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds);
+    }
+
+    [Fact]
+    public async Task ContainsDuplicates_Fails()
+    {
+        var dup = Guid.NewGuid();
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { dup, dup },
+            Note: null,
+            TriggeredByUserId: _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.AttemptIds);
+    }
+
+    [Fact]
+    public async Task NoteOver500Chars_Fails()
+    {
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid() },
+            Note: new string('a', AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxNoteLength + 1),
+            TriggeredByUserId: _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.Note)
+            .WithErrorMessage($"Note must be {AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxNoteLength} characters or fewer.");
+    }
+
+    [Fact]
+    public async Task TriggeredByUserIdEmpty_Fails()
+    {
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid() },
+            Note: null,
+            TriggeredByUserId: Guid.Empty);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldHaveValidationErrorFor(c => c.TriggeredByUserId);
+    }
+
+    [Fact]
+    public async Task ValidCommand_NoteNull_Passes()
+    {
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid(), Guid.NewGuid() },
+            Note: null,
+            TriggeredByUserId: _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task ValidCommand_NoteAtMaxLength_Passes()
+    {
+        var cmd = new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: new[] { Guid.NewGuid() },
+            Note: new string('a', AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxNoteLength),
+            TriggeredByUserId: _userId);
+
+        var r = await _sut.TestValidateAsync(cmd);
+        r.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void MaxBatchSize_Is50()
+    {
+        // ADR-driven cap; mirror of F2 bulk-retry budget. If this changes the
+        // operations runbook + FE multi-select limit MUST update too.
+        AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxBatchSize
+            .Should().Be(50, "DEC-3e rate-limiter budget caps each bulk click at 50 acknowledgements");
+    }
+
+    [Fact]
+    public void MaxNoteLength_Is500()
+    {
+        // DEC-F-4: free-text note is log-only, capped at 500 to keep payload small.
+        AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxNoteLength
+            .Should().Be(500, "DEC-F-4 caps acknowledgement notes at 500 chars (log-only)");
+    }
+
+    [Fact]
+    public void OutcomeConstants_Defined()
+    {
+        // F5 contract: 4 outcome strings must exist for the result row payload.
+        AdminBulkAcknowledgeRow.OutcomeAcked.Should().Be("acked");
+        AdminBulkAcknowledgeRow.OutcomeAlreadyAcked.Should().Be("already-acked");
+        AdminBulkAcknowledgeRow.OutcomeNotFound.Should().Be("not-found");
+        AdminBulkAcknowledgeRow.OutcomeWrongState.Should().Be("wrong-state");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptAcknowledgeTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptAcknowledgeTests.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Unit tests for <see cref="WikidataCoverEnrichmentAttempt.Acknowledge"/> — Issue #1823 Phase F F5.
+/// Verifies the dead-letter acknowledgement mutator: only-on-dead-letter guard,
+/// non-empty user id guard, and idempotency on repeated calls.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2254")]
+public class WikidataCoverEnrichmentAttemptAcknowledgeTests
+{
+    private static readonly Guid GameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime AttemptedAt = new(2026, 06, 13, 10, 00, 00, DateTimeKind.Utc);
+    private static readonly DateTime AckedAt = new(2026, 06, 13, 11, 00, 00, DateTimeKind.Utc);
+
+    [Fact]
+    public void Acknowledge_OnDeadLetter_PersistsAtAndBy()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", details: null, retryCount: 3, attemptedAt: AttemptedAt);
+
+        dl.Acknowledge(UserId, AckedAt);
+
+        dl.AcknowledgedAt.Should().Be(AckedAt);
+        dl.AcknowledgedBy.Should().Be(UserId);
+    }
+
+    [Fact]
+    public void Acknowledge_TwiceIsIdempotent_PreservesFirstAck()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", null, 3, AttemptedAt);
+
+        dl.Acknowledge(UserId, AckedAt);
+
+        var laterUserId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var laterAt = AckedAt.AddHours(2);
+        dl.Acknowledge(laterUserId, laterAt);
+
+        dl.AcknowledgedAt.Should().Be(AckedAt);  // preserved
+        dl.AcknowledgedBy.Should().Be(UserId);    // preserved
+    }
+
+    [Fact]
+    public void Acknowledge_GuidEmpty_ThrowsArgumentException()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", null, 3, AttemptedAt);
+
+        var act = () => dl.Acknowledge(Guid.Empty, AckedAt);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("userId");
+    }
+
+    [Theory]
+    [InlineData(WikidataCoverEnrichmentOutcome.Success)]
+    [InlineData(WikidataCoverEnrichmentOutcome.Skipped)]
+    [InlineData(WikidataCoverEnrichmentOutcome.Failed)]
+    public void Acknowledge_NonDeadLetterState_ThrowsInvalidOperationException(
+        WikidataCoverEnrichmentOutcome outcome)
+    {
+        WikidataCoverEnrichmentAttempt attempt = outcome switch
+        {
+            WikidataCoverEnrichmentOutcome.Success =>
+                WikidataCoverEnrichmentAttempt.RecordSuccess(GameId, 0, AttemptedAt),
+            WikidataCoverEnrichmentOutcome.Skipped =>
+                WikidataCoverEnrichmentAttempt.RecordSkipped(GameId, "qid-missing", 0, AttemptedAt),
+            WikidataCoverEnrichmentOutcome.Failed =>
+                WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+                    GameId, "r2-upload-error", null, 1, AttemptedAt, AttemptedAt.AddMinutes(5)),
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+        };
+
+        var act = () => attempt.Acknowledge(UserId, AckedAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{outcome}*");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTests.cs
@@ -162,7 +162,10 @@ public class WikidataCoverEnrichmentAttemptTests
             details: null,
             retryCount: 0,
             nextRetryAt: null,
-            deadLetteredAt: FixedNow);
+            deadLetteredAt: FixedNow,
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+            triggeredByAdminUserId: null);
 
         attempt.Id.Should().Be(id);
         attempt.SharedGameId.Should().Be(sgid);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTriggerSourceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTriggerSourceTests.cs
@@ -69,4 +69,21 @@ public class WikidataCoverEnrichmentAttemptTriggerSourceTests
         hydrated.AcknowledgedAt.Should().BeNull();
         hydrated.AcknowledgedBy.Should().BeNull();
     }
+
+    [Fact]
+    public void RecordSkipped_AdminTriggered_PersistsAdminId()
+    {
+        var a = WikidataCoverEnrichmentAttempt.RecordSkipped(
+            GameId, "qid-missing", 0, At, triggeredByAdminUserId: AdminId);
+        a.TriggeredByAdminUserId.Should().Be(AdminId);
+    }
+
+    [Fact]
+    public void RecordFailedWithRetry_AdminTriggered_PersistsAdminId()
+    {
+        var a = WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+            GameId, "r2-upload-error", null, 1, At, At.AddMinutes(5),
+            triggeredByAdminUserId: AdminId);
+        a.TriggeredByAdminUserId.Should().Be(AdminId);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTriggerSourceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTriggerSourceTests.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Unit tests for <see cref="WikidataCoverEnrichmentAttempt"/> trigger-source
+/// attribution — Issue #1823 Phase F F6. Verifies the optional
+/// <c>TriggeredByAdminUserId</c> factory parameter (default <see langword="null"/>
+/// for the M9 scheduler path; non-null for M12 single-trigger or F2 bulk-retry
+/// admin invocations) and that <see cref="WikidataCoverEnrichmentAttempt.Reconstitute"/>
+/// round-trips all Phase F state fields (<c>AcknowledgedAt</c>, <c>AcknowledgedBy</c>,
+/// <c>TriggeredByAdminUserId</c>).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2255")]
+public class WikidataCoverEnrichmentAttemptTriggerSourceTests
+{
+    private static readonly Guid GameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid AdminId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime At = new(2026, 06, 13, 10, 00, 00, DateTimeKind.Utc);
+
+    [Fact]
+    public void RecordDeadLetter_InitialState_AllPhaseFFieldsAreNull()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", null, 3, At);
+
+        dl.AcknowledgedAt.Should().BeNull();
+        dl.AcknowledgedBy.Should().BeNull();
+        dl.TriggeredByAdminUserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordSuccess_DefaultSchedulerPath_TriggeredByAdminUserIdIsNull()
+    {
+        var a = WikidataCoverEnrichmentAttempt.RecordSuccess(GameId, 0, At);
+        a.TriggeredByAdminUserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordSuccess_AdminTriggered_PersistsAdminId()
+    {
+        var a = WikidataCoverEnrichmentAttempt.RecordSuccess(
+            GameId, 0, At, triggeredByAdminUserId: AdminId);
+        a.TriggeredByAdminUserId.Should().Be(AdminId);
+    }
+
+    [Fact]
+    public void Reconstitute_RoundTripsTriggeredByAdminUserId()
+    {
+        var hydrated = WikidataCoverEnrichmentAttempt.Reconstitute(
+            id: Guid.NewGuid(),
+            sharedGameId: GameId,
+            attemptedAt: At,
+            outcome: WikidataCoverEnrichmentOutcome.Success,
+            reason: "success",
+            details: null,
+            retryCount: 0,
+            nextRetryAt: null,
+            deadLetteredAt: null,
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+            triggeredByAdminUserId: AdminId);
+
+        hydrated.TriggeredByAdminUserId.Should().Be(AdminId);
+        hydrated.AcknowledgedAt.Should().BeNull();
+        hydrated.AcknowledgedBy.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfigurationTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfigurationTests.cs
@@ -1,0 +1,45 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.EntityConfigurations.SharedGameCatalog;
+
+/// <summary>
+/// Issue #2254+#2255 Phase F bundle — pins the EF Core configuration for the
+/// new <c>acknowledged_at</c> / <c>acknowledged_by</c> (F5 bulk-acknowledge)
+/// and <c>triggered_by_admin_user_id</c> (F6 attribution) columns plus the
+/// partial index that powers the default "hide acknowledged" list view.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class WikidataCoverEnrichmentAttemptEntityConfigurationTests
+{
+    [Fact]
+    public void EntityModel_Has_PhaseF_ColumnsAndIndex()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"phasef-{Guid.NewGuid()}")
+            .Options;
+
+        var mediator = new Mock<IMediator>();
+        var collector = new Mock<IDomainEventCollector>();
+
+        using var ctx = new MeepleAiDbContext(options, mediator.Object, collector.Object);
+
+        var entityType = ctx.Model.FindEntityType(typeof(WikidataCoverEnrichmentAttemptEntity))!;
+        var props = entityType.GetProperties().Select(p => p.GetColumnName()).ToList();
+
+        props.Should().Contain(new[] { "acknowledged_at", "acknowledged_by", "triggered_by_admin_user_id" });
+
+        var idx = entityType.GetIndexes().FirstOrDefault(i =>
+            i.GetDatabaseName() == "ix_wikidata_cover_attempts_acknowledged_at");
+        idx.Should().NotBeNull("partial index required for fast 'exclude acked' default list");
+        idx!.GetFilter().Should().Be("acknowledged_at IS NOT NULL");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
@@ -318,6 +318,7 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
         result!.AckedCount.Should().Be(1);
         result.IdempotentNoOpCount.Should().Be(0);
         result.NotFoundCount.Should().Be(0);
+        result.WrongStateCount.Should().Be(0);
         result.Rows.Should().ContainSingle();
         result.Rows[0].AttemptId.Should().Be(attemptId);
         result.Rows[0].GameId.Should().Be(gameId);

--- a/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
@@ -206,6 +207,19 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
         string gameTitle = "M16 Test Game",
         string reason = "r2-upload-error")
     {
+        var (gameId, _) = await SeedDeadLetterAttemptAsync(gameTitle, reason);
+        return gameId;
+    }
+
+    /// <summary>
+    /// Phase F sibling of <see cref="SeedDeadLetterAsync"/> that also surfaces
+    /// the attempt id (required by F5 bulk-acknowledge tests, which pass attempt
+    /// ids — NOT game ids — in the request body).
+    /// </summary>
+    private async Task<(Guid GameId, Guid AttemptId)> SeedDeadLetterAttemptAsync(
+        string gameTitle = "M16 Test Game",
+        string reason = "r2-upload-error")
+    {
         using var scope = _factory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
 
@@ -241,6 +255,138 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
         dbContext.WikidataCoverEnrichmentAttempts.Add(attempt);
         await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        return game.Id;
+        return (game.Id, attempt.Id);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Phase F F5 (#2254) — bulk-acknowledge endpoint integration coverage.
+    //
+    // These tests close the F5 endpoint contract: anonymous probes get 401,
+    // admin sessions ack a real dead-letter row (the result envelope reports
+    // ackedCount=1 and the default list view immediately drops it), and
+    // over-cap batches are rejected by the FluentValidation pipeline as 422
+    // (the project-wide convention from Issue #1449 — the plan-text "400" is
+    // shorthand for "validation rejection"; the ApiExceptionHandlerMiddleware
+    // returns 422 for FluentValidation.ValidationException).
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BulkAcknowledge_AnonymousRequest_Returns401()
+    {
+        // Auth filter must reject anonymous probes BEFORE the MediatR pipeline.
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"{EndpointBase}/bulk-acknowledge")
+        {
+            Content = JsonContent.Create(new
+            {
+                attemptIds = new[] { Guid.NewGuid() },
+                note = (string?)null,
+            }),
+        };
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "the bulk-acknowledge admin endpoint must require an admin session");
+    }
+
+    [Fact]
+    public async Task BulkAcknowledge_AdminWithDeadLetter_AcksRowAndDropsFromDefaultList()
+    {
+        var (gameId, attemptId) = await SeedDeadLetterAttemptAsync(
+            gameTitle: "F5 Acknowledge Game",
+            reason: "r2-upload-error");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{EndpointBase}/bulk-acknowledge",
+            _adminSessionToken,
+            new
+            {
+                attemptIds = new[] { attemptId },
+                note = "F5 endpoint smoke test",
+            });
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<AdminBulkAcknowledgeResult>(body, JsonOptions);
+
+        result.Should().NotBeNull();
+        result!.AckedCount.Should().Be(1);
+        result.IdempotentNoOpCount.Should().Be(0);
+        result.NotFoundCount.Should().Be(0);
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].AttemptId.Should().Be(attemptId);
+        result.Rows[0].GameId.Should().Be(gameId);
+        result.Rows[0].Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeAcked);
+
+        // Direct DB verification: bypass the list endpoint to isolate the layer
+        // (handler vs query). If THIS fails, the handler/repo persistence path
+        // is broken; if the LIST endpoint check below fails while this passes,
+        // the bug is in the query / filter.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var persisted = await dbContext.WikidataCoverEnrichmentAttempts
+                .AsNoTracking()
+                .FirstOrDefaultAsync(a => a.Id == attemptId, TestContext.Current.CancellationToken);
+            persisted.Should().NotBeNull();
+            persisted!.AcknowledgedAt.Should().NotBeNull(
+                "the F5 handler+repo must persist AcknowledgedAt via SaveChangesAsync");
+            persisted.AcknowledgedBy.Should().Be(TestAdminId,
+                "the F5 handler must record the admin user id who acked the row");
+        }
+
+        // Default list view (includeAcknowledged omitted) hides the acked row.
+        var listRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"{EndpointBase}/dead-letters",
+            _adminSessionToken);
+        var listResponse = await _client.SendAsync(listRequest, TestContext.Current.CancellationToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var listBody = await listResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var list = JsonSerializer.Deserialize<WikidataDeadLetterAttemptsResult>(listBody, JsonOptions);
+        list!.Items.Should().NotContain(i => i.Id == attemptId,
+            "default list view hides acknowledged rows so operators only see open work");
+
+        // includeAcknowledged=true surfaces the row again for the audit view.
+        var includedRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"{EndpointBase}/dead-letters?includeAcknowledged=true",
+            _adminSessionToken);
+        var includedResponse = await _client.SendAsync(includedRequest, TestContext.Current.CancellationToken);
+        includedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var includedBody = await includedResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var included = JsonSerializer.Deserialize<WikidataDeadLetterAttemptsResult>(includedBody, JsonOptions);
+        var includedItem = included!.Items.Should().ContainSingle(i => i.Id == attemptId).Subject;
+        includedItem.AcknowledgedAt.Should().NotBeNull("F5 ack metadata must round-trip via the audit view");
+        includedItem.AcknowledgedBy.Should().Be(TestAdminId);
+    }
+
+    [Fact]
+    public async Task BulkAcknowledge_OverFifty_ReturnsValidationError()
+    {
+        // FluentValidation rejects batches > MaxBatchSize. Issue #1449 convention:
+        // FluentValidation.ValidationException → HTTP 422 (NOT 400) via
+        // ApiExceptionHandlerMiddleware. Plan-text uses "400" as shorthand.
+        var ids = Enumerable.Range(0, 51).Select(_ => Guid.NewGuid()).ToArray();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{EndpointBase}/bulk-acknowledge",
+            _adminSessionToken,
+            new
+            {
+                attemptIds = ids,
+                note = (string?)null,
+            });
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity,
+            "FluentValidation rejects > MaxBatchSize batches and the middleware maps to 422");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
@@ -179,6 +180,7 @@ public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLi
 
         var page = await _sut.GetDeadLettersAsync(
             skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: false,
             cancellationToken: TestContext.Current.CancellationToken);
 
         page.TotalCount.Should().Be(1);
@@ -203,6 +205,7 @@ public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLi
 
         var page = await _sut.GetDeadLettersAsync(
             skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: false,
             cancellationToken: TestContext.Current.CancellationToken);
 
         page.TotalCount.Should().Be(1, "soft-deleting the game MUST NOT drop the attempt from the count");
@@ -224,6 +227,7 @@ public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLi
 
         var page = await _sut.GetDeadLettersAsync(
             skip: 0, take: 50, reasonFilter: "image-processing-error",
+            includeAcknowledged: false,
             cancellationToken: TestContext.Current.CancellationToken);
 
         page.TotalCount.Should().Be(1);
@@ -243,6 +247,7 @@ public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLi
 
         var page = await _sut.GetDeadLettersAsync(
             skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: false,
             cancellationToken: TestContext.Current.CancellationToken);
 
         page.Items.Should().HaveCount(2);
@@ -262,6 +267,7 @@ public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLi
 
         var page = await _sut.GetDeadLettersAsync(
             skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: false,
             cancellationToken: TestContext.Current.CancellationToken);
 
         page.TotalCount.Should().Be(0,
@@ -384,8 +390,132 @@ public class WikidataCoverEnrichmentAttemptRepositoryIntegrationTests : IAsyncLi
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // F5 (#2254) — includeAcknowledged filter + Users JOIN for AcknowledgedByFullName
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDeadLettersAsync_DefaultExcludesAcknowledgedRows()
+    {
+        var g1 = SeedGame(qid: "Q1", title: "Acked Game");
+        var g2 = SeedGame(qid: "Q2", title: "Open Game");
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var dl1 = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            g1.Id, "r2-upload-error", details: null, retryCount: 3,
+            attemptedAt: FixedNow.AddDays(-2));
+        var dl2 = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            g2.Id, "r2-upload-error", details: null, retryCount: 3,
+            attemptedAt: FixedNow.AddDays(-1));
+        dl1.Acknowledge(Guid.NewGuid(), FixedNow.AddDays(-1));
+
+        await _sut.AddAsync(dl1, TestContext.Current.CancellationToken);
+        await _sut.AddAsync(dl2, TestContext.Current.CancellationToken);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: false,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.TotalCount.Should().Be(1,
+            "default view hides acknowledged dead-letters so operators see only open work");
+        page.Items[0].SharedGameId.Should().Be(g2.Id);
+    }
+
+    [Fact]
+    public async Task GetDeadLettersAsync_IncludeAcknowledgedTrue_IncludesThem()
+    {
+        var g1 = SeedGame(qid: "Q1", title: "Acked Game");
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            g1.Id, "r2-upload-error", details: null, retryCount: 3,
+            attemptedAt: FixedNow.AddDays(-1));
+        dl.Acknowledge(Guid.NewGuid(), FixedNow);
+        await _sut.AddAsync(dl, TestContext.Current.CancellationToken);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.TotalCount.Should().Be(1);
+        page.Items[0].AcknowledgedAt.Should().NotBeNull();
+        page.Items[0].AcknowledgedBy.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetDeadLettersAsync_PopulatesAcknowledgedByDisplayName_FromUsersJoin()
+    {
+        // User entity uses DisplayName (nullable) rather than FullName; repo
+        // exposes it via DeadLetterRow.AcknowledgedByFullName (semantic name
+        // chosen by the F5 spec — the column populates from DisplayName).
+        var admin = SeedUser(displayName: "Alice Admin");
+        var g1 = SeedGame(qid: "Q1", title: "Game 1");
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            g1.Id, "r2-upload-error", details: null, retryCount: 3,
+            attemptedAt: FixedNow.AddDays(-1));
+        dl.Acknowledge(admin.Id, FixedNow);
+        await _sut.AddAsync(dl, TestContext.Current.CancellationToken);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await _sut.GetDeadLettersAsync(
+            skip: 0, take: 50, reasonFilter: null,
+            includeAcknowledged: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        page.Items[0].AcknowledgedByFullName.Should().Be("Alice Admin",
+            "LEFT JOIN on Users.DisplayName populates the denormalized admin name on the row");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // F6 (#2255) — GetAttemptsByGameIdAsync timeline rows with admin LEFT JOIN
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAttemptsByGameIdAsync_PopulatesTriggeredByAdminFullName()
+    {
+        var admin = SeedUser(displayName: "Bob Admin");
+        var g1 = SeedGame(qid: "Q1", title: "Game 1");
+        await _dbContext!.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var attempt = WikidataCoverEnrichmentAttempt.RecordSuccess(
+            g1.Id, retryCount: 0, attemptedAt: FixedNow,
+            triggeredByAdminUserId: admin.Id);
+        await _sut.AddAsync(attempt, TestContext.Current.CancellationToken);
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var rows = await _sut.GetAttemptsByGameIdAsync(
+            g1.Id, limit: 50,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        rows.Should().HaveCount(1);
+        rows[0].TriggeredByAdminUserId.Should().Be(admin.Id);
+        rows[0].TriggeredByAdminFullName.Should().Be("Bob Admin",
+            "LEFT JOIN on Users.DisplayName surfaces the admin attribution on the F3 timeline drawer");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────────────
+
+    private UserEntity SeedUser(string displayName)
+    {
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = $"{Guid.NewGuid():N}@test.local",
+            DisplayName = displayName,
+            Role = "admin",
+            Tier = "premium",
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext!.Users.Add(user);
+        return user;
+    }
 
     private SharedGameEntity SeedGame(string? qid, string? title = null)
     {

--- a/apps/web/e2e/admin-wikidata-bulk-acknowledge-flow.spec.ts
+++ b/apps/web/e2e/admin-wikidata-bulk-acknowledge-flow.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #2254 — F5 bulk acknowledge UI E2E skeleton.
+ *
+ * Validates end-to-end the admin bulk-acknowledge flow on the Wikidata
+ * dead-letter visibility page:
+ *   1. Operator logs in
+ *   2. Selects N dead-letters via checkbox
+ *   3. Opens the acknowledge modal, optionally types a note, confirms
+ *   4. Acknowledged rows disappear from the default list
+ *   5. Toggling "Show acknowledged" surfaces them with a dimmed marker
+ *
+ * Non-blocking on CI (continue-on-error: true) because it depends on:
+ *   - Admin credentials via E2E_ADMIN_EMAIL/PASSWORD
+ *   - A staging snapshot with ≥2 live dead-letter rows
+ *
+ * Will be promoted to a blocking suite after the BGG-cover-enrichment
+ * fixture seeds reliably create the required dead-letter rows on every
+ * test run.
+ */
+test.describe('Admin Wikidata bulk acknowledge flow (#2254)', () => {
+  test.skip(
+    !process.env.E2E_ADMIN_EMAIL || !process.env.E2E_ADMIN_PASSWORD,
+    'Requires E2E_ADMIN_EMAIL + E2E_ADMIN_PASSWORD env vars'
+  );
+
+  test('select dead-letters, acknowledge with note, toggle Show acked', async ({ page }) => {
+    // 1. Login as admin
+    await page.goto('/login');
+    await page.getByLabel(/email/i).fill(process.env.E2E_ADMIN_EMAIL!);
+    await page.getByLabel(/password/i).fill(process.env.E2E_ADMIN_PASSWORD!);
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await page.waitForURL(/\/(admin|dashboard)/);
+
+    // 2. Navigate to dead-letter page
+    await page.goto('/admin/monitor/wikidata-dead-letters');
+    await expect(page.getByRole('heading', { name: /dead.*letter/i })).toBeVisible();
+
+    // 3. Need ≥ 2 dead-letters to run a meaningful bulk-ack
+    const rows = page.getByRole('row').filter({ has: page.getByRole('checkbox') });
+    const count = await rows.count();
+    test.skip(count < 2, 'Requires ≥ 2 dead-letters in the staging snapshot');
+
+    // 4. Select first 2 rows
+    await rows.nth(0).getByRole('checkbox').check();
+    await rows.nth(1).getByRole('checkbox').check();
+
+    // 5. Open modal, type note, confirm
+    await page.getByRole('button', { name: /Acknowledge selected/i }).click();
+    await page.getByLabel(/note/i).fill('e2e: known commons-deleted asset');
+    await page.getByRole('button', { name: /^Confirm$/i }).click();
+
+    // 6. Modal closes, page reloads, acked rows hidden from default view
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 7. Toggle Show acknowledged → reappear with dimmed marker
+    await page.getByRole('switch', { name: /Show acknowledged/i }).click();
+    await expect(page.getByText(/Acked by/i).first()).toBeVisible();
+  });
+
+  test('over-50 batch returns validation error', async ({ page }) => {
+    // Skeleton: requires fixture seed of ≥51 dead-letters which is impractical
+    // without dedicated test factory. Documented as a follow-up.
+    test.skip(true, 'Pending dedicated factory for 51+ dead-letter seed');
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AcknowledgeSelectedModal.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AcknowledgeSelectedModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 
 import { BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH } from '@/lib/api/admin-wikidata-dead-letters';
 
@@ -15,6 +15,7 @@ interface AcknowledgeSelectedModalProps {
  * Issue #1823 Phase F F5 — confirmation modal for bulk-acknowledge.
  * Optional free-text note (max 500 chars, log-only on the BE per DEC-F-4).
  * Pre-empties to `null` instead of empty string so the BE log line shows `note=<none>`.
+ * A11y: aria-modal + aria-labelledby; Escape dismisses; opens with focus on textarea.
  */
 export function AcknowledgeSelectedModal({
   open,
@@ -24,8 +25,24 @@ export function AcknowledgeSelectedModal({
 }: AcknowledgeSelectedModalProps) {
   const [note, setNote] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // A11y: when the modal opens, programmatically focus the textarea so screen-reader
+  // users land inside the dialog without having to tab through the page background.
+  useEffect(() => {
+    if (open) {
+      textareaRef.current?.focus();
+    }
+  }, [open]);
 
   if (!open) return null;
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape' && !submitting) {
+      e.stopPropagation();
+      onCancel();
+    }
+  };
 
   const handleConfirm = async () => {
     setSubmitting(true);
@@ -42,6 +59,7 @@ export function AcknowledgeSelectedModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="ack-modal-title"
+      onKeyDown={handleKeyDown}
       className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
     >
       <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
@@ -58,6 +76,7 @@ export function AcknowledgeSelectedModal({
         </label>
         <textarea
           id="ack-note"
+          ref={textareaRef}
           aria-label="note"
           maxLength={BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH}
           value={note}

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AcknowledgeSelectedModal.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AcknowledgeSelectedModal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+
+import { BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH } from '@/lib/api/admin-wikidata-dead-letters';
+
+interface AcknowledgeSelectedModalProps {
+  open: boolean;
+  selectedCount: number;
+  onConfirm: (note: string | null) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+/**
+ * Issue #1823 Phase F F5 — confirmation modal for bulk-acknowledge.
+ * Optional free-text note (max 500 chars, log-only on the BE per DEC-F-4).
+ * Pre-empties to `null` instead of empty string so the BE log line shows `note=<none>`.
+ */
+export function AcknowledgeSelectedModal({
+  open,
+  selectedCount,
+  onConfirm,
+  onCancel,
+}: AcknowledgeSelectedModalProps) {
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await onConfirm(note.trim() === '' ? null : note);
+      setNote('');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ack-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
+        <h2 id="ack-modal-title" className="text-lg font-semibold text-foreground">
+          Acknowledge {selectedCount} dead-letter row{selectedCount === 1 ? '' : 's'}?
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Acknowledged rows are hidden from the default list view and won&apos;t consume scheduler
+          retry budget. They are deleted after the 7-day retention sweep regardless.
+        </p>
+
+        <label htmlFor="ack-note" className="mt-4 block text-sm font-medium text-foreground">
+          Note (optional, log only)
+        </label>
+        <textarea
+          id="ack-note"
+          aria-label="note"
+          maxLength={BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH}
+          value={note}
+          onChange={e => setNote(e.target.value)}
+          rows={3}
+          className="mt-1 w-full rounded border border-border bg-background p-2 text-sm text-foreground"
+          placeholder="e.g. Commons deleted file"
+          disabled={submitting}
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          {note.length}/{BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH}
+        </p>
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-border bg-background px-3 py-1.5 text-sm hover:bg-muted"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            disabled={submitting}
+          >
+            {submitting ? 'Acknowledging…' : 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx
@@ -112,7 +112,21 @@ export function AttemptTimelineDrawer({
                   data-outcome={node.outcome}
                 >
                   <div className="flex items-baseline justify-between gap-3">
-                    <span className="text-sm font-semibold">{node.outcome}</span>
+                    <span className="text-sm font-semibold">
+                      {node.outcome}
+                      {node.triggeredByAdminUserId && (
+                        <span
+                          title={
+                            node.triggeredByAdminFullName
+                              ? `Triggered by admin ${node.triggeredByAdminFullName}`
+                              : 'Triggered by admin (deleted user)'
+                          }
+                          className="ml-2 inline-flex items-center rounded border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary"
+                        >
+                          admin
+                        </span>
+                      )}
+                    </span>
                     <time className="text-xs text-muted-foreground" dateTime={node.attemptedAt}>
                       {formatUtc(node.attemptedAt)}
                     </time>

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AcknowledgeSelectedModal.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AcknowledgeSelectedModal.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AcknowledgeSelectedModal } from '../AcknowledgeSelectedModal';
+
+describe('AcknowledgeSelectedModal', () => {
+  it('renders count and submits with note', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onCancel = vi.fn();
+
+    render(
+      <AcknowledgeSelectedModal open selectedCount={3} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+
+    expect(screen.getByText(/Acknowledge 3 dead-letter row/i)).toBeInTheDocument();
+    const textarea = screen.getByLabelText(/note/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'commons deleted file' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith('commons deleted file'));
+  });
+
+  it('cancel returns control without note submission', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <AcknowledgeSelectedModal open selectedCount={1} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('enforces 500-char note limit on textarea maxLength', () => {
+    render(
+      <AcknowledgeSelectedModal open selectedCount={1} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+
+    const textarea = screen.getByLabelText(/note/i) as HTMLTextAreaElement;
+    expect(textarea.maxLength).toBe(500);
+  });
+
+  it('singular grammar for selectedCount=1', () => {
+    render(
+      <AcknowledgeSelectedModal open selectedCount={1} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+
+    expect(screen.getByText(/Acknowledge 1 dead-letter row\?/i)).toBeInTheDocument();
+  });
+
+  it('passes null instead of empty string when textarea is empty', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AcknowledgeSelectedModal open selectedCount={1} onConfirm={onConfirm} onCancel={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(null));
+  });
+
+  it('does not render when open is false', () => {
+    render(
+      <AcknowledgeSelectedModal
+        open={false}
+        selectedCount={1}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AcknowledgeSelectedModal.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AcknowledgeSelectedModal.test.tsx
@@ -72,4 +72,28 @@ describe('AcknowledgeSelectedModal', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  it('a11y: Escape key invokes onCancel', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <AcknowledgeSelectedModal open selectedCount={1} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('a11y: textarea receives focus on open', () => {
+    render(
+      <AcknowledgeSelectedModal open selectedCount={1} onConfirm={vi.fn()} onCancel={vi.fn()} />
+    );
+
+    const textarea = screen.getByLabelText(/note/i) as HTMLTextAreaElement;
+    expect(document.activeElement).toBe(textarea);
+  });
 });

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AttemptTimelineDrawer-phase-f.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AttemptTimelineDrawer-phase-f.test.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AttemptTimelineDrawer } from '../AttemptTimelineDrawer';
+import * as api from '@/lib/api/admin-wikidata-dead-letters';
+
+vi.mock('@/lib/api/admin-wikidata-dead-letters');
+
+// Stub Radix Drawer with a simple wrapper that mounts children inline (no portal,
+// no focus trap, no aria-hidden) so queries can find the inner content
+// synchronously in the test DOM. Behaviour of Phase F badge is independent of
+// the drawer chrome.
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div data-testid="drawer">{children}</div> : null,
+  DrawerContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DrawerHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DrawerDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+}));
+
+describe('AttemptTimelineDrawer — F6 admin badge', () => {
+  it('shows admin badge when triggeredByAdminUserId is non-null', async () => {
+    vi.mocked(api.getAttemptTimeline).mockResolvedValue({
+      gameId: 'g-1',
+      items: [
+        {
+          id: 'a-1',
+          attemptedAt: '2026-06-10T00:00:00Z',
+          outcome: 'Success',
+          reason: 'success',
+          details: null,
+          retryCount: 0,
+          nextRetryAt: null,
+          deadLetteredAt: null,
+          triggeredByAdminUserId: 'admin-1',
+          triggeredByAdminFullName: 'Alice Admin',
+        },
+      ],
+    });
+    render(<AttemptTimelineDrawer gameId="g-1" gameTitle="Test Game" open onClose={() => {}} />);
+
+    // Wait for the async timeline load to complete (ol with aria-label renders post-fetch)
+    await screen.findByRole('list', { name: /Attempt history/i });
+
+    const badge = screen.getByText(
+      (_, node) => node?.textContent === 'admin' && node.tagName === 'SPAN'
+    );
+    expect(badge).toBeInTheDocument();
+    expect(badge.getAttribute('title')).toBe('Triggered by admin Alice Admin');
+  });
+
+  it('hides admin badge when triggeredByAdminUserId is null', async () => {
+    vi.mocked(api.getAttemptTimeline).mockResolvedValue({
+      gameId: 'g-1',
+      items: [
+        {
+          id: 'a-1',
+          attemptedAt: '2026-06-10T00:00:00Z',
+          outcome: 'Success',
+          reason: 'success',
+          details: null,
+          retryCount: 0,
+          nextRetryAt: null,
+          deadLetteredAt: null,
+          triggeredByAdminUserId: null,
+          triggeredByAdminFullName: null,
+        },
+      ],
+    });
+    render(<AttemptTimelineDrawer gameId="g-1" gameTitle="Test Game" open onClose={() => {}} />);
+
+    await screen.findByRole('list', { name: /Attempt history/i });
+
+    expect(
+      screen.queryByText((_, node) => node?.textContent === 'admin' && node.tagName === 'SPAN')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows fallback tooltip when admin user is deleted (id non-null but fullName null)', async () => {
+    vi.mocked(api.getAttemptTimeline).mockResolvedValue({
+      gameId: 'g-1',
+      items: [
+        {
+          id: 'a-1',
+          attemptedAt: '2026-06-10T00:00:00Z',
+          outcome: 'Success',
+          reason: 'success',
+          details: null,
+          retryCount: 0,
+          nextRetryAt: null,
+          deadLetteredAt: null,
+          triggeredByAdminUserId: 'deleted-admin-id',
+          triggeredByAdminFullName: null,
+        },
+      ],
+    });
+    render(<AttemptTimelineDrawer gameId="g-1" gameTitle="Test Game" open onClose={() => {}} />);
+
+    await screen.findByRole('list', { name: /Attempt history/i });
+
+    const badge = screen.getByText(
+      (_, node) => node?.textContent === 'admin' && node.tagName === 'SPAN'
+    );
+    expect(badge.getAttribute('title')).toBe('Triggered by admin (deleted user)');
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/page-phase-f.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/page-phase-f.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Issue #1823 Phase F F5 + F6 — Wikidata dead-letters page integration smoke tests.
+ *
+ * Coverage:
+ *   - "Acknowledge selected" toolbar button mounts alongside "Retry selected" (F5)
+ *   - "Show acknowledged" toggle defaults to off and refetches with the flag set
+ *   - Acked rows render the inline "Acked by … on …" chip (F5)
+ *   - F6 attempt-source marker placeholder: covered by Task 5.4 in the timeline drawer
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import WikidataDeadLettersPage from '../page';
+import * as api from '@/lib/api/admin-wikidata-dead-letters';
+
+vi.mock('@/lib/api/admin-wikidata-dead-letters');
+vi.mock('../useWikidataEnrichmentEvents', () => ({
+  useWikidataEnrichmentEvents: () => ({ state: 'open', lastEvent: null }),
+}));
+
+describe('WikidataDeadLettersPage — Phase F integration', () => {
+  beforeEach(() => {
+    vi.mocked(api.listDeadLetters).mockResolvedValue({
+      items: [
+        {
+          id: 'a-1',
+          sharedGameId: 'g-1',
+          gameTitle: 'Game',
+          attemptedAt: '2026-06-10T00:00:00Z',
+          deadLetteredAt: '2026-06-10T00:00:00Z',
+          reason: 'r2-upload-error',
+          details: null,
+          retryCount: 3,
+          acknowledgedAt: null,
+          acknowledgedBy: null,
+          acknowledgedByFullName: null,
+          triggeredByAdminUserId: null,
+          triggeredByAdminFullName: null,
+        },
+      ],
+      totalCount: 1,
+      skip: 0,
+      take: 50,
+    });
+    vi.mocked(api.bulkAcknowledgeDeadLetters).mockResolvedValue({
+      ackedCount: 1,
+      idempotentNoOpCount: 0,
+      notFoundCount: 0,
+      rows: [
+        {
+          attemptId: 'a-1',
+          gameId: 'g-1',
+          outcome: 'acked',
+          reason: null,
+        },
+      ],
+    });
+  });
+
+  it('renders Acknowledge selected button alongside Retry selected', async () => {
+    render(<WikidataDeadLettersPage />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Open timeline for Game/i })).toBeInTheDocument()
+    );
+
+    // Row-level checkboxes (index 0 = select-all header, index 1 = row 1)
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+
+    expect(screen.getByRole('button', { name: /Acknowledge selected/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry selected/i })).toBeInTheDocument();
+  });
+
+  it('renders Show acknowledged toggle (off by default)', async () => {
+    render(<WikidataDeadLettersPage />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Open timeline for Game/i })).toBeInTheDocument()
+    );
+
+    const toggle = screen.getByRole('switch', { name: /Show acknowledged/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('toggling Show acknowledged refetches with includeAcknowledged=true', async () => {
+    render(<WikidataDeadLettersPage />);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Open timeline for Game/i })).toBeInTheDocument()
+    );
+
+    const toggle = screen.getByRole('switch', { name: /Show acknowledged/i });
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(api.listDeadLetters).toHaveBeenCalledWith(
+        expect.objectContaining({ includeAcknowledged: true })
+      )
+    );
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/page-phase-f.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/page-phase-f.test.tsx
@@ -47,6 +47,7 @@ describe('WikidataDeadLettersPage — Phase F integration', () => {
       ackedCount: 1,
       idempotentNoOpCount: 0,
       notFoundCount: 0,
+      wrongStateCount: 0,
       rows: [
         {
           attemptId: 'a-1',

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
@@ -18,14 +18,18 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import {
+  BULK_ACKNOWLEDGE_MAX_BATCH,
   BULK_RETRY_MAX_BATCH,
+  bulkAcknowledgeDeadLetters,
   bulkRetryDeadLetters,
   listDeadLetters,
   retryDeadLetter,
+  type AdminBulkAcknowledgeResult,
   type AdminBulkRetryWikidataCoverResult,
   type WikidataDeadLetterAttemptDto,
 } from '@/lib/api/admin-wikidata-dead-letters';
 
+import { AcknowledgeSelectedModal } from './AcknowledgeSelectedModal';
 import { AttemptTimelineDrawer } from './AttemptTimelineDrawer';
 import { useWikidataEnrichmentEvents } from './useWikidataEnrichmentEvents';
 
@@ -72,6 +76,15 @@ export default function WikidataDeadLettersPage() {
     | { state: 'done'; result: AdminBulkRetryWikidataCoverResult }
     | { state: 'error'; error: string }
   >({ state: 'idle' });
+  // Phase F F5 — bulk acknowledge (Issue #2254)
+  const [includeAcknowledged, setIncludeAcknowledged] = useState(false);
+  const [ackModalOpen, setAckModalOpen] = useState(false);
+  const [ackState, setAckState] = useState<
+    | { state: 'idle' }
+    | { state: 'running' }
+    | { state: 'done'; result: AdminBulkAcknowledgeResult }
+    | { state: 'error'; error: string }
+  >({ state: 'idle' });
   const [drawer, setDrawer] = useState<DrawerState | null>(null);
 
   // Phase E F4 — live attempt-recorded SSE feed. Each new event triggers a
@@ -86,6 +99,7 @@ export default function WikidataDeadLettersPage() {
         skip: page * PAGE_SIZE,
         take: PAGE_SIZE,
         reason: reasonFilter || undefined,
+        includeAcknowledged,
       });
       setItems(response.items);
       setTotalCount(response.totalCount);
@@ -98,7 +112,7 @@ export default function WikidataDeadLettersPage() {
     } finally {
       setLoading(false);
     }
-  }, [page, reasonFilter]);
+  }, [page, reasonFilter, includeAcknowledged]);
 
   useEffect(() => {
     void load();
@@ -175,6 +189,27 @@ export default function WikidataDeadLettersPage() {
     }
   };
 
+  // Phase F F5 — handler invoked by the AcknowledgeSelectedModal Confirm action.
+  // Note is forwarded to the BE log-only (DEC-F-4), not persisted on the row.
+  const handleAcknowledgeConfirm = useCallback(
+    async (note: string | null) => {
+      setAckState({ state: 'running' });
+      try {
+        const result = await bulkAcknowledgeDeadLetters(Array.from(selectedIds), note);
+        setAckState({ state: 'done', result });
+        setSelectedIds(new Set());
+        setAckModalOpen(false);
+        await load();
+      } catch (err) {
+        setAckState({
+          state: 'error',
+          error: err instanceof Error ? err.message : 'Unknown error',
+        });
+      }
+    },
+    [selectedIds, load]
+  );
+
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const selectionAtCap = selectedIds.size >= BULK_RETRY_MAX_BATCH;
   const allOnPageSelected = items.length > 0 && items.every(i => selectedIds.has(i.id));
@@ -217,6 +252,30 @@ export default function WikidataDeadLettersPage() {
         >
           Refresh
         </button>
+
+        {/* Phase F F5 — toggle for acknowledged rows (default hidden). */}
+        <label className="flex items-center gap-2 text-sm text-foreground">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={includeAcknowledged}
+            aria-label="Show acknowledged"
+            onClick={() => {
+              setIncludeAcknowledged(v => !v);
+              setPage(0);
+            }}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+              includeAcknowledged ? 'bg-primary' : 'bg-muted'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 rounded-full bg-background shadow transition-transform ${
+                includeAcknowledged ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+          Show acknowledged
+        </label>
 
         <div className="ml-auto flex items-center gap-3 text-sm text-muted-foreground">
           <span
@@ -264,6 +323,23 @@ export default function WikidataDeadLettersPage() {
           {bulkState.state === 'running' ? 'Retrying…' : 'Retry selected'}
         </button>
 
+        {/* Phase F F5 — bulk acknowledge (Issue #2254). Opens the confirmation
+            modal; the modal owns the optional note and forwards to the BE. */}
+        <button
+          type="button"
+          className="rounded bg-secondary px-3 py-1 text-sm font-medium text-secondary-foreground hover:bg-secondary/90 disabled:opacity-50"
+          onClick={() => setAckModalOpen(true)}
+          disabled={
+            selectedIds.size === 0 ||
+            selectedIds.size > BULK_ACKNOWLEDGE_MAX_BATCH ||
+            ackState.state === 'running'
+          }
+        >
+          {ackState.state === 'running'
+            ? 'Acknowledging…'
+            : `Acknowledge selected (${selectedIds.size})`}
+        </button>
+
         <button
           type="button"
           className="rounded border px-3 py-1 text-sm hover:bg-muted disabled:opacity-50"
@@ -282,6 +358,17 @@ export default function WikidataDeadLettersPage() {
         {bulkState.state === 'error' && (
           <span className="text-xs text-destructive" role="alert">
             ✗ {bulkState.error}
+          </span>
+        )}
+        {ackState.state === 'done' && (
+          <span className="text-xs text-muted-foreground">
+            ✔ {ackState.result.ackedCount} acked · {ackState.result.idempotentNoOpCount}{' '}
+            already-acked · {ackState.result.notFoundCount} not-found
+          </span>
+        )}
+        {ackState.state === 'error' && (
+          <span className="text-xs text-destructive" role="alert">
+            ✗ {ackState.error}
           </span>
         )}
       </section>
@@ -325,8 +412,9 @@ export default function WikidataDeadLettersPage() {
             {items.map(row => {
               const status = retryStatus[row.id]?.state ?? 'idle';
               const checked = selectedIds.has(row.id);
+              const isAcked = row.acknowledgedAt !== null;
               return (
-                <tr key={row.id} className="border-b">
+                <tr key={row.id} className={`border-b ${isAcked ? 'opacity-60' : ''}`}>
                   <td className="p-2">
                     <input
                       type="checkbox"
@@ -347,6 +435,12 @@ export default function WikidataDeadLettersPage() {
                     >
                       {row.gameTitle}
                     </button>
+                    {isAcked && row.acknowledgedByFullName && row.acknowledgedAt && (
+                      <span className="ml-2 inline-flex rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        Acked by {row.acknowledgedByFullName} on{' '}
+                        {new Date(row.acknowledgedAt).toLocaleDateString()}
+                      </span>
+                    )}
                   </td>
                   <td className="p-2">
                     <code className="rounded bg-muted px-1 py-0.5 text-xs">{row.reason}</code>
@@ -409,6 +503,13 @@ export default function WikidataDeadLettersPage() {
           onClose={() => setDrawer(null)}
         />
       )}
+
+      <AcknowledgeSelectedModal
+        open={ackModalOpen}
+        selectedCount={selectedIds.size}
+        onConfirm={handleAcknowledgeConfirm}
+        onCancel={() => setAckModalOpen(false)}
+      />
     </main>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx
@@ -364,6 +364,9 @@ export default function WikidataDeadLettersPage() {
           <span className="text-xs text-muted-foreground">
             ✔ {ackState.result.ackedCount} acked · {ackState.result.idempotentNoOpCount}{' '}
             already-acked · {ackState.result.notFoundCount} not-found
+            {ackState.result.wrongStateCount > 0 && (
+              <> · {ackState.result.wrongStateCount} skipped (wrong state)</>
+            )}
           </span>
         )}
         {ackState.state === 'error' && (

--- a/apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-f.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-f.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Phase F F5 + F6 client coverage for admin-wikidata-dead-letters.
+ * Issue #2254 (bulk-acknowledge) + #2255 (attempt-source attribution).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AdminBulkAcknowledgeResult,
+  BULK_ACKNOWLEDGE_MAX_BATCH,
+  BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH,
+  bulkAcknowledgeDeadLetters,
+  listDeadLetters,
+} from '../admin-wikidata-dead-letters';
+
+const ENDPOINT_BASE = '/api/v1/admin/wikidata/enrichment';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('bulkAcknowledgeDeadLetters (F5 client)', () => {
+  it('POSTs attemptIds + note to /bulk-acknowledge with credentials', async () => {
+    const payload: AdminBulkAcknowledgeResult = {
+      ackedCount: 1,
+      idempotentNoOpCount: 0,
+      notFoundCount: 0,
+      rows: [{ attemptId: 'a-1', gameId: 'g-1', outcome: 'acked', reason: null }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await bulkAcknowledgeDeadLetters(['a-1'], 'op note');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ENDPOINT_BASE}/bulk-acknowledge`);
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(JSON.parse(init.body as string)).toEqual({
+      attemptIds: ['a-1'],
+      note: 'op note',
+    });
+    expect(result.ackedCount).toBe(1);
+    expect(result.rows[0]?.outcome).toBe('acked');
+  });
+
+  it('threads a null note unchanged in the JSON body', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ ackedCount: 0, idempotentNoOpCount: 0, notFoundCount: 0, rows: [] }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await bulkAcknowledgeDeadLetters(['a-1'], null);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      attemptIds: ['a-1'],
+      note: null,
+    });
+  });
+
+  it('throws Error on 422 with body included in the message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('Too many', { status: 422, statusText: 'Unprocessable Entity' })
+        )
+    );
+
+    await expect(bulkAcknowledgeDeadLetters(['a-1'], null)).rejects.toThrow(
+      /Failed to bulk-acknowledge.*422.*Too many/i
+    );
+  });
+
+  it('exposes BE-mirrored constants for MaxBatchSize + MaxNoteLength', () => {
+    expect(BULK_ACKNOWLEDGE_MAX_BATCH).toBe(50);
+    expect(BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH).toBe(500);
+  });
+});
+
+describe('listDeadLetters (includeAcknowledged threading)', () => {
+  it('threads includeAcknowledged=true into the query string', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], totalCount: 0, skip: 0, take: 50 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listDeadLetters({ includeAcknowledged: true });
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('includeAcknowledged=true');
+  });
+
+  it('omits includeAcknowledged when false / default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], totalCount: 0, skip: 0, take: 50 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listDeadLetters({});
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain('includeAcknowledged');
+  });
+
+  it('omits includeAcknowledged when explicitly false', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], totalCount: 0, skip: 0, take: 50 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listDeadLetters({ includeAcknowledged: false });
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain('includeAcknowledged');
+  });
+});

--- a/apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-f.test.ts
+++ b/apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-f.test.ts
@@ -25,6 +25,7 @@ describe('bulkAcknowledgeDeadLetters (F5 client)', () => {
       ackedCount: 1,
       idempotentNoOpCount: 0,
       notFoundCount: 0,
+      wrongStateCount: 0,
       rows: [{ attemptId: 'a-1', gameId: 'g-1', outcome: 'acked', reason: null }],
     };
     const fetchMock = vi.fn().mockResolvedValue(
@@ -55,7 +56,13 @@ describe('bulkAcknowledgeDeadLetters (F5 client)', () => {
       .fn()
       .mockResolvedValue(
         new Response(
-          JSON.stringify({ ackedCount: 0, idempotentNoOpCount: 0, notFoundCount: 0, rows: [] }),
+          JSON.stringify({
+            ackedCount: 0,
+            idempotentNoOpCount: 0,
+            notFoundCount: 0,
+            wrongStateCount: 0,
+            rows: [],
+          }),
           { status: 200, headers: { 'content-type': 'application/json' } }
         )
       );

--- a/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
+++ b/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
@@ -20,6 +20,13 @@ export interface WikidataDeadLetterAttemptDto {
   reason: string;
   details: string | null;
   retryCount: number;
+  // Phase F F5 — acknowledgement (Issue #2254)
+  acknowledgedAt: string | null;
+  acknowledgedBy: string | null;
+  acknowledgedByFullName: string | null;
+  // Phase F F6 — attempt-source attribution (Issue #2255)
+  triggeredByAdminUserId: string | null;
+  triggeredByAdminFullName: string | null;
 }
 
 export interface WikidataDeadLetterAttemptsResult {
@@ -54,12 +61,18 @@ async function rejectAs(response: Response, message: string): Promise<never> {
 }
 
 export async function listDeadLetters(
-  options: { skip?: number; take?: number; reason?: string } = {}
+  options: {
+    skip?: number;
+    take?: number;
+    reason?: string;
+    includeAcknowledged?: boolean;
+  } = {}
 ): Promise<WikidataDeadLetterAttemptsResult> {
   const params = new URLSearchParams();
   if (options.skip !== undefined) params.set('skip', String(options.skip));
   if (options.take !== undefined) params.set('take', String(options.take));
   if (options.reason) params.set('reason', options.reason);
+  if (options.includeAcknowledged) params.set('includeAcknowledged', 'true');
 
   const url = `${ENDPOINT_BASE}/dead-letters${params.size > 0 ? `?${params.toString()}` : ''}`;
   const response = await fetch(url, { credentials: 'include' });
@@ -146,6 +159,9 @@ export interface WikidataAttemptTimelineNode {
   retryCount: number;
   nextRetryAt: string | null;
   deadLetteredAt: string | null;
+  // Phase F F6 — attempt-source attribution (Issue #2255)
+  triggeredByAdminUserId: string | null;
+  triggeredByAdminFullName: string | null;
 }
 
 export interface WikidataAttemptTimelineResult {
@@ -166,4 +182,55 @@ export async function getAttemptTimeline(
     await rejectAs(response, 'Failed to load attempt timeline');
   }
   return (await response.json()) as WikidataAttemptTimelineResult;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase F F5 — bulk acknowledge (Issue #2254)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * BE-side cap (mirrors AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxBatchSize).
+ * Larger client-side selections MUST be chunked before invoking the endpoint.
+ */
+export const BULK_ACKNOWLEDGE_MAX_BATCH = 50;
+
+/**
+ * BE-side note maxLength (mirrors AdminBulkAcknowledgeWikidataCoverCommandValidator.MaxNoteLength).
+ */
+export const BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH = 500;
+
+export type BulkAcknowledgeRowOutcome = 'acked' | 'already-acked' | 'not-found' | 'wrong-state';
+
+export interface BulkAcknowledgeRow {
+  attemptId: string;
+  gameId: string | null;
+  outcome: BulkAcknowledgeRowOutcome;
+  reason: string | null;
+}
+
+export interface AdminBulkAcknowledgeResult {
+  ackedCount: number;
+  idempotentNoOpCount: number;
+  notFoundCount: number;
+  rows: BulkAcknowledgeRow[];
+}
+
+/**
+ * Bulk-acknowledge dead-letter attempts. Optional note is log-only on the BE
+ * (DEC-F-4); not persisted on the attempt row.
+ */
+export async function bulkAcknowledgeDeadLetters(
+  attemptIds: string[],
+  note: string | null
+): Promise<AdminBulkAcknowledgeResult> {
+  const response = await fetch(`${ENDPOINT_BASE}/bulk-acknowledge`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ attemptIds, note }),
+  });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to bulk-acknowledge enrichments');
+  }
+  return (await response.json()) as AdminBulkAcknowledgeResult;
 }

--- a/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
+++ b/apps/web/src/lib/api/admin-wikidata-dead-letters.ts
@@ -212,6 +212,13 @@ export interface AdminBulkAcknowledgeResult {
   ackedCount: number;
   idempotentNoOpCount: number;
   notFoundCount: number;
+  /**
+   * Rows resolved to an attempt NOT in the dead-letter state (race with the
+   * 7-day retention sweep deleting + re-creating rows). Surfaced so the admin
+   * chip can report "K skipped (wrong state)" instead of silently dropping
+   * these rows from the operator-visible count.
+   */
+  wrongStateCount: number;
   rows: BulkAcknowledgeRow[];
 }
 

--- a/docs/superpowers/plans/2026-06-13-issue-2254-2255-phase-f-bundle.md
+++ b/docs/superpowers/plans/2026-06-13-issue-2254-2255-phase-f-bundle.md
@@ -1,0 +1,2609 @@
+# F5+F6 Phase F bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship #2254 F5 bulk acknowledge UI + #2255 F6 attempt-source attribution in one PR, closing Phase F follow-up of epic #1823.
+
+**Architecture:** Mirror Phase E F2/F3/F4 patterns. Bundle 1 migration (3 columns + 1 partial index) + extend aggregate (mutator + factory params) + 1 new CQRS command + 2 query DTO extensions + 1 new endpoint + FE toolbar/modal/badge on existing dead-letter visibility page.
+
+**Tech Stack:** .NET 9, EF Core, FluentValidation, MediatR, PostgreSQL, xUnit + Testcontainers, Next.js 16 + React 19, Tailwind 4, Vitest, Playwright.
+
+**Spec:** [`docs/superpowers/specs/2026-06-13-issue-2254-2255-phase-f-bundle-design.md`](../specs/2026-06-13-issue-2254-2255-phase-f-bundle-design.md)
+**Branch:** `feature/issue-2254-2255-phase-f-bundle`
+**Estimate:** ~19h (~2.5gg)
+
+---
+
+## Phase 1 — Backend Domain
+
+### Task 1.1: Aggregate F5 mutator `Acknowledge()`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptAcknowledgeTests.cs` (new file)
+
+- [ ] **Step 1: Write the failing test** (4 cases in one file)
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+public class WikidataCoverEnrichmentAttemptAcknowledgeTests
+{
+    private static readonly Guid GameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime AttemptedAt = new(2026, 06, 13, 10, 00, 00, DateTimeKind.Utc);
+    private static readonly DateTime AckedAt = new(2026, 06, 13, 11, 00, 00, DateTimeKind.Utc);
+
+    [Fact]
+    public void Acknowledge_OnDeadLetter_PersistsAtAndBy()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", details: null, retryCount: 3, attemptedAt: AttemptedAt);
+
+        dl.Acknowledge(UserId, AckedAt);
+
+        dl.AcknowledgedAt.Should().Be(AckedAt);
+        dl.AcknowledgedBy.Should().Be(UserId);
+    }
+
+    [Fact]
+    public void Acknowledge_TwiceIsIdempotent_PreservesFirstAck()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", null, 3, AttemptedAt);
+
+        dl.Acknowledge(UserId, AckedAt);
+
+        var laterUserId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var laterAt = AckedAt.AddHours(2);
+        dl.Acknowledge(laterUserId, laterAt);
+
+        dl.AcknowledgedAt.Should().Be(AckedAt);  // preserved
+        dl.AcknowledgedBy.Should().Be(UserId);    // preserved
+    }
+
+    [Fact]
+    public void Acknowledge_GuidEmpty_ThrowsArgumentException()
+    {
+        var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+            GameId, "r2-upload-error", null, 3, AttemptedAt);
+
+        var act = () => dl.Acknowledge(Guid.Empty, AckedAt);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("userId");
+    }
+
+    [Theory]
+    [InlineData(WikidataCoverEnrichmentOutcome.Success)]
+    [InlineData(WikidataCoverEnrichmentOutcome.Skipped)]
+    [InlineData(WikidataCoverEnrichmentOutcome.Failed)]
+    public void Acknowledge_NonDeadLetterState_ThrowsInvalidOperationException(
+        WikidataCoverEnrichmentOutcome outcome)
+    {
+        WikidataCoverEnrichmentAttempt attempt = outcome switch
+        {
+            WikidataCoverEnrichmentOutcome.Success =>
+                WikidataCoverEnrichmentAttempt.RecordSuccess(GameId, 0, AttemptedAt),
+            WikidataCoverEnrichmentOutcome.Skipped =>
+                WikidataCoverEnrichmentAttempt.RecordSkipped(GameId, "qid-missing", 0, AttemptedAt),
+            WikidataCoverEnrichmentOutcome.Failed =>
+                WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+                    GameId, "r2-upload-error", null, 1, AttemptedAt, AttemptedAt.AddMinutes(5)),
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+        };
+
+        var act = () => attempt.Acknowledge(UserId, AckedAt);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{outcome}*");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttemptAcknowledgeTests" --no-restore`
+Expected: FAIL with `'WikidataCoverEnrichmentAttempt' does not contain a definition for 'Acknowledge'` and `'AcknowledgedAt'/'AcknowledgedBy'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `WikidataCoverEnrichmentAttempt.cs` — add 2 properties and the mutator below `DeadLetteredAt`:
+
+```csharp
+/// <summary>UTC timestamp when an operator acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged or not a dead-letter.</summary>
+public DateTime? AcknowledgedAt { get; private set; }
+
+/// <summary>User id of the operator who acknowledged the dead-letter; <see langword="null"/> when not yet acknowledged.</summary>
+public Guid? AcknowledgedBy { get; private set; }
+
+// (place the mutator at the end of the type, after Reconstitute)
+
+/// <summary>
+/// Issue #1823 Phase F F5 — operator marks a dead-letter as "not actionable".
+/// EXCEPTION to the record-of-fact pattern documented on the type: ack is
+/// operational metadata orthogonal to the pipeline (parallel to
+/// <see cref="DeadLetteredAt"/>), not a new pipeline event. Idempotent on
+/// re-call: the first ack is preserved and subsequent calls are no-ops so
+/// repeated bulk-acknowledge clicks cannot rewrite the audit trail.
+/// </summary>
+/// <param name="userId">Acknowledging admin user id; must not be <see cref="Guid.Empty"/>.</param>
+/// <param name="ackedAt">UTC acknowledgement timestamp.</param>
+public void Acknowledge(Guid userId, DateTime ackedAt)
+{
+    if (Outcome != WikidataCoverEnrichmentOutcome.DeadLetter)
+        throw new InvalidOperationException(
+            $"Only DeadLetter attempts can be acknowledged; current Outcome={Outcome}.");
+
+    if (userId == Guid.Empty)
+        throw new ArgumentException("UserId cannot be Guid.Empty.", nameof(userId));
+
+    if (AcknowledgedAt is not null) return; // idempotent
+
+    AcknowledgedAt = ackedAt;
+    AcknowledgedBy = userId;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttemptAcknowledgeTests" --no-restore`
+Expected: PASS (6 tests — 3 happy + 3 theory).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptAcknowledgeTests.cs
+git commit -m "feat(catalog-be): #2254 Acknowledge() mutator on WikidataCoverEnrichmentAttempt"
+```
+
+---
+
+### Task 1.2: Aggregate F6 factory + Reconstitute params
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTriggerSourceTests.cs` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+public class WikidataCoverEnrichmentAttemptTriggerSourceTests
+{
+    private static readonly Guid GameId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid AdminId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime At = new(2026, 06, 13, 10, 00, 00, DateTimeKind.Utc);
+
+    [Fact]
+    public void RecordSuccess_DefaultSchedulerPath_TriggeredByAdminUserIdIsNull()
+    {
+        var a = WikidataCoverEnrichmentAttempt.RecordSuccess(GameId, 0, At);
+
+        a.TriggeredByAdminUserId.Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordSuccess_AdminTriggered_PersistsAdminId()
+    {
+        var a = WikidataCoverEnrichmentAttempt.RecordSuccess(
+            GameId, 0, At, triggeredByAdminUserId: AdminId);
+
+        a.TriggeredByAdminUserId.Should().Be(AdminId);
+    }
+
+    [Fact]
+    public void Reconstitute_RoundTripsTriggeredByAdminUserId()
+    {
+        var hydrated = WikidataCoverEnrichmentAttempt.Reconstitute(
+            id: Guid.NewGuid(),
+            sharedGameId: GameId,
+            attemptedAt: At,
+            outcome: WikidataCoverEnrichmentOutcome.Success,
+            reason: "success",
+            details: null,
+            retryCount: 0,
+            nextRetryAt: null,
+            deadLetteredAt: null,
+            acknowledgedAt: null,
+            acknowledgedBy: null,
+            triggeredByAdminUserId: AdminId);
+
+        hydrated.TriggeredByAdminUserId.Should().Be(AdminId);
+        hydrated.AcknowledgedAt.Should().BeNull();
+        hydrated.AcknowledgedBy.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttemptTriggerSourceTests" --no-restore`
+Expected: FAIL on `triggeredByAdminUserId` keyword unknown to factories.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `WikidataCoverEnrichmentAttempt.cs`:
+
+1. Add property below `AcknowledgedBy`:
+```csharp
+/// <summary>
+/// Issue #1823 Phase F F6 — user id of the admin who manually triggered this
+/// attempt via M12 (single trigger) or F2 (bulk retry). <see langword="null"/>
+/// when invoked by the M9 scheduler (the default path).
+/// </summary>
+public Guid? TriggeredByAdminUserId { get; private set; }
+```
+
+2. Update constructor signature + body to accept all 3 new fields:
+```csharp
+private WikidataCoverEnrichmentAttempt(
+    Guid id, Guid sharedGameId, DateTime attemptedAt,
+    WikidataCoverEnrichmentOutcome outcome, string reason, string? details,
+    int retryCount, DateTime? nextRetryAt, DateTime? deadLetteredAt,
+    DateTime? acknowledgedAt, Guid? acknowledgedBy,
+    Guid? triggeredByAdminUserId) : base(id)
+{
+    SharedGameId = sharedGameId;
+    AttemptedAt = attemptedAt;
+    Outcome = outcome;
+    Reason = reason;
+    Details = details;
+    RetryCount = retryCount;
+    NextRetryAt = nextRetryAt;
+    DeadLetteredAt = deadLetteredAt;
+    AcknowledgedAt = acknowledgedAt;
+    AcknowledgedBy = acknowledgedBy;
+    TriggeredByAdminUserId = triggeredByAdminUserId;
+}
+```
+
+3. Update `Create(...)` private helper to accept + propagate `Guid? triggeredByAdminUserId`:
+```csharp
+private static WikidataCoverEnrichmentAttempt Create(
+    Guid sharedGameId, DateTime attemptedAt, WikidataCoverEnrichmentOutcome outcome,
+    string reason, string? details, int retryCount,
+    DateTime? nextRetryAt, DateTime? deadLetteredAt,
+    Guid? triggeredByAdminUserId)
+{
+    if (sharedGameId == Guid.Empty)
+        throw new ArgumentException("SharedGameId cannot be Guid.Empty.", nameof(sharedGameId));
+    if (string.IsNullOrWhiteSpace(reason))
+        throw new ArgumentException("Reason is required.", nameof(reason));
+    if (reason.Length > 64)
+        throw new ArgumentException("Reason must be 64 characters or fewer.", nameof(reason));
+    if (details is { Length: > 1024 })
+        throw new ArgumentException("Details must be 1024 characters or fewer.", nameof(details));
+    if (retryCount < 0)
+        throw new ArgumentOutOfRangeException(nameof(retryCount), retryCount, "RetryCount must be non-negative.");
+
+    return new WikidataCoverEnrichmentAttempt(
+        id: Guid.NewGuid(),
+        sharedGameId, attemptedAt, outcome, reason, details, retryCount,
+        nextRetryAt, deadLetteredAt,
+        acknowledgedAt: null, acknowledgedBy: null,
+        triggeredByAdminUserId);
+}
+```
+
+4. Add `Guid? triggeredByAdminUserId = null` (default null) to each public factory and propagate:
+```csharp
+public static WikidataCoverEnrichmentAttempt RecordSuccess(
+    Guid sharedGameId, int retryCount, DateTime attemptedAt,
+    Guid? triggeredByAdminUserId = null) =>
+    Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.Success,
+        "success", null, retryCount, null, null, triggeredByAdminUserId);
+
+public static WikidataCoverEnrichmentAttempt RecordSkipped(
+    Guid sharedGameId, string reason, int retryCount, DateTime attemptedAt,
+    Guid? triggeredByAdminUserId = null) =>
+    Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.Skipped,
+        reason, null, retryCount, null, null, triggeredByAdminUserId);
+
+public static WikidataCoverEnrichmentAttempt RecordFailedWithRetry(
+    Guid sharedGameId, string reason, string? details, int retryCount,
+    DateTime attemptedAt, DateTime nextRetryAt,
+    Guid? triggeredByAdminUserId = null) =>
+    Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.Failed,
+        reason, details, retryCount, nextRetryAt, null, triggeredByAdminUserId);
+
+public static WikidataCoverEnrichmentAttempt RecordDeadLetter(
+    Guid sharedGameId, string reason, string? details, int retryCount,
+    DateTime attemptedAt,
+    Guid? triggeredByAdminUserId = null) =>
+    Create(sharedGameId, attemptedAt, WikidataCoverEnrichmentOutcome.DeadLetter,
+        reason, details, retryCount, null, attemptedAt, triggeredByAdminUserId);
+```
+
+5. Update `Reconstitute(...)` signature:
+```csharp
+public static WikidataCoverEnrichmentAttempt Reconstitute(
+    Guid id, Guid sharedGameId, DateTime attemptedAt,
+    WikidataCoverEnrichmentOutcome outcome, string reason, string? details,
+    int retryCount, DateTime? nextRetryAt, DateTime? deadLetteredAt,
+    DateTime? acknowledgedAt, Guid? acknowledgedBy,
+    Guid? triggeredByAdminUserId) =>
+    new(id, sharedGameId, attemptedAt, outcome, reason, details,
+        retryCount, nextRetryAt, deadLetteredAt,
+        acknowledgedAt, acknowledgedBy, triggeredByAdminUserId);
+```
+
+- [ ] **Step 4: Run all aggregate tests + verify Task 1.1 still passes**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttempt" --no-restore`
+Expected: PASS (Task 1.1 6 tests + Task 1.2 3 tests = 9 total).
+
+If `Reconstitute(...)` callers in `WikidataCoverEnrichmentAttemptRepository.Map` break compile, Task 2.3 (Repository update) will fix them properly — but compile MUST succeed here for the test to run. If it doesn't, temporarily add `acknowledgedAt: null, acknowledgedBy: null, triggeredByAdminUserId: null` in the existing `Map(...)` call to unblock; Task 2.3 will overwrite that.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttempt.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/WikidataCoverEnrichmentAttemptTriggerSourceTests.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs
+git commit -m "feat(catalog-be): #2255 TriggeredByAdminUserId factory param + Reconstitute"
+```
+
+---
+
+## Phase 2 — Backend Infrastructure (Entity + EF + Migration + Repo)
+
+### Task 2.1: Entity properties + EF config columns/index
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfiguration.cs`
+
+- [ ] **Step 1: Write the failing test (entity config test via DbContext)**
+
+`apps/api/tests/Api.Tests/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfigurationTests.cs` (new):
+
+```csharp
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.EntityConfigurations.SharedGameCatalog;
+
+public class WikidataCoverEnrichmentAttemptEntityConfigurationTests
+{
+    [Fact]
+    public void EntityModel_Has_PhaseF_ColumnsAndIndex()
+    {
+        using var ctx = TestDbContextFactory.CreateInMemory();
+
+        var entityType = ctx.Model.FindEntityType(typeof(WikidataCoverEnrichmentAttemptEntity))!;
+        var props = entityType.GetProperties().Select(p => p.GetColumnName()).ToList();
+
+        props.Should().Contain(new[] { "acknowledged_at", "acknowledged_by", "triggered_by_admin_user_id" });
+
+        var idx = entityType.GetIndexes().FirstOrDefault(i =>
+            i.GetDatabaseName() == "ix_wikidata_cover_attempts_acknowledged_at");
+        idx.Should().NotBeNull("partial index required for fast 'exclude acked' default list");
+        idx!.GetFilter().Should().Be("acknowledged_at IS NOT NULL");
+    }
+}
+```
+
+> **Note:** if `TestDbContextFactory` does not exist (verify with `find apps/api/tests -name 'TestDbContextFactory*'`), inline the DbContext creation:
+> ```csharp
+> var opts = new DbContextOptionsBuilder<MeepleAiDbContext>()
+>     .UseInMemoryDatabase($"phasef-{Guid.NewGuid()}")
+>     .Options;
+> using var ctx = new MeepleAiDbContext(opts);
+> ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttemptEntityConfigurationTests" --no-restore`
+Expected: FAIL (columns missing, no `acknowledged_*` property).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `WikidataCoverEnrichmentAttemptEntity.cs` — add 3 properties after `DeadLetteredAt`:
+
+```csharp
+/// <summary>F5 — UTC timestamp when an operator acknowledged the dead-letter; null otherwise.</summary>
+public DateTime? AcknowledgedAt { get; set; }
+
+/// <summary>F5 — User id of the operator who acknowledged; null otherwise.</summary>
+public Guid? AcknowledgedBy { get; set; }
+
+/// <summary>F6 — Admin user id when triggered via M12 or F2; null for M9 scheduler.</summary>
+public Guid? TriggeredByAdminUserId { get; set; }
+```
+
+Edit `WikidataCoverEnrichmentAttemptEntityConfiguration.cs` — add 3 column mappings + 1 partial index after the existing config (before the closing brace):
+
+```csharp
+builder.Property(e => e.AcknowledgedAt)
+    .HasColumnName("acknowledged_at")
+    .IsRequired(false);
+
+builder.Property(e => e.AcknowledgedBy)
+    .HasColumnName("acknowledged_by")
+    .IsRequired(false);
+
+builder.Property(e => e.TriggeredByAdminUserId)
+    .HasColumnName("triggered_by_admin_user_id")
+    .IsRequired(false);
+
+// F5 partial index: speeds up default list view (exclude acked = WHERE acknowledged_at IS NULL)
+builder.HasIndex(e => e.AcknowledgedAt)
+    .HasDatabaseName("ix_wikidata_cover_attempts_acknowledged_at")
+    .HasFilter("acknowledged_at IS NOT NULL");
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: same as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntity.cs \
+        apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfiguration.cs \
+        apps/api/tests/Api.Tests/Infrastructure/EntityConfigurations/SharedGameCatalog/WikidataCoverEnrichmentAttemptEntityConfigurationTests.cs
+git commit -m "feat(catalog-be): #2254+#2255 entity columns + acknowledged_at partial index"
+```
+
+---
+
+### Task 2.2: EF Core migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Migrations/2026XXXXXXXX_AddAcknowledgeAndTriggerSourceToWikidataAttempts.cs` (auto-generated)
+- Create: `apps/api/src/Api/Infrastructure/Migrations/2026XXXXXXXX_AddAcknowledgeAndTriggerSourceToWikidataAttempts.Designer.cs` (auto-generated)
+- Modify: `apps/api/src/Api/Infrastructure/Migrations/MeepleAiDbContextModelSnapshot.cs` (auto-updated)
+
+- [ ] **Step 1: Generate migration**
+
+Run: `cd apps/api/src/Api && dotnet ef migrations add AddAcknowledgeAndTriggerSourceToWikidataAttempts --no-build`
+Expected: 3 files created/modified above.
+
+- [ ] **Step 2: Inspect generated SQL**
+
+Open the new `*_AddAcknowledgeAndTriggerSourceToWikidataAttempts.cs` and verify `Up()` contains exactly:
+- `migrationBuilder.AddColumn<DateTime>(name: "acknowledged_at", ...)` (nullable)
+- `migrationBuilder.AddColumn<Guid>(name: "acknowledged_by", ...)` (nullable)
+- `migrationBuilder.AddColumn<Guid>(name: "triggered_by_admin_user_id", ...)` (nullable)
+- `migrationBuilder.CreateIndex(name: "ix_wikidata_cover_attempts_acknowledged_at", ..., filter: "acknowledged_at IS NOT NULL")`
+
+If the index filter is missing (EF sometimes drops it), manually add `, filter: "acknowledged_at IS NOT NULL"` to the `CreateIndex` call.
+
+- [ ] **Step 3: Verify migration applies cleanly on a fresh DB**
+
+Run: `cd apps/api/src/Api && dotnet ef database update --no-build --connection "Host=localhost;Database=meepleai_dev;Username=postgres;Password=postgres"`
+Expected: `Done.` (no errors). If you're not running Postgres locally, skip this step — Phase 6 IT will exercise it via Testcontainers.
+
+- [ ] **Step 4: Verify build**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore 2>&1 | tail -20`
+Expected: build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(catalog-be): #2254+#2255 migration — 3 columns + acknowledged_at partial index"
+```
+
+---
+
+### Task 2.3: Repository update — `AddAsync`, `Map`, extend query signatures
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IWikidataCoverEnrichmentAttemptRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/WikidataCoverEnrichmentAttemptRepository.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs` (modify — add 4 IT tests)
+
+- [ ] **Step 1: Write the failing IT tests**
+
+Append to `WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs` (use existing fixture pattern):
+
+```csharp
+[Fact]
+public async Task GetDeadLettersAsync_DefaultExcludesAcknowledgedRows()
+{
+    // Arrange: seed 2 dead-letters, ack the first
+    await using var fixture = await IntegrationFixture.CreateAsync();
+    var g1 = await fixture.SeedGameAsync("G1");
+    var g2 = await fixture.SeedGameAsync("G2");
+    var dl1 = WikidataCoverEnrichmentAttempt.RecordDeadLetter(g1, "r2-upload-error", null, 3, DateTime.UtcNow);
+    var dl2 = WikidataCoverEnrichmentAttempt.RecordDeadLetter(g2, "r2-upload-error", null, 3, DateTime.UtcNow);
+    dl1.Acknowledge(Guid.NewGuid(), DateTime.UtcNow);
+    await fixture.Repo.AddAsync(dl1);
+    await fixture.Repo.AddAsync(dl2);
+    await fixture.SaveAsync();
+
+    // Act
+    var page = await fixture.Repo.GetDeadLettersAsync(
+        skip: 0, take: 10, reasonFilter: null,
+        includeAcknowledged: false, ct: default);
+
+    // Assert
+    page.TotalCount.Should().Be(1);
+    page.Items.Should().HaveCount(1);
+    page.Items[0].SharedGameId.Should().Be(g2);
+}
+
+[Fact]
+public async Task GetDeadLettersAsync_IncludeAcknowledgedTrue_IncludesThem()
+{
+    await using var fixture = await IntegrationFixture.CreateAsync();
+    var g1 = await fixture.SeedGameAsync("G1");
+    var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(g1, "r2-upload-error", null, 3, DateTime.UtcNow);
+    dl.Acknowledge(Guid.NewGuid(), DateTime.UtcNow);
+    await fixture.Repo.AddAsync(dl);
+    await fixture.SaveAsync();
+
+    var page = await fixture.Repo.GetDeadLettersAsync(
+        skip: 0, take: 10, reasonFilter: null,
+        includeAcknowledged: true, ct: default);
+
+    page.TotalCount.Should().Be(1);
+    page.Items.Should().HaveCount(1);
+    page.Items[0].AcknowledgedAt.Should().NotBeNull();
+    page.Items[0].AcknowledgedBy.Should().NotBeNull();
+}
+
+[Fact]
+public async Task GetDeadLettersAsync_PopulatesAcknowledgedByFullName_FromUsersJoin()
+{
+    await using var fixture = await IntegrationFixture.CreateAsync();
+    var (adminId, _) = await fixture.SeedUserAsync("Alice Admin");
+    var g1 = await fixture.SeedGameAsync("G1");
+    var dl = WikidataCoverEnrichmentAttempt.RecordDeadLetter(g1, "r2-upload-error", null, 3, DateTime.UtcNow);
+    dl.Acknowledge(adminId, DateTime.UtcNow);
+    await fixture.Repo.AddAsync(dl);
+    await fixture.SaveAsync();
+
+    var page = await fixture.Repo.GetDeadLettersAsync(0, 10, null, includeAcknowledged: true, default);
+
+    page.Items[0].AcknowledgedByFullName.Should().Be("Alice Admin");
+}
+
+[Fact]
+public async Task GetAttemptsByGameIdAsync_PopulatesTriggeredByAdminFullName()
+{
+    await using var fixture = await IntegrationFixture.CreateAsync();
+    var (adminId, _) = await fixture.SeedUserAsync("Bob Admin");
+    var g1 = await fixture.SeedGameAsync("G1");
+    var a = WikidataCoverEnrichmentAttempt.RecordSuccess(g1, 0, DateTime.UtcNow, triggeredByAdminUserId: adminId);
+    await fixture.Repo.AddAsync(a);
+    await fixture.SaveAsync();
+
+    var rows = await fixture.Repo.GetAttemptsByGameIdAsync(g1, limit: 50, default);
+
+    rows.Should().HaveCount(1);
+    rows[0].TriggeredByAdminUserId.Should().Be(adminId);
+    rows[0].TriggeredByAdminFullName.Should().Be("Bob Admin");
+}
+```
+
+> **Note:** the existing `IntegrationFixture` class in the same test file already wraps `WikidataCoverEnrichmentAttemptRepository`. If `SeedGameAsync` / `SeedUserAsync` / `Repo` / `SaveAsync` helpers don't exist, add them by following the pattern from `WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs` existing setup helpers. The new `GetAttemptsByGameIdAsync` overload returns `IReadOnlyList<WikidataAttemptTimelineRow>` (record with TriggeredByAdminUserId + TriggeredByAdminFullName) — not the domain aggregate; this is the F6 query DTO. Update fixture's `Repo` type to match.
+
+- [ ] **Step 2: Run failing IT tests**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttemptRepositoryIntegrationTests" --no-restore`
+Expected: FAIL — `GetDeadLettersAsync` signature missing `includeAcknowledged`, `DeadLetterRow` missing `AcknowledgedAt/By/FullName`, etc.
+
+- [ ] **Step 3: Update repository interface + impl**
+
+In `IWikidataCoverEnrichmentAttemptRepository.cs`:
+
+```csharp
+// Replace existing GetDeadLettersAsync signature
+Task<DeadLetterPage> GetDeadLettersAsync(
+    int skip, int take, string? reasonFilter,
+    bool includeAcknowledged,                              // F5 NEW
+    CancellationToken cancellationToken = default);
+
+// Replace existing GetAttemptsByGameIdAsync return type
+Task<IReadOnlyList<WikidataAttemptTimelineRow>> GetAttemptsByGameIdAsync(
+    Guid sharedGameId, int limit,
+    CancellationToken cancellationToken = default);
+
+// Add new bulk lookup for F5 handler
+Task<IReadOnlyDictionary<Guid, WikidataCoverEnrichmentAttempt>> GetByIdsAsync(
+    IReadOnlyCollection<Guid> attemptIds,
+    CancellationToken cancellationToken = default);
+
+// Add new persist method (handler calls aggregate.Acknowledge → repo.UpdateAsync)
+Task UpdateAsync(
+    WikidataCoverEnrichmentAttempt attempt,
+    CancellationToken cancellationToken = default);
+```
+
+Extend `DeadLetterRow` record:
+```csharp
+public sealed record DeadLetterRow(
+    Guid Id, Guid SharedGameId, string GameTitle,
+    DateTime AttemptedAt, DateTime DeadLetteredAt,
+    string Reason, string? Details, int RetryCount,
+    // F5
+    DateTime? AcknowledgedAt,
+    Guid?     AcknowledgedBy,
+    string?   AcknowledgedByFullName,
+    // F6
+    Guid?     TriggeredByAdminUserId,
+    string?   TriggeredByAdminFullName);
+```
+
+Add new record for F3 timeline rows with F6 fields:
+```csharp
+/// <summary>F3 timeline row with F6 admin attribution. Mirrors the aggregate
+/// shape needed by the admin drawer (does not need full Reconstitute).</summary>
+public sealed record WikidataAttemptTimelineRow(
+    Guid Id, DateTime AttemptedAt, WikidataCoverEnrichmentOutcome Outcome,
+    string Reason, string? Details, int RetryCount,
+    DateTime? NextRetryAt, DateTime? DeadLetteredAt,
+    Guid?   TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
+```
+
+In `WikidataCoverEnrichmentAttemptRepository.cs`:
+
+1. Update `AddAsync` to persist 3 new fields:
+```csharp
+await DbContext.WikidataCoverEnrichmentAttempts.AddAsync(new()
+{
+    Id = attempt.Id,
+    SharedGameId = attempt.SharedGameId,
+    AttemptedAt = attempt.AttemptedAt,
+    Outcome = (int)attempt.Outcome,
+    Reason = attempt.Reason,
+    Details = attempt.Details,
+    RetryCount = attempt.RetryCount,
+    NextRetryAt = attempt.NextRetryAt,
+    DeadLetteredAt = attempt.DeadLetteredAt,
+    AcknowledgedAt = attempt.AcknowledgedAt,
+    AcknowledgedBy = attempt.AcknowledgedBy,
+    TriggeredByAdminUserId = attempt.TriggeredByAdminUserId,
+}, cancellationToken).ConfigureAwait(false);
+```
+
+2. Update `Map(entity)` to pass all 3 new fields to `Reconstitute`:
+```csharp
+private static WikidataCoverEnrichmentAttempt Map(WikidataCoverEnrichmentAttemptEntity entity) =>
+    WikidataCoverEnrichmentAttempt.Reconstitute(
+        id: entity.Id,
+        sharedGameId: entity.SharedGameId,
+        attemptedAt: entity.AttemptedAt,
+        outcome: (WikidataCoverEnrichmentOutcome)entity.Outcome,
+        reason: entity.Reason,
+        details: entity.Details,
+        retryCount: entity.RetryCount,
+        nextRetryAt: entity.NextRetryAt,
+        deadLetteredAt: entity.DeadLetteredAt,
+        acknowledgedAt: entity.AcknowledgedAt,
+        acknowledgedBy: entity.AcknowledgedBy,
+        triggeredByAdminUserId: entity.TriggeredByAdminUserId);
+```
+
+3. Replace `GetDeadLettersAsync` body — add `includeAcknowledged` filter + LEFT JOIN users x2:
+```csharp
+public async Task<DeadLetterPage> GetDeadLettersAsync(
+    int skip, int take, string? reasonFilter,
+    bool includeAcknowledged,
+    CancellationToken cancellationToken = default)
+{
+    if (skip < 0) skip = 0;
+    if (take < 1) take = 1;
+    if (take > 200) take = 200;
+
+    const int DeadLetterOutcome = (int)WikidataCoverEnrichmentOutcome.DeadLetter;
+
+    var query =
+        from a in DbContext.WikidataCoverEnrichmentAttempts.AsNoTracking()
+        where a.DeadLetteredAt != null && a.Outcome == DeadLetterOutcome
+        select a;
+
+    if (!includeAcknowledged)
+        query = query.Where(a => a.AcknowledgedAt == null);
+
+    if (!string.IsNullOrWhiteSpace(reasonFilter))
+        query = query.Where(a => a.Reason == reasonFilter);
+
+    var totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+    if (totalCount == 0)
+        return new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0);
+
+    var pageQuery =
+        from a in query.OrderByDescending(x => x.DeadLetteredAt).Skip(skip).Take(take)
+        join sg in DbContext.SharedGames.AsNoTracking().IgnoreQueryFilters()
+            on a.SharedGameId equals sg.Id into sgs
+        from sg in sgs.DefaultIfEmpty()
+        join ackUser in DbContext.Users.AsNoTracking()
+            on a.AcknowledgedBy equals ackUser.Id into ackUsers
+        from ackUser in ackUsers.DefaultIfEmpty()
+        join trgUser in DbContext.Users.AsNoTracking()
+            on a.TriggeredByAdminUserId equals trgUser.Id into trgUsers
+        from trgUser in trgUsers.DefaultIfEmpty()
+        select new DeadLetterRow(
+            a.Id, a.SharedGameId,
+            sg != null ? sg.Title : "(deleted game)",
+            a.AttemptedAt, a.DeadLetteredAt!.Value,
+            a.Reason, a.Details, a.RetryCount,
+            a.AcknowledgedAt, a.AcknowledgedBy,
+            ackUser != null ? ackUser.FullName : null,
+            a.TriggeredByAdminUserId,
+            trgUser != null ? trgUser.FullName : null);
+
+    var items = await pageQuery.ToListAsync(cancellationToken).ConfigureAwait(false);
+    return new DeadLetterPage(items, totalCount);
+}
+```
+
+> **NOTE:** if `DbContext.Users` doesn't expose `FullName`, search the existing user entity (`grep -rn 'FullName\|DisplayName' apps/api/src/Api/Infrastructure/Entities/Identity/`) and use the actual property name. Fall back to `ackUser.Email` if no display name field exists — the badge tooltip then shows email instead.
+
+4. Replace `GetAttemptsByGameIdAsync` body — return `WikidataAttemptTimelineRow` with F6 join:
+```csharp
+public async Task<IReadOnlyList<WikidataAttemptTimelineRow>> GetAttemptsByGameIdAsync(
+    Guid sharedGameId, int limit,
+    CancellationToken cancellationToken = default)
+{
+    limit = Math.Clamp(limit, 1, 200);
+
+    var query =
+        from a in DbContext.WikidataCoverEnrichmentAttempts.AsNoTracking()
+        where a.SharedGameId == sharedGameId
+        orderby a.AttemptedAt descending
+        join u in DbContext.Users.AsNoTracking()
+            on a.TriggeredByAdminUserId equals u.Id into us
+        from u in us.DefaultIfEmpty()
+        select new WikidataAttemptTimelineRow(
+            a.Id, a.AttemptedAt,
+            (WikidataCoverEnrichmentOutcome)a.Outcome,
+            a.Reason, a.Details, a.RetryCount,
+            a.NextRetryAt, a.DeadLetteredAt,
+            a.TriggeredByAdminUserId,
+            u != null ? u.FullName : null);
+
+    return await query.Take(limit).ToListAsync(cancellationToken).ConfigureAwait(false);
+}
+```
+
+5. Add new methods `GetByIdsAsync` + `UpdateAsync`:
+```csharp
+public async Task<IReadOnlyDictionary<Guid, WikidataCoverEnrichmentAttempt>> GetByIdsAsync(
+    IReadOnlyCollection<Guid> attemptIds,
+    CancellationToken cancellationToken = default)
+{
+    ArgumentNullException.ThrowIfNull(attemptIds);
+    if (attemptIds.Count == 0) return new Dictionary<Guid, WikidataCoverEnrichmentAttempt>();
+    var ids = attemptIds.Distinct().Take(50).ToArray();
+    var entities = await DbContext.WikidataCoverEnrichmentAttempts
+        .Where(a => ids.Contains(a.Id))
+        .ToListAsync(cancellationToken).ConfigureAwait(false);
+    return entities.ToDictionary(e => e.Id, Map);
+}
+
+public async Task UpdateAsync(
+    WikidataCoverEnrichmentAttempt attempt,
+    CancellationToken cancellationToken = default)
+{
+    ArgumentNullException.ThrowIfNull(attempt);
+    var entity = await DbContext.WikidataCoverEnrichmentAttempts
+        .FirstOrDefaultAsync(e => e.Id == attempt.Id, cancellationToken)
+        .ConfigureAwait(false)
+        ?? throw new InvalidOperationException(
+            $"WikidataCoverEnrichmentAttempt {attempt.Id} not found for update.");
+
+    entity.AcknowledgedAt = attempt.AcknowledgedAt;
+    entity.AcknowledgedBy = attempt.AcknowledgedBy;
+    // Note: only ack metadata is mutable per F5 spec; other fields stay frozen
+    // per the record-of-fact pattern.
+    CollectDomainEvents(attempt);
+}
+```
+
+6. **Update existing callers**: `WikidataCoverEnrichmentRunner.cs` (`GetLatestBySharedGameIdAsync` Map → no signature change needed) — only `Map(...)` was the call site; already covered by Step 3 update (2).
+
+7. **F4 SSE flow**: the existing M13 query handler still calls `GetDeadLettersAsync` with old 3-arg signature. Fix by adding `includeAcknowledged: false` to existing call site in `GetWikidataDeadLetterAttemptsQuery.cs` Handler (Task 3.3 will do this — but bridge by updating the existing handler call here so build doesn't break):
+```csharp
+var page = await _attempts.GetDeadLettersAsync(
+    skip, take, request.ReasonFilter,
+    includeAcknowledged: false, cancellationToken).ConfigureAwait(false);
+```
+
+- [ ] **Step 4: Run IT tests + verify build**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentAttemptRepositoryIntegrationTests" --no-restore`
+Expected: PASS (4 new tests + existing IT tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/ \
+        apps/api/tests/Api.Tests/Integration/SharedGameCatalog/WikidataCoverEnrichmentAttemptRepositoryIntegrationTests.cs
+git commit -m "feat(catalog-be): #2254+#2255 repo — includeAcknowledged + JOIN users + GetByIds/UpdateAsync"
+```
+
+---
+
+## Phase 3 — Backend Application (CQRS)
+
+### Task 3.1: Command + Validator F5
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidator.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidatorTests.cs` (new)
+
+- [ ] **Step 1: Write the failing validator test**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+public class AdminBulkAcknowledgeWikidataCoverCommandValidatorTests
+{
+    private readonly AdminBulkAcknowledgeWikidataCoverCommandValidator _v = new();
+    private readonly Guid _userId = Guid.NewGuid();
+
+    [Fact]
+    public void Empty_AttemptIds_Fails()
+    {
+        var r = _v.TestValidate(new AdminBulkAcknowledgeWikidataCoverCommand(
+            AttemptIds: Array.Empty<Guid>(), Note: null, TriggeredByUserId: _userId));
+        r.ShouldHaveValidationErrorFor(x => x.AttemptIds);
+    }
+
+    [Fact]
+    public void Over_50_AttemptIds_Fails()
+    {
+        var ids = Enumerable.Range(0, 51).Select(_ => Guid.NewGuid()).ToList();
+        var r = _v.TestValidate(new AdminBulkAcknowledgeWikidataCoverCommand(
+            ids, null, _userId));
+        r.ShouldHaveValidationErrorFor(x => x.AttemptIds);
+    }
+
+    [Fact]
+    public void Note_Over_500Chars_Fails()
+    {
+        var r = _v.TestValidate(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { Guid.NewGuid() }, Note: new string('a', 501), TriggeredByUserId: _userId));
+        r.ShouldHaveValidationErrorFor(x => x.Note);
+    }
+
+    [Fact]
+    public void TriggeredByUserId_Empty_Fails()
+    {
+        var r = _v.TestValidate(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { Guid.NewGuid() }, null, Guid.Empty));
+        r.ShouldHaveValidationErrorFor(x => x.TriggeredByUserId);
+    }
+
+    [Fact]
+    public void Valid_Command_NoteNull_Passes()
+    {
+        var r = _v.TestValidate(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { Guid.NewGuid() }, null, _userId));
+        r.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Valid_Command_NoteUnder500_Passes()
+    {
+        var r = _v.TestValidate(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { Guid.NewGuid() }, new string('a', 500), _userId));
+        r.ShouldNotHaveAnyValidationErrors();
+    }
+}
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminBulkAcknowledgeWikidataCoverCommandValidatorTests" --no-restore`
+Expected: FAIL — types don't exist.
+
+- [ ] **Step 3: Create command + validator**
+
+`AdminBulkAcknowledgeWikidataCoverCommand.cs`:
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Phase F F5 — admin bulk-acknowledge of one or more dead-letter
+/// attempts. Operator marks a row as "not actionable" so it disappears from
+/// the default list view without waiting for the DEC-3j 7-day retention sweep.
+/// Idempotent: re-acknowledging an already-acked row is a no-op.
+/// </summary>
+/// <param name="AttemptIds">Dead-letter attempt ids selected on the admin page (max 50).</param>
+/// <param name="Note">Optional free-text note shown in the confirmation modal; persisted log-only (DEC-F-4).</param>
+/// <param name="TriggeredByUserId">Acknowledging admin user id (log-only).</param>
+internal sealed record AdminBulkAcknowledgeWikidataCoverCommand(
+    IReadOnlyList<Guid> AttemptIds,
+    string? Note,
+    Guid TriggeredByUserId) : ICommand<AdminBulkAcknowledgeResult>;
+
+public sealed record AdminBulkAcknowledgeRow(
+    Guid AttemptId, Guid? GameId, string Outcome, string? Reason)
+{
+    public const string OutcomeAcked = "acked";
+    public const string OutcomeAlreadyAcked = "already-acked";
+    public const string OutcomeNotFound = "not-found";
+    public const string OutcomeWrongState = "wrong-state";
+}
+
+public sealed record AdminBulkAcknowledgeResult(
+    int AckedCount,
+    int IdempotentNoOpCount,
+    int NotFoundCount,
+    IReadOnlyList<AdminBulkAcknowledgeRow> Rows);
+```
+
+`AdminBulkAcknowledgeWikidataCoverCommandValidator.cs`:
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Validators;
+
+internal sealed class AdminBulkAcknowledgeWikidataCoverCommandValidator
+    : AbstractValidator<AdminBulkAcknowledgeWikidataCoverCommand>
+{
+    public const int MaxBatchSize = 50;
+    public const int MaxNoteLength = 500;
+
+    public AdminBulkAcknowledgeWikidataCoverCommandValidator()
+    {
+        RuleFor(x => x.AttemptIds)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().NotEmpty()
+            .WithMessage("AttemptIds must contain at least one id.")
+            .Must(ids => ids.Count <= MaxBatchSize)
+            .WithMessage($"AttemptIds cannot exceed {MaxBatchSize} per request.")
+            .Must(ids => ids.All(id => id != Guid.Empty))
+            .WithMessage("AttemptIds must not contain Guid.Empty.")
+            .Must(ids => ids.Distinct().Count() == ids.Count)
+            .WithMessage("AttemptIds must not contain duplicates.");
+
+        RuleFor(x => x.Note)
+            .MaximumLength(MaxNoteLength)
+            .When(x => x.Note is not null)
+            .WithMessage($"Note must be {MaxNoteLength} characters or fewer.");
+
+        RuleFor(x => x.TriggeredByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("TriggeredByUserId must not be empty.");
+    }
+}
+```
+
+- [ ] **Step 4: Run failing test, expect PASS**
+
+Run: same as Step 2. Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommand.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidator.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Validators/AdminBulkAcknowledgeWikidataCoverCommandValidatorTests.cs
+git commit -m "feat(catalog-be): #2254 F5 bulk-acknowledge command + validator"
+```
+
+---
+
+### Task 3.2: Command handler F5
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandlerTests.cs` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+public class AdminBulkAcknowledgeWikidataCoverCommandHandlerTests
+{
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly TimeProvider _time = TimeProvider.System;
+    private readonly Guid _user = Guid.NewGuid();
+
+    private AdminBulkAcknowledgeWikidataCoverCommandHandler Build() =>
+        new(_repo.Object, _uow.Object, _time, NullLogger<AdminBulkAcknowledgeWikidataCoverCommandHandler>.Instance);
+
+    private static WikidataCoverEnrichmentAttempt MakeDeadLetter(Guid? id = null) =>
+        WikidataCoverEnrichmentAttempt.Reconstitute(
+            id ?? Guid.NewGuid(), Guid.NewGuid(), DateTime.UtcNow,
+            WikidataCoverEnrichmentOutcome.DeadLetter, "r2-upload-error", null, 3,
+            null, DateTime.UtcNow, null, null, null);
+
+    [Fact]
+    public async Task SingleDeadLetter_Acked_ReturnsAckedCountOne()
+    {
+        var dl = MakeDeadLetter();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt> { [dl.Id] = dl });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { dl.Id }, null, _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(1);
+        result.IdempotentNoOpCount.Should().Be(0);
+        result.NotFoundCount.Should().Be(0);
+        result.Rows.Should().ContainSingle(r =>
+            r.AttemptId == dl.Id && r.Outcome == AdminBulkAcknowledgeRow.OutcomeAcked);
+        dl.AcknowledgedAt.Should().NotBeNull();
+        dl.AcknowledgedBy.Should().Be(_user);
+        _repo.Verify(r => r.UpdateAsync(dl, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AlreadyAcked_Idempotent_NotPersistedAgain()
+    {
+        var dl = MakeDeadLetter();
+        dl.Acknowledge(Guid.NewGuid(), DateTime.UtcNow);
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt> { [dl.Id] = dl });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { dl.Id }, null, _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(0);
+        result.IdempotentNoOpCount.Should().Be(1);
+        result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeAlreadyAcked);
+        _repo.Verify(r => r.UpdateAsync(It.IsAny<WikidataCoverEnrichmentAttempt>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NotFoundId_ReportedAsNotFound()
+    {
+        var missing = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt>());
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { missing }, null, _user), CancellationToken.None);
+
+        result.NotFoundCount.Should().Be(1);
+        result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeNotFound);
+    }
+
+    [Fact]
+    public async Task NonDeadLetterRow_ReportedAsWrongState()
+    {
+        var success = WikidataCoverEnrichmentAttempt.Reconstitute(
+            Guid.NewGuid(), Guid.NewGuid(), DateTime.UtcNow,
+            WikidataCoverEnrichmentOutcome.Success, "success", null, 0,
+            null, null, null, null, null);
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt> { [success.Id] = success });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { success.Id }, null, _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(0);
+        result.Rows.Single().Outcome.Should().Be(AdminBulkAcknowledgeRow.OutcomeWrongState);
+    }
+
+    [Fact]
+    public async Task BatchMixedOutcomes_CountsAreAggregated()
+    {
+        var dl1 = MakeDeadLetter();
+        var dl2Already = MakeDeadLetter();
+        dl2Already.Acknowledge(Guid.NewGuid(), DateTime.UtcNow);
+        var missing = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, WikidataCoverEnrichmentAttempt>
+            {
+                [dl1.Id] = dl1,
+                [dl2Already.Id] = dl2Already,
+            });
+
+        var result = await Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { dl1.Id, dl2Already.Id, missing }, "operator note", _user), CancellationToken.None);
+
+        result.AckedCount.Should().Be(1);
+        result.IdempotentNoOpCount.Should().Be(1);
+        result.NotFoundCount.Should().Be(1);
+        result.Rows.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task CancellationToken_Propagated()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        _repo.Setup(r => r.GetByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), cts.Token))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = () => Build().Handle(new AdminBulkAcknowledgeWikidataCoverCommand(
+            new[] { Guid.NewGuid() }, null, _user), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminBulkAcknowledgeWikidataCoverCommandHandlerTests" --no-restore`
+Expected: FAIL — handler doesn't exist.
+
+- [ ] **Step 3: Create handler**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+
+/// <summary>
+/// Issue #1823 Phase F F5 — bulk-acknowledge dead-letter attempts. Loads each
+/// id, calls <see cref="WikidataCoverEnrichmentAttempt.Acknowledge"/> with
+/// idempotency in-domain, persists via repo + UoW. Per-row outcomes are bucketed
+/// into the result envelope (acked / already-acked / not-found / wrong-state)
+/// so the admin UI can render partial success/failure.
+/// </summary>
+internal sealed class AdminBulkAcknowledgeWikidataCoverCommandHandler
+    : ICommandHandler<AdminBulkAcknowledgeWikidataCoverCommand, AdminBulkAcknowledgeResult>
+{
+    private readonly IWikidataCoverEnrichmentAttemptRepository _attempts;
+    private readonly IUnitOfWork _uow;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<AdminBulkAcknowledgeWikidataCoverCommandHandler> _logger;
+
+    public AdminBulkAcknowledgeWikidataCoverCommandHandler(
+        IWikidataCoverEnrichmentAttemptRepository attempts,
+        IUnitOfWork uow,
+        TimeProvider timeProvider,
+        ILogger<AdminBulkAcknowledgeWikidataCoverCommandHandler> logger)
+    {
+        _attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+        _uow = uow ?? throw new ArgumentNullException(nameof(uow));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AdminBulkAcknowledgeResult> Handle(
+        AdminBulkAcknowledgeWikidataCoverCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        _logger.LogInformation(
+            "AdminBulkAcknowledgeWikidataCover: user {UserId} acking {Count} attempt(s); note={Note}",
+            request.TriggeredByUserId, request.AttemptIds.Count, request.Note ?? "<none>");
+
+        var loaded = await _attempts
+            .GetByIdsAsync(request.AttemptIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        var rows = new List<AdminBulkAcknowledgeRow>(request.AttemptIds.Count);
+        var acked = 0;
+        var alreadyAcked = 0;
+        var notFound = 0;
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var anyUpdated = false;
+
+        foreach (var id in request.AttemptIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!loaded.TryGetValue(id, out var attempt))
+            {
+                rows.Add(new(id, null, AdminBulkAcknowledgeRow.OutcomeNotFound, "attempt-id-not-found"));
+                notFound++;
+                continue;
+            }
+
+            if (attempt.Outcome != WikidataCoverEnrichmentOutcome.DeadLetter)
+            {
+                rows.Add(new(id, attempt.SharedGameId, AdminBulkAcknowledgeRow.OutcomeWrongState,
+                    $"current-outcome:{attempt.Outcome}"));
+                continue;
+            }
+
+            if (attempt.AcknowledgedAt is not null)
+            {
+                rows.Add(new(id, attempt.SharedGameId, AdminBulkAcknowledgeRow.OutcomeAlreadyAcked, null));
+                alreadyAcked++;
+                continue;
+            }
+
+            attempt.Acknowledge(request.TriggeredByUserId, nowUtc);
+            await _attempts.UpdateAsync(attempt, cancellationToken).ConfigureAwait(false);
+            rows.Add(new(id, attempt.SharedGameId, AdminBulkAcknowledgeRow.OutcomeAcked, null));
+            acked++;
+            anyUpdated = true;
+        }
+
+        if (anyUpdated)
+            await _uow.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new AdminBulkAcknowledgeResult(
+            AckedCount: acked,
+            IdempotentNoOpCount: alreadyAcked,
+            NotFoundCount: notFound,
+            Rows: rows);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: same as Step 2. Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkAcknowledgeWikidataCoverCommandHandlerTests.cs
+git commit -m "feat(catalog-be): #2254 F5 bulk-acknowledge handler with per-row outcomes"
+```
+
+---
+
+### Task 3.3: Query F5 update — `GetWikidataDeadLetterAttemptsQuery`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs` (new or modify existing)
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+public class GetWikidataDeadLetterAttemptsQueryHandlerTests
+{
+    private readonly Mock<IWikidataCoverEnrichmentAttemptRepository> _repo = new();
+    private GetWikidataDeadLetterAttemptsQueryHandler Build() => new(_repo.Object);
+
+    [Fact]
+    public async Task DefaultIncludeAcknowledgedFalse_PassedToRepo()
+    {
+        _repo.Setup(r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        var query = new GetWikidataDeadLetterAttemptsQuery(0, 50, null, IncludeAcknowledged: false);
+        await Build().Handle(query, CancellationToken.None);
+
+        _repo.Verify(r => r.GetDeadLettersAsync(0, 50, null, false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task IncludeAcknowledgedTrue_PassedThrough()
+    {
+        _repo.Setup(r => r.GetDeadLettersAsync(0, 50, null, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(Array.Empty<DeadLetterRow>(), 0));
+
+        var query = new GetWikidataDeadLetterAttemptsQuery(0, 50, null, IncludeAcknowledged: true);
+        await Build().Handle(query, CancellationToken.None);
+
+        _repo.Verify(r => r.GetDeadLettersAsync(0, 50, null, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DtoIncludesAckAndAdminFields()
+    {
+        var row = new DeadLetterRow(
+            Guid.NewGuid(), Guid.NewGuid(), "Game", DateTime.UtcNow, DateTime.UtcNow,
+            "r2-upload-error", null, 3,
+            AcknowledgedAt: DateTime.UtcNow, AcknowledgedBy: Guid.NewGuid(),
+            AcknowledgedByFullName: "Alice", TriggeredByAdminUserId: Guid.NewGuid(),
+            TriggeredByAdminFullName: "Bob");
+        _repo.Setup(r => r.GetDeadLettersAsync(0, 50, null, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeadLetterPage(new[] { row }, 1));
+
+        var query = new GetWikidataDeadLetterAttemptsQuery(0, 50, null, IncludeAcknowledged: true);
+        var result = await Build().Handle(query, CancellationToken.None);
+
+        result.Items.Single().AcknowledgedByFullName.Should().Be("Alice");
+        result.Items.Single().TriggeredByAdminFullName.Should().Be("Bob");
+    }
+}
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetWikidataDeadLetterAttemptsQueryHandlerTests" --no-restore`
+Expected: FAIL — `IncludeAcknowledged` keyword unknown + DTO missing fields.
+
+- [ ] **Step 3: Update query + DTO + handler**
+
+Edit `GetWikidataDeadLetterAttemptsQuery.cs`:
+
+```csharp
+internal sealed record GetWikidataDeadLetterAttemptsQuery(
+    int Skip, int Take, string? ReasonFilter,
+    bool IncludeAcknowledged = false) : IRequest<WikidataDeadLetterAttemptsResult>;
+
+public sealed record WikidataDeadLetterAttemptDto(
+    Guid Id, Guid SharedGameId, string GameTitle,
+    DateTime AttemptedAt, DateTime DeadLetteredAt,
+    string Reason, string? Details, int RetryCount,
+    DateTime? AcknowledgedAt,
+    Guid?     AcknowledgedBy,
+    string?   AcknowledgedByFullName,
+    Guid?     TriggeredByAdminUserId,
+    string?   TriggeredByAdminFullName);
+```
+
+Update handler body:
+```csharp
+public async Task<WikidataDeadLetterAttemptsResult> Handle(
+    GetWikidataDeadLetterAttemptsQuery request,
+    CancellationToken cancellationToken)
+{
+    ArgumentNullException.ThrowIfNull(request);
+    var skip = Math.Max(0, request.Skip);
+    var take = Math.Clamp(request.Take, 1, 200);
+
+    var page = await _attempts
+        .GetDeadLettersAsync(skip, take, request.ReasonFilter,
+            request.IncludeAcknowledged, cancellationToken)
+        .ConfigureAwait(false);
+
+    var items = page.Items
+        .Select(row => new WikidataDeadLetterAttemptDto(
+            row.Id, row.SharedGameId, row.GameTitle,
+            row.AttemptedAt, row.DeadLetteredAt,
+            row.Reason, row.Details, row.RetryCount,
+            row.AcknowledgedAt, row.AcknowledgedBy, row.AcknowledgedByFullName,
+            row.TriggeredByAdminUserId, row.TriggeredByAdminFullName))
+        .ToList();
+
+    return new WikidataDeadLetterAttemptsResult(items, page.TotalCount, skip, take);
+}
+```
+
+- [ ] **Step 4: Run tests + ensure prior tests still green**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetWikidataDeadLetter" --no-restore`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQuery.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataDeadLetterAttemptsQueryHandlerTests.cs
+git commit -m "feat(catalog-be): #2254+#2255 query DTO — includeAcknowledged + ack/admin name fields"
+```
+
+---
+
+### Task 3.4: Query F6 timeline DTO update
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries;
+
+public class GetWikidataAttemptTimelineQueryHandlerTests
+{
+    [Fact]
+    public async Task Handler_MapsTriggeredByAdminFullName_FromRepoRow()
+    {
+        var repo = new Mock<IWikidataCoverEnrichmentAttemptRepository>();
+        var adminId = Guid.NewGuid();
+        var row = new WikidataAttemptTimelineRow(
+            Id: Guid.NewGuid(), AttemptedAt: DateTime.UtcNow,
+            Outcome: WikidataCoverEnrichmentOutcome.Success, Reason: "success", Details: null,
+            RetryCount: 0, NextRetryAt: null, DeadLetteredAt: null,
+            TriggeredByAdminUserId: adminId, TriggeredByAdminFullName: "Carol");
+        repo.Setup(r => r.GetAttemptsByGameIdAsync(It.IsAny<Guid>(), 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { row });
+
+        var handler = new GetWikidataAttemptTimelineQueryHandler(repo.Object);
+        var result = await handler.Handle(new GetWikidataAttemptTimelineQuery(Guid.NewGuid(), 50), default);
+
+        result.Items.Single().TriggeredByAdminUserId.Should().Be(adminId);
+        result.Items.Single().TriggeredByAdminFullName.Should().Be("Carol");
+    }
+}
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetWikidataAttemptTimelineQueryHandlerTests" --no-restore`
+Expected: FAIL — `WikidataAttemptTimelineNode` missing new fields.
+
+- [ ] **Step 3: Update DTO + handler**
+
+Edit `GetWikidataAttemptTimelineQuery.cs`:
+
+```csharp
+public sealed record WikidataAttemptTimelineNode(
+    Guid Id, DateTime AttemptedAt, string Outcome,
+    string? Reason, string? Details, int RetryCount,
+    DateTime? NextRetryAt, DateTime? DeadLetteredAt,
+    Guid?   TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
+```
+
+Update handler `Handle` body (the repo now returns `WikidataAttemptTimelineRow` instead of aggregates):
+```csharp
+public async Task<WikidataAttemptTimelineResult> Handle(
+    GetWikidataAttemptTimelineQuery request,
+    CancellationToken cancellationToken)
+{
+    ArgumentNullException.ThrowIfNull(request);
+
+    var rows = await _attempts
+        .GetAttemptsByGameIdAsync(request.GameId, request.Limit, cancellationToken)
+        .ConfigureAwait(false);
+
+    var items = rows
+        .Select(r => new WikidataAttemptTimelineNode(
+            r.Id, r.AttemptedAt, r.Outcome.ToString(),
+            r.Reason, r.Details, r.RetryCount,
+            r.NextRetryAt, r.DeadLetteredAt,
+            r.TriggeredByAdminUserId, r.TriggeredByAdminFullName))
+        .ToList();
+
+    return new WikidataAttemptTimelineResult(request.GameId, items);
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: same as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQuery.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetWikidataAttemptTimelineQueryHandlerTests.cs
+git commit -m "feat(catalog-be): #2255 F6 timeline DTO with TriggeredByAdmin fields"
+```
+
+---
+
+### Task 3.5: Runner F6 — interface + impl + event payload
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataCoverEnrichmentRunner.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataEnrichmentEventBroadcaster.cs` (extend `WikidataEnrichmentEvent` record)
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandler.cs` (M12 caller)
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs` (F2 caller)
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs` (M9 caller — passes `null`)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs` (new or extend)
+
+- [ ] **Step 1: Write failing tests**
+
+`WikidataCoverEnrichmentRunnerTests.cs` (extend existing or create):
+
+```csharp
+[Fact]
+public async Task EnrichAndRecord_NullAdminId_PersistsNullOnAttempt()
+{
+    // Arrange mocks: mediator returns Success result for any gameId
+    // Repo captures AddAsync attempt — assert TriggeredByAdminUserId is null
+    // ... wire mocks following existing test pattern ...
+
+    var addedAttempt = await CallRunnerAndCaptureAddedAttempt(triggeredByAdminUserId: null);
+
+    addedAttempt.TriggeredByAdminUserId.Should().BeNull();
+}
+
+[Fact]
+public async Task EnrichAndRecord_AdminTriggered_PersistsAdminIdOnAttempt()
+{
+    var adminId = Guid.NewGuid();
+    var addedAttempt = await CallRunnerAndCaptureAddedAttempt(triggeredByAdminUserId: adminId);
+
+    addedAttempt.TriggeredByAdminUserId.Should().Be(adminId);
+}
+
+[Fact]
+public async Task EnrichAndRecord_PublishesEventWithTriggeredByAdmin()
+{
+    var adminId = Guid.NewGuid();
+    var captured = await CallRunnerAndCaptureBroadcastEvent(triggeredByAdminUserId: adminId);
+
+    captured.TriggeredByAdminUserId.Should().Be(adminId);
+    captured.TriggeredByAdminFullName.Should().BeNull();
+    // NOTE: TriggeredByAdminFullName is populated in the BROADCAST payload only
+    // if the runner enriches via a user lookup. Per DEC-F-5 we resolve in the
+    // QUERY path (GetDeadLettersAsync + GetAttemptsByGameIdAsync JOINs), and
+    // the broadcaster pushes the slim attempt projection — so the FE refresh
+    // on SSE will re-fetch the page (already wired in F4) and pick up the name
+    // via the next listDeadLetters call. Hence we assert FullName is NULL here.
+}
+```
+
+> **Note:** the helper methods `CallRunnerAndCaptureAddedAttempt` / `CallRunnerAndCaptureBroadcastEvent` MUST be added in the test file. They wire `IMediator` (returns `EnrichCatalogCoverResult.Success`), `IWikidataCoverEnrichmentAttemptRepository`, `IUnitOfWork`, `IWikidataCoverEnrichmentRetryPolicy` (returns `Terminal` for Success), `IWikidataEnrichmentEventBroadcaster` (captures `Publish`), and `TimeProvider`. Look at the existing test file to find the existing helper pattern and extend.
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentRunnerTests" --no-restore`
+Expected: FAIL — signature missing `triggeredByAdminUserId`.
+
+- [ ] **Step 3: Apply implementation changes**
+
+`IWikidataCoverEnrichmentRunner.cs`:
+```csharp
+Task<EnrichCatalogCoverResult> EnrichAndRecordAsync(
+    Guid gameId,
+    bool forceRefresh,
+    Guid? triggeredByAdminUserId = null,
+    CancellationToken cancellationToken = default);
+```
+
+`IWikidataEnrichmentEventBroadcaster.cs` — extend `WikidataEnrichmentEvent`:
+```csharp
+public sealed record WikidataEnrichmentEvent(
+    Guid AttemptId, Guid SharedGameId,
+    string Outcome, string? Reason,
+    DateTime AttemptedAt, int RetryCount,
+    DateTime? NextRetryAt, DateTime? DeadLetteredAt,
+    Guid?   TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
+```
+
+`WikidataCoverEnrichmentRunner.cs`:
+1. Update signature:
+```csharp
+public async Task<EnrichCatalogCoverResult> EnrichAndRecordAsync(
+    Guid gameId, bool forceRefresh,
+    Guid? triggeredByAdminUserId = null,
+    CancellationToken cancellationToken = default)
+```
+2. Pass `triggeredByAdminUserId` into each factory call:
+```csharp
+(WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Success) =>
+    WikidataCoverEnrichmentAttempt.RecordSuccess(gameId, nextRetryCount, nowUtc, triggeredByAdminUserId),
+
+(WikidataCoverEnrichmentRetryDecision.Terminal, EnrichCatalogCoverResult.Skipped skipped) =>
+    WikidataCoverEnrichmentAttempt.RecordSkipped(gameId, skipped.Reason, nextRetryCount, nowUtc, triggeredByAdminUserId),
+
+(WikidataCoverEnrichmentRetryDecision.ScheduleRetry retry, EnrichCatalogCoverResult.Failed failed) =>
+    WikidataCoverEnrichmentAttempt.RecordFailedWithRetry(
+        gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, retry.NextRetryAt,
+        triggeredByAdminUserId),
+
+(WikidataCoverEnrichmentRetryDecision.DeadLetter, EnrichCatalogCoverResult.Failed failed) =>
+    WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+        gameId, failed.Reason, failed.Details, nextRetryCount, nowUtc, triggeredByAdminUserId),
+
+_ => WikidataCoverEnrichmentAttempt.RecordDeadLetter(
+    gameId, "unexpected-decision",
+    $"{decision.GetType().Name} for {result.GetType().Name}",
+    nextRetryCount, nowUtc, triggeredByAdminUserId),
+```
+3. Update broadcast payload (`TriggeredByAdminFullName` is null in the broadcast — resolved in the query path):
+```csharp
+_broadcaster.Publish(new WikidataEnrichmentEvent(
+    AttemptId: newAttempt.Id,
+    SharedGameId: newAttempt.SharedGameId,
+    Outcome: newAttempt.Outcome.ToString(),
+    Reason: newAttempt.Reason,
+    AttemptedAt: newAttempt.AttemptedAt,
+    RetryCount: newAttempt.RetryCount,
+    NextRetryAt: newAttempt.NextRetryAt,
+    DeadLetteredAt: newAttempt.DeadLetteredAt,
+    TriggeredByAdminUserId: newAttempt.TriggeredByAdminUserId,
+    TriggeredByAdminFullName: null));
+```
+
+Update 3 callers to pass `triggeredByAdminUserId`:
+
+- `AdminEnrichWikidataCoverCommandHandler.cs`: change `await _runner.EnrichAndRecordAsync(command.GameId, command.ForceRefresh, ct)` → `(...).EnrichAndRecordAsync(command.GameId, command.ForceRefresh, command.TriggeredByUserId, ct)`.
+- `AdminBulkRetryWikidataCoverCommandHandler.cs`: change `await _runner.EnrichAndRecordAsync(gameId, forceRefresh: true, cancellationToken)` → `(...).EnrichAndRecordAsync(gameId, forceRefresh: true, triggeredByAdminUserId: request.TriggeredByUserId, cancellationToken)`.
+- `WikidataCoverEnrichmentJob.cs`: M9 cron call site stays `EnrichAndRecordAsync(gameId, false, cancellationToken)` — default `null` is correct (scheduler path).
+
+- [ ] **Step 4: Run all runner + caller tests**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~WikidataCoverEnrichmentRunnerTests|FullyQualifiedName~AdminEnrichWikidataCoverCommandHandlerTests|FullyQualifiedName~AdminBulkRetryWikidataCoverCommandHandlerTests" --no-restore`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataCoverEnrichmentRunner.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunner.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IWikidataEnrichmentEventBroadcaster.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminEnrichWikidataCoverCommandHandler.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCover/AdminBulkRetryWikidataCoverCommandHandler.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Jobs/WikidataCoverEnrichmentJob.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataCoverEnrichmentRunnerTests.cs
+git commit -m "feat(catalog-be): #2255 F6 runner persists triggeredByAdminUserId + SSE payload"
+```
+
+---
+
+## Phase 4 — Backend Endpoint + Routing
+
+### Task 4.1: New endpoint `POST /bulk-acknowledge` + update `GET /dead-letters`
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs` (modify — add tests)
+
+- [ ] **Step 1: Write failing IT tests**
+
+Append to `AdminWikidataCoverEnrichmentEndpointsTests.cs`:
+
+```csharp
+[Fact]
+public async Task BulkAcknowledge_Anonymous_Returns401()
+{
+    using var factory = new IntegrationWebApplicationFactory();
+    var client = factory.CreateAnonClient();
+
+    var response = await client.PostAsJsonAsync(
+        "/api/v1/admin/wikidata/enrichment/bulk-acknowledge",
+        new { attemptIds = new[] { Guid.NewGuid() }, note = (string?)null });
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+}
+
+[Fact]
+public async Task BulkAcknowledge_AdminWithDeadLetter_ReturnsAckedCountOne()
+{
+    using var factory = new IntegrationWebApplicationFactory();
+    var (adminId, client) = await factory.CreateAdminClientAsync();
+    // Seed: 1 game + 1 dead-letter
+    var dl = await factory.SeedDeadLetterAsync();
+
+    var response = await client.PostAsJsonAsync(
+        "/api/v1/admin/wikidata/enrichment/bulk-acknowledge",
+        new { attemptIds = new[] { dl.Id }, note = "test note" });
+
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var body = await response.Content.ReadFromJsonAsync<AdminBulkAcknowledgeResult>();
+    body!.AckedCount.Should().Be(1);
+    body.Rows.Single().AttemptId.Should().Be(dl.Id);
+
+    // Verify default list view now excludes it
+    var listResponse = await client.GetAsync("/api/v1/admin/wikidata/enrichment/dead-letters");
+    var list = await listResponse.Content.ReadFromJsonAsync<WikidataDeadLetterAttemptsResult>();
+    list!.Items.Should().NotContain(i => i.Id == dl.Id);
+
+    // Verify includeAcknowledged=true surfaces it
+    var includedResponse = await client.GetAsync("/api/v1/admin/wikidata/enrichment/dead-letters?includeAcknowledged=true");
+    var included = await includedResponse.Content.ReadFromJsonAsync<WikidataDeadLetterAttemptsResult>();
+    included!.Items.Should().Contain(i => i.Id == dl.Id);
+}
+
+[Fact]
+public async Task BulkAcknowledge_OverFifty_Returns400()
+{
+    using var factory = new IntegrationWebApplicationFactory();
+    var (_, client) = await factory.CreateAdminClientAsync();
+    var ids = Enumerable.Range(0, 51).Select(_ => Guid.NewGuid()).ToArray();
+
+    var response = await client.PostAsJsonAsync(
+        "/api/v1/admin/wikidata/enrichment/bulk-acknowledge",
+        new { attemptIds = ids, note = (string?)null });
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+}
+```
+
+> **Note:** the `IntegrationWebApplicationFactory.SeedDeadLetterAsync` / `CreateAdminClientAsync` / `CreateAnonClient` helpers should already exist in the existing test class for Phase E F2 (PR #2222). Search the existing file before adding; reuse or extend.
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminWikidataCoverEnrichmentEndpointsTests" --no-restore`
+Expected: FAIL on `bulk-acknowledge` 404 (route not registered).
+
+- [ ] **Step 3: Add endpoint mapping**
+
+Edit `AdminWikidataCoverEnrichmentEndpoints.cs`:
+
+1. Inside `MapAdminWikidataCoverEnrichmentEndpoints` add:
+```csharp
+// Phase F F5 — bulk-acknowledge endpoint.
+group.MapPost("/bulk-acknowledge", HandleBulkAcknowledge)
+    .WithName("AdminWikidataCoverEnrichment_BulkAcknowledge")
+    .WithTags("Admin", "WikidataCoverEnrichment");
+```
+
+2. Add request DTO + handler:
+```csharp
+/// <summary>Body for the F5 bulk-acknowledge endpoint.</summary>
+internal sealed record AdminBulkAcknowledgeWikidataRequest(
+    IReadOnlyList<Guid>? AttemptIds,
+    string? Note);
+
+private static async Task<IResult> HandleBulkAcknowledge(
+    AdminBulkAcknowledgeWikidataRequest? request,
+    HttpContext context,
+    IMediator mediator,
+    CancellationToken ct)
+{
+    var command = new AdminBulkAcknowledgeWikidataCoverCommand(
+        AttemptIds: request?.AttemptIds ?? Array.Empty<Guid>(),
+        Note: request?.Note,
+        TriggeredByUserId: context.User.GetUserId());
+
+    var result = await mediator.Send(command, ct).ConfigureAwait(false);
+    return Results.Ok(result);
+}
+```
+
+3. Extend `HandleListDeadLetters` to accept `includeAcknowledged`:
+```csharp
+private static async Task<IResult> HandleListDeadLetters(
+    [FromQuery] int? skip,
+    [FromQuery] int? take,
+    [FromQuery] string? reason,
+    [FromQuery] bool? includeAcknowledged,   // F5 NEW
+    IMediator mediator,
+    CancellationToken ct)
+{
+    var query = new GetWikidataDeadLetterAttemptsQuery(
+        Skip: skip ?? 0,
+        Take: take ?? 50,
+        ReasonFilter: string.IsNullOrWhiteSpace(reason) ? null : reason,
+        IncludeAcknowledged: includeAcknowledged ?? false);
+
+    var result = await mediator.Send(query, ct).ConfigureAwait(false);
+    return Results.Ok(result);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminWikidataCoverEnrichmentEndpointsTests" --no-restore`
+Expected: PASS (existing + 3 new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs \
+        apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+git commit -m "feat(catalog-be): #2254 POST /bulk-acknowledge + #2255 includeAcknowledged query"
+```
+
+---
+
+## Phase 5 — Frontend
+
+### Task 5.1: API client — `bulkAcknowledgeDeadLetters` + extended DTOs
+
+**Files:**
+- Modify: `apps/web/src/lib/api/admin-wikidata-dead-letters.ts`
+- Test: `apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-f.test.ts` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  bulkAcknowledgeDeadLetters,
+  listDeadLetters,
+  type AdminBulkAcknowledgeResult,
+} from '@/lib/api/admin-wikidata-dead-letters';
+
+const mockFetch = vi.fn();
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+describe('bulkAcknowledgeDeadLetters', () => {
+  it('POSTs attemptIds + note to /bulk-acknowledge with credentials', async () => {
+    const payload: AdminBulkAcknowledgeResult = {
+      ackedCount: 1, idempotentNoOpCount: 0, notFoundCount: 0,
+      rows: [{ attemptId: 'a-1', gameId: 'g-1', outcome: 'acked', reason: null }],
+    };
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(payload), { status: 200 }));
+
+    const result = await bulkAcknowledgeDeadLetters(['a-1'], 'op note');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/admin/wikidata/enrichment/bulk-acknowledge',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ attemptIds: ['a-1'], note: 'op note' }),
+      }),
+    );
+    expect(result.ackedCount).toBe(1);
+  });
+
+  it('throws Error on 400', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Too many', { status: 400, statusText: 'Bad Request' }));
+    await expect(bulkAcknowledgeDeadLetters(['a-1'], null)).rejects.toThrow(/Failed to bulk-acknowledge/);
+  });
+});
+
+describe('listDeadLetters', () => {
+  it('threads includeAcknowledged=true into query string', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({
+      items: [], totalCount: 0, skip: 0, take: 50,
+    }), { status: 200 }));
+
+    await listDeadLetters({ includeAcknowledged: true });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('includeAcknowledged=true'),
+      expect.any(Object),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/web && pnpm test -- --run admin-wikidata-dead-letters-phase-f`
+Expected: FAIL — `bulkAcknowledgeDeadLetters` not exported.
+
+- [ ] **Step 3: Update API client**
+
+Edit `apps/web/src/lib/api/admin-wikidata-dead-letters.ts`:
+
+1. Extend `WikidataDeadLetterAttemptDto`:
+```typescript
+export interface WikidataDeadLetterAttemptDto {
+  id: string;
+  sharedGameId: string;
+  gameTitle: string;
+  attemptedAt: string;
+  deadLetteredAt: string;
+  reason: string;
+  details: string | null;
+  retryCount: number;
+  // F5
+  acknowledgedAt: string | null;
+  acknowledgedBy: string | null;
+  acknowledgedByFullName: string | null;
+  // F6
+  triggeredByAdminUserId: string | null;
+  triggeredByAdminFullName: string | null;
+}
+```
+
+2. Extend `listDeadLetters` to accept `includeAcknowledged`:
+```typescript
+export async function listDeadLetters(
+  options: {
+    skip?: number;
+    take?: number;
+    reason?: string;
+    includeAcknowledged?: boolean;
+  } = {}
+): Promise<WikidataDeadLetterAttemptsResult> {
+  const params = new URLSearchParams();
+  if (options.skip !== undefined) params.set('skip', String(options.skip));
+  if (options.take !== undefined) params.set('take', String(options.take));
+  if (options.reason) params.set('reason', options.reason);
+  if (options.includeAcknowledged) params.set('includeAcknowledged', 'true');
+
+  const url = `${ENDPOINT_BASE}/dead-letters${params.size > 0 ? `?${params.toString()}` : ''}`;
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) await rejectAs(response, 'Failed to list dead-letters');
+  return (await response.json()) as WikidataDeadLetterAttemptsResult;
+}
+```
+
+3. Extend `WikidataAttemptTimelineNode`:
+```typescript
+export interface WikidataAttemptTimelineNode {
+  id: string;
+  attemptedAt: string;
+  outcome: AttemptTimelineOutcome;
+  reason: string | null;
+  details: string | null;
+  retryCount: number;
+  nextRetryAt: string | null;
+  deadLetteredAt: string | null;
+  // F6
+  triggeredByAdminUserId: string | null;
+  triggeredByAdminFullName: string | null;
+}
+```
+
+4. Add F5 section at the end:
+```typescript
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase F F5 — bulk acknowledge
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const BULK_ACKNOWLEDGE_MAX_BATCH = 50;
+export const BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH = 500;
+
+export type BulkAcknowledgeRowOutcome = 'acked' | 'already-acked' | 'not-found' | 'wrong-state';
+
+export interface BulkAcknowledgeRow {
+  attemptId: string;
+  gameId: string | null;
+  outcome: BulkAcknowledgeRowOutcome;
+  reason: string | null;
+}
+
+export interface AdminBulkAcknowledgeResult {
+  ackedCount: number;
+  idempotentNoOpCount: number;
+  notFoundCount: number;
+  rows: BulkAcknowledgeRow[];
+}
+
+export async function bulkAcknowledgeDeadLetters(
+  attemptIds: string[],
+  note: string | null,
+): Promise<AdminBulkAcknowledgeResult> {
+  const response = await fetch(`${ENDPOINT_BASE}/bulk-acknowledge`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ attemptIds, note }),
+  });
+  if (!response.ok) await rejectAs(response, 'Failed to bulk-acknowledge enrichments');
+  return (await response.json()) as AdminBulkAcknowledgeResult;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: same as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/admin-wikidata-dead-letters.ts \
+        apps/web/src/lib/api/__tests__/admin-wikidata-dead-letters-phase-f.test.ts
+git commit -m "feat(catalog-fe): #2254+#2255 API client — bulkAcknowledge + extended DTOs"
+```
+
+---
+
+### Task 5.2: `AcknowledgeSelectedModal` component
+
+**Files:**
+- Create: `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AcknowledgeSelectedModal.tsx`
+- Create: `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AcknowledgeSelectedModal.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AcknowledgeSelectedModal } from '../AcknowledgeSelectedModal';
+
+describe('AcknowledgeSelectedModal', () => {
+  it('renders count and submits with note', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onCancel = vi.fn();
+
+    render(<AcknowledgeSelectedModal
+      open
+      selectedCount={3}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />);
+
+    expect(screen.getByText(/Acknowledge 3 dead-letter row/i)).toBeInTheDocument();
+    const textarea = screen.getByLabelText(/note/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'commons deleted file' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/i }));
+
+    await vi.waitFor(() => expect(onConfirm).toHaveBeenCalledWith('commons deleted file'));
+  });
+
+  it('cancel returns control without note submission', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<AcknowledgeSelectedModal
+      open
+      selectedCount={1}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />);
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('enforces 500-char note limit', () => {
+    render(<AcknowledgeSelectedModal
+      open
+      selectedCount={1}
+      onConfirm={vi.fn()}
+      onCancel={vi.fn()}
+    />);
+
+    const textarea = screen.getByLabelText(/note/i) as HTMLTextAreaElement;
+    expect(textarea.maxLength).toBe(500);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/web && pnpm test -- --run AcknowledgeSelectedModal`
+Expected: FAIL — component missing.
+
+- [ ] **Step 3: Create component**
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+import { BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH } from '@/lib/api/admin-wikidata-dead-letters';
+
+interface AcknowledgeSelectedModalProps {
+  open: boolean;
+  selectedCount: number;
+  onConfirm: (note: string | null) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+/**
+ * Issue #1823 Phase F F5 — confirmation modal for bulk-acknowledge.
+ * Optional free-text note (max 500 chars, log-only per DEC-F-4).
+ */
+export function AcknowledgeSelectedModal({
+  open, selectedCount, onConfirm, onCancel,
+}: AcknowledgeSelectedModalProps) {
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await onConfirm(note.trim() === '' ? null : note);
+      setNote('');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ack-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
+        <h2 id="ack-modal-title" className="text-lg font-semibold text-foreground">
+          Acknowledge {selectedCount} dead-letter row{selectedCount === 1 ? '' : 's'}?
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Acknowledged rows are hidden from the default list view and won&apos;t consume
+          scheduler retry budget. They are deleted after the 7-day retention sweep
+          regardless.
+        </p>
+
+        <label htmlFor="ack-note" className="mt-4 block text-sm font-medium text-foreground">
+          Note (optional, log only)
+        </label>
+        <textarea
+          id="ack-note"
+          aria-label="note"
+          maxLength={BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          className="mt-1 w-full rounded border border-border bg-background p-2 text-sm text-foreground"
+          placeholder="e.g. Commons deleted file"
+          disabled={submitting}
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          {note.length}/{BULK_ACKNOWLEDGE_NOTE_MAX_LENGTH}
+        </p>
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-border bg-background px-3 py-1.5 text-sm hover:bg-muted"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            disabled={submitting}
+          >
+            {submitting ? 'Acknowledging…' : 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: same as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/wikidata-dead-letters/AcknowledgeSelectedModal.tsx \
+        apps/web/src/app/admin/\(dashboard\)/monitor/wikidata-dead-letters/__tests__/AcknowledgeSelectedModal.test.tsx
+git commit -m "feat(catalog-fe): #2254 AcknowledgeSelectedModal with optional note"
+```
+
+---
+
+### Task 5.3: Wire toolbar + toggle + visual marker on dead-letters page
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx`
+- Test (smoke): `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/page-phase-f.test.tsx` (new)
+
+- [ ] **Step 1: Write failing smoke test**
+
+```tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import WikidataDeadLettersPage from '../page';
+import * as api from '@/lib/api/admin-wikidata-dead-letters';
+
+vi.mock('@/lib/api/admin-wikidata-dead-letters');
+vi.mock('../useWikidataEnrichmentEvents', () => ({
+  useWikidataEnrichmentEvents: () => ({ state: 'open', lastEvent: null }),
+}));
+
+describe('WikidataDeadLettersPage — Phase F integration', () => {
+  beforeEach(() => {
+    vi.mocked(api.listDeadLetters).mockResolvedValue({
+      items: [{
+        id: 'a-1', sharedGameId: 'g-1', gameTitle: 'Game',
+        attemptedAt: '2026-06-10T00:00:00Z', deadLetteredAt: '2026-06-10T00:00:00Z',
+        reason: 'r2-upload-error', details: null, retryCount: 3,
+        acknowledgedAt: null, acknowledgedBy: null, acknowledgedByFullName: null,
+        triggeredByAdminUserId: null, triggeredByAdminFullName: null,
+      }],
+      totalCount: 1, skip: 0, take: 50,
+    });
+    vi.mocked(api.bulkAcknowledgeDeadLetters).mockResolvedValue({
+      ackedCount: 1, idempotentNoOpCount: 0, notFoundCount: 0,
+      rows: [{ attemptId: 'a-1', gameId: 'g-1', outcome: 'acked', reason: null }],
+    });
+  });
+
+  it('renders Acknowledge selected button alongside Retry selected', async () => {
+    render(<WikidataDeadLettersPage />);
+    await waitFor(() => expect(screen.getByText('Game')).toBeInTheDocument());
+
+    // Select the only row
+    const checkbox = screen.getAllByRole('checkbox')[0];
+    fireEvent.click(checkbox);
+
+    expect(screen.getByRole('button', { name: /Acknowledge selected/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry selected/i })).toBeInTheDocument();
+  });
+
+  it('renders Show acknowledged toggle (off by default)', async () => {
+    render(<WikidataDeadLettersPage />);
+    await waitFor(() => expect(screen.getByText('Game')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('switch', { name: /Show acknowledged/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('toggling Show acknowledged refetches with includeAcknowledged=true', async () => {
+    render(<WikidataDeadLettersPage />);
+    await waitFor(() => expect(screen.getByText('Game')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('switch', { name: /Show acknowledged/i });
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(api.listDeadLetters).toHaveBeenCalledWith(
+      expect.objectContaining({ includeAcknowledged: true })
+    ));
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/web && pnpm test -- --run page-phase-f`
+Expected: FAIL — Acknowledge button/switch not rendered.
+
+- [ ] **Step 3: Wire into page**
+
+Edit `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/page.tsx`:
+
+1. Import additions (top of file):
+```typescript
+import {
+  BULK_ACKNOWLEDGE_MAX_BATCH,
+  bulkAcknowledgeDeadLetters,
+  type AdminBulkAcknowledgeResult,
+  // ... existing imports
+} from '@/lib/api/admin-wikidata-dead-letters';
+
+import { AcknowledgeSelectedModal } from './AcknowledgeSelectedModal';
+```
+
+2. Add new state alongside `bulkState`:
+```typescript
+const [includeAcknowledged, setIncludeAcknowledged] = useState(false);
+const [ackModalOpen, setAckModalOpen] = useState(false);
+const [ackState, setAckState] = useState<
+  | { state: 'idle' }
+  | { state: 'running' }
+  | { state: 'done'; result: AdminBulkAcknowledgeResult }
+  | { state: 'error'; error: string }
+>({ state: 'idle' });
+```
+
+3. Update `load()` callback to pass `includeAcknowledged`:
+```typescript
+const response = await listDeadLetters({
+  skip: page * PAGE_SIZE,
+  take: PAGE_SIZE,
+  reason: reasonFilter || undefined,
+  includeAcknowledged,                 // F5
+});
+```
+
+4. Add toggle effect:
+```typescript
+useEffect(() => { void load(); }, [load, includeAcknowledged]);
+```
+
+5. Add Acknowledge handler:
+```typescript
+const handleAcknowledgeConfirm = useCallback(async (note: string | null) => {
+  setAckState({ state: 'running' });
+  try {
+    const result = await bulkAcknowledgeDeadLetters(Array.from(selectedIds), note);
+    setAckState({ state: 'done', result });
+    setSelectedIds(new Set());
+    setAckModalOpen(false);
+    await load();
+  } catch (err) {
+    setAckState({ state: 'error', error: err instanceof Error ? err.message : 'Unknown error' });
+  }
+}, [selectedIds, load]);
+```
+
+6. In JSX, add toggle (somewhere in the filter bar):
+```tsx
+<label className="flex items-center gap-2 text-sm text-foreground">
+  <button
+    type="button"
+    role="switch"
+    aria-checked={includeAcknowledged}
+    aria-label="Show acknowledged"
+    onClick={() => setIncludeAcknowledged((v) => !v)}
+    className={`h-5 w-9 rounded-full transition-colors ${
+      includeAcknowledged ? 'bg-primary' : 'bg-muted'
+    }`}
+  >
+    <span
+      className={`block h-4 w-4 rounded-full bg-background shadow transition-transform ${
+        includeAcknowledged ? 'translate-x-4' : 'translate-x-0.5'
+      }`}
+    />
+  </button>
+  Show acknowledged
+</label>
+```
+
+7. Add "Acknowledge selected" button alongside "Retry selected" (find existing Retry button JSX and add):
+```tsx
+<button
+  type="button"
+  onClick={() => setAckModalOpen(true)}
+  disabled={selectedIds.size === 0 || selectedIds.size > BULK_ACKNOWLEDGE_MAX_BATCH}
+  className="rounded bg-secondary px-3 py-1.5 text-sm font-medium text-secondary-foreground hover:bg-secondary/90 disabled:opacity-50"
+>
+  Acknowledge selected ({selectedIds.size})
+</button>
+```
+
+8. Render modal at the end of the JSX (before the closing fragment):
+```tsx
+<AcknowledgeSelectedModal
+  open={ackModalOpen}
+  selectedCount={selectedIds.size}
+  onConfirm={handleAcknowledgeConfirm}
+  onCancel={() => setAckModalOpen(false)}
+/>
+```
+
+9. Visual marker for acked rows (in the row rendering, when `item.acknowledgedAt !== null`):
+```tsx
+<tr
+  key={item.id}
+  className={item.acknowledgedAt ? 'opacity-60' : ''}
+>
+  {/* ... existing cells ... */}
+  {item.acknowledgedAt && item.acknowledgedByFullName && (
+    <span className="ml-2 inline-flex rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      Acked by {item.acknowledgedByFullName} on{' '}
+      {new Date(item.acknowledgedAt).toLocaleDateString()}
+    </span>
+  )}
+</tr>
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: same as Step 2. Expected: PASS (3 new tests + all existing page tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/wikidata-dead-letters/page.tsx \
+        apps/web/src/app/admin/\(dashboard\)/monitor/wikidata-dead-letters/__tests__/page-phase-f.test.tsx
+git commit -m "feat(catalog-fe): #2254 wire toolbar+toggle+marker on dead-letters page"
+```
+
+---
+
+### Task 5.4: F6 badge in `AttemptTimelineDrawer`
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx`
+- Test (modify or new): `apps/web/src/app/admin/(dashboard)/monitor/wikidata-dead-letters/__tests__/AttemptTimelineDrawer-phase-f.test.tsx` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AttemptTimelineDrawer } from '../AttemptTimelineDrawer';
+import * as api from '@/lib/api/admin-wikidata-dead-letters';
+
+vi.mock('@/lib/api/admin-wikidata-dead-letters');
+
+describe('AttemptTimelineDrawer — F6 admin badge', () => {
+  it('shows admin badge when triggeredByAdminUserId is non-null', async () => {
+    vi.mocked(api.getAttemptTimeline).mockResolvedValue({
+      gameId: 'g-1',
+      items: [{
+        id: 'a-1', attemptedAt: '2026-06-10T00:00:00Z',
+        outcome: 'Success', reason: 'success', details: null, retryCount: 0,
+        nextRetryAt: null, deadLetteredAt: null,
+        triggeredByAdminUserId: 'admin-1',
+        triggeredByAdminFullName: 'Alice Admin',
+      }],
+    });
+    render(<AttemptTimelineDrawer
+      gameId="g-1" gameTitle="Test Game" open onClose={() => {}}
+    />);
+    await waitFor(() => expect(screen.getByText(/Success/i)).toBeInTheDocument());
+
+    const badge = screen.getByText(/admin/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge.closest('[title]')).toHaveAttribute('title', 'Triggered by admin Alice Admin');
+  });
+
+  it('hides admin badge when triggeredByAdminUserId is null', async () => {
+    vi.mocked(api.getAttemptTimeline).mockResolvedValue({
+      gameId: 'g-1',
+      items: [{
+        id: 'a-1', attemptedAt: '2026-06-10T00:00:00Z',
+        outcome: 'Success', reason: 'success', details: null, retryCount: 0,
+        nextRetryAt: null, deadLetteredAt: null,
+        triggeredByAdminUserId: null,
+        triggeredByAdminFullName: null,
+      }],
+    });
+    render(<AttemptTimelineDrawer
+      gameId="g-1" gameTitle="Test Game" open onClose={() => {}}
+    />);
+    await waitFor(() => expect(screen.getByText(/Success/i)).toBeInTheDocument());
+
+    expect(screen.queryByText(/^admin$/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd apps/web && pnpm test -- --run AttemptTimelineDrawer-phase-f`
+Expected: FAIL — badge not rendered.
+
+- [ ] **Step 3: Add badge in drawer**
+
+Edit `AttemptTimelineDrawer.tsx` — locate the per-node rendering (search for `node.outcome` or `Outcome` JSX), add:
+
+```tsx
+{node.triggeredByAdminUserId && (
+  <span
+    title={
+      node.triggeredByAdminFullName
+        ? `Triggered by admin ${node.triggeredByAdminFullName}`
+        : 'Triggered by admin (deleted user)'
+    }
+    className="ml-2 inline-flex items-center rounded border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary"
+  >
+    admin
+  </span>
+)}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: same as Step 2. Expected: PASS (2 new tests + existing drawer tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/admin/\(dashboard\)/monitor/wikidata-dead-letters/AttemptTimelineDrawer.tsx \
+        apps/web/src/app/admin/\(dashboard\)/monitor/wikidata-dead-letters/__tests__/AttemptTimelineDrawer-phase-f.test.tsx
+git commit -m "feat(catalog-fe): #2255 F6 admin badge in attempt timeline drawer"
+```
+
+---
+
+## Phase 6 — Integration + E2E
+
+### Task 6.1: E2E Playwright skeleton
+
+**Files:**
+- Create: `apps/web/e2e/admin-wikidata-bulk-acknowledge-flow.spec.ts`
+
+- [ ] **Step 1: Write skeleton E2E spec**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin Wikidata bulk acknowledge flow (#2254)', () => {
+  test.skip(
+    !process.env.E2E_ADMIN_EMAIL || !process.env.E2E_ADMIN_PASSWORD,
+    'Requires admin credentials',
+  );
+
+  test('select dead-letters, acknowledge with note, toggle Show acked', async ({ page }) => {
+    // 1. Login as admin
+    await page.goto('/login');
+    await page.getByLabel(/email/i).fill(process.env.E2E_ADMIN_EMAIL!);
+    await page.getByLabel(/password/i).fill(process.env.E2E_ADMIN_PASSWORD!);
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await page.waitForURL(/\/(admin|dashboard)/);
+
+    // 2. Navigate to dead-letter page
+    await page.goto('/admin/monitor/wikidata-dead-letters');
+    await expect(page.getByRole('heading', { name: /dead.*letter/i })).toBeVisible();
+
+    // 3. If there are any dead-letters, select the first 2
+    const rows = page.getByRole('row').filter({ has: page.getByRole('checkbox') });
+    const count = await rows.count();
+    test.skip(count < 2, 'Requires ≥ 2 dead-letters to run a meaningful bulk-ack');
+    await rows.nth(0).getByRole('checkbox').check();
+    await rows.nth(1).getByRole('checkbox').check();
+
+    // 4. Open modal, type note, confirm
+    await page.getByRole('button', { name: /Acknowledge selected/i }).click();
+    await page.getByLabel(/note/i).fill('e2e: known commons-deleted asset');
+    await page.getByRole('button', { name: /^Confirm$/i }).click();
+
+    // 5. Modal closes, page reloads, selected rows hidden
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    // (cannot assert specific row ids without coupling; rely on count decrease)
+
+    // 6. Toggle Show acknowledged → reappear
+    await page.getByRole('switch', { name: /Show acknowledged/i }).click();
+    await expect(page.getByText(/Acked by/i).first()).toBeVisible();
+  });
+});
+```
+
+> **Note:** if E2E is configured via `apps/web/e2e/playwright.config.ts` with a global `setup` for admin login, prefer that pattern over inline login.
+
+- [ ] **Step 2: Verify test file syntax**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no new errors.
+
+- [ ] **Step 3: (No implementation step — spec is the deliverable)**
+
+- [ ] **Step 4: (Skip — E2E runs on `continue-on-error: true`, validation in CI)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/e2e/admin-wikidata-bulk-acknowledge-flow.spec.ts
+git commit -m "test(catalog-fe-e2e): #2254 bulk-acknowledge flow skeleton"
+```
+
+---
+
+## Final steps
+
+### Task F.1: Run full BE suite + FE suite + push
+
+- [ ] **Step 1: Backend full suite**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --no-restore --verbosity minimal 2>&1 | tail -30`
+Expected: 0 failed. Failing tests not yet documented in CLAUDE.md "Known Flaky Tests" must be investigated before push.
+
+- [ ] **Step 2: Frontend full unit suite**
+
+Run: `cd apps/web && pnpm test:coverage 2>&1 | tail -30`
+Expected: 0 failed.
+
+- [ ] **Step 3: Frontend lint + typecheck**
+
+Run: `cd apps/web && pnpm lint && pnpm typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 4: Push branch + open draft PR**
+
+```bash
+git push -u origin feature/issue-2254-2255-phase-f-bundle
+gh pr create --base main-dev --draft --title "feat(catalog): #2254+#2255 Phase F bundle — F5 bulk acknowledge + F6 attempt-source" --body "$(cat <<'EOF'
+## Summary
+
+Closes Phase F follow-up of epic #1823 (Wikidata cover enrichment). Bundles F5 (#2254) bulk acknowledge UI + F6 (#2255) attempt-source attribution in 1 PR per design DEC-F-1.
+
+- **F5**: aggregate mutator `Acknowledge()` (eccezione record-of-fact documentata) + CQRS command + endpoint POST /bulk-acknowledge + FE toolbar/modal/toggle/visual marker
+- **F6**: factory `triggeredByAdminUserId` param + runner signature change + DTO/SSE field + FE badge in timeline drawer
+- 1 migration: 3 nullable columns + 1 partial index `ix_wikidata_cover_attempts_acknowledged_at`
+- 8 design decisions locked: see [spec](docs/superpowers/specs/2026-06-13-issue-2254-2255-phase-f-bundle-design.md)
+
+## Test plan
+
+- [ ] Backend: `dotnet test` (Phase F adds ~25 unit + 6 IT tests)
+- [ ] Frontend: `pnpm test:coverage` (Phase F adds ~9 Vitest tests)
+- [ ] Lint+typecheck green
+- [ ] E2E skeleton ships non-blocking (continue-on-error)
+- [ ] Manual smoke on staging: select 2 dead-letters → ack with note → toggle show acked → reappear
+
+Closes #2254
+Closes #2255
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for CI green, request code-review subagent**
+
+Use code-review subagent (`/code-review:code-review <PR-URL>`) before marking PR ready-for-review.

--- a/docs/superpowers/specs/2026-06-13-issue-2254-2255-phase-f-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-13-issue-2254-2255-phase-f-bundle-design.md
@@ -1,0 +1,366 @@
+# F5+F6 Phase F bundle — Design (#2254 + #2255)
+
+**Status**: APPROVED 2026-06-13 (brainstorming session)
+**Branch**: `feature/issue-2254-2255-phase-f-bundle`
+**Issues**: [#2254](https://github.com/meepleAi-app/meepleai-monorepo/issues/2254) F5 bulk acknowledge UI · [#2255](https://github.com/meepleAi-app/meepleai-monorepo/issues/2255) F6 attempt-source attribution
+**Parent epic**: #1823 (Wikidata cover enrichment) — Phase E shipped 2026-06-12, M17 staging dry-run ✅
+**Estimate**: ~19h (2.5gg). Bundled delivery in 1 PR (decision DEC-F-1).
+**Pattern reference**: F2 bulk-retry (PR #2222), F3 timeline drawer (PR #2222), F4 SSE broadcaster (PR #2227)
+
+---
+
+## 1. Context
+
+Phase E closed epic #1823 at 100% of original acceptance criteria (M17 staging dry-run 8/8 gates ✅). 3 follow-up issues were filed 2026-06-12 to close residual operator UX gaps:
+
+- **#2254 F5 bulk acknowledge UI** — operator marks a terminal dead-letter as "not actionable" (e.g. `image-bytes-not-available` for a Commons-deleted file, or `license-not-whitelisted` for a known-non-CC game) without burning an M9 scheduler tick or waiting 7 days for the DEC-3j retention sweep.
+- **#2255 F6 attempt-source attribution** — visual distinguishing between scheduler-triggered and admin-triggered attempts in the F3 timeline drawer.
+- **#2256 multi-pod Redis fan-out** — out of scope for this bundle (deferred until DEC-3e single-pod assumption is revisited).
+
+This bundle ships F5+F6 in **one PR**. Both touch the same `wikidata_cover_enrichment_attempts` table, so combining migrations avoids 2 sequential ALTER TABLE round-trips. Same admin surface, same code-review pass.
+
+## 2. Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| **DEC-F-1** | **1 PR mega bundle** (BE F5+F6 + 1 migration + FE F5 toolbar/modal + FE F6 badge) | Stessa tabella + stesso review surface + contesto Phase E fresco (mergiato ieri). Trade-off: PR più grande ~20 file, ma review pass unico è preferibile a 2 cicli sequenziali. |
+| **DEC-F-2** | **1 migration combinata 3 colonne + 1 partial index** (`AddAcknowledgeAndTriggerSourceToWikidataAttempts`) | Evita 2 ALTER TABLE consecutivi su tabella attiva. Index parziale `WHERE acknowledged_at IS NOT NULL` ottimizza filter "exclude acked" del default list view senza inflare l'index su null. |
+| **DEC-F-3** | **F5 aggregate pattern: mutator `Acknowledge(userId, ackedAt)` su aggregate esistente** (eccezione record-of-fact) | Approach A vs B (sibling aggregate) vs C (SQL bypass). A è semplice, 1 aggregate, idempotency in-domain. Eccezione documentata via XML doc: ack è metadata operativa orthogonal (parallelo a `DeadLetteredAt`), non un evento pipeline. |
+| **DEC-F-4** | **Note F5 NOT persisted** — log-only nel structured log line (mirror F2 `TriggeredByUserId` pattern). Modal mostra textarea per "intent" operatore | Riduce scope (no colonna `acknowledge_note`), preserva pattern. F5 issue dice "Audit log of who acknowledged what — separate issue if needed". Decisione reversibile in follow-up. |
+| **DEC-F-5** | **F6 user resolver: server-side LEFT JOIN, embed displayName nei DTO** | Approach (a) vs (b) FE lazy lookup vs (c) badge senza tooltip. (a) ha 1 round-trip, FE banale, costo +1 JOIN su query a basso traffico (M13 admin page). |
+| **DEC-F-6** | **F5 toggle "Show acknowledged" default OFF; row acked dimmed (`opacity-60`) + chip "Acked by {fullName} on {date}"** | Default ON nasconde noise; toggle scoperta opzionale per ops auditing. Visual marker minimal: opacity + chip semantic `bg-muted` (no destructive). |
+| **DEC-F-7** | **F5 endpoint shape mirror F2**: result envelope `{ ackedCount, idempotentNoOpCount, notFoundCount, rows[] }` | Coerenza con bulk-retry — operator UX uniforme, FE pattern noto. |
+| **DEC-F-8** | **F6 runner signature change**: `EnrichAndRecordAsync(gameId, forceRefresh, triggeredByAdminUserId, ct)` con parametro nullable | Wave 3 M12 keep TriggeredByUserId log-only; F6 lo persiste. M9 scheduler passa `null`; M12 + F2 passano admin id. Backward-compatible per IT che usano default `null`. |
+
+## 3. Architecture
+
+### 3.1 Bounded context
+
+Tutto in `Api.BoundedContexts.SharedGameCatalog`. Tocca 4 strati:
+- **Domain**: `WikidataCoverEnrichmentAttempt` aggregate (mutator + factory params)
+- **Application**: 1 new command + 1 query update + 1 query DTO update + runner interface change
+- **Infrastructure**: 1 entity update + 1 entity config update + 1 migration + 1 repository update
+- **Routing**: 1 new endpoint + 1 endpoint query param
+
+### 3.2 Diagrams
+
+```
+[Admin UI] --POST /bulk-acknowledge--> [Endpoint] --IMediator--> [Handler]
+                                                                    |
+                                                            [Repo.GetByIdsAsync]
+                                                                    |
+                                                              for each row:
+                                                            [aggregate.Acknowledge()]
+                                                            [Repo.UpdateAsync]
+                                                                    |
+                                                            return envelope
+
+[M9 / M12 / F2] --runner.EnrichAndRecordAsync(triggeredBy)--> persist attempt
+                                                              with TriggeredByAdminUserId
+```
+
+## 4. Data model
+
+### 4.1 Migration (`20260613XXXXXX_AddAcknowledgeAndTriggerSourceToWikidataAttempts.cs`)
+
+```sql
+ALTER TABLE wikidata_cover_enrichment_attempts
+  ADD COLUMN acknowledged_at              timestamp with time zone NULL,
+  ADD COLUMN acknowledged_by              uuid                     NULL,
+  ADD COLUMN triggered_by_admin_user_id   uuid                     NULL;
+
+-- F5 partial index: speeds up default list view (exclude acked = WHERE acknowledged_at IS NULL)
+CREATE INDEX ix_wikidata_cover_attempts_acknowledged_at
+  ON wikidata_cover_enrichment_attempts (acknowledged_at)
+  WHERE acknowledged_at IS NOT NULL;
+```
+
+**No FK** on `users` for `acknowledged_by` / `triggered_by_admin_user_id` — mirror `created_by` pattern in `audit_logs` (preserves hard-delete tolerance). User lookup happens at query-time via JOIN.
+
+### 4.2 Aggregate `WikidataCoverEnrichmentAttempt`
+
+```csharp
+// F5 mutator state (private setters preserved)
+public DateTime? AcknowledgedAt { get; private set; }
+public Guid?     AcknowledgedBy { get; private set; }
+
+// F6 attribution state
+public Guid?     TriggeredByAdminUserId { get; private set; }
+
+/// <summary>
+/// F5 — operator marks dead-letter as "not actionable". Idempotent.
+/// EXCEPTION to record-of-fact pattern: ack is operational metadata,
+/// not a pipeline event (parallel to DeadLetteredAt). Preserves original
+/// ack on re-call (no overwrite).
+/// </summary>
+public void Acknowledge(Guid userId, DateTime ackedAt)
+{
+    if (Outcome != WikidataCoverEnrichmentOutcome.DeadLetter)
+        throw new InvalidOperationException(
+            $"Only DeadLetter attempts can be acknowledged; current Outcome={Outcome}.");
+    if (userId == Guid.Empty)
+        throw new ArgumentException("UserId cannot be Guid.Empty.", nameof(userId));
+    if (AcknowledgedAt is not null) return; // idempotent
+    AcknowledgedAt = ackedAt;
+    AcknowledgedBy = userId;
+}
+
+// F6 — factory methods accept optional triggeredByAdminUserId
+public static WikidataCoverEnrichmentAttempt RecordSuccess(
+    Guid sharedGameId, int retryCount, DateTime attemptedAt,
+    Guid? triggeredByAdminUserId = null) => ...;
+
+// (same for RecordSkipped / RecordFailedWithRetry / RecordDeadLetter)
+
+// Reconstitute hydrates AcknowledgedAt/AcknowledgedBy/TriggeredByAdminUserId
+public static WikidataCoverEnrichmentAttempt Reconstitute(
+    Guid id, Guid sharedGameId, DateTime attemptedAt,
+    WikidataCoverEnrichmentOutcome outcome, string reason, string? details,
+    int retryCount, DateTime? nextRetryAt, DateTime? deadLetteredAt,
+    DateTime? acknowledgedAt, Guid? acknowledgedBy,         // F5
+    Guid? triggeredByAdminUserId) => ...;                    // F6
+```
+
+### 4.3 EF Core entity + config
+
+- `WikidataCoverEnrichmentAttemptEntity`: 3 nuove properties (`AcknowledgedAt`, `AcknowledgedBy`, `TriggeredByAdminUserId`) nullable.
+- `WikidataCoverEnrichmentAttemptEntityConfiguration`: column mappings + partial index via `HasIndex(e => e.AcknowledgedAt).HasFilter("acknowledged_at IS NOT NULL").HasDatabaseName("ix_wikidata_cover_attempts_acknowledged_at")`.
+- `WikidataCoverEnrichmentAttemptRepository`: `Reconstitute` mapping update (3 new args).
+
+## 5. CQRS
+
+### 5.1 F5 Command — `AdminBulkAcknowledgeWikidataCoverCommand`
+
+```csharp
+internal sealed record AdminBulkAcknowledgeWikidataCoverCommand(
+    IReadOnlyList<Guid> AttemptIds,
+    string? Note,                         // optional, max 500 chars, log-only
+    Guid TriggeredByUserId)               // admin user id (log-only, mirror F2)
+    : ICommand<AdminBulkAcknowledgeResult>;
+
+public sealed record AdminBulkAcknowledgeResult(
+    int AckedCount,                       // newly acknowledged this batch
+    int IdempotentNoOpCount,              // already acknowledged, no-op
+    int NotFoundCount,                    // attempt id not found / swept
+    IReadOnlyList<AdminBulkAcknowledgeRow> Rows);
+
+public sealed record AdminBulkAcknowledgeRow(
+    Guid AttemptId,
+    Guid? GameId,
+    string Outcome,                       // "acked" | "already-acked" | "not-found" | "wrong-state"
+    string? Reason);
+```
+
+**Handler** (mirror `AdminBulkRetryWikidataCoverCommandHandler` pattern):
+- Repo lookup `GetByIdsAsync(attemptIds, ct)` returns dictionary
+- Per-row try/catch:
+  - Missing → row outcome `not-found`, increment `notFoundCount`
+  - Found + not DeadLetter → row outcome `wrong-state`, log warning
+  - Found + already acked → row outcome `already-acked`, increment `idempotentNoOpCount`
+  - Found + DeadLetter + not-yet-acked → `aggregate.Acknowledge(userId, now)` + `repo.UpdateAsync`, row outcome `acked`, increment `ackedCount`
+- `OperationCanceledException` rethrown (mirror F2)
+- Note string logged via structured `_logger.LogInformation("AdminBulkAcknowledge: user={UserId} count={Count} note={Note}", ...)` — NOT persisted (DEC-F-4)
+
+**Validator** `AdminBulkAcknowledgeWikidataCoverCommandValidator`:
+- `AttemptIds`: NotEmpty, max 50 (DEC-3e cap), no Guid.Empty
+- `Note`: optional, max 500 chars (when non-null)
+- `TriggeredByUserId`: NotEmpty Guid
+
+### 5.2 F5 Query update — `GetWikidataDeadLetterAttemptsQuery`
+
+```csharp
+internal sealed record GetWikidataDeadLetterAttemptsQuery(
+    int Skip,
+    int Take,
+    string? ReasonFilter,
+    bool IncludeAcknowledged = false)         // F5 NEW (default backward-compat)
+    : IRequest<WikidataDeadLetterAttemptsResult>;
+
+public sealed record WikidataDeadLetterAttemptDto(
+    Guid Id, Guid SharedGameId, string GameTitle,
+    DateTime AttemptedAt, DateTime DeadLetteredAt,
+    string Reason, string? Details, int RetryCount,
+    // F5 fields
+    DateTime? AcknowledgedAt,
+    Guid?     AcknowledgedBy,
+    string?   AcknowledgedByFullName,         // server-side LEFT JOIN users.full_name
+    // F6 fields
+    Guid?     TriggeredByAdminUserId,
+    string?   TriggeredByAdminFullName);      // server-side LEFT JOIN users.full_name
+```
+
+**Repository signature change**:
+```csharp
+Task<WikidataDeadLetterPage> GetDeadLettersAsync(
+    int skip, int take, string? reasonFilter,
+    bool includeAcknowledged,                 // F5 NEW
+    CancellationToken ct);
+```
+- EF Core query: filter `Outcome == DeadLetter && (includeAcknowledged || AcknowledgedAt == null)`
+- LEFT JOIN on `users` x 2 (acknowledged_by + triggered_by_admin_user_id) → select FullName projection
+
+### 5.3 F6 Query update — `GetWikidataAttemptTimelineQuery`
+
+```csharp
+public sealed record WikidataAttemptTimelineNode(
+    Guid Id, DateTime AttemptedAt, string Outcome,
+    string? Reason, string? Details, int RetryCount,
+    DateTime? NextRetryAt, DateTime? DeadLetteredAt,
+    // F6 fields
+    Guid?   TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);        // server-side LEFT JOIN
+```
+
+**Repository signature change**:
+```csharp
+Task<IReadOnlyList<WikidataAttemptTimelineRow>> GetAttemptsByGameIdAsync(
+    Guid gameId, int limit, CancellationToken ct);
+// Row DTO now includes TriggeredByAdminFullName
+```
+
+### 5.4 F6 Runner interface change — `IWikidataCoverEnrichmentRunner`
+
+```csharp
+public interface IWikidataCoverEnrichmentRunner
+{
+    Task EnrichAndRecordAsync(
+        Guid sharedGameId,
+        bool forceRefresh,
+        Guid? triggeredByAdminUserId,         // F6 NEW (null = M9 scheduler)
+        CancellationToken ct);
+}
+```
+
+Callers:
+- `WikidataCoverEnrichmentJob` (M9 scheduler) → passes `null`
+- `AdminEnrichWikidataCoverCommandHandler` (M12) → passes `command.TriggeredByUserId`
+- `AdminBulkRetryWikidataCoverCommandHandler` (F2) → passes `request.TriggeredByUserId`
+
+Runner internal: when creating attempt via aggregate factory, passes `triggeredByAdminUserId` parameter.
+
+### 5.5 F4 SSE event payload update — `WikidataEnrichmentEvent`
+
+```csharp
+public sealed record WikidataEnrichmentEvent(
+    Guid AttemptId, Guid SharedGameId, DateTime AttemptedAt,
+    string Outcome, string Reason, int RetryCount,
+    DateTime? NextRetryAt, DateTime? DeadLetteredAt,
+    // F6 fields
+    Guid?   TriggeredByAdminUserId,
+    string? TriggeredByAdminFullName);
+```
+
+Broadcaster publishes from runner POST-SaveChanges (mirror F1 dead-letter gauge placement). FullName JOIN done in broadcast publish path (single user lookup, cached server-side per pod).
+
+## 6. Endpoints
+
+### 6.1 New — POST `/api/v1/admin/wikidata/enrichment/bulk-acknowledge`
+
+- **Auth**: `RequireAdminSessionFilter` (group-level)
+- **Body**: `{ attemptIds: Guid[], note?: string }`
+- **Response 200**: `{ ackedCount, idempotentNoOpCount, notFoundCount, rows[] }`
+- **Response 400**: validation error (empty / >50 / note > 500 chars)
+- **Response 401**: not admin
+- **Cancellation**: propagates via `HttpContext.RequestAborted`
+
+### 6.2 Update — GET `/api/v1/admin/wikidata/enrichment/dead-letters`
+
+Adds optional query param `?includeAcknowledged=true` (default false). Otherwise unchanged response shape (DTO enriched with new fields — backward-compatible additive).
+
+## 7. Frontend
+
+### 7.1 F5 admin page (`apps/web/src/app/admin/wikidata-enrichment/...`)
+
+**New components**:
+- `AcknowledgeSelectedButton` — sticky toolbar 3rd button (after "Retry selected" + clear-selection)
+- `AcknowledgeSelectedModal` — confirmation modal with:
+  - Summary "Acknowledge {count} dead-letter row(s)?"
+  - Optional `<Textarea>` "Note (optional, for log only)" maxLen 500
+  - Cancel + Confirm buttons; submit calls `useBulkAcknowledgeMutation`
+- `ShowAcknowledgedToggle` — `<Switch>` "Show acknowledged" (default off) → toggles `includeAcknowledged` query param
+
+**Visual marker for acked rows** (default hidden, visible only when toggle on):
+- Row wrapper: `opacity-60` + Tailwind utility
+- Inline chip "Acked by {fullName} on {date}" via `<Badge variant="secondary">` with `bg-muted text-muted-foreground` semantic tokens (DS-15 compliance — no hardcoded slate/gray)
+
+**New hook**: `useBulkAcknowledgeMutation` (mirror `useBulkRetryMutation` pattern via `@tanstack/react-query`):
+- `mutationFn: (input: { attemptIds: string[]; note?: string }) => api.adminWikidata.bulkAcknowledge(input)`
+- `onSuccess`: invalidate `['admin', 'wikidata', 'dead-letters']` query
+- Error envelope `{ kind: 'validation' | 'server', message }` mirror existing pattern
+
+### 7.2 F6 timeline drawer (`AttemptTimelineDrawer.tsx`)
+
+**Inline badge** when `triggeredByAdminUserId !== null`:
+```tsx
+<Badge variant="outline" className="ml-2 text-xs">
+  admin
+</Badge>
+```
+With border + bg semantic tokens (`border-primary/40 bg-primary/10` or similar, NOT hardcoded blue-500).
+
+**Hover tooltip** via existing `<Tooltip>` primitive: `Triggered by admin {triggeredByAdminFullName}` (or `"Triggered by admin (deleted user)"` fallback when FullName is null but Id non-null).
+
+## 8. Tests
+
+### 8.1 Backend
+
+| Suite | F5 | F6 |
+|---|---|---|
+| Aggregate unit | 4: Acknowledge happy / idempotent no-op / ArgumentException Guid.Empty / InvalidOp not DeadLetter | 1: Reconstitute roundtrip TriggeredByAdminUserId |
+| Command handler unit | 5: single ack / batch ack / idempotency (mixed new+old) / not-found row / cancellation propagation | — |
+| Query handler unit | 3: default excludes acked / includeAcknowledged=true includes them / count corrretto post-filter | 1: timeline DTO populated with admin name via JOIN mock |
+| Runner unit | — | 2: scheduler path persists null / admin path persists admin id |
+| Validator unit | 4: empty list / >50 / note >500 chars / TriggeredByUserId empty | — |
+| Endpoint IT (Testcontainers) | 1: POST /bulk-acknowledge end-to-end → assert AcknowledgedAt/By persisted + partial index hit via EXPLAIN sanity | 1: M12 endpoint persists admin id; M9 cron path leaves null |
+
+### 8.2 Frontend (Vitest)
+
+| Suite | F5 | F6 |
+|---|---|---|
+| Hook | 3: `useBulkAcknowledgeMutation` happy / server-error envelope / invalidates dead-letter query | 2: badge shown when admin id non-null / hidden when null |
+| Component smoke | 1: `AcknowledgeSelectedModal` render + submit with note + cancel | — |
+
+### 8.3 E2E
+
+Skeleton (not blocking, `continue-on-error: true`):
+- `apps/web/e2e/admin-wikidata-bulk-acknowledge-flow.spec.ts` — login admin → select 2 dead-letters → ack with note → assert default list excludes them → toggle Show acked → assert visible
+- (no separate F6 spec — coverage in admin-wikidata smoke tests already covers timeline drawer)
+
+## 9. Effort breakdown
+
+| Area | Effort |
+|---|---|
+| BE F5 (aggregate + command + handler + validator + query update + endpoint) | ~5h |
+| BE F6 (aggregate factory params + runner interface + DTO updates) | ~3h |
+| Migration | ~0.5h |
+| FE F5 (button + modal + toggle + hook + marker) | ~4h |
+| FE F6 (badge + tooltip) | ~1h |
+| Tests (BE unit + IT + FE Vitest + E2E skeleton) | ~4h |
+| Spec + plan + docs + PR description | ~1.5h |
+| **Total** | **~19h (~2.5gg)** |
+
+Aligned with issue estimates (10-14h + 6-8h = 16-22h).
+
+## 10. Out of scope
+
+- Per-row inline acknowledge button (F2 per-row retry sufficient today)
+- Note persistence (DEC-F-4 — log-only, follow-up if audit needed)
+- Admin "all triggers" audit log surface (F6 out-of-scope per issue)
+- Multi-pod Redis fan-out backplane for SSE (#2256 — deferred until multi-pod)
+- Filtering dead-letter list by source/admin (operator can already filter by Reason)
+
+## 11. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Aggregate mutator deroga al pattern record-of-fact può confondere futuri devs | XML doc esplicito sul metodo `Acknowledge()` + ADR-style comment in spec |
+| 1 PR mega aumenta review surface | Subagent code-reviewer pre-merge (~0 finding target); commit splitting per BE/FE/migration leggibile |
+| Partial index su acknowledged_at potrebbe non essere usato da query planner | EXPLAIN test nell'IT; fallback è full-table scan (acceptable per low-traffic admin page) |
+| F6 LEFT JOIN su users in hot path SSE può rallentare publish | User lookup è cached server-side (DEC-F-5); single id resolve per attempt — overhead trascurabile |
+| Backward compat: M9 cron sub-pod hydration legge rows pre-migration con TriggeredByAdminUserId=null | Nullable column, default null — pre-existing rows render senza badge (issue requirement explicit) |
+
+## 12. Open follow-ups (post-merge)
+
+- Issue follow-up se operatori chiedono persisted note → riapri DEC-F-4
+- Issue follow-up se serve audit log "all admin triggers" (filter by `WHERE triggered_by_admin_user_id IS NOT NULL`)
+- Multi-pod backplane #2256 quando si rompe DEC-3e single-pod assumption


### PR DESCRIPTION
## Summary

Closes Phase F follow-up of epic #1823 (Wikidata cover enrichment). Bundles F5 (#2254) bulk acknowledge UI + F6 (#2255) attempt-source attribution in 1 PR per design DEC-F-1.

- **F5**: aggregate mutator `Acknowledge()` (eccezione record-of-fact documentata) + CQRS command + endpoint `POST /bulk-acknowledge` + FE toolbar/modal/toggle/visual marker
- **F6**: factory `triggeredByAdminUserId` param + runner signature change + DTO/SSE field + FE badge in timeline drawer
- 1 migration: 3 nullable columns + 1 partial index `ix_wikidata_cover_attempts_acknowledged_at`
- Bonus fix: `WikidataCoverEnrichmentAttemptRepository.UpdateAsync` now uses `.AsTracking()` (caught by real IT pipeline during Task 4.1; F5 mock unit tests had masked it — memoria-feedback `acceptance_tests_must_exercise_real_pipeline`)

8 design decisions locked: see [spec](docs/superpowers/specs/2026-06-13-issue-2254-2255-phase-f-bundle-design.md) + [plan](docs/superpowers/plans/2026-06-13-issue-2254-2255-phase-f-bundle.md).

## Test plan

- [x] Backend Wikidata filter: 205/205 pass
- [x] Frontend Phase F filter: 30/30 pass (incl 4 new test files)
- [x] Lint + typecheck green (pre-commit hooks every commit)
- [x] E2E skeleton ships non-blocking (continue-on-error, requires staging seed)
- [ ] Manual smoke on staging: select 2 dead-letters → ack with note → toggle show acked → reappear with dimmed marker
- [ ] Code-review subagent before ready-for-review

## File changes

**BE (~12 files)**:
- Domain: `WikidataCoverEnrichmentAttempt` (Acknowledge mutator + factory params + Reconstitute extended)
- Infrastructure: entity + EF config + migration + repo (`AddAsync`/`Map`/`GetDeadLettersAsync` JOIN x2/`GetAttemptsByGameIdAsync` JOIN/`GetByIdsAsync`/`UpdateAsync`)
- Application: `AdminBulkAcknowledgeWikidataCoverCommand` + validator + handler + query DTO extensions + runner signature change + SSE event payload extension
- Routing: `POST /bulk-acknowledge` + `GET /dead-letters?includeAcknowledged`

**FE (~8 files)**:
- API client: `bulkAcknowledgeDeadLetters` + extended DTOs
- `AcknowledgeSelectedModal` component (note textarea + confirm/cancel)
- Page wiring: toolbar button + Show acknowledged toggle + dimmed row + chip
- `AttemptTimelineDrawer` F6 admin badge + tooltip
- E2E Playwright skeleton

## Out of scope (filed as follow-ups in #1823 Phase F backlog)

- #2256 multi-pod Redis fan-out backplane for SSE (single-pod assumption DEC-3e)
- Per-row inline acknowledge button (F2 per-row retry covers today)
- Audit log surface for admin triggers (separate operator-tooling issue)

## Notes

- 19 commits (TDD discipline, ~1 commit per task following plan)
- ~3 days actual implementation time (aligned with ~19h estimate)
- `infra/env/api.env.dev` unstaged (local STORAGE_PROVIDER=local override per memoria)

Closes #2254
Closes #2255

🤖 Generated with [Claude Code](https://claude.com/claude-code)