### PR TITLE
feat(session-live): wire G4 LiveTopBar elapsedMs + connectionState (#2355)

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -80,6 +80,7 @@ import {
 import { useSession } from '@/hooks/queries/useActiveSessions';
 import { useTranslation } from '@/hooks/useTranslation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
+import { mapConnectionState } from '@/lib/session-live/map-connection-state';
 import { hasRequiredRole } from '@/lib/session-live/participant-role';
 import {
   deriveSessionLiveUiState,
@@ -97,6 +98,7 @@ import {
   VISUAL_TEST_FIXTURE_SESSION_PAUSED,
   type LiveSessionFixture,
 } from '@/lib/session-live/session-live-visual-test-fixture';
+import { useElapsedTime } from '@/lib/session-live/use-elapsed-time';
 import { useSessionLiveStream } from '@/lib/session-live/use-session-live-stream';
 
 // ─── Lazy dialogs (orchestrator-side lazy import per Task 3 spec) ──────────────
@@ -576,8 +578,19 @@ export function SessionLiveView(): ReactElement {
       resumeCta: t('pages.sessionLive.topBar.resumeCta'),
       endgameCta: t('pages.sessionLive.topBar.endgameCta'),
       exitAriaLabel: t('pages.sessionLive.topBar.exitAriaLabel'),
+      // G4 — Issue #2355 wiring
+      elapsedTimeAriaLabel: t('pages.sessionLive.topBar.elapsedTimeAriaLabel'),
+      connectionStateAriaLabels: {
+        connected: t('pages.sessionLive.topBar.connectionStateConnected'),
+        reconnecting: t('pages.sessionLive.topBar.connectionStateReconnecting'),
+        failed: t('pages.sessionLive.topBar.connectionStateFailed'),
+      },
     };
   }, [t, activeSession?.currentTurn, activeSession?.totalTurns, activeSession?.name]);
+
+  // G4 — Issue #2355: live elapsed time + connection pip wiring
+  const elapsedMs = useElapsedTime(sessionQuery.data?.startedAt);
+  const connectionPipState = mapConnectionState(liveStream.connectionState);
 
   const turnIndicatorLabels = useMemo<TurnIndicatorLabels>(
     (): TurnIndicatorLabels => ({
@@ -1014,6 +1027,8 @@ export function SessionLiveView(): ReactElement {
         viewerRole={activeSession.viewerRole}
         onExit={handleExit}
         labels={topBarLabels}
+        elapsedMs={elapsedMs}
+        connectionState={connectionPipState}
       />
 
       {/* ConnectionLostBanner — SSE non-healthy states */}

--- a/apps/web/src/lib/session-live/__tests__/map-connection-state.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/map-connection-state.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapConnectionState } from '../map-connection-state';
+
+describe('mapConnectionState', () => {
+  it("returns undefined for 'connecting' (hide pip on initial connect)", () => {
+    expect(mapConnectionState('connecting')).toBeUndefined();
+  });
+
+  it("returns 'connected' for 'connected'", () => {
+    expect(mapConnectionState('connected')).toBe('connected');
+  });
+
+  it("returns 'reconnecting' for 'reconnecting'", () => {
+    expect(mapConnectionState('reconnecting')).toBe('reconnecting');
+  });
+
+  it("returns 'reconnecting' for 'degraded-polling' (amber fallback)", () => {
+    expect(mapConnectionState('degraded-polling')).toBe('reconnecting');
+  });
+
+  it("returns 'failed' for 'failed'", () => {
+    expect(mapConnectionState('failed')).toBe('failed');
+  });
+
+  it('throws on unknown SSE state (defense-in-depth)', () => {
+    expect(() => mapConnectionState('unknown' as never)).toThrow(/unhandled SseConnectionState/);
+  });
+});

--- a/apps/web/src/lib/session-live/__tests__/use-elapsed-time.test.tsx
+++ b/apps/web/src/lib/session-live/__tests__/use-elapsed-time.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useElapsedTime } from '../use-elapsed-time';
+
+describe('useElapsedTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T10:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns undefined when startedAt is undefined', () => {
+    const { result } = renderHook(() => useElapsedTime(undefined));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when startedAt is null', () => {
+    const { result } = renderHook(() => useElapsedTime(null));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined for invalid ISO string (defensive)', () => {
+    const { result } = renderHook(() => useElapsedTime('not-a-date'));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns 0 when startedAt equals current time', () => {
+    const { result } = renderHook(() => useElapsedTime('2026-06-15T10:00:00Z'));
+    expect(result.current).toBe(0);
+  });
+
+  it('returns elapsed ms when startedAt is in the past', () => {
+    const { result } = renderHook(() => useElapsedTime('2026-06-15T09:30:00Z'));
+    // 30 minutes = 1_800_000 ms
+    expect(result.current).toBe(1_800_000);
+  });
+
+  it('ticks every second by default', () => {
+    const { result } = renderHook(() => useElapsedTime('2026-06-15T09:59:55Z'));
+    expect(result.current).toBe(5_000); // 5 seconds elapsed initially
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(result.current).toBe(6_000);
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(result.current).toBe(8_000);
+  });
+
+  it('returns 0 (not negative) for startedAt in the future', () => {
+    const { result } = renderHook(() => useElapsedTime('2026-06-15T11:00:00Z'));
+    expect(result.current).toBe(0);
+  });
+
+  it('respects custom intervalMs', () => {
+    const { result } = renderHook(() => useElapsedTime('2026-06-15T09:59:55Z', 500));
+    expect(result.current).toBe(5_000);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current).toBe(5_500);
+  });
+
+  it('clears interval on unmount (no leaked timers)', () => {
+    const { unmount } = renderHook(() => useElapsedTime('2026-06-15T10:00:00Z'));
+    unmount();
+    // If interval leaked, advanceTimersByTime would call setTick on unmounted component
+    // (React would log a warning). Test passes if no warning.
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+  });
+});

--- a/apps/web/src/lib/session-live/map-connection-state.ts
+++ b/apps/web/src/lib/session-live/map-connection-state.ts
@@ -1,0 +1,51 @@
+/**
+ * mapConnectionState — wire G4 LiveTopBar connection pip (Issue #2355).
+ *
+ * Maps the 5-value SSE connection state from `useSessionLiveStream` to the
+ * 3-value pip enum exposed by `LiveTopBar`. The `connecting` initial state
+ * returns `undefined` to keep the pip hidden until the first connection
+ * attempt resolves — avoids a flash of amber on every mount.
+ *
+ * | SSE state          | Pip state      | Visual           |
+ * |--------------------|----------------|------------------|
+ * | `connecting`       | undefined      | (hidden)         |
+ * | `connected`        | 'connected'    | emerald          |
+ * | `reconnecting`     | 'reconnecting' | amber            |
+ * | `degraded-polling` | 'reconnecting' | amber (fallback) |
+ * | `failed`           | 'failed'       | destructive      |
+ *
+ * @see apps/web/src/lib/session-live/use-session-live-stream.ts (SseConnectionState)
+ * @see apps/web/src/components/features/session-live/LiveTopBar.tsx (LiveTopBarConnectionState)
+ * @see Issue #2355 (G4 wiring), parent #2352 (G4 primitive shipped)
+ */
+
+import type { LiveTopBarConnectionState } from '@/components/features/session-live';
+
+type SseConnectionState =
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'degraded-polling'
+  | 'failed';
+
+export function mapConnectionState(
+  state: SseConnectionState
+): LiveTopBarConnectionState | undefined {
+  switch (state) {
+    case 'connecting':
+      return undefined;
+    case 'connected':
+      return 'connected';
+    case 'reconnecting':
+    case 'degraded-polling':
+      return 'reconnecting';
+    case 'failed':
+      return 'failed';
+    default:
+      return assertNever(state);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`mapConnectionState: unhandled SseConnectionState "${String(value)}".`);
+}

--- a/apps/web/src/lib/session-live/use-elapsed-time.ts
+++ b/apps/web/src/lib/session-live/use-elapsed-time.ts
@@ -1,0 +1,39 @@
+'use client';
+
+/**
+ * useElapsedTime — wire G4 LiveTopBar timer chip (Issue #2355).
+ *
+ * Returns elapsed milliseconds since `startedAt`, ticking every `intervalMs`
+ * (default 1000ms). Returns `undefined` when `startedAt` is null/undefined
+ * so the timer chip is hidden gracefully during loading or for sessions
+ * without a start time.
+ *
+ * The interval is paused via cleanup on unmount; visibility-change isn't
+ * required because LiveTopBar mounts inside the session-live shell which
+ * itself remounts on tab visibility transitions.
+ *
+ * @see apps/web/src/lib/session-live/format-elapsed-time.ts (formatting layer)
+ * @see Issue #2355 (G4 wiring), parent #2352 (G4 primitive shipped)
+ */
+
+import { useEffect, useState } from 'react';
+
+export function useElapsedTime(
+  startedAt: string | null | undefined,
+  intervalMs = 1000
+): number | undefined {
+  const [tick, setTick] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!startedAt) return;
+    const id = setInterval(() => setTick(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [startedAt, intervalMs]);
+
+  if (!startedAt) return undefined;
+
+  const startMs = Date.parse(startedAt);
+  if (Number.isNaN(startMs)) return undefined;
+
+  return Math.max(0, tick - startMs);
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3065,7 +3065,11 @@
         "pauseCta": "Pause",
         "resumeCta": "Resume",
         "endgameCta": "End session",
-        "exitAriaLabel": "Exit session"
+        "exitAriaLabel": "Exit session",
+        "elapsedTimeAriaLabel": "Elapsed time",
+        "connectionStateConnected": "Connection active",
+        "connectionStateReconnecting": "Reconnecting",
+        "connectionStateFailed": "Connection lost"
       },
       "turnIndicator": {
         "currentTurnAriaLabel": "Turn {current} of {total}",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3172,7 +3172,11 @@
         "pauseCta": "Pausa",
         "resumeCta": "Riprendi",
         "endgameCta": "Termina sessione",
-        "exitAriaLabel": "Esci dalla sessione"
+        "exitAriaLabel": "Esci dalla sessione",
+        "elapsedTimeAriaLabel": "Tempo trascorso",
+        "connectionStateConnected": "Connessione attiva",
+        "connectionStateReconnecting": "Riconnessione in corso",
+        "connectionStateFailed": "Connessione persa"
       },
       "turnIndicator": {
         "currentTurnAriaLabel": "Turno {current} di {total}",


### PR DESCRIPTION
## Summary

Wires the G4 LiveTopBar props (#2352 merged via PR #2353) to the actual call site in `SessionLiveView`. Closes #2355.

Closes the G4 loop: the timer chip + connection-state pip are now live in `/sessions/[id]/live` for real users (not just behind the API).

Parent: #2342 (Mockup-to-US Coverage execution).

## Changes

### New helpers

- `apps/web/src/lib/session-live/use-elapsed-time.ts` (39 LOC) — React hook ticking every `intervalMs` (default 1s). Returns `undefined` for null/undefined `startedAt`. Floors to ms; clamps negatives to 0.
- `apps/web/src/lib/session-live/map-connection-state.ts` (53 LOC) — Pure helper mapping the 5-value SSE state from `useSessionLiveStream` to the 3-value pip enum from `LiveTopBar`:
  - `connecting` → `undefined` (pip hidden on initial connect — avoids amber flash)
  - `connected` → `'connected'` (emerald)
  - `reconnecting` + `degraded-polling` → `'reconnecting'` (amber)
  - `failed` → `'failed'` (destructive)
- TypeScript exhaustiveness via `assertNever` (defense-in-depth).

### Wiring in SessionLiveView

- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` (+15 LOC):
  - `useElapsedTime(sessionQuery.data?.startedAt)` → `elapsedMs`
  - `mapConnectionState(liveStream.connectionState)` → `connectionPipState`
  - Extends `topBarLabels` memo con 4 nuovi i18n labels
  - Passes both props to `<LiveTopBar>`

### i18n labels

- `apps/web/src/locales/it.json` (+4 keys): `elapsedTimeAriaLabel` + 3 `connectionState*` labels
- `apps/web/src/locales/en.json` (+4 keys): same

## Verification

```
✓ src/lib/session-live/__tests__/map-connection-state.test.ts (6 tests) 11ms
✓ src/lib/session-live/__tests__/use-elapsed-time.test.tsx (9 tests) 55ms
Test Files  2 passed (2)
     Tests  15 passed (15)
```

Pre-commit: typecheck PASS · lint-staged (eslint + prettier) PASS · commitlint PASS.

## Spec decisions honored

| Spec requirement | Status |
|---|---|
| Wire `elapsedMs` from session-live store selector | ✓ Sourced from `sessionQuery.data?.startedAt` (DTO via `useSession`) + `useElapsedTime` hook |
| Wire `connectionState` from 5-value SSE → 3-value pip enum | ✓ `mapConnectionState` helper with `connecting → undefined` decision |
| Add new i18n labels for aria | ✓ 4 keys per locale (it + en) |
| ConnectionLostBanner stays in place for failed actionable surface | ✓ Banner unchanged; pip is glanceable summary only |

## What this does NOT do (out of scope)

- **Wire NightLiveHub.tsx** — that component uses its own `NightLiveTopBar` (different component, not the shared `LiveTopBar`); no wiring needed
- **Extend `LiveSessionFixture` with `startedAt`** — visual-test fixtures don't need live timer; would be additional scope creep
- **Add E2E Playwright spec** for visible timer tick — deferred follow-up (would require fake timers in Playwright)

## Test plan

- [x] Unit tests pass (15/15)
- [x] Pre-commit hooks pass (typecheck, lint, commitlint)
- [ ] Lychee link check verde post-PR-open
- [ ] axe AA pass (existing a11y suite covers TopBar)
- [ ] Visual smoke: open `/sessions/[id]/live` in browser, verify timer ticks + pip appears on connection change

## Refs

- Closes #2355
- Parent G4: #2352 (merged PR #2353, commit `ac2a84daf`)
- Sibling G7 primitive: #2356 (merged PR #2357, commit `c86121351`)
- Umbrella: #2342
- Spec: `docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md` §G4
- Parent DS-17: #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code) — `/sc:spec-panel` sprint trigger 2026-06-15
