### PR TITLE
fix(catalog): #2157 enrich-batch per-game error resilience (timeout/http/circuit)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCoverBatch/EnrichCatalogCoverBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCoverBatch/EnrichCatalogCoverBatchCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatalogCover;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Resilience;
 using Api.SharedKernel.Application.Interfaces;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -9,14 +10,32 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatal
 /// Handler for <see cref="EnrichCatalogCoverBatchCommand"/>. Dispatches one
 /// <see cref="EnrichCatalogCoverCommand"/> per game id through
 /// <see cref="IMediator"/>, capturing per-game outcomes and aggregating
-/// bucket counters. Issue #2123 Phase B.
+/// bucket counters. Issue #2123 Phase B + Issue #2157 (per-game resilience).
 /// </summary>
 /// <remarks>
+/// <para>
 /// Sequential dispatch is intentional: parallel dispatch would defeat the
 /// 1 req/sec Wikimedia SPARQL rate limit enforced by the M8 single-entry
 /// handler (the rate-limiter is a singleton; parallel calls would still
 /// serialize at the rate-limit boundary, but the order of completion would
 /// become nondeterministic and harder to reason about for the operator).
+/// </para>
+/// <para>
+/// Issue #2157 defense-in-depth catch hierarchy: even though the M3/M4
+/// providers map <see cref="System.Net.Http.HttpClient.Timeout"/> to NotFound
+/// internally, the batch handler still guards against any future leak from
+/// the M8 single-entry handler — a single per-game exception MUST NOT abort
+/// the entire batch. The hierarchy distinguishes:
+/// <list type="bullet">
+///   <item><c>OperationCanceledException</c> + caller token cancelled → rethrow (batch aborts cleanly)</item>
+///   <item><c>OperationCanceledException</c> + caller token NOT cancelled → <c>"child-timeout"</c> (HttpClient.Timeout leak)</item>
+///   <item><c>HttpRequestException</c> → <c>"http-error"</c> (DNS, connection refused, 5xx that bypasses provider catch)</item>
+///   <item>Polly <c>BrokenCircuitException</c> → <c>"circuit-open"</c> (M10 circuit breaker tripped)</item>
+///   <item>Any other <see cref="System.Exception"/> → <c>"unhandled-exception"</c> (catch-all fallback)</item>
+/// </list>
+/// Each non-cancellation path records an entry in <see cref="EnrichCatalogCoverBatchResult.FailedDetails"/>
+/// so the admin UI can drill down into the underlying exception type + message.
+/// </para>
 /// </remarks>
 internal sealed class EnrichCatalogCoverBatchCommandHandler
     : ICommandHandler<EnrichCatalogCoverBatchCommand, EnrichCatalogCoverBatchResult>
@@ -25,6 +44,10 @@ internal sealed class EnrichCatalogCoverBatchCommandHandler
     private const string OutcomeSkipped = "skipped";
     private const string OutcomeFailed = "failed";
     private const string UnhandledExceptionReason = "unhandled-exception";
+    private const string ChildTimeoutReason = "child-timeout";
+    private const string HttpErrorReason = "http-error";
+    private const string CircuitOpenReason = "circuit-open";
+    private const string BrokenCircuitExceptionTypeName = "BrokenCircuitException";
 
     private readonly IMediator _mediator;
     private readonly ILogger<EnrichCatalogCoverBatchCommandHandler> _logger;
@@ -45,6 +68,7 @@ internal sealed class EnrichCatalogCoverBatchCommandHandler
 
         var totalRequested = command.GameIds.Count;
         var perGame = new List<EnrichCatalogCoverBatchEntry>(totalRequested);
+        var failedDetails = new List<EnrichCatalogCoverBatchFailedDetail>();
         var successCount = 0;
         var skippedCount = 0;
         var failedCount = 0;
@@ -63,9 +87,58 @@ internal sealed class EnrichCatalogCoverBatchCommandHandler
                     .Send(new EnrichCatalogCoverCommand(gameId), cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            // Issue #2157: real caller cancellation propagates so the admin
+            // client sees a clean abort. The `when (cancellationToken.IsCancellationRequested)`
+            // guard MUST come before the timeout-leak branch — otherwise
+            // HttpClient.Timeout leaks would be conflated with user cancel.
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
+            }
+            // Issue #2157: HttpClient.Timeout leak (TaskCanceledException raised
+            // from inside the provider chain when the caller token is NOT
+            // cancelled). Map to per-game "child-timeout" so the batch
+            // continues with the next id and the admin UI can retry just the
+            // timed-out subset.
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogError(ex,
+                    "EnrichCatalogCoverBatch: child timeout for GameId={GameId}, continuing batch",
+                    gameId);
+                perGame.Add(new EnrichCatalogCoverBatchEntry(gameId, OutcomeFailed, ChildTimeoutReason));
+                failedDetails.Add(new EnrichCatalogCoverBatchFailedDetail(gameId, ex.GetType().Name, ex.Message));
+                failedCount++;
+                continue;
+            }
+            // Issue #2157: any HttpRequestException leaked from the M8 chain
+            // (DNS failure, connection refused, 5xx that bypassed the
+            // provider's catch) maps to "http-error" so the admin UI can
+            // distinguish upstream HTTP outages from circuit-breaker trips.
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex,
+                    "EnrichCatalogCoverBatch: HTTP error for GameId={GameId}, continuing batch",
+                    gameId);
+                perGame.Add(new EnrichCatalogCoverBatchEntry(gameId, OutcomeFailed, HttpErrorReason));
+                failedDetails.Add(new EnrichCatalogCoverBatchFailedDetail(gameId, ex.GetType().Name, ex.Message));
+                failedCount++;
+                continue;
+            }
+            // Issue #2157: Polly BrokenCircuitException raised by the
+            // WikimediaCircuitBreakerHandler (M10) when the circuit is OPEN.
+            // Detected via reflection (Polly v7+v8 export the same FQN, see
+            // CircuitBreakerExceptionDetector). Recorded as "circuit-open" so
+            // the M9 scheduler / admin retry surface can distinguish transient
+            // breaker trips from genuine HTTP failures.
+            catch (Exception ex) when (CircuitBreakerExceptionDetector.IsBrokenCircuit(ex))
+            {
+                _logger.LogError(ex,
+                    "EnrichCatalogCoverBatch: circuit OPEN for GameId={GameId}, continuing batch",
+                    gameId);
+                perGame.Add(new EnrichCatalogCoverBatchEntry(gameId, OutcomeFailed, CircuitOpenReason));
+                failedDetails.Add(new EnrichCatalogCoverBatchFailedDetail(gameId, BrokenCircuitExceptionTypeName, ex.Message));
+                failedCount++;
+                continue;
             }
             catch (Exception ex)
             {
@@ -73,6 +146,7 @@ internal sealed class EnrichCatalogCoverBatchCommandHandler
                     "EnrichCatalogCoverBatch: unhandled exception for GameId={GameId}, continuing batch",
                     gameId);
                 perGame.Add(new EnrichCatalogCoverBatchEntry(gameId, OutcomeFailed, UnhandledExceptionReason));
+                failedDetails.Add(new EnrichCatalogCoverBatchFailedDetail(gameId, ex.GetType().Name, ex.Message));
                 failedCount++;
                 continue;
             }
@@ -103,7 +177,15 @@ internal sealed class EnrichCatalogCoverBatchCommandHandler
             "EnrichCatalogCoverBatch completed: total={Total}, success={Success}, skipped={Skipped}, failed={Failed}",
             totalRequested, successCount, skippedCount, failedCount);
 
+        // Issue #2157: FailedDetails stays null when no exception path fired
+        // (in-band Failed results carry their reason on the per-game entry).
+        // Preserves the JSON contract for the green-path case.
         return new EnrichCatalogCoverBatchResult(
-            totalRequested, successCount, skippedCount, failedCount, perGame);
+            totalRequested,
+            successCount,
+            skippedCount,
+            failedCount,
+            perGame,
+            failedDetails.Count > 0 ? failedDetails : null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCoverBatch/EnrichCatalogCoverBatchResult.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCoverBatch/EnrichCatalogCoverBatchResult.cs
@@ -3,19 +3,21 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.EnrichCatal
 /// <summary>
 /// Aggregated outcome of <see cref="EnrichCatalogCoverBatchCommand"/>. Carries
 /// per-bucket counters and a per-game audit trail so the admin UI can render a
-/// progress summary plus a drill-down list. Issue #2123.
+/// progress summary plus a drill-down list. Issue #2123 + #2157.
 /// </summary>
 /// <param name="TotalRequested">Equals <c>GameIds.Count</c> — even when the handler short-circuits on cancellation, this reflects the requested batch size.</param>
 /// <param name="SuccessCount">Number of games where M8 returned <see cref="EnrichCatalogCover.EnrichCatalogCoverResult.Success"/>.</param>
 /// <param name="SkippedCount">Number of games where M8 returned <see cref="EnrichCatalogCover.EnrichCatalogCoverResult.Skipped"/> for an expected business reason (missing QID, license not whitelisted, recently enriched, …).</param>
 /// <param name="FailedCount">Number of games where M8 returned <see cref="EnrichCatalogCover.EnrichCatalogCoverResult.Failed"/> OR threw an unhandled exception captured by the batch.</param>
 /// <param name="PerGame">Ordered per-game outcomes, enumeration matches the input <c>GameIds</c> order. Useful for UI drill-down + retry filtering.</param>
+/// <param name="FailedDetails">Issue #2157 — exception drill-down payload for each per-game failure path (child-timeout / http-error / circuit-open / unhandled-exception). <see langword="null"/> when no exception was caught (every failure originated from an in-band <see cref="EnrichCatalogCover.EnrichCatalogCoverResult.Failed"/> result, which already carries its own reason on <see cref="EnrichCatalogCoverBatchEntry.Reason"/>). Optional + null default preserves backward compat for the JSON contract.</param>
 internal sealed record EnrichCatalogCoverBatchResult(
     int TotalRequested,
     int SuccessCount,
     int SkippedCount,
     int FailedCount,
-    IReadOnlyList<EnrichCatalogCoverBatchEntry> PerGame);
+    IReadOnlyList<EnrichCatalogCoverBatchEntry> PerGame,
+    IReadOnlyList<EnrichCatalogCoverBatchFailedDetail>? FailedDetails = null);
 
 /// <summary>
 /// Per-game audit entry produced by <see cref="EnrichCatalogCoverBatchCommand"/>.
@@ -27,3 +29,30 @@ internal sealed record EnrichCatalogCoverBatchEntry(
     Guid GameId,
     string Outcome,
     string? Reason);
+
+/// <summary>
+/// Issue #2157 — exception drill-down for a single per-game failure. Captured
+/// only when the batch handler's defense-in-depth catch hierarchy fires
+/// (HTTP timeout leak, HttpRequestException, BrokenCircuitException, or any
+/// other unhandled exception). The admin UI uses this payload to distinguish
+/// transient (retryable) vs permanent (data-fix-required) failures inside the
+/// <c>failed</c> bucket of <see cref="EnrichCatalogCoverBatchResult"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ExceptionMessage"/> is the raw <see cref="Exception.Message"/>.
+/// The producing exceptions (<see cref="System.Net.Http.HttpRequestException"/>,
+/// <see cref="System.Threading.Tasks.TaskCanceledException"/>, Polly
+/// <c>BrokenCircuitException</c>) do NOT include internal file paths or
+/// credentials in their message text — they describe the failure mode only.
+/// If a future exception type with sensitive payload is added, sanitisation
+/// MUST happen at the catch site before constructing this record.
+/// </para>
+/// </remarks>
+/// <param name="GameId">The game id this failure refers to (matches a <see cref="EnrichCatalogCoverBatchEntry.GameId"/>).</param>
+/// <param name="ExceptionType">Short type name of the exception (e.g. <c>"TaskCanceledException"</c>, <c>"HttpRequestException"</c>, <c>"BrokenCircuitException"</c>).</param>
+/// <param name="ExceptionMessage">Sanitized exception message — see remarks for sanitisation policy.</param>
+internal sealed record EnrichCatalogCoverBatchFailedDetail(
+    Guid GameId,
+    string ExceptionType,
+    string ExceptionMessage);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -161,7 +161,26 @@ internal sealed class WikidataCatalogProvider : ICatalogProvider
 
             return ParseCoverResponse(body, qid, sourceUrl);
         }
-        catch (OperationCanceledException) { throw; }
+        // Issue #2157: real caller cancellation propagates so the batch handler
+        // can decide to abort. We MUST guard with `when (ct.IsCancellationRequested)`
+        // because HttpClient.Timeout firing also raises a TaskCanceledException
+        // (subclass of OperationCanceledException) WITHOUT cancelling the caller
+        // token — without the guard we would conflate a per-game HTTP timeout
+        // with a batch-wide user cancel, aborting the entire batch on the first
+        // slow upstream response.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        // Issue #2157: HttpClient.Timeout (TaskCanceledException) with caller
+        // token NOT cancelled = upstream timeout. Map to NotFound so the batch
+        // continues with the next game; the batch handler still records a
+        // distinct outcome for ops via the per-game audit trail.
+        catch (OperationCanceledException oce)
+        {
+            _logger.LogWarning(oce, "Wikidata cover fetch TIMEOUT for QID {Qid}", qid);
+            return WikidataCoverImageResult.NotFound(qid);
+        }
         // Issue #1823 Wave 3 M13 (M10 follow-up): the WikimediaCircuitBreakerHandler
         // (DEC-3f) throws BrokenCircuitException when its circuit is OPEN. Letting
         // the generic catch swallow it would silently map "upstream temporarily

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClient.cs
@@ -98,9 +98,24 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
             var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             return ParseResponse(body, filename, decoded);
         }
-        // OperationCanceledException is intentionally NOT caught: it is not a
-        // subclass of HttpRequestException or JsonException, so it propagates
-        // naturally to honour caller cancellation (see XML doc on the interface).
+        // Issue #2157: real caller cancellation propagates so the batch handler
+        // can decide to abort. HttpClient.Timeout firing also raises
+        // TaskCanceledException (subclass of OperationCanceledException) WITHOUT
+        // cancelling the caller token; we MUST distinguish via the
+        // `when (ct.IsCancellationRequested)` guard or the batch handler will
+        // mistake a per-game upstream timeout for a batch-wide user cancel.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons imageinfo TIMEOUT for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
+                filename,
+                decoded);
+            return CommonsLicenseResult.NotAvailable();
+        }
         catch (HttpRequestException ex)
         {
             _logger.LogWarning(ex,
@@ -168,8 +183,24 @@ internal sealed class WikimediaCommonsClient : IWikimediaCommonsClient
 
             return bytes;
         }
-        // OperationCanceledException intentionally NOT caught: propagates to
-        // honour caller cancellation (see XML doc on the interface).
+        // Issue #2157: real caller cancellation propagates so the batch handler
+        // can decide to abort. HttpClient.Timeout firing also raises
+        // TaskCanceledException (subclass of OperationCanceledException) WITHOUT
+        // cancelling the caller token; we MUST distinguish via the
+        // `when (ct.IsCancellationRequested)` guard so the batch handler can
+        // record the per-game timeout and continue with the next id.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogWarning(ex,
+                "Commons FilePath TIMEOUT for file '{Filename}' (decoded='{Decoded}'). Caller decides retry.",
+                filename,
+                decoded);
+            return null;
+        }
         catch (HttpRequestException ex)
         {
             _logger.LogWarning(ex,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCoverBatchCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/EnrichCatalogCoverBatchCommandHandlerTests.cs
@@ -141,4 +141,98 @@ public sealed class EnrichCatalogCoverBatchCommandHandlerTests
         await act.Should().ThrowAsync<OperationCanceledException>();
         callCount.Should().Be(1, "cancellation must short-circuit before dispatching the second command");
     }
+
+    [Fact]
+    public async Task Handle_TreatsTaskCanceledFromTimeoutAsFailed_ContinuesNotPropagates()
+    {
+        // Issue #2157: defense-in-depth. Even if a provider somehow leaks
+        // TaskCanceledException (e.g. HttpClient.Timeout above the provider
+        // guard, or any future code path bypassing the M3/M4 fix), the batch
+        // handler MUST distinguish it from a real caller cancellation and
+        // continue with the next game. The discriminator is the caller's
+        // CancellationToken state: if NOT cancelled, the leak is mapped to a
+        // per-game Failed("child-timeout") entry; if cancelled, it propagates.
+        var ok = Guid.NewGuid();
+        var timedOut = Guid.NewGuid();
+        _mediator
+            .Setup(m => m.Send(It.Is<EnrichCatalogCoverCommand>(c => c.GameId == ok), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "https://w/Q"));
+        _mediator
+            .Setup(m => m.Send(It.Is<EnrichCatalogCoverCommand>(c => c.GameId == timedOut), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("simulated HTTP timeout leak"));
+
+        using var cts = new CancellationTokenSource(); // NOT cancelled
+        var result = await CreateHandler().Handle(
+            new EnrichCatalogCoverBatchCommand(new[] { ok, timedOut }), cts.Token);
+
+        result.TotalRequested.Should().Be(2);
+        result.SuccessCount.Should().Be(1);
+        result.FailedCount.Should().Be(1);
+        result.PerGame.Single(p => p.GameId == timedOut).Outcome.Should().Be("failed");
+        result.PerGame.Single(p => p.GameId == timedOut).Reason.Should().Be("child-timeout");
+
+        // FailedDetails carries exception drill-down for the admin UI.
+        result.FailedDetails.Should().NotBeNull();
+        result.FailedDetails!.Should().ContainSingle(d => d.GameId == timedOut);
+        var detail = result.FailedDetails!.Single(d => d.GameId == timedOut);
+        detail.ExceptionType.Should().Be("TaskCanceledException");
+        detail.ExceptionMessage.Should().Contain("HTTP timeout");
+    }
+
+    [Fact]
+    public async Task Handle_TreatsHttpRequestExceptionAsFailed_RecordsExceptionType()
+    {
+        // Issue #2157: any HttpRequestException leaked from the M8 single-entry
+        // handler (e.g. DNS error, connection refused, 5xx that bypasses the
+        // provider's catch) maps to a per-game Failed("http-error") entry with
+        // a FailedDetail payload carrying the exception type and (sanitised)
+        // message so the admin UI can drill down into transient vs permanent
+        // failures.
+        var ok = Guid.NewGuid();
+        var httpFail = Guid.NewGuid();
+        _mediator
+            .Setup(m => m.Send(It.Is<EnrichCatalogCoverCommand>(c => c.GameId == ok), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "https://w/Q"));
+        _mediator
+            .Setup(m => m.Send(It.Is<EnrichCatalogCoverCommand>(c => c.GameId == httpFail), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("DNS resolution failed", null, System.Net.HttpStatusCode.ServiceUnavailable));
+
+        var result = await CreateHandler().Handle(
+            new EnrichCatalogCoverBatchCommand(new[] { ok, httpFail }), CancellationToken.None);
+
+        result.TotalRequested.Should().Be(2);
+        result.SuccessCount.Should().Be(1);
+        result.FailedCount.Should().Be(1);
+        var entry = result.PerGame.Single(p => p.GameId == httpFail);
+        entry.Outcome.Should().Be("failed");
+        entry.Reason.Should().Be("http-error");
+
+        // FailedDetails populated for drill-down.
+        result.FailedDetails.Should().NotBeNull();
+        result.FailedDetails!.Should().ContainSingle(d => d.GameId == httpFail);
+        var detail = result.FailedDetails!.Single(d => d.GameId == httpFail);
+        detail.ExceptionType.Should().Be("HttpRequestException");
+        detail.ExceptionMessage.Should().Contain("DNS resolution failed");
+    }
+
+    [Fact]
+    public async Task Handle_FailedDetailsIsNull_WhenNoFailuresOccur()
+    {
+        // Backward-compat: existing callers MUST observe FailedDetails == null
+        // when every game succeeds (no allocation of empty list). This locks
+        // the optional-parameter default to null so any future serialization
+        // (JSON to admin UI, audit log) does not change shape on the green path.
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        _mediator
+            .Setup(m => m.Send(It.IsAny<EnrichCatalogCoverCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrichCatalogCoverResult.Success("k", "CC0", null, "https://w/Q"));
+
+        var result = await CreateHandler().Handle(
+            new EnrichCatalogCoverBatchCommand(new[] { a, b }), CancellationToken.None);
+
+        result.SuccessCount.Should().Be(2);
+        result.FailedCount.Should().Be(0);
+        result.FailedDetails.Should().BeNull("no exception path was taken — no drill-down payload allocated");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderCoverImageTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderCoverImageTests.cs
@@ -239,8 +239,12 @@ public sealed class WikidataCatalogProviderCoverImageTests
     }
 
     [Fact]
-    public async Task FetchCoverImageAsync_HttpCancellation_RethrowsOperationCanceledException()
+    public async Task FetchCoverImageAsync_CallerCancellation_RethrowsOperationCanceledException()
     {
+        // Issue #2157: caller cancellation MUST propagate. We assert by using a
+        // CancellationTokenSource that IS cancelled — the provider's exception
+        // filter `when (ct.IsCancellationRequested)` rethrows for real caller
+        // cancel and swallows-as-NotFound only for HttpClient.Timeout leaks.
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
             .Setup<Task<HttpResponseMessage>>(
@@ -254,9 +258,105 @@ public sealed class WikidataCatalogProviderCoverImageTests
         };
         var provider = MakeProvider(client);
 
-        var act = async () => await provider.FetchCoverImageAsync("Q17215001", CancellationToken.None);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await provider.FetchCoverImageAsync("Q17215001", cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
+    /// Issue #2157: <see cref="HttpClient.Timeout"/> firing produces
+    /// <see cref="TaskCanceledException"/> (subclass of
+    /// <see cref="OperationCanceledException"/>) EVEN WHEN the caller's
+    /// <see cref="CancellationToken"/> is NOT cancelled. The provider must
+    /// distinguish these two cases by guarding the rethrow with
+    /// <c>when (ct.IsCancellationRequested)</c> and mapping the HTTP timeout
+    /// to <see cref="WikidataCoverImageResult.NotFound"/>. Otherwise the
+    /// batch handler's `OperationCanceledException` catch aborts the entire
+    /// batch on the first slow Wikidata response, surfacing a 500 to the
+    /// admin client and forfeiting any partial enrichment.
+    /// </summary>
+    [Fact]
+    public async Task FetchCoverImageAsync_HttpClientTimeout_ReturnsNotFound_DoesNotRethrow()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("HttpClient timeout simulation"));
+        var client = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("https://query.wikidata.org/"),
+        };
+        var provider = MakeProvider(client);
+
+        using var callerCts = new CancellationTokenSource();
+        // callerCts is NOT cancelled — the TaskCanceledException originates
+        // from HttpClient.Timeout, not the caller's token.
+        var result = await provider.FetchCoverImageAsync("Q17215001", callerCts.Token);
+
+        result.HasImage.Should().BeFalse("HttpClient.Timeout maps to NotFound, not exception");
+        result.Filename.Should().BeNull();
+        result.SourceUrl.Should().Be("https://www.wikidata.org/wiki/Q17215001");
+        callerCts.IsCancellationRequested.Should().BeFalse(
+            "sanity check: caller token was never cancelled in this scenario");
+    }
+
+    /// <summary>
+    /// Issue #2157 integration-style coverage: spin up a real
+    /// <see cref="HttpClient"/> with a 100 ms timeout pointed at a delegating
+    /// handler that delays 500 ms — exercises the actual
+    /// <see cref="HttpClient.Timeout"/> code path (vs the Moq throw above)
+    /// to lock the guard against future Polly / .NET runtime changes.
+    /// </summary>
+    [Fact]
+    public async Task FetchCoverImageAsync_RealHttpClientTimeout_IsCaughtAsNotFound()
+    {
+        using var slowHandler = new SlowResponseHandler(TimeSpan.FromMilliseconds(500));
+        using var httpClient = new HttpClient(slowHandler)
+        {
+            BaseAddress = new Uri("https://query.wikidata.org/"),
+            Timeout = TimeSpan.FromMilliseconds(100),
+        };
+        var rateLimiter = new Mock<IWikimediaRateLimiter>();
+        rateLimiter.Setup(r => r.AcquireAsync(It.IsAny<CancellationToken>())).Returns(ValueTask.CompletedTask);
+        var provider = new WikidataCatalogProvider(
+            httpClient,
+            NullLogger<WikidataCatalogProvider>.Instance,
+            rateLimiter.Object);
+
+        using var callerCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var result = await provider.FetchCoverImageAsync("Q17215001", callerCts.Token);
+
+        result.HasImage.Should().BeFalse();
+        callerCts.IsCancellationRequested.Should().BeFalse(
+            "real HttpClient.Timeout fires independently of caller token");
+    }
+
+    private sealed class SlowResponseHandler : DelegatingHandler
+    {
+        private readonly TimeSpan _delay;
+
+        public SlowResponseHandler(TimeSpan delay)
+        {
+            _delay = delay;
+            InnerHandler = new HttpClientHandler();
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"results\":{\"bindings\":[]}}", System.Text.Encoding.UTF8, "application/sparql-results+json"),
+            };
+        }
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/WikimediaCommonsClientTests.cs
@@ -347,8 +347,13 @@ public class WikimediaCommonsClientTests
     }
 
     [Fact]
-    public async Task FetchLicenseAsync_HttpCancellation_RethrowsOperationCanceledException()
+    public async Task FetchLicenseAsync_CallerCancellation_RethrowsOperationCanceledException()
     {
+        // Issue #2157: real caller cancellation MUST propagate so the batch
+        // handler can abort. We assert this by using a CancellationTokenSource
+        // that IS cancelled — the client's `when (ct.IsCancellationRequested)`
+        // guard rethrows, while HttpClient.Timeout leaks (next test) are
+        // mapped to NotAvailable so the batch can continue with the next game.
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
@@ -358,8 +363,39 @@ public class WikimediaCommonsClientTests
 
         var client = CreateClient(handler.Object);
 
-        await client.Invoking(c => c.FetchLicenseAsync("Cover.jpg", CancellationToken.None))
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await client.Invoking(c => c.FetchLicenseAsync("Cover.jpg", cts.Token))
             .Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task FetchLicenseAsync_HttpClientTimeout_ReturnsNotAvailable_DoesNotRethrow()
+    {
+        // Issue #2157: HttpClient.Timeout firing raises TaskCanceledException
+        // (subclass of OperationCanceledException) WITHOUT cancelling the
+        // caller token. The client MUST distinguish this from a real caller
+        // cancel and map it to NotAvailable so the batch handler can continue
+        // with the next game instead of aborting the entire batch.
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("HttpClient timeout simulation"));
+
+        var client = CreateClient(handler.Object);
+
+        using var callerCts = new CancellationTokenSource();
+        // callerCts is NOT cancelled — the TaskCanceledException originates from
+        // HttpClient.Timeout, not the caller's token.
+        var result = await client.FetchLicenseAsync("Cover.jpg", callerCts.Token);
+
+        result.Should().Be(CommonsLicenseResult.NotAvailable(),
+            "HttpClient.Timeout is mapped to NotAvailable so the batch continues with the next game");
+        callerCts.IsCancellationRequested.Should().BeFalse(
+            "sanity check: caller token was never cancelled in this scenario");
     }
 
     [Fact]
@@ -590,8 +626,11 @@ public class WikimediaCommonsClientTests
     }
 
     [Fact]
-    public async Task FetchImageBytesAsync_Cancellation_RethrowsOperationCanceledException()
+    public async Task FetchImageBytesAsync_CallerCancellation_RethrowsOperationCanceledException()
     {
+        // Issue #2157: real caller cancellation MUST propagate. Asserted via
+        // a CancellationTokenSource that IS cancelled so the
+        // `when (ct.IsCancellationRequested)` guard rethrows.
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
@@ -601,8 +640,37 @@ public class WikimediaCommonsClientTests
 
         var client = CreateClient(handler.Object);
 
-        await client.Invoking(c => c.FetchImageBytesAsync("Cover.jpg", CancellationToken.None))
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await client.Invoking(c => c.FetchImageBytesAsync("Cover.jpg", cts.Token))
             .Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task FetchImageBytesAsync_HttpClientTimeout_ReturnsNull_DoesNotRethrow()
+    {
+        // Issue #2157: HttpClient.Timeout firing raises TaskCanceledException
+        // (subclass of OperationCanceledException) WITHOUT cancelling the
+        // caller token. The client MUST distinguish this from a real caller
+        // cancel and map it to null so the batch handler can continue with
+        // the next game instead of aborting the entire batch.
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("HttpClient timeout simulation"));
+
+        var client = CreateClient(handler.Object);
+
+        using var callerCts = new CancellationTokenSource();
+        var result = await client.FetchImageBytesAsync("Cover.jpg", callerCts.Token);
+
+        result.Should().BeNull(
+            "HttpClient.Timeout is mapped to null so the batch continues with the next game");
+        callerCts.IsCancellationRequested.Should().BeFalse(
+            "sanity check: caller token was never cancelled in this scenario");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Risolve l'errore 500 HTTP del `POST /api/v1/admin/catalog/covers/enrich-batch` con partial-commit segnalato da operational run su 128-game batch (29/128 R2 covers populated, restanti unprocessed).

### Defense-in-depth a 3 layer

**Layer 1 — Provider** (`WikidataCatalogProvider.cs:171-183`):
- Distingue `TaskCanceledException : OperationCanceledException` (HttpClient.Timeout) da caller-initiated cancel via filter `when (ct.IsCancellationRequested)`
- Timeout → mappa a `WikidataCoverImageResult.NotFound` (batch continua); real cancel → rethrow

**Layer 2 — Commons client** (`WikimediaCommonsClient.cs:107-118,192-203`):
- Stesso pattern applicato a `FetchLicenseAsync` + `FetchImageBytesAsync` (defense-in-depth — i metodi NON catturavano OCE prima)

**Layer 3 — Batch handler** (`EnrichCatalogCoverBatchCommandHandler.cs:94-152`):
- Catch hierarchy a 5 livelli: OCE-cancel rethrow → OCE-timeout → HttpRequestException → BrokenCircuitException (via `CircuitBreakerExceptionDetector.IsBrokenCircuit`) → unhandled-exception
- Ogni non-cancel path appende a `failedDetails` list

### Result DTO extension

Nuovo record `EnrichCatalogCoverBatchFailedDetail(GameId, ExceptionType, ExceptionMessage)` + optional 6° param `FailedDetails: IReadOnlyList<...>? = null` su `EnrichCatalogCoverBatchResult`. Backward-compat preservato (5-param call sites unaffected; FailedDetails serializes null/omitted su green path).

XML remarks documentano sanitisation policy: i 3 exception type prodotti (`HttpRequestException`, `TaskCanceledException`, `BrokenCircuitException`) emit failure-mode-only messages senza path interni o credenziali.

### Files (7 totali, +440/-17)

- 4 source: `WikidataCatalogProvider.cs`, `WikimediaCommonsClient.cs`, `EnrichCatalogCoverBatchResult.cs`, `EnrichCatalogCoverBatchCommandHandler.cs`
- 3 test: `EnrichCatalogCoverBatchCommandHandlerTests.cs`, `WikidataCatalogProviderCoverImageTests.cs`, `WikimediaCommonsClientTests.cs`

## Test plan

- [x] `EnrichCatalogCoverBatchCommandHandlerTests`: 8/8 pass (5 esistenti + 3 nuovi: TaskCanceled→failed, HttpRequestException→failed, FailedDetails-null green path)
- [x] `WikidataCatalogProviderCoverImageTests`: 17/17 pass (14 esistenti + 3 nuovi: real HttpClient.Timeout via `SlowResponseHandler`, Moq timeout, updated caller-cancel con CTS effettivamente cancellata)
- [x] `WikimediaCommonsClientTests`: 38/38 pass (36 esistenti + 2 nuovi su FetchLicense + FetchImageBytes timeout)
- [x] Build: 0 warning, 0 error
- [x] No regression in scope-adjacent tests

## Review

Internal holistic review (`feature-dev:code-reviewer`) APPROVED:
- Spec compliant — filter pattern verificato in 3 location, catch hierarchy ordering corretto
- Quality: 0 Critical / 0 Important findings; 1 Minor confidence-55 (SlowResponseHandler DNS pre-timeout in sandboxed CI — non-blocking, test passa)
- Sanitisation policy documentata in XML remarks
- No `ex.Message` leak pattern regression
- Backward-compat constructor preserved
- Pipeline behavior: `EnrichCatalogCover*Command` non ha `[AuditableAction]` → `AuditLoggingBehavior` skip confermato (NON root cause)

## Plan reference

`docs/superpowers/plans/2026-06-14-issue-2157-enrich-cover-batch-resilience.md`

## Refs

- Parent issue: #2123 (BGG ToS ban + 3-layer enforcement)
- Parent PR: #2125 (Wikidata QID bootstrap)
- Operational trigger: 128-game batch dev DB run, 49s timeout → HTTP 500 con partial commit

Closes #2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)