### PR TITLE
feat(discover): #2085 F2/F3 — wire card click navigation via resolveCardHref

### DIFF
--- a/apps/web/src/components/features/discover/DiscoverHub.tsx
+++ b/apps/web/src/components/features/discover/DiscoverHub.tsx
@@ -13,6 +13,7 @@ import {
   type EntityFilter,
   type RowItemBase,
 } from '@/components/features/discover';
+import { resolveCardHref } from '@/components/features/discover/resolveCardHref';
 import { HubLayout } from '@/components/layout/HubLayout';
 import { useCatalogTrending } from '@/hooks/queries/useCatalogTrending';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -182,14 +183,23 @@ export function DiscoverHub({ pathnameOverride }: DiscoverHubProps = {}) {
     [entity, updateUrl]
   );
 
-  // ── Telemetry: card click + disabled-row impression ───────────────────────
-  const handleCardClick = useCallback((rowId: string, item: RowItemBase) => {
-    trackEvent('discover_card_clicked', {
-      row: rowId,
-      entityId: item.id,
-      entityType: rowId,
-    });
-  }, []);
+  // ── Card click: telemetry + navigation (#2085 F2/F3) ──────────────────────
+  // Order matters: track FIRST so the event fires even if the user cancels
+  // navigation (middle-click, ctrl-click → opens in new tab via the router's
+  // own handling). Navigation is best-effort: unknown rowIds resolve to null
+  // and we silently skip the push (telemetry already captured the click).
+  const handleCardClick = useCallback(
+    (rowId: string, item: RowItemBase) => {
+      trackEvent('discover_card_clicked', {
+        row: rowId,
+        entityId: item.id,
+        entityType: rowId,
+      });
+      const href = resolveCardHref(rowId, item);
+      if (href) router.push(href);
+    },
+    [router]
+  );
 
   const handleDisabledRowVisible = useCallback((rowId: string) => {
     trackEvent('discover_disabled_row_visible', { row: rowId });

--- a/apps/web/src/components/features/discover/__tests__/DiscoverHub.test.tsx
+++ b/apps/web/src/components/features/discover/__tests__/DiscoverHub.test.tsx
@@ -20,6 +20,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const searchParamsState: Record<string, string | null> = {};
 const replaceSpy = vi.fn();
+const pushSpy = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useSearchParams: () => ({
@@ -30,7 +31,7 @@ vi.mock('next/navigation', () => ({
         .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
         .join('&'),
   }),
-  useRouter: () => ({ replace: replaceSpy, push: vi.fn() }),
+  useRouter: () => ({ replace: replaceSpy, push: pushSpy }),
   usePathname: () => '/discover',
 }));
 
@@ -40,11 +41,17 @@ vi.mock('@/hooks/useTranslation', () => ({
   }),
 }));
 
+const trendingState: { data: unknown[]; isLoading: boolean; isError: boolean } = {
+  data: [],
+  isLoading: false,
+  isError: false,
+};
+
 vi.mock('@/hooks/queries/useCatalogTrending', () => ({
   useCatalogTrending: () => ({
-    data: [],
-    isLoading: false,
-    isError: false,
+    data: trendingState.data,
+    isLoading: trendingState.isLoading,
+    isError: trendingState.isError,
     refetch: vi.fn(),
   }),
 }));
@@ -73,6 +80,9 @@ import { DiscoverHub } from '../DiscoverHub';
 
 function resetParams() {
   Object.keys(searchParamsState).forEach(k => delete searchParamsState[k]);
+  trendingState.data = [];
+  trendingState.isLoading = false;
+  trendingState.isError = false;
 }
 
 function renderHub(props: Parameters<typeof DiscoverHub>[0] = {}) {
@@ -119,5 +129,45 @@ describe('DiscoverHub component (extracted surface)', () => {
     // but we can assert that passing the override does not break the render.
     const { getByTestId } = renderHub({ pathnameOverride: '/games' });
     expect(getByTestId('hub-layout')).toBeInTheDocument();
+  });
+});
+
+describe('DiscoverHub navigation (#2085 F2/F3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetParams();
+  });
+
+  it('navigates to /games/{id} when a trending card is clicked', async () => {
+    trendingState.data = [
+      {
+        rank: 1,
+        gameId: 'g-azul',
+        title: 'Azul',
+        thumbnailUrl: null,
+        score: 99,
+        searchCount: 0,
+        viewCount: 0,
+        libraryAddCount: 0,
+        playCount: 0,
+        hasKnowledgeBase: true,
+      },
+    ];
+
+    const { container } = renderHub();
+    const card = container.querySelector('[data-slot="row-card"]') as HTMLElement | null;
+    expect(card).not.toBeNull();
+
+    // Find the inner clickable element (button or link wrapper).
+    const clickable = (card!.tagName === 'BUTTON' ? card : card!.querySelector('button,a'))!;
+    (clickable as HTMLElement).click();
+
+    expect(pushSpy).toHaveBeenCalledWith('/games/g-azul');
+  });
+
+  it('does not navigate when the trending row is empty (no card to click)', () => {
+    trendingState.data = [];
+    renderHub();
+    expect(pushSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/features/discover/__tests__/resolveCardHref.test.ts
+++ b/apps/web/src/components/features/discover/__tests__/resolveCardHref.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RowItemBase } from '../HorizontalRow';
+import { resolveCardHref } from '../resolveCardHref';
+
+const stubItem = (overrides?: Partial<RowItemBase>): RowItemBase => ({
+  id: 'entity-id-stub',
+  ...overrides,
+});
+
+describe('resolveCardHref (#2085 F2/F3)', () => {
+  it('maps trending row → /games/{id}', () => {
+    expect(resolveCardHref('trending', stubItem({ id: 'g-azul' }))).toBe('/games/g-azul');
+  });
+
+  it('maps games row → /games/{id}', () => {
+    expect(resolveCardHref('games', stubItem({ id: 'g-catan' }))).toBe('/games/g-catan');
+  });
+
+  it('maps agents row → /agents/{id}', () => {
+    expect(resolveCardHref('agents', stubItem({ id: 'a-azul-rules' }))).toBe(
+      '/agents/a-azul-rules'
+    );
+  });
+
+  it('maps toolkits row → /toolkits/{id}', () => {
+    expect(resolveCardHref('toolkits', stubItem({ id: 'tk-solo' }))).toBe('/toolkits/tk-solo');
+  });
+
+  it('maps kbs row → /knowledge-base/{id} (#2085 F3)', () => {
+    expect(resolveCardHref('kbs', stubItem({ id: 'kb-azul-ita' }))).toBe(
+      '/knowledge-base/kb-azul-ita'
+    );
+  });
+
+  it('maps people row → /players/{id}', () => {
+    expect(resolveCardHref('people', stubItem({ id: 'p-marco' }))).toBe('/players/p-marco');
+  });
+
+  it('maps events row → /game-nights/{id}', () => {
+    expect(resolveCardHref('events', stubItem({ id: 'gn-friday' }))).toBe('/game-nights/gn-friday');
+  });
+
+  it('returns null for unknown rowId (defensive)', () => {
+    expect(resolveCardHref('unknown-row', stubItem())).toBeNull();
+  });
+
+  it('returns null when item.id is empty (defensive)', () => {
+    expect(resolveCardHref('games', stubItem({ id: '' }))).toBeNull();
+  });
+
+  it('encodes IDs with special characters for safe URL routing', () => {
+    expect(resolveCardHref('games', stubItem({ id: 'g-id/with slash' }))).toBe(
+      '/games/g-id%2Fwith%20slash'
+    );
+  });
+});

--- a/apps/web/src/components/features/discover/resolveCardHref.ts
+++ b/apps/web/src/components/features/discover/resolveCardHref.ts
@@ -1,0 +1,42 @@
+import type { RowItemBase } from './HorizontalRow';
+
+/**
+ * Maps a Discover row + item to its detail-page href.
+ *
+ * Resolves #2085 F2 (card click no navigation) + F3 (KB row click no navigation).
+ * Before this helper landed, `handleCardClick` in `DiscoverHub.tsx` emitted only
+ * telemetry; cards rendered as `<button>` with no `<Link href>` semantics.
+ *
+ * The 7 rowIds align with `EntityFilter | 'trending'` from `HorizontalRow.tsx`.
+ * Returning `null` is the defensive default for unknown rowIds OR empty ids —
+ * callers must skip the navigation step (telemetry already fired).
+ *
+ * KB row maps to `/knowledge-base/{id}` (the canonical KB document detail route)
+ * rather than `/library/{gameId}?tab=knowledge-base` because `RowItemBase` from
+ * the recent-kb-docs mapper does not expose `gameId` (only `gameName`). The
+ * route is the same entity surface tracked by #2223 (sp4-kb-detail forward
+ * refactor) — see that issue for the layout iteration.
+ */
+export function resolveCardHref(rowId: string, item: RowItemBase): string | null {
+  if (!item.id) return null;
+
+  const safeId = encodeURIComponent(item.id);
+
+  switch (rowId) {
+    case 'trending':
+    case 'games':
+      return `/games/${safeId}`;
+    case 'agents':
+      return `/agents/${safeId}`;
+    case 'toolkits':
+      return `/toolkits/${safeId}`;
+    case 'kbs':
+      return `/knowledge-base/${safeId}`;
+    case 'people':
+      return `/players/${safeId}`;
+    case 'events':
+      return `/game-nights/${safeId}`;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2085 finding 2 (card click no navigation, all rows) + finding 3 (KB row click no navigation specifically).

Discover hub cards previously emitted only telemetry on click (`handleCardClick` in `DiscoverHub.tsx:186-192`). This PR adds a pure `resolveCardHref(rowId, item)` helper that maps the 6 entity rows + trending to detail-page routes, then calls `router.push` in `handleCardClick` after telemetry fires.

Telemetry continues to fire first so middle-click / ctrl-click (open-in-new-tab) telemetry isn't lost when the user cancels in-tab navigation.

## Route map

| Row | Target |
|---|---|
| `trending`, `games` | `/games/{id}` |
| `agents` | `/agents/{id}` |
| `toolkits` | `/toolkits/{id}` |
| `kbs` | `/knowledge-base/{id}` ← finding 3 |
| `people` | `/players/{id}` |
| `events` | `/game-nights/{id}` |
| unknown / empty `id` | `null` (telemetry-only, no nav) |

IDs are passed through `encodeURIComponent` for defensive URL safety.

## KB row routing note (finding 3 detail)

KB row maps to `/knowledge-base/{id}` rather than the original proposal `/library/{gameId}?tab=knowledge-base` because `RowItemBase` from the recent-kb-docs mapper does not expose `gameId` (only `gameName`). The `/knowledge-base/{id}` route exists and is the canonical KB document detail surface; its layout iteration is tracked separately in #2223 (sp4-kb-detail forward-refactor) — see the gap report posted there in this same session.

## Out of scope (explicit)

- **Finding 1** (search disabled — `/api/v1/catalog/search` missing): BE work, separate issue / future revival of #728.
- **`HorizontalRow.renderCard` `<button>` → `<Link href>` refactor**: a11y + middle-click + SEO improvement that landed in the original #2085 scope, but the pure-function helper unblocks F2/F3 shipping without the larger card primitive refactor. Follow-up PR.

## Test plan

- [x] 10 new unit tests for `resolveCardHref` (each of the 7 entity rows + defensive `null` for unknown rowId + empty `id` + URL encoding edge case)
- [x] 2 new integration tests for `DiscoverHub` (trending card click → `router.push` called with `/games/g-azul`; empty trending row → push never called)
- [x] 4 existing `DiscoverHub` smoke tests preserved
- [x] `pnpm typecheck` clean
- [x] `pnpm lint --quiet` clean

**Total: 16/16 green**

## Refs

- Closes #2085 F2 + F3
- Related: #2309 (Documents tab wiring, opened this session as Block A part 2)
- Related: #2223 (sp4-kb-detail forward-refactor — gap report comment posted this session)
- Parent epic context: #2242 PDF indexing (CLOSED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)