### PR TITLE
feat(mockups): #2148 — 5 AI placeholder mockups for /games/[id] sub-tabs (US-9 bridge)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -74,6 +74,11 @@
 | `sp4-discover.html` | page-mock | `/discover` |
 | `sp4-game-chat-tab.html` | component-mock | Chat tab embedded in `/library/[gameId]/agent`, `/games/[id]` |
 | `sp4-game-detail.html` | page-mock | `/games/[id]`, `/library/[gameId]`, `/private-games/[id]` |
+| `sp4-game-detail-tab-rules.html` | sub-tab placeholder (#2148) | `/games/[id]/rules` — AI placeholder, designer review required |
+| `sp4-game-detail-tab-reviews.html` | sub-tab placeholder (#2148) | `/games/[id]/reviews` — friend-first M1 variant, designer review required |
+| `sp4-game-detail-tab-strategies.html` | sub-tab placeholder (#2148) | `/games/[id]/strategies` — AI placeholder, designer review required |
+| `sp4-game-detail-tab-chat.html` | sub-tab placeholder (#2148) | `/games/[id]/chat` — standalone (was partial via composite), designer review required |
+| `sp4-game-detail-tab-faqs.html` | sub-tab placeholder (#2148) | `/games/[id]/faqs` — game-scoped variant of public FAQ, designer review required |
 | `sp4-game-nights-index.html` | page-mock | `/game-nights` |
 | `sp4-games-index.html` | page-mock | `/games` |
 | `sp4-kb-detail.html` | page-mock | `/knowledge-base/[id]` (deferred — G4 v3 pivot) |

--- a/admin-mockups/design_files/sp4-game-detail-tab-chat.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-detail-tab-chat.fidelity.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "AI-generated placeholder (#2148). Standalone chat sub-tab for /games/[id]/chat; previously only partial coverage via sp4-game-chat-tab.html composite. Designer review required.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp4-game-detail-tab-chat.html",
+    "states": [
+      "default"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 12,
+    "color_delta_e_max": 5,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "forward-refactor",
+    "viewports": [
+      "desktop"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp4-game-detail-tab-chat.html
+++ b/admin-mockups/design_files/sp4-game-detail-tab-chat.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · game-detail sub-tab — Chat (placeholder)</title>
+<!--
+  @route /games/{id}/chat
+  @last-verified 2026-06-14
+  @verified-by ai-placeholder
+  @status placeholder
+  @parent-mockup sp4-game-detail.html
+  @tracking-issue 2148
+
+  AI-generated standalone placeholder mockup (#2148). Previously partial
+  via the sp4-game-chat-tab.html composite; this stub gives `/games/[id]/chat`
+  its own canonical mockup. Designer review required.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  body { font-family: 'Nunito', system-ui, sans-serif; background: hsl(var(--bg, 0 0% 100%)); color: hsl(var(--fg, 0 0% 12%)); margin: 0; padding: 24px; }
+  .placeholder-banner { background: hsl(var(--c-agent, 220 80% 55%) / 0.08); border: 1px dashed hsl(var(--c-agent, 220 80% 55%) / 0.4); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px; font-size: 13px; line-height: 1.5; }
+  .placeholder-banner strong { color: hsl(var(--c-agent, 220 80% 55%)); }
+  main { max-width: 720px; margin: 0 auto; }
+  h1 { font-family: 'Quicksand', sans-serif; font-weight: 700; font-size: 28px; margin: 0 0 8px; display: flex; align-items: center; gap: 12px; }
+  h1 .entity-chip { font-family: 'JetBrains Mono', monospace; font-weight: 800; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 8px; border-radius: 999px; background: hsl(var(--c-agent, 220 80% 55%) / 0.14); color: hsl(var(--c-agent, 220 80% 55%)); }
+  .subtitle { color: hsl(var(--fg-muted, 0 0% 40%)); font-size: 14px; margin-bottom: 32px; }
+  .chat-stream { background: hsl(var(--card, 0 0% 100%)); border: 1px solid hsl(var(--border, 0 0% 88%)); border-radius: 12px; padding: 16px; margin-bottom: 16px; min-height: 280px; display: flex; flex-direction: column; gap: 12px; }
+  .msg { padding: 12px 14px; border-radius: 12px; max-width: 80%; line-height: 1.55; font-size: 14px; }
+  .msg.user { align-self: flex-end; background: hsl(var(--c-game, 25 95% 53%) / 0.12); color: hsl(var(--fg, 0 0% 12%)); }
+  .msg.agent { align-self: flex-start; background: hsl(var(--c-agent, 220 80% 55%) / 0.12); color: hsl(var(--fg, 0 0% 12%)); }
+  .msg .who { font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 4px; }
+  .msg.user .who { color: hsl(var(--c-game, 25 95% 53%)); }
+  .msg.agent .who { color: hsl(var(--c-agent, 220 80% 55%)); }
+  .citation { font-size: 11px; color: hsl(var(--fg-muted, 0 0% 40%)); margin-top: 6px; display: block; }
+  .composer { display: flex; gap: 8px; }
+  .composer input { flex: 1; padding: 12px 14px; border: 1px solid hsl(var(--border, 0 0% 88%)); border-radius: 999px; font-size: 14px; font-family: inherit; }
+  .composer button { padding: 12px 22px; background: hsl(var(--c-agent, 220 80% 55%)); color: white; border: none; border-radius: 999px; font-weight: 700; cursor: pointer; }
+</style>
+</head>
+<body>
+<main>
+  <p class="placeholder-banner">
+    <strong>AI-generated placeholder (#2148)</strong> — sub-tab `/games/[id]/chat`
+    standalone. Previously only partial coverage via sp4-game-chat-tab.html composite.
+    <strong>Designer review required.</strong>
+  </p>
+  <header>
+    <h1>Chat con l'Agente <span class="entity-chip">🤖 Agent</span></h1>
+    <p class="subtitle">Domande sulle regole, strategie o dispute. Risposte con citazioni al manuale.</p>
+  </header>
+  <div class="chat-stream">
+    <div class="msg user"><div class="who">Tu</div>Quante carte si pescano in caso di pareggio?</div>
+    <div class="msg agent">
+      <div class="who">Agente</div>
+      In caso di pareggio si pesca 1 carta extra per ogni giocatore coinvolto.
+      <span class="citation">📄 Manuale Cap. 4, p. 18</span>
+    </div>
+    <div class="msg user"><div class="who">Tu</div>E se la pila è vuota?</div>
+    <div class="msg agent">
+      <div class="who">Agente</div>
+      Si rimischia lo scarto e si forma una nuova pila.
+      <span class="citation">📄 Manuale Cap. 4, p. 19</span>
+    </div>
+  </div>
+  <form class="composer">
+    <input type="text" placeholder="Fai una domanda..." aria-label="Domanda all'Agente"/>
+    <button type="submit">Invia</button>
+  </form>
+</main>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-detail-tab-chat.jsx
+++ b/admin-mockups/design_files/sp4-game-detail-tab-chat.jsx
@@ -1,0 +1,82 @@
+/**
+ * sp4-game-detail-tab-chat.jsx — AI placeholder (#2148)
+ *
+ * Standalone chat tab for `/games/[id]/chat`. Previously partial coverage
+ * via `sp4-game-chat-tab.html` composite; this stub gives the sub-route its
+ * own canonical mockup. Designer review required.
+ *
+ * Parent canonical mockup: sp4-game-detail.html.
+ */
+
+function ChatTab({ messages = SAMPLE_MESSAGES }) {
+  return (
+    <section data-tab="chat" aria-label="Chat con l'agente">
+      <header className="tab-header">
+        <h1>
+          Chat con l&apos;Agente{' '}
+          <span className="entity-chip e-agent" aria-hidden>
+            🤖 Agent
+          </span>
+        </h1>
+        <p className="subtitle">
+          Domande sulle regole, strategie o dispute. Risposte con citazioni al manuale.
+        </p>
+      </header>
+
+      <div className="chat-stream" role="log" aria-live="polite">
+        {messages.map(m => (
+          <Message key={m.id} message={m} />
+        ))}
+      </div>
+
+      <ChatComposer onSubmit={text => console.log('placeholder send:', text)} />
+    </section>
+  );
+}
+
+function Message({ message }) {
+  return (
+    <div className={`msg ${message.role}`}>
+      <div className="who">{message.role === 'user' ? 'Tu' : 'Agente'}</div>
+      <p className="msg-text">{message.text}</p>
+      {message.citation && (
+        <span className="citation" aria-label={`Riferimento: ${message.citation}`}>
+          📄 {message.citation}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ChatComposer({ onSubmit }) {
+  const [draft, setDraft] = React.useState('');
+  return (
+    <form
+      className="composer"
+      onSubmit={e => {
+        e.preventDefault();
+        if (!draft.trim()) return;
+        onSubmit(draft);
+        setDraft('');
+      }}
+    >
+      <input
+        type="text"
+        placeholder="Fai una domanda..."
+        aria-label="Domanda all'Agente"
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+      />
+      <button type="submit">Invia</button>
+    </form>
+  );
+}
+
+const SAMPLE_MESSAGES = [
+  { id: 'm1', role: 'user', text: 'Quante carte si pescano in caso di pareggio?', citation: null },
+  { id: 'm2', role: 'agent', text: 'In caso di pareggio si pesca 1 carta extra per ogni giocatore coinvolto.', citation: 'Manuale Cap. 4, p. 18' },
+  { id: 'm3', role: 'user', text: 'E se la pila è vuota?', citation: null },
+  { id: 'm4', role: 'agent', text: 'Si rimischia lo scarto e si forma una nuova pila.', citation: 'Manuale Cap. 4, p. 19' },
+];
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ChatTab />);

--- a/admin-mockups/design_files/sp4-game-detail-tab-faqs.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-detail-tab-faqs.fidelity.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "AI-generated placeholder (#2148). Game-detail-scoped FAQ sub-tab. Designer review required: pin acceptance, add state variants.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp4-game-detail-tab-faqs.html",
+    "states": [
+      "default"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 12,
+    "color_delta_e_max": 5,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "forward-refactor",
+    "viewports": [
+      "desktop"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp4-game-detail-tab-faqs.html
+++ b/admin-mockups/design_files/sp4-game-detail-tab-faqs.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · game-detail sub-tab — FAQs (placeholder)</title>
+<!--
+  @route /games/{id}/faqs
+  @last-verified 2026-06-14
+  @verified-by ai-placeholder
+  @status placeholder
+  @parent-mockup sp4-game-detail.html
+  @tracking-issue 2148
+
+  AI-generated game-detail-scoped FAQ stub (#2148). The shared
+  sp3-faq-enhanced.html covers public-app FAQ; this variant scopes to
+  game-specific questions (rules clarifications, common edge cases).
+  Designer review required.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  body { font-family: 'Nunito', system-ui, sans-serif; background: hsl(var(--bg, 0 0% 100%)); color: hsl(var(--fg, 0 0% 12%)); margin: 0; padding: 24px; }
+  .placeholder-banner { background: hsl(var(--c-kb, 50 90% 50%) / 0.10); border: 1px dashed hsl(var(--c-kb, 50 90% 50%) / 0.4); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px; font-size: 13px; line-height: 1.5; }
+  .placeholder-banner strong { color: hsl(var(--c-kb, 50 90% 50%)); }
+  main { max-width: 880px; margin: 0 auto; }
+  h1 { font-family: 'Quicksand', sans-serif; font-weight: 700; font-size: 28px; margin: 0 0 8px; display: flex; align-items: center; gap: 12px; }
+  h1 .entity-chip { font-family: 'JetBrains Mono', monospace; font-weight: 800; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 8px; border-radius: 999px; background: hsl(var(--c-kb, 50 90% 50%) / 0.14); color: hsl(var(--c-kb, 50 90% 50%)); }
+  .subtitle { color: hsl(var(--fg-muted, 0 0% 40%)); font-size: 14px; margin-bottom: 32px; }
+  details.faq { background: hsl(var(--card, 0 0% 100%)); border: 1px solid hsl(var(--border, 0 0% 88%)); border-radius: 12px; padding: 16px 20px; margin-bottom: 12px; }
+  details.faq summary { font-family: 'Quicksand', sans-serif; font-weight: 700; font-size: 16px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; align-items: center; }
+  details.faq summary::after { content: '+'; color: hsl(var(--c-kb, 50 90% 50%)); font-size: 22px; font-weight: 800; }
+  details.faq[open] summary::after { content: '−'; }
+  details.faq p { margin: 12px 0 0; line-height: 1.6; color: hsl(var(--fg-muted, 0 0% 30%)); }
+  .meta-row { display: flex; gap: 12px; font-size: 12px; color: hsl(var(--fg-muted, 0 0% 40%)); margin-top: 8px; }
+</style>
+</head>
+<body>
+<main>
+  <p class="placeholder-banner">
+    <strong>AI-generated placeholder (#2148)</strong> — sub-tab `/games/[id]/faqs`.
+    Variant scoped to game-specific FAQs (rules clarifications, edge cases) —
+    distinct from the public-app sp3-faq-enhanced.html. <strong>Designer review required.</strong>
+  </p>
+  <header>
+    <h1>FAQ <span class="entity-chip">📚 KB</span></h1>
+    <p class="subtitle">Domande frequenti su questo gioco. Approvate dalla community.</p>
+  </header>
+
+  <details class="faq" open>
+    <summary>Si possono giocare in 2 giocatori?</summary>
+    <p>Sì, con la variante "duello" descritta nel manuale (Cap. 7). Cambiano alcune regole di setup ma non il flusso di gioco.</p>
+    <div class="meta-row"><span>👁️ 320 visualizzazioni</span><span>👍 28 utili</span></div>
+  </details>
+
+  <details class="faq">
+    <summary>Cosa succede se l'azione termina senza vincitore?</summary>
+    <p>Si applica la regola del "tempo limite" (Cap. 4, p. 16): chi ha più punti vince.</p>
+    <div class="meta-row"><span>👁️ 180 visualizzazioni</span><span>👍 14 utili</span></div>
+  </details>
+
+  <details class="faq">
+    <summary>Il setup avanzato è raccomandato per principianti?</summary>
+    <p>No, è raccomandato iniziare con il setup base. Il setup avanzato aggiunge 2 carte azione e regole speciali.</p>
+    <div class="meta-row"><span>👁️ 95 visualizzazioni</span><span>👍 8 utili</span></div>
+  </details>
+</main>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-detail-tab-faqs.jsx
+++ b/admin-mockups/design_files/sp4-game-detail-tab-faqs.jsx
@@ -1,0 +1,55 @@
+/**
+ * sp4-game-detail-tab-faqs.jsx — AI placeholder (#2148)
+ *
+ * Game-detail-scoped FAQ sub-tab for `/games/[id]/faqs`. The shared
+ * `sp3-faq-enhanced.html` covers public-app FAQ; this variant scopes to
+ * game-specific questions (rules clarifications, edge cases).
+ * Designer review required.
+ *
+ * Parent canonical mockup: sp4-game-detail.html.
+ */
+
+function FaqsTab({ faqs = SAMPLE_FAQS }) {
+  return (
+    <section data-tab="faqs" aria-label="Domande frequenti">
+      <header className="tab-header">
+        <h1>
+          FAQ{' '}
+          <span className="entity-chip e-kb" aria-hidden>
+            📚 KB
+          </span>
+        </h1>
+        <p className="subtitle">Domande frequenti su questo gioco. Approvate dalla community.</p>
+      </header>
+
+      {faqs.length === 0 ? (
+        <p className="empty-state" role="status">
+          Nessuna FAQ pubblicata ancora. Le prime domande approvate compariranno qui.
+        </p>
+      ) : (
+        faqs.map((f, i) => <FaqItem key={f.id} faq={f} defaultOpen={i === 0} />)
+      )}
+    </section>
+  );
+}
+
+function FaqItem({ faq, defaultOpen }) {
+  return (
+    <details className="faq" open={defaultOpen}>
+      <summary>{faq.question}</summary>
+      <p>{faq.answer}</p>
+      <div className="meta-row">
+        <span>👁️ {faq.views} visualizzazioni</span>
+        <span>👍 {faq.helpful} utili</span>
+      </div>
+    </details>
+  );
+}
+
+const SAMPLE_FAQS = [
+  { id: 'q1', question: 'Si possono giocare in 2 giocatori?', answer: 'Sì, con la variante "duello" descritta nel manuale (Cap. 7). Cambiano alcune regole di setup ma non il flusso di gioco.', views: 320, helpful: 28 },
+  { id: 'q2', question: "Cosa succede se l'azione termina senza vincitore?", answer: 'Si applica la regola del "tempo limite" (Cap. 4, p. 16): chi ha più punti vince.', views: 180, helpful: 14 },
+  { id: 'q3', question: 'Il setup avanzato è raccomandato per principianti?', answer: 'No, è raccomandato iniziare con il setup base. Il setup avanzato aggiunge 2 carte azione e regole speciali.', views: 95, helpful: 8 },
+];
+
+ReactDOM.createRoot(document.getElementById('root')).render(<FaqsTab />);

--- a/admin-mockups/design_files/sp4-game-detail-tab-reviews.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-detail-tab-reviews.fidelity.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "AI-generated placeholder (#2148). Friend-first commentary M1 variant. Designer review required: pin acceptance values, polish typography, add state variants (empty/loading/error).",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp4-game-detail-tab-reviews.html",
+    "states": [
+      "default"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 12,
+    "color_delta_e_max": 5,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "forward-refactor",
+    "viewports": [
+      "desktop"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp4-game-detail-tab-reviews.html
+++ b/admin-mockups/design_files/sp4-game-detail-tab-reviews.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · game-detail sub-tab — Recensioni (placeholder)</title>
+<!--
+  @route /games/{id}/reviews
+  @last-verified 2026-06-14
+  @verified-by ai-placeholder
+  @status placeholder
+  @parent-mockup sp4-game-detail.html
+  @tracking-issue 2148
+
+  AI-generated placeholder mockup (Issue #2148). Friend-first commentary M1
+  variant — show reviews from people the user follows BEFORE community at
+  large (per audit `2026-06-10-mockup-coverage-gap-report.md`).
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  body { font-family: 'Nunito', system-ui, sans-serif; background: hsl(var(--bg, 0 0% 100%)); color: hsl(var(--fg, 0 0% 12%)); margin: 0; padding: 24px; }
+  .placeholder-banner { background: hsl(var(--c-game, 25 95% 53%) / 0.08); border: 1px dashed hsl(var(--c-game, 25 95% 53%) / 0.4); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px; font-size: 13px; line-height: 1.5; }
+  .placeholder-banner strong { color: hsl(var(--c-game, 25 95% 53%)); }
+  main { max-width: 880px; margin: 0 auto; }
+  h1 { font-family: 'Quicksand', sans-serif; font-weight: 700; font-size: 28px; margin: 0 0 8px; display: flex; align-items: center; gap: 12px; }
+  h1 .entity-chip { font-family: 'JetBrains Mono', monospace; font-weight: 800; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 8px; border-radius: 999px; background: hsl(var(--c-game, 25 95% 53%) / 0.14); color: hsl(var(--c-game, 25 95% 53%)); }
+  .subtitle { color: hsl(var(--fg-muted, 0 0% 40%)); font-size: 14px; margin-bottom: 32px; }
+  .section-title { font-family: 'Quicksand', sans-serif; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: hsl(var(--fg-muted, 0 0% 40%)); margin: 24px 0 12px; }
+  .review-card { background: hsl(var(--card, 0 0% 100%)); border: 1px solid hsl(var(--border, 0 0% 88%)); border-radius: 12px; padding: 16px 20px; margin-bottom: 12px; display: flex; gap: 12px; }
+  .avatar { width: 44px; height: 44px; border-radius: 50%; flex-shrink: 0; background: linear-gradient(135deg, hsl(var(--c-player, 270 70% 60%) / 0.6), hsl(var(--c-player, 270 70% 60%) / 0.2)); display: flex; align-items: center; justify-content: center; font-weight: 800; color: white; font-size: 16px; }
+  .review-body { flex: 1; min-width: 0; }
+  .review-header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 6px; font-size: 14px; }
+  .reviewer-name { font-weight: 700; }
+  .friend-pip { font-size: 11px; background: hsl(var(--c-player, 270 70% 60%) / 0.14); color: hsl(var(--c-player, 270 70% 60%)); padding: 2px 6px; border-radius: 999px; font-weight: 700; }
+  .rating { color: hsl(var(--c-game, 25 95% 53%)); font-weight: 700; }
+  .review-text { line-height: 1.55; margin: 0 0 6px; font-size: 14px; }
+  .review-meta { font-size: 12px; color: hsl(var(--fg-muted, 0 0% 40%)); }
+</style>
+</head>
+<body>
+<main>
+  <p class="placeholder-banner">
+    <strong>AI-generated placeholder (#2148)</strong> — sub-tab `/games/[id]/reviews`
+    of the canonical <code>sp4-game-detail.html</code>. Friend-first commentary M1
+    variant. <strong>Designer review required.</strong>
+  </p>
+
+  <header>
+    <h1>Recensioni <span class="entity-chip">🎲 Game</span></h1>
+    <p class="subtitle">Cosa pensano i tuoi amici e la community di questo gioco.</p>
+  </header>
+
+  <h2 class="section-title">👥 Dai tuoi amici</h2>
+
+  <article class="review-card">
+    <div class="avatar">LU</div>
+    <div class="review-body">
+      <div class="review-header">
+        <span class="reviewer-name">Luigi</span>
+        <span class="friend-pip">amico</span>
+        <span class="rating">★★★★☆ 4.2</span>
+      </div>
+      <p class="review-text">Bel gioco, ma le prime partite sono un po' lente. Dopo si vola.</p>
+      <span class="review-meta">2 giorni fa · 3 partite giocate</span>
+    </div>
+  </article>
+
+  <article class="review-card">
+    <div class="avatar">MA</div>
+    <div class="review-body">
+      <div class="review-header">
+        <span class="reviewer-name">Marco</span>
+        <span class="friend-pip">amico</span>
+        <span class="rating">★★★★★ 4.8</span>
+      </div>
+      <p class="review-text">Capolavoro. Ogni partita è diversa, scelte significative dall'inizio.</p>
+      <span class="review-meta">1 settimana fa · 12 partite giocate</span>
+    </div>
+  </article>
+
+  <h2 class="section-title">🌐 Dalla community</h2>
+
+  <article class="review-card">
+    <div class="avatar">AN</div>
+    <div class="review-body">
+      <div class="review-header">
+        <span class="reviewer-name">Anna_2024</span>
+        <span class="rating">★★★★☆ 4.5</span>
+      </div>
+      <p class="review-text">Setup un po' lungo, ma il gameplay ripaga ampiamente.</p>
+      <span class="review-meta">3 settimane fa · community</span>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-detail-tab-reviews.jsx
+++ b/admin-mockups/design_files/sp4-game-detail-tab-reviews.jsx
@@ -1,0 +1,90 @@
+/**
+ * sp4-game-detail-tab-reviews.jsx — AI placeholder (#2148)
+ *
+ * Friend-first commentary M1 variant for the `/games/[id]/reviews` sub-tab.
+ * Friends section rendered ABOVE community per audit
+ * `2026-06-10-mockup-coverage-gap-report.md`.
+ *
+ * Designer review required: polish typography, add state variants
+ * (loading/empty/error), pin acceptance values.
+ *
+ * Parent canonical mockup: sp4-game-detail.html.
+ */
+
+function ReviewsTab({ friendReviews = SAMPLE_FRIENDS, communityReviews = SAMPLE_COMMUNITY }) {
+  return (
+    <section data-tab="reviews" aria-label="Recensioni">
+      <header className="tab-header">
+        <h1>
+          Recensioni{' '}
+          <span className="entity-chip e-game" aria-hidden>
+            🎲 Game
+          </span>
+        </h1>
+        <p className="subtitle">Cosa pensano i tuoi amici e la community di questo gioco.</p>
+      </header>
+
+      <h2 className="section-title" id="friends-reviews">
+        👥 Dai tuoi amici
+      </h2>
+      {friendReviews.length === 0 ? (
+        <EmptyFriends />
+      ) : (
+        <ul aria-labelledby="friends-reviews">
+          {friendReviews.map(r => (
+            <ReviewCard key={r.id} review={r} isFriend />
+          ))}
+        </ul>
+      )}
+
+      <h2 className="section-title" id="community-reviews">
+        🌐 Dalla community
+      </h2>
+      <ul aria-labelledby="community-reviews">
+        {communityReviews.map(r => (
+          <ReviewCard key={r.id} review={r} isFriend={false} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ReviewCard({ review, isFriend }) {
+  return (
+    <li className="review-card">
+      <span className="avatar" aria-hidden>
+        {review.initials}
+      </span>
+      <div className="review-body">
+        <div className="review-header">
+          <span className="reviewer-name">{review.name}</span>
+          {isFriend && <span className="friend-pip">amico</span>}
+          <span className="rating">★ {review.rating.toFixed(1)}</span>
+        </div>
+        <p className="review-text">{review.text}</p>
+        <span className="review-meta">
+          {review.date} · {review.playedCount > 0 ? `${review.playedCount} partite` : 'community'}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+function EmptyFriends() {
+  return (
+    <p className="empty-friends" role="status">
+      Nessun amico ha ancora recensito questo gioco. Sii il primo!
+    </p>
+  );
+}
+
+const SAMPLE_FRIENDS = [
+  { id: 'f1', name: 'Luigi', initials: 'LU', rating: 4.2, text: "Bel gioco, ma le prime partite sono un po' lente. Dopo si vola.", date: '2 giorni fa', playedCount: 3 },
+  { id: 'f2', name: 'Marco', initials: 'MA', rating: 4.8, text: "Capolavoro. Ogni partita è diversa, scelte significative dall'inizio.", date: '1 settimana fa', playedCount: 12 },
+];
+
+const SAMPLE_COMMUNITY = [
+  { id: 'c1', name: 'Anna_2024', initials: 'AN', rating: 4.5, text: 'Setup un po\' lungo, ma il gameplay ripaga ampiamente.', date: '3 settimane fa', playedCount: 0 },
+];
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ReviewsTab />);

--- a/admin-mockups/design_files/sp4-game-detail-tab-rules.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-detail-tab-rules.fidelity.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "AI-generated placeholder (#2148). Low-fidelity stub to unblock US-9 conformity coverage. Designer review required: pin acceptance values, polish typography, add state variants, and graduate design_intent.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp4-game-detail-tab-rules.html",
+    "states": [
+      "default"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 12,
+    "color_delta_e_max": 5,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "forward-refactor",
+    "viewports": [
+      "desktop"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp4-game-detail-tab-rules.html
+++ b/admin-mockups/design_files/sp4-game-detail-tab-rules.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · game-detail sub-tab — Regole (placeholder)</title>
+<!--
+  @route /games/{id}/rules
+  @last-verified 2026-06-14
+  @verified-by ai-placeholder
+  @status placeholder
+  @parent-mockup sp4-game-detail.html
+  @tracking-issue 2148
+
+  AI-generated placeholder mockup (Issue #2148). Low-fidelity stub provided
+  to unblock US-9 conformity coverage. Designer review required: pin acceptance
+  values, polish typography, add empty/loading/error state variants, and graduate
+  `design_intent` from "forward-refactor" to "current".
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  body { font-family: 'Nunito', system-ui, sans-serif; background: hsl(var(--bg, 0 0% 100%)); color: hsl(var(--fg, 0 0% 12%)); margin: 0; padding: 24px; }
+  .placeholder-banner { background: hsl(var(--c-game, 25 95% 53%) / 0.08); border: 1px dashed hsl(var(--c-game, 25 95% 53%) / 0.4); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px; font-size: 13px; line-height: 1.5; }
+  .placeholder-banner strong { color: hsl(var(--c-game, 25 95% 53%)); }
+  main { max-width: 880px; margin: 0 auto; }
+  h1 { font-family: 'Quicksand', sans-serif; font-weight: 700; font-size: 28px; margin: 0 0 8px; display: flex; align-items: center; gap: 12px; }
+  h1 .entity-chip { font-family: 'JetBrains Mono', monospace; font-weight: 800; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 8px; border-radius: 999px; background: hsl(var(--c-game, 25 95% 53%) / 0.14); color: hsl(var(--c-game, 25 95% 53%)); }
+  .subtitle { color: hsl(var(--fg-muted, 0 0% 40%)); font-size: 14px; margin-bottom: 32px; }
+  .rule-section { background: hsl(var(--card, 0 0% 100%)); border: 1px solid hsl(var(--border, 0 0% 88%)); border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
+  .rule-section h2 { font-family: 'Quicksand', sans-serif; font-size: 18px; font-weight: 700; margin: 0 0 12px; }
+  .rule-section p { margin: 0 0 8px; line-height: 1.6; }
+  .rule-section .citation { font-size: 12px; color: hsl(var(--fg-muted, 0 0% 40%)); display: inline-flex; align-items: center; gap: 4px; }
+  .citation::before { content: "📄"; }
+  .floating-cta { position: fixed; bottom: 24px; right: 24px; padding: 14px 22px; background: hsl(var(--c-agent, 220 80% 55%)); color: white; border: none; border-radius: 999px; font-family: 'Nunito', sans-serif; font-weight: 700; font-size: 14px; cursor: pointer; box-shadow: 0 8px 24px hsl(var(--c-agent, 220 80% 55%) / 0.4); }
+</style>
+</head>
+<body>
+<main>
+  <p class="placeholder-banner">
+    <strong>AI-generated placeholder (#2148)</strong> — sub-tab `/games/[id]/rules`
+    of the canonical <code>sp4-game-detail.html</code>. Stub layout provided to
+    unblock US-9 conformity coverage. <strong>Designer review required.</strong>
+  </p>
+
+  <header>
+    <h1>Regole <span class="entity-chip">🎲 Game</span></h1>
+    <p class="subtitle">Sintesi delle regole del gioco, con citazioni al PDF originale.</p>
+  </header>
+
+  <section class="rule-section">
+    <h2>Preparazione</h2>
+    <p>Ogni giocatore riceve la propria plancia, 3 carte iniziali e 5 risorse di partenza.</p>
+    <span class="citation">Manuale Cap. 1, p. 4</span>
+  </section>
+
+  <section class="rule-section">
+    <h2>Svolgimento del turno</h2>
+    <p>Il turno si svolge in 3 fasi: azione principale, scambio, mantenimento.</p>
+    <span class="citation">Manuale Cap. 2, p. 8</span>
+  </section>
+
+  <section class="rule-section">
+    <h2>Condizioni di vittoria</h2>
+    <p>Il primo giocatore a raggiungere 10 punti vittoria vince la partita.</p>
+    <span class="citation">Manuale Cap. 5, p. 22</span>
+  </section>
+</main>
+
+<button class="floating-cta" type="button">💬 Chiedi all'Agente</button>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-detail-tab-rules.jsx
+++ b/admin-mockups/design_files/sp4-game-detail-tab-rules.jsx
@@ -1,0 +1,89 @@
+/**
+ * sp4-game-detail-tab-rules.jsx — AI placeholder (#2148)
+ *
+ * Low-fidelity stub for the `/games/[id]/rules` sub-tab. Provides minimal
+ * semantic structure + entity tokens to unblock US-9 conformity coverage.
+ *
+ * Designer review required: polish typography, add state variants
+ * (loading/empty/error), pin acceptance values, graduate design_intent
+ * from "forward-refactor" to "current".
+ *
+ * Parent canonical mockup: sp4-game-detail.html (multi-tab game detail).
+ */
+
+function RulesTab({ rules = SAMPLE_RULES }) {
+  return (
+    <section data-tab="rules" aria-label="Regole">
+      <header className="tab-header">
+        <h1>
+          Regole{' '}
+          <span className="entity-chip e-game" aria-hidden>
+            🎲 Game
+          </span>
+        </h1>
+        <p className="subtitle">
+          Sintesi delle regole del gioco, con citazioni al PDF originale.
+        </p>
+      </header>
+
+      {rules.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ul className="rule-list">
+          {rules.map(r => (
+            <RuleSection key={r.id} title={r.title} body={r.body} citation={r.citation} />
+          ))}
+        </ul>
+      )}
+
+      <button type="button" className="floating-cta e-bg-agent" data-action="ask-agent">
+        💬 Chiedi all&apos;Agente
+      </button>
+    </section>
+  );
+}
+
+function RuleSection({ title, body, citation }) {
+  return (
+    <li className="rule-section">
+      <h2>{title}</h2>
+      <p>{body}</p>
+      {citation && (
+        <span className="citation" aria-label={`Riferimento: ${citation}`}>
+          📄 {citation}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="empty-state" role="status">
+      <p>Nessuna regola caricata. Carica il PDF del manuale per iniziare.</p>
+    </div>
+  );
+}
+
+const SAMPLE_RULES = [
+  {
+    id: 'r1',
+    title: 'Preparazione',
+    body: 'Ogni giocatore riceve la propria plancia, 3 carte iniziali e 5 risorse di partenza.',
+    citation: 'Manuale Cap. 1, p. 4',
+  },
+  {
+    id: 'r2',
+    title: 'Svolgimento del turno',
+    body: 'Il turno si svolge in 3 fasi: azione principale, scambio, mantenimento.',
+    citation: 'Manuale Cap. 2, p. 8',
+  },
+  {
+    id: 'r3',
+    title: 'Condizioni di vittoria',
+    body: 'Il primo giocatore a raggiungere 10 punti vittoria vince la partita.',
+    citation: 'Manuale Cap. 5, p. 22',
+  },
+];
+
+ReactDOM.createRoot(document.getElementById('root')).render(<RulesTab />);

--- a/admin-mockups/design_files/sp4-game-detail-tab-strategies.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-detail-tab-strategies.fidelity.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "AI-generated placeholder (#2148). Designer review required: pin acceptance, polish typography, add state variants.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp4-game-detail-tab-strategies.html",
+    "states": [
+      "default"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 12,
+    "color_delta_e_max": 5,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "forward-refactor",
+    "viewports": [
+      "desktop"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp4-game-detail-tab-strategies.html
+++ b/admin-mockups/design_files/sp4-game-detail-tab-strategies.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP4 · game-detail sub-tab — Strategie (placeholder)</title>
+<!--
+  @route /games/{id}/strategies
+  @last-verified 2026-06-14
+  @verified-by ai-placeholder
+  @status placeholder
+  @parent-mockup sp4-game-detail.html
+  @tracking-issue 2148
+
+  AI-generated placeholder mockup (#2148). Designer review required.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  body { font-family: 'Nunito', system-ui, sans-serif; background: hsl(var(--bg, 0 0% 100%)); color: hsl(var(--fg, 0 0% 12%)); margin: 0; padding: 24px; }
+  .placeholder-banner { background: hsl(var(--c-toolkit, 145 60% 45%) / 0.08); border: 1px dashed hsl(var(--c-toolkit, 145 60% 45%) / 0.4); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px; font-size: 13px; line-height: 1.5; }
+  .placeholder-banner strong { color: hsl(var(--c-toolkit, 145 60% 45%)); }
+  main { max-width: 880px; margin: 0 auto; }
+  h1 { font-family: 'Quicksand', sans-serif; font-weight: 700; font-size: 28px; margin: 0 0 8px; display: flex; align-items: center; gap: 12px; }
+  h1 .entity-chip { font-family: 'JetBrains Mono', monospace; font-weight: 800; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 8px; border-radius: 999px; background: hsl(var(--c-toolkit, 145 60% 45%) / 0.14); color: hsl(var(--c-toolkit, 145 60% 45%)); }
+  .subtitle { color: hsl(var(--fg-muted, 0 0% 40%)); font-size: 14px; margin-bottom: 32px; }
+  .strategy-card { background: hsl(var(--card, 0 0% 100%)); border: 1px solid hsl(var(--border, 0 0% 88%)); border-radius: 12px; padding: 20px 24px; margin-bottom: 12px; }
+  .strategy-card .meta { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 12px; }
+  .difficulty { padding: 2px 8px; border-radius: 999px; background: hsl(var(--c-toolkit, 145 60% 45%) / 0.14); color: hsl(var(--c-toolkit, 145 60% 45%)); font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
+  .strategy-card h2 { font-family: 'Quicksand', sans-serif; font-size: 18px; font-weight: 700; margin: 0 0 8px; }
+  .strategy-card p { margin: 0 0 8px; line-height: 1.55; }
+  .strategy-card .author { font-size: 12px; color: hsl(var(--fg-muted, 0 0% 40%)); }
+</style>
+</head>
+<body>
+<main>
+  <p class="placeholder-banner">
+    <strong>AI-generated placeholder (#2148)</strong> — sub-tab `/games/[id]/strategies`.
+    <strong>Designer review required.</strong>
+  </p>
+  <header>
+    <h1>Strategie <span class="entity-chip">🧰 Toolkit</span></h1>
+    <p class="subtitle">Strategie condivise dalla community per dominare questo gioco.</p>
+  </header>
+  <article class="strategy-card">
+    <div class="meta"><span class="difficulty">Beginner</span><span>👁️ 1.2k visualizzazioni</span></div>
+    <h2>Apertura economica — controllo risorse</h2>
+    <p>Concentrati sulla raccolta risorse nei primi 3 turni. Evita conflitti diretti finché non hai un vantaggio numerico chiaro.</p>
+    <span class="author">di @marco_strategist · 12 like</span>
+  </article>
+  <article class="strategy-card">
+    <div class="meta"><span class="difficulty">Advanced</span><span>👁️ 740 visualizzazioni</span></div>
+    <h2>Pressione tempo — rush in 5 turni</h2>
+    <p>Sacrifica risorse mid-game per accelerare la condizione di vittoria. Funziona solo se avversari restano passivi.</p>
+    <span class="author">di @luigi_aggressive · 8 like</span>
+  </article>
+</main>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-game-detail-tab-strategies.jsx
+++ b/admin-mockups/design_files/sp4-game-detail-tab-strategies.jsx
@@ -1,0 +1,59 @@
+/**
+ * sp4-game-detail-tab-strategies.jsx — AI placeholder (#2148)
+ *
+ * Low-fidelity stub for the `/games/[id]/strategies` sub-tab. Designer review
+ * required: pin acceptance, add state variants (empty/loading/error).
+ *
+ * Parent canonical mockup: sp4-game-detail.html.
+ */
+
+function StrategiesTab({ strategies = SAMPLE_STRATEGIES }) {
+  return (
+    <section data-tab="strategies" aria-label="Strategie">
+      <header className="tab-header">
+        <h1>
+          Strategie{' '}
+          <span className="entity-chip e-toolkit" aria-hidden>
+            🧰 Toolkit
+          </span>
+        </h1>
+        <p className="subtitle">Strategie condivise dalla community per dominare questo gioco.</p>
+      </header>
+
+      {strategies.length === 0 ? (
+        <p className="empty-state" role="status">
+          Nessuna strategia ancora. Sii il primo a condividere la tua!
+        </p>
+      ) : (
+        <ul>
+          {strategies.map(s => (
+            <StrategyCard key={s.id} strategy={s} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function StrategyCard({ strategy }) {
+  return (
+    <li className="strategy-card">
+      <div className="meta">
+        <span className="difficulty">{strategy.difficulty}</span>
+        <span>👁️ {strategy.views} visualizzazioni</span>
+      </div>
+      <h2>{strategy.title}</h2>
+      <p>{strategy.body}</p>
+      <span className="author">
+        di @{strategy.author} · {strategy.likes} like
+      </span>
+    </li>
+  );
+}
+
+const SAMPLE_STRATEGIES = [
+  { id: 's1', difficulty: 'Beginner', views: '1.2k', title: 'Apertura economica — controllo risorse', body: 'Concentrati sulla raccolta risorse nei primi 3 turni. Evita conflitti diretti finché non hai un vantaggio numerico chiaro.', author: 'marco_strategist', likes: 12 },
+  { id: 's2', difficulty: 'Advanced', views: '740', title: 'Pressione tempo — rush in 5 turni', body: 'Sacrifica risorse mid-game per accelerare la condizione di vittoria. Funziona solo se avversari restano passivi.', author: 'luigi_aggressive', likes: 8 },
+];
+
+ReactDOM.createRoot(document.getElementById('root')).render(<StrategiesTab />);

--- a/docs/for-developers/frontend/mockup-designer-review-queue.md
+++ b/docs/for-developers/frontend/mockup-designer-review-queue.md
@@ -138,3 +138,22 @@ These mockups carry user-side BGG surfaces forbidden per #1903 ADR. Phase B init
 | Naming consistency | 5.0/10 |
 | Route architecture | 6.0/10 |
 | **Overall structural** | **5.5/10** |
+
+## US-9 sub-tab coverage — AI placeholder stubs (#2148, 2026-06-14)
+
+5 game-detail sub-tabs were shipped without designer-validated mockup
+coverage (PRD f3 #1929 game-detail rebuild). To unblock US-9 conformity
+testing in the short term, AI-generated low-fidelity placeholders were
+committed under `design_intent: "forward-refactor"`. **Designer review is
+required** to pin acceptance values, polish typography, add state variants
+(loading / empty / error), and graduate each to `design_intent: "current"`.
+
+- [ ] **#2148 — `sp4-game-detail-tab-rules.{html,jsx}`** — `/games/[id]/rules`. Sections: setup, turn flow, victory conditions, with PDF citations. Floating "Ask Agent" CTA.
+- [ ] **#2148 — `sp4-game-detail-tab-reviews.{html,jsx}`** — `/games/[id]/reviews`. Friend-first commentary M1 variant — friends section above community per gap report. Avatar + rating + helpful-meta.
+- [ ] **#2148 — `sp4-game-detail-tab-strategies.{html,jsx}`** — `/games/[id]/strategies`. Community-shared strategy cards with difficulty pill + view/like counters.
+- [ ] **#2148 — `sp4-game-detail-tab-chat.{html,jsx}`** — `/games/[id]/chat`. Standalone (replaces partial coverage via `sp4-game-chat-tab.html` composite). User/agent message bubbles + citation footer + composer.
+- [ ] **#2148 — `sp4-game-detail-tab-faqs.{html,jsx}`** — `/games/[id]/faqs`. Game-scoped variant of public `sp3-faq-enhanced.html`. Collapsible `<details>` cards with view/helpful counters.
+
+Once a designer reviews each pair, flip the corresponding `fidelity.json`
+`design_intent` from `forward-refactor` to `current` (and set
+`designer_approved_by` + `designer_approved_on`) to mark the row done.


### PR DESCRIPTION
## Summary

US-9 conformity bridge per the Phase B coverage gap report (`audits/2026-06-10-mockup-coverage-gap-report.md`). PRD f3 (#1929 game-detail rebuild) shipped 5 sub-tabs without designer-validated mockup coverage; this PR commits AI-generated low-fidelity stubs to unblock conformity testing.

Each `.fidelity.json` ships with `design_intent: "forward-refactor"` — the explicit signal that this is a placeholder. Once a designer reviews and pins acceptance, the intent flips to `current`.

## Mockup pairs (15 files total)

| Mockup | Sub-route | Note |
|---|---|---|
| `sp4-game-detail-tab-rules` | `/games/[id]/rules` | Sections: setup / turn / victory + PDF citations + "Ask Agent" CTA. |
| `sp4-game-detail-tab-reviews` | `/games/[id]/reviews` | Friend-first M1 variant — friends section above community per gap report. |
| `sp4-game-detail-tab-strategies` | `/games/[id]/strategies` | Difficulty-pill cards + view/like meta. |
| `sp4-game-detail-tab-chat` | `/games/[id]/chat` | Standalone — replaces partial coverage via `sp4-game-chat-tab.html` composite. |
| `sp4-game-detail-tab-faqs` | `/games/[id]/faqs` | Game-scoped variant of public `sp3-faq-enhanced.html`. Collapsible `<details>` cards. |

## Bookkeeping

- `admin-mockups/MOCKUPS_INDEX.md` — 5 new rows under SP4 (sub-tab placeholder entries with `#2148` tag + "designer review required" note).
- `docs/for-developers/frontend/mockup-designer-review-queue.md` — new "US-9 sub-tab coverage" section with 5 graduation checkboxes.

## Fidelity contract for AI placeholders

- `design_intent: "forward-refactor"` (intentional placeholder).
- Relaxed acceptance: `visual_diff_max_px: 12` + `color_delta_e_max: 5` (vs `5/3` for production). Designer can tighten on review.
- `designer_approved_by` / `designer_approved_on` empty until graduation.
- `story_path` / `fixtures_path` empty — wired on graduation.

## Test plan

- [x] 15 files committed (5 mockup pairs × 3 files).
- [x] MOCKUPS_INDEX.md updated.
- [x] Designer review queue updated.
- [x] All 5 `fidelity.json` reference an existing `.html` source (via the new files in the same commit).
- [ ] CI: `pnpm lint:fidelity` validates all 5 stubs.

## Spec-panel rationale

> **Wiegers**: each placeholder ships with explicit acceptance criteria (relaxed but measurable), `forward-refactor` intent signals "not yet validated", and the designer-review queue defines the graduation contract.
> **Cockburn**: the primary stakeholder is US-9 dev team blocked on conformity coverage; AI stub is the bridge while designer-time is constrained.
> **Crispin**: relaxed `visual_diff_max_px: 12` admits the placeholder nature without making the gate vacuous.

Closes #2148

🤖 Generated with [Claude Code](https://claude.com/claude-code)