### PR TITLE
refactor(routing): #2153 — retire /hub/* legacy routes via runtime redirects

### DIFF
--- a/apps/web/src/app/(authenticated)/hub/agents/page.tsx
+++ b/apps/web/src/app/(authenticated)/hub/agents/page.tsx
@@ -1,121 +1,24 @@
 /**
- * /hub/agents — authenticated community agents catalog (Stage 3 #1166).
+ * /hub/agents — retired legacy route (Issue #2153).
  *
- * Authenticated route (via `(authenticated)` route group). Uses
- * `useDiscoverPopularAgents({ limit: 50 })` per Path C top-50 listing.
- * Full pagination deferred.
+ * The community agents catalog now lives at the canonical `/agents`. This
+ * runtime redirect preserves back-links from chat, email, and external
+ * sources. The previous `HubCatalogView<PopularAgent>` implementation was
+ * a duplicate of `/agents/page.tsx`; consolidating reduces drift risk.
+ *
+ * Companion redirects retired in the same sweep:
+ *   - /hub               → /games?tab=discover (already in place since #2190)
+ *   - /hub/games/[id]    → /games/[id]
+ *   - /hub/toolkits      → /toolkits (already in place since #1480)
+ *
+ * Kept as a runtime redirect (not pure next.config.js) so that the
+ * `(authenticated)` chrome stays mounted during the hop — short-circuiting
+ * to a config redirect would lose UserShell continuity for users coming
+ * from authenticated contexts.
  */
 
-'use client';
+import { redirect } from 'next/navigation';
 
-import { Suspense, useCallback, useMemo, type ReactElement } from 'react';
-
-import {
-  HubAgentCard,
-  HubCatalogView,
-  type HubFilter,
-  type HubKpi,
-} from '@/components/features/hub';
-import { useDiscoverPopularAgents } from '@/hooks/queries/useDiscoverPopularAgents';
-import { useTranslation } from '@/hooks/useTranslation';
-import { trackEvent } from '@/lib/analytics/track-event';
-import type { PopularAgent } from '@/lib/api/schemas/discover.schemas';
-
-function matchAgent(agent: PopularAgent, filter: HubFilter, q: string): boolean {
-  if (q) {
-    const needle = q.toLowerCase();
-    const hay = `${agent.name} ${agent.gameName ?? ''}`.toLowerCase();
-    if (!hay.includes(needle)) return false;
-  }
-  if (filter === 'all') return true;
-  if (filter === 'featured') return agent.invocationCount >= 100;
-  if (filter === 'new') return true; // backend doesn't expose createdAt; "new" is permissive in v1
-  if (filter === 'top') return agent.invocationCount >= 500;
-  return true;
-}
-
-function HubAgentsContent(): ReactElement {
-  const { t } = useTranslation();
-  const query = useDiscoverPopularAgents({ limit: 50 });
-  const items = useMemo<ReadonlyArray<PopularAgent>>(() => query.data ?? [], [query.data]);
-
-  const kpi = useMemo<ReadonlyArray<HubKpi>>(() => {
-    const total = items.length;
-    const popular = items.filter(a => a.invocationCount >= 100).length;
-    const withGame = items.filter(a => a.gameName).length;
-    return [
-      { label: t('pages.hub.agents.kpi.total'), value: total },
-      { label: t('pages.hub.agents.kpi.popular'), value: popular },
-      { label: t('pages.hub.agents.kpi.gameAgents'), value: withGame },
-    ];
-  }, [items, t]);
-
-  const handleCardClick = useCallback((id: string) => {
-    trackEvent('hub_card_clicked', { entity: 'agents', itemId: id });
-  }, []);
-
-  const handleInstall = useCallback((id: string) => {
-    trackEvent('hub_install_clicked', { entity: 'agents', itemId: id });
-  }, []);
-
-  const cardLabels = {
-    installLabel: t('pages.hub.agents.installLabel'),
-    invocationsTemplate: t('pages.hub.agents.invocationsTemplate'),
-  };
-
-  const labels = {
-    badge: t('pages.hub.agents.badge'),
-    title: t('pages.hub.agents.title'),
-    subtitle: t('pages.hub.agents.subtitle'),
-    searchPlaceholder: t('pages.hub.common.searchPlaceholder'),
-    filterAriaLabel: t('pages.hub.common.filterAriaLabel'),
-    filterLabels: {
-      all: t('pages.hub.common.filters.all'),
-      featured: t('pages.hub.common.filters.featured'),
-      new: t('pages.hub.common.filters.new'),
-      top: t('pages.hub.common.filters.top'),
-    },
-    emptyTitle: t('pages.hub.agents.emptyTitle'),
-    emptyBody: t('pages.hub.agents.emptyBody'),
-    filteredEmptyTitle: t('pages.hub.common.filteredEmptyTitle'),
-    filteredEmptyBody: t('pages.hub.common.filteredEmptyBody'),
-    errorTitle: t('pages.hub.common.errorTitle'),
-    errorBody: t('pages.hub.common.errorBody'),
-    retryLabel: t('pages.hub.common.retry'),
-    resultsCountTemplate: t('pages.hub.common.resultsCountTemplate'),
-  };
-
-  return (
-    <HubCatalogView<PopularAgent>
-      entity="agent"
-      labels={labels}
-      kpi={kpi}
-      items={items}
-      itemMatches={matchAgent}
-      renderCard={agent => (
-        <HubAgentCard
-          agent={agent}
-          labels={cardLabels}
-          onClick={handleCardClick}
-          onInstall={handleInstall}
-        />
-      )}
-      getItemKey={agent => agent.id}
-      isLoading={query.isLoading}
-      isError={query.isError}
-      onRetry={() => query.refetch()}
-      onSearchCommitted={q => trackEvent('hub_search_committed', { entity: 'agents', q })}
-      onFilterChanged={(from, to) =>
-        trackEvent('hub_filter_changed', { entity: 'agents', from, to })
-      }
-    />
-  );
-}
-
-export default function HubAgentsPage() {
-  return (
-    <Suspense fallback={null}>
-      <HubAgentsContent />
-    </Suspense>
-  );
+export default function HubAgentsLegacyRedirect(): never {
+  redirect('/agents');
 }

--- a/apps/web/src/app/(authenticated)/hub/games/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/hub/games/[id]/page.tsx
@@ -1,150 +1,31 @@
 /**
- * /hub/games/[id] — authenticated detail page (#2118).
+ * /hub/games/[id] — retired legacy detail route (Issue #2153).
  *
- * Mirrors the public catalog detail at `/shared-games/[id]` (#603), but renders
- * inside the `(authenticated)` `UserShell` so the `AppTopBar` stays mounted
- * during intra-`/hub/*` navigation. The previous implementation was a thin
- * `redirect('/shared-games/[id]')` which re-introduced the chrome drift this
- * PR is supposed to fix.
+ * The previous implementation (#2118) was a thin mirror of
+ * `/shared-games/[id]` rendered inside the authenticated shell to preserve
+ * chrome continuity during intra-`/hub/*` navigation. With the broader
+ * `/hub/*` retirement (this issue), the chrome-continuity justification
+ * disappears — the canonical authenticated game detail lives at
+ * `/games/[id]` (private library + shared catalog merged view).
  *
- * Server-component shell:
- *   - ISR `revalidate = 60` (aligned with HybridCache TTL — Wave A.3a §3.6)
- *   - `Promise.allSettled` 2-way fetch (detail + global top contributors)
- *   - `notFound()` on backend 404
- *   - OG metadata; `robots: noindex` — SEO is owned by the public mirror
+ * Companion redirects retired in the same sweep:
+ *   - /hub               → /games?tab=discover (since #2190)
+ *   - /hub/agents        → /agents
+ *   - /hub/toolkits      → /toolkits (since #1480)
  *
- * Render delegate is `SharedGameDetailPageClient` from the `(public)` sibling,
- * reused 1:1. Loader logic is intentionally duplicated from the public route
- * shell — the cleaner consolidation (`lib/shared-games/detail-loader.ts`) is
- * tracked as a follow-up and out of scope for this PR.
- *
- * Skipped vs. public mirror:
- *   - `tryLoadVisualTestFixture` (visual-regression bootstrap is anon-only)
+ * Kept as a runtime redirect (not pure next.config.js) so the
+ * `(authenticated)` UserShell stays mounted during the hop. The `[id]`
+ * param is forwarded transparently — `/games/[id]` performs its own
+ * `notFound()` on missing detail.
  */
 
-import { Suspense, type JSX } from 'react';
-
-import { notFound } from 'next/navigation';
-
-import { SharedGameDetailPageClient } from '@/app/(public)/shared-games/[id]/page-client';
-import {
-  getSharedGameDetail,
-  getTopContributors,
-  SharedGamesApiError,
-  type SharedGameDetail,
-  type TopContributor,
-} from '@/lib/api/shared-games';
-import { getSsrMessages } from '@/lib/i18n/ssr';
-
-import type { Metadata } from 'next';
-
-export const revalidate = 60;
-
-const SSR_METADATA = getSsrMessages('pages.sharedGameDetail.metadata');
-
-interface RouteParams {
-  readonly id: string;
-}
+import { redirect } from 'next/navigation';
 
 interface PageProps {
-  readonly params: Promise<RouteParams>;
+  readonly params: Promise<{ readonly id: string }>;
 }
 
-interface SsrInitialData {
-  readonly detail: SharedGameDetail | null;
-  readonly contributors: readonly TopContributor[];
-}
-
-async function loadInitialData(id: string): Promise<SsrInitialData> {
-  let detail: SharedGameDetail | null = null;
-  let contributors: readonly TopContributor[] = [];
-
-  const [detailResult, contributorsResult] = await Promise.allSettled([
-    getSharedGameDetail(id, { next: { revalidate: 60 }, timeoutMs: 2000 }),
-    getTopContributors(8, { next: { revalidate: 60 }, timeoutMs: 2000 }),
-  ]);
-
-  if (detailResult.status === 'fulfilled') {
-    detail = detailResult.value;
-  } else {
-    const reason = detailResult.reason;
-    const isHttp404 =
-      reason instanceof SharedGamesApiError && reason.kind === 'http' && reason.httpStatus === 404;
-    if (!isHttp404) {
-      throw reason instanceof Error
-        ? reason
-        : new Error('Unknown SSR failure loading shared game detail');
-    }
-    // 404 → fall through with detail = null; page() calls notFound().
-  }
-
-  if (contributorsResult.status === 'fulfilled') {
-    contributors = contributorsResult.value;
-  }
-  // Contributors failure is non-fatal — carousel renders empty.
-
-  return { detail, contributors };
-}
-
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+export default async function HubGameDetailLegacyRedirect({ params }: PageProps): Promise<never> {
   const { id } = await params;
-
-  let detail: SharedGameDetail | null = null;
-  try {
-    detail = await getSharedGameDetail(id, {
-      next: { revalidate: 60 },
-      timeoutMs: 2000,
-    });
-  } catch {
-    // Fall through — page will render notFound() if detail is null.
-  }
-
-  const baseTitle = detail?.title ?? SSR_METADATA.titleFallback;
-  const fullTitle = `${baseTitle}${SSR_METADATA.titleSuffix}`;
-  const description =
-    detail?.description && detail.description.length > 0
-      ? detail.description.slice(0, 200)
-      : SSR_METADATA.descriptionFallback;
-
-  return {
-    title: fullTitle,
-    description,
-    // Auth-gated detail: the public mirror at /shared-games/[id] owns SEO.
-    robots: { index: false, follow: false },
-    openGraph: {
-      title: fullTitle,
-      description,
-      type: 'website',
-      images:
-        detail?.imageUrl && detail.imageUrl.length > 0 ? [{ url: detail.imageUrl }] : undefined,
-    },
-  };
-}
-
-export default async function HubGameDetailPage({ params }: PageProps): Promise<JSX.Element> {
-  const { id } = await params;
-  const { detail, contributors } = await loadInitialData(id);
-
-  if (!detail) {
-    notFound();
-  }
-
-  return (
-    <Suspense fallback={<HubGameDetailFallback />}>
-      <SharedGameDetailPageClient
-        id={id}
-        detail={detail}
-        contributors={contributors}
-        hideStickyCta
-      />
-    </Suspense>
-  );
-}
-
-function HubGameDetailFallback(): JSX.Element {
-  return (
-    <main aria-busy="true" aria-live="polite" className="min-h-screen bg-background">
-      <div className="mx-auto max-w-[1280px] px-4 py-12 sm:px-8" />
-    </main>
-  );
+  redirect(`/games/${id}`);
 }

--- a/apps/web/src/components/features/hub/HubGameCard.tsx
+++ b/apps/web/src/components/features/hub/HubGameCard.tsx
@@ -1,9 +1,11 @@
 /**
  * HubGameCard — public catalog card variant for `/hub/games` (#1166).
  * Pure presentational. Cover gradient + entity chip + title + rating + publisher.
- * Click → /hub/games/[id] (which forwards to the canonical detail at
- * /shared-games/[id]). Issue #2043 Bug 3: was previously linking to a
- * non-existent /games/[id] route, producing 404 on every card click.
+ *
+ * Click → `/games/[id]` (canonical authenticated game detail). Previously
+ * linked at `/hub/games/[id]` (#2043 Bug 3 workaround); Issue #2153 retires
+ * the `/hub/*` namespace, so the card now points at the canonical detail
+ * route directly and skips the redirect hop.
  */
 'use client';
 
@@ -30,7 +32,7 @@ export function HubGameCard({ game, onClick }: HubGameCardProps) {
   const showImage = !shouldUsePlaceholder(coverSrc);
   return (
     <Link
-      href={`/hub/games/${game.id}`}
+      href={`/games/${game.id}`}
       data-slot="hub-game-card"
       onClick={() => onClick?.(game.id)}
       className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/25"

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2200,7 +2200,7 @@
         "emptyBody": "No games have been added to the community catalog yet."
       },
       "agents": {
-        "badge": "Hub · /hub/agents",
+        "badge": "Hub · /agents",
         "title": "Community agents",
         "subtitle": "Discover AI agents shared by the community for your favourite games.",
         "installLabel": "Install agent",
@@ -2214,7 +2214,7 @@
         "emptyBody": "The community has not published any AI agents yet."
       },
       "toolkits": {
-        "badge": "Hub · /hub/toolkits",
+        "badge": "Hub · /toolkits",
         "title": "Community toolkits",
         "subtitle": "Community-shared toolkits of tools to enrich your sessions.",
         "installLabel": "Install toolkit",
@@ -2298,7 +2298,7 @@
           "statusIdle": "Idle",
           "callsTemplate": "{count} call",
           "emptyTitle": "No active AI agents.",
-          "emptyCta": "Explore /hub/agents"
+          "emptyCta": "Explore /agents"
         },
         "sessions": {
           "title": "Sessions",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2250,7 +2250,7 @@
         "emptyBody": "Nessun gioco è ancora stato aggiunto al catalogo della community."
       },
       "agents": {
-        "badge": "Hub · /hub/agents",
+        "badge": "Hub · /agents",
         "title": "Agenti community",
         "subtitle": "Scopri agenti AI condivisi dalla community per i tuoi giochi preferiti.",
         "installLabel": "Installa agente",
@@ -2264,7 +2264,7 @@
         "emptyBody": "La community non ha ancora pubblicato agenti AI."
       },
       "toolkits": {
-        "badge": "Hub · /hub/toolkits",
+        "badge": "Hub · /toolkits",
         "title": "Toolkit community",
         "subtitle": "Toolkit di strumenti condivisi dalla community per arricchire le tue sessioni.",
         "installLabel": "Installa toolkit",
@@ -2348,7 +2348,7 @@
           "statusIdle": "Inattivo",
           "callsTemplate": "{count} call",
           "emptyTitle": "Nessun agente AI attivo.",
-          "emptyCta": "Esplora /hub/agents"
+          "emptyCta": "Esplora /agents"
         },
         "sessions": {
           "title": "Sessioni",


### PR DESCRIPTION
## Summary

Completes the Stage 3 #1026 deversioning + DS-17 Phase B sweep that retired the `/hub/*` mockup family. Converts the surviving live `page.tsx` files into thin runtime redirects and re-points internal back-links to the canonical replacements.

| Legacy route | Canonical target | Before this PR | After |
|---|---|---|---|
| `/hub` | `/games?tab=discover` | redirect (#2190) | unchanged |
| `/hub/agents` | `/agents` | LIVE `HubCatalogView<PopularAgent>` | redirect 308 |
| `/hub/games/[id]` | `/games/[id]` | LIVE detail mirror (#2118) | redirect 308 (forwards `[id]`) |
| `/hub/toolkits` | `/toolkits` | redirect (#1480) | unchanged |

## Internal links

- `HubGameCard.tsx`: `href={`/hub/games/${id}`}` → `href={`/games/${id}`}`. Skips the redirect hop entirely. The card previously linked to the retired mirror as workaround #2043 Bug 3 (back then the canonical `/games/[id]` did not exist; today it does).
- `it.json` + `en.json`: 6 badge / CTA strings re-pointed from `/hub/{agents,toolkits}` to `/{agents,toolkits}`.

## Preserved on purpose

- `config/navigation.ts` `activePattern` still matches `/hub/*` so the sidebar voice highlight stays consistent during the redirect transition (URL bar briefly shows `/hub/...` before the hop). Test in `__tests__/navigation.test.ts:303-304` documents this contract.
- `HubCatalogView.smoke.test.tsx:12` fixture `usePathname: '/hub/games'` — smoke test does not exercise href, untouched.
- `proxy.ts:54` comment referencing `/hub/games` for the #2118 sweep audit context — historical documentation, untouched.
- Comment-only references in `HubAgentCard.tsx`, `HubToolkitCard.tsx`, `HubCatalogView.tsx`, `shared-games/[id]/page-client.tsx:98` — JSDoc derivation anchors, untouched.

## Test plan

- [x] Redirects use Next.js `redirect()` from `next/navigation` — server-component-friendly, returns `never`.
- [x] Dynamic `[id]` forwarded transparently in `/hub/games/[id]/page.tsx` (await params per Next 15 app router).
- [x] Existing `navigation.test.ts` legacy-URL highlight contract unchanged (regression guard preserved).
- [x] Pre-commit: lint + typecheck pass on the branch.
- [ ] CI: full vitest + lint + typecheck pass.

## Numbers

5 files changed · **+49 / −263** (~214 LOC removed: previous LIVE `/hub/agents` + `/hub/games/[id]` implementations replaced by 30-line redirect stubs).

Closes #2153

🤖 Generated with [Claude Code](https://claude.com/claude-code)