### PR TITLE
feat(catalog): #2290 surface TrendingGame.HasKnowledgeBase + Discover KB badge

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/TrendingGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/TrendingGameDto.cs
@@ -50,4 +50,12 @@ public sealed record TrendingGameDto
     /// Number of play session events in the time window.
     /// </summary>
     public int PlayCount { get; init; }
+
+    /// <summary>
+    /// Issue #2290: mirrors <see cref="Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity.HasKnowledgeBase"/>
+    /// so Discover row 1 can render the "AI Ready" / KB badge inline (Block B
+    /// of <see href="https://github.com/meepleAi-app/meepleai-monorepo/issues/2289">#2289</see>)
+    /// without an N+1 lookup on <see cref="SharedGameDto"/>.
+    /// </summary>
+    public bool HasKnowledgeBase { get; init; }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogTrending/GetCatalogTrendingQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogTrending/GetCatalogTrendingQueryHandler.cs
@@ -16,7 +16,11 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCatalogTr
 /// </summary>
 internal sealed class GetCatalogTrendingQueryHandler : IRequestHandler<GetCatalogTrendingQuery, List<TrendingGameDto>>
 {
-    private const string CacheKey = "catalog:trending";
+    // Issue #2290: bumped to :v2 because the cached DTO schema gained
+    // HasKnowledgeBase. Old :v1 entries lacked the field, so deserializing
+    // them would render every trending card without the KB badge for up to
+    // 12 h after deploy. The new key naturally orphans the old cache.
+    private const string CacheKey = "catalog:trending:v2";
     private const int MaxCacheLimit = 50;
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(12);
 
@@ -100,12 +104,14 @@ internal sealed class GetCatalogTrendingQueryHandler : IRequestHandler<GetCatalo
             .Take(limit)
             .ToList();
 
-        // Fetch game details for the trending games
+        // Fetch game details for the trending games. Issue #2290: project
+        // HasKnowledgeBase into the same round-trip so Discover row 1 has the
+        // KB badge data inline (no N+1 on SharedGameDto downstream).
         var gameIds = gameScores.Select(g => g.GameId).ToList();
         var games = await _context.Set<SharedGameEntity>()
             .AsNoTracking()
             .Where(g => gameIds.Contains(g.Id))
-            .Select(g => new { g.Id, g.Title, g.ThumbnailUrl })
+            .Select(g => new { g.Id, g.Title, g.ThumbnailUrl, g.HasKnowledgeBase })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -126,7 +132,8 @@ internal sealed class GetCatalogTrendingQueryHandler : IRequestHandler<GetCatalo
                 SearchCount = g.SearchCount,
                 ViewCount = g.ViewCount,
                 LibraryAddCount = g.LibraryAddCount,
-                PlayCount = g.PlayCount
+                PlayCount = g.PlayCount,
+                HasKnowledgeBase = game?.HasKnowledgeBase ?? false
             };
         }).ToList();
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogTrending/GetCatalogTrendingQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetCatalogTrending/GetCatalogTrendingQueryHandlerTests.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCatalogTrending;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.GetCatalogTrending;
+
+/// <summary>
+/// Unit tests for <see cref="GetCatalogTrendingQueryHandler"/>.
+///
+/// Issue #2290: pin the contract that <see cref="TrendingGameDto.HasKnowledgeBase"/>
+/// is populated from the joined <see cref="SharedGameEntity.HasKnowledgeBase"/>
+/// projection, so the Discover Row 1 KB badge can render without an N+1 lookup
+/// on <see cref="SharedGameDto"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2290")]
+public sealed class GetCatalogTrendingQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IHybridCacheService> _cacheMock;
+    private readonly Mock<ILogger<GetCatalogTrendingQueryHandler>> _loggerMock;
+    private readonly GetCatalogTrendingQueryHandler _handler;
+
+    public GetCatalogTrendingQueryHandlerTests()
+    {
+        _db = TestDbContextFactory.CreateInMemoryDbContext();
+        _cacheMock = new Mock<IHybridCacheService>();
+        _loggerMock = new Mock<ILogger<GetCatalogTrendingQueryHandler>>();
+
+        // Cache pass-through: invoke factory directly so we test handler logic, not cache.
+        _cacheMock
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<CancellationToken, Task<List<TrendingGameDto>>>>(),
+                It.IsAny<string[]?>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((
+                string _,
+                Func<CancellationToken, Task<List<TrendingGameDto>>> factory,
+                string[]? __,
+                TimeSpan? ___,
+                CancellationToken ct) => factory(ct));
+
+        _handler = new GetCatalogTrendingQueryHandler(_db, _cacheMock.Object, _loggerMock.Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Handle_ProjectsHasKnowledgeBase_FromSharedGameEntity_Issue2290()
+    {
+        // Arrange — two games with distinct HasKnowledgeBase values and one
+        // analytics event per game so both surface in the trending result set.
+        var gameA = SeedGame(hasKnowledgeBase: true, title: "AI-Ready Game");
+        var gameB = SeedGame(hasKnowledgeBase: false, title: "Plain Game");
+
+        SeedEvent(gameA.Id, GameEventType.Play);   // weight 10 → ranks first
+        SeedEvent(gameB.Id, GameEventType.Search); // weight 3  → ranks second
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCatalogTrendingQuery { Limit = 10 },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().HaveCount(2, "both games have at least one event in the last 7 days");
+
+        var aiReady = result.Single(r => r.GameId == gameA.Id);
+        aiReady.HasKnowledgeBase.Should().BeTrue(
+            "GameA has HasKnowledgeBase=true on the entity — the new projection must surface it");
+        aiReady.Title.Should().Be("AI-Ready Game");
+
+        var plain = result.Single(r => r.GameId == gameB.Id);
+        plain.HasKnowledgeBase.Should().BeFalse(
+            "GameB has HasKnowledgeBase=false on the entity — the projection must preserve the negative case");
+        plain.Title.Should().Be("Plain Game");
+    }
+
+    [Fact]
+    public async Task Handle_DefaultsHasKnowledgeBaseToFalse_WhenGameRowIsMissing_Issue2290()
+    {
+        // Arrange — one analytics event but no SharedGameEntity row (orphan
+        // event row, e.g. game deleted after the event was recorded). The
+        // handler uses `gameMap.TryGetValue(...)` so the DTO must default
+        // safely instead of throwing.
+        var orphanGameId = Guid.NewGuid();
+        SeedEvent(orphanGameId, GameEventType.View);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(
+            new GetCatalogTrendingQuery { Limit = 10 },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].GameId.Should().Be(orphanGameId);
+        result[0].Title.Should().Be("Unknown Game", "the existing fallback path is preserved");
+        result[0].HasKnowledgeBase.Should().BeFalse(
+            "missing SharedGameEntity rows must default HasKnowledgeBase to false");
+    }
+
+    private SharedGameEntity SeedGame(bool hasKnowledgeBase, string title)
+    {
+        var entity = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            YearPublished = 2024,
+            Description = "Test game",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1, // Published
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            HasKnowledgeBase = hasKnowledgeBase,
+            IsDeleted = false,
+        };
+        _db.SharedGames.Add(entity);
+        return entity;
+    }
+
+    private void SeedEvent(Guid gameId, GameEventType eventType)
+    {
+        _db.Set<GameAnalyticsEventEntity>().Add(new GameAnalyticsEventEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            EventType = (int)eventType,
+            UserId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow.AddHours(-1),
+        });
+    }
+}

--- a/apps/web/src/components/features/discover/DiscoverHub.tsx
+++ b/apps/web/src/components/features/discover/DiscoverHub.tsx
@@ -128,12 +128,15 @@ export function DiscoverHub({ pathnameOverride }: DiscoverHubProps = {}) {
   const trending = useCatalogTrending(10);
 
   // ── DTO → RowItemBase adapter for Row 1 (trending) ───────────────────────
+  // Issue #2290: pass `hasKnowledgeBase` through so the featured card can
+  // render the KB badge (Block B of #2289).
   const trendingItems = useMemo<ReadonlyArray<RowItemBase>>(
     () =>
       (trending.data ?? []).map(g => ({
         id: g.gameId,
         name: g.title,
         imageUrl: g.thumbnailUrl,
+        hasKnowledgeBase: g.hasKnowledgeBase,
       })),
     [trending.data]
   );

--- a/apps/web/src/components/features/discover/HorizontalRow.tsx
+++ b/apps/web/src/components/features/discover/HorizontalRow.tsx
@@ -28,6 +28,12 @@ export interface RowItemBase {
   readonly chunkCount?: number;
   readonly docType?: string;
   readonly contributionCount?: number;
+  /**
+   * Issue #2290 — when true, the card renders a "KB" pill matching the
+   * existing badge style from `HubGameCard.tsx`. Currently wired by the
+   * Row 1 trending mapper in `DiscoverHub.tsx`; other rows leave undefined.
+   */
+  readonly hasKnowledgeBase?: boolean;
 }
 
 export type RowVariant = 'featured' | 'compact' | 'grid' | 'list-row';
@@ -166,8 +172,20 @@ export function HorizontalRow({
               🎲
             </div>
             <div className="flex flex-col gap-1 p-3">
-              <div className="line-clamp-1 font-bold font-[Quicksand] text-sm text-foreground">
-                {item.name ?? item.title ?? 'Senza titolo'}
+              <div className="flex items-center gap-2">
+                <div className="line-clamp-1 flex-1 font-bold font-[Quicksand] text-sm text-foreground">
+                  {item.name ?? item.title ?? 'Senza titolo'}
+                </div>
+                {/* Issue #2290: KB badge mirrors HubGameCard.tsx style. */}
+                {item.hasKnowledgeBase && (
+                  <span
+                    data-slot="row-card-kb-badge"
+                    aria-label="AI Ready"
+                    className="inline-flex shrink-0 items-center rounded bg-[hsl(var(--c-kb)/0.15)] px-1.5 py-0.5 font-bold text-[9px] uppercase tracking-wider text-[hsl(var(--c-kb))]"
+                  >
+                    KB
+                  </span>
+                )}
               </div>
               <div className="font-mono text-[10px] text-muted-foreground">
                 {[item.publisher, item.year].filter(Boolean).join(' · ') || ' '}

--- a/apps/web/src/components/features/discover/__tests__/HorizontalRow.test.tsx
+++ b/apps/web/src/components/features/discover/__tests__/HorizontalRow.test.tsx
@@ -381,4 +381,48 @@ describe('HorizontalRow', () => {
     );
     expect(screen.getByText('Mario Rossi')).toBeInTheDocument();
   });
+
+  // Issue #2290: featured card renders the "KB" pill (mirror of HubGameCard
+  // style) when item.hasKnowledgeBase === true. Drives the AI-Ready badge on
+  // Discover Row 1 (Block B of #2289).
+  describe('featured card — KB badge (#2290)', () => {
+    it('renders KB badge when hasKnowledgeBase=true', () => {
+      const { container } = render(
+        <HorizontalRow
+          rowId="trending"
+          title="Trending"
+          variant="featured"
+          items={[{ id: '1', name: 'Catan', hasKnowledgeBase: true }]}
+        />
+      );
+      const badge = container.querySelector('[data-slot="row-card-kb-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge).toHaveAttribute('aria-label', 'AI Ready');
+      expect(badge?.textContent).toBe('KB');
+    });
+
+    it('omits KB badge when hasKnowledgeBase=false', () => {
+      const { container } = render(
+        <HorizontalRow
+          rowId="trending"
+          title="Trending"
+          variant="featured"
+          items={[{ id: '1', name: 'Catan', hasKnowledgeBase: false }]}
+        />
+      );
+      expect(container.querySelector('[data-slot="row-card-kb-badge"]')).toBeNull();
+    });
+
+    it('omits KB badge when hasKnowledgeBase is undefined (other-row safety)', () => {
+      const { container } = render(
+        <HorizontalRow
+          rowId="games"
+          title="Giochi"
+          variant="featured"
+          items={[{ id: '1', name: 'Catan' }]}
+        />
+      );
+      expect(container.querySelector('[data-slot="row-card-kb-badge"]')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/lib/api/catalog.ts
+++ b/apps/web/src/lib/api/catalog.ts
@@ -10,6 +10,12 @@ export interface TrendingGame {
   viewCount: number;
   libraryAddCount: number;
   playCount: number;
+  /**
+   * Issue #2290 — mirrors `SharedGameDto.hasKnowledgeBase`. True when the
+   * game has at least one indexed KB. Drives the "KB" / AI-Ready badge on
+   * the Discover Row 1 card (Block B of #2289).
+   */
+  hasKnowledgeBase: boolean;
 }
 
 export async function getTrendingGames(limit = 10): Promise<TrendingGame[]> {


### PR DESCRIPTION
## Summary

Closes #2290 — unblocks Block B of #2289.

`GET /api/v1/catalog/trending` previously returned a `TrendingGameDto` without `hasKnowledgeBase`, so the Discover Row 1 card had no way to render the AI-Ready / KB badge without an N+1 lookup on `SharedGameDto`. This PR plumbs the flag end-to-end.

## BE

- **`TrendingGameDto.cs`** — added `bool HasKnowledgeBase { get; init; }` (mirror of `SharedGameDto.HasKnowledgeBase`).
- **`GetCatalogTrendingQueryHandler.cs`** — extended the existing `SharedGameEntity` projection to include `HasKnowledgeBase` in the same round-trip (no extra DB call). Defensive default `false` when the join misses (orphan analytics event after a game delete).
- **Cache key bump** `catalog:trending` → `catalog:trending:v2`. Avoids deserializing pre-deploy cached entries as `HasKnowledgeBase=false` for up to 12 h after release; the old key is naturally orphaned by TTL.

## FE

- **`catalog.ts`** — added `hasKnowledgeBase: boolean` to the `TrendingGame` interface.
- **`HorizontalRow.tsx` (`RowItemBase`)** — added optional `hasKnowledgeBase?: boolean` so other rows (which don't surface the flag) remain unaffected.
- **`DiscoverHub.tsx`** — `trendingItems` mapper now passes `hasKnowledgeBase: g.hasKnowledgeBase` through to `RowItemBase`.
- **`HorizontalRow.tsx` (`featured` variant)** — renders a `KB` pill (matching `HubGameCard.tsx` style: `bg-[hsl(var(--c-kb)/0.15)] text-[hsl(var(--c-kb))]`) with `aria-label=\"AI Ready\"` when `item.hasKnowledgeBase === true`.

## Test plan

- [x] **BE unit** `GetCatalogTrendingQueryHandlerTests` (new) — 2 cases:
  - `Handle_ProjectsHasKnowledgeBase_FromSharedGameEntity_Issue2290` — seeds two games (one with `HasKnowledgeBase=true`, one with `false`) + analytics events, asserts both DTOs preserve the flag correctly.
  - `Handle_DefaultsHasKnowledgeBaseToFalse_WhenGameRowIsMissing_Issue2290` — pins the orphan-event safety default.
- [x] **FE unit** `HorizontalRow.test.tsx` (new sub-suite \"featured card — KB badge (#2290)\") — 3 cases:
  - `hasKnowledgeBase=true` → badge present with `aria-label='AI Ready'` + text `KB`.
  - `hasKnowledgeBase=false` → badge absent.
  - `hasKnowledgeBase=undefined` → badge absent (other-row safety).
- [x] **FE typecheck** (`pnpm typecheck`) — clean.

### Why no DiscoverHub integration test for the mapper

The mapper is a single property pass-through (`hasKnowledgeBase: g.hasKnowledgeBase` inside the existing `useMemo`). The BE handler test pins the DTO contract; the FE primitive test pins the badge render contract. An end-to-end test would require mocking `useCatalogTrending` with seeded data + the heavy `DiscoverBelowFoldRows` lazy chunk, with zero net coverage gain over the two layered tests.

## Badge label note

The issue body uses \"AI Ready\" as the *concept*; the rendered text is `KB` for consistency with the existing `HubGameCard.tsx` badge (`text-[hsl(var(--c-kb))]` design token). The `aria-label='AI Ready'` carries the long-form for AT users. Happy to flip to `AI Ready` text instead if design wants the verbose label on featured cards specifically — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)