### PR TITLE
fix(hub): #2081 StickyCta auto-hides when user is authenticated

### DIFF
--- a/apps/web/src/components/ui/detail-layout/sticky-cta.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/sticky-cta.test.tsx
@@ -9,9 +9,17 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(),
+}));
+
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 
 import { StickyCta } from './sticky-cta';
+
+const mockedUseCurrentUser = vi.mocked(useCurrentUser);
 
 const labels = {
   mobileLabel: 'Accedi per installare',
@@ -21,6 +29,15 @@ const labels = {
 };
 
 describe('StickyCta (Wave A.4)', () => {
+  beforeEach(() => {
+    mockedUseCurrentUser.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+    } as never);
+  });
+
   it('renders both mobile and desktop region landmarks', () => {
     render(<StickyCta signInHref="/sign-in" labels={labels} />);
     const regions = screen.getAllByRole('region', { name: 'Sticky CTA' });
@@ -56,5 +73,49 @@ describe('StickyCta (Wave A.4)', () => {
     render(<StickyCta signInHref="/sign-in" labels={labels} />);
     expect(screen.getByText('Per installare questi contenuti...')).toBeInTheDocument();
     expect(screen.getByText('Accedi')).toBeInTheDocument();
+  });
+
+  describe('issue #2081 — auth guard', () => {
+    afterEach(() => {
+      mockedUseCurrentUser.mockReset();
+    });
+
+    it('returns null when user is authenticated (no CTA rendered)', () => {
+      mockedUseCurrentUser.mockReturnValue({
+        data: { id: 'u1', email: 'a@b.com', role: 'user' } as never,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+      } as never);
+
+      const { container } = render(<StickyCta signInHref="/sign-in" labels={labels} />);
+      expect(container.firstChild).toBeNull();
+      expect(screen.queryAllByRole('region', { name: 'Sticky CTA' })).toHaveLength(0);
+    });
+
+    it('returns null while auth state is loading (no flash)', () => {
+      mockedUseCurrentUser.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        isSuccess: false,
+      } as never);
+
+      const { container } = render(<StickyCta signInHref="/sign-in" labels={labels} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders full CTA when user is not authenticated (guest)', () => {
+      mockedUseCurrentUser.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+      } as never);
+
+      render(<StickyCta signInHref="/sign-in" labels={labels} />);
+      const regions = screen.getAllByRole('region', { name: 'Sticky CTA' });
+      expect(regions).toHaveLength(2); // mobile + desktop
+    });
   });
 });

--- a/apps/web/src/components/ui/detail-layout/sticky-cta.tsx
+++ b/apps/web/src/components/ui/detail-layout/sticky-cta.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 primitive — see token-bridge-map.md for migration plan. */
+'use client';
+
 /**
  * StickyCta — guest gating CTA for /shared-games/[id] V2.
  *
@@ -13,6 +15,13 @@
  *
  * Both share the same href + label (`signInHref` + `installLabel`). Component is
  * stateless / link-only — actual auth flow happens on `signInHref` route.
+ *
+ * Issue #2081 — Internal auth guard via useCurrentUser():
+ *  - Returns null when authenticated (no flash for logged-in users)
+ *  - Returns null during auth loading (conservative — prevents flash)
+ *  - Renders full CTA only for confirmed guests
+ *  - Caller's `hideStickyCta` prop on SharedGameDetailPageClient is still
+ *    honored as explicit override.
  */
 
 import type { JSX } from 'react';
@@ -20,6 +29,7 @@ import type { JSX } from 'react';
 import clsx from 'clsx';
 
 import { entityHsl } from '@/components/ui/data-display/meeple-card/tokens';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 
 export interface StickyCtaLabels {
   /** Mobile full-width button label, e.g. "🔒 Accedi per installare". */
@@ -38,7 +48,14 @@ export interface StickyCtaProps {
   readonly className?: string;
 }
 
-export function StickyCta({ signInHref, labels, className }: StickyCtaProps): JSX.Element {
+export function StickyCta({ signInHref, labels, className }: StickyCtaProps): JSX.Element | null {
+  const { data: user, isLoading } = useCurrentUser();
+
+  // Issue #2081: hide CTA when user is authenticated or during initial auth check
+  if (isLoading || user) {
+    return null;
+  }
+
   return (
     <>
       {/* Mobile: full-width sticky bar */}


### PR DESCRIPTION
## Summary

Risolve il bug user-reported in #2081: utente autenticato che visita `/shared-games/[id]` o `/hub/games/[id]` vede il `StickyCta` "Accedi per installare" anche se loggato.

### Fix

Component ora self-guards via `useCurrentUser()`:
- Returns `null` quando autenticato (no flash per logged-in users)
- Returns `null` durante `isLoading=true` (conservative, prevents flash transizionale)
- Renders full CTA solo per guest confermati

Pattern allineato a `EmailVerificationBanner.tsx:59` (return `null` based on hook data).

### Backward-compat

Il prop `hideStickyCta` su `SharedGameDetailPageClient` resta come override esplicito (defensive). Il check JSX esterno `{!hideStickyCta && <StickyCta ...>}` è ora ridondante ma non-breaking — `hideStickyCta=true` short-circuit prima ancora che il hook fire (lieve efficiency gain).

### Files

- `apps/web/src/components/ui/detail-layout/sticky-cta.tsx` (+30, -2) — `'use client'` + guard + return type `JSX.Element | null`
- `apps/web/src/components/ui/detail-layout/sticky-cta.test.tsx` (+50, -0) — mock setup + 3 nuovi test (authenticated/loading/guest)

## Test plan

- [x] 5 existing Wave A.4 tests updated con `beforeEach` mock guest user
- [x] 3 new tests per issue #2081
- [x] 8/8 vitest passing (`pnpm vitest run src/components/ui/detail-layout/sticky-cta.test.tsx`)
- [x] `pnpm typecheck` clean
- [x] `pnpm eslint` 0 errors

## Review

Internal holistic review (`feature-dev:code-reviewer`) APPROVED:
- Spec compliant — tutti i 5 requirements del plan presenti
- Quality: 1 minor finding non-blocking (mockReset vs mockClear theoretical risk)
- Race condition coverage: 3 stati TanStack Query (loading/guest/authenticated) tutti gestiti
- A11y: aria-region disappear cleanly, no keyboard trap, no focus management issue
- Backward-compat: nessun consumer rotto

## Plan reference

`docs/superpowers/plans/2026-06-14-issue-2081-sticky-cta-auth-guard.md`

Closes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)