### PR TITLE
test(kb): #2311 close — add missing M1.3 projection unit test

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
@@ -172,6 +172,52 @@ public sealed class GetKbChunksHandlerTests
         result.NextCursor.Should().BeNull();
     }
 
+    /// <summary>
+    /// #2311 M1.3 — verifies that <c>TextChunkEntity.UsageCount</c> is projected verbatim
+    /// as <c>KbChunkSummaryDto.UsedInChats</c>. DEC-D2 start-from-0: zero is the baseline,
+    /// arbitrary value after increment must round-trip unchanged.
+    /// </summary>
+    [Fact]
+    public async Task GetKbChunks_ProjectsUsageCountAsUsedInChats()
+    {
+        // Arrange: seed a document with a single chunk that already has UsageCount=5.
+        var docId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "usage-count-test.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/usage.pdf",
+            IsPublic = true
+        });
+        _dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = docId,
+            Content = "Content for usage count projection test",
+            ChunkIndex = 0,
+            PageNumber = 1,
+            CharacterCount = 40,
+            ElementType = "NarrativeText",
+            Level = 1,
+            UsageCount = 5
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Act.
+        var result = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), null, 50, UserIsAdmin: false),
+            CancellationToken.None);
+
+        // Assert: UsedInChats mirrors the entity's UsageCount verbatim.
+        result.Items.Should().HaveCount(1);
+        result.Items[0].UsedInChats.Should().Be(5);
+    }
+
     private async Task<Guid> SeedDocumentWithChunksAsync(int chunkCount)
     {
         var docId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

Closes #2311 — the feature was already shipped via PR #2323 (BE migration + RAG citation increment hook) and PR #2331 (FE 5 components + 4 hooks + page rewrite + axe AA test + storybook + fidelity designer-approved). PR #2331 closed #2223 (parent tracking) but left #2311 open by oversight.

This PR adds the **only missing piece** identified by the M1 implementer subagent during a final audit of the [plan](docs/superpowers/plans/2026-06-14-issue-2311-kb-detail-split-view.md): the M1.3 projection unit test `GetKbChunks_ProjectsUsageCountAsUsedInChats` that the plan called for but was absent from `GetKbChunksHandlerTests`.

## Acceptance criteria status (12/12 ✅)

- ✅ D1-D5 lockate (plan §5 DEC)
- ✅ 5 componenti FE (`MarkdownRenderBlock`, `ChunkSearchBox`, `KbHeader`, `KbChunkListPanel`, `KbChunkPreview`) + `ConnectionBar` wire-up — PR #2331
- ✅ 4 hook query (`useKbDocument`, `useKbChunks`, `useKbChunk`, `useSearchKbChunks`) consolidated in `use-kb-detail.ts` — PR #2331
- ✅ BE migration `AddUsageCountToTextChunks` + RAG citation increment hook + `KbChunkSummaryDto.UsedInChats` — PR #2323
- ✅ Route `/knowledge-base/[id]` split-view operativo (186 LOC, 4 hook wired)
- ✅ Ricerca debounced (`ChunkSearchBox` + `useSearchKbChunks`)
- ✅ Empty/error states (`KbChunkPreview` discriminated union FSM)
- ✅ axe AA pass — `knowledge-base-axe.test.tsx` 5/5 pass (Vitest jest-axe, project convention)
- ✅ Token canonicalization (`pnpm lint:tokens` 0 violations, `text-entity-kb`/`bg-entity-kb` per DEC-D5)
- ✅ Storybook story (`apps/web/src/app/(authenticated)/knowledge-base/[id]/page.stories.tsx`)
- ✅ `sp4-kb-detail.fidelity.json` designer-approved (P250 self-waiver #2127)
- ✅ M1.3 projection test (this PR)

## Files changed

- `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs` — add `GetKbChunks_ProjectsUsageCountAsUsedInChats` unit test

## Test results

- `GetKbChunksHandlerTests`: 7/7 pass (6 pre-existing + 1 new)
- KnowledgeBase Unit suite: 2241 pass, 0 fail, 2 skip (pre-existing)

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~GetKbChunksHandlerTests"` (7/7 pass locally)
- [x] Manual smoke: `/knowledge-base/<id>` renders split-view (already validated via PR #2331 merge)

## Notes for reviewer

API deviations from the plan documented by PR #2331 (intentional adaptations, not regressions):
- `MarkdownRenderBlock` prop `content` (not `markdown`)
- `ChunkSearchBox` no `totalCount`/`filteredCount` (page owns counter rendering — KISS)
- `KbChunkListPanel` non-virtualized (50-200 chunks within DOM budget, virtualization deferred; `react-window@2` API mismatch with `FixedSizeList`)
- `KbChunkPreview` discriminated union state instead of nullable `chunk` prop
- `AnimatedUnderlineTabs` (DEC-D5 primitive extracted in #2331) instead of shadcn `Tabs`

Plan: `docs/superpowers/plans/2026-06-14-issue-2311-kb-detail-split-view.md` (untracked, not committed — pure scratch plan, may add separately if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)