### PR TITLE
ci(bgg): #2137 re-apply BGG ToS CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,10 @@ jobs:
         run: pnpm mockup-annotations:audit --denominator mappable --threshold 80
         # Note: script resolves REPO_ROOT from __dirname; runs from apps/web (job default).
 
+      # Issue #2123 — BGG ToS compliance gate
+      - name: BGG ToS compliance gate (#2123)
+        run: pnpm lint:bgg
+
       - name: Upload mockup annotation coverage report
         if: always()
         uses: actions/upload-artifact@v7
@@ -773,6 +777,18 @@ jobs:
           CI: true
         # Note: Coverage requirement removed - test isolation makes 85% threshold impractical
         # Coverage is still measured and reported to Codecov for monitoring
+
+      - name: Install ruamel.yaml for codemod tests
+        run: pip install 'ruamel.yaml>=0.19'
+        working-directory: ${{ github.workspace }}
+
+      - name: Run BGG manifest scrub codemod tests (#2123)
+        run: python -m pytest scripts/tests/test_scrub_bgg_manifest.py -v
+        working-directory: ${{ github.workspace }}
+
+      - name: Run Wikidata QID bootstrap tests (#2123)
+        run: python -m pytest scripts/tests/test_bootstrap_wikidata_qid.py -v
+        working-directory: ${{ github.workspace }}
 
       - name: Upload Python Coverage
         if: always()

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Run bake
         working-directory: infra

--- a/.github/workflows/seed-snapshot-bake-full.yml
+++ b/.github/workflows/seed-snapshot-bake-full.yml
@@ -87,7 +87,7 @@ jobs:
           sudo apt-get install -y jq awscli
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Bake (dev.yml manifest, ~3–6h on CPU)
         working-directory: infra


### PR DESCRIPTION
## Summary
- `Frontend - Lint` job: adds blocking `pnpm lint:bgg` gate after the DS-17-1 mockup annotation coverage step (network-plane enforcement per ADR-059 §5).
- `Python - Orchestration Service Tests` job: adds `ruamel.yaml>=0.19` install + 2 pytest runs (`scripts/tests/test_scrub_bgg_manifest.py`, `scripts/tests/test_bootstrap_wikidata_qid.py`) executed from `${{ github.workspace }}` to bypass the job's `apps/orchestration-service` default working directory.

Re-applies workflow edits originally landed in PR #2125 but reverted before push because the OAuth token used for the merge lacked the `workflow` scope.

## Why this PR
Issue #2123 shipped a 3-layer BGG ToS ban (data plane + resolution plane + network plane). The network-plane enforcement (ESLint custom rule `local/no-bgg-host` + grep gate + manifest scrub codemod) is only effective when wired into the CI pipeline as blocking checks. Until this PR lands, the gates exist as scripts but no PR is forced to run them.

## Test plan
- [x] Local smoke `pnpm lint:bgg` → clean across 4 scanned scopes.
- [x] Local smoke `python -m pytest scripts/tests/test_{scrub_bgg_manifest,bootstrap_wikidata_qid}.py -v` → 24/24 pass (11 scrub + 13 bootstrap).
- [ ] CI `Frontend - Lint` step green on this PR.
- [ ] CI `Python - Orchestration Service Tests` runs the 2 new pytest steps green on this PR.

## Refs
- Parent issue: #2123 (BGG user-side asset ban, 3-layer enforcement)
- Predecessor PRs: #2125 (merged 0aa9e6b0a), #2133 (hotfix 7cc7e486a), #2136 (pending)
- ADR-059 §5: BGG ToS legal posture

Closes #2137

🤖 Generated with [Claude Code](https://claude.com/claude-code)