### PR TITLE
feat(session-live): G7 pilot — wire SessionStateRenderer in ScoreboardPage (#2356)

### DIFF
--- a/apps/web/src/components/session/ScoreboardPage.tsx
+++ b/apps/web/src/components/session/ScoreboardPage.tsx
@@ -20,6 +20,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Trophy, Users } from 'lucide-react';
 import Link from 'next/link';
 
+import { SessionStateRenderer } from '@/components/features/session-live';
 import {
   Sheet,
   SheetContent,
@@ -69,6 +70,8 @@ export function ScoreboardPage({ sessionId }: ScoreboardPageProps) {
     data: session,
     isPending,
     isError,
+    error,
+    refetch,
   } = useQuery({
     queryKey: ['session', sessionId],
     queryFn: () => api.sessions.getById(sessionId),
@@ -76,43 +79,40 @@ export function ScoreboardPage({ sessionId }: ScoreboardPageProps) {
     retry: false,
   });
 
-  // ----------- Loading state -----------
+  // ----------- Loading state (G7 SessionStateRenderer pilot — Issue #2356) -----------
   if (isPending) {
     return (
       <div data-testid="scoreboard-loading" className="min-h-screen bg-background p-4">
-        {/* Header skeleton */}
-        <div className="mb-6 flex items-center gap-3">
-          <div className="h-8 w-8 animate-pulse rounded-lg bg-muted" />
-          <div className="space-y-2">
-            <div className="h-4 w-40 animate-pulse rounded bg-muted" />
-            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
-          </div>
-        </div>
-        {/* Player card skeletons */}
-        <div className="space-y-3">
-          {[1, 2, 3].map(i => (
-            <div
-              key={i}
-              className="flex h-16 items-center gap-4 rounded-xl border border-border bg-card p-4"
-            >
-              <div className="h-10 w-10 animate-pulse rounded-lg bg-muted" />
-              <div className="h-4 w-32 animate-pulse rounded bg-muted" />
-            </div>
-          ))}
-        </div>
+        <SessionStateRenderer
+          state={{
+            kind: 'loading',
+            loadingAriaLabel: 'Caricamento classifica in corso',
+          }}
+        />
       </div>
     );
   }
 
-  // ----------- Error / empty state -----------
+  // ----------- Error state (G7 SessionStateRenderer pilot — Issue #2356) -----------
   if (isError || !session) {
+    const fallbackError =
+      error instanceof Error ? error : new Error('Impossibile caricare la sessione');
     return (
       <div
         data-testid="scoreboard-error"
         className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background p-4 text-center"
       >
-        <p className="text-sm font-medium text-destructive">Impossibile caricare la sessione</p>
-        <p className="text-xs text-muted-foreground">Verifica la connessione e riprova.</p>
+        <SessionStateRenderer
+          state={{
+            kind: 'error',
+            error: fallbackError,
+            onRetry: () => {
+              void refetch();
+            },
+            errorTitle: 'Impossibile caricare la sessione',
+            retryLabel: 'Riprova',
+          }}
+        />
         <Button variant="outline" size="sm" asChild>
           <Link href="/sessions">Torna alle sessioni</Link>
         </Button>


### PR DESCRIPTION
## Summary

G7 SessionStateRenderer **pilot wire** — refactor `ScoreboardPage` to use the discriminated-union primitive shipped in PR #2357 (#2356, commit `c86121351`).

Validates the G7 pattern in real production code with minimal disruption: the existing tests pass unchanged (data-testid wrappers preserved).

Parent G7 primitive: #2356. Sibling: #2355 (G4 wiring, merged via PR #2362).
Umbrella: #2342.

## Changes

`apps/web/src/components/session/ScoreboardPage.tsx` (+24/-24 LOC):

- Loading state: replaces 30+ LOC of ad-hoc skeleton with `<SessionStateRenderer state={{ kind: 'loading', loadingAriaLabel: '...' }} />`
- Error state: replaces ad-hoc banner (icon + title + description + back link) with `<SessionStateRenderer state={{ kind: 'error', error, onRetry: refetch, errorTitle, retryLabel }} />` (back link preserved)
- Exposes `error` + `refetch` from `useQuery` for retry wiring
- Preserves `data-testid="scoreboard-loading"` and `data-testid="scoreboard-error"` on wrapping divs (15 existing tests pass unchanged)

## Verification

```
✓ src/components/session/__tests__/ScoreboardPage.test.tsx (15 tests) 1194ms
Test Files  1 passed (1)
     Tests  15 passed (15)
```

Pre-commit: typecheck PASS · lint-staged (eslint + prettier) PASS · commitlint PASS.

## Pattern validated

The G7 pilot demonstrates:

1. **Consistency**: empty/loading/error states render identically across tabs (vs ad-hoc per-tab divergence)
2. **Backward compat**: existing tests asserting on `data-testid="scoreboard-loading"` etc. continue to pass because the data-testid lives on the wrapper div around `SessionStateRenderer`
3. **Retry wiring**: `refetch` from `useQuery` flows through `state.onRetry` — generic retry path
4. **Exhaustiveness**: TypeScript compile-time check forces all 5 states to be handled

## Out of scope (deferred follow-up)

- **Wire other tabs**: play, players, notes, chat tabs in live shell still use ad-hoc state handling. Future PR per-tab.
- **Empty state for ScoreboardPage**: the existing "Nessun giocatore in questa sessione" remains inline. Could become `{ kind: 'empty' }` in a follow-up to demonstrate that 5th state too.
- **SSE-disconnect state**: ScoreboardPage doesn't subscribe to SSE; the 5th state (`sse-disconnect`) is N/A here. Live tabs (where SSE is active) will pilot that state separately.

## Test plan

- [x] 15/15 existing ScoreboardPage tests pass (no test changes needed)
- [x] Pre-commit hooks pass (typecheck, lint, commitlint)
- [ ] Lychee link check verde post-PR-open
- [ ] Visual smoke: visit `/sessions/[id]/scoreboard` with a non-existent sessionId → see G7 error state
- [ ] Visual smoke: visit `/sessions/[id]/scoreboard` mid-network → see G7 loading skeleton

## Refs

- Closes #2356 (G7 follow-up: pilot wire)
- Parent G7 primitive: #2356 (merged PR #2357, commit `c86121351`)
- Sibling G4 wiring: #2355 (merged PR #2362, commit `a191f53de`)
- Umbrella: #2342
- Scope spec: `docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md` §G7
- Parent DS-17: #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code) — `/sc:spec-panel` sprint trigger 2026-06-15
