### PR TITLE
fix(auth): #2171 — dedup caller-side error logging in login/2FA/register

### DIFF
--- a/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
@@ -336,6 +336,35 @@ describe('LoginPageContent — open redirect protection (#2168)', () => {
   });
 });
 
+describe('LoginPageContent — error logging dedup (#2171)', () => {
+  // Bug #2171: previously 4 console.error per failed login (HTTP 400 from
+  // browser + 2× [API Error] from retry layer + 1× [ERROR] Login failed from
+  // caller). PR #2236 removed the retry-layer duplicate; this PR removes the
+  // caller-side `logger.error('Login failed:', err)` because HttpClient already
+  // calls logApiError on failed responses. The caller's job is UX feedback
+  // via setError, not logging.
+  it('does NOT call logger.error when login API call rejects', async () => {
+    loginMock.mockRejectedValueOnce(new Error('Invalid email or password'));
+
+    render(<LoginPageContent />);
+
+    fireEvent.change(screen.getByLabelText(/auth\.login\.emailLabel/i), {
+      target: { value: 'bad@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/auth\.login\.passwordLabel/i), {
+      target: { value: 'WrongPassword1' },
+    });
+    fireEvent.submit(screen.getByTestId('login-form'));
+
+    // Wait until error path settles (setError → re-render)
+    await waitFor(() => {
+      expect(screen.getByText('Invalid email or password')).toBeInTheDocument();
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});
+
 describe('LoginFallback', () => {
   it('renders loading message', () => {
     render(<LoginFallback />);

--- a/apps/web/src/app/(auth)/login/_content.tsx
+++ b/apps/web/src/app/(auth)/login/_content.tsx
@@ -110,7 +110,9 @@ export function LoginPageContent() {
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : t('auth.login.genericError');
         setError(errorMessage);
-        logger.error('Login failed:', err);
+        // Issue #2171: HttpClient already calls logApiError on failed responses
+        // (apps/web/src/lib/api/core/httpClient.ts) → re-logging here produced
+        // duplicate console.error noise. UX feedback is preserved via setError.
       } finally {
         setIsAuthenticating(false);
       }
@@ -139,7 +141,7 @@ export function LoginPageContent() {
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : t('auth.twoFactor.error');
         setTwoFactorError(errorMessage);
-        logger.error('2FA verification failed:', err);
+        // Issue #2171: HttpClient already logs API failures — see comment in handleLogin.
       } finally {
         setIsAuthenticating(false);
       }

--- a/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
@@ -68,6 +68,7 @@ vi.mock('@/lib/analytics/flywheel-events', () => ({
 
 // Import AFTER mocks
 import { RegisterPageContent, RegisterFallback } from '../_content';
+import { logger } from '@/lib/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -226,6 +227,10 @@ describe('RegisterPageContent (v2 AuthCard)', () => {
         expect(screen.getByText(/Email already taken/i)).toBeInTheDocument();
       });
       expect(pushMock).not.toHaveBeenCalled();
+
+      // Issue #2171: HttpClient already calls logApiError on failed responses —
+      // the caller MUST NOT re-log to avoid duplicate console.error noise.
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('renders OAuth buttons when oauthEnabled flag is true', async () => {

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -15,7 +15,6 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTranslation } from '@/hooks/useTranslation';
 import { trackSignUp } from '@/lib/analytics/flywheel-events';
 import { useApiClient } from '@/lib/api/context';
-import { logger } from '@/lib/logger';
 
 // ============================================================================
 // Types
@@ -103,7 +102,8 @@ export function RegisterPageContent() {
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : t('auth.register.genericError');
         setError(errorMessage);
-        logger.error('Registration failed:', err);
+        // Issue #2171: HttpClient already calls logApiError on failed responses —
+        // re-logging here produced duplicate console.error noise.
       } finally {
         setIsAuthenticating(false);
       }


### PR DESCRIPTION
## Summary

Completes the dedup work started in PR #2236 (which removed the retry-layer duplicate from `retryPolicy.ts`). The caller-side `logger.error` calls in login and register `_content.tsx` were still producing an extra `console.error` per failed auth request — `HttpClient.logApiError` already logs the failure with full context.

**Post-fix log count per failed login**: `1× HTTP 4xx (browser)` + `1× [API Error] (HttpClient)` = **2 console.error** (matches issue #2171 DoD "max 2 console.error").

## Changes

| File | Change |
|------|--------|
| `apps/web/src/app/(auth)/login/_content.tsx` | Removed `logger.error('Login failed:', err)` (line 113) + `logger.error('2FA verification failed:', err)` (line 142). Kept `logger` import for `logger.warn` open-redirect path (#2168). |
| `apps/web/src/app/(auth)/register/_content.tsx` | Removed `logger.error('Registration failed:', err)` (line 106) + now-unused `logger` import. |
| `apps/web/src/app/(auth)/login/__tests__/_content.test.tsx` | New `describe('LoginPageContent — error logging dedup (#2171)')` block with regression test asserting `logger.error` not called on rejected login. |
| `apps/web/src/app/(auth)/register/__tests__/_content.test.tsx` | Extended existing error-path test with `expect(logger.error).not.toHaveBeenCalled()` assertion. |

UX feedback preserved via `setError` → inline form error (no behavioural change for end-user).

## Test plan

- [x] `pnpm vitest run "(auth)/login/__tests__/_content" "(auth)/register/__tests__/_content"` → **31/31 pass** (login 17 + register 14, 14.66s)
- [x] Pre-commit hooks pass (eslint, prettier, typecheck)
- [x] Login `logger` import preserved (still used for `logger.warn` on ?from sanitization)

## Bonus: #2178 closed

While investigating, verified that **#2178 (FriendsActivity label truncated)** was already fixed in main-dev by PR #2236 (`SECTION_TITLE = 'Cosa fanno i tuoi amici'`), but the issue stayed open because PR #2236's `## Closes` heading didn't trigger GitHub auto-close. Closed manually as part of this Wave 2 sweep.

## Closes

Closes #2171

🤖 Generated with [Claude Code](https://claude.com/claude-code)