### PR TITLE
feat(lint): #2151 BGG user-side copy gate (whitelist-incremental)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,23 @@ jobs:
             audits/2026-06-09-mockup-annotation-coverage.md
           retention-days: 14
 
+      # Issue #2151 — BGG user-side copy gate (mockup + FE source, whitelist-incremental).
+      # Mirror of the DS-17-2 lint:tokens:mockups pattern (#2070). Baseline locked to
+      # the current inventory; a NEW BGG reference fails the gate. Reduce the baseline
+      # opportunistically as cleanup PRs land. See ADR-059 §2.
+      - name: BGG mockup + FE copy gate (#2151)
+        run: pnpm lint:bgg-mockups --strict --max-baseline 325
+
+      - name: Upload BGG mockup violations report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bgg-mockup-violations-${{ github.run_number }}
+          path: |
+            audits/2026-06-14-bgg-mockup-violations.json
+            audits/2026-06-14-bgg-mockup-violations.md
+          retention-days: 14
+
       # DS-17-8-v2 (mockup-to-app fidelity, 2026-06-10):
       # Non-blocking Storybook snapshot scaffolding per Phase 2 pilot stories.
       # Phase 2 ships scaffolding only (config + specs + scripts); baseline

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "audit-mockups:create-issues": "node scripts/audit-mockups/create-tracking-issues.mjs",
     "audit-mockups:cluster-queue": "node scripts/audit-mockups/generate-cluster-review-queue.mjs",
     "lint:bgg": "node scripts/lint-bgg.mjs",
+    "lint:bgg-mockups": "node scripts/lint-bgg-mockups.mjs",
     "lint:mockup-state-naming": "node scripts/validate-state-naming.mjs",
     "lint:fidelity": "node scripts/mockup-annotations/validate-fidelity.mjs --all",
     "mockup-annotations:inject": "node scripts/mockup-annotations/inject-annotations.mjs",

--- a/apps/web/scripts/__tests__/lint-bgg-mockups.test.ts
+++ b/apps/web/scripts/__tests__/lint-bgg-mockups.test.ts
@@ -1,0 +1,318 @@
+/**
+ * lint-bgg-mockups.test.ts — unit tests for lint-bgg-mockups.mjs (DS-17 §2151)
+ *
+ * Run: pnpm vitest run scripts/__tests__/lint-bgg-mockups.test.ts
+ *
+ * Refs:
+ *   - Issue: #2151
+ *   - Pattern: scripts/__tests__/lint-tokens-mockups.test.ts (DS-17-2 #2070)
+ *   - ADR: docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  BGG_USER_COPY_REGEX,
+  findViolationsInText,
+  hasAllowedJustification,
+  isAdminScope,
+  isWellKnownLegitimate,
+  readDesignIntent,
+  lintFiles,
+} from '../lint-bgg-mockups.mjs';
+
+const TMP_DIR = resolve(tmpdir(), `lint-bgg-mockups-tests-${process.pid}`);
+
+beforeAll(() => {
+  if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('BGG_USER_COPY_REGEX', () => {
+  it('matches BGG, BoardGameGeek, boardgamegeek case-insensitive', () => {
+    const cases = ['BGG', 'bgg', 'BoardGameGeek', 'boardgamegeek', 'BOARDGAMEGEEK'];
+    for (const s of cases) {
+      const re = new RegExp(BGG_USER_COPY_REGEX.source, BGG_USER_COPY_REGEX.flags);
+      expect(re.test(s), `should match: ${s}`).toBe(true);
+    }
+  });
+
+  it('honors word boundaries — does NOT match substrings inside identifiers', () => {
+    // "blogger" contains "bgg" but not as a word — must NOT match.
+    const cases = ['blogger', 'beggar', 'BGGish identifier'];
+    for (const s of cases) {
+      const re = new RegExp(BGG_USER_COPY_REGEX.source, BGG_USER_COPY_REGEX.flags);
+      const match = re.test(s);
+      if (s === 'BGGish identifier') {
+        // 'BGGish' should NOT match because 'BGG' has no trailing word boundary.
+        expect(match, `should NOT match (no word boundary): ${s}`).toBe(false);
+      } else {
+        expect(match, `should NOT match (substring): ${s}`).toBe(false);
+      }
+    }
+  });
+
+  it('matches BGG followed by punctuation (still a word boundary)', () => {
+    const cases = ['Cerca su BGG.', 'BGG?', '"BGG"', 'BGG-tagged'];
+    for (const s of cases) {
+      const re = new RegExp(BGG_USER_COPY_REGEX.source, BGG_USER_COPY_REGEX.flags);
+      expect(re.test(s), `should match: ${s}`).toBe(true);
+    }
+  });
+});
+
+describe('hasAllowedJustification', () => {
+  it('returns true when marker is on the same line', () => {
+    const lines = ['const x = "BGG"; // BGG-ALLOWED: legitimate'];
+    expect(hasAllowedJustification(lines, 0)).toBe(true);
+  });
+
+  it('returns true when marker is on the immediately preceding line', () => {
+    const lines = ['// BGG-ALLOWED: block-comment header', 'const x = "BoardGameGeek";'];
+    expect(hasAllowedJustification(lines, 1)).toBe(true);
+  });
+
+  it('returns true when marker is 2 lines above (block-comment + blank + usage)', () => {
+    const lines = ['/* BGG-ALLOWED: parser */', '', 'const x = "BGG";'];
+    expect(hasAllowedJustification(lines, 2)).toBe(true);
+  });
+
+  it('returns false when marker is 3+ lines above (out of window)', () => {
+    const lines = ['// BGG-ALLOWED: top of file', '', '', 'const x = "BGG";'];
+    expect(hasAllowedJustification(lines, 3)).toBe(false);
+  });
+
+  it('returns false when no marker is present', () => {
+    const lines = ['const x = "BGG";'];
+    expect(hasAllowedJustification(lines, 0)).toBe(false);
+  });
+});
+
+describe('findViolationsInText', () => {
+  it('returns empty array for clean text', () => {
+    const result = findViolationsInText('const x = "neutral copy";', 'clean.ts');
+    expect(result).toEqual([]);
+  });
+
+  it('flags BGG occurrence without justification marker', () => {
+    const text = 'const cta = "Importa BGG";';
+    const result = findViolationsInText(text, 'cta.ts');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ file: 'cta.ts', line: 1, match: 'BGG' });
+  });
+
+  it('skips BGG occurrence with same-line justification', () => {
+    const text = 'const cta = "Importa BGG"; // BGG-ALLOWED: legacy admin tool';
+    const result = findViolationsInText(text, 'admin-cta.ts');
+    expect(result).toEqual([]);
+  });
+
+  it('skips BGG occurrence with justification on the preceding line', () => {
+    const text = [
+      '// BGG-ALLOWED: legitimate gamebook parser',
+      'const TSV = "BoardGameGeek collection";',
+    ].join('\n');
+    const result = findViolationsInText(text, 'parser.ts');
+    expect(result).toEqual([]);
+  });
+
+  it('flags multiple violations across separate unjustified lines', () => {
+    const text = [
+      'const cta1 = "Importa BGG";',
+      'const cta2 = "Connetti BoardGameGeek";',
+      'const cta3 = "Cerca su boardgamegeek";',
+    ].join('\n');
+    const result = findViolationsInText(text, 'multi.ts');
+    expect(result).toHaveLength(3);
+  });
+
+  it('flags all hits on a line when none has justification', () => {
+    const text = 'const both = "BGG and BoardGameGeek";';
+    const result = findViolationsInText(text, 'same-line.ts');
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips ALL hits on a line when the line itself has justification', () => {
+    const text = 'const both = "BGG and BoardGameGeek"; // BGG-ALLOWED: docstring example';
+    const result = findViolationsInText(text, 'justified-same-line.ts');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('isAdminScope', () => {
+  it('matches FE admin app paths', () => {
+    expect(isAdminScope('apps/web/src/app/admin/page.tsx')).toBe(true);
+    expect(isAdminScope('apps/web/src/components/admin/foo.tsx')).toBe(true);
+    expect(isAdminScope('apps/web/src/app/api/route.ts')).toBe(true);
+  });
+
+  it('normalizes backslashes', () => {
+    expect(isAdminScope('apps\\web\\src\\app\\admin\\page.tsx')).toBe(true);
+  });
+
+  it('does NOT match non-admin paths', () => {
+    expect(isAdminScope('apps/web/src/app/dashboard/page.tsx')).toBe(false);
+    expect(isAdminScope('apps/web/src/components/dashboard/foo.tsx')).toBe(false);
+  });
+});
+
+describe('isWellKnownLegitimate', () => {
+  it('matches the documented allowlist exactly', () => {
+    expect(isWellKnownLegitimate('apps/web/src/types/bgg.ts')).toBe(true);
+    expect(isWellKnownLegitimate('apps/web/src/lib/api/clients/bggClient.ts')).toBe(true);
+    expect(isWellKnownLegitimate('apps/web/src/lib/parsers/bgg-tsv.ts')).toBe(true);
+    expect(isWellKnownLegitimate('apps/web/src/lib/games/cover-utils.ts')).toBe(true);
+  });
+
+  it('does NOT match unrelated files', () => {
+    expect(isWellKnownLegitimate('apps/web/src/components/random.tsx')).toBe(false);
+    expect(isWellKnownLegitimate('apps/web/src/types/other.ts')).toBe(false);
+  });
+});
+
+describe('readDesignIntent', () => {
+  it('returns design_intent from sibling fidelity.json', () => {
+    const dir = resolve(TMP_DIR, 'fidelity-current');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page.html'), '<div>BGG</div>', 'utf-8');
+    writeFileSync(
+      resolve(dir, 'page.fidelity.json'),
+      JSON.stringify({ design_intent: 'current' }),
+      'utf-8'
+    );
+    const intent = readDesignIntent(resolve(dir, 'page.html'));
+    expect(intent).toBe('current');
+  });
+
+  it('returns "forward-refactor-obsolete" when set', () => {
+    const dir = resolve(TMP_DIR, 'fidelity-obsolete');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page.jsx'), 'const x = "BGG";', 'utf-8');
+    writeFileSync(
+      resolve(dir, 'page.fidelity.json'),
+      JSON.stringify({ design_intent: 'forward-refactor-obsolete' }),
+      'utf-8'
+    );
+    const intent = readDesignIntent(resolve(dir, 'page.jsx'));
+    expect(intent).toBe('forward-refactor-obsolete');
+  });
+
+  it('strips -state-NN-<label> suffix to find canonical fidelity', () => {
+    const dir = resolve(TMP_DIR, 'fidelity-state');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page-state-02-empty.html'), '<div>BGG</div>', 'utf-8');
+    writeFileSync(
+      resolve(dir, 'page.fidelity.json'),
+      JSON.stringify({ design_intent: 'forward-refactor-obsolete' }),
+      'utf-8'
+    );
+    const intent = readDesignIntent(resolve(dir, 'page-state-02-empty.html'));
+    expect(intent).toBe('forward-refactor-obsolete');
+  });
+
+  it('returns null when fidelity.json is absent', () => {
+    const dir = resolve(TMP_DIR, 'fidelity-missing');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page.html'), '<div>x</div>', 'utf-8');
+    expect(readDesignIntent(resolve(dir, 'page.html'))).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    const dir = resolve(TMP_DIR, 'fidelity-malformed');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page.html'), '<div>x</div>', 'utf-8');
+    writeFileSync(resolve(dir, 'page.fidelity.json'), '{ this is not json }', 'utf-8');
+    expect(readDesignIntent(resolve(dir, 'page.html'))).toBeNull();
+  });
+});
+
+describe('lintFiles (mockup mode — design_intent allowlist)', () => {
+  it('flags violations when design_intent is "current"', () => {
+    const dir = resolve(TMP_DIR, 'mockup-current');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page.html'), '<div>Importa BGG</div>', 'utf-8');
+    writeFileSync(
+      resolve(dir, 'page.fidelity.json'),
+      JSON.stringify({ design_intent: 'current' }),
+      'utf-8'
+    );
+    const result = lintFiles('mockup-current/**/*.{html,jsx}', TMP_DIR, { isMockup: true });
+    expect(result.violations.length).toBeGreaterThanOrEqual(1);
+    expect(result.skipped.design_intent_obsolete).toBe(0);
+  });
+
+  it('skips entire file when design_intent is "forward-refactor-obsolete"', () => {
+    const dir = resolve(TMP_DIR, 'mockup-obsolete');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'page.html'), '<div>Importa BGG cento volte</div>', 'utf-8');
+    writeFileSync(
+      resolve(dir, 'page.fidelity.json'),
+      JSON.stringify({ design_intent: 'forward-refactor-obsolete' }),
+      'utf-8'
+    );
+    const result = lintFiles('mockup-obsolete/**/*.{html,jsx}', TMP_DIR, { isMockup: true });
+    expect(result.violations).toEqual([]);
+    expect(result.skipped.design_intent_obsolete).toBe(1);
+  });
+});
+
+describe('lintFiles (FE source mode — admin + well-known allowlist)', () => {
+  it('skips files under admin paths', () => {
+    const adminDir = resolve(TMP_DIR, 'apps/web/src/app/admin');
+    mkdirSync(adminDir, { recursive: true });
+    writeFileSync(resolve(adminDir, 'page.tsx'), 'const x = "BGG";', 'utf-8');
+
+    const result = lintFiles('apps/web/src/app/admin/**/*.{ts,tsx,js,jsx}', TMP_DIR, {
+      isMockup: false,
+    });
+    expect(result.violations).toEqual([]);
+    expect(result.skipped.admin_scope).toBe(1);
+  });
+
+  it('skips well-known legitimate files', () => {
+    const dir = resolve(TMP_DIR, 'apps/web/src/types');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'bgg.ts'), 'export interface BggSearchResult { /* … */ }', 'utf-8');
+
+    const result = lintFiles('apps/web/src/types/**/*.{ts,tsx,js,jsx}', TMP_DIR, {
+      isMockup: false,
+    });
+    expect(result.violations).toEqual([]);
+    expect(result.skipped.well_known_legitimate).toBe(1);
+  });
+
+  it('flags non-allowlisted FE files', () => {
+    const dir = resolve(TMP_DIR, 'apps/web/src/components/dashboard');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'card.tsx'), 'const cta = "Importa BGG";', 'utf-8');
+
+    const result = lintFiles('apps/web/src/components/dashboard/**/*.{ts,tsx,js,jsx}', TMP_DIR, {
+      isMockup: false,
+    });
+    expect(result.violations.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('lintFiles (stable output)', () => {
+  it('produces stable file/line/column sort', () => {
+    const dir = resolve(TMP_DIR, 'sort-stable');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'b-second.tsx'), 'const x = "BGG";', 'utf-8');
+    writeFileSync(
+      resolve(dir, 'a-first.tsx'),
+      'const x = "BGG";\nconst y = "BoardGameGeek";',
+      'utf-8'
+    );
+
+    const result = lintFiles('sort-stable/**/*.tsx', TMP_DIR, { isMockup: false });
+    expect(result.violations.length).toBe(3);
+    expect(result.violations[0].file).toContain('a-first.tsx');
+    expect(result.violations[2].file).toContain('b-second.tsx');
+  });
+});

--- a/apps/web/scripts/lint-bgg-mockups.mjs
+++ b/apps/web/scripts/lint-bgg-mockups.mjs
@@ -1,0 +1,537 @@
+#!/usr/bin/env node
+/**
+ * lint-bgg-mockups.mjs — user-side BGG copy reporter for mockups + FE source (DS-17 §2151)
+ *
+ * Defense-in-depth complement to:
+ *   - `local/no-bgg-host` ESLint rule (HOSTNAME-level, FE source only)
+ *   - `pnpm lint:bgg` (HOSTNAME-level, broader file scope incl. seed manifests)
+ *
+ * This script is BROADER than both: it flags the *user-facing strings*
+ * "BGG", "BoardGameGeek", "boardgamegeek" (case-insensitive) wherever a
+ * user could see them. It's the policy-level gate for ADR-059 §2: even
+ * mentioning BGG to end users is forbidden unless explicitly justified.
+ *
+ * Scope:
+ *   - admin-mockups/design_files/**\/*.{html,jsx}
+ *   - apps/web/src/**\/*.{ts,tsx,js,jsx}
+ *
+ * Allowlist semantics (any one is enough to pass):
+ *   1. Mockup sibling `<base>.fidelity.json` has `design_intent: "forward-refactor-obsolete"`
+ *      (the mockup is documented as legacy by design — see ADR-059).
+ *   2. File path matches an admin scope (admin server-to-server BGG is legit per ADR-059 §2).
+ *   3. The line itself, the line immediately above it, or anywhere in the
+ *      enclosing 3-line window has a `BGG-ALLOWED:` justification marker.
+ *      Accepted comment forms (HTML, block-comment, line-comment):
+ *         <!-- BGG-ALLOWED: server-to-server admin OAuth -->
+ *         // BGG-ALLOWED: test asserts the BGG host blocklist behavior
+ *      Block-comment form (using fence to avoid breaking this JSDoc):
+ *         block-comment with BGG-ALLOWED: justification text inside
+ *   4. File path is on the well-known legitimate list (types/bgg.ts, bggClient.ts,
+ *      bgg-tsv.ts, cover-utils.ts) — these implement the BGG ban itself.
+ *   5. Test/story files are excluded (assertions about BGG don't surface to users).
+ *
+ * Whitelist-incremental rationale (mirrors DS-17-2 #2070 lint-tokens-mockups.mjs):
+ *   Many mockups carry residual BGG copy from before the cleanup waves
+ *   (#2166, #2208, #2214, #2220). Rather than block on a one-shot full
+ *   sweep, we snapshot the current count as a hard ceiling. NEW BGG copy
+ *   is rejected by CI; existing copy is tracked until later cleanup rounds
+ *   bring the baseline down.
+ *
+ * Usage:
+ *   node lint-bgg-mockups.mjs                            # inventory, exit 0
+ *   node lint-bgg-mockups.mjs --strict --max-baseline N  # CI gate
+ *   node lint-bgg-mockups.mjs --verbose                  # print each hit
+ *   node lint-bgg-mockups.mjs --help
+ *
+ * Exit codes:
+ *   0  inventory ok OR strict run within baseline
+ *   1  strict run exceeded baseline (NEW BGG copy introduced)
+ *   2  invocation error (bad flag, IO failure)
+ *
+ * Refs:
+ *   Issue:    #2151 (DS-17 BGG mockup lint gate)
+ *   Pattern:  apps/web/scripts/lint-tokens-mockups.mjs (DS-17-2 #2070)
+ *   ADR:      docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
+ *   Parent:   #2123 (BGG ToS user-side asset ban — 3 plane enforcement)
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { globSync } from 'glob';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const AUDIT_DIR = resolve(REPO_ROOT, 'audits');
+const JSON_OUT = resolve(AUDIT_DIR, '2026-06-14-bgg-mockup-violations.json');
+const MD_OUT = resolve(AUDIT_DIR, '2026-06-14-bgg-mockup-violations.md');
+
+// ---------------------------------------------------------------------------
+// Regex & defaults — exported for unit testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches user-facing BGG strings. Word-boundary anchors prevent false
+ * positives on identifiers like "blogger" that happen to contain "bgg" but
+ * also intentionally allow no-space contexts like "BoardGameGeek?" or
+ * "BGG-rating" common in copy text.
+ */
+export const BGG_USER_COPY_REGEX = /\bBGG\b|\bBoardGameGeek\b|\bboardgamegeek\b/gi;
+
+/**
+ * Line-level justification marker. The token name avoids the literal
+ * "BGG" outside the marker so we don't false-flag the comment itself.
+ */
+export const BGG_ALLOWED_MARKER_REGEX = /BGG-ALLOWED:/;
+
+export const MOCKUP_GLOB = 'admin-mockups/design_files/**/*.{html,jsx}';
+export const FE_SOURCE_GLOB = 'apps/web/src/**/*.{ts,tsx,js,jsx}';
+
+export const DEFAULT_IGNORE = [
+  '**/node_modules/**',
+  '**/.next/**',
+  '**/dist/**',
+  '**/.git/**',
+  '**/coverage/**',
+  // Test files: BGG references assert the BGG ban itself.
+  '**/__tests__/**',
+  '**/*.test.ts',
+  '**/*.test.tsx',
+  '**/*.test.js',
+  '**/*.test.jsx',
+  '**/*.spec.ts',
+  '**/*.spec.tsx',
+  '**/*.spec.js',
+  '**/*.spec.jsx',
+  // Storybook stories: not user-facing runtime.
+  '**/*.stories.ts',
+  '**/*.stories.tsx',
+  '**/*.stories.js',
+  '**/*.stories.jsx',
+  '**/*.story.ts',
+  '**/*.story.tsx',
+  '**/*.story.js',
+  '**/*.story.jsx',
+];
+
+/**
+ * File paths or directory prefixes that are admin scope per ADR-059 §2
+ * (server-to-server BGG is legitimate for admin curators).
+ */
+export const ADMIN_SCOPE_RELS = [
+  // FE admin dashboards
+  'apps/web/src/app/admin/',
+  'apps/web/src/app/api/',
+  'apps/web/src/components/admin/',
+  // Admin-side server config / route configs
+  'apps/web/src/config/admin-navigation.ts',
+];
+
+/**
+ * Files implementing the BGG ban itself or legitimate BGG-aware data types.
+ * These reference BGG by name in a non-user-facing way.
+ */
+export const WELL_KNOWN_LEGITIMATE_RELS = [
+  'apps/web/src/types/bgg.ts',
+  'apps/web/src/types/collection.ts',
+  'apps/web/src/lib/api/clients/bggClient.ts',
+  'apps/web/src/lib/parsers/bgg-tsv.ts',
+  'apps/web/src/lib/games/cover-utils.ts',
+  'apps/web/src/lib/images/safe-loader.ts',
+  // Public next.config.js host blocklist literals + ADR docstrings
+  'apps/web/next.config.js',
+];
+
+// ---------------------------------------------------------------------------
+// Fidelity classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the sibling `<base>.fidelity.json` for a mockup file and return its
+ * `design_intent` value (one of "current" | "forward-refactor" |
+ * "forward-refactor-obsolete" | null). Returns null on any error.
+ *
+ * The lookup is best-effort: missing files, malformed JSON, or absent
+ * `design_intent` keys all resolve to null (= treat as `current`).
+ */
+export function readDesignIntent(mockupAbsPath, fs = { readFileSync, statSync }) {
+  // Strip extension: foo.html → foo, foo.jsx → foo, foo.state-02-empty.html → foo.state-02-empty
+  const m = mockupAbsPath.match(/^(.*)\.(html|jsx)$/i);
+  if (!m) return null;
+  const base = m[1];
+  // Multi-state mockups share the canonical mockup's fidelity file.
+  // Strip a `-state-NN-<label>` tail so e.g. `sp4-library-desktop-state-02-empty`
+  // reads from `sp4-library-desktop.fidelity.json`.
+  const canonical = base.replace(/-state-\d{2}-[a-z0-9-]+$/i, '');
+  const fidelityPath = `${canonical}.fidelity.json`;
+  try {
+    fs.statSync(fidelityPath);
+  } catch {
+    return null;
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(fidelityPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  try {
+    const obj = JSON.parse(raw);
+    return typeof obj.design_intent === 'string' ? obj.design_intent : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path classification
+// ---------------------------------------------------------------------------
+
+export function isAdminScope(repoRelPath) {
+  const norm = repoRelPath.replace(/\\/g, '/');
+  return ADMIN_SCOPE_RELS.some(prefix => norm === prefix || norm.startsWith(prefix));
+}
+
+export function isWellKnownLegitimate(repoRelPath) {
+  const norm = repoRelPath.replace(/\\/g, '/');
+  return WELL_KNOWN_LEGITIMATE_RELS.includes(norm);
+}
+
+// ---------------------------------------------------------------------------
+// Core lint primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the line at index `lineIdx` (0-based) sits inside a
+ * `BGG-ALLOWED:` justification window. We accept the marker on the same
+ * line OR on any of the 2 preceding lines (block-comment patterns:
+ * `/* BGG-ALLOWED: …` followed by a JSX/HTML usage line).
+ */
+export function hasAllowedJustification(lines, lineIdx) {
+  const start = Math.max(0, lineIdx - 2);
+  for (let i = start; i <= lineIdx; i++) {
+    if (BGG_ALLOWED_MARKER_REGEX.test(lines[i] ?? '')) return true;
+  }
+  return false;
+}
+
+/**
+ * Scan a single text blob for BGG copy. Returns violations not covered by
+ * a `BGG-ALLOWED:` window. Each record: `{ file, line, column, match }`.
+ */
+export function findViolationsInText(text, filePath) {
+  if (!text || typeof text !== 'string') return [];
+  const out = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const re = new RegExp(BGG_USER_COPY_REGEX.source, BGG_USER_COPY_REGEX.flags);
+    let matchHit = false;
+    const lineHits = [];
+    for (const m of lines[i].matchAll(re)) {
+      matchHit = true;
+      lineHits.push({
+        file: filePath,
+        line: i + 1,
+        column: (m.index ?? 0) + 1,
+        match: m[0],
+      });
+    }
+    if (matchHit && !hasAllowedJustification(lines, i)) {
+      out.push(...lineHits);
+    }
+  }
+  return out;
+}
+
+/**
+ * Lint a glob of files relative to `repoRoot`. Applies the full allowlist
+ * pipeline (path scope, well-known list, design_intent file-level skip,
+ * per-line justification marker).
+ *
+ * Returns `{ fileCount, violations, skipped }` where:
+ *   - fileCount: total matched by the glob (pre-allowlist)
+ *   - violations: surviving hits (post-allowlist), sorted file/line/column
+ *   - skipped: counts by allowlist reason for the audit report
+ */
+export function lintFiles(globPattern, repoRoot, opts = {}) {
+  const ignore = opts.ignore ?? DEFAULT_IGNORE;
+  const isMockup = opts.isMockup ?? false; // when true, apply design_intent skip
+  const absoluteFiles = globSync(globPattern, {
+    cwd: repoRoot,
+    ignore,
+    absolute: true,
+    nodir: true,
+  });
+
+  const allViolations = [];
+  const skipped = {
+    admin_scope: 0,
+    well_known_legitimate: 0,
+    design_intent_obsolete: 0,
+  };
+
+  for (const abs of absoluteFiles) {
+    const rel = relative(repoRoot, abs).replace(/\\/g, '/');
+
+    if (!isMockup) {
+      if (isAdminScope(rel)) {
+        skipped.admin_scope++;
+        continue;
+      }
+      if (isWellKnownLegitimate(rel)) {
+        skipped.well_known_legitimate++;
+        continue;
+      }
+    } else {
+      const intent = readDesignIntent(abs);
+      if (intent === 'forward-refactor-obsolete') {
+        skipped.design_intent_obsolete++;
+        continue;
+      }
+    }
+
+    let text;
+    try {
+      text = readFileSync(abs, 'utf-8');
+    } catch {
+      continue;
+    }
+    allViolations.push(...findViolationsInText(text, rel));
+  }
+
+  allViolations.sort((a, b) => {
+    if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+    if (a.line !== b.line) return a.line - b.line;
+    return a.column - b.column;
+  });
+
+  return { fileCount: absoluteFiles.length, violations: allViolations, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function groupBy(items, keyFn) {
+  const out = {};
+  for (const it of items) {
+    const k = keyFn(it);
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
+function buildJsonReport(mockupResult, feResult, baseline) {
+  const combined = [...mockupResult.violations, ...feResult.violations];
+  const byFile = groupBy(combined, v => v.file);
+  return {
+    generatedAt: new Date().toISOString(),
+    scopes: {
+      mockups: MOCKUP_GLOB,
+      feSource: FE_SOURCE_GLOB,
+    },
+    pattern: BGG_USER_COPY_REGEX.source,
+    totalViolations: combined.length,
+    mockup: {
+      fileCount: mockupResult.fileCount,
+      violations: mockupResult.violations.length,
+      filesAffected: new Set(mockupResult.violations.map(v => v.file)).size,
+      skipped: mockupResult.skipped,
+    },
+    feSource: {
+      fileCount: feResult.fileCount,
+      violations: feResult.violations.length,
+      filesAffected: new Set(feResult.violations.map(v => v.file)).size,
+      skipped: feResult.skipped,
+    },
+    baselineMaxViolations: baseline,
+    byFile,
+    violations: combined,
+  };
+}
+
+function buildMdReport(report) {
+  const lines = [
+    '# BGG Mockup + FE Source Violations — Inventory (DS-17 §2151)',
+    '',
+    '| Field | Value |',
+    '|---|---|',
+    `| **Date** | ${report.generatedAt.slice(0, 10)} |`,
+    `| **Generator** | \`pnpm lint:bgg-mockups\` (DS-17 §2151) |`,
+    `| **ADR** | [\`adr-059-catalog-seed-legal-posture\`](../docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md) |`,
+    `| **Pattern** | \`${report.pattern}\` |`,
+    `| **Total violations** | ${report.totalViolations} |`,
+    `| **Baseline ceiling** | ${report.baselineMaxViolations === null ? '_(none — inventory mode)_' : report.baselineMaxViolations} |`,
+    '',
+    '## Scope summary',
+    '',
+    '| Scope | Files scanned | Violations | Files affected | Skipped (admin) | Skipped (well-known) | Skipped (obsolete fidelity) |',
+    '|---|---|---|---|---|---|---|',
+    `| Mockups (\`${report.scopes.mockups}\`) | ${report.mockup.fileCount} | ${report.mockup.violations} | ${report.mockup.filesAffected} | _(n/a)_ | _(n/a)_ | ${report.mockup.skipped.design_intent_obsolete} |`,
+    `| FE source (\`${report.scopes.feSource}\`) | ${report.feSource.fileCount} | ${report.feSource.violations} | ${report.feSource.filesAffected} | ${report.feSource.skipped.admin_scope} | ${report.feSource.skipped.well_known_legitimate} | _(n/a)_ |`,
+    '',
+    '## Violations by file',
+    '',
+    '| File | Count |',
+    '|---|---|',
+  ];
+  const fileEntries = Object.entries(report.byFile).sort((a, b) => b[1] - a[1]);
+  for (const [file, count] of fileEntries) {
+    lines.push(`| \`${file}\` | ${count} |`);
+  }
+  if (fileEntries.length === 0) {
+    lines.push('| _(none)_ | 0 |');
+  }
+  lines.push(
+    '',
+    '## How to suppress a legitimate occurrence',
+    '',
+    '1. **Mockup is intentionally obsolete** — set `design_intent: "forward-refactor-obsolete"` in the sibling `<base>.fidelity.json` (reference #1903 ADR).',
+    '2. **Admin server-to-server BGG** (per ADR-059 §2) — move the file under `apps/web/src/app/admin/`, `apps/web/src/components/admin/`, or `apps/web/src/app/api/`. Already-known admin paths pass automatically.',
+    '3. **Line-level justification** — add `BGG-ALLOWED: <reason>` as a comment on the offending line, or within the 2 preceding lines:',
+    '   ```',
+    '   /* BGG-ALLOWED: legitimate parser for legacy BGG export TSV */',
+    '   const BGG_TSV_HEADER = "boardgamegeek collection export";',
+    '   ```',
+    '',
+    '## CI gate semantics',
+    '',
+    '- Default (`pnpm lint:bgg-mockups`) = inventory only, exit 0.',
+    '- Strict (`pnpm lint:bgg-mockups --strict --max-baseline N`) = exit 1 when count > N. CI passes N as a frozen ceiling; introducing a NEW BGG copy fails the gate.',
+    '- Whitelist is intentional: residual BGG copy in `current` mockups is tracked until later cleanup waves bring the ceiling down. NEW copy is rejected.',
+    '',
+    '## Refs',
+    '',
+    '- Issue: [#2151](https://github.com/meepleAi-app/meepleai-monorepo/issues/2151)',
+    '- ADR: [`adr-059-catalog-seed-legal-posture.md`](../docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md)',
+    '- Pattern reference: [`lint-tokens-mockups.mjs`](../apps/web/scripts/lint-tokens-mockups.mjs) (DS-17-2 #2070)',
+    '- Parent BGG ban: [#2123](https://github.com/meepleAi-app/meepleai-monorepo/issues/2123) (3-plane enforcement)',
+    ''
+  );
+  return lines.join('\n');
+}
+
+export function writeReports(report, outPaths) {
+  const { jsonOut, mdOut } = outPaths;
+  if (!existsSync(dirname(jsonOut))) mkdirSync(dirname(jsonOut), { recursive: true });
+  if (!existsSync(dirname(mdOut))) mkdirSync(dirname(mdOut), { recursive: true });
+  writeFileSync(jsonOut, JSON.stringify(report, null, 2) + '\n', 'utf-8');
+  writeFileSync(mdOut, buildMdReport(report), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { strict: false, maxBaseline: null, verbose: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--strict') args.strict = true;
+    else if (a === '--verbose' || a === '-v') args.verbose = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--max-baseline') {
+      const n = Number.parseInt(argv[++i], 10);
+      if (Number.isNaN(n) || n < 0) {
+        throw new Error(`--max-baseline requires a non-negative integer, got: ${argv[i]}`);
+      }
+      args.maxBaseline = n;
+    } else if (a.startsWith('--max-baseline=')) {
+      const n = Number.parseInt(a.slice('--max-baseline='.length), 10);
+      if (Number.isNaN(n) || n < 0) {
+        throw new Error(`--max-baseline requires a non-negative integer, got: ${a}`);
+      }
+      args.maxBaseline = n;
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'lint-bgg-mockups.mjs — user-side BGG copy reporter (DS-17 §2151)',
+      '',
+      'Usage:',
+      '  node lint-bgg-mockups.mjs                            # inventory dump, exit 0',
+      '  node lint-bgg-mockups.mjs --strict --max-baseline N  # CI gate',
+      '  node lint-bgg-mockups.mjs --verbose                  # print each hit',
+      '',
+      'Scopes:',
+      `  - ${MOCKUP_GLOB}`,
+      `  - ${FE_SOURCE_GLOB} (admin paths + well-known legit files auto-skipped)`,
+      'Pattern: /(BGG|BoardGameGeek|boardgamegeek)/gi (word-boundary anchored)',
+      'Allowlist: design_intent="forward-refactor-obsolete" OR admin path OR well-known legit file OR `BGG-ALLOWED:` marker (line or up to 2 preceding lines)',
+      '',
+      'Exit codes: 0 ok | 1 baseline exceeded | 2 invocation error',
+      '',
+    ].join('\n')
+  );
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`[lint:bgg-mockups] ERROR: ${err.message}\n`);
+    printHelp();
+    process.exit(2);
+  }
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (args.strict && args.maxBaseline === null) {
+    process.stderr.write('[lint:bgg-mockups] ERROR: --strict requires --max-baseline N\n');
+    process.exit(2);
+  }
+
+  const mockupResult = lintFiles(MOCKUP_GLOB, REPO_ROOT, { isMockup: true });
+  const feResult = lintFiles(FE_SOURCE_GLOB, REPO_ROOT, { isMockup: false });
+  const report = buildJsonReport(mockupResult, feResult, args.maxBaseline);
+  writeReports(report, { jsonOut: JSON_OUT, mdOut: MD_OUT });
+
+  const total = mockupResult.violations.length + feResult.violations.length;
+  const summary =
+    `[lint:bgg-mockups] ${total} violations: ${mockupResult.violations.length} mockup + ${feResult.violations.length} FE source\n` +
+    `  Mockup skipped (forward-refactor-obsolete): ${mockupResult.skipped.design_intent_obsolete}\n` +
+    `  FE skipped (admin: ${feResult.skipped.admin_scope}, well-known: ${feResult.skipped.well_known_legitimate})\n` +
+    `  JSON: ${relative(REPO_ROOT, JSON_OUT)}\n` +
+    `  MD:   ${relative(REPO_ROOT, MD_OUT)}\n`;
+  process.stdout.write(summary);
+
+  if (args.verbose) {
+    const all = [...mockupResult.violations, ...feResult.violations];
+    for (const v of all) {
+      process.stdout.write(`  ${v.file}:${v.line}:${v.column}: ${v.match}\n`);
+    }
+  }
+
+  if (args.strict && total > args.maxBaseline) {
+    process.stderr.write(
+      `[lint:bgg-mockups] FAIL: ${total} violations exceed --max-baseline ${args.maxBaseline}\n` +
+        '       A new BGG copy was introduced in user-facing surface. Either:\n' +
+        '         1. Remove the BGG reference (preferred — replace with neutral copy)\n' +
+        '         2. Move the file to an admin path (apps/web/src/app/admin, /components/admin, /app/api)\n' +
+        '         3. For mockups: set design_intent="forward-refactor-obsolete" in <base>.fidelity.json\n' +
+        '         4. Add a line-level `BGG-ALLOWED: <reason>` justification comment\n' +
+        '       See docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md\n'
+    );
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+// CLI guard — only run main() when invoked directly (cross-platform Windows safe via pathToFileURL).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    process.stderr.write(`[lint:bgg-mockups] UNEXPECTED: ${err.stack || err.message}\n`);
+    process.exit(2);
+  });
+}

--- a/apps/web/src/components/dashboard/QuickActionCards.tsx
+++ b/apps/web/src/components/dashboard/QuickActionCards.tsx
@@ -46,9 +46,7 @@ export function QuickActionCards({ onSearchClick }: QuickActionCardsProps) {
             <GlassCard className="flex flex-col gap-2 p-4">
               <Icon className={`h-6 w-6 ${action.iconColor}`} />
               <div>
-                <p className="text-sm font-semibold text-[var(--text)]">
-                  {action.label}
-                </p>
+                <p className="text-sm font-semibold text-[var(--text)]">{action.label}</p>
                 <p className="text-xs text-[var(--text-sec)]">{action.description}</p>
               </div>
             </GlassCard>
@@ -60,7 +58,7 @@ export function QuickActionCards({ onSearchClick }: QuickActionCardsProps) {
           <Search className="h-6 w-6 text-blue-400" />
           <div>
             <p className="text-sm font-semibold text-[var(--text)]">Esplora</p>
-            <p className="text-xs text-[var(--text-sec)]">Cerca nel catalogo BGG</p>
+            <p className="text-xs text-[var(--text-sec)]">Cerca nel catalogo</p>
           </div>
         </GlassCard>
       </button>

--- a/apps/web/src/components/features/settings/settings-sections.ts
+++ b/apps/web/src/components/features/settings/settings-sections.ts
@@ -74,7 +74,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
   {
     id: 'services',
     label: 'Connected services',
-    subtitle: 'BGG, Discord',
+    subtitle: 'Integrazioni esterne',
     entity: 'entity-toolkit',
     icon: Link2,
     placeholder: true,

--- a/audits/2026-06-14-bgg-mockup-violations.json
+++ b/audits/2026-06-14-bgg-mockup-violations.json
@@ -1,0 +1,2068 @@
+{
+  "generatedAt": "2026-06-14T18:00:32.293Z",
+  "scopes": {
+    "mockups": "admin-mockups/design_files/**/*.{html,jsx}",
+    "feSource": "apps/web/src/**/*.{ts,tsx,js,jsx}"
+  },
+  "pattern": "\\bBGG\\b|\\bBoardGameGeek\\b|\\bboardgamegeek\\b",
+  "totalViolations": 325,
+  "mockup": {
+    "fileCount": 219,
+    "violations": 52,
+    "filesAffected": 17,
+    "skipped": {
+      "admin_scope": 0,
+      "well_known_legitimate": 0,
+      "design_intent_obsolete": 0
+    }
+  },
+  "feSource": {
+    "fileCount": 3456,
+    "violations": 273,
+    "filesAffected": 67,
+    "skipped": {
+      "admin_scope": 627,
+      "well_known_legitimate": 6,
+      "design_intent_obsolete": 0
+    }
+  },
+  "baselineMaxViolations": 0,
+  "byFile": {
+    "admin-mockups/design_files/00-hub.html": 7,
+    "admin-mockups/design_files/02-desktop-patterns.html": 1,
+    "admin-mockups/design_files/librogame-game-night-storyboard.html": 1,
+    "admin-mockups/design_files/librogame-runthrough-game-detail.html": 2,
+    "admin-mockups/design_files/settings.jsx": 6,
+    "admin-mockups/design_files/sp3-how-it-works.jsx": 1,
+    "admin-mockups/design_files/sp3-shared-game-detail.jsx": 1,
+    "admin-mockups/design_files/sp4-add-game-drawer.html": 2,
+    "admin-mockups/design_files/sp4-add-game-drawer.jsx": 4,
+    "admin-mockups/design_files/sp4-citation-pdf-viewer.html": 1,
+    "admin-mockups/design_files/sp4-game-chat-tab.html": 6,
+    "admin-mockups/design_files/sp4-library-wishlist-ui.jsx": 5,
+    "admin-mockups/design_files/sp4-library-wishlist.jsx": 4,
+    "admin-mockups/design_files/sp4-upload-wizard-extended.html": 2,
+    "admin-mockups/design_files/sp4-upload-wizard-extended.jsx": 7,
+    "admin-mockups/design_files/sp5-profile-settings.html": 1,
+    "admin-mockups/design_files/sp5-profile-settings.jsx": 1,
+    "apps/web/src/app/(authenticated)/dashboard/_components/sections/GamesCarousel.tsx": 1,
+    "apps/web/src/app/(authenticated)/dashboard/_components/sections/RecentiSection.tsx": 1,
+    "apps/web/src/app/(authenticated)/dashboard/_components/sections/SuggestedSection.tsx": 3,
+    "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx": 21,
+    "apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx": 1,
+    "apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx": 4,
+    "apps/web/src/app/(authenticated)/onboarding/OnboardingGenericWizard.tsx": 2,
+    "apps/web/src/app/(public)/shared-games/[id]/page-client.tsx": 1,
+    "apps/web/src/app/(public)/shared-games/page-client.tsx": 1,
+    "apps/web/src/components/catalog/GamesFilterPanel.tsx": 1,
+    "apps/web/src/components/collection/CollectionGameGrid.tsx": 1,
+    "apps/web/src/components/features/gamebook/ActionCard.tsx": 1,
+    "apps/web/src/components/features/gamebook/GameSearchBar.tsx": 7,
+    "apps/web/src/components/features/gamebook/GameSearchCard.tsx": 13,
+    "apps/web/src/components/features/gamebook/LibroGameDetailView.tsx": 2,
+    "apps/web/src/components/features/gamebook/NoResultsPanel.tsx": 6,
+    "apps/web/src/components/features/hub/HubGameCard.tsx": 1,
+    "apps/web/src/components/features/library/EmptyLibrary.tsx": 4,
+    "apps/web/src/components/features/library/LibraryHeroDesktop.tsx": 1,
+    "apps/web/src/components/features/toolkit-detail/Stars.tsx": 1,
+    "apps/web/src/components/game-detail/GameDetailDesktop.tsx": 1,
+    "apps/web/src/components/game-detail/GameHero.tsx": 2,
+    "apps/web/src/components/game-night/GameNightWizard.tsx": 1,
+    "apps/web/src/components/library/AddPrivateGameForm.tsx": 1,
+    "apps/web/src/components/library/add-game-sheet/AddGameWizardProvider.tsx": 1,
+    "apps/web/src/components/library/add-game-sheet/steps/GameInfoStep.tsx": 2,
+    "apps/web/src/components/library/add-game-sheet/steps/GameSearchResults.tsx": 1,
+    "apps/web/src/components/play-records/GameCombobox.tsx": 1,
+    "apps/web/src/components/shared-games/SharedGameSearch.tsx": 1,
+    "apps/web/src/components/showcase/stories/metadata.ts": 1,
+    "apps/web/src/components/ui/data-display/entity-link/entity-link-card.tsx": 4,
+    "apps/web/src/components/ui/data-display/meeple-card/parts/Cover.tsx": 1,
+    "apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx": 1,
+    "apps/web/src/components/ui/data-display/meeple-card/types.ts": 1,
+    "apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx": 1,
+    "apps/web/src/components/ui/data-display/meeple-info-card.tsx": 1,
+    "apps/web/src/components/ui/data-display/rating-stars.tsx": 7,
+    "apps/web/src/config/component-registry.ts": 2,
+    "apps/web/src/hooks/admin/useGoldenForGame.ts": 1,
+    "apps/web/src/hooks/admin/useImportBggTags.ts": 4,
+    "apps/web/src/hooks/queries/useAdminGameWizard.ts": 1,
+    "apps/web/src/hooks/queries/useBggSearch.ts": 10,
+    "apps/web/src/hooks/queries/useGames.ts": 1,
+    "apps/web/src/hooks/queries/useLibrary.ts": 2,
+    "apps/web/src/hooks/queries/useSearchBggGames.ts": 6,
+    "apps/web/src/hooks/wizard/useCheckDuplicate.ts": 4,
+    "apps/web/src/lib/analytics/flywheel-events.ts": 1,
+    "apps/web/src/lib/api/clients/admin/adminContentClient.ts": 1,
+    "apps/web/src/lib/api/clients/admin/adminMechanicExtractorValidationClient.ts": 3,
+    "apps/web/src/lib/api/clients/gameNightBggClient.ts": 11,
+    "apps/web/src/lib/api/clients/gamesClient.ts": 2,
+    "apps/web/src/lib/api/clients/libraryClient.ts": 1,
+    "apps/web/src/lib/api/clients/sharedGamesClient.ts": 42,
+    "apps/web/src/lib/api/core/httpClient.ts": 1,
+    "apps/web/src/lib/api/index.ts": 8,
+    "apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts": 5,
+    "apps/web/src/lib/api/schemas/games.schemas.ts": 3,
+    "apps/web/src/lib/api/schemas/private-games.schemas.ts": 1,
+    "apps/web/src/lib/api/schemas/shared-games.schemas.ts": 9,
+    "apps/web/src/lib/domain-hooks/useBggRateLimit.ts": 7,
+    "apps/web/src/lib/gamebook-upload/fsm.ts": 18,
+    "apps/web/src/lib/gamebook-upload/schemas.ts": 12,
+    "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts": 10,
+    "apps/web/src/lib/library/hybrid-hub.mappers.ts": 2,
+    "apps/web/src/lib/stores/add-game-wizard-store.ts": 1,
+    "apps/web/src/lib/utils/string-similarity.ts": 2,
+    "apps/web/src/stores/useGameImportWizardStore.ts": 1
+  },
+  "violations": [
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 202,
+      "column": 208,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 238,
+      "column": 49,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 241,
+      "column": 25,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 242,
+      "column": 31,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 243,
+      "column": 73,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 274,
+      "column": 64,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/00-hub.html",
+      "line": 354,
+      "column": 214,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/02-desktop-patterns.html",
+      "line": 992,
+      "column": 114,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/librogame-game-night-storyboard.html",
+      "line": 323,
+      "column": 66,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/librogame-runthrough-game-detail.html",
+      "line": 383,
+      "column": 75,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/librogame-runthrough-game-detail.html",
+      "line": 471,
+      "column": 77,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/settings.jsx",
+      "line": 244,
+      "column": 76,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/settings.jsx",
+      "line": 740,
+      "column": 72,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/settings.jsx",
+      "line": 747,
+      "column": 8,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/settings.jsx",
+      "line": 747,
+      "column": 24,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "admin-mockups/design_files/settings.jsx",
+      "line": 747,
+      "column": 76,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/settings.jsx",
+      "line": 829,
+      "column": 87,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp3-how-it-works.jsx",
+      "line": 275,
+      "column": 81,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp3-shared-game-detail.jsx",
+      "line": 64,
+      "column": 43,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-add-game-drawer.html",
+      "line": 12,
+      "column": 40,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-add-game-drawer.html",
+      "line": 12,
+      "column": 73,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-add-game-drawer.jsx",
+      "line": 9,
+      "column": 47,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-add-game-drawer.jsx",
+      "line": 10,
+      "column": 27,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-add-game-drawer.jsx",
+      "line": 10,
+      "column": 41,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-add-game-drawer.jsx",
+      "line": 11,
+      "column": 72,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-citation-pdf-viewer.html",
+      "line": 17,
+      "column": 5,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "line": 27,
+      "column": 56,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "line": 541,
+      "column": 220,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "line": 564,
+      "column": 21,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "line": 569,
+      "column": 46,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "line": 622,
+      "column": 25,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "line": 629,
+      "column": 50,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist-ui.jsx",
+      "line": 39,
+      "column": 122,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist-ui.jsx",
+      "line": 39,
+      "column": 130,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist-ui.jsx",
+      "line": 46,
+      "column": 33,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist-ui.jsx",
+      "line": 46,
+      "column": 71,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist-ui.jsx",
+      "line": 46,
+      "column": 78,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist.jsx",
+      "line": 81,
+      "column": 47,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist.jsx",
+      "line": 102,
+      "column": 54,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist.jsx",
+      "line": 107,
+      "column": 49,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-library-wishlist.jsx",
+      "line": 266,
+      "column": 11,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.html",
+      "line": 3,
+      "column": 35,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.html",
+      "line": 7,
+      "column": 31,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 4,
+      "column": 43,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 14,
+      "column": 29,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 830,
+      "column": 48,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 840,
+      "column": 15,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 840,
+      "column": 53,
+      "match": "bgg"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 929,
+      "column": 50,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp4-upload-wizard-extended.jsx",
+      "line": 943,
+      "column": 77,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp5-profile-settings.html",
+      "line": 1681,
+      "column": 32,
+      "match": "BGG"
+    },
+    {
+      "file": "admin-mockups/design_files/sp5-profile-settings.jsx",
+      "line": 88,
+      "column": 61,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/dashboard/_components/sections/GamesCarousel.tsx",
+      "line": 85,
+      "column": 132,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/dashboard/_components/sections/RecentiSection.tsx",
+      "line": 178,
+      "column": 137,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/dashboard/_components/sections/SuggestedSection.tsx",
+      "line": 19,
+      "column": 16,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/dashboard/_components/sections/SuggestedSection.tsx",
+      "line": 27,
+      "column": 63,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/dashboard/_components/sections/SuggestedSection.tsx",
+      "line": 138,
+      "column": 130,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 27,
+      "column": 8,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 28,
+      "column": 51,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 33,
+      "column": 20,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 34,
+      "column": 59,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 127,
+      "column": 19,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 127,
+      "column": 27,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 165,
+      "column": 17,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 166,
+      "column": 6,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 167,
+      "column": 45,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 208,
+      "column": 6,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 209,
+      "column": 45,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 212,
+      "column": 46,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 212,
+      "column": 71,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 215,
+      "column": 68,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 221,
+      "column": 46,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 690,
+      "column": 53,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 955,
+      "column": 42,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 984,
+      "column": 17,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 992,
+      "column": 26,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 1232,
+      "column": 33,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx",
+      "line": 1270,
+      "column": 14,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx",
+      "line": 18,
+      "column": 10,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx",
+      "line": 116,
+      "column": 18,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx",
+      "line": 116,
+      "column": 44,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx",
+      "line": 296,
+      "column": 40,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx",
+      "line": 405,
+      "column": 81,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/onboarding/OnboardingGenericWizard.tsx",
+      "line": 30,
+      "column": 12,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/app/(authenticated)/onboarding/OnboardingGenericWizard.tsx",
+      "line": 30,
+      "column": 38,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(public)/shared-games/[id]/page-client.tsx",
+      "line": 340,
+      "column": 59,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/app/(public)/shared-games/page-client.tsx",
+      "line": 231,
+      "column": 55,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/catalog/GamesFilterPanel.tsx",
+      "line": 5,
+      "column": 30,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/collection/CollectionGameGrid.tsx",
+      "line": 196,
+      "column": 37,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/ActionCard.tsx",
+      "line": 6,
+      "column": 11,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 4,
+      "column": 27,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 39,
+      "column": 7,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 39,
+      "column": 28,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 59,
+      "column": 29,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 60,
+      "column": 45,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 65,
+      "column": 67,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchBar.tsx",
+      "line": 109,
+      "column": 17,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 5,
+      "column": 17,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 28,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 30,
+      "column": 17,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 52,
+      "column": 68,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 59,
+      "column": 23,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 62,
+      "column": 33,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 68,
+      "column": 10,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 68,
+      "column": 16,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 88,
+      "column": 41,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 89,
+      "column": 19,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 111,
+      "column": 24,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 116,
+      "column": 84,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/GameSearchCard.tsx",
+      "line": 118,
+      "column": 11,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/LibroGameDetailView.tsx",
+      "line": 94,
+      "column": 48,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/LibroGameDetailView.tsx",
+      "line": 113,
+      "column": 45,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/NoResultsPanel.tsx",
+      "line": 4,
+      "column": 66,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/NoResultsPanel.tsx",
+      "line": 7,
+      "column": 52,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/NoResultsPanel.tsx",
+      "line": 41,
+      "column": 14,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/NoResultsPanel.tsx",
+      "line": 58,
+      "column": 35,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/NoResultsPanel.tsx",
+      "line": 65,
+      "column": 39,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/components/features/gamebook/NoResultsPanel.tsx",
+      "line": 66,
+      "column": 70,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/hub/HubGameCard.tsx",
+      "line": 29,
+      "column": 54,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/library/EmptyLibrary.tsx",
+      "line": 13,
+      "column": 48,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/library/EmptyLibrary.tsx",
+      "line": 19,
+      "column": 8,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/library/EmptyLibrary.tsx",
+      "line": 69,
+      "column": 57,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/library/EmptyLibrary.tsx",
+      "line": 200,
+      "column": 57,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/features/library/LibraryHeroDesktop.tsx",
+      "line": 14,
+      "column": 53,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/features/toolkit-detail/Stars.tsx",
+      "line": 5,
+      "column": 68,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/game-detail/GameDetailDesktop.tsx",
+      "line": 109,
+      "column": 8,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/game-detail/GameHero.tsx",
+      "line": 18,
+      "column": 28,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/game-detail/GameHero.tsx",
+      "line": 39,
+      "column": 29,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/game-night/GameNightWizard.tsx",
+      "line": 7,
+      "column": 30,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/library/AddPrivateGameForm.tsx",
+      "line": 53,
+      "column": 68,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/library/add-game-sheet/AddGameWizardProvider.tsx",
+      "line": 83,
+      "column": 75,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/library/add-game-sheet/steps/GameInfoStep.tsx",
+      "line": 44,
+      "column": 3,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/library/add-game-sheet/steps/GameInfoStep.tsx",
+      "line": 73,
+      "column": 86,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/library/add-game-sheet/steps/GameSearchResults.tsx",
+      "line": 22,
+      "column": 24,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/play-records/GameCombobox.tsx",
+      "line": 8,
+      "column": 34,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/shared-games/SharedGameSearch.tsx",
+      "line": 12,
+      "column": 10,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/showcase/stories/metadata.ts",
+      "line": 61,
+      "column": 33,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/entity-link/entity-link-card.tsx",
+      "line": 65,
+      "column": 6,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/entity-link/entity-link-card.tsx",
+      "line": 68,
+      "column": 26,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/entity-link/entity-link-card.tsx",
+      "line": 136,
+      "column": 13,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/entity-link/entity-link-card.tsx",
+      "line": 168,
+      "column": 61,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/meeple-card/parts/Cover.tsx",
+      "line": 43,
+      "column": 30,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx",
+      "line": 15,
+      "column": 63,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/meeple-card/types.ts",
+      "line": 165,
+      "column": 63,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx",
+      "line": 34,
+      "column": 20,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/meeple-info-card.tsx",
+      "line": 109,
+      "column": 3,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 8,
+      "column": 26,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 20,
+      "column": 30,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 21,
+      "column": 29,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 25,
+      "column": 44,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 65,
+      "column": 13,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 69,
+      "column": 7,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/components/ui/data-display/rating-stars.tsx",
+      "line": 84,
+      "column": 38,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/config/component-registry.ts",
+      "line": 2923,
+      "column": 10,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/config/component-registry.ts",
+      "line": 2930,
+      "column": 13,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/hooks/admin/useGoldenForGame.ts",
+      "line": 18,
+      "column": 42,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/admin/useImportBggTags.ts",
+      "line": 4,
+      "column": 31,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/admin/useImportBggTags.ts",
+      "line": 30,
+      "column": 34,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/admin/useImportBggTags.ts",
+      "line": 33,
+      "column": 32,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/admin/useImportBggTags.ts",
+      "line": 54,
+      "column": 37,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useAdminGameWizard.ts",
+      "line": 79,
+      "column": 36,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 2,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 4,
+      "column": 62,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 6,
+      "column": 60,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 9,
+      "column": 26,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 12,
+      "column": 34,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 17,
+      "column": 15,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 19,
+      "column": 25,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 40,
+      "column": 11,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 52,
+      "column": 17,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useBggSearch.ts",
+      "line": 53,
+      "column": 24,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useGames.ts",
+      "line": 34,
+      "column": 75,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useLibrary.ts",
+      "line": 1082,
+      "column": 36,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useLibrary.ts",
+      "line": 1087,
+      "column": 60,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useSearchBggGames.ts",
+      "line": 2,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useSearchBggGames.ts",
+      "line": 3,
+      "column": 24,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useSearchBggGames.ts",
+      "line": 6,
+      "column": 35,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useSearchBggGames.ts",
+      "line": 36,
+      "column": 11,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useSearchBggGames.ts",
+      "line": 54,
+      "column": 17,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/hooks/queries/useSearchBggGames.ts",
+      "line": 55,
+      "column": 24,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/hooks/wizard/useCheckDuplicate.ts",
+      "line": 5,
+      "column": 60,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/wizard/useCheckDuplicate.ts",
+      "line": 14,
+      "column": 7,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/wizard/useCheckDuplicate.ts",
+      "line": 21,
+      "column": 35,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/hooks/wizard/useCheckDuplicate.ts",
+      "line": 33,
+      "column": 17,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/analytics/flywheel-events.ts",
+      "line": 17,
+      "column": 36,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/admin/adminContentClient.ts",
+      "line": 343,
+      "column": 44,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/admin/adminMechanicExtractorValidationClient.ts",
+      "line": 55,
+      "column": 57,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/admin/adminMechanicExtractorValidationClient.ts",
+      "line": 124,
+      "column": 38,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/admin/adminMechanicExtractorValidationClient.ts",
+      "line": 124,
+      "column": 62,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 2,
+      "column": 15,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 4,
+      "column": 39,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 5,
+      "column": 12,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 5,
+      "column": 53,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 50,
+      "column": 31,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 51,
+      "column": 38,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 58,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 66,
+      "column": 15,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 71,
+      "column": 46,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 113,
+      "column": 17,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gameNightBggClient.ts",
+      "line": 114,
+      "column": 21,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gamesClient.ts",
+      "line": 131,
+      "column": 74,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/gamesClient.ts",
+      "line": 211,
+      "column": 14,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/libraryClient.ts",
+      "line": 746,
+      "column": 47,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 723,
+      "column": 19,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 723,
+      "column": 51,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 726,
+      "column": 15,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 728,
+      "column": 46,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 732,
+      "column": 25,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 740,
+      "column": 37,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 747,
+      "column": 35,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 749,
+      "column": 50,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 752,
+      "column": 23,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 753,
+      "column": 58,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 757,
+      "column": 37,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 766,
+      "column": 31,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 768,
+      "column": 64,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 770,
+      "column": 23,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 775,
+      "column": 44,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 783,
+      "column": 34,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 785,
+      "column": 54,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 789,
+      "column": 25,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 794,
+      "column": 59,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 880,
+      "column": 40,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 883,
+      "column": 52,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 886,
+      "column": 66,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 925,
+      "column": 15,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 926,
+      "column": 46,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 928,
+      "column": 26,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 943,
+      "column": 44,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 949,
+      "column": 12,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 950,
+      "column": 46,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 952,
+      "column": 56,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 978,
+      "column": 64,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 987,
+      "column": 75,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1217,
+      "column": 41,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1236,
+      "column": 12,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1237,
+      "column": 26,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1240,
+      "column": 58,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1245,
+      "column": 27,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1246,
+      "column": 27,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1248,
+      "column": 33,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1251,
+      "column": 44,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1255,
+      "column": 26,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1256,
+      "column": 27,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/clients/sharedGamesClient.ts",
+      "line": 1260,
+      "column": 44,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/core/httpClient.ts",
+      "line": 49,
+      "column": 23,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 222,
+      "column": 20,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 237,
+      "column": 7,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 238,
+      "column": 3,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 324,
+      "column": 18,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 417,
+      "column": 7,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 418,
+      "column": 30,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 419,
+      "column": 30,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/index.ts",
+      "line": 437,
+      "column": 5,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts",
+      "line": 66,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts",
+      "line": 116,
+      "column": 11,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts",
+      "line": 126,
+      "column": 58,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts",
+      "line": 126,
+      "column": 82,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts",
+      "line": 145,
+      "column": 46,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/games.schemas.ts",
+      "line": 5,
+      "column": 34,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/games.schemas.ts",
+      "line": 21,
+      "column": 41,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/games.schemas.ts",
+      "line": 143,
+      "column": 15,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/private-games.schemas.ts",
+      "line": 11,
+      "column": 59,
+      "match": "BoardGameGeek"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 10,
+      "column": 25,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 168,
+      "column": 57,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 265,
+      "column": 57,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 610,
+      "column": 15,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 610,
+      "column": 54,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 616,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 617,
+      "column": 46,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 629,
+      "column": 16,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/api/schemas/shared-games.schemas.ts",
+      "line": 637,
+      "column": 31,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 2,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 3,
+      "column": 35,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 5,
+      "column": 38,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 44,
+      "column": 34,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 87,
+      "column": 22,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 93,
+      "column": 13,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/domain-hooks/useBggRateLimit.ts",
+      "line": 94,
+      "column": 42,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 16,
+      "column": 14,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 16,
+      "column": 28,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 16,
+      "column": 68,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 79,
+      "column": 31,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 88,
+      "column": 20,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 193,
+      "column": 30,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 193,
+      "column": 43,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 194,
+      "column": 36,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 196,
+      "column": 7,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 196,
+      "column": 66,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 273,
+      "column": 23,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 313,
+      "column": 6,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 313,
+      "column": 73,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 314,
+      "column": 28,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 315,
+      "column": 27,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 332,
+      "column": 58,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 332,
+      "column": 72,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/fsm.ts",
+      "line": 337,
+      "column": 49,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 5,
+      "column": 64,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 21,
+      "column": 24,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 41,
+      "column": 55,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 43,
+      "column": 56,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 62,
+      "column": 4,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 62,
+      "column": 49,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 76,
+      "column": 79,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 77,
+      "column": 16,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 77,
+      "column": 48,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 80,
+      "column": 68,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 196,
+      "column": 73,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/schemas.ts",
+      "line": 208,
+      "column": 10,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 18,
+      "column": 67,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 23,
+      "column": 73,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 79,
+      "column": 16,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 86,
+      "column": 36,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 88,
+      "column": 24,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 196,
+      "column": 20,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 196,
+      "column": 50,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 197,
+      "column": 18,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 282,
+      "column": 15,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/gamebook-upload/visual-test-fixture.ts",
+      "line": 423,
+      "column": 10,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/library/hybrid-hub.mappers.ts",
+      "line": 66,
+      "column": 48,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/library/hybrid-hub.mappers.ts",
+      "line": 69,
+      "column": 12,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/stores/add-game-wizard-store.ts",
+      "line": 31,
+      "column": 24,
+      "match": "bgg"
+    },
+    {
+      "file": "apps/web/src/lib/utils/string-similarity.ts",
+      "line": 3,
+      "column": 17,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/lib/utils/string-similarity.ts",
+      "line": 6,
+      "column": 76,
+      "match": "BGG"
+    },
+    {
+      "file": "apps/web/src/stores/useGameImportWizardStore.ts",
+      "line": 292,
+      "column": 21,
+      "match": "BGG"
+    }
+  ]
+}

--- a/audits/2026-06-14-bgg-mockup-violations.md
+++ b/audits/2026-06-14-bgg-mockup-violations.md
@@ -1,0 +1,129 @@
+# BGG Mockup + FE Source Violations — Inventory (DS-17 §2151)
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-06-14 |
+| **Generator** | `pnpm lint:bgg-mockups` (DS-17 §2151) |
+| **ADR** | [`adr-059-catalog-seed-legal-posture`](../docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md) |
+| **Pattern** | `\bBGG\b|\bBoardGameGeek\b|\bboardgamegeek\b` |
+| **Total violations** | 325 |
+| **Baseline ceiling** | 0 |
+
+## Scope summary
+
+| Scope | Files scanned | Violations | Files affected | Skipped (admin) | Skipped (well-known) | Skipped (obsolete fidelity) |
+|---|---|---|---|---|---|---|
+| Mockups (`admin-mockups/design_files/**/*.{html,jsx}`) | 219 | 52 | 17 | _(n/a)_ | _(n/a)_ | 0 |
+| FE source (`apps/web/src/**/*.{ts,tsx,js,jsx}`) | 3456 | 273 | 67 | 627 | 6 | _(n/a)_ |
+
+## Violations by file
+
+| File | Count |
+|---|---|
+| `apps/web/src/lib/api/clients/sharedGamesClient.ts` | 42 |
+| `apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx` | 21 |
+| `apps/web/src/lib/gamebook-upload/fsm.ts` | 18 |
+| `apps/web/src/components/features/gamebook/GameSearchCard.tsx` | 13 |
+| `apps/web/src/lib/gamebook-upload/schemas.ts` | 12 |
+| `apps/web/src/lib/api/clients/gameNightBggClient.ts` | 11 |
+| `apps/web/src/hooks/queries/useBggSearch.ts` | 10 |
+| `apps/web/src/lib/gamebook-upload/visual-test-fixture.ts` | 10 |
+| `apps/web/src/lib/api/schemas/shared-games.schemas.ts` | 9 |
+| `apps/web/src/lib/api/index.ts` | 8 |
+| `admin-mockups/design_files/00-hub.html` | 7 |
+| `admin-mockups/design_files/sp4-upload-wizard-extended.jsx` | 7 |
+| `apps/web/src/components/features/gamebook/GameSearchBar.tsx` | 7 |
+| `apps/web/src/components/ui/data-display/rating-stars.tsx` | 7 |
+| `apps/web/src/lib/domain-hooks/useBggRateLimit.ts` | 7 |
+| `admin-mockups/design_files/settings.jsx` | 6 |
+| `admin-mockups/design_files/sp4-game-chat-tab.html` | 6 |
+| `apps/web/src/components/features/gamebook/NoResultsPanel.tsx` | 6 |
+| `apps/web/src/hooks/queries/useSearchBggGames.ts` | 6 |
+| `admin-mockups/design_files/sp4-library-wishlist-ui.jsx` | 5 |
+| `apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts` | 5 |
+| `admin-mockups/design_files/sp4-add-game-drawer.jsx` | 4 |
+| `admin-mockups/design_files/sp4-library-wishlist.jsx` | 4 |
+| `apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx` | 4 |
+| `apps/web/src/components/features/library/EmptyLibrary.tsx` | 4 |
+| `apps/web/src/components/ui/data-display/entity-link/entity-link-card.tsx` | 4 |
+| `apps/web/src/hooks/admin/useImportBggTags.ts` | 4 |
+| `apps/web/src/hooks/wizard/useCheckDuplicate.ts` | 4 |
+| `apps/web/src/app/(authenticated)/dashboard/_components/sections/SuggestedSection.tsx` | 3 |
+| `apps/web/src/lib/api/clients/admin/adminMechanicExtractorValidationClient.ts` | 3 |
+| `apps/web/src/lib/api/schemas/games.schemas.ts` | 3 |
+| `admin-mockups/design_files/librogame-runthrough-game-detail.html` | 2 |
+| `admin-mockups/design_files/sp4-add-game-drawer.html` | 2 |
+| `admin-mockups/design_files/sp4-upload-wizard-extended.html` | 2 |
+| `apps/web/src/app/(authenticated)/onboarding/OnboardingGenericWizard.tsx` | 2 |
+| `apps/web/src/components/features/gamebook/LibroGameDetailView.tsx` | 2 |
+| `apps/web/src/components/game-detail/GameHero.tsx` | 2 |
+| `apps/web/src/components/library/add-game-sheet/steps/GameInfoStep.tsx` | 2 |
+| `apps/web/src/config/component-registry.ts` | 2 |
+| `apps/web/src/hooks/queries/useLibrary.ts` | 2 |
+| `apps/web/src/lib/api/clients/gamesClient.ts` | 2 |
+| `apps/web/src/lib/library/hybrid-hub.mappers.ts` | 2 |
+| `apps/web/src/lib/utils/string-similarity.ts` | 2 |
+| `admin-mockups/design_files/02-desktop-patterns.html` | 1 |
+| `admin-mockups/design_files/librogame-game-night-storyboard.html` | 1 |
+| `admin-mockups/design_files/sp3-how-it-works.jsx` | 1 |
+| `admin-mockups/design_files/sp3-shared-game-detail.jsx` | 1 |
+| `admin-mockups/design_files/sp4-citation-pdf-viewer.html` | 1 |
+| `admin-mockups/design_files/sp5-profile-settings.html` | 1 |
+| `admin-mockups/design_files/sp5-profile-settings.jsx` | 1 |
+| `apps/web/src/app/(authenticated)/dashboard/_components/sections/GamesCarousel.tsx` | 1 |
+| `apps/web/src/app/(authenticated)/dashboard/_components/sections/RecentiSection.tsx` | 1 |
+| `apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx` | 1 |
+| `apps/web/src/app/(public)/shared-games/[id]/page-client.tsx` | 1 |
+| `apps/web/src/app/(public)/shared-games/page-client.tsx` | 1 |
+| `apps/web/src/components/catalog/GamesFilterPanel.tsx` | 1 |
+| `apps/web/src/components/collection/CollectionGameGrid.tsx` | 1 |
+| `apps/web/src/components/features/gamebook/ActionCard.tsx` | 1 |
+| `apps/web/src/components/features/hub/HubGameCard.tsx` | 1 |
+| `apps/web/src/components/features/library/LibraryHeroDesktop.tsx` | 1 |
+| `apps/web/src/components/features/toolkit-detail/Stars.tsx` | 1 |
+| `apps/web/src/components/game-detail/GameDetailDesktop.tsx` | 1 |
+| `apps/web/src/components/game-night/GameNightWizard.tsx` | 1 |
+| `apps/web/src/components/library/AddPrivateGameForm.tsx` | 1 |
+| `apps/web/src/components/library/add-game-sheet/AddGameWizardProvider.tsx` | 1 |
+| `apps/web/src/components/library/add-game-sheet/steps/GameSearchResults.tsx` | 1 |
+| `apps/web/src/components/play-records/GameCombobox.tsx` | 1 |
+| `apps/web/src/components/shared-games/SharedGameSearch.tsx` | 1 |
+| `apps/web/src/components/showcase/stories/metadata.ts` | 1 |
+| `apps/web/src/components/ui/data-display/meeple-card/parts/Cover.tsx` | 1 |
+| `apps/web/src/components/ui/data-display/meeple-card/parts/GameCoverPlaceholder.tsx` | 1 |
+| `apps/web/src/components/ui/data-display/meeple-card/types.ts` | 1 |
+| `apps/web/src/components/ui/data-display/meeple-card/variants/HeroCard.tsx` | 1 |
+| `apps/web/src/components/ui/data-display/meeple-info-card.tsx` | 1 |
+| `apps/web/src/hooks/admin/useGoldenForGame.ts` | 1 |
+| `apps/web/src/hooks/queries/useAdminGameWizard.ts` | 1 |
+| `apps/web/src/hooks/queries/useGames.ts` | 1 |
+| `apps/web/src/lib/analytics/flywheel-events.ts` | 1 |
+| `apps/web/src/lib/api/clients/admin/adminContentClient.ts` | 1 |
+| `apps/web/src/lib/api/clients/libraryClient.ts` | 1 |
+| `apps/web/src/lib/api/core/httpClient.ts` | 1 |
+| `apps/web/src/lib/api/schemas/private-games.schemas.ts` | 1 |
+| `apps/web/src/lib/stores/add-game-wizard-store.ts` | 1 |
+| `apps/web/src/stores/useGameImportWizardStore.ts` | 1 |
+
+## How to suppress a legitimate occurrence
+
+1. **Mockup is intentionally obsolete** — set `design_intent: "forward-refactor-obsolete"` in the sibling `<base>.fidelity.json` (reference #1903 ADR).
+2. **Admin server-to-server BGG** (per ADR-059 §2) — move the file under `apps/web/src/app/admin/`, `apps/web/src/components/admin/`, or `apps/web/src/app/api/`. Already-known admin paths pass automatically.
+3. **Line-level justification** — add `BGG-ALLOWED: <reason>` as a comment on the offending line, or within the 2 preceding lines:
+   ```
+   /* BGG-ALLOWED: legitimate parser for legacy BGG export TSV */
+   const BGG_TSV_HEADER = "boardgamegeek collection export";
+   ```
+
+## CI gate semantics
+
+- Default (`pnpm lint:bgg-mockups`) = inventory only, exit 0.
+- Strict (`pnpm lint:bgg-mockups --strict --max-baseline N`) = exit 1 when count > N. CI passes N as a frozen ceiling; introducing a NEW BGG copy fails the gate.
+- Whitelist is intentional: residual BGG copy in `current` mockups is tracked until later cleanup waves bring the ceiling down. NEW copy is rejected.
+
+## Refs
+
+- Issue: [#2151](https://github.com/meepleAi-app/meepleai-monorepo/issues/2151)
+- ADR: [`adr-059-catalog-seed-legal-posture.md`](../docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md)
+- Pattern reference: [`lint-tokens-mockups.mjs`](../apps/web/scripts/lint-tokens-mockups.mjs) (DS-17-2 #2070)
+- Parent BGG ban: [#2123](https://github.com/meepleAi-app/meepleai-monorepo/issues/2123) (3-plane enforcement)


### PR DESCRIPTION
## Summary

Adds `pnpm lint:bgg-mockups` — defense-in-depth gate for user-facing BGG copy across the FE source tree and the `admin-mockups/design_files/` design surface.

This is a **policy-level** gate that complements the existing **hostname-level** gates from #2123:
- `local/no-bgg-host` ESLint rule (FE source URLs only)
- `pnpm lint:bgg` (FE source + seeders + Next config hostnames)

While #2123 stops the *network plane* (no BGG host fetched at runtime), this script stops the *copy plane* — even mentioning "BGG" or "BoardGameGeek" to end users is forbidden unless explicitly justified per ADR-059 §2.

## Allowlist (4 escape hatches)

1. Mockup sibling `<base>.fidelity.json` has `design_intent: "forward-refactor-obsolete"` (the mockup is documented as legacy by design — #1903)
2. File path matches admin scope (`/admin/`, `/app/api/`, `/components/admin/`)
3. File is on the well-known legitimate list (`types/bgg.ts`, `bggClient.ts`, `bgg-tsv.ts`, `cover-utils.ts`, `safe-loader.ts`, `next.config.js`)
4. Line-level `BGG-ALLOWED: <reason>` justification marker (on the offending line or up to 2 lines above)

Test/spec/story files excluded — BGG assertions there *verify* the ban.

## Whitelist-incremental semantics

Mirror of the DS-17-2 #2070 `lint:tokens:mockups` pattern. Baseline 325 captured 2026-06-14 (52 mockup + 273 FE source post-cleanup waves #2166/#2208/#2214/#2220). NEW BGG copy in a non-allowlisted location → CI fails. Future cleanup PRs drop the ceiling opportunistically.

## Codebase fixes (the 2 surfaces called out in the issue body)

| File | Before | After |
|---|---|---|
| `apps/web/src/components/dashboard/QuickActionCards.tsx:63` | "Cerca nel catalogo BGG" | "Cerca nel catalogo" |
| `apps/web/src/components/features/settings/settings-sections.ts:77` | "BGG, Discord" | "Integrazioni esterne" |

Baseline before fix: 327. After fix: 325 (= the captured ceiling).

## Files

- `apps/web/scripts/lint-bgg-mockups.mjs` — script (mirror of `lint-tokens-mockups.mjs` structure)
- `apps/web/scripts/__tests__/lint-bgg-mockups.test.ts` — 31 unit tests
- `audits/2026-06-14-bgg-mockup-violations.{json,md}` — initial inventory
- `apps/web/package.json` — `lint:bgg-mockups` script entry
- `.github/workflows/ci.yml` — Frontend - Lint job runs `pnpm lint:bgg-mockups --strict --max-baseline 325` + uploads the inventory artifact

## Test plan
- [x] `pnpm vitest run scripts/__tests__/lint-bgg-mockups.test.ts` → 31/31 pass.
- [x] `pnpm lint:bgg-mockups` (inventory) → exit 0, 325 violations.
- [x] `pnpm lint:bgg-mockups --strict --max-baseline 325` → exit 0 (= ceiling).
- [x] `pnpm lint:bgg-mockups --strict --max-baseline 0` → exit 1 (= regression simulation).
- [ ] CI `Frontend - Lint` job green on this PR (baseline 325 holds).

## Refs

- Issue: #2151
- Parent BGG ban: #2123 (network + data plane)
- Pattern reference: #2070 (DS-17-2 whitelist-incremental)
- ADR: `docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md` §2

Closes #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)