### PR TITLE
feat(session-live): G7 SessionStateRenderer discriminated-union primitive (#2356)

### DIFF
--- a/apps/web/src/components/features/session-live/SessionStateRenderer.tsx
+++ b/apps/web/src/components/features/session-live/SessionStateRenderer.tsx
@@ -1,0 +1,136 @@
+/**
+ * SessionStateRenderer — G7 polymorphic discriminated-union primitive.
+ *
+ * Renders one of 5 canonical session-live states (per spec
+ * `2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md` §G7):
+ *
+ *   - default        → children passthrough (no wrapper)
+ *   - empty          → existing `EmptyState` component
+ *   - loading        → minimal inline skeleton
+ *   - error          → minimal inline error banner + retry CTA
+ *   - sse-disconnect → existing `ConnectionLostBanner` kind='failed'
+ *
+ * Exhaustiveness is enforced by TypeScript: adding a 6th state requires
+ * a code change AND a type change (the `assertNever` default catches drift).
+ *
+ * @see docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md §G7
+ * @see Issue #2356 (G7 primitive), parent #2342 (umbrella)
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+
+import { AlertCircle, RefreshCw } from 'lucide-react';
+
+import { EmptyState } from '@/components/empty-state/EmptyState';
+
+import { ConnectionLostBanner, type ConnectionLostBannerLabels } from './ConnectionLostBanner';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SessionLiveState =
+  | { kind: 'default'; children: ReactNode }
+  | {
+      kind: 'empty';
+      title: string;
+      description?: string;
+      emptyCta?: { label: string; onClick: () => void };
+    }
+  | { kind: 'loading'; loadingAriaLabel: string }
+  | {
+      kind: 'error';
+      error: Error;
+      onRetry: () => void;
+      errorTitle: string;
+      retryLabel: string;
+    }
+  | { kind: 'sse-disconnect'; connectionLabels: ConnectionLostBannerLabels };
+
+export interface SessionStateRendererProps {
+  readonly state: SessionLiveState;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SessionStateRenderer({ state }: SessionStateRendererProps): ReactElement {
+  switch (state.kind) {
+    case 'default':
+      return <>{state.children}</>;
+
+    case 'empty':
+      return (
+        <div data-slot="session-state-empty">
+          <EmptyState
+            title={state.title}
+            description={state.description}
+            action={
+              state.emptyCta
+                ? { label: state.emptyCta.label, onClick: state.emptyCta.onClick }
+                : undefined
+            }
+          />
+        </div>
+      );
+
+    case 'loading':
+      return (
+        <div
+          data-slot="session-state-loading"
+          role="status"
+          aria-live="polite"
+          aria-label={state.loadingAriaLabel}
+          className="space-y-3 p-6"
+        >
+          <div className="h-6 w-1/3 animate-pulse rounded-md bg-muted/50" />
+          <div className="h-32 animate-pulse rounded-lg bg-muted/40" />
+          <div className="h-6 w-2/3 animate-pulse rounded-md bg-muted/50" />
+        </div>
+      );
+
+    case 'error':
+      return (
+        <div
+          data-slot="session-state-error"
+          role="alert"
+          className="flex flex-col gap-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+        >
+          <div className="flex items-center gap-2 text-destructive">
+            <AlertCircle className="h-5 w-5" aria-hidden="true" />
+            <span className="text-sm font-medium">{state.errorTitle}</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{state.error.message}</p>
+          <button
+            type="button"
+            data-slot="session-state-error-retry"
+            onClick={state.onRetry}
+            className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border
+              bg-card px-3 py-1.5 text-xs font-medium text-foreground
+              hover:bg-muted focus-visible:outline-none focus-visible:ring-2
+              focus-visible:ring-ring"
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+            {state.retryLabel}
+          </button>
+        </div>
+      );
+
+    case 'sse-disconnect':
+      return (
+        <div data-slot="session-state-sse-disconnect">
+          <ConnectionLostBanner kind="failed" labels={state.connectionLabels} />
+        </div>
+      );
+
+    default:
+      // Exhaustiveness check — TypeScript will error if a new kind is added without handling.
+      return assertNever(state);
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function assertNever(value: never): never {
+  throw new Error(
+    `SessionStateRenderer: unhandled state kind "${(value as { kind: string }).kind}". ` +
+      'Add a case to the switch in SessionStateRenderer.'
+  );
+}

--- a/apps/web/src/components/features/session-live/__tests__/SessionStateRenderer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/SessionStateRenderer.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * SessionStateRenderer unit tests — G7 primitive (Issue #2356).
+ *
+ * Coverage:
+ * - default: children passthrough
+ * - empty: delegates to EmptyState (title + description + action)
+ * - loading: skeleton with aria-live polite + aria-label
+ * - error: inline banner with title + message + retry CTA
+ * - sse-disconnect: delegates to ConnectionLostBanner kind='failed'
+ * - exhaustiveness: assertNever throws on unknown kind (runtime defense)
+ *
+ * @see docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md §G7
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ConnectionLostBannerLabels } from '../ConnectionLostBanner';
+import { SessionStateRenderer, type SessionLiveState } from '../SessionStateRenderer';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const CONNECTION_LABELS: ConnectionLostBannerLabels = {
+  retryCountResolved: 'Tentativo 1/5',
+  reconnecting: 'Riconnessione in corso',
+  degradedPolling: 'Aggiornamenti ogni 5s',
+  failed: 'Connessione persa',
+  manualRetryLabel: 'Riprova',
+};
+
+// ─── default ──────────────────────────────────────────────────────────────────
+
+describe('SessionStateRenderer — default', () => {
+  it('renders children passthrough (no wrapper visible)', () => {
+    const state: SessionLiveState = {
+      kind: 'default',
+      children: <div data-testid="passthrough-content">Score 12</div>,
+    };
+    render(<SessionStateRenderer state={state} />);
+    expect(screen.getByTestId('passthrough-content')).toBeInTheDocument();
+    // No state-slot wrapper for default (passthrough)
+    expect(document.querySelector('[data-slot^="session-state-"]')).toBeNull();
+  });
+});
+
+// ─── empty ────────────────────────────────────────────────────────────────────
+
+describe('SessionStateRenderer — empty', () => {
+  it('renders EmptyState with title + description', () => {
+    const state: SessionLiveState = {
+      kind: 'empty',
+      title: 'Nessun evento',
+      description: 'La sessione non ha ancora dati',
+    };
+    render(<SessionStateRenderer state={state} />);
+    expect(document.querySelector('[data-slot="session-state-empty"]')).not.toBeNull();
+    expect(screen.getByText('Nessun evento')).toBeInTheDocument();
+    expect(screen.getByText('La sessione non ha ancora dati')).toBeInTheDocument();
+  });
+
+  it('renders emptyCta action button when provided', async () => {
+    const onClick = vi.fn();
+    const state: SessionLiveState = {
+      kind: 'empty',
+      title: 'Vuota',
+      emptyCta: { label: 'Aggiungi giocatori', onClick },
+    };
+    render(<SessionStateRenderer state={state} />);
+    const button = screen.getByRole('button', { name: 'Aggiungi giocatori' });
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── loading ──────────────────────────────────────────────────────────────────
+
+describe('SessionStateRenderer — loading', () => {
+  it('renders skeleton with role=status + aria-live=polite + aria-label', () => {
+    const state: SessionLiveState = {
+      kind: 'loading',
+      loadingAriaLabel: 'Caricamento sessione in corso',
+    };
+    render(<SessionStateRenderer state={state} />);
+    const slot = document.querySelector('[data-slot="session-state-loading"]');
+    expect(slot).not.toBeNull();
+    expect(slot?.getAttribute('role')).toBe('status');
+    expect(slot?.getAttribute('aria-live')).toBe('polite');
+    expect(slot?.getAttribute('aria-label')).toBe('Caricamento sessione in corso');
+  });
+});
+
+// ─── error ────────────────────────────────────────────────────────────────────
+
+describe('SessionStateRenderer — error', () => {
+  it('renders inline banner with title + error message', () => {
+    const state: SessionLiveState = {
+      kind: 'error',
+      error: new Error('Backend 500: handler timeout'),
+      onRetry: vi.fn(),
+      errorTitle: 'Errore durante il caricamento',
+      retryLabel: 'Riprova',
+    };
+    render(<SessionStateRenderer state={state} />);
+    const slot = document.querySelector('[data-slot="session-state-error"]');
+    expect(slot).not.toBeNull();
+    expect(slot?.getAttribute('role')).toBe('alert');
+    expect(screen.getByText('Errore durante il caricamento')).toBeInTheDocument();
+    expect(screen.getByText('Backend 500: handler timeout')).toBeInTheDocument();
+  });
+
+  it('fires onRetry when retry button is clicked', async () => {
+    const onRetry = vi.fn();
+    const state: SessionLiveState = {
+      kind: 'error',
+      error: new Error('Network'),
+      onRetry,
+      errorTitle: 'Errore',
+      retryLabel: 'Riprova',
+    };
+    render(<SessionStateRenderer state={state} />);
+    const button = screen.getByRole('button', { name: /Riprova/ });
+    await userEvent.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── sse-disconnect ───────────────────────────────────────────────────────────
+
+describe('SessionStateRenderer — sse-disconnect', () => {
+  it('delegates to ConnectionLostBanner kind="failed"', () => {
+    const state: SessionLiveState = {
+      kind: 'sse-disconnect',
+      connectionLabels: CONNECTION_LABELS,
+    };
+    render(<SessionStateRenderer state={state} />);
+    expect(document.querySelector('[data-slot="session-state-sse-disconnect"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="connection-lost-banner"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-slot="connection-lost-banner"]')?.getAttribute('data-kind')
+    ).toBe('failed');
+  });
+});
+
+// ─── exhaustiveness ───────────────────────────────────────────────────────────
+
+describe('SessionStateRenderer — exhaustiveness', () => {
+  it('assertNever throws on unknown kind (defense-in-depth)', () => {
+    // Force an invalid state at runtime (TypeScript would catch at compile time).
+    const invalid = { kind: 'totally-unknown-state' } as unknown as SessionLiveState;
+    expect(() => render(<SessionStateRenderer state={invalid} />)).toThrow(/unhandled state kind/);
+  });
+});

--- a/apps/web/src/components/features/session-live/index.ts
+++ b/apps/web/src/components/features/session-live/index.ts
@@ -41,9 +41,16 @@ export type {
 
 export { LiveTopBar } from '@/components/features/session-live/LiveTopBar';
 export type {
+  LiveTopBarConnectionState,
   LiveTopBarLabels,
   LiveTopBarProps,
 } from '@/components/features/session-live/LiveTopBar';
+
+export { SessionStateRenderer } from '@/components/features/session-live/SessionStateRenderer';
+export type {
+  SessionLiveState,
+  SessionStateRendererProps,
+} from '@/components/features/session-live/SessionStateRenderer';
 
 export { MobileBody } from '@/components/features/session-live/MobileBody';
 export type {


### PR DESCRIPTION
## Summary

Implements **G7** from spec `docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md` — `SessionStateRenderer` discriminated-union primitive for consistent 5-state rendering across session-live surfaces.

Closes #2356. Parent umbrella: #2342. Sibling: #2352 G4 (merged via PR #2353, commit `ac2a84daf`).

## Changes

### New primitive

`apps/web/src/components/features/session-live/SessionStateRenderer.tsx` (139 LOC):

- **Discriminated union** `SessionLiveState` with 5 kinds:
  - `default` → children passthrough (no wrapper visible)
  - `empty` → delegates to existing `EmptyState` (title + description + optional CTA)
  - `loading` → inline skeleton (3-row animated pulse) with `role="status"` + `aria-live="polite"`
  - `error` → inline banner (icon + title + error.message + retry CTA) with `role="alert"`
  - `sse-disconnect` → delegates to existing `ConnectionLostBanner kind='failed'`
- **TypeScript exhaustiveness check** via `assertNever`: adding a 6th state requires a code change AND a type change — no silent drift.
- **Runtime defense**: `assertNever` throws on unknown kind (defense-in-depth).
- **data-slot** attributes per state for testing/styling targeting.

### Tests

`apps/web/src/components/features/session-live/__tests__/SessionStateRenderer.test.tsx` (163 LOC):

**8 unit tests** organized in 6 describes:
- `default` (1): children passthrough, no wrapper
- `empty` (2): title+description rendering, action button click fires onClick
- `loading` (1): skeleton + aria-live polite + aria-label
- `error` (2): inline banner with title/message + retry button click fires onRetry
- `sse-disconnect` (1): delegates to ConnectionLostBanner kind='failed'
- `exhaustiveness` (1): assertNever throws on unknown kind

### Barrel export

`apps/web/src/components/features/session-live/index.ts` (+7 LOC): exports `SessionStateRenderer` + `SessionLiveState` + `SessionStateRendererProps` types. Also exports `LiveTopBarConnectionState` type from G4 (was missing).

## Verification

```
✓ src/components/features/session-live/__tests__/SessionStateRenderer.test.tsx (8 tests) 593ms
Test Files  1 passed (1)
     Tests  8 passed (8)
```

Pre-commit: typecheck PASS · lint-staged (eslint + prettier) PASS · commitlint PASS.

## Spec decisions honored

| Spec requirement | Status |
|---|---|
| Discriminated-union 5-state | ✓ |
| TypeScript exhaustiveness check | ✓ (assertNever + tsc) |
| Delegate empty → existing `EmptyState` | ✓ |
| Delegate sse-disconnect → existing `ConnectionLostBanner` | ✓ |
| Storybook surface ready (O(state) instead of O(state × tab)) | ✓ (primitive shape supports this; stories in follow-up) |

## What this does NOT do (deferred follow-up)

- **Pilot wire on `/sessions/[id]/live/scoreboard`** — separate PR per spec §G7 "Action items" step 2
- **Wire other tabs** (play, players, notes, chat) — sequence after pilot scoreboard validates the pattern
- **Storybook variants** for the 5 states — post DS-17 phase 3
- **DS-17 state-naming convention** mapping (`<base>-state-NN-<label>`) — applied at Storybook integration time

## Test plan

- [x] Unit tests pass (8/8)
- [x] Pre-commit hooks pass (typecheck, lint, commitlint)
- [ ] Lychee link check verde post-PR-open
- [ ] axe AA pass (smoke test post-merge via existing a11y suite)

## Refs

- Closes #2356
- Parent umbrella: #2342
- Sibling (merged): #2353 G4 LiveTopBar timer + connection pip
- Scope spec: `docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md` §G7
- US-INT-4 context: `docs/for-developers/specs/2026-06-14-mockup-us-coverage-map.md` §4a
- Future epic (G1/G3/G5/G6): #2354
- Wiring follow-up (G4 props): #2355
- Parent DS-17: #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code) — `/sc:spec-panel` sprint trigger 2026-06-15
