### PR TITLE
feat(nav-chrome): #2320 wire CommandPalette + SearchPill in AppTopBar

### DIFF
--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -16,6 +16,7 @@ import { AccessibleSkipLink } from '@/components/accessible';
 import { AuthProvider } from '@/components/auth/AuthProvider';
 import { ErrorBoundary, RouteErrorBoundary } from '@/components/errors';
 import { KeyboardShortcutsHelp, LayoutProvider } from '@/components/layout';
+import { CommandPalette } from '@/components/layout/CommandPalette';
 import { CookieConsentBanner } from '@/components/legal';
 import { AddGameWizardProvider } from '@/components/library/add-game-sheet/AddGameWizardProvider';
 import { SessionWarningModal } from '@/components/modals';
@@ -41,7 +42,24 @@ function AppContent({ children }: { children: ReactNode }) {
 
   // Issue #1100: Keyboard shortcuts system
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
-  const [_showCommandPalette, setShowCommandPalette] = useState(false);
+  // Issue #2320: wire CommandPalette into the providers tree so the keyboard
+  // shortcut (Cmd/Ctrl+K, registered by useGlobalKeyboardShortcuts below)
+  // actually surfaces the palette. The SearchPill button in `AppTopBar`
+  // calls into the same state via the `meeple:command-palette:open` event hub
+  // (see useEffect below). Keeps providers.tsx + AppTopBar decoupled —
+  // no React context plumbing required.
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
+
+  // Issue #2320: listen for `meeple:command-palette:open` from the
+  // SearchPill trigger button in `AppTopBar`. Decouples the trigger from
+  // the modal state without introducing a new context layer.
+  useEffect(() => {
+    function handleOpen() {
+      setShowCommandPalette(true);
+    }
+    window.addEventListener('meeple:command-palette:open', handleOpen);
+    return () => window.removeEventListener('meeple:command-palette:open', handleOpen);
+  }, []);
 
   // Enable axe-core accessibility checks in development (UI-05, Issue #841)
   // Moved to useEffect to avoid page crashes during Playwright tests
@@ -124,6 +142,18 @@ function AppContent({ children }: { children: ReactNode }) {
       <KeyboardShortcutsHelp
         isOpen={showShortcutsHelp}
         onClose={() => setShowShortcutsHelp(false)}
+      />
+
+      {/* Issue #2320 (#1101 v1): mount CommandPalette so Cmd/Ctrl+K and the
+          AppTopBar SearchPill trigger an actual modal. v1 ships with empty
+          dataSources — the cmdk index renders correctly (graceful empty
+          state) while a follow-up issue wires per-domain React Query hooks
+          (messages / chats / games / agents) or a unified global-search BE
+          endpoint. The keyboard shortcut + open/close UX is testable today. */}
+      <CommandPalette
+        isOpen={showCommandPalette}
+        onClose={() => setShowCommandPalette(false)}
+        dataSources={{}}
       />
     </PWAProvider>
   );

--- a/apps/web/src/components/layout/AppNav/AppTopBar.tsx
+++ b/apps/web/src/components/layout/AppNav/AppTopBar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { LiveSessionPill } from '@/components/layout/AppNav/LiveSessionPill';
+import { SearchPill } from '@/components/layout/AppNav/SearchPill';
 import { UserMenuDropdown } from '@/components/layout/UserMenuDropdown';
 import { BrandMark } from '@/components/ui/brand';
 import {
@@ -124,6 +125,12 @@ export function AppTopBar({ adminMode, onMenuClick, className }: AppTopBarProps)
       )}
 
       <div className="flex-1" />
+
+      {/* Issue #2320 — D5 search slot trigger. Click dispatches a window
+          event that the CommandPalette host in `providers.tsx` listens for.
+          Keyboard shortcut (Cmd/Ctrl+K) is wired in `useGlobalKeyboardShortcuts`
+          and opens the same modal. Visible in both user and admin shells. */}
+      <SearchPill />
 
       {/* Issue #2150 — runtime backfill of nav-chrome primitive D5: surfaces a
           chip when a live session is active, with a Resume CTA. Hidden when

--- a/apps/web/src/components/layout/AppNav/SearchPill.tsx
+++ b/apps/web/src/components/layout/AppNav/SearchPill.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+/**
+ * SearchPill — runtime backfill of nav-chrome primitive D5 search slot (Issue #2320).
+ *
+ * Renders the search-pill trigger in the AppTopBar. Clicking dispatches a
+ * `meeple:command-palette:open` window event that the CommandPalette host
+ * in `providers.tsx` listens for. Decouples the trigger from the modal
+ * state without introducing a new React context layer.
+ *
+ * The keyboard shortcut (Cmd/Ctrl+K) lives in
+ * `useGlobalKeyboardShortcuts` and is already wired into the same
+ * provider state; this button is the *visual + click* alternative.
+ *
+ * Design source: `primitive-nav-topbar.html` (D5 search slot — collapsed
+ * pill state). Once focused / clicked, the CommandPalette modal takes
+ * over from the static pill.
+ */
+
+import { useCallback } from 'react';
+
+import { Search } from 'lucide-react';
+
+import { isMac, modKey } from '@/hooks/useKeyboardShortcuts';
+import { cn } from '@/lib/utils';
+
+interface SearchPillProps {
+  className?: string;
+}
+
+export function SearchPill({ className }: SearchPillProps) {
+  const handleClick = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('meeple:command-palette:open'));
+  }, []);
+
+  return (
+    <button
+      type="button"
+      data-testid="topbar-search-pill"
+      data-slot="topbar-search-pill"
+      onClick={handleClick}
+      aria-label={`Apri ricerca globale (${isMac ? '⌘K' : 'Ctrl+K'})`}
+      className={cn(
+        'group inline-flex shrink-0 items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-1.5',
+        'text-[12px] font-medium text-muted-foreground transition-colors',
+        'hover:bg-muted hover:text-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        className
+      )}
+    >
+      <Search aria-hidden="true" className="h-3.5 w-3.5 opacity-75" />
+      <span className="hidden lg:inline">Cerca…</span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'hidden items-center gap-0.5 rounded border border-border bg-background px-1 py-0.5 font-mono text-[10px] font-semibold opacity-70 lg:inline-flex'
+        )}
+      >
+        {modKey}K
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/AppNav/__tests__/SearchPill.test.tsx
+++ b/apps/web/src/components/layout/AppNav/__tests__/SearchPill.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * SearchPill — unit tests (#2320 CommandPalette wiring).
+ *
+ * Covers the basic trigger contract: rendering, the dispatched window event,
+ * and the a11y label.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SearchPill } from '../SearchPill';
+
+describe('SearchPill', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the search-pill trigger button', () => {
+    render(<SearchPill />);
+    expect(screen.getByTestId('topbar-search-pill')).toBeInTheDocument();
+  });
+
+  it('dispatches `meeple:command-palette:open` when clicked', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    render(<SearchPill />);
+    fireEvent.click(screen.getByTestId('topbar-search-pill'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    const event = spy.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe('meeple:command-palette:open');
+  });
+
+  it('exposes an a11y label mentioning the keyboard shortcut', () => {
+    render(<SearchPill />);
+    const button = screen.getByTestId('topbar-search-pill');
+    expect(button.getAttribute('aria-label')).toMatch(/ricerca globale/i);
+    // platform-dependent (⌘ on mac, Ctrl on win/linux) — just check the K suffix.
+    expect(button.getAttribute('aria-label')).toMatch(/K\)$/);
+  });
+});


### PR DESCRIPTION
Wires dormant CommandPalette in providers.tsx + adds SearchPill trigger. v1 ships with empty dataSources (graceful empty state); per-domain wiring deferred. Cmd/Ctrl+K + click trigger same modal via window event bus. 3/3 new SearchPill tests + 7/7 AppTopBar tests pass. Closes #2320