### PR TITLE
feat(lint): #2071 mockup state-variant naming pattern (DS-17 Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,13 @@ jobs:
         run: pnpm lint
         # Note: package.json lint script has --max-warnings=15 for security false positives
 
+      # DS-17 Phase 1 (mockup state naming, #2071): hard gate on the
+      # canonical `<base>-state-NN-<label>.{html,jsx}` pattern. Cheap (regex
+      # over admin-mockups/**/*.{html,jsx} only) — runs before the heavier
+      # token/annotation/BGG scans below.
+      - name: Mockup state-variant naming gate (#2071)
+        run: pnpm lint:mockup-state-naming
+
       # DS-2 (token canonicalization, 2026-05-12):
       # Non-blocking inventory of `local/no-hardcoded-color-utility` violations.
       # Produces audits/2026-05-12-token-violations.{json,md} for cluster

--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -22,6 +22,23 @@
 > The two are equivalent: HTML for browser preview, JSX for codebase clone. The index lists the
 > HTML file as canonical when both exist.
 
+> **State variants (DS-17 Phase 1, #2071)**: a mockup that ships multiple states uses the
+> `<base>-state-NN-<label>.{html,jsx}` pattern with a fixed `NN` slot per state. See the
+> dedicated section ["State variants"](./README.md#state-variants-2071-ds-17-phase-1)
+> in `README.md` for the canonical table. Quick reference:
+>
+> | Suffix | State |
+> |---|---|
+> | _(none — bare `<base>.html`)_ | `01-default` |
+> | `-state-02-empty` | empty / zero-data |
+> | `-state-03-loading` | skeleton / loading |
+> | `-state-04-error` | error / failure |
+> | `-state-05-sse` | live stream (opt-in) |
+> | `-state-06-offline` | offline / PWA fallback (opt-in) |
+>
+> Enforcement: `pnpm lint:mockup-state-naming` fails CI when a `*-state-*` file violates
+> the pattern (missing `NN`, unknown label, or `NN` outside the catalog).
+
 ## Dev fixtures (design system, prototype, tokens)
 
 | File | Type | Note |

--- a/admin-mockups/README.md
+++ b/admin-mockups/README.md
@@ -85,6 +85,66 @@ edits this table — do not coin synonyms.
 
 ---
 
+## State variants (#2071, DS-17 Phase 1)
+
+Multi-state mockups follow a canonical naming pattern so designers and
+developers can refer to each state unambiguously. A mockup that ships
+empty / loading / error / SSE / offline variants names them with a
+fixed `-state-NN-<label>` tail:
+
+| Pattern | Meaning |
+|---|---|
+| `<base>.html`                          | `state-01-default` (canonical, no tail) |
+| `<base>-state-02-empty.html`           | Zero-data state (no records yet) |
+| `<base>-state-03-loading.html`         | Skeleton / shimmer while data fetches |
+| `<base>-state-04-error.html`           | Failure (network, server, validation) |
+| `<base>-state-05-sse.html`             | Live SSE stream rendering (incremental) |
+| `<base>-state-06-offline.html`         | Offline / PWA fallback |
+
+Rules:
+
+1. **`NN` is fixed** — `02` always means empty, `04` always means error.
+   This lets `<base>-state-04-error.html` mean the same thing across all
+   mockups and frees the lint check from per-mockup config.
+2. **The default state has NO `-state-NN-default` suffix.** The bare
+   `<base>.html` IS the default — adding a redundant `-state-01-default`
+   creates two files for the same view.
+3. **Only states actually shipped are present.** A page that never has
+   an empty state (e.g. a 404 page) does not need `state-02-empty`. A
+   page that does not stream data (e.g. settings) does not need
+   `state-05-sse`. States `05` and `06` are opt-in.
+4. **Sibling fidelity.json is shared.** The canonical
+   `<base>.fidelity.json` covers all `<base>-state-NN-*.html` variants.
+   The DS-17 lint scripts (`lint:tokens:mockups`, `lint:bgg-mockups`)
+   strip the `-state-NN-<label>` tail before reading the fidelity file.
+
+Lint enforcement: `pnpm lint:mockup-state-naming` (`scripts/validate-state-naming.mjs`)
+fails CI when a file matches `*-state-*.html` or `*-state-*.jsx` but
+violates the `state-NN-<label>` pattern (e.g. `*-state-empty.html`
+missing the `NN` prefix, or `state-99-typo` outside the catalog of
+defined NN slots).
+
+State content guidance (#2071):
+
+- Empty states use an icon (96px) + tagline + CTA. **No emoji-heavy
+  default illustrations.** Use a placeholder until a brand illustrator
+  is briefed.
+- Loading states use the skeleton primitives from
+  `admin-mockups/design_files/04-design-system.html`.
+- Error states are inline banners, not modals (per the existing
+  "Error states" guidance in the design system section below).
+- SSE states show the first frame of incremental content + the
+  "streaming" indicator from `sp4-chat.html`.
+
+Refs:
+
+- Spec: [`2026-06-09-mockup-to-app-drift-spec-panel-review.md`](../docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md) § Adzic CRIT-2
+- Sub-issue: [#2071](https://github.com/meepleAi-app/meepleai-monorepo/issues/2071)
+- Umbrella: [#2063](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063)
+- Pattern reference (dev fixture): `admin-mockups/design_files/state-matrix.html`
+
+---
+
 ## About the Design Files
 
 The files in `design_files/` are **design references created in HTML** — prototypes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "audit-mockups:create-issues": "node scripts/audit-mockups/create-tracking-issues.mjs",
     "audit-mockups:cluster-queue": "node scripts/audit-mockups/generate-cluster-review-queue.mjs",
     "lint:bgg": "node scripts/lint-bgg.mjs",
+    "lint:mockup-state-naming": "node scripts/validate-state-naming.mjs",
     "lint:fidelity": "node scripts/mockup-annotations/validate-fidelity.mjs --all",
     "mockup-annotations:inject": "node scripts/mockup-annotations/inject-annotations.mjs",
     "mockup-annotations:audit": "node scripts/mockup-annotations/audit-coverage.mjs",

--- a/apps/web/scripts/__tests__/validate-state-naming.test.ts
+++ b/apps/web/scripts/__tests__/validate-state-naming.test.ts
@@ -1,0 +1,173 @@
+/**
+ * validate-state-naming.test.ts — unit tests for validate-state-naming.mjs (DS-17 Phase 1 §2071)
+ *
+ * Run: pnpm vitest run scripts/__tests__/validate-state-naming.test.ts
+ *
+ * Refs:
+ *   - Issue: #2071 (DS-17 Phase 1)
+ *   - Pattern: scripts/__tests__/lint-tokens-mockups.test.ts (DS-17-2 #2070)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  STATE_CATALOG,
+  CANONICAL_STATE_REGEX,
+  STATE_VARIANT_DETECTOR,
+  classifyStateFilename,
+  lintMockupStateFiles,
+} from '../validate-state-naming.mjs';
+
+const TMP_DIR = resolve(tmpdir(), `validate-state-naming-tests-${process.pid}`);
+
+beforeAll(() => {
+  if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('STATE_CATALOG', () => {
+  it('contains the 6 canonical slots in order', () => {
+    expect(Object.keys(STATE_CATALOG)).toEqual(['01', '02', '03', '04', '05', '06']);
+  });
+
+  it('maps each NN to the documented label', () => {
+    expect(STATE_CATALOG['01']).toBe('default');
+    expect(STATE_CATALOG['02']).toBe('empty');
+    expect(STATE_CATALOG['03']).toBe('loading');
+    expect(STATE_CATALOG['04']).toBe('error');
+    expect(STATE_CATALOG['05']).toBe('sse');
+    expect(STATE_CATALOG['06']).toBe('offline');
+  });
+
+  it('is immutable (frozen)', () => {
+    expect(Object.isFrozen(STATE_CATALOG)).toBe(true);
+  });
+});
+
+describe('STATE_VARIANT_DETECTOR', () => {
+  it('matches stems containing `-state-`', () => {
+    expect(STATE_VARIANT_DETECTOR.test('sp4-library-desktop-state-02-empty')).toBe(true);
+  });
+
+  it('does NOT match bare default stems', () => {
+    expect(STATE_VARIANT_DETECTOR.test('sp4-library-desktop')).toBe(false);
+    expect(STATE_VARIANT_DETECTOR.test('state-matrix')).toBe(false); // no `-state-` prefix-tail
+  });
+});
+
+describe('CANONICAL_STATE_REGEX', () => {
+  it('captures base, NN, label from a conforming stem', () => {
+    const m = 'sp4-library-desktop-state-02-empty'.match(CANONICAL_STATE_REGEX);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe('sp4-library-desktop');
+    expect(m![2]).toBe('02');
+    expect(m![3]).toBe('empty');
+  });
+
+  it('rejects single-digit NN', () => {
+    expect('sp4-library-desktop-state-2-empty'.match(CANONICAL_STATE_REGEX)).toBeNull();
+  });
+
+  it('rejects missing label', () => {
+    expect('sp4-library-desktop-state-02'.match(CANONICAL_STATE_REGEX)).toBeNull();
+  });
+
+  it('rejects UpperCase label', () => {
+    expect('sp4-library-desktop-state-02-Empty'.match(CANONICAL_STATE_REGEX)).toBeNull();
+  });
+});
+
+describe('classifyStateFilename', () => {
+  it('returns null for non-state filenames', () => {
+    expect(classifyStateFilename('sp4-library-desktop')).toBeNull();
+    expect(classifyStateFilename('settings')).toBeNull();
+  });
+
+  it('returns ok for canonical conforming names', () => {
+    const r = classifyStateFilename('sp4-library-desktop-state-02-empty');
+    expect(r).toEqual({ ok: true, base: 'sp4-library-desktop', nn: '02', label: 'empty' });
+  });
+
+  it('flags filename matching `-state-` but missing NN-label', () => {
+    const r = classifyStateFilename('sp4-library-state-empty');
+    expect(r?.ok).toBe(false);
+    expect(r?.reason).toContain('NN prefix');
+  });
+
+  it('flags NN outside the catalog', () => {
+    const r = classifyStateFilename('sp4-library-state-99-custom');
+    expect(r?.ok).toBe(false);
+    expect(r?.reason).toContain('outside the canonical catalog');
+  });
+
+  it('flags label mismatched against canonical', () => {
+    const r = classifyStateFilename('sp4-library-state-02-loading');
+    expect(r?.ok).toBe(false);
+    expect(r?.reason).toContain('does not match the canonical "empty"');
+    expect(r?.suggestion).toContain('sp4-library-state-02-empty');
+  });
+
+  it('flags 01-default (forbidden — bare `<base>` IS default)', () => {
+    const r = classifyStateFilename('sp4-library-state-01-default');
+    expect(r?.ok).toBe(false);
+    expect(r?.reason).toContain('01-default is forbidden');
+  });
+
+  it('accepts all 5 canonical opt-in/required states', () => {
+    for (const [nn, label] of Object.entries(STATE_CATALOG)) {
+      if (nn === '01') continue; // 01-default is forbidden as a filename
+      const r = classifyStateFilename(`base-state-${nn}-${label}`);
+      expect(r?.ok, `state ${nn}-${label} should pass`).toBe(true);
+    }
+  });
+});
+
+describe('lintMockupStateFiles (glob integration)', () => {
+  it('returns 0 violations on a clean tree with no state variants', () => {
+    const dir = resolve(TMP_DIR, 'admin-mockups/design_files');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'sp4-library-desktop.html'), '<div/>', 'utf-8');
+
+    const result = lintMockupStateFiles('admin-mockups/design_files/**/*.{html,jsx}', TMP_DIR);
+    expect(result.violations).toEqual([]);
+    expect(result.conforming).toEqual([]);
+    expect(result.scanned).toBe(1);
+  });
+
+  it('counts conforming state files', () => {
+    const dir = resolve(TMP_DIR, 'tree-ok/admin-mockups/design_files');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'sp4-library.html'), '<div/>', 'utf-8');
+    writeFileSync(resolve(dir, 'sp4-library-state-02-empty.html'), '<div/>', 'utf-8');
+    writeFileSync(resolve(dir, 'sp4-library-state-04-error.html'), '<div/>', 'utf-8');
+
+    const result = lintMockupStateFiles(
+      'tree-ok/admin-mockups/design_files/**/*.{html,jsx}',
+      TMP_DIR
+    );
+    expect(result.violations).toEqual([]);
+    expect(result.conforming).toHaveLength(2);
+    expect(result.scanned).toBe(3);
+  });
+
+  it('reports violations', () => {
+    const dir = resolve(TMP_DIR, 'tree-bad/admin-mockups/design_files');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'sp4-library-state-empty.html'), '<div/>', 'utf-8');
+    writeFileSync(resolve(dir, 'sp4-other-state-99-typo.jsx'), '<div/>', 'utf-8');
+
+    const result = lintMockupStateFiles(
+      'tree-bad/admin-mockups/design_files/**/*.{html,jsx}',
+      TMP_DIR
+    );
+    expect(result.violations).toHaveLength(2);
+    expect(result.violations[0].file).toContain('sp4-library-state-empty.html');
+    expect(result.violations[1].file).toContain('sp4-other-state-99-typo.jsx');
+  });
+});

--- a/apps/web/scripts/validate-state-naming.mjs
+++ b/apps/web/scripts/validate-state-naming.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * validate-state-naming.mjs — DS-17 Phase 1 §2071: enforce mockup state-variant naming.
+ *
+ * Scans `admin-mockups/design_files/**\/*.{html,jsx}` and fails when any file
+ * matches `*-state-*.{html,jsx}` but violates the canonical
+ * `<base>-state-NN-<label>.<ext>` pattern.
+ *
+ * Canonical NN → label mapping (fixed; new states require a CODEMOD pass + this script update):
+ *   01 → default   (NEVER used in a filename — the bare `<base>.html` IS the default)
+ *   02 → empty
+ *   03 → loading
+ *   04 → error
+ *   05 → sse       (opt-in for streaming surfaces)
+ *   06 → offline   (opt-in for PWA-relevant surfaces)
+ *
+ * Failure modes (each exits 1):
+ *   - File like `*-state-empty.html` (missing `NN` prefix)
+ *   - File like `*-state-99-typo.html` (NN outside catalog)
+ *   - File like `*-state-02-loading.html` (NN mismatched with the canonical label)
+ *   - File like `*-state-04.html` (missing `-<label>` tail)
+ *   - File like `*-state-01-default.html` (`01-default` is forbidden — use bare `<base>`)
+ *
+ * Usage:
+ *   node validate-state-naming.mjs            # exit 0 if all conform
+ *   node validate-state-naming.mjs --verbose  # list every state file scanned + verdict
+ *
+ * Exit codes:
+ *   0  all state files conform
+ *   1  at least one violation
+ *   2  invocation error
+ *
+ * Refs:
+ *   Issue:    #2071 (DS-17 Phase 1)
+ *   Umbrella: #2063 (DS-17 Mockup-to-App Fidelity)
+ *   Spec:     docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md § Adzic CRIT-2
+ *   Pattern:  admin-mockups/README.md § State variants (#2071, DS-17 Phase 1)
+ */
+
+import { resolve, dirname, relative, basename } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { globSync } from 'glob';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+
+// Exported for unit testing.
+export const STATE_CATALOG = Object.freeze({
+  '01': 'default',
+  '02': 'empty',
+  '03': 'loading',
+  '04': 'error',
+  '05': 'sse',
+  '06': 'offline',
+});
+
+export const DEFAULT_GLOB = 'admin-mockups/design_files/**/*.{html,jsx}';
+
+/**
+ * Matches `<base>-state-<NN>-<label>` where NN is exactly 2 digits and
+ * label is a kebab-case identifier. Anchored to the filename stem only.
+ */
+export const CANONICAL_STATE_REGEX = /^(.+?)-state-(\d{2})-([a-z][a-z0-9-]*)$/;
+
+/**
+ * Loose detector: any file whose stem contains `-state-` is considered
+ * a state-variant file and must match `CANONICAL_STATE_REGEX`.
+ */
+export const STATE_VARIANT_DETECTOR = /-state-/;
+
+/**
+ * Classify a single filename. Returns one of:
+ *   { ok: true, base, nn, label }     — conforms
+ *   { ok: false, reason, suggestion } — does not conform
+ *   null                              — not a state variant (skip)
+ *
+ * Filenames are expected without extension; pass `stem = basename(file, ext)`.
+ */
+export function classifyStateFilename(stem) {
+  if (!STATE_VARIANT_DETECTOR.test(stem)) {
+    return null;
+  }
+
+  const m = stem.match(CANONICAL_STATE_REGEX);
+  if (!m) {
+    return {
+      ok: false,
+      reason:
+        'filename matches `-state-` but not `<base>-state-NN-<label>` (missing NN prefix or label)',
+      suggestion: 'rename to `<base>-state-NN-<label>` (e.g. `<base>-state-02-empty`)',
+    };
+  }
+
+  const [, base, nn, label] = m;
+  const canonical = STATE_CATALOG[nn];
+
+  if (!canonical) {
+    return {
+      ok: false,
+      reason: `NN=${nn} is outside the canonical catalog (allowed: ${Object.keys(STATE_CATALOG).join(', ')})`,
+      suggestion: 'use one of the canonical NN slots — see admin-mockups/README.md § State variants',
+    };
+  }
+
+  if (nn === '01') {
+    return {
+      ok: false,
+      reason:
+        '01-default is forbidden — the bare `<base>.{html,jsx}` IS the default state',
+      suggestion: `delete \`${stem}.{html,jsx}\` and keep only \`${base}.{html,jsx}\``,
+    };
+  }
+
+  if (label !== canonical) {
+    return {
+      ok: false,
+      reason: `label "${label}" does not match the canonical "${canonical}" for NN=${nn}`,
+      suggestion: `rename to \`${base}-state-${nn}-${canonical}\``,
+    };
+  }
+
+  return { ok: true, base, nn, label };
+}
+
+/**
+ * Walk the glob and return `{ scanned, violations, conforming }` where:
+ *   scanned     — total files matched by the glob (pre-classification)
+ *   violations  — [{ file, reason, suggestion }] sorted by file
+ *   conforming  — [{ file, base, nn, label }] sorted by file
+ */
+export function lintMockupStateFiles(globPattern, repoRoot) {
+  const absoluteFiles = globSync(globPattern, {
+    cwd: repoRoot,
+    ignore: ['**/node_modules/**', '**/.git/**'],
+    absolute: true,
+    nodir: true,
+  });
+
+  const violations = [];
+  const conforming = [];
+
+  for (const abs of absoluteFiles) {
+    const rel = relative(repoRoot, abs).replace(/\\/g, '/');
+    const fileName = basename(abs);
+    const stem = fileName.replace(/\.(html|jsx)$/i, '');
+
+    const classification = classifyStateFilename(stem);
+    if (classification === null) continue;
+
+    if (classification.ok) {
+      conforming.push({ file: rel, ...classification });
+    } else {
+      violations.push({ file: rel, reason: classification.reason, suggestion: classification.suggestion });
+    }
+  }
+
+  violations.sort((a, b) => a.file.localeCompare(b.file));
+  conforming.sort((a, b) => a.file.localeCompare(b.file));
+
+  return { scanned: absoluteFiles.length, violations, conforming };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { verbose: false, help: false };
+  for (const a of argv) {
+    if (a === '--verbose' || a === '-v') args.verbose = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'validate-state-naming.mjs — DS-17 Phase 1 mockup state-variant lint (#2071)',
+      '',
+      'Usage:',
+      '  node validate-state-naming.mjs            # exit 0 if all conform',
+      '  node validate-state-naming.mjs --verbose  # list every state file scanned',
+      '',
+      `Scope: ${DEFAULT_GLOB}`,
+      'Pattern: <base>-state-NN-<label>.{html,jsx}',
+      `Catalog: ${Object.entries(STATE_CATALOG).map(([nn, label]) => `${nn}=${label}`).join(', ')}`,
+      '',
+      'Exit codes: 0 ok | 1 violation found | 2 invocation error',
+      '',
+    ].join('\n')
+  );
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`[lint:mockup-state-naming] ERROR: ${err.message}\n`);
+    printHelp();
+    process.exit(2);
+  }
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const result = lintMockupStateFiles(DEFAULT_GLOB, REPO_ROOT);
+
+  process.stdout.write(
+    `[lint:mockup-state-naming] scanned ${result.scanned} files, ` +
+      `${result.conforming.length} state variants conform, ` +
+      `${result.violations.length} violations\n`
+  );
+
+  if (args.verbose) {
+    for (const v of result.conforming) {
+      process.stdout.write(`  OK  ${v.file}  → state-${v.nn}-${v.label}\n`);
+    }
+  }
+
+  if (result.violations.length > 0) {
+    process.stderr.write('\n[lint:mockup-state-naming] FAIL — naming violations:\n');
+    for (const v of result.violations) {
+      process.stderr.write(`  ${v.file}\n    reason: ${v.reason}\n    fix:    ${v.suggestion}\n`);
+    }
+    process.stderr.write(
+      '\nSee admin-mockups/README.md § State variants for the canonical naming table.\n'
+    );
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    process.stderr.write(`[lint:mockup-state-naming] UNEXPECTED: ${err.stack || err.message}\n`);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## Summary

Standardizes the multi-state mockup naming pattern documented in
\`admin-mockups/README.md\` § State variants and enforces it via a new
hard CI gate.

## Pattern

| Filename | State |
|---|---|
| \`<base>.{html,jsx}\` _(bare, no tail)_ | \`01-default\` |
| \`<base>-state-02-empty.{html,jsx}\` | empty / zero-data |
| \`<base>-state-03-loading.{html,jsx}\` | skeleton / loading |
| \`<base>-state-04-error.{html,jsx}\` | error / failure |
| \`<base>-state-05-sse.{html,jsx}\` | live stream (opt-in) |
| \`<base>-state-06-offline.{html,jsx}\` | offline / PWA fallback (opt-in) |

Each NN → label binding is **fixed**. \`01-default\` is forbidden as a
filename (the bare \`<base>\` IS the default). The DS-17-2 / DS-17 §2151
scripts already strip the \`-state-NN-<label>\` tail when looking up the
sibling fidelity.json, so this convention is transparent to them.

## What this PR ships

| Deliverable | File |
|---|---|
| Pattern docs (canonical table + state-content guidance) | \`admin-mockups/README.md\` § State variants (#2071, DS-17 Phase 1) |
| Quick reference in the developer index | \`admin-mockups/MOCKUPS_INDEX.md\` |
| Lint script (regex + classifier + glob driver) | \`apps/web/scripts/validate-state-naming.mjs\` |
| Unit tests (19 cases — STATE_CATALOG / regex / classifier / glob integration) | \`apps/web/scripts/__tests__/validate-state-naming.test.ts\` |
| \`pnpm lint:mockup-state-naming\` script entry | \`apps/web/package.json\` |
| Blocking CI gate in \`Frontend - Lint\` job | \`.github/workflows/ci.yml\` (placed BEFORE the heavier token/annotation/BGG scans so naming failures surface fast) |

## NOT in this PR (deferred — designer required)

The issue body explicitly flags that the 10 mockup × 3-5 states variants
(~30 new files with empty/loading/error illustrations) requires designer
input. This PR ships the **convention + enforcement** so:

- Future mockup PRs that add states use the canonical pattern from day 1.
- Existing mockups can be migrated incrementally without a one-shot designer dependency.

The lint script returns **0 violations on the current tree** (no state
variants exist yet), so the gate is ready to catch the **first**
mis-named file in any future PR.

## Test plan
- [x] \`pnpm vitest run scripts/__tests__/validate-state-naming.test.ts\` → 19/19 pass.
- [x] \`pnpm lint:mockup-state-naming\` on current tree → exit 0 (0 violations, 219 files scanned, 0 conform — expected, no state variants yet).
- [ ] CI \`Frontend - Lint\` step green on this PR.
- [ ] CI fails when a regression test introduces \`*-state-empty.html\` (sanity).

## Refs

- Issue: #2071 (DS-17 Phase 1)
- Umbrella: #2063 (DS-17 Mockup-to-App Fidelity)
- Spec: \`docs/superpowers/specs/2026-06-09-mockup-to-app-drift-spec-panel-review.md\` § Adzic CRIT-2
- Pattern reference (dev-fixture): \`admin-mockups/design_files/state-matrix.html\`

Closes #2071

🤖 Generated with [Claude Code](https://claude.com/claude-code)