### PR TITLE
ci(runner): #2019 follow-up — wire runner-availability alerts into Prometheus

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -344,6 +344,9 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
+      # Issue #2019 — additional rule file for self-hosted GitHub Actions
+      # runner availability (referenced from prometheus.yml + prometheus.staging.yml).
+      - ./prometheus/alerts/runner-availability.yml:/etc/prometheus/runner-availability.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -21,6 +21,8 @@ alerting:
 
 rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
+  # Issue #2019 — self-hosted GitHub Actions runner availability alerts.
+  - '/etc/prometheus/runner-availability.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -26,6 +26,8 @@ alerting:
 # OPS-05: Rule files for recording and alerting rules
 rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
+  # Issue #2019 — self-hosted GitHub Actions runner availability alerts.
+  - '/etc/prometheus/runner-availability.yml'
 
 # Scrape configurations
 scrape_configs:


### PR DESCRIPTION
## Summary

Follow-up to PR #2336 (#2019). The alert rule file landed at \`infra/prometheus/alerts/runner-availability.yml\` was **shipped but not loaded** — the staging Prometheus container mounts only \`prometheus-rules.yml\`; the \`prometheus/alerts/*.yml\` directory was an organizational pattern documented in \`alerts/README.md\` but not a live load path.

This PR closes the gap with the smallest possible surface (3 files, 7 lines).

## Changes

1. \`infra/docker-compose.yml\` — mount the new rule file at \`/etc/prometheus/runner-availability.yml\` (read-only).
2. \`infra/prometheus.yml\` — append the file to \`rule_files\` for dev/integration use.
3. \`infra/prometheus.staging.yml\` — same for the staging-specific config (which uses \`external_labels: environment=staging\`).

## Deploy

\`\`\`bash
ssh meepleai-staging
cd /opt/meepleai/repo && git pull --ff-only origin main-dev
docker compose -f docker-compose.yml -f compose.staging.yml up -d prometheus
# Or, hot-reload without restart:
docker exec meepleai-prometheus kill -HUP 1
\`\`\`

## Verify

\`\`\`bash
curl http://localhost:9091/api/v1/rules | jq -r '.data.groups[] | .name'
# Expected to include:
#   runner_availability_warning
#   runner_availability_critical
\`\`\`

## Out of scope

The other 12 alert files in \`infra/prometheus/alerts/\` remain documentation-only. A follow-up issue can wire them globally via a glob mount + glob \`rule_files\` if the team decides to standardize the layout.

## Refs

- Parent: #2019
- Predecessor PR: #2336 (shipped the rule file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)