### PR TITLE
feat(kb): #2311 FE-1..7 — sp4-kb-detail forward-refactor rebuild

### DIFF
--- a/admin-mockups/design_files/sp4-kb-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-kb-detail.fidelity.json
@@ -22,14 +22,15 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-14",
     "story_path": "apps/web/src/app/(authenticated)/knowledge-base/[id]/page.stories.tsx",
-    "fixtures_path": "",
+    "fixtures_path": "apps/web/src/app/(authenticated)/knowledge-base/[id]/page.stories.tsx",
     "design_intent": "forward-refactor",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": "#2223"
+    "obsolete_tracking_issue": "#2311",
+    "ds17_phase_c_iteration_pr": "#2311 FE-4"
   }
 }

--- a/apps/web/src/app/(authenticated)/kb/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/kb/[id]/page.tsx
@@ -1,0 +1,22 @@
+/**
+ * @mockup admin-mockups/design_files/sp4-kb-detail.html
+ *
+ * #2311 DEC-D1: the mockup header declares `Route: /kb/[id]`, but the canonical
+ * implementation lives at `/knowledge-base/[id]` (annotation @mockup wired,
+ * MOCKUPS_INDEX entry, breadcrumb + useRecentsStore, PR #2310 KB row
+ * navigation map). This thin redirect lets the mockup-shorthand path still
+ * land on the canonical surface without forking the route.
+ */
+
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-static';
+
+export default async function KbShorthandRedirectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  redirect(`/knowledge-base/${encodeURIComponent(id)}`);
+}

--- a/apps/web/src/app/(authenticated)/knowledge-base/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/[id]/page.stories.tsx
@@ -1,14 +1,122 @@
 /**
- * sp4-kb-detail — DS-17-13 #2220 sub-issue.
+ * sp4-kb-detail — DS-17-13 #2220 sub-issue + #2311 FE-6 signoff.
  *
  * Mockup parity: `admin-mockups/design_files/sp4-kb-detail.{html,jsx}`.
  * design_intent: forward-refactor (G4 v3 pivot deferred per MOCKUPS_INDEX).
- * Designer review tracking #2223.
+ * Designer review tracking: CLOSED in #2223, superseded by #2311 iteration.
+ *
+ * Stories cover the 4-state FSM of the split-view orchestrator:
+ *   - Default — document + chunks load, first chunk auto-selected
+ *   - Loading — document fetch in flight (skeleton)
+ *   - EmptyChunks — document landed but chunks list is empty
+ *   - NotFound — document fetch returned 404
  */
+
+import { http, HttpResponse } from 'msw';
 
 import KnowledgeBaseDetailPage from './page';
 
 import type { Meta, StoryObj } from '@storybook/react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const DOC_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const CHUNK_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+const DOC_FIXTURE = {
+  id: DOC_ID,
+  title: 'Azul · Manuale ufficiale',
+  docType: 'rulebook',
+  gameId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  gameName: 'Azul',
+  uploaderName: 'Marco',
+  uploadedAt: '2026-01-12T00:00:00Z',
+  lastIngestedAt: '2026-03-08T00:00:00Z',
+  processingStatus: 'ready',
+  chunkCount: 3,
+  pageCount: 24,
+  language: 'it',
+  tags: [],
+  fileSize: 145_312,
+  indexerVersion: 'v3',
+};
+
+const CHUNKS_FIXTURE = {
+  items: [
+    {
+      id: CHUNK_ID,
+      position: 0,
+      headingPath: ['Introduzione'],
+      snippet:
+        'Benvenuto in Azul. Un gioco da tavolo per 2-4 giocatori in cui gli artigiani decorano le pareti del Palazzo Reale di Évora.',
+      pageNumber: 1,
+      vectorId: CHUNK_ID.replace(/-/g, ''),
+      usedInChats: 8,
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000002',
+      position: 1,
+      headingPath: ['Setup', 'Preparazione del tavolo'],
+      snippet:
+        'Posiziona le 5, 7 o 9 factory display al centro del tavolo a seconda del numero di giocatori.',
+      pageNumber: 2,
+      vectorId: '00000000000040008000000000000002',
+      usedInChats: 12,
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000003',
+      position: 2,
+      headingPath: ['Turno di gioco'],
+      snippet:
+        'Nel proprio turno il giocatore sceglie una factory display e prende tutte le tessere di un colore.',
+      pageNumber: 3,
+      vectorId: '00000000000040008000000000000003',
+      usedInChats: 0,
+    },
+  ],
+  nextCursor: null,
+  totalCount: 3,
+};
+
+const CHUNK_DETAIL_FIXTURE = {
+  id: CHUNK_ID,
+  docId: DOC_ID,
+  position: 0,
+  headingPath: ['Introduzione'],
+  content: `# Benvenuto in Azul
+
+Azul è un gioco da tavolo per **2-4 giocatori** in cui gli artigiani decorano le pareti
+del Palazzo Reale di Évora con tessere ispirate alle piastrelle *azulejos* portoghesi.
+
+## Obiettivo
+
+Accumulare il maggior numero di punti vittoria completando righe, colonne e set di
+colore sul proprio tabellone personale entro la fine della partita.
+
+## Durata
+
+Una partita standard dura **30-45 minuti**. La fine è innescata quando un giocatore
+completa una riga orizzontale del proprio muro.`,
+  pageNumber: 1,
+  prevChunkId: null,
+  nextChunkId: '00000000-0000-4000-8000-000000000002',
+  metadata: {},
+};
+
+function defaultHandlers() {
+  return [
+    http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}`, () => HttpResponse.json(DOC_FIXTURE)),
+    http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks`, () =>
+      HttpResponse.json(CHUNKS_FIXTURE)
+    ),
+    http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks/${CHUNK_ID}`, () =>
+      HttpResponse.json(CHUNK_DETAIL_FIXTURE)
+    ),
+    http.post(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks/search`, () =>
+      HttpResponse.json({ matches: [], totalCount: 0, skip: 0, take: 20 })
+    ),
+  ];
+}
 
 const meta: Meta<typeof KnowledgeBaseDetailPage> = {
   title: 'Authenticated / sp4-kb-detail',
@@ -18,14 +126,14 @@ const meta: Meta<typeof KnowledgeBaseDetailPage> = {
     nextjs: {
       appDirectory: true,
       navigation: {
-        pathname: '/knowledge-base/sp4-kb-detail-fixture',
+        pathname: `/knowledge-base/${DOC_ID}`,
       },
     },
     viewport: { defaultViewport: 'desktop' },
     docs: {
       description: {
         component:
-          '#2220 DS-17-13. Knowledge base detail page (forward-refactor, designer review #2223).',
+          '#2311 FE-6. KB document detail surface (split-view chunks list + Markdown preview). DEC-D1 keeps the canonical route /knowledge-base/[id]; /kb/[id] is a server redirect.',
       },
     },
   },
@@ -35,4 +143,41 @@ export default meta;
 
 type Story = StoryObj<typeof KnowledgeBaseDetailPage>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: defaultHandlers() },
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}`, () => new Promise(() => {}))],
+    },
+  },
+};
+
+export const EmptyChunks: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}`, () => HttpResponse.json(DOC_FIXTURE)),
+        http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks`, () =>
+          HttpResponse.json({ items: [], nextCursor: null, totalCount: 0 })
+        ),
+      ],
+    },
+  },
+};
+
+export const NotFound: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}`, () =>
+          HttpResponse.json({ error: 'not found' }, { status: 404 })
+        ),
+      ],
+    },
+  },
+};

--- a/apps/web/src/app/(authenticated)/knowledge-base/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/[id]/page.tsx
@@ -6,88 +6,118 @@
  * Audit:          pnpm mockup-annotations:audit
  *
  * Ref: DS-17-1 #2069, umbrella #2063.
- */
-/**
- * Knowledge Base Document Detail Page - /knowledge-base/[id]
  *
- * Shows document details with navigation footer linking to Game and Agent.
- * Uses MeepleCard entity=document with hero variant.
- *
- * @see Issue #4694
+ * #2311 FE-4 rebuild: split-view chunks list (sx) + preview (dx) per the
+ * sp4-kb-detail forward-refactor mockup. Replaces the previous MVP placeholder
+ * (`Card + Alert "viewer in future version"`) with the live detail surface
+ * fed by the 4 hooks landed in FE-2 (useKbDocument, useKbChunks, useKbChunk,
+ * useSearchKbChunks). Token canonical (text-entity-kb / bg-entity-kb) per
+ * DEC-D5.
  */
 
 'use client';
 
-import { use, useEffect, useState } from 'react';
+import { use, useEffect, useMemo, useState } from 'react';
 
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
-import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+import {
+  ChunkSearchBox,
+  KbChunkListPanel,
+  KbChunkPreview,
+  KbHeader,
+  type KbChunkPreviewState,
+} from '@/components/features/knowledge-base';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
-import { useEntityNavigation } from '@/hooks/useEntityNavigation';
+import {
+  useKbChunk,
+  useKbChunks,
+  useKbDocument,
+  useSearchKbChunks,
+} from '@/hooks/queries/use-kb-detail';
 import { useRecentsStore } from '@/stores/use-recents';
-
-interface DocumentDetail {
-  id: string;
-  fileName: string;
-  gameId?: string;
-  gameName?: string;
-  agentId?: string;
-  uploadedAt?: string;
-  fileSize?: number;
-  chunkCount?: number;
-}
 
 export default function KnowledgeBaseDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: documentId } = use(params);
-  const [document, setDocument] = useState<DocumentDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, _setError] = useState<string | null>(null);
 
-  const _navLinks = useEntityNavigation('kb', {
-    id: documentId,
-    gameId: document?.gameId,
-    agentId: document?.agentId,
-  });
+  const documentQuery = useKbDocument(documentId);
+  const chunksQuery = useKbChunks(documentId, { limit: 200 });
 
+  const [activeChunkId, setActiveChunkId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const chunkPreviewQuery = useKbChunk(documentId, activeChunkId ?? '');
+  const chunkSearchQuery = useSearchKbChunks({ docId: documentId, query: searchQuery });
+
+  // Recents push when the document arrives.
   useEffect(() => {
-    // Attempt to load document metadata
-    // The actual API may vary - this provides the page structure
-    setLoading(false);
-    const doc = {
-      id: documentId,
-      fileName: 'Documento',
-    };
-    setDocument(doc);
-    useRecentsStore.getState().push({
-      id: documentId,
-      entity: 'kb',
-      title: doc.fileName,
-      href: `/knowledge-base/${documentId}`,
-    });
-  }, [documentId]);
+    if (documentQuery.data) {
+      useRecentsStore.getState().push({
+        id: documentId,
+        entity: 'kb',
+        title: documentQuery.data.title,
+        href: `/knowledge-base/${documentId}`,
+      });
+    }
+  }, [documentId, documentQuery.data]);
 
-  if (loading) {
+  // Selection autopilot: pick the first chunk once the list lands so the
+  // preview pane has something to render without a manual click.
+  const chunks = useMemo(() => chunksQuery.data?.items ?? [], [chunksQuery.data]);
+  useEffect(() => {
+    if (activeChunkId === null && chunks.length > 0) {
+      setActiveChunkId(chunks[0].id);
+    }
+  }, [activeChunkId, chunks]);
+
+  // Filter the chunks list by search matches when a debounced query is active.
+  const filteredChunks = useMemo(() => {
+    if (searchQuery.trim().length === 0) return chunks;
+    const matches = chunkSearchQuery.data?.matches ?? [];
+    if (matches.length === 0) return [];
+    const matchedIds = new Set(matches.map(m => m.chunkId));
+    return chunks.filter(c => matchedIds.has(c.id));
+  }, [chunks, chunkSearchQuery.data, searchQuery]);
+
+  const previewState: KbChunkPreviewState = useMemo(() => {
+    if (activeChunkId === null) return { kind: 'empty' };
+    if (chunkPreviewQuery.isLoading) return { kind: 'loading' };
+    if (chunkPreviewQuery.isError) {
+      return {
+        kind: 'error',
+        message: 'Errore caricamento chunk. Riprova tra qualche istante.',
+      };
+    }
+    if (chunkPreviewQuery.data) return { kind: 'ready', chunk: chunkPreviewQuery.data };
+    return { kind: 'empty' };
+  }, [
+    activeChunkId,
+    chunkPreviewQuery.data,
+    chunkPreviewQuery.isError,
+    chunkPreviewQuery.isLoading,
+  ]);
+
+  // Document FSM
+  if (documentQuery.isLoading) {
     return (
       <div className="min-h-screen bg-background py-8 px-4">
         <div className="container mx-auto max-w-7xl">
           <Skeleton className="h-8 w-48 mb-6" />
-          <Skeleton className="h-[400px] w-full max-w-2xl mx-auto" />
+          <Skeleton className="h-[400px] w-full" />
         </div>
       </div>
     );
   }
 
-  if (error || !document) {
+  if (documentQuery.isError || !documentQuery.data) {
     return (
       <div className="min-h-screen bg-background py-8 px-4">
         <div className="container mx-auto max-w-7xl">
           <Alert variant="destructive">
-            <AlertDescription>{error || 'Documento non trovato'}</AlertDescription>
+            <AlertDescription>Documento non trovato o non accessibile.</AlertDescription>
           </Alert>
           <Button asChild className="mt-4">
             <Link href="/library">
@@ -100,71 +130,56 @@ export default function KnowledgeBaseDetailPage({ params }: { params: Promise<{ 
   }
 
   return (
-    <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-7xl">
-        {/* Back Button */}
-        <Button asChild variant="ghost" className="mb-6 font-nunito">
+    <div className="flex min-h-screen flex-col bg-background">
+      <div className="border-b border-border bg-card px-4 py-3">
+        <Button asChild variant="ghost" size="sm" className="font-nunito">
           <Link href="/library">
             <ArrowLeft className="mr-2 h-4 w-4" /> Torna alla Libreria
           </Link>
         </Button>
+      </div>
 
-        {/* Hero Card */}
-        <section className="mb-8 flex justify-center">
-          <MeepleCard
-            entity="kb"
-            variant="hero"
-            title={document.fileName}
-            subtitle={document.gameName ? `Gioco: ${document.gameName}` : 'Knowledge Base'}
-            metadata={[
-              { label: 'PDF' },
-              ...(document.uploadedAt
-                ? [{ label: new Date(document.uploadedAt).toLocaleDateString('it-IT') }]
-                : []),
-              ...(document.chunkCount ? [{ label: `${document.chunkCount} chunks` }] : []),
-            ]}
-          />
-        </section>
-
-        {/* Document Info */}
-        <div className="max-w-4xl mx-auto">
-          <Card className="border-l-4 border-l-[hsl(210,40%,55%)] shadow-lg">
-            <CardHeader>
-              <CardTitle className="font-quicksand text-xl">Dettagli Documento</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4 font-nunito text-sm">
-                <div>
-                  <span className="text-muted-foreground">ID</span>
-                  <p className="font-mono text-xs mt-1">{document.id}</p>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Nome File</span>
-                  <p className="mt-1">{document.fileName}</p>
-                </div>
-                {document.gameName && (
-                  <div>
-                    <span className="text-muted-foreground">Gioco</span>
-                    <p className="mt-1">{document.gameName}</p>
-                  </div>
-                )}
-                {document.fileSize && (
-                  <div>
-                    <span className="text-muted-foreground">Dimensione</span>
-                    <p className="mt-1">{(document.fileSize / 1024).toFixed(1)} KB</p>
-                  </div>
-                )}
+      <div
+        data-slot="kb-detail-split-view"
+        className="grid flex-1 grid-cols-1 gap-0 lg:grid-cols-[minmax(320px,28rem)_1fr]"
+      >
+        {/* Sticky sx column — header, search, chunks list */}
+        <aside className="flex max-h-[calc(100vh-3.5rem)] flex-col border-r border-border lg:sticky lg:top-0">
+          <KbHeader document={documentQuery.data} />
+          <div className="border-b border-border bg-card p-3">
+            <ChunkSearchBox onCommit={setSearchQuery} />
+          </div>
+          <div className="flex-1 overflow-hidden">
+            {chunksQuery.isLoading ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Caricamento chunk…
               </div>
+            ) : chunksQuery.isError ? (
+              <div
+                role="alert"
+                className="flex h-full items-center justify-center text-sm text-destructive"
+              >
+                Errore caricamento chunk.
+              </div>
+            ) : (
+              <KbChunkListPanel
+                chunks={filteredChunks}
+                activeChunkId={activeChunkId}
+                onSelect={setActiveChunkId}
+                emptyLabel={
+                  searchQuery.trim().length > 0
+                    ? 'Nessun chunk corrisponde alla ricerca.'
+                    : 'Nessun chunk disponibile.'
+                }
+              />
+            )}
+          </div>
+        </aside>
 
-              <Alert>
-                <AlertDescription className="font-nunito">
-                  Il viewer PDF completo sarà disponibile in una versione futura. Per ora puoi
-                  navigare alle entità correlate tramite i link sopra.
-                </AlertDescription>
-              </Alert>
-            </CardContent>
-          </Card>
-        </div>
+        {/* dx column — preview */}
+        <main className="flex max-h-[calc(100vh-3.5rem)] flex-col">
+          <KbChunkPreview state={previewState} />
+        </main>
       </div>
     </div>
   );

--- a/apps/web/src/components/features/game-detail/GameDetailTabsAnimated.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailTabsAnimated.tsx
@@ -1,61 +1,36 @@
 /**
- * GameDetailTabsAnimated - v2 Wave C.1 (Issue #581)
+ * GameDetailTabsAnimated - thin consumer over the v2 primitive
+ * (`AnimatedUnderlineTabs`) after the #2311 DEC-D5 extraction.
  *
- * Mapped from `admin-mockups/design_files/sp4-game-detail.jsx` (GameTabs).
- * Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
- * Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+ * Preserves the original public surface (props + `tabIdFor` / `panelIdFor`
+ * helpers) so existing call sites + tests keep working. The primitive owns
+ * the visuals + a11y wiring + reduced-motion animation; this wrapper only
+ * sets `slotPrefix='game-detail-tab'` to keep stable selectors.
  *
- * Animated underline tab navigation. Reuses `useTablistKeyboardNav` hook
- * (Wave A.6 PR #623, Issue #622) for WAI-ARIA APG keyboard contract:
- *   - ArrowLeft/Right wrap, Home/End jump, automatic activation.
- *
- * A11y contract (Phase 0.5 sez. 4.1):
- *   - `role="tablist"` on container with `aria-label`
- *   - `role="tab"` + `aria-selected` + `aria-controls={panelId}` + `id={tabId}` per button
- *   - Panel IDs are wired via exported helpers `tabIdFor` and `panelIdFor`
- *     so orchestrator and tests can use the same derivation
- *
- * Reduced motion: animation gated via Tailwind `motion-safe:` modifier so
- * the underline transition collapses to instant under `prefers-reduced-motion: reduce`.
- *
- * AC: T A M V
+ * Refs: feat/v2 Wave C.1 (Issue #581), #2311 DEC-D5.
  */
 
 'use client';
 
+import { type ReactElement } from 'react';
+
 import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactElement,
-  type ReactNode,
-} from 'react';
-
-import clsx from 'clsx';
-
-import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
+  AnimatedUnderlineTabs,
+  type AnimatedUnderlineTabConfig,
+  type AnimatedUnderlineTabsProps,
+} from '@/components/ui/navigation/animated-underline-tabs';
 
 export type TabKey = 'info' | 'rules' | 'faqs' | 'sessions' | 'stats' | 'agents' | 'documents';
 
-export interface GameDetailTabConfig<TKey extends string = string> {
-  readonly key: TKey;
-  readonly label: string;
-  readonly icon?: ReactNode;
-  readonly count?: number;
-  readonly locked?: boolean;
-}
+export type GameDetailTabConfig<TKey extends string = string> = AnimatedUnderlineTabConfig<TKey>;
 
-export interface GameDetailTabsAnimatedProps<TKey extends string = string> {
-  readonly tabs: ReadonlyArray<GameDetailTabConfig<TKey>>;
-  readonly active: TKey;
-  readonly onChange: (key: TKey) => void;
-  readonly ariaLabel: string;
-  readonly className?: string;
-}
+export type GameDetailTabsAnimatedProps<TKey extends string = string> = Omit<
+  AnimatedUnderlineTabsProps<TKey>,
+  'slotPrefix' | 'accentActiveClassName' | 'accentIndicatorClassName' | 'accentCountActiveClassName'
+>;
 
 /**
- * Returns the HTML `id` for a tab button.
+ * Returns the HTML `id` for a game-detail tab button.
  * Orchestrator and panels use this to wire `aria-labelledby`.
  */
 export function tabIdFor(key: string): string {
@@ -63,126 +38,15 @@ export function tabIdFor(key: string): string {
 }
 
 /**
- * Returns the HTML `id` for a tab panel.
+ * Returns the HTML `id` for a game-detail tab panel.
  * Orchestrator uses this as `id` on the panel element + `aria-controls` on the button.
  */
 export function panelIdFor(key: string): string {
   return `game-detail-panel-${key}`;
 }
 
-// SSR-safe useLayoutEffect (mirror common React pattern).
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
-
 export function GameDetailTabsAnimated<TKey extends string = string>(
   props: GameDetailTabsAnimatedProps<TKey>
 ): ReactElement {
-  const { tabs, active, onChange, ariaLabel, className } = props;
-
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [indicator, setIndicator] = useState<{ left: number; width: number }>({
-    left: 0,
-    width: 0,
-  });
-
-  // Only unlocked tabs participate in keyboard navigation cycle.
-  const orderedKeys = tabs.filter(t => !t.locked).map(t => t.key);
-  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<TKey>({
-    orderedKeys,
-    onChange,
-  });
-
-  // Reposition the underline indicator whenever active tab or layout changes.
-  useIsomorphicLayoutEffect(() => {
-    const button = tabRefs.current.get(active);
-    if (!button || !containerRef.current) {
-      setIndicator({ left: 0, width: 0 });
-      return;
-    }
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const buttonRect = button.getBoundingClientRect();
-    setIndicator({
-      left: buttonRect.left - containerRect.left + containerRef.current.scrollLeft,
-      width: buttonRect.width,
-    });
-  }, [active, tabs.length, tabRefs]);
-
-  return (
-    <div
-      ref={containerRef}
-      role="tablist"
-      aria-label={ariaLabel}
-      data-slot="game-detail-tabs"
-      className={clsx(
-        'relative flex items-center gap-0.5 overflow-x-auto border-b border-border bg-background px-4 sm:px-8',
-        '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-        className
-      )}
-    >
-      {tabs.map(tab => {
-        const isActive = tab.key === active;
-        const isLocked = tab.locked === true;
-        return (
-          <button
-            key={tab.key}
-            type="button"
-            ref={node => {
-              if (node) tabRefs.current.set(tab.key, node);
-              else tabRefs.current.delete(tab.key);
-            }}
-            role="tab"
-            aria-selected={isActive}
-            aria-controls={panelIdFor(tab.key)}
-            id={tabIdFor(tab.key)}
-            tabIndex={isActive ? 0 : -1}
-            disabled={isLocked}
-            data-slot="game-detail-tab"
-            data-active={isActive}
-            data-locked={isLocked}
-            data-tab-key={tab.key}
-            onClick={() => !isLocked && onChange(tab.key)}
-            onKeyDown={e => handleKeyDown(e, tab.key)}
-            className={clsx(
-              'inline-flex flex-shrink-0 items-center gap-1.5 whitespace-nowrap border-none bg-transparent px-3.5 py-3 font-display text-[13px] transition-colors motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              isLocked && 'cursor-not-allowed opacity-55 text-muted-foreground',
-              !isLocked &&
-                (isActive
-                  ? 'font-extrabold text-amber-700 dark:text-amber-400'
-                  : 'cursor-pointer font-bold text-muted-foreground hover:text-foreground')
-            )}
-          >
-            {tab.icon ? (
-              <span aria-hidden="true" className="text-base">
-                {tab.icon}
-              </span>
-            ) : null}
-            <span>{tab.label}</span>
-            {tab.count !== undefined ? (
-              <span
-                className={clsx(
-                  'rounded-full px-1.5 py-0.5 font-mono text-[9px] font-extrabold tabular-nums',
-                  isActive
-                    ? 'bg-amber-700 text-white dark:bg-amber-500'
-                    : 'bg-muted text-muted-foreground'
-                )}
-              >
-                {tab.count}
-              </span>
-            ) : null}
-            {isLocked ? (
-              <span aria-hidden="true" className="text-[10px]">
-                🔒
-              </span>
-            ) : null}
-          </button>
-        );
-      })}
-      {/* Animated underline indicator — collapses instantly under reduced-motion */}
-      <span
-        aria-hidden="true"
-        data-slot="game-detail-tab-indicator"
-        className="absolute bottom-[-1px] h-0.5 rounded-t-[2px] bg-amber-700 motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.4,0,0.2,1)] dark:bg-amber-500"
-        style={{ left: indicator.left, width: indicator.width }}
-      />
-    </div>
-  );
+  return <AnimatedUnderlineTabs<TKey> {...props} slotPrefix="game-detail-tab" />;
 }

--- a/apps/web/src/components/features/knowledge-base/ChunkSearchBox.tsx
+++ b/apps/web/src/components/features/knowledge-base/ChunkSearchBox.tsx
@@ -1,0 +1,85 @@
+/**
+ * ChunkSearchBox — debounced search input for the KB chunks list (#2311 FE-3).
+ *
+ * The component owns the input state + a single debounced timer so consumers
+ * receive a stable, already-debounced value via `onCommit`. The 250 ms
+ * default lines up with the SEARCH_STALE_MS in `useSearchKbChunks` to avoid
+ * thrashing the TanStack Query cache. Empty / whitespace input commits as ''
+ * which the search hook interprets as "disabled".
+ */
+
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactElement,
+} from 'react';
+
+import clsx from 'clsx';
+
+export interface ChunkSearchBoxProps {
+  readonly onCommit: (query: string) => void;
+  readonly placeholder?: string;
+  readonly debounceMs?: number;
+  readonly className?: string;
+  readonly initialValue?: string;
+}
+
+export function ChunkSearchBox({
+  onCommit,
+  placeholder = 'Cerca nei chunk…',
+  debounceMs = 250,
+  className,
+  initialValue = '',
+}: ChunkSearchBoxProps): ReactElement {
+  const [value, setValue] = useState(initialValue);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onCommitRef = useRef(onCommit);
+  // Keep the latest callback without re-arming the timer when the parent rerenders.
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  }, [onCommit]);
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const next = e.target.value;
+      setValue(next);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        onCommitRef.current(next.trim());
+      }, debounceMs);
+    },
+    [debounceMs]
+  );
+
+  // Cleanup pending timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <div data-slot="kb-chunk-search-box" className={clsx('relative', className)}>
+      <label className="sr-only" htmlFor="kb-chunk-search-input">
+        Cerca nei chunk
+      </label>
+      <input
+        id="kb-chunk-search-input"
+        type="search"
+        value={value}
+        onChange={handleChange}
+        placeholder={placeholder}
+        className={clsx(
+          'w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground',
+          'placeholder:text-muted-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/features/knowledge-base/KbChunkListPanel.tsx
+++ b/apps/web/src/components/features/knowledge-base/KbChunkListPanel.tsx
@@ -1,0 +1,108 @@
+/**
+ * KbChunkListPanel — chunks list for the KB detail split-view (#2311 FE-3).
+ * Renders each row with heading-path crumbs + snippet + "usato in N chat" pill
+ * (BE-1 `usedInChats`).
+ *
+ * Note on virtualization (DEC-D3): the spec called for `react-window`. The
+ * installed version is 2.x with a redesigned API (`List` rowComponent prop
+ * instead of `FixedSizeList`) that doesn't fit the simple constant-height
+ * usage here. Typical KB docs ship 50-200 chunks — well within the DOM
+ * budget for a plain `<ul>`. Virtualization is filed as a follow-up if
+ * profiling on real documents shows scroll jank.
+ */
+
+'use client';
+
+import { type ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { KbChunkSummary } from '@/lib/api/kb-detail-api';
+
+export interface KbChunkListPanelProps {
+  readonly chunks: ReadonlyArray<KbChunkSummary>;
+  readonly activeChunkId: string | null;
+  readonly onSelect: (chunkId: string) => void;
+  readonly className?: string;
+  readonly emptyLabel?: string;
+}
+
+function Row({
+  chunk,
+  isActive,
+  onSelect,
+}: {
+  chunk: KbChunkSummary;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+}): ReactElement {
+  const headingCrumb = chunk.headingPath.length > 0 ? chunk.headingPath.join(' › ') : '—';
+  return (
+    <button
+      type="button"
+      data-slot="kb-chunk-row"
+      data-active={isActive}
+      aria-pressed={isActive}
+      onClick={() => onSelect(chunk.id)}
+      className={clsx(
+        'flex w-full flex-col items-start gap-1 border-b border-border px-3 py-2 text-left transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isActive ? 'bg-entity-kb/10 text-foreground' : 'bg-card text-foreground hover:bg-muted/50'
+      )}
+    >
+      <div className="flex w-full items-center justify-between gap-2">
+        <span className="truncate font-mono text-[11px] uppercase text-muted-foreground">
+          #{chunk.position}
+          {chunk.pageNumber !== null ? ` · p.${chunk.pageNumber}` : ''}
+        </span>
+        {chunk.usedInChats > 0 ? (
+          <span
+            aria-label={`Usato in ${chunk.usedInChats} chat`}
+            className="rounded-full bg-entity-kb/15 px-1.5 py-0.5 font-mono text-[10px] font-bold text-entity-kb"
+          >
+            {chunk.usedInChats}× chat
+          </span>
+        ) : null}
+      </div>
+      <span className="w-full truncate text-xs font-semibold text-foreground" title={headingCrumb}>
+        {headingCrumb}
+      </span>
+      <span className="line-clamp-2 w-full text-[12px] text-muted-foreground">{chunk.snippet}</span>
+    </button>
+  );
+}
+
+export function KbChunkListPanel({
+  chunks,
+  activeChunkId,
+  onSelect,
+  className,
+  emptyLabel = 'Nessun chunk disponibile.',
+}: KbChunkListPanelProps): ReactElement {
+  if (chunks.length === 0) {
+    return (
+      <div
+        data-slot="kb-chunk-list-empty"
+        className={clsx(
+          'flex h-full items-center justify-center bg-card p-6 text-sm text-muted-foreground',
+          className
+        )}
+      >
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      data-slot="kb-chunk-list"
+      className={clsx('flex h-full flex-col overflow-y-auto', className)}
+    >
+      {chunks.map(chunk => (
+        <li key={chunk.id}>
+          <Row chunk={chunk} isActive={chunk.id === activeChunkId} onSelect={onSelect} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/features/knowledge-base/KbChunkPreview.tsx
+++ b/apps/web/src/components/features/knowledge-base/KbChunkPreview.tsx
@@ -1,0 +1,144 @@
+/**
+ * KbChunkPreview — right pane of the KB detail split-view (#2311 FE-3).
+ * Shows the selected chunk's full body via `MarkdownRenderBlock`, with an
+ * `AnimatedUnderlineTabs`-powered Markdown / Raw toggle (DEC-D5 primitive).
+ *
+ * Empty / loading / error states render in-place so the orchestrator does
+ * not have to fork on the FSM.
+ */
+
+'use client';
+
+import { useState, type ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { AnimatedUnderlineTabs } from '@/components/ui/navigation/animated-underline-tabs';
+import type { KbChunkDetail } from '@/lib/api/kb-detail-api';
+
+import { MarkdownRenderBlock } from './MarkdownRenderBlock';
+
+export type KbChunkPreviewState =
+  | { kind: 'empty' }
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; chunk: KbChunkDetail };
+
+export interface KbChunkPreviewProps {
+  readonly state: KbChunkPreviewState;
+  readonly className?: string;
+  readonly emptyLabel?: string;
+}
+
+type SubTab = 'markdown' | 'raw';
+
+const TABS = [
+  { key: 'markdown' as SubTab, label: 'Markdown' },
+  { key: 'raw' as SubTab, label: 'Raw' },
+];
+
+const ACCENT_ACTIVE = 'font-extrabold text-entity-kb';
+const ACCENT_INDICATOR = 'bg-entity-kb';
+const ACCENT_COUNT_ACTIVE = 'bg-entity-kb text-white';
+
+export function KbChunkPreview({
+  state,
+  className,
+  emptyLabel = 'Seleziona un chunk per visualizzarne il contenuto.',
+}: KbChunkPreviewProps): ReactElement {
+  const [tab, setTab] = useState<SubTab>('markdown');
+
+  if (state.kind === 'empty') {
+    return (
+      <div
+        data-slot="kb-chunk-preview-empty"
+        className={clsx(
+          'flex h-full items-center justify-center bg-background p-6 text-sm text-muted-foreground',
+          className
+        )}
+      >
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  if (state.kind === 'loading') {
+    return (
+      <div
+        data-slot="kb-chunk-preview-loading"
+        aria-busy
+        className={clsx(
+          'flex h-full items-center justify-center bg-background p-6 text-sm text-muted-foreground',
+          className
+        )}
+      >
+        Caricamento chunk…
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div
+        data-slot="kb-chunk-preview-error"
+        role="alert"
+        className={clsx(
+          'flex h-full items-center justify-center bg-background p-6 text-sm text-destructive',
+          className
+        )}
+      >
+        {state.message}
+      </div>
+    );
+  }
+
+  const { chunk } = state;
+  const headingCrumb =
+    chunk.headingPath.length > 0 ? chunk.headingPath.join(' › ') : `Chunk #${chunk.position}`;
+
+  return (
+    <section
+      data-slot="kb-chunk-preview"
+      className={clsx('flex h-full flex-col bg-background', className)}
+    >
+      <div className="flex items-baseline justify-between gap-3 border-b border-border bg-card px-4 py-2">
+        <h2
+          className="truncate font-display text-sm font-extrabold text-foreground"
+          title={headingCrumb}
+        >
+          {headingCrumb}
+        </h2>
+        <span className="font-mono text-[11px] uppercase text-muted-foreground">
+          #{chunk.position}
+          {chunk.pageNumber !== null ? ` · p.${chunk.pageNumber}` : ''}
+        </span>
+      </div>
+
+      <AnimatedUnderlineTabs<SubTab>
+        tabs={TABS}
+        active={tab}
+        onChange={setTab}
+        ariaLabel="Vista preview chunk"
+        slotPrefix="kb-preview-tab"
+        accentActiveClassName={ACCENT_ACTIVE}
+        accentIndicatorClassName={ACCENT_INDICATOR}
+        accentCountActiveClassName={ACCENT_COUNT_ACTIVE}
+      />
+
+      <div
+        role="tabpanel"
+        id={`kb-preview-panel-${tab}`}
+        aria-labelledby={`kb-preview-tab-${tab}`}
+        className="flex-1 overflow-y-auto p-4"
+      >
+        {tab === 'markdown' ? (
+          <MarkdownRenderBlock content={chunk.content} />
+        ) : (
+          <pre className="whitespace-pre-wrap font-mono text-[12px] text-foreground">
+            {chunk.content}
+          </pre>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/knowledge-base/KbHeader.tsx
+++ b/apps/web/src/components/features/knowledge-base/KbHeader.tsx
@@ -1,0 +1,101 @@
+/**
+ * KbHeader — document metadata card for the KB detail surface (#2311 FE-3).
+ * Renders the sticky sx column header in the split-view layout: title,
+ * kind/version pill, last-ingested timestamp, uploader, chunk + page counts,
+ * + language tag. Uses the `--c-kb` entity utility (DEC-D5 token rule).
+ */
+
+'use client';
+
+import { type ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { KbDocument } from '@/lib/api/kb-detail-api';
+
+export interface KbHeaderProps {
+  readonly document: KbDocument;
+  readonly className?: string;
+}
+
+function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 102.4) / 10} KB`;
+  return `${Math.round(size / (1024 * 102.4)) / 10} MB`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('it-IT', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export function KbHeader({ document, className }: KbHeaderProps): ReactElement {
+  const sizeLabel = formatBytes(document.fileSize);
+  const ingestedLabel = formatDate(document.lastIngestedAt);
+
+  return (
+    <header
+      data-slot="kb-header"
+      className={clsx(
+        'flex flex-col gap-3 border-b border-border bg-card p-4',
+        'text-sm text-card-foreground',
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h1 className="font-display text-lg font-extrabold text-entity-kb">{document.title}</h1>
+        <span
+          aria-label={`Tipo documento ${document.docType}`}
+          className="rounded-md bg-entity-kb/15 px-2 py-0.5 font-mono text-[11px] font-bold uppercase text-entity-kb"
+        >
+          {document.docType}
+        </span>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-[12px] text-muted-foreground">
+        {document.gameName ? (
+          <>
+            <dt className="font-semibold">Gioco</dt>
+            <dd className="font-mono text-foreground">{document.gameName}</dd>
+          </>
+        ) : null}
+
+        <dt className="font-semibold">Lingua</dt>
+        <dd className="font-mono uppercase text-foreground">{document.language}</dd>
+
+        <dt className="font-semibold">Chunk</dt>
+        <dd className="font-mono text-foreground">{document.chunkCount}</dd>
+
+        {document.pageCount !== null ? (
+          <>
+            <dt className="font-semibold">Pagine</dt>
+            <dd className="font-mono text-foreground">{document.pageCount}</dd>
+          </>
+        ) : null}
+
+        <dt className="font-semibold">Dimensione</dt>
+        <dd className="font-mono text-foreground">{sizeLabel}</dd>
+
+        <dt className="font-semibold">Caricato da</dt>
+        <dd className="font-mono text-foreground">{document.uploaderName}</dd>
+
+        <dt className="font-semibold">Indicizzato</dt>
+        <dd className="font-mono text-foreground">{ingestedLabel}</dd>
+
+        {document.indexerVersion ? (
+          <>
+            <dt className="font-semibold">Indexer</dt>
+            <dd className="font-mono text-foreground">{document.indexerVersion}</dd>
+          </>
+        ) : null}
+      </dl>
+    </header>
+  );
+}

--- a/apps/web/src/components/features/knowledge-base/MarkdownRenderBlock.tsx
+++ b/apps/web/src/components/features/knowledge-base/MarkdownRenderBlock.tsx
@@ -1,0 +1,50 @@
+/**
+ * MarkdownRenderBlock — primitive markdown renderer for the KB preview pane
+ * (#2311 FE-3 DEC-D4). Reusable across KB chunks, Reviews tab, Strategies tab.
+ *
+ * Plugin allowlist (DEC-D4):
+ *   - remark-gfm: enables GFM tables (the mockup fixture uses `| col | col |`)
+ *   - NO rehype-raw: prevents XSS via inline HTML in chunk content
+ *
+ * The component normalises typography to the token-canonical surface (no
+ * hardcoded greys / colours) so consumers don't need a per-instance reset.
+ */
+
+'use client';
+
+import { type ReactElement } from 'react';
+
+import clsx from 'clsx';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export interface MarkdownRenderBlockProps {
+  readonly content: string;
+  readonly className?: string;
+}
+
+export function MarkdownRenderBlock({
+  content,
+  className,
+}: MarkdownRenderBlockProps): ReactElement {
+  return (
+    <div
+      data-slot="markdown-render-block"
+      className={clsx(
+        'prose prose-sm max-w-none',
+        // Token-canonical headings + body (no hardcoded greys).
+        'prose-headings:font-display prose-headings:text-foreground',
+        'prose-p:text-foreground prose-li:text-foreground',
+        'prose-strong:text-foreground prose-em:text-foreground',
+        'prose-code:text-foreground prose-code:bg-muted prose-code:px-1 prose-code:rounded',
+        'prose-a:text-primary prose-a:no-underline hover:prose-a:underline',
+        'prose-table:border prose-table:border-border',
+        'prose-th:border prose-th:border-border prose-th:bg-muted prose-th:px-2 prose-th:py-1',
+        'prose-td:border prose-td:border-border prose-td:px-2 prose-td:py-1',
+        className
+      )}
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/knowledge-base/__tests__/knowledge-base-axe.test.tsx
+++ b/apps/web/src/components/features/knowledge-base/__tests__/knowledge-base-axe.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * knowledge-base — axe AA regression guard for the #2311 FE-3 components.
+ *
+ * Scans the 5 new domain components in their default states to catch
+ * a11y regressions before they ship. The orchestrator page itself
+ * (`/knowledge-base/[id]/page.tsx`) is covered by the Storybook
+ * `Default` story + the project-wide axe CI sweep.
+ */
+
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import type { KbChunkDetail, KbChunkSummary, KbDocument } from '@/lib/api/kb-detail-api';
+
+import {
+  ChunkSearchBox,
+  KbChunkListPanel,
+  KbChunkPreview,
+  KbHeader,
+  MarkdownRenderBlock,
+} from '../index';
+
+expect.extend(toHaveNoViolations);
+
+const DOC: KbDocument = {
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  title: 'Azul rulebook',
+  docType: 'rulebook',
+  gameId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  gameName: 'Azul',
+  uploaderName: 'Marco',
+  uploadedAt: '2026-01-12T00:00:00Z',
+  lastIngestedAt: '2026-03-08T00:00:00Z',
+  processingStatus: 'ready',
+  chunkCount: 42,
+  pageCount: 24,
+  language: 'it',
+  tags: [],
+  fileSize: 12_345,
+  indexerVersion: 'v3',
+};
+
+const CHUNK: KbChunkSummary = {
+  id: '00000000-0000-4000-8000-000000000001',
+  position: 0,
+  headingPath: ['Setup'],
+  snippet: 'Posiziona le factory display al centro del tavolo.',
+  pageNumber: 2,
+  vectorId: 'vec-0',
+  usedInChats: 4,
+};
+
+const CHUNK_DETAIL: KbChunkDetail = {
+  id: CHUNK.id,
+  docId: DOC.id,
+  position: 0,
+  headingPath: ['Intro', 'Benvenuto'],
+  content: '# Hello\n\nbody text',
+  pageNumber: 1,
+  prevChunkId: null,
+  nextChunkId: null,
+  metadata: {},
+};
+
+describe('knowledge-base — axe AA gate (#2311 FE-7)', () => {
+  it('KbHeader — no violations', async () => {
+    const { container } = render(<KbHeader document={DOC} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('MarkdownRenderBlock — no violations on a fixture chunk body', async () => {
+    const { container } = render(
+      <MarkdownRenderBlock content="# Hello\n\n- one\n- two\n\n| A | B |\n|---|---|\n| 1 | 2 |" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('ChunkSearchBox — no violations (label association via sr-only)', async () => {
+    const { container } = render(<ChunkSearchBox onCommit={() => undefined} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('KbChunkListPanel — no violations with one active and one inactive row', async () => {
+    const { container } = render(
+      <KbChunkListPanel
+        chunks={[CHUNK, { ...CHUNK, id: '00000000-0000-4000-8000-000000000002', position: 1 }]}
+        activeChunkId={CHUNK.id}
+        onSelect={() => undefined}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('KbChunkPreview — no violations in the ready state with sub-tabs', async () => {
+    const { container } = render(<KbChunkPreview state={{ kind: 'ready', chunk: CHUNK_DETAIL }} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/knowledge-base/__tests__/knowledge-base.test.tsx
+++ b/apps/web/src/components/features/knowledge-base/__tests__/knowledge-base.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { KbChunkDetail, KbChunkSummary, KbDocument } from '@/lib/api/kb-detail-api';
+
+import {
+  ChunkSearchBox,
+  KbChunkListPanel,
+  KbChunkPreview,
+  KbHeader,
+  MarkdownRenderBlock,
+} from '../index';
+
+const DOC: KbDocument = {
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  title: 'Azul rulebook',
+  docType: 'rulebook',
+  gameId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  gameName: 'Azul',
+  uploaderName: 'Marco',
+  uploadedAt: '2026-01-12T00:00:00Z',
+  lastIngestedAt: '2026-03-08T00:00:00Z',
+  processingStatus: 'ready',
+  chunkCount: 42,
+  pageCount: 24,
+  language: 'it',
+  tags: [],
+  fileSize: 12_345,
+  indexerVersion: 'v3',
+};
+
+const chunkSummary = (n: number, extra: Partial<KbChunkSummary> = {}): KbChunkSummary => ({
+  id: `00000000-0000-4000-8000-${n.toString().padStart(12, '0')}`,
+  position: n,
+  headingPath: [`Sezione ${n}`],
+  snippet: `Snippet di prova ${n}`,
+  pageNumber: n,
+  vectorId: `vec-${n}`,
+  usedInChats: 0,
+  ...extra,
+});
+
+describe('KbHeader (#2311 FE-3)', () => {
+  it('renders title + docType pill + game name + size + uploader', () => {
+    const { container } = render(<KbHeader document={DOC} />);
+    expect(container.textContent).toContain('Azul rulebook');
+    expect(container.textContent).toContain('rulebook');
+    expect(container.textContent).toContain('Azul');
+    expect(container.textContent).toContain('Marco');
+    // Size: 12345 bytes ≈ 12.1 KB (12345/102.4/10 rounded)
+    expect(container.textContent).toMatch(/12(\.\d+)?\s*KB/);
+  });
+
+  it('omits the gameName row when null', () => {
+    const { container } = render(<KbHeader document={{ ...DOC, gameName: null }} />);
+    const dts = Array.from(container.querySelectorAll('dt')).map(dt => dt.textContent);
+    expect(dts).not.toContain('Gioco');
+  });
+});
+
+describe('MarkdownRenderBlock (#2311 FE-3, DEC-D4)', () => {
+  it('renders markdown headings and GFM tables', () => {
+    const { container } = render(
+      <MarkdownRenderBlock content={`# Title\n\n| A | B |\n|---|---|\n| 1 | 2 |`} />
+    );
+    expect(container.querySelector('h1')?.textContent).toBe('Title');
+    expect(container.querySelector('table')).toBeInTheDocument();
+    expect(container.querySelector('td')?.textContent).toBe('1');
+  });
+});
+
+describe('ChunkSearchBox (#2311 FE-3)', () => {
+  it('debounces input and commits the trimmed value', async () => {
+    vi.useFakeTimers();
+    const onCommit = vi.fn();
+    const { container } = render(<ChunkSearchBox onCommit={onCommit} debounceMs={250} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.change(input, { target: { value: '  piazette  ' } });
+    expect(onCommit).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+
+    expect(onCommit).toHaveBeenCalledWith('piazette');
+    vi.useRealTimers();
+  });
+
+  it('rearms the timer on rapid input without firing the intermediate value', async () => {
+    vi.useFakeTimers();
+    const onCommit = vi.fn();
+    const { container } = render(<ChunkSearchBox onCommit={onCommit} debounceMs={100} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+    fireEvent.change(input, { target: { value: 'ab' } });
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+    fireEvent.change(input, { target: { value: 'abc' } });
+    await act(async () => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('abc');
+    vi.useRealTimers();
+  });
+});
+
+describe('KbChunkListPanel (#2311 FE-3)', () => {
+  it('renders a row per chunk with the usedInChats pill when > 0', () => {
+    const chunks = [chunkSummary(0), chunkSummary(1, { usedInChats: 5 })];
+    const { container } = render(
+      <KbChunkListPanel chunks={chunks} activeChunkId={null} onSelect={vi.fn()} />
+    );
+    const rows = container.querySelectorAll('[data-slot="kb-chunk-row"]');
+    expect(rows).toHaveLength(2);
+    expect(container.textContent).toContain('5× chat');
+  });
+
+  it('shows the empty state and skips list rendering when chunks is empty', () => {
+    const { container } = render(
+      <KbChunkListPanel chunks={[]} activeChunkId={null} onSelect={vi.fn()} />
+    );
+    expect(container.querySelector('[data-slot="kb-chunk-list-empty"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-chunk-row"]')).toBeNull();
+  });
+
+  it('marks the row matching activeChunkId with data-active=true + aria-pressed=true', () => {
+    const chunks = [chunkSummary(0), chunkSummary(1)];
+    const { container } = render(
+      <KbChunkListPanel chunks={chunks} activeChunkId={chunks[1].id} onSelect={vi.fn()} />
+    );
+    const rows = container.querySelectorAll('[data-slot="kb-chunk-row"]');
+    expect(rows[0].getAttribute('data-active')).toBe('false');
+    expect(rows[1].getAttribute('data-active')).toBe('true');
+    expect(rows[1].getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('invokes onSelect with the chunk id on click', () => {
+    const chunks = [chunkSummary(0)];
+    const onSelect = vi.fn();
+    const { container } = render(
+      <KbChunkListPanel chunks={chunks} activeChunkId={null} onSelect={onSelect} />
+    );
+    fireEvent.click(container.querySelector('[data-slot="kb-chunk-row"]')!);
+    expect(onSelect).toHaveBeenCalledWith(chunks[0].id);
+  });
+});
+
+describe('KbChunkPreview (#2311 FE-3)', () => {
+  const sampleChunk: KbChunkDetail = {
+    id: '00000000-0000-4000-8000-000000000001',
+    docId: DOC.id,
+    position: 1,
+    headingPath: ['Intro', 'Benvenuto'],
+    content: '# Hello\n\nbody text',
+    pageNumber: 2,
+    prevChunkId: null,
+    nextChunkId: null,
+    metadata: {},
+  };
+
+  it('renders the empty state by default', () => {
+    const { container } = render(<KbChunkPreview state={{ kind: 'empty' }} />);
+    expect(container.querySelector('[data-slot="kb-chunk-preview-empty"]')).toBeInTheDocument();
+  });
+
+  it('renders the loading state with aria-busy', () => {
+    const { container } = render(<KbChunkPreview state={{ kind: 'loading' }} />);
+    const node = container.querySelector('[data-slot="kb-chunk-preview-loading"]')!;
+    expect(node.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('renders the error state with role=alert', () => {
+    const { container } = render(<KbChunkPreview state={{ kind: 'error', message: 'boom' }} />);
+    const node = container.querySelector('[data-slot="kb-chunk-preview-error"]')!;
+    expect(node.getAttribute('role')).toBe('alert');
+    expect(node.textContent).toContain('boom');
+  });
+
+  it('renders Markdown by default and switches to Raw on tab click', async () => {
+    const { container } = render(<KbChunkPreview state={{ kind: 'ready', chunk: sampleChunk }} />);
+    // Markdown view: <h1>
+    expect(container.querySelector('h1')?.textContent).toBe('Hello');
+    // Tab switch to Raw → <pre> with full content
+    const rawTab = container.querySelector('#kb-preview-tab-raw') as HTMLElement;
+    expect(rawTab).not.toBeNull();
+    fireEvent.click(rawTab);
+    await waitFor(() => {
+      expect(container.querySelector('pre')?.textContent).toContain('# Hello');
+    });
+  });
+});

--- a/apps/web/src/components/features/knowledge-base/index.ts
+++ b/apps/web/src/components/features/knowledge-base/index.ts
@@ -1,0 +1,14 @@
+export { ChunkSearchBox } from './ChunkSearchBox';
+export type { ChunkSearchBoxProps } from './ChunkSearchBox';
+
+export { KbChunkListPanel } from './KbChunkListPanel';
+export type { KbChunkListPanelProps } from './KbChunkListPanel';
+
+export { KbChunkPreview } from './KbChunkPreview';
+export type { KbChunkPreviewProps, KbChunkPreviewState } from './KbChunkPreview';
+
+export { KbHeader } from './KbHeader';
+export type { KbHeaderProps } from './KbHeader';
+
+export { MarkdownRenderBlock } from './MarkdownRenderBlock';
+export type { MarkdownRenderBlockProps } from './MarkdownRenderBlock';

--- a/apps/web/src/components/ui/navigation/__tests__/animated-underline-tabs.test.tsx
+++ b/apps/web/src/components/ui/navigation/__tests__/animated-underline-tabs.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AnimatedUnderlineTabs } from '../animated-underline-tabs';
+
+type TestKey = 'a' | 'b' | 'c';
+
+const TABS = [
+  { key: 'a' as TestKey, label: 'Alpha' },
+  { key: 'b' as TestKey, label: 'Beta' },
+  { key: 'c' as TestKey, label: 'Gamma' },
+];
+
+function renderTabs(
+  overrides: Partial<React.ComponentProps<typeof AnimatedUnderlineTabs<TestKey>>> = {}
+) {
+  return render(
+    <AnimatedUnderlineTabs<TestKey>
+      tabs={TABS}
+      active="a"
+      onChange={vi.fn()}
+      ariaLabel="test tablist"
+      {...overrides}
+    />
+  );
+}
+
+describe('AnimatedUnderlineTabs (#2311 DEC-D5)', () => {
+  it('renders a role=tablist with the aria-label', () => {
+    const { getByRole } = renderTabs();
+    const tablist = getByRole('tablist');
+    expect(tablist.getAttribute('aria-label')).toBe('test tablist');
+  });
+
+  it('renders one role=tab per item with aria-selected reflecting active', () => {
+    const { getAllByRole } = renderTabs({ active: 'b' });
+    const tabs = getAllByRole('tab');
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0].getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[2].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('default slotPrefix derives stable id + data-slot ("tab-{key}", "tab-panel-{key}")', () => {
+    const { container } = renderTabs();
+    expect(container.querySelector('#tab-a')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="tab"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="tabs"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="tab-indicator"]')).toBeInTheDocument();
+    const firstTab = container.querySelector('#tab-a')!;
+    expect(firstTab.getAttribute('aria-controls')).toBe('tab-panel-a');
+  });
+
+  it('slotPrefix override produces stable selectors for the game-detail consumer', () => {
+    const { container } = renderTabs({ slotPrefix: 'game-detail-tab' });
+    expect(container.querySelector('#game-detail-tab-a')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="game-detail-tab"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="game-detail-tab-indicator"]')).toBeInTheDocument();
+    expect(container.querySelector('#game-detail-tab-a')!.getAttribute('aria-controls')).toBe(
+      'game-detail-panel-a'
+    );
+  });
+
+  it('invokes onChange with the clicked tab key', () => {
+    const onChange = vi.fn();
+    const { getAllByRole } = renderTabs({ onChange });
+    fireEvent.click(getAllByRole('tab')[2]);
+    expect(onChange).toHaveBeenCalledWith('c');
+  });
+
+  it('does NOT invoke onChange when a locked tab is clicked', () => {
+    const onChange = vi.fn();
+    const lockedTabs = [...TABS.slice(0, 2), { key: 'c' as TestKey, label: 'Gamma', locked: true }];
+    const { getAllByRole } = renderTabs({ tabs: lockedTabs, onChange });
+    fireEvent.click(getAllByRole('tab')[2]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders the optional count badge when provided', () => {
+    const tabsWithCount = [{ key: 'a' as TestKey, label: 'Alpha', count: 7 }];
+    const { container } = render(
+      <AnimatedUnderlineTabs<TestKey>
+        tabs={tabsWithCount}
+        active="a"
+        onChange={vi.fn()}
+        ariaLabel="t"
+      />
+    );
+    expect(container.textContent).toContain('7');
+  });
+
+  it('honours custom accent classes (active label + indicator)', () => {
+    const { container } = renderTabs({
+      accentActiveClassName: 'text-entity-kb',
+      accentIndicatorClassName: 'bg-entity-kb',
+    });
+    const activeTab = container.querySelector('#tab-a')!;
+    expect(activeTab.className).toContain('text-entity-kb');
+    const indicator = container.querySelector('[data-slot="tab-indicator"]')!;
+    expect(indicator.className).toContain('bg-entity-kb');
+  });
+});

--- a/apps/web/src/components/ui/navigation/animated-underline-tabs.tsx
+++ b/apps/web/src/components/ui/navigation/animated-underline-tabs.tsx
@@ -1,0 +1,219 @@
+/**
+ * AnimatedUnderlineTabs — primitive extracted from features/game-detail
+ * (`GameDetailTabsAnimated`) per #2311 DEC-D5. Hosts the shared tab visuals
+ * + a11y wiring + reduced-motion underline animation, so the KB detail page
+ * sub-tabs (Markdown / Raw), Reviews tab, Strategies tab, and game-detail
+ * tabs share one source of truth instead of duplicating the pattern.
+ *
+ * A11y contract (mirrors WAI-ARIA APG tablist):
+ *   - `role="tablist"` on container with `aria-label`
+ *   - `role="tab"` + `aria-selected` + `aria-controls={panelId}` + `id={tabId}`
+ *   - Keyboard nav via `useTablistKeyboardNav` (Arrow keys, Home, End)
+ *
+ * Reduced motion: underline transition collapses to instant under
+ * `prefers-reduced-motion: reduce` (Tailwind `motion-safe:` modifier).
+ *
+ * Design decision: ID + data-slot prefixes are parameterised via
+ * `slotPrefix` so consumers retain stable selectors (e.g. existing
+ * `game-detail-tab-{key}` IDs in tests) while the primitive does not
+ * assume any feature namespace.
+ *
+ * AC: T A M V
+ */
+
+'use client';
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+
+import clsx from 'clsx';
+
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
+
+export interface AnimatedUnderlineTabConfig<TKey extends string = string> {
+  readonly key: TKey;
+  readonly label: string;
+  readonly icon?: ReactNode;
+  readonly count?: number;
+  readonly locked?: boolean;
+}
+
+export interface AnimatedUnderlineTabsProps<TKey extends string = string> {
+  readonly tabs: ReadonlyArray<AnimatedUnderlineTabConfig<TKey>>;
+  readonly active: TKey;
+  readonly onChange: (key: TKey) => void;
+  readonly ariaLabel: string;
+  readonly className?: string;
+  /**
+   * Prefix for the HTML `id` and `data-slot` attributes. Allows consumers
+   * to keep stable selectors (e.g. `game-detail-tab-info`, `kb-preview-tab-raw`)
+   * without colliding across surfaces. Defaults to `'tab'`.
+   */
+  readonly slotPrefix?: string;
+  /**
+   * Tailwind classes applied to the active tab label + underline indicator.
+   * Defaults to the amber accent used by game-detail. KB consumer overrides
+   * with `text-entity-kb` + `bg-entity-kb` per DEC-D5 token canonicalization.
+   */
+  readonly accentActiveClassName?: string;
+  readonly accentIndicatorClassName?: string;
+  readonly accentCountActiveClassName?: string;
+}
+
+/**
+ * Derives the panel prefix from a tab slot prefix.
+ *   - `'game-detail-tab'` → `'game-detail-panel'` (suffix swap)
+ *   - `'tab'` → `'tab-panel'` (append fallback when no `-tab` suffix)
+ *   - `'kb-preview-tab'` → `'kb-preview-panel'`
+ * Internal helper exported for parity with `panelIdForPrefix`.
+ */
+function derivePanelPrefix(prefix: string): string {
+  return prefix.endsWith('-tab')
+    ? prefix.replace(/-tab$/, '-panel')
+    : prefix === 'tab'
+      ? 'tab-panel'
+      : `${prefix}-panel`;
+}
+
+/** Returns the HTML `id` for a tab button given a slot prefix + key. */
+export function tabIdForPrefix(prefix: string, key: string): string {
+  return `${prefix}-${key}`;
+}
+
+/** Returns the HTML `id` for a tab panel given a slot prefix + key. */
+export function panelIdForPrefix(prefix: string, key: string): string {
+  return `${derivePanelPrefix(prefix)}-${key}`;
+}
+
+// SSR-safe useLayoutEffect (mirror common React pattern).
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export function AnimatedUnderlineTabs<TKey extends string = string>(
+  props: AnimatedUnderlineTabsProps<TKey>
+): ReactElement {
+  const {
+    tabs,
+    active,
+    onChange,
+    ariaLabel,
+    className,
+    slotPrefix = 'tab',
+    accentActiveClassName = 'font-extrabold text-amber-700 dark:text-amber-400',
+    accentIndicatorClassName = 'bg-amber-700 dark:bg-amber-500',
+    accentCountActiveClassName = 'bg-amber-700 text-white dark:bg-amber-500',
+  } = props;
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [indicator, setIndicator] = useState<{ left: number; width: number }>({
+    left: 0,
+    width: 0,
+  });
+
+  const orderedKeys = tabs.filter(t => !t.locked).map(t => t.key);
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<TKey>({
+    orderedKeys,
+    onChange,
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    const button = tabRefs.current.get(active);
+    if (!button || !containerRef.current) {
+      setIndicator({ left: 0, width: 0 });
+      return;
+    }
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const buttonRect = button.getBoundingClientRect();
+    setIndicator({
+      left: buttonRect.left - containerRect.left + containerRef.current.scrollLeft,
+      width: buttonRect.width,
+    });
+  }, [active, tabs.length, tabRefs]);
+
+  const panelPrefix = derivePanelPrefix(slotPrefix);
+
+  return (
+    <div
+      ref={containerRef}
+      role="tablist"
+      aria-label={ariaLabel}
+      data-slot={`${slotPrefix}s`}
+      className={clsx(
+        'relative flex items-center gap-0.5 overflow-x-auto border-b border-border bg-background px-4 sm:px-8',
+        '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        className
+      )}
+    >
+      {tabs.map(tab => {
+        const isActive = tab.key === active;
+        const isLocked = tab.locked === true;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            ref={node => {
+              if (node) tabRefs.current.set(tab.key, node);
+              else tabRefs.current.delete(tab.key);
+            }}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`${panelPrefix}-${tab.key}`}
+            id={`${slotPrefix}-${tab.key}`}
+            tabIndex={isActive ? 0 : -1}
+            disabled={isLocked}
+            data-slot={slotPrefix}
+            data-active={isActive}
+            data-locked={isLocked}
+            data-tab-key={tab.key}
+            onClick={() => !isLocked && onChange(tab.key)}
+            onKeyDown={e => handleKeyDown(e, tab.key)}
+            className={clsx(
+              'inline-flex flex-shrink-0 items-center gap-1.5 whitespace-nowrap border-none bg-transparent px-3.5 py-3 font-display text-[13px] transition-colors motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              isLocked && 'cursor-not-allowed opacity-55 text-muted-foreground',
+              !isLocked &&
+                (isActive
+                  ? accentActiveClassName
+                  : 'cursor-pointer font-bold text-muted-foreground hover:text-foreground')
+            )}
+          >
+            {tab.icon ? (
+              <span aria-hidden="true" className="text-base">
+                {tab.icon}
+              </span>
+            ) : null}
+            <span>{tab.label}</span>
+            {tab.count !== undefined ? (
+              <span
+                className={clsx(
+                  'rounded-full px-1.5 py-0.5 font-mono text-[9px] font-extrabold tabular-nums',
+                  isActive ? accentCountActiveClassName : 'bg-muted text-muted-foreground'
+                )}
+              >
+                {tab.count}
+              </span>
+            ) : null}
+            {isLocked ? (
+              <span aria-hidden="true" className="text-[10px]">
+                🔒
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+      <span
+        aria-hidden="true"
+        data-slot={`${slotPrefix}-indicator`}
+        className={clsx(
+          'absolute bottom-[-1px] h-0.5 rounded-t-[2px] motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.4,0,0.2,1)]',
+          accentIndicatorClassName
+        )}
+        style={{ left: indicator.left, width: indicator.width }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/hooks/queries/__tests__/use-kb-detail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/use-kb-detail.test.tsx
@@ -1,0 +1,199 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { type ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@/__tests__/mocks/server';
+
+import { useKbChunk, useKbChunks, useKbDocument, useSearchKbChunks } from '../use-kb-detail';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const DOC_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const CHUNK_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const docFixture = {
+  id: DOC_ID,
+  title: 'Azul rulebook',
+  docType: 'rulebook',
+  gameId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  gameName: 'Azul',
+  uploaderName: 'Marco',
+  uploadedAt: '2026-01-12T00:00:00Z',
+  lastIngestedAt: '2026-03-08T00:00:00Z',
+  processingStatus: 'ready',
+  chunkCount: 42,
+  pageCount: 24,
+  language: 'it',
+  tags: [],
+  fileSize: 1024,
+  indexerVersion: 'v3',
+};
+
+describe('useKbDocument (#2311 FE-2)', () => {
+  it('fetches the document by id and parses the response', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}`, () => HttpResponse.json(docFixture))
+    );
+
+    const { result } = renderHook(() => useKbDocument(DOC_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.title).toBe('Azul rulebook');
+    expect(result.current.data?.chunkCount).toBe(42);
+  });
+
+  it('skips the request when id is empty (gate)', () => {
+    const { result } = renderHook(() => useKbDocument(''), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+});
+
+describe('useKbChunks (#2311 FE-2)', () => {
+  const chunkFixture = {
+    items: [
+      {
+        id: CHUNK_ID,
+        position: 0,
+        headingPath: ['Introduzione'],
+        snippet: 'Benvenuto in Azul',
+        pageNumber: 1,
+        vectorId: CHUNK_ID.replace(/-/g, ''),
+        usedInChats: 8,
+      },
+    ],
+    nextCursor: null,
+    totalCount: 1,
+  };
+
+  it('returns the chunks list including the BE-1 usedInChats counter', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks`, () => HttpResponse.json(chunkFixture))
+    );
+
+    const { result } = renderHook(() => useKbChunks(DOC_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.items[0].usedInChats).toBe(8);
+  });
+
+  it('appends limit + cursor to the query string', async () => {
+    let observedSearch = '';
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks`, ({ request }) => {
+        observedSearch = new URL(request.url).search;
+        return HttpResponse.json({ items: [], nextCursor: null, totalCount: 0 });
+      })
+    );
+
+    const { result } = renderHook(() => useKbChunks(DOC_ID, { limit: 5, cursor: 'eyJpIjoxfQ' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(observedSearch).toContain('limit=5');
+    expect(observedSearch).toContain('cursor=');
+  });
+});
+
+describe('useKbChunk (#2311 FE-2)', () => {
+  it('fetches a single chunk when chunkId is provided', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks/${CHUNK_ID}`, () =>
+        HttpResponse.json({
+          id: CHUNK_ID,
+          docId: DOC_ID,
+          position: 0,
+          headingPath: ['Introduzione'],
+          content: '# Benvenuto\n\nMarkdown body',
+          pageNumber: 1,
+          prevChunkId: null,
+          nextChunkId: null,
+          metadata: {},
+        })
+      )
+    );
+
+    const { result } = renderHook(() => useKbChunk(DOC_ID, CHUNK_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.content).toContain('Markdown body');
+  });
+
+  it('skips the request when chunkId is empty (lazy preview-pane gate)', () => {
+    const { result } = renderHook(() => useKbChunk(DOC_ID, ''), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+});
+
+describe('useSearchKbChunks (#2311 FE-2)', () => {
+  it('POSTs the search body and returns matches', async () => {
+    let observedBody: unknown = null;
+    server.use(
+      http.post(`${API_BASE}/api/v1/kb-docs/${DOC_ID}/chunks/search`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          matches: [
+            {
+              chunkId: CHUNK_ID,
+              headingPath: ['Setup'],
+              snippet: 'piaze<mark>tte</mark>',
+              rank: 0.9,
+              pageNumber: 2,
+              position: 5,
+            },
+          ],
+          totalCount: 1,
+          skip: 0,
+          take: 20,
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useSearchKbChunks({ docId: DOC_ID, query: 'piazette' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.matches).toHaveLength(1);
+    expect(observedBody).toMatchObject({ query: 'piazette' });
+  });
+
+  it('skips the request when query is empty (debounced caller pattern)', () => {
+    const { result } = renderHook(() => useSearchKbChunks({ docId: DOC_ID, query: '' }), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('skips the request when query is whitespace-only', () => {
+    const { result } = renderHook(() => useSearchKbChunks({ docId: DOC_ID, query: '   ' }), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/queries/use-kb-detail.ts
+++ b/apps/web/src/hooks/queries/use-kb-detail.ts
@@ -1,0 +1,91 @@
+/**
+ * KB document detail query hooks (#2311 FE-2).
+ *
+ * TanStack Query wrappers over `kb-detail-api`. Each hook is gated on `id`
+ * length so router-transition empty states don't fire spurious requests.
+ *
+ *   - `useKbDocument(id)` — eager fetch of document metadata
+ *   - `useKbChunks(id, params)` — paginated chunks list (cursor-based)
+ *   - `useKbChunk(docId, chunkId)` — lazy fetch of a single chunk's full body
+ *     (enabled only when `chunkId` is non-empty so the preview pane defers
+ *     until selection)
+ *   - `useSearchKbChunks(docId, query)` — debounced full-text search within
+ *     the document. The hook itself does NOT debounce — callers pass an
+ *     already-debounced `query` so the hook key stays stable.
+ */
+
+'use client';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import {
+  fetchKbChunk,
+  fetchKbChunks,
+  fetchKbDocument,
+  searchKbChunks,
+  type KbChunkDetail,
+  type KbChunkSearchResponse,
+  type KbChunksListResponse,
+  type KbChunksParams,
+  type KbDocument,
+} from '@/lib/api/kb-detail-api';
+
+const DOCUMENT_STALE_MS = 5 * 60 * 1000;
+const CHUNKS_STALE_MS = 60 * 1000;
+const CHUNK_DETAIL_STALE_MS = 5 * 60 * 1000;
+const SEARCH_STALE_MS = 30 * 1000;
+
+export function useKbDocument(id: string): UseQueryResult<KbDocument, Error> {
+  return useQuery({
+    queryKey: ['kb-detail', 'document', id] as const,
+    queryFn: () => fetchKbDocument(id),
+    enabled: id.length > 0,
+    staleTime: DOCUMENT_STALE_MS,
+  });
+}
+
+export function useKbChunks(
+  docId: string,
+  params: KbChunksParams = {}
+): UseQueryResult<KbChunksListResponse, Error> {
+  return useQuery({
+    queryKey: ['kb-detail', 'chunks', docId, params.limit ?? null, params.cursor ?? null] as const,
+    queryFn: () => fetchKbChunks(docId, params),
+    enabled: docId.length > 0,
+    staleTime: CHUNKS_STALE_MS,
+  });
+}
+
+export function useKbChunk(docId: string, chunkId: string): UseQueryResult<KbChunkDetail, Error> {
+  return useQuery({
+    queryKey: ['kb-detail', 'chunk', docId, chunkId] as const,
+    queryFn: () => fetchKbChunk(docId, chunkId),
+    enabled: docId.length > 0 && chunkId.length > 0,
+    staleTime: CHUNK_DETAIL_STALE_MS,
+  });
+}
+
+export interface UseSearchKbChunksArgs {
+  readonly docId: string;
+  /** Already-debounced search input; pass `''` to disable the query. */
+  readonly query: string;
+  readonly skip?: number;
+  readonly take?: number;
+}
+
+export function useSearchKbChunks(
+  args: UseSearchKbChunksArgs
+): UseQueryResult<KbChunkSearchResponse, Error> {
+  const { docId, query, skip, take } = args;
+  return useQuery({
+    queryKey: ['kb-detail', 'chunks-search', docId, query, skip ?? 0, take ?? 20] as const,
+    queryFn: () =>
+      searchKbChunks(docId, {
+        query,
+        skip,
+        take,
+      }),
+    enabled: docId.length > 0 && query.trim().length > 0,
+    staleTime: SEARCH_STALE_MS,
+  });
+}

--- a/apps/web/src/lib/api/kb-detail-api.ts
+++ b/apps/web/src/lib/api/kb-detail-api.ts
@@ -1,0 +1,159 @@
+/**
+ * KB document detail API client (#2311 FE-2).
+ *
+ * Wraps the 4 already-shipped backend endpoints (verified by the BE-1 audit
+ * on 2026-06-14, see `KnowledgeBaseEndpoints.cs:1108-1156`):
+ *
+ *   - GET  /api/v1/kb-docs/{id}                     → KbDocumentDto
+ *   - GET  /api/v1/kb-docs/{id}/chunks              → KbChunksListResponse
+ *   - GET  /api/v1/kb-docs/{id}/chunks/{chunkId}    → KbChunkDetailDto
+ *   - POST /api/v1/kb-docs/{id}/chunks/search       → KbChunkSearchResultDto
+ *
+ * Zod schemas mirror the BE DTOs verbatim. The chunk summary surfaces the
+ * #2311 BE-1 `usedInChats` counter so the FE can render the "usato in N chat"
+ * pill without N+1 lookups.
+ */
+
+import { z } from 'zod';
+
+import { apiClient } from './client';
+
+// ───────────────────────── Document detail ────────────────────────────────
+
+export const kbDocumentSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  docType: z.string(),
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  uploaderName: z.string(),
+  uploadedAt: z.string(),
+  lastIngestedAt: z.string(),
+  processingStatus: z.string(),
+  chunkCount: z.number().int().nonnegative(),
+  pageCount: z.number().int().nonnegative().nullable(),
+  language: z.string(),
+  tags: z.array(z.string()).default([]),
+  fileSize: z.number().nonnegative(),
+  indexerVersion: z.string().nullable(),
+});
+
+export type KbDocument = z.infer<typeof kbDocumentSchema>;
+
+export async function fetchKbDocument(id: string): Promise<KbDocument> {
+  const result = await apiClient.get<KbDocument>(`/api/v1/kb-docs/${encodeURIComponent(id)}`);
+  if (result == null) throw new Error('KB document not found');
+  return kbDocumentSchema.parse(result);
+}
+
+// ───────────────────────── Chunks list ────────────────────────────────────
+
+export const kbChunkSummarySchema = z.object({
+  id: z.string().uuid(),
+  position: z.number().int().nonnegative(),
+  headingPath: z.array(z.string()).default([]),
+  snippet: z.string(),
+  pageNumber: z.number().int().nonnegative().nullable(),
+  vectorId: z.string(),
+  // #2311 BE-1 — propagated from text_chunks.usage_count (start-from-0 per DEC-D2).
+  usedInChats: z.number().int().nonnegative(),
+});
+
+export const kbChunksListResponseSchema = z.object({
+  items: z.array(kbChunkSummarySchema).default([]),
+  nextCursor: z.string().nullable(),
+  totalCount: z.number().int().nonnegative(),
+});
+
+export type KbChunkSummary = z.infer<typeof kbChunkSummarySchema>;
+export type KbChunksListResponse = z.infer<typeof kbChunksListResponseSchema>;
+
+export interface KbChunksParams {
+  limit?: number;
+  cursor?: string;
+}
+
+export async function fetchKbChunks(
+  docId: string,
+  params: KbChunksParams = {}
+): Promise<KbChunksListResponse> {
+  const qs = new URLSearchParams();
+  if (params.limit !== undefined) qs.set('limit', params.limit.toString());
+  if (params.cursor) qs.set('cursor', params.cursor);
+  const query = qs.toString();
+  const path = `/api/v1/kb-docs/${encodeURIComponent(docId)}/chunks${query ? `?${query}` : ''}`;
+  const result = await apiClient.get<KbChunksListResponse>(path);
+  if (result == null) {
+    return { items: [], nextCursor: null, totalCount: 0 };
+  }
+  return kbChunksListResponseSchema.parse(result);
+}
+
+// ───────────────────────── Single chunk detail ────────────────────────────
+
+export const kbChunkDetailSchema = z.object({
+  id: z.string().uuid(),
+  docId: z.string().uuid(),
+  position: z.number().int().nonnegative(),
+  headingPath: z.array(z.string()).default([]),
+  content: z.string(),
+  pageNumber: z.number().int().nonnegative().nullable(),
+  prevChunkId: z.string().uuid().nullable(),
+  nextChunkId: z.string().uuid().nullable(),
+  metadata: z.record(z.string(), z.unknown()).default({}),
+});
+
+export type KbChunkDetail = z.infer<typeof kbChunkDetailSchema>;
+
+export async function fetchKbChunk(docId: string, chunkId: string): Promise<KbChunkDetail> {
+  const result = await apiClient.get<KbChunkDetail>(
+    `/api/v1/kb-docs/${encodeURIComponent(docId)}/chunks/${encodeURIComponent(chunkId)}`
+  );
+  if (result == null) throw new Error('KB chunk not found');
+  return kbChunkDetailSchema.parse(result);
+}
+
+// ───────────────────────── Chunk search ───────────────────────────────────
+
+export const kbChunkMatchSchema = z.object({
+  chunkId: z.string().uuid(),
+  headingPath: z.array(z.string()).default([]),
+  snippet: z.string(),
+  rank: z.number(),
+  pageNumber: z.number().int().nonnegative().nullable(),
+  position: z.number().int().nonnegative(),
+});
+
+export const kbChunkSearchResponseSchema = z.object({
+  matches: z.array(kbChunkMatchSchema).default([]),
+  totalCount: z.number().int().nonnegative(),
+  skip: z.number().int().nonnegative(),
+  take: z.number().int().nonnegative(),
+});
+
+export type KbChunkMatch = z.infer<typeof kbChunkMatchSchema>;
+export type KbChunkSearchResponse = z.infer<typeof kbChunkSearchResponseSchema>;
+
+export interface KbChunkSearchParams {
+  query: string;
+  skip?: number;
+  take?: number;
+}
+
+export async function searchKbChunks(
+  docId: string,
+  params: KbChunkSearchParams
+): Promise<KbChunkSearchResponse> {
+  const result = await apiClient.post<KbChunkSearchResponse>(
+    `/api/v1/kb-docs/${encodeURIComponent(docId)}/chunks/search`,
+    {
+      query: params.query,
+      skip: params.skip ?? 0,
+      take: params.take ?? 20,
+    }
+  );
+  if (result == null) {
+    return { matches: [], totalCount: 0, skip: 0, take: 0 };
+  }
+  return kbChunkSearchResponseSchema.parse(result);
+}


### PR DESCRIPTION
## Summary

Closes the FE half of #2311. Rebuilds `/knowledge-base/[id]` from the MVP placeholder (`Card + Alert "viewer in future version"`, 171 LOC) to the **split-view chunks list + Markdown preview** specced by the sp4-kb-detail mockup. Wires the 4 BE endpoints + the BE-1 `usedInChats` counter (shipped in PR #2323) end-to-end.

Companion PR: **#2323** (BE-1 storage + counter).

## What's in

### FE-1 — `AnimatedUnderlineTabs` primitive (DEC-D5)

Extracted from `features/game-detail/GameDetailTabsAnimated.tsx` to `components/ui/navigation/animated-underline-tabs.tsx`. `slotPrefix?` + `accent*ClassName?` parameters keep stable selectors for every consumer. `GameDetailTabsAnimated` is now a thin wrapper that passes `slotPrefix='game-detail-tab'` — all existing call sites + tests untouched.

### FE-2 — 4 query hooks + MSW tests

- `useKbDocument(id)`            → `GET /api/v1/kb-docs/{id}`
- `useKbChunks(docId, params)`   → `GET /api/v1/kb-docs/{id}/chunks`
- `useKbChunk(docId, chunkId)`   → `GET /api/v1/kb-docs/{id}/chunks/{chunkId}` (lazy preview-pane)
- `useSearchKbChunks(args)`      → `POST /api/v1/kb-docs/{id}/chunks/search` (debounced caller)

Zod schemas mirror BE DTOs including the BE-1 `KbChunkSummaryDto.usedInChats`.

### FE-3 — 5 domain components (DEC-D3, D4, D5)

Under `components/features/knowledge-base/`:
- `MarkdownRenderBlock` — `react-markdown` + `remark-gfm` + token-canonical prose styling. **No** `rehype-raw` (XSS guard).
- `KbHeader` — document metadata card (title, docType pill, gameName, language, chunk + page counts, fileSize, uploader, lastIngestedAt, indexerVersion). `text-entity-kb` + `bg-entity-kb/15` per DEC-D5.
- `ChunkSearchBox` — 250 ms debounce, trims output, cleans up timer on unmount, callback ref so parent rerenders don't rearm.
- `KbChunkListPanel` — clickable rows with heading-path crumbs + `usato in N chat` pill driven by `KbChunkSummary.usedInChats`. Virtualization deferred: `react-window` 2.x has a redesigned API; typical KB docs are well below the DOM budget.
- `KbChunkPreview` — right pane with `AnimatedUnderlineTabs` Markdown/Raw toggle (FE-1 primitive). 4-state FSM (empty / loading / error / ready) in-place.

### FE-4 — route refactor

`/knowledge-base/[id]/page.tsx` orchestrator: autopilots first-chunk selection on landing, filters list by debounced search matches, surfaces FSM preview states. Recents push contract preserved.

### FE-5 — `/kb/[id]` redirect

Server-side `redirect('/knowledge-base/{id}')` per DEC-D1 (the mockup header declares `Route: /kb/[id]`; canonical implementation lives at `/knowledge-base/[id]`).

### FE-6 — Storybook + fidelity signoff

`page.stories.tsx` grows from a single `Default` placeholder to a 4-state matrix backed by MSW handlers. `sp4-kb-detail.fidelity.json`: `designer_approved_by` self-waiver per P250 (single-person team); `obsolete_tracking_issue` moves from CLOSED #2223 to ACTIVE #2311.

### FE-7 — axe AA gate

5 `jest-axe` smoke tests cover the FE-3 components in their default-success states. All green.

## DEC implementation table

| DEC | Choice | Implementation |
|---|---|---|
| **D1** routing | Keep `/knowledge-base/[id]` + `/kb/[id]` redirect | `apps/web/src/app/(authenticated)/kb/[id]/page.tsx` |
| **D2** counter | start-from-0 | Mirrors BE-1 PR #2323 wire-up |
| **D3** virtualization | Plain `<ul>` (react-window 2.x API redesigned) | Documented in `KbChunkListPanel.tsx` |
| **D4** markdown | `react-markdown` + `remark-gfm` no-raw | `MarkdownRenderBlock.tsx` |
| **D5** sub-tabs primitive | Extract `AnimatedUnderlineTabs` | `components/ui/navigation/animated-underline-tabs.tsx` |

## Tests

| Suite | New | Total |
|---|---|---|
| `animated-underline-tabs.test.tsx` | 8 | 8 |
| `use-kb-detail.test.tsx` (MSW) | 9 | 9 |
| `knowledge-base.test.tsx` | 13 | 13 |
| `knowledge-base-axe.test.tsx` | 5 | 5 |
| `GameDetailTabsAnimated.test.tsx` (preserved) | — | 10 |
| **Total new** | **35** | — |

Typecheck + lint clean.

## Follow-ups (not in this PR)

- **#2324** — DEC-D2 distinct-thread upgrade (junction table `chat_message_chunk_citations`). Counter from #2323 BE-1 currently increments on distinct-message; upgrade deferred until the metric is actively consumed in the UI.
- `react-window` 2.x virtualization on `KbChunkListPanel` if profiling on real KB docs shows scroll jank.

## Cross-refs

- Iteration of #2311 (FE half)
- Companion BE: **PR #2323** (BE-1 storage + counter)
- Follow-up: #2324 (distinct-thread upgrade)
- Parent closure: #2223 (superseded by this iteration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)