### PR TITLE
feat(nav-chrome): #2150 — runtime backfill primitives D5 + D6 (Hybrid pragmatico, Phase 1+3)

### DIFF
--- a/apps/web/src/components/layout/AppNav/AppTopBar.tsx
+++ b/apps/web/src/components/layout/AppNav/AppTopBar.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, Menu } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+import { LiveSessionPill } from '@/components/layout/AppNav/LiveSessionPill';
 import { UserMenuDropdown } from '@/components/layout/UserMenuDropdown';
 import { BrandMark } from '@/components/ui/brand';
 import {
@@ -123,6 +124,11 @@ export function AppTopBar({ adminMode, onMenuClick, className }: AppTopBarProps)
       )}
 
       <div className="flex-1" />
+
+      {/* Issue #2150 — runtime backfill of nav-chrome primitive D5: surfaces a
+          chip when a live session is active, with a Resume CTA. Hidden when
+          `useLiveSessionStore.sessionId === null` or `status === 'Completed'`. */}
+      {!adminMode && <LiveSessionPill />}
 
       <UserMenuDropdown variant="pill" />
     </header>

--- a/apps/web/src/components/layout/AppNav/LiveSessionPill.tsx
+++ b/apps/web/src/components/layout/AppNav/LiveSessionPill.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * LiveSessionPill — runtime backfill of nav-chrome primitive D5 (Issue #2150).
+ *
+ * Renders an entity-typed chip in the AppTopBar when a live game session is
+ * active. Provides:
+ *   - quick visual reminder that a session is in progress (entity color +
+ *     game name + elapsed timer)
+ *   - "Resume" CTA to jump back to `/sessions/[id]/live`
+ *
+ * Hybrid backfill rationale (#2150 decision):
+ *   - The `primitive-nav-topbar.html` mockup documents a LiveSessionPill on
+ *     the topbar; the runtime AppTopBar was missing it.
+ *   - Rather than regenerating 4 page-mocks to also document the pill
+ *     (Option B full backfill), we promote the runtime to feature-complete
+ *     and keep the page-mock convention of "no chrome shown" (Option A).
+ *   - The `primitive-nav-chat-panel.html` (D7) primitive is concurrently
+ *     marked `forward-refactor-obsolete` because there is no demand evidence.
+ *
+ * Source of truth for live state: `useLiveSessionStore` (Zustand,
+ * driven by SignalR `GameStateHub` events).
+ */
+
+import Link from 'next/link';
+
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+import { cn } from '@/lib/utils';
+
+interface LiveSessionPillProps {
+  className?: string;
+}
+
+/**
+ * Format `elapsedSeconds` as `mm:ss` (< 1h) or `h:mm` (>= 1h).
+ * Negative/null → `0:00`.
+ */
+function formatElapsed(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0:00';
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export function LiveSessionPill({ className }: LiveSessionPillProps) {
+  const sessionId = useLiveSessionStore(s => s.sessionId);
+  const gameName = useLiveSessionStore(s => s.gameName);
+  const status = useLiveSessionStore(s => s.status);
+  const elapsedSeconds = useLiveSessionStore(s => s.elapsedSeconds);
+
+  // No active session → render nothing. The topbar spacer collapses naturally.
+  if (!sessionId || status === 'Completed') return null;
+
+  const isPaused = status === 'Paused';
+  const elapsedLabel = formatElapsed(elapsedSeconds);
+  const displayName = gameName?.trim().length > 0 ? gameName : 'Sessione';
+
+  return (
+    <Link
+      href={`/sessions/${sessionId}/live`}
+      data-testid="live-session-pill"
+      data-slot="live-session-pill"
+      data-paused={isPaused ? 'true' : undefined}
+      aria-label={
+        isPaused
+          ? `Sessione ${displayName} in pausa, ${elapsedLabel} trascorsi. Riprendi.`
+          : `Sessione ${displayName} attiva, ${elapsedLabel} trascorsi. Riprendi.`
+      }
+      className={cn(
+        'group inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5',
+        'text-[12px] font-bold transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        // Two visual states: live (pulse + entity-game) vs paused (muted + amber).
+        isPaused
+          ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 hover:bg-amber-500/15'
+          : 'border-entity-game/40 bg-entity-game/10 text-entity-game-text hover:bg-entity-game/15',
+        className
+      )}
+    >
+      <span aria-hidden="true" className="text-base leading-none">
+        🎲
+      </span>
+      <span className="max-w-[140px] truncate" data-slot="live-session-pill-name">
+        {displayName}
+      </span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'inline-flex items-center gap-0.5 font-mono text-[11px] tabular-nums',
+          isPaused ? 'opacity-80' : 'opacity-90'
+        )}
+        data-slot="live-session-pill-elapsed"
+      >
+        <span className="text-[10px] leading-none">⏱</span>
+        {elapsedLabel}
+      </span>
+      {isPaused && (
+        <span
+          className="rounded-full bg-amber-500/20 px-1.5 py-0.5 text-[9px] uppercase tracking-wide"
+          data-slot="live-session-pill-status"
+        >
+          Pausa
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/apps/web/src/components/layout/AppNav/MobileBottomBar.tsx
+++ b/apps/web/src/components/layout/AppNav/MobileBottomBar.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { Gamepad2 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { BOTTOM_TAB_LABEL_OVERRIDES } from '@/config/navigation';
 import { useNavigationItems } from '@/hooks/useNavigationItems';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
 import { cn } from '@/lib/utils';
 
 import { isImmersiveRoute } from './immersive-routes';
@@ -19,14 +21,26 @@ interface MobileBottomBarProps {
 /**
  * Mobile bottom tab bar (sp4-dashboard graphic): the fixed primary tabs.
  * Hidden at `md`+ and on immersive in-session routes.
+ *
+ * Issue #2150 — runtime backfill of nav-chrome primitive D6:
+ * the `chat` slot (slot 3 of `BOTTOM_TAB_NAV_IDS`) is dynamically swapped
+ * with a "Live" entry pointing at the active live session when
+ * `useLiveSessionStore.sessionId !== null` and the session is not yet
+ * `Completed`. The slot returns to `chat` automatically when the session
+ * ends. Matches the `primitive-nav-bottom-mobile.html` mockup contract
+ * (`Aaron in /library, slot 3 = "💬 Chat"` idle, swapped during play).
  */
 export function MobileBottomBar({ className }: MobileBottomBarProps) {
   const pathname = usePathname();
   const { bottomTabItems, isItemActive } = useNavigationItems();
+  const liveSessionId = useLiveSessionStore(s => s.sessionId);
+  const liveSessionStatus = useLiveSessionStore(s => s.status);
 
   if (isImmersiveRoute(pathname) || bottomTabItems.length === 0) {
     return null;
   }
+
+  const showLiveSlot = liveSessionId !== null && liveSessionStatus !== 'Completed';
 
   return (
     <nav
@@ -44,6 +58,34 @@ export function MobileBottomBar({ className }: MobileBottomBarProps) {
       }}
     >
       {bottomTabItems.map(item => {
+        // Issue #2150 — D6 dynamic slot-3: swap `chat` for a `live` link when
+        // a session is active. Tested via the same `data-testid` slot prefix
+        // (`bottom-tab-live`) so consumers can detect the swap.
+        if (item.id === 'chat' && showLiveSlot && liveSessionId) {
+          const liveActive = pathname?.startsWith(`/sessions/${liveSessionId}`);
+          return (
+            <Link
+              key="live"
+              href={`/sessions/${liveSessionId}/live`}
+              data-testid="bottom-tab-live"
+              data-slot="bottom-tab-live"
+              aria-current={liveActive ? 'page' : undefined}
+              aria-label="Riprendi sessione in corso"
+              className={cn(
+                'flex min-h-[44px] flex-1 flex-col items-center justify-center gap-0.5 rounded-md py-1 text-[10px] font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                liveActive
+                  ? 'text-entity-game-text'
+                  : 'text-entity-game-text/80 hover:text-entity-game-text'
+              )}
+            >
+              <Gamepad2
+                className={cn('h-[22px] w-[22px] transition-transform', liveActive && 'scale-105')}
+              />
+              <span>Live</span>
+            </Link>
+          );
+        }
+
         const Icon = item.icon;
         const active = isItemActive(item, pathname);
         const label = BOTTOM_TAB_LABEL_OVERRIDES[item.id] ?? item.label;

--- a/apps/web/src/components/layout/AppNav/__tests__/LiveSessionPill.test.tsx
+++ b/apps/web/src/components/layout/AppNav/__tests__/LiveSessionPill.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * LiveSessionPill — unit tests (#2150 runtime backfill).
+ *
+ * Covers the 3 visual states (hidden / live / paused), elapsed-format edge
+ * cases, the a11y label contract, and the gameName fallback.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (registered before component import)
+// ---------------------------------------------------------------------------
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+interface MockStoreSnapshot {
+  sessionId: string | null;
+  gameName: string;
+  status: 'InProgress' | 'Paused' | 'Completed';
+  elapsedSeconds: number;
+}
+
+const mockStore: MockStoreSnapshot = {
+  sessionId: null,
+  gameName: '',
+  status: 'InProgress',
+  elapsedSeconds: 0,
+};
+
+vi.mock('@/lib/stores/live-session-store', () => ({
+  useLiveSessionStore: (selector: (s: MockStoreSnapshot) => unknown) => selector(mockStore),
+}));
+
+// Import AFTER mocks
+import { LiveSessionPill } from '../LiveSessionPill';
+
+function setStore(patch: Partial<MockStoreSnapshot>) {
+  Object.assign(mockStore, patch);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LiveSessionPill', () => {
+  beforeEach(() => {
+    setStore({ sessionId: null, gameName: '', status: 'InProgress', elapsedSeconds: 0 });
+  });
+
+  it('renders nothing when no session is active', () => {
+    const { container } = render(<LiveSessionPill />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the session has completed', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'Completed',
+      elapsedSeconds: 3600,
+    });
+    const { container } = render(<LiveSessionPill />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the game name and elapsed time when a session is in progress', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'InProgress',
+      elapsedSeconds: 90, // 1:30
+    });
+    render(<LiveSessionPill />);
+
+    const pill = screen.getByTestId('live-session-pill');
+    expect(pill).toHaveAttribute('href', '/sessions/sess-1/live');
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('1:30')).toBeInTheDocument();
+    expect(pill).not.toHaveAttribute('data-paused');
+    expect(screen.queryByText('Pausa')).not.toBeInTheDocument();
+  });
+
+  it('formats elapsed time as h:mm when longer than 1 hour', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Twilight Imperium',
+      status: 'InProgress',
+      elapsedSeconds: 3 * 3600 + 25 * 60, // 3:25
+    });
+    render(<LiveSessionPill />);
+    expect(screen.getByText('3:25')).toBeInTheDocument();
+  });
+
+  it('falls back to "Sessione" when gameName is empty', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: '   ',
+      status: 'InProgress',
+      elapsedSeconds: 42,
+    });
+    render(<LiveSessionPill />);
+    expect(screen.getByText('Sessione')).toBeInTheDocument();
+  });
+
+  it('shows the "Pausa" badge and amber styling when paused', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'Paused',
+      elapsedSeconds: 600, // 10:00
+    });
+    render(<LiveSessionPill />);
+    const pill = screen.getByTestId('live-session-pill');
+    expect(pill).toHaveAttribute('data-paused', 'true');
+    expect(screen.getByText('Pausa')).toBeInTheDocument();
+  });
+
+  it('uses a paused-specific aria-label when paused', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'Paused',
+      elapsedSeconds: 600,
+    });
+    render(<LiveSessionPill />);
+    const pill = screen.getByTestId('live-session-pill');
+    expect(pill).toHaveAccessibleName(/in pausa/i);
+    expect(pill).toHaveAccessibleName(/10:00/);
+  });
+
+  it('uses an active-specific aria-label when in progress', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'InProgress',
+      elapsedSeconds: 75,
+    });
+    render(<LiveSessionPill />);
+    const pill = screen.getByTestId('live-session-pill');
+    expect(pill).toHaveAccessibleName(/attiva/i);
+    expect(pill).toHaveAccessibleName(/1:15/);
+  });
+
+  it('clamps negative / non-finite elapsed seconds to "0:00"', () => {
+    setStore({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'InProgress',
+      elapsedSeconds: -42,
+    });
+    render(<LiveSessionPill />);
+    expect(screen.getByText('0:00')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/AppNav/__tests__/MobileBottomBar.test.tsx
+++ b/apps/web/src/components/layout/AppNav/__tests__/MobileBottomBar.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/hooks/queries/useCurrentUser', () => ({
 }));
 
 import { MobileBottomBar, isImmersiveRoute } from '@/components/layout/AppNav/MobileBottomBar';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
 
 describe('MobileBottomBar', () => {
   it('renders the 5 fixed sp4 tabs (Dashboard tab labelled "Home")', () => {
@@ -43,6 +44,65 @@ describe('MobileBottomBar', () => {
   it('links the Home tab to /dashboard', () => {
     render(<MobileBottomBar />);
     expect(screen.getByText('Home').closest('a')?.getAttribute('href')).toBe('/dashboard');
+  });
+});
+
+describe('MobileBottomBar — dynamic slot-3 (Issue #2150 D6)', () => {
+  // The live session store is the real Zustand store; we drive it directly
+  // via its `setSession`/`reset` actions. This avoids over-mocking and
+  // exercises the actual selector wiring.
+  function withLiveSession(
+    sessionId: string,
+    status: 'InProgress' | 'Paused' | 'Completed' = 'InProgress'
+  ) {
+    useLiveSessionStore.setState({ sessionId, status, gameName: 'Catan' });
+  }
+
+  function resetSession() {
+    useLiveSessionStore.getState().reset();
+  }
+
+  it('swaps the Chat slot for a Live link when a session is in progress', () => {
+    withLiveSession('sess-1', 'InProgress');
+    try {
+      render(<MobileBottomBar />);
+      expect(screen.queryByText('Chat')).toBeNull();
+      expect(screen.getByText('Live')).toBeDefined();
+      expect(screen.getByTestId('bottom-tab-live').getAttribute('href')).toBe(
+        '/sessions/sess-1/live'
+      );
+    } finally {
+      resetSession();
+    }
+  });
+
+  it('keeps the Chat slot when the session is Completed', () => {
+    withLiveSession('sess-1', 'Completed');
+    try {
+      render(<MobileBottomBar />);
+      expect(screen.getByText('Chat')).toBeDefined();
+      expect(screen.queryByText('Live')).toBeNull();
+    } finally {
+      resetSession();
+    }
+  });
+
+  it('keeps the Chat slot when no session is active', () => {
+    resetSession(); // ensure clean state
+    render(<MobileBottomBar />);
+    expect(screen.getByText('Chat')).toBeDefined();
+    expect(screen.queryByText('Live')).toBeNull();
+  });
+
+  it('also swaps the slot when the session is Paused (still actively live)', () => {
+    withLiveSession('sess-1', 'Paused');
+    try {
+      render(<MobileBottomBar />);
+      expect(screen.getByText('Live')).toBeDefined();
+      expect(screen.queryByText('Chat')).toBeNull();
+    } finally {
+      resetSession();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

DS-17 Phase B audit Section A found a 3-way drift between the `primitive-nav-*` mockup primitives and the runtime `AppTopBar` + `MobileBottomBar`. This PR ships the **Hybrid pragmatico** option locked during planning: backfill the runtime with the UX-critical pieces (D5 LiveSessionPill, D6 dynamic slot-3) and accept the convention that page-mocks never document chrome.

## Phase 1 — D5 LiveSessionPill on AppTopBar

New `apps/web/src/components/layout/AppNav/LiveSessionPill.tsx`:

- Subscribes to `useLiveSessionStore` (Zustand) for `sessionId`, `gameName`, `status`, `elapsedSeconds`.
- Renders nothing when no session is active or `status === 'Completed'` — the topbar spacer collapses naturally.
- Renders an entity-game-colored pill with:
  - `🎲` emoji + game name (truncated >140px),
  - elapsed timer formatted `mm:ss` (<1h) or `h:mm` (≥1h),
  - "Pausa" amber badge when `status === 'Paused'`.
- Links to `/sessions/[id]/live` so the pill doubles as a Resume CTA.
- A11y: distinct aria-label for paused vs in-progress states.

Wired in `AppTopBar.tsx` between the spacer and `UserMenuDropdown` (user shell only — admin chrome unchanged).

## Phase 3 — D6 dynamic slot-3 on MobileBottomBar

`MobileBottomBar.tsx` now subscribes to the same store and swaps the fixed `chat` slot for a `Live` link pointing at the active session when `sessionId !== null && status !== 'Completed'`. The slot returns to `chat` automatically when the session completes or the store is reset. Mirrors the `primitive-nav-bottom-mobile.html` mockup contract.

## Numbers

**5 files changed · +386 LOC** (1 new component + 1 new test + 1 component edit + 1 test edit + 1 topbar wiring).

## Test plan

- [x] **9 unit tests** for `LiveSessionPill` covering hidden / live / paused states, `h:mm` vs `mm:ss` formatting, `gameName` fallback, negative-seconds clamp, a11y labels.
- [x] **4 new unit tests** for `MobileBottomBar` slot swap in InProgress / Paused / Completed / no-session states.
- [x] **16 existing tests** (AppTopBar + MobileTopBar + MobileBottomBar) continue to pass (backward-compatible: store default `sessionId = null` → render path unchanged).
- [x] **Total 29/29** in `src/components/layout/AppNav/__tests__/`.
- [ ] CI: full vitest + lint + typecheck pass.

## Deferred — sub-issues spawned

| Sub-issue | Phase | Reason |
|---|---|---|
| **#2320** | **Phase 2** — ⌘K SearchPill trigger | `CommandPalette` + `useCommandPalette` exist but the palette is **never mounted** (`_showCommandPalette` in `providers.tsx` is `_`-prefixed unused). Wiring requires `dataSources` plumbing — bigger than this PR. |
| **#2321** | **Phase 4** — D7 chat-panel obsolete flip | Sequenced after #2317 (#2152 Bundle B rename) merges, to avoid file-name conflict on the `fidelity.json`. 2-line follow-up post-merge. |

Phase 5 (E2E spec + Storybook snapshot) also deferred to a focused follow-up so the runtime PR stays reviewable.

## Spec-panel rationale

> **Fowler**: Hybrid keeps the D5/D6 institutional memory and ships the LiveSession UX (the most-valuable primitive concept) without the cost of regenerating 4 page-mocks.
> **Crispin**: backward-compat regression suite preserved — 16 unmodified tests continue to pass because the Zustand store default (`sessionId: null`) collapses to the legacy render path.
> **Nygard**: the dormant `CommandPalette` discovery (Phase 2 scope creep) is captured in the follow-up issue rather than silently bloating this PR.

Closes #2150

🤖 Generated with [Claude Code](https://claude.com/claude-code)