### PR TITLE
feat(layout): unify page container max-width via PageContainer primitive (#2367)

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
@@ -48,6 +48,7 @@ import {
   type KbDocsState,
   type SettingsState,
 } from '@/components/features/agent-detail';
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { useAgent } from '@/hooks/queries/useAgent';
 import { useAgentConfig } from '@/hooks/queries/useAgentConfig';
 import { useAgentKbDocs, useAgentThreads } from '@/hooks/queries/useAgentData';
@@ -572,7 +573,7 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
       />
 
       {/* Tab panels — role=tabpanel, aria-labelledby wired to tabIdFor */}
-      <div className="container mx-auto max-w-4xl px-4 py-6 sm:px-8">
+      <DetailPageContainer>
         {/* Identity tab — Cell 5: persona + system prompt (no sub-hook fetch) */}
         <div
           role="tabpanel"
@@ -667,7 +668,7 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
             />
           </div>
         </div>
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -31,6 +31,7 @@ import Link from 'next/link';
 
 import { useAuth } from '@/components/auth/AuthProvider';
 import { CascadeDrawerHost } from '@/components/dashboard/CascadeDrawerHost';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import { useActiveSessions } from '@/hooks/queries/useActiveSessions';
 import { useCompletedGameNights, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
@@ -263,10 +264,7 @@ export function DashboardClient(): ReactElement {
         labels={heroLabels}
       />
 
-      <div
-        data-slot="dashboard-priority-sections"
-        className="container mx-auto flex flex-col gap-8 px-4 py-8 pb-16 sm:px-8"
-      >
+      <HubPageContainer data-slot="dashboard-priority-sections" className="gap-8 py-8 pb-16">
         <ProssimiSection
           state={prossimiState}
           gameNights={prossimiCards}
@@ -353,7 +351,7 @@ export function DashboardClient(): ReactElement {
         ) : null}
 
         <FriendsActivitySection state={friendsState} activities={friendsActivities} />
-      </div>
+      </HubPageContainer>
 
       {/* #1929 WP5: cascade-store driven drawer renderer for dashboard card clicks */}
       <CascadeDrawerHost />

--- a/apps/web/src/app/(authenticated)/editor/agent-proposals/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/editor/agent-proposals/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import { FormPageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/primitives/button';
 
 /**
@@ -12,7 +13,7 @@ export default function EditProposalPage() {
   const router = useRouter();
 
   return (
-    <div className="container mx-auto p-6 max-w-2xl">
+    <FormPageContainer className="p-6">
       <div className="text-center py-24 space-y-4">
         <h1 className="text-2xl font-bold">Feature Removed</h1>
         <p className="text-muted-foreground">
@@ -20,6 +21,6 @@ export default function EditProposalPage() {
         </p>
         <Button onClick={() => router.push('/editor/agent-proposals')}>Back to Proposals</Button>
       </div>
-    </div>
+    </FormPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/editor/agent-proposals/[id]/test/page.tsx
+++ b/apps/web/src/app/(authenticated)/editor/agent-proposals/[id]/test/page.tsx
@@ -19,6 +19,7 @@ import { useRouter, useParams } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { useAuthUser } from '@/components/auth/AuthProvider';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { Badge } from '@/components/ui/data-display/badge';
 import {
   Card,
@@ -55,19 +56,19 @@ function EditorAuthGuard({
   user: { role: string; id: string } | null;
 }) {
   if (loading) {
-    return <div className="container mx-auto p-6">Loading...</div>;
+    return <HubPageContainer className="p-6">Loading...</HubPageContainer>;
   }
 
   if (!user || (user.role !== 'Editor' && user.role !== 'Admin')) {
     return (
-      <div className="container mx-auto p-6">
+      <HubPageContainer className="p-6">
         <div className="text-center p-12">
           <h2 className="text-2xl font-bold mb-4">Access Denied</h2>
           <p className="text-muted-foreground">
             This page is only accessible to Editors and Administrators.
           </p>
         </div>
-      </div>
+      </HubPageContainer>
     );
   }
 
@@ -198,16 +199,16 @@ function TestSandboxClient() {
   // Loading state
   if (authLoading || isLoading) {
     return (
-      <div className="container mx-auto p-6">
+      <HubPageContainer className="p-6">
         <div className="text-center p-12">Loading...</div>
-      </div>
+      </HubPageContainer>
     );
   }
 
   // Error state
   if (error || !typology) {
     return (
-      <div className="container mx-auto p-6">
+      <HubPageContainer className="p-6">
         <div className="text-center p-12">
           <h2 className="text-2xl font-bold mb-4">Proposal Not Found</h2>
           <p className="text-muted-foreground">
@@ -216,7 +217,7 @@ function TestSandboxClient() {
               : 'The proposal you are looking for does not exist.'}
           </p>
         </div>
-      </div>
+      </HubPageContainer>
     );
   }
 
@@ -224,7 +225,7 @@ function TestSandboxClient() {
 
   return (
     <EditorAuthGuard loading={authLoading} user={user}>
-      <div className="container mx-auto p-6 max-w-7xl">
+      <HubPageContainer className="p-6">
         {/* Header */}
         <div className="mb-6 flex items-start justify-between">
           <div>
@@ -379,7 +380,7 @@ function TestSandboxClient() {
             </Card>
           </div>
         </div>
-      </div>
+      </HubPageContainer>
     </EditorAuthGuard>
   );
 }

--- a/apps/web/src/app/(authenticated)/editor/agent-proposals/client.tsx
+++ b/apps/web/src/app/(authenticated)/editor/agent-proposals/client.tsx
@@ -16,6 +16,7 @@ import { Plus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 import { useAuth } from '@/components/auth/AuthProvider';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/primitives/button';
 
 import { ProposalsList } from './_components/ProposalsList';
@@ -25,25 +26,29 @@ import { ProposalsList } from './_components/ProposalsList';
  * TODO: Create proper EditorAuthGuard component
  * For now, check role === 'Editor' or 'Admin'
  */
-function EditorAuthGuard({ children, loading, user }: {
+function EditorAuthGuard({
+  children,
+  loading,
+  user,
+}: {
   children: React.ReactNode;
   loading: boolean;
   user: { role: string } | null;
 }) {
   if (loading) {
-    return <div className="container mx-auto p-6">Loading...</div>;
+    return <HubPageContainer className="p-6">Loading...</HubPageContainer>;
   }
 
   if (!user || (user.role !== 'Editor' && user.role !== 'Admin')) {
     return (
-      <div className="container mx-auto p-6">
+      <HubPageContainer className="p-6">
         <div className="text-center p-12">
           <h2 className="text-2xl font-bold mb-4">Access Denied</h2>
           <p className="text-muted-foreground">
             This page is only accessible to Editors and Administrators.
           </p>
         </div>
-      </div>
+      </HubPageContainer>
     );
   }
 
@@ -60,7 +65,7 @@ export function ProposalsClient() {
 
   return (
     <EditorAuthGuard loading={authLoading} user={user}>
-      <div className="container mx-auto p-6 max-w-7xl">
+      <HubPageContainer className="p-6">
         <div className="mb-6 flex items-start justify-between">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">My Typology Proposals</h1>
@@ -77,7 +82,7 @@ export function ProposalsClient() {
         </div>
 
         <ProposalsList />
-      </div>
+      </HubPageContainer>
     </EditorAuthGuard>
   );
 }

--- a/apps/web/src/app/(authenticated)/editor/agent-proposals/create/page.tsx
+++ b/apps/web/src/app/(authenticated)/editor/agent-proposals/create/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import { FormPageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/primitives/button';
 
 /**
@@ -13,7 +14,7 @@ export default function CreateProposalPage() {
   const router = useRouter();
 
   return (
-    <div className="container mx-auto p-6 max-w-2xl">
+    <FormPageContainer className="p-6">
       <div className="text-center py-24 space-y-4">
         <h1 className="text-2xl font-bold">Feature Removed</h1>
         <p className="text-muted-foreground">
@@ -22,6 +23,6 @@ export default function CreateProposalPage() {
         </p>
         <Button onClick={() => router.push('/editor/agent-proposals')}>Back to Proposals</Button>
       </div>
-    </div>
+    </FormPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/editor/editor-client.tsx
+++ b/apps/web/src/app/(authenticated)/editor/editor-client.tsx
@@ -32,6 +32,7 @@ import {
   ConflictResolutionModal,
   PresenceIndicator,
 } from '@/components/editor';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { useAuthUser } from '@/hooks/useAuthUser';
 import { useDebounce } from '@/hooks/useDebounce';
 import { api } from '@/lib/api';
@@ -511,7 +512,7 @@ export function EditorClient() {
   }
 
   return (
-    <main className="p-6 font-sans max-w-[1400px] mx-auto">
+    <HubPageContainer className="p-6 font-sans">
       {/* Issue #2055: Conflict Resolution Modal */}
       <ConflictResolutionModal
         open={showConflictModal}
@@ -664,7 +665,7 @@ export function EditorClient() {
           </div>
         </div>
       )}
-    </main>
+    </HubPageContainer>
   );
 }
 

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
@@ -37,6 +37,7 @@ import { GameNightActions } from '@/components/game-night/GameNightActions';
 import { GameNightDiaryPanel } from '@/components/game-night/GameNightDiaryPanel';
 import { GameNightSessionsList } from '@/components/game-night/GameNightSessionsList';
 import { GameNightPlanningLayout } from '@/components/game-night/planning/GameNightPlanningLayout';
+import { FormPageContainer } from '@/components/layout/PageContainer';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
@@ -176,11 +177,11 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
 
   if (isLoading) {
     return (
-      <div className="p-4 max-w-2xl mx-auto space-y-4">
+      <FormPageContainer className="p-4 space-y-4">
         <Skeleton className="h-8 w-3/4" />
         <Skeleton className="h-4 w-1/2" />
         <Skeleton className="h-32 w-full" />
-      </div>
+      </FormPageContainer>
     );
   }
 
@@ -270,7 +271,7 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 p-4">
+    <FormPageContainer className="space-y-6 p-4">
       <GameNightDetailHero
         title={event.title}
         status={event.status}
@@ -378,6 +379,6 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
           </ul>
         </section>
       )}
-    </div>
+    </FormPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/edit/page.tsx
@@ -18,6 +18,7 @@ import { use } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { FormPageContainer } from '@/components/layout/PageContainer';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { useGameNight, useUpdateGameNight } from '@/hooks/queries/useGameNights';
 import { useToast } from '@/hooks/useToast';
@@ -54,10 +55,10 @@ export default function EditGameNightPage({ params }: { params: Promise<{ id: st
 
   if (isLoading || !event) {
     return (
-      <div className="p-4 max-w-2xl mx-auto space-y-4">
+      <FormPageContainer className="p-4 space-y-4">
         <Skeleton className="h-8 w-3/4" />
         <Skeleton className="h-64 w-full" />
-      </div>
+      </FormPageContainer>
     );
   }
 

--- a/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
@@ -20,6 +20,7 @@ import {
   type GameNightCreateWizardLabels,
   type GameCandidateOption,
 } from '@/components/features/game-night-create';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useCreateGameNight } from '@/hooks/queries/useGameNights';
 import { useLibrary } from '@/hooks/queries/useLibrary';
@@ -326,7 +327,7 @@ export function NewGameNightContent(): ReactElement {
   const labels = useMemo(() => buildWizardLabels(t), [t]);
 
   return (
-    <div className="container mx-auto px-4 py-6">
+    <HubPageContainer className="py-6">
       <div className="mb-4">
         <label htmlFor="game-night-title" className="text-sm font-medium text-foreground">
           {t('gameNightsIndex.header.ctaNew')}
@@ -372,6 +373,6 @@ export function NewGameNightContent(): ReactElement {
           {t('gameNightCreate.draft.savingStatus')}
         </p>
       )}
-    </div>
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/gamebook/_components/GamebookIndexView.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/_components/GamebookIndexView.tsx
@@ -63,6 +63,7 @@ import {
   type QuotaWidgetVariant,
   type SoftWarningCreditsLabels,
 } from '@/components/features/gamebook';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { useGamebooks, useQuotaInfo } from '@/hooks/queries/useGamebooks';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { CheckoutPackId } from '@/lib/gamebook/checkout-packs';
@@ -87,19 +88,18 @@ const SKELETON_COUNT = 6;
 // Inline Italian labels. Future i18n extraction is out-of-scope per spec.
 
 const CHECKOUT_LABELS: CheckoutLabels = {
-  modalTitle: (s) => `Checkout · passo ${s} di 4`,
+  modalTitle: s => `Checkout · passo ${s} di 4`,
   close: 'Chiudi checkout',
   stepIndicator: {
     step1: 'Quota',
     step2: 'Pacchetto',
     step3: 'Pagamento',
     step4: 'Fatto',
-    ariaCurrent: (s) => `Passo ${s} di 4`,
+    ariaCurrent: s => `Passo ${s} di 4`,
   },
   step1: {
     heading: 'Quota raggiunta',
-    subheading:
-      'Hai tradotto 50 paragrafi questo mese. La quota gratuita si resetta il 1° giugno.',
+    subheading: 'Hai tradotto 50 paragrafi questo mese. La quota gratuita si resetta il 1° giugno.',
     quotaLabel: 'Quota mensile',
     resetIn: 'Reset tra 12 giorni',
     primaryCta: '💎 Acquista 100 crediti (€5)',
@@ -129,7 +129,7 @@ const CHECKOUT_LABELS: CheckoutLabels = {
       country: 'Paese',
     },
     trustChips: ['SSL secure', 'Stripe powered', 'Politica rimborso 14gg'],
-    payCta: (eur) => `Paga ${eur}`,
+    payCta: eur => `Paga ${eur}`,
     loadingCta: 'Elaborazione…',
     backLink: '← Torna ai pacchetti',
     failedBanner: {
@@ -140,7 +140,7 @@ const CHECKOUT_LABELS: CheckoutLabels = {
   },
   step4: {
     title: 'Crediti aggiunti!',
-    subtitle: (credits) => `${credits} crediti aggiunti al tuo account. Buon gioco!`,
+    subtitle: credits => `${credits} crediti aggiunti al tuo account. Buon gioco!`,
     recapLabels: {
       previous: 'Crediti precedenti',
       purchased: 'Crediti acquistati',
@@ -150,7 +150,7 @@ const CHECKOUT_LABELS: CheckoutLabels = {
       rate: '1 paragrafo = 1 credito',
     },
     backToGameCta: '🎯 Torna al gioco →',
-    receiptLink: (email) =>
+    receiptLink: email =>
       email ? `Vedi ricevuta · email a ${email}` : 'Vedi ricevuta · email inviata',
   },
 };
@@ -305,14 +305,11 @@ export function GamebookIndexView(): ReactElement {
     setCheckoutOpen(true);
   }, [dismissSoftWarning]);
 
-  const handlePurchaseSuccess = useCallback(
-    (_packId: CheckoutPackId, _creditsAdded: number) => {
-      // MVP: no real persistence (visual-only mockup). Future PR will
-      // invalidate the quota query here when the real billing endpoint
-      // lands. Underscore prefix signals intentional unused parameters.
-    },
-    []
-  );
+  const handlePurchaseSuccess = useCallback((_packId: CheckoutPackId, _creditsAdded: number) => {
+    // MVP: no real persistence (visual-only mockup). Future PR will
+    // invalidate the quota query here when the real billing endpoint
+    // lands. Underscore prefix signals intentional unused parameters.
+  }, []);
 
   // Format resetDate from ISO to human-readable Italian ("1 giugno").
   const formattedResetDate = useMemo(() => {
@@ -416,7 +413,11 @@ export function GamebookIndexView(): ReactElement {
   // Cell: loading
   if (fsmCell.kind === 'loading') {
     return (
-      <div data-slot="gamebook-index-view" data-ui-state="loading" className="flex flex-col">
+      <HubPageContainer
+        data-slot="gamebook-index-view"
+        data-ui-state="loading"
+        className="flex-col p-0"
+      >
         <GamebookHero
           totalGamebooks={0}
           totalSessions={0}
@@ -428,20 +429,24 @@ export function GamebookIndexView(): ReactElement {
           role="status"
           aria-label={t('gamebook.index.loading.label')}
           aria-live="polite"
-          className="mx-auto grid w-full max-w-[1280px] grid-cols-1 gap-4 px-4 py-4 sm:grid-cols-2 sm:px-8 lg:grid-cols-3"
+          className="grid w-full grid-cols-1 gap-4 py-4 sm:grid-cols-2 lg:grid-cols-3"
         >
           {Array.from({ length: SKELETON_COUNT }).map((_, idx) => (
             <GamebookCardSkeleton key={`gb-skeleton-${idx}`} />
           ))}
         </div>
-      </div>
+      </HubPageContainer>
     );
   }
 
   // Cell: error
   if (fsmCell.kind === 'error') {
     return (
-      <div data-slot="gamebook-index-view" data-ui-state="error" className="flex flex-col">
+      <HubPageContainer
+        data-slot="gamebook-index-view"
+        data-ui-state="error"
+        className="flex-col p-0"
+      >
         <GamebookHero
           totalGamebooks={0}
           totalSessions={0}
@@ -452,7 +457,7 @@ export function GamebookIndexView(): ReactElement {
         <div
           role="alert"
           data-slot="gamebook-index-error"
-          className="mx-auto flex max-w-[1280px] flex-col items-center gap-4 px-4 py-12 text-center sm:px-8"
+          className="flex flex-col items-center gap-4 py-12 text-center"
         >
           <p className="text-lg font-semibold text-foreground">{t('gamebook.index.error.title')}</p>
           <p className="text-sm text-foreground">{t('gamebook.index.error.description')}</p>
@@ -465,14 +470,18 @@ export function GamebookIndexView(): ReactElement {
             {t('gamebook.index.error.retry')}
           </button>
         </div>
-      </div>
+      </HubPageContainer>
     );
   }
 
   // Cell: empty (quota always present in this cell per FSM contract)
   if (fsmCell.kind === 'empty') {
     return (
-      <div data-slot="gamebook-index-view" data-ui-state="empty" className="flex flex-col">
+      <HubPageContainer
+        data-slot="gamebook-index-view"
+        data-ui-state="empty"
+        className="flex-col p-0"
+      >
         <GamebookHero
           totalGamebooks={0}
           totalSessions={0}
@@ -480,7 +489,7 @@ export function GamebookIndexView(): ReactElement {
           onAddManualClick={handleAddManualClick}
           labels={heroLabels}
         />
-        <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-6 px-4 py-6 sm:px-8">
+        <div className="flex w-full flex-col gap-6 py-6">
           <QuotaWidget
             quota={fsmCell.quota}
             variant="default"
@@ -489,7 +498,7 @@ export function GamebookIndexView(): ReactElement {
           />
           <EmptyGamebooks onAddManualClick={handleAddManualClick} labels={emptyLabels} />
         </div>
-      </div>
+      </HubPageContainer>
     );
   }
 
@@ -500,7 +509,11 @@ export function GamebookIndexView(): ReactElement {
     fsmCell.kind === 'quota-hard' ? 'hard' : fsmCell.kind === 'quota-soft' ? 'soft' : 'default';
 
   return (
-    <div data-slot="gamebook-index-view" data-ui-state={fsmCell.kind} className="flex flex-col">
+    <HubPageContainer
+      data-slot="gamebook-index-view"
+      data-ui-state={fsmCell.kind}
+      className="flex-col p-0"
+    >
       <GamebookHero
         totalGamebooks={kpiCounts.totalGamebooks}
         totalSessions={kpiCounts.totalSessions}
@@ -571,7 +584,7 @@ export function GamebookIndexView(): ReactElement {
         onClose={() => setCheckoutOpen(false)}
         onPurchaseSuccess={handlePurchaseSuccess}
       />
-    </div>
+    </HubPageContainer>
   );
 }
 

--- a/apps/web/src/app/(authenticated)/gamebook/page.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/page.tsx
@@ -33,6 +33,8 @@
 
 import { Suspense, type JSX } from 'react';
 
+import { HubPageContainer } from '@/components/layout/PageContainer';
+
 import { GamebookIndexView } from './_components/GamebookIndexView';
 
 export const metadata = {
@@ -42,14 +44,14 @@ export const metadata = {
 
 function PageFallback(): JSX.Element {
   return (
-    <div
+    <HubPageContainer
       data-slot="gamebook-index-page-fallback"
       role="status"
       aria-live="polite"
-      className="mx-auto max-w-[1280px] px-4 py-12"
+      className="py-12"
     >
       <div className="h-48 animate-pulse rounded-lg bg-muted/40" />
-    </div>
+    </HubPageContainer>
   );
 }
 

--- a/apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadView.tsx
@@ -85,6 +85,7 @@ import {
   type PageThumbLabels,
   type StepIndicatorLabels,
 } from '@/components/features/gamebook';
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { useBggSearch } from '@/hooks/queries/useBggSearch';
 import { useGames } from '@/hooks/queries/useGames';
 import { useAdminRole } from '@/hooks/useAdminRole';
@@ -816,10 +817,10 @@ export function GamebookUploadView(): ReactElement {
 
   // ── Render ──────────────────────────────────────────────────────────────
   return (
-    <div
+    <DetailPageContainer
       data-slot="gamebook-upload-view"
       data-ui-state={cell.kind}
-      className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-4xl flex-col"
+      className="min-h-[calc(100vh-4rem)] p-0"
     >
       <StepIndicator currentStep={currentStep} labels={stepIndicatorLabels} />
 
@@ -875,7 +876,7 @@ export function GamebookUploadView(): ReactElement {
         onDismiss={handleCancelDismiss}
         labels={cancelModalLabels}
       />
-    </div>
+    </DetailPageContainer>
   );
 }
 

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -49,6 +49,7 @@ import {
   type GameDetailHeroMeta,
   type TabKey,
 } from '@/components/features/game-detail';
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { toast } from '@/components/layout/Toast';
 import { useGameAgents } from '@/hooks/queries/useGameAgents';
 import {
@@ -749,7 +750,7 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
       />
 
       {/* Tab panels — role=tabpanel, aria-labelledby wired to tabIdFor */}
-      <div className="container mx-auto max-w-4xl px-4 py-6 sm:px-8">
+      <DetailPageContainer>
         {/* Cell 5: info tab */}
         <div
           role="tabpanel"
@@ -920,7 +921,7 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
         >
           <GameDetailKbDocList docs={documentsTabDocs} labels={kbDocLabels} />
         </div>
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/games/[id]/faqs/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/faqs/page.tsx
@@ -24,6 +24,7 @@ import { ChevronDown, ChevronRight, HelpCircle, ThumbsUp } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -91,7 +92,7 @@ export default function GameFaqsPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* #2158 (Fix #2 codemod): replaced legacy PageHeader with inline header.
             Tabs/primaryAction were unused here, so MiniNavSlot is not registered. */}
         <header className="mb-8">
@@ -180,7 +181,7 @@ export default function GameFaqsPage() {
             )}
           </>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/games/[id]/rules/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/rules/page.tsx
@@ -15,6 +15,7 @@ import { ChevronDown, ChevronRight, FileText } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
@@ -90,7 +91,7 @@ export default function GameRulesPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* #2158 (Fix #2 codemod): replaced legacy PageHeader with inline header. */}
         <header className="mb-8">
           <Link
@@ -141,7 +142,7 @@ export default function GameRulesPage() {
             )}
           </>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/games/[id]/sessions/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/sessions/page.tsx
@@ -24,6 +24,7 @@ import { ArrowLeft, Clock, Gamepad2, Trophy, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
@@ -97,7 +98,7 @@ export default function GameSessionsPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* Back Button */}
         <Button asChild variant="ghost" className="mb-6 font-nunito">
           <Link href={`/library/${gameId}`}>
@@ -161,7 +162,7 @@ export default function GameSessionsPage() {
             )}
           </>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/knowledge-base/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   KbHeader,
   type KbChunkPreviewState,
 } from '@/components/features/knowledge-base';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
@@ -104,10 +105,10 @@ export default function KnowledgeBaseDetailPage({ params }: { params: Promise<{ 
   if (documentQuery.isLoading) {
     return (
       <div className="min-h-screen bg-background py-8 px-4">
-        <div className="container mx-auto max-w-7xl">
+        <HubPageContainer className="p-0">
           <Skeleton className="h-8 w-48 mb-6" />
           <Skeleton className="h-[400px] w-full" />
-        </div>
+        </HubPageContainer>
       </div>
     );
   }
@@ -115,7 +116,7 @@ export default function KnowledgeBaseDetailPage({ params }: { params: Promise<{ 
   if (documentQuery.isError || !documentQuery.data) {
     return (
       <div className="min-h-screen bg-background py-8 px-4">
-        <div className="container mx-auto max-w-7xl">
+        <HubPageContainer className="p-0">
           <Alert variant="destructive">
             <AlertDescription>Documento non trovato o non accessibile.</AlertDescription>
           </Alert>
@@ -124,7 +125,7 @@ export default function KnowledgeBaseDetailPage({ params }: { params: Promise<{ 
               <ArrowLeft className="mr-2 h-4 w-4" /> Torna alla Libreria
             </Link>
           </Button>
-        </div>
+        </HubPageContainer>
       </div>
     );
   }

--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -51,6 +51,7 @@ import {
   type LibraryTabConfig,
   type LibraryViewMode,
 } from '@/components/features/library';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { useHybridHubItems } from '@/hooks/queries/useHybridHubItems';
 import { useLibrary, useRemoveGameFromLibrary } from '@/hooks/queries/useLibrary';
 import { useActivityFeed } from '@/hooks/useActivityFeed';
@@ -473,10 +474,10 @@ export function LibraryHub(): ReactElement {
   // breadcrumb/tabs/primaryAction sul MiniNavSlot creava duplicazione visiva e
   // ridondanza semantica (Hub/Wishlist non aggiungono nulla rispetto alle hub tabs).
   return (
-    <div
+    <HubPageContainer
       data-slot="library-hub-v2"
       data-state={effectiveKind}
-      className="mx-auto flex max-w-[1440px] flex-col gap-6 p-6 pb-24 sm:p-7"
+      className="gap-6 p-6 pb-24 sm:p-7"
     >
       <LibraryHeroDesktop
         labels={heroLabels}
@@ -573,6 +574,6 @@ export function LibraryHub(): ReactElement {
         onApply={setActiveFilters}
         onClear={() => setActiveFilters({})}
       />
-    </div>
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/library/wishlist/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/page.tsx
@@ -15,6 +15,7 @@ import { useMemo } from 'react';
 
 import { Heart, PlusCircle } from 'lucide-react';
 
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
 import { AddToWishlistDialog } from '@/components/wishlist/AddToWishlistDialog';
@@ -99,7 +100,7 @@ export default function WishlistPage() {
   );
 
   return (
-    <div className="container mx-auto py-6 space-y-6">
+    <HubPageContainer className="py-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -136,6 +137,6 @@ export default function WishlistPage() {
           ))}
         </div>
       )}
-    </div>
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/n8n/page.tsx
+++ b/apps/web/src/app/(authenticated)/n8n/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
 
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { cn } from '@/lib/utils';
 
 type N8nConfig = {
@@ -189,26 +190,26 @@ export default function N8nWorkflowManagement() {
 
   if (loading) {
     return (
-      <main className="p-6 font-sans max-w-7xl mx-auto">
+      <HubPageContainer className="p-6 font-sans">
         <h1>Loading...</h1>
-      </main>
+      </HubPageContainer>
     );
   }
 
   if (error) {
     return (
-      <main className="p-6 font-sans max-w-7xl mx-auto">
+      <HubPageContainer className="p-6 font-sans">
         <h1>Error</h1>
         <p className="text-red-600">{error}</p>
         <Link href="/" className="text-blue-600 hover:underline">
           Back to Home
         </Link>
-      </main>
+      </HubPageContainer>
     );
   }
 
   return (
-    <main className="p-6 font-sans max-w-7xl mx-auto">
+    <HubPageContainer className="p-6 font-sans">
       <div className="flex justify-between items-center mb-6">
         <div>
           <h1 className="m-0">n8n Workflow Management</h1>
@@ -327,7 +328,9 @@ export default function N8nWorkflowManagement() {
                   </div>
                   <p className="mt-1 mb-0 text-muted-foreground text-sm">{config.baseUrl}</p>
                   {config.webhookUrl && (
-                    <p className="mt-1 mb-0 text-muted-foreground text-sm">Webhook: {config.webhookUrl}</p>
+                    <p className="mt-1 mb-0 text-muted-foreground text-sm">
+                      Webhook: {config.webhookUrl}
+                    </p>
                   )}
                 </div>
                 <div className="flex gap-2">
@@ -390,6 +393,6 @@ export default function N8nWorkflowManagement() {
           ))}
         </div>
       )}
-    </main>
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/page.tsx
@@ -31,6 +31,7 @@ import { Bell, BellOff, CheckCheck, Loader2, Settings } from 'lucide-react';
 import Link from 'next/link';
 
 import { CatalogPagination } from '@/components/catalog/CatalogPagination';
+import { SettingsPageContainer } from '@/components/layout/PageContainer';
 import { Btn } from '@/components/ui/btn';
 import {
   Drawer,
@@ -233,7 +234,7 @@ export default function NotificationsPage() {
   );
 
   return (
-    <div className="container max-w-3xl mx-auto py-8">
+    <SettingsPageContainer className="py-8">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex flex-col gap-1">
@@ -449,6 +450,6 @@ export default function NotificationsPage() {
           )}
         </DrawerContent>
       </Drawer>
-    </div>
+    </SettingsPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/notifications/preferences/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/preferences/page.tsx
@@ -16,16 +16,17 @@
 
 export const dynamic = 'force-dynamic';
 
+import { SettingsPageContainer } from '@/components/layout/PageContainer';
 import { NotificationPreferences } from '@/components/notifications/NotificationPreferences';
 
 export default function NotificationPreferencesPage() {
   return (
-    <div className="container max-w-3xl mx-auto py-8">
+    <SettingsPageContainer className="py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2">Preferenze notifiche</h1>
         <p className="text-muted-foreground">Configura come e quando ricevere le notifiche</p>
       </div>
       <NotificationPreferences />
-    </div>
+    </SettingsPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
@@ -31,6 +31,7 @@ import { ArrowLeft } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { FormPageContainer } from '@/components/layout/PageContainer';
 import { EditGateBanner } from '@/components/play-records/EditGateBanner';
 import { SessionCreateForm } from '@/components/play-records/SessionCreateForm';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
@@ -109,21 +110,21 @@ export default function EditPlayRecordPage() {
   // Loading state
   if (isLoading) {
     return (
-      <div className="container mx-auto p-6">
+      <FormPageContainer className="p-6">
         <div className="h-8 bg-muted animate-pulse rounded w-48 mb-6" />
         <div className="space-y-4">
           <div className="h-12 bg-muted animate-pulse rounded" />
           <div className="h-12 bg-muted animate-pulse rounded" />
           <div className="h-32 bg-muted animate-pulse rounded" />
         </div>
-      </div>
+      </FormPageContainer>
     );
   }
 
   // Error state
   if (error || !record) {
     return (
-      <div className="container mx-auto p-6">
+      <FormPageContainer className="p-6">
         <Alert variant="destructive">
           <AlertDescription>
             {error instanceof Error ? error.message : t('playRecords.edit.error.loadFailed')}
@@ -133,14 +134,14 @@ export default function EditPlayRecordPage() {
           <ArrowLeft className="w-4 h-4 mr-2" />
           {t('playRecords.edit.actions.back')}
         </Button>
-      </div>
+      </FormPageContainer>
     );
   }
 
   // Archived state
   if (record.status === 'Archived') {
     return (
-      <div className="container mx-auto p-6">
+      <FormPageContainer className="p-6">
         <Alert>
           <AlertDescription>
             Archived sessions cannot be edited. This is a read-only view.
@@ -150,7 +151,7 @@ export default function EditPlayRecordPage() {
           <ArrowLeft className="w-4 h-4 mr-2" />
           {t('playRecords.edit.actions.back')}
         </Button>
-      </div>
+      </FormPageContainer>
     );
   }
 

--- a/apps/web/src/app/(authenticated)/play-records/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/new/page.tsx
@@ -20,6 +20,7 @@ import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { FormPageContainer } from '@/components/layout/PageContainer';
 import { SessionCreateForm } from '@/components/play-records/SessionCreateForm';
 import { Button } from '@/components/ui/primitives/button';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -61,7 +62,7 @@ export default function NewPlayRecordPage() {
   };
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <FormPageContainer className="p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center gap-4">
         <Button
@@ -84,6 +85,6 @@ export default function NewPlayRecordPage() {
         onCancel={handleCancel}
         isSubmitting={createRecord.isPending}
       />
-    </div>
+    </FormPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/GamesTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/GamesTabPanel.tsx
@@ -13,6 +13,8 @@ import { useMemo } from 'react';
 
 import Link from 'next/link';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
+
 export interface GamesTabPanelLabels {
   readonly title: string;
   readonly viewAll: string;
@@ -42,10 +44,7 @@ export function GamesTabPanel({
   const isEmpty = ranked.length === 0;
 
   return (
-    <div
-      data-slot="games-tab-panel"
-      className="mx-auto w-full max-w-4xl px-4 sm:px-8 flex flex-col gap-4"
-    >
+    <DetailPageContainer data-slot="games-tab-panel" className="gap-4 py-0">
       <h2 className="text-lg font-semibold">{labels.title}</h2>
       {isEmpty ? (
         <p className="text-muted-foreground">{labels.empty}</p>
@@ -72,6 +71,6 @@ export function GamesTabPanel({
           </Link>
         </>
       )}
-    </div>
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerOverviewRegion.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerOverviewRegion.tsx
@@ -22,6 +22,7 @@ import {
   type PlayerTopGamesCardLabels,
   type PlayerTrendCardLabels,
 } from '@/components/features/player-detail';
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import type { PlayerProfileFixture } from '@/lib/player-detail/player-detail-visual-test-fixture';
 
 export interface PlayerOverviewRegionLabels {
@@ -44,10 +45,7 @@ export function PlayerOverviewRegion({
   onFavoriteAgentClick,
 }: PlayerOverviewRegionProps): JSX.Element {
   return (
-    <div
-      data-slot="player-overview-region"
-      className="mx-auto w-full max-w-4xl px-4 sm:px-8 flex flex-col gap-4"
-    >
+    <DetailPageContainer data-slot="player-overview-region" className="gap-4 py-0">
       <PlayerStatsGrid
         totalSessions={stats.totalSessions}
         totalWins={stats.totalWins}
@@ -66,6 +64,6 @@ export function PlayerOverviewRegion({
       </div>
       <PlayerTopGamesCard items={stats.topGames} labels={labels.topGames} />
       <PlayerTrendCard points={stats.trendPoints} labels={labels.trend} />
-    </div>
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/SessionsTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/SessionsTabPanel.tsx
@@ -13,6 +13,7 @@ import type { JSX } from 'react';
 
 import Link from 'next/link';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import type { PlayerProfileFixture } from '@/lib/player-detail/player-detail-visual-test-fixture';
 
 export interface SessionsTabPanelLabels {
@@ -30,10 +31,7 @@ export interface SessionsTabPanelProps {
 export function SessionsTabPanel({ stats, labels }: SessionsTabPanelProps): JSX.Element {
   const isEmpty = stats.totalSessions === 0;
   return (
-    <div
-      data-slot="sessions-tab-panel"
-      className="mx-auto w-full max-w-4xl px-4 sm:px-8 flex flex-col gap-4"
-    >
+    <DetailPageContainer data-slot="sessions-tab-panel" className="gap-4 py-0">
       <h2 className="text-lg font-semibold">{labels.title}</h2>
       {isEmpty ? (
         <p className="text-muted-foreground">{labels.empty}</p>
@@ -51,6 +49,6 @@ export function SessionsTabPanel({ stats, labels }: SessionsTabPanelProps): JSX.
           </Link>
         </>
       )}
-    </div>
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/ToolkitsTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/ToolkitsTabPanel.tsx
@@ -10,6 +10,8 @@
 
 import type { JSX } from 'react';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
+
 export interface ToolkitsTabPanelLabels {
   readonly title: string;
   readonly comingSoon: string;
@@ -21,12 +23,9 @@ export interface ToolkitsTabPanelProps {
 
 export function ToolkitsTabPanel({ labels }: ToolkitsTabPanelProps): JSX.Element {
   return (
-    <div
-      data-slot="toolkits-tab-panel"
-      className="mx-auto w-full max-w-4xl px-4 sm:px-8 flex flex-col items-center gap-2 py-12"
-    >
+    <DetailPageContainer data-slot="toolkits-tab-panel" className="items-center gap-2 py-12">
       <h2 className="text-lg font-semibold">{labels.title}</h2>
       <p className="text-muted-foreground text-center">{labels.comingSoon}</p>
-    </div>
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/achievements/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/achievements/page.tsx
@@ -54,109 +54,107 @@ export default function PlayerAchievementsPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background py-8 px-4">
-      <DetailPageContainer className="p-0">
-        {/* Back Button */}
-        <Button asChild variant="ghost" className="mb-6 font-nunito">
-          <Link href={`/players/${playerId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
-          </Link>
-        </Button>
+    <DetailPageContainer className="min-h-screen bg-background py-8 px-4">
+      {/* Back Button */}
+      <Button asChild variant="ghost" className="mb-6 font-nunito">
+        <Link href={`/players/${playerId}`}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
+        </Link>
+      </Button>
 
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <Trophy className="h-6 w-6 text-primary" />
-          <div>
-            <h1 className="text-3xl font-bold font-quicksand">Achievements</h1>
-            <p className="text-muted-foreground font-nunito text-sm">
-              Badges and milestones earned by {playerName}
-            </p>
-          </div>
-          {!loading && badges.length > 0 && (
-            <Badge variant="secondary" className="ml-auto">
-              {badges.length} earned
-            </Badge>
-          )}
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-8">
+        <Trophy className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-3xl font-bold font-quicksand">Achievements</h1>
+          <p className="text-muted-foreground font-nunito text-sm">
+            Badges and milestones earned by {playerName}
+          </p>
         </div>
-
-        {/* Loading */}
-        {loading && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {[...Array(6)].map((_, i) => (
-              <Skeleton key={i} className="h-36 w-full rounded-xl" />
-            ))}
-          </div>
+        {!loading && badges.length > 0 && (
+          <Badge variant="secondary" className="ml-auto">
+            {badges.length} earned
+          </Badge>
         )}
+      </div>
 
-        {/* Error */}
-        {error && !loading && (
-          <Alert variant="destructive">
-            <AlertDescription className="font-nunito">{error}</AlertDescription>
-          </Alert>
-        )}
+      {/* Loading */}
+      {loading && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[...Array(6)].map((_, i) => (
+            <Skeleton key={i} className="h-36 w-full rounded-xl" />
+          ))}
+        </div>
+      )}
 
-        {/* Badges Grid */}
-        {!loading && !error && (
-          <>
-            {badges.length === 0 ? (
-              <Card>
-                <CardContent className="py-12 flex flex-col items-center gap-4 text-center">
-                  <Lock className="h-12 w-12 text-muted-foreground/40" />
-                  <div>
-                    <p className="font-semibold font-quicksand">No badges yet</p>
-                    <p className="text-sm text-muted-foreground font-nunito mt-1">
-                      Keep playing to earn your first badge!
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {badges.map(badge => (
-                  <div
-                    key={badge.id}
-                    className="p-5 rounded-xl border border-primary/30 bg-card shadow-sm hover:shadow-md transition-shadow"
-                  >
-                    <div className="flex items-start gap-3 mb-3">
-                      {badge.iconUrl ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={badge.iconUrl}
-                          alt={badge.name}
-                          className="h-10 w-10 rounded-full object-cover shrink-0"
-                        />
-                      ) : (
-                        <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                          <Star className="h-5 w-5 text-primary" />
-                        </div>
-                      )}
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-bold font-quicksand truncate">{badge.name}</h3>
-                        <p className="text-sm text-muted-foreground font-nunito line-clamp-2">
-                          {badge.description}
-                        </p>
+      {/* Error */}
+      {error && !loading && (
+        <Alert variant="destructive">
+          <AlertDescription className="font-nunito">{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Badges Grid */}
+      {!loading && !error && (
+        <>
+          {badges.length === 0 ? (
+            <Card>
+              <CardContent className="py-12 flex flex-col items-center gap-4 text-center">
+                <Lock className="h-12 w-12 text-muted-foreground/40" />
+                <div>
+                  <p className="font-semibold font-quicksand">No badges yet</p>
+                  <p className="text-sm text-muted-foreground font-nunito mt-1">
+                    Keep playing to earn your first badge!
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {badges.map(badge => (
+                <div
+                  key={badge.id}
+                  className="p-5 rounded-xl border border-primary/30 bg-card shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="flex items-start gap-3 mb-3">
+                    {badge.iconUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={badge.iconUrl}
+                        alt={badge.name}
+                        className="h-10 w-10 rounded-full object-cover shrink-0"
+                      />
+                    ) : (
+                      <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                        <Star className="h-5 w-5 text-primary" />
                       </div>
-                    </div>
-
-                    <div className="flex items-center justify-between gap-2">
-                      <Badge variant="outline" className={cn('text-xs', TIER_COLORS[badge.tier])}>
-                        {badge.tier}
-                      </Badge>
-                      <p className="text-xs text-muted-foreground font-nunito">
-                        {new Intl.DateTimeFormat('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                        }).format(new Date(badge.earnedAt))}
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-bold font-quicksand truncate">{badge.name}</h3>
+                      <p className="text-sm text-muted-foreground font-nunito line-clamp-2">
+                        {badge.description}
                       </p>
                     </div>
                   </div>
-                ))}
-              </div>
-            )}
-          </>
-        )}
-      </DetailPageContainer>
-    </div>
+
+                  <div className="flex items-center justify-between gap-2">
+                    <Badge variant="outline" className={cn('text-xs', TIER_COLORS[badge.tier])}>
+                      {badge.tier}
+                    </Badge>
+                    <p className="text-xs text-muted-foreground font-nunito">
+                      {new Intl.DateTimeFormat('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      }).format(new Date(badge.earnedAt))}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/achievements/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/achievements/page.tsx
@@ -15,6 +15,7 @@ import { ArrowLeft, Lock, Star, Trophy } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Card, CardContent } from '@/components/ui/data-display/card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
@@ -45,8 +46,8 @@ export default function PlayerAchievementsPage() {
     setLoading(true);
     api.badges
       .getMyBadges()
-      .then((data) => setBadges(data))
-      .catch((err) => {
+      .then(data => setBadges(data))
+      .catch(err => {
         setError(err instanceof Error ? err.message : 'Failed to load badges');
       })
       .finally(() => setLoading(false));
@@ -54,7 +55,7 @@ export default function PlayerAchievementsPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* Back Button */}
         <Button asChild variant="ghost" className="mb-6 font-nunito">
           <Link href={`/players/${playerId}`}>
@@ -111,7 +112,7 @@ export default function PlayerAchievementsPage() {
               </Card>
             ) : (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {badges.map((badge) => (
+                {badges.map(badge => (
                   <div
                     key={badge.id}
                     className="p-5 rounded-xl border border-primary/30 bg-card shadow-sm hover:shadow-md transition-shadow"
@@ -138,10 +139,7 @@ export default function PlayerAchievementsPage() {
                     </div>
 
                     <div className="flex items-center justify-between gap-2">
-                      <Badge
-                        variant="outline"
-                        className={cn('text-xs', TIER_COLORS[badge.tier])}
-                      >
+                      <Badge variant="outline" className={cn('text-xs', TIER_COLORS[badge.tier])}>
                         {badge.tier}
                       </Badge>
                       <p className="text-xs text-muted-foreground font-nunito">
@@ -158,7 +156,7 @@ export default function PlayerAchievementsPage() {
             )}
           </>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/games/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/games/page.tsx
@@ -13,6 +13,7 @@ import { ArrowLeft, Gamepad2, Trophy } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -39,7 +40,7 @@ export default function PlayerGamesPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* Back Button */}
         <Button asChild variant="ghost" className="mb-6 font-nunito">
           <Link href={`/players/${playerId}`}>
@@ -122,7 +123,7 @@ export default function PlayerGamesPage() {
             )}
           </>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/games/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/games/page.tsx
@@ -39,91 +39,89 @@ export default function PlayerGamesPage() {
     : [];
 
   return (
-    <div className="min-h-screen bg-background py-8 px-4">
-      <DetailPageContainer className="p-0">
-        {/* Back Button */}
-        <Button asChild variant="ghost" className="mb-6 font-nunito">
-          <Link href={`/players/${playerId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
-          </Link>
-        </Button>
+    <DetailPageContainer className="min-h-screen bg-background py-8 px-4">
+      {/* Back Button */}
+      <Button asChild variant="ghost" className="mb-6 font-nunito">
+        <Link href={`/players/${playerId}`}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
+        </Link>
+      </Button>
 
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <Gamepad2 className="h-6 w-6 text-primary" />
-          <div>
-            <h1 className="text-3xl font-bold font-quicksand">Games Played</h1>
-            <p className="text-muted-foreground font-nunito text-sm">
-              All games {playerName} has participated in
-            </p>
-          </div>
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-8">
+        <Gamepad2 className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-3xl font-bold font-quicksand">Games Played</h1>
+          <p className="text-muted-foreground font-nunito text-sm">
+            All games {playerName} has participated in
+          </p>
         </div>
+      </div>
 
-        {/* Content */}
-        {isLoading && (
-          <div className="space-y-3">
-            {[...Array(5)].map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-xl" />
-            ))}
-          </div>
-        )}
+      {/* Content */}
+      {isLoading && (
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+          ))}
+        </div>
+      )}
 
-        {error && (
-          <Alert variant="destructive">
-            <AlertDescription className="font-nunito">
-              Failed to load game statistics.
-            </AlertDescription>
-          </Alert>
-        )}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription className="font-nunito">
+            Failed to load game statistics.
+          </AlertDescription>
+        </Alert>
+      )}
 
-        {!isLoading && !error && (
-          <>
-            {games.length === 0 ? (
-              <Card>
-                <CardContent className="py-12 text-center text-muted-foreground font-nunito">
-                  No games recorded yet.
-                </CardContent>
-              </Card>
-            ) : (
-              <Card className="border-l-4 border-l-[hsl(262,83%,58%)] shadow-lg">
-                <CardHeader>
-                  <CardTitle className="font-quicksand text-xl flex items-center gap-2">
-                    <Trophy className="h-5 w-5 text-primary" />
-                    {games.length} Game{games.length !== 1 ? 's' : ''}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-3 font-nunito" role="list">
-                    {games.map((game, index) => (
-                      <li
-                        key={game.name}
-                        className="flex items-center gap-4 p-3 rounded-lg hover:bg-muted/40 transition-colors"
-                      >
-                        <span className="text-lg font-bold text-muted-foreground w-7 text-center shrink-0">
-                          #{index + 1}
-                        </span>
-                        <div className="flex-1 min-w-0">
-                          <p className="font-medium truncate">{game.name}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {game.count} session{game.count !== 1 ? 's' : ''}
-                            {game.avgScore !== null && (
-                              <span> · avg {game.avgScore.toFixed(1)} pts</span>
-                            )}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-1 shrink-0 text-sm text-muted-foreground">
-                          <Gamepad2 className="h-4 w-4" />
-                          <span>{game.count}</span>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            )}
-          </>
-        )}
-      </DetailPageContainer>
-    </div>
+      {!isLoading && !error && (
+        <>
+          {games.length === 0 ? (
+            <Card>
+              <CardContent className="py-12 text-center text-muted-foreground font-nunito">
+                No games recorded yet.
+              </CardContent>
+            </Card>
+          ) : (
+            <Card className="border-l-4 border-l-[hsl(262,83%,58%)] shadow-lg">
+              <CardHeader>
+                <CardTitle className="font-quicksand text-xl flex items-center gap-2">
+                  <Trophy className="h-5 w-5 text-primary" />
+                  {games.length} Game{games.length !== 1 ? 's' : ''}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3 font-nunito" role="list">
+                  {games.map((game, index) => (
+                    <li
+                      key={game.name}
+                      className="flex items-center gap-4 p-3 rounded-lg hover:bg-muted/40 transition-colors"
+                    >
+                      <span className="text-lg font-bold text-muted-foreground w-7 text-center shrink-0">
+                        #{index + 1}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium truncate">{game.name}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {game.count} session{game.count !== 1 ? 's' : ''}
+                          {game.avgScore !== null && (
+                            <span> · avg {game.avgScore.toFixed(1)} pts</span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0 text-sm text-muted-foreground">
+                        <Gamepad2 className="h-4 w-4" />
+                        <span>{game.count}</span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/sessions/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/sessions/page.tsx
@@ -15,8 +15,15 @@ import { ArrowLeft, Calendar, Clock, Trophy } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Badge } from '@/components/ui/data-display/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/data-display/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
 import { api, type GameSessionDto } from '@/lib/api';
@@ -57,16 +64,14 @@ export default function PlayerSessionsPage() {
     setLoading(true);
     api.sessions
       .getHistory({ limit: 50 })
-      .then((res) => {
+      .then(res => {
         // Filter sessions where this player participated
-        const playerSessions = res.sessions.filter((s) =>
-          s.players.some(
-            (p) => p.playerName.toLowerCase() === playerName.toLowerCase()
-          )
+        const playerSessions = res.sessions.filter(s =>
+          s.players.some(p => p.playerName.toLowerCase() === playerName.toLowerCase())
         );
         setSessions(playerSessions);
       })
-      .catch((err) => {
+      .catch(err => {
         setError(err instanceof Error ? err.message : 'Failed to load sessions');
       })
       .finally(() => setLoading(false));
@@ -74,7 +79,7 @@ export default function PlayerSessionsPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* Back Button */}
         <Button asChild variant="ghost" className="mb-6 font-nunito">
           <Link href={`/players/${playerId}`}>
@@ -127,9 +132,9 @@ export default function PlayerSessionsPage() {
               </Card>
             ) : (
               <div className="space-y-3">
-                {sessions.map((session) => {
+                {sessions.map(session => {
                   const playerEntry = session.players.find(
-                    (p) => p.playerName.toLowerCase() === playerName.toLowerCase()
+                    p => p.playerName.toLowerCase() === playerName.toLowerCase()
                   );
                   const isWinner = session.winnerName?.toLowerCase() === playerName.toLowerCase();
 
@@ -140,16 +145,11 @@ export default function PlayerSessionsPage() {
                           <div className="flex items-start justify-between gap-3">
                             <CardTitle className="font-quicksand text-base flex items-center gap-2">
                               Session
-                              {isWinner && (
-                                <Trophy className="h-4 w-4 text-amber-500" />
-                              )}
+                              {isWinner && <Trophy className="h-4 w-4 text-amber-500" />}
                             </CardTitle>
                             <Badge
                               variant="outline"
-                              className={cn(
-                                'text-xs shrink-0',
-                                STATUS_COLORS[session.status]
-                              )}
+                              className={cn('text-xs shrink-0', STATUS_COLORS[session.status])}
                             >
                               {session.status}
                             </Badge>
@@ -163,14 +163,19 @@ export default function PlayerSessionsPage() {
                               <Clock className="h-3 w-3" />
                               {formatDuration(session.durationMinutes)}
                             </span>
-                            <span>{session.playerCount} player{session.playerCount !== 1 ? 's' : ''}</span>
+                            <span>
+                              {session.playerCount} player{session.playerCount !== 1 ? 's' : ''}
+                            </span>
                           </CardDescription>
                         </CardHeader>
                         {(session.winnerName ?? playerEntry?.color) && (
                           <CardContent className="pt-0 font-nunito text-sm text-muted-foreground">
                             {session.winnerName && (
                               <span>
-                                Winner: <span className="font-medium text-foreground">{session.winnerName}</span>
+                                Winner:{' '}
+                                <span className="font-medium text-foreground">
+                                  {session.winnerName}
+                                </span>
                               </span>
                             )}
                           </CardContent>
@@ -183,7 +188,7 @@ export default function PlayerSessionsPage() {
             )}
           </>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/sessions/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/sessions/page.tsx
@@ -78,117 +78,115 @@ export default function PlayerSessionsPage() {
   }, [playerId, playerName]);
 
   return (
-    <div className="min-h-screen bg-background py-8 px-4">
-      <DetailPageContainer className="p-0">
-        {/* Back Button */}
-        <Button asChild variant="ghost" className="mb-6 font-nunito">
-          <Link href={`/players/${playerId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
-          </Link>
-        </Button>
+    <DetailPageContainer className="min-h-screen bg-background py-8 px-4">
+      {/* Back Button */}
+      <Button asChild variant="ghost" className="mb-6 font-nunito">
+        <Link href={`/players/${playerId}`}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
+        </Link>
+      </Button>
 
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <Calendar className="h-6 w-6 text-primary" />
-          <div>
-            <h1 className="text-3xl font-bold font-quicksand">Sessions</h1>
-            <p className="text-muted-foreground font-nunito text-sm">
-              Game sessions involving {playerName}
-            </p>
-          </div>
-          {!loading && sessions.length > 0 && (
-            <Badge variant="secondary" className="ml-auto">
-              {sessions.length}
-            </Badge>
-          )}
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-8">
+        <Calendar className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-3xl font-bold font-quicksand">Sessions</h1>
+          <p className="text-muted-foreground font-nunito text-sm">
+            Game sessions involving {playerName}
+          </p>
         </div>
-
-        {/* Loading */}
-        {loading && (
-          <div className="space-y-4">
-            {[...Array(4)].map((_, i) => (
-              <Skeleton key={i} className="h-24 w-full rounded-xl" />
-            ))}
-          </div>
+        {!loading && sessions.length > 0 && (
+          <Badge variant="secondary" className="ml-auto">
+            {sessions.length}
+          </Badge>
         )}
+      </div>
 
-        {/* Error */}
-        {error && !loading && (
-          <Card>
-            <CardContent className="py-8 text-center">
-              <p className="text-destructive font-nunito">{error}</p>
-            </CardContent>
-          </Card>
-        )}
+      {/* Loading */}
+      {loading && (
+        <div className="space-y-4">
+          {[...Array(4)].map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      )}
 
-        {/* Sessions List */}
-        {!loading && !error && (
-          <>
-            {sessions.length === 0 ? (
-              <Card>
-                <CardContent className="py-12 text-center text-muted-foreground font-nunito">
-                  No sessions found for {playerName}.
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="space-y-3">
-                {sessions.map(session => {
-                  const playerEntry = session.players.find(
-                    p => p.playerName.toLowerCase() === playerName.toLowerCase()
-                  );
-                  const isWinner = session.winnerName?.toLowerCase() === playerName.toLowerCase();
+      {/* Error */}
+      {error && !loading && (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-destructive font-nunito">{error}</p>
+          </CardContent>
+        </Card>
+      )}
 
-                  return (
-                    <Link key={session.id} href={`/sessions/${session.id}`}>
-                      <Card className="hover:shadow-md transition-shadow cursor-pointer border border-border/60">
-                        <CardHeader className="pb-2">
-                          <div className="flex items-start justify-between gap-3">
-                            <CardTitle className="font-quicksand text-base flex items-center gap-2">
-                              Session
-                              {isWinner && <Trophy className="h-4 w-4 text-amber-500" />}
-                            </CardTitle>
-                            <Badge
-                              variant="outline"
-                              className={cn('text-xs shrink-0', STATUS_COLORS[session.status])}
-                            >
-                              {session.status}
-                            </Badge>
-                          </div>
-                          <CardDescription className="font-nunito flex items-center gap-4 flex-wrap">
-                            <span className="flex items-center gap-1">
-                              <Calendar className="h-3 w-3" />
-                              {formatDate(session.startedAt)}
-                            </span>
-                            <span className="flex items-center gap-1">
-                              <Clock className="h-3 w-3" />
-                              {formatDuration(session.durationMinutes)}
-                            </span>
+      {/* Sessions List */}
+      {!loading && !error && (
+        <>
+          {sessions.length === 0 ? (
+            <Card>
+              <CardContent className="py-12 text-center text-muted-foreground font-nunito">
+                No sessions found for {playerName}.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {sessions.map(session => {
+                const playerEntry = session.players.find(
+                  p => p.playerName.toLowerCase() === playerName.toLowerCase()
+                );
+                const isWinner = session.winnerName?.toLowerCase() === playerName.toLowerCase();
+
+                return (
+                  <Link key={session.id} href={`/sessions/${session.id}`}>
+                    <Card className="hover:shadow-md transition-shadow cursor-pointer border border-border/60">
+                      <CardHeader className="pb-2">
+                        <div className="flex items-start justify-between gap-3">
+                          <CardTitle className="font-quicksand text-base flex items-center gap-2">
+                            Session
+                            {isWinner && <Trophy className="h-4 w-4 text-amber-500" />}
+                          </CardTitle>
+                          <Badge
+                            variant="outline"
+                            className={cn('text-xs shrink-0', STATUS_COLORS[session.status])}
+                          >
+                            {session.status}
+                          </Badge>
+                        </div>
+                        <CardDescription className="font-nunito flex items-center gap-4 flex-wrap">
+                          <span className="flex items-center gap-1">
+                            <Calendar className="h-3 w-3" />
+                            {formatDate(session.startedAt)}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            {formatDuration(session.durationMinutes)}
+                          </span>
+                          <span>
+                            {session.playerCount} player{session.playerCount !== 1 ? 's' : ''}
+                          </span>
+                        </CardDescription>
+                      </CardHeader>
+                      {(session.winnerName ?? playerEntry?.color) && (
+                        <CardContent className="pt-0 font-nunito text-sm text-muted-foreground">
+                          {session.winnerName && (
                             <span>
-                              {session.playerCount} player{session.playerCount !== 1 ? 's' : ''}
-                            </span>
-                          </CardDescription>
-                        </CardHeader>
-                        {(session.winnerName ?? playerEntry?.color) && (
-                          <CardContent className="pt-0 font-nunito text-sm text-muted-foreground">
-                            {session.winnerName && (
-                              <span>
-                                Winner:{' '}
-                                <span className="font-medium text-foreground">
-                                  {session.winnerName}
-                                </span>
+                              Winner:{' '}
+                              <span className="font-medium text-foreground">
+                                {session.winnerName}
                               </span>
-                            )}
-                          </CardContent>
-                        )}
-                      </Card>
-                    </Link>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
-      </DetailPageContainer>
-    </div>
+                            </span>
+                          )}
+                        </CardContent>
+                      )}
+                    </Card>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/stats/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/stats/page.tsx
@@ -13,6 +13,7 @@ import { ArrowLeft, BarChart2, Gamepad2, Target, Trophy } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -60,7 +61,7 @@ export default function PlayerStatsPage() {
 
   return (
     <div className="min-h-screen bg-background py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+      <DetailPageContainer className="p-0">
         {/* Back Button */}
         <Button asChild variant="ghost" className="mb-6 font-nunito">
           <Link href={`/players/${playerId}`}>
@@ -94,9 +95,7 @@ export default function PlayerStatsPage() {
         {/* Error */}
         {error && (
           <Alert variant="destructive">
-            <AlertDescription className="font-nunito">
-              Failed to load statistics.
-            </AlertDescription>
+            <AlertDescription className="font-nunito">Failed to load statistics.</AlertDescription>
           </Alert>
         )}
 
@@ -200,7 +199,7 @@ export default function PlayerStatsPage() {
             </CardContent>
           </Card>
         )}
-      </div>
+      </DetailPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/stats/page.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/stats/page.tsx
@@ -60,146 +60,144 @@ export default function PlayerStatsPage() {
       : 0;
 
   return (
-    <div className="min-h-screen bg-background py-8 px-4">
-      <DetailPageContainer className="p-0">
-        {/* Back Button */}
-        <Button asChild variant="ghost" className="mb-6 font-nunito">
-          <Link href={`/players/${playerId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
-          </Link>
-        </Button>
+    <DetailPageContainer className="min-h-screen bg-background py-8 px-4">
+      {/* Back Button */}
+      <Button asChild variant="ghost" className="mb-6 font-nunito">
+        <Link href={`/players/${playerId}`}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to {playerName}
+        </Link>
+      </Button>
 
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-8">
-          <BarChart2 className="h-6 w-6 text-primary" />
-          <div>
-            <h1 className="text-3xl font-bold font-quicksand">Statistics</h1>
-            <p className="text-muted-foreground font-nunito text-sm">
-              Performance stats for {playerName}
-            </p>
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-8">
+        <BarChart2 className="h-6 w-6 text-primary" />
+        <div>
+          <h1 className="text-3xl font-bold font-quicksand">Statistics</h1>
+          <p className="text-muted-foreground font-nunito text-sm">
+            Performance stats for {playerName}
+          </p>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {[...Array(4)].map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-xl" />
+            ))}
+          </div>
+          <Skeleton className="h-64 w-full rounded-xl" />
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription className="font-nunito">Failed to load statistics.</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Stats Content */}
+      {!isLoading && !error && stats && (
+        <div className="space-y-6">
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              icon={Gamepad2}
+              label="Total Sessions"
+              value={stats.totalSessions}
+              color="border-l-[hsl(262,83%,58%)]"
+            />
+            <StatCard
+              icon={Trophy}
+              label="Total Wins"
+              value={stats.totalWins}
+              color="border-l-amber-400"
+            />
+            <StatCard
+              icon={Target}
+              label="Win Rate"
+              value={`${winRate}%`}
+              color="border-l-green-400"
+            />
+            <StatCard
+              icon={BarChart2}
+              label="Unique Games"
+              value={totalGames}
+              color="border-l-blue-400"
+            />
+          </div>
+
+          {/* Per-game breakdown */}
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card className="border-l-4 border-l-[hsl(262,83%,58%)] shadow-lg">
+              <CardHeader>
+                <CardTitle className="font-quicksand text-xl">Sessions by Game</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {Object.keys(stats.gamePlayCounts).length > 0 ? (
+                  <ul className="space-y-2 font-nunito">
+                    {Object.entries(stats.gamePlayCounts)
+                      .sort(([, a], [, b]) => b - a)
+                      .map(([game, count]) => (
+                        <li key={game} className="flex justify-between text-sm items-center">
+                          <span className="truncate mr-2">{game}</span>
+                          <span className="text-muted-foreground shrink-0">
+                            {count} session{count !== 1 ? 's' : ''}
+                          </span>
+                        </li>
+                      ))}
+                  </ul>
+                ) : (
+                  <Alert>
+                    <AlertDescription className="font-nunito">
+                      No sessions recorded.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-l-4 border-l-[hsl(240,60%,55%)] shadow-lg">
+              <CardHeader>
+                <CardTitle className="font-quicksand text-xl">Average Scores</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {Object.keys(stats.averageScoresByGame).length > 0 ? (
+                  <ul className="space-y-2 font-nunito">
+                    {Object.entries(stats.averageScoresByGame)
+                      .sort(([, a], [, b]) => b - a)
+                      .map(([game, avg]) => (
+                        <li key={game} className="flex justify-between text-sm items-center">
+                          <span className="truncate mr-2">{game}</span>
+                          <span className="text-muted-foreground shrink-0">
+                            {avg.toFixed(1)} pts
+                          </span>
+                        </li>
+                      ))}
+                  </ul>
+                ) : (
+                  <Alert>
+                    <AlertDescription className="font-nunito">
+                      No score data recorded.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </CardContent>
+            </Card>
           </div>
         </div>
+      )}
 
-        {/* Loading */}
-        {isLoading && (
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              {[...Array(4)].map((_, i) => (
-                <Skeleton key={i} className="h-24 w-full rounded-xl" />
-              ))}
-            </div>
-            <Skeleton className="h-64 w-full rounded-xl" />
-          </div>
-        )}
-
-        {/* Error */}
-        {error && (
-          <Alert variant="destructive">
-            <AlertDescription className="font-nunito">Failed to load statistics.</AlertDescription>
-          </Alert>
-        )}
-
-        {/* Stats Content */}
-        {!isLoading && !error && stats && (
-          <div className="space-y-6">
-            {/* Summary cards */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <StatCard
-                icon={Gamepad2}
-                label="Total Sessions"
-                value={stats.totalSessions}
-                color="border-l-[hsl(262,83%,58%)]"
-              />
-              <StatCard
-                icon={Trophy}
-                label="Total Wins"
-                value={stats.totalWins}
-                color="border-l-amber-400"
-              />
-              <StatCard
-                icon={Target}
-                label="Win Rate"
-                value={`${winRate}%`}
-                color="border-l-green-400"
-              />
-              <StatCard
-                icon={BarChart2}
-                label="Unique Games"
-                value={totalGames}
-                color="border-l-blue-400"
-              />
-            </div>
-
-            {/* Per-game breakdown */}
-            <div className="grid md:grid-cols-2 gap-6">
-              <Card className="border-l-4 border-l-[hsl(262,83%,58%)] shadow-lg">
-                <CardHeader>
-                  <CardTitle className="font-quicksand text-xl">Sessions by Game</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {Object.keys(stats.gamePlayCounts).length > 0 ? (
-                    <ul className="space-y-2 font-nunito">
-                      {Object.entries(stats.gamePlayCounts)
-                        .sort(([, a], [, b]) => b - a)
-                        .map(([game, count]) => (
-                          <li key={game} className="flex justify-between text-sm items-center">
-                            <span className="truncate mr-2">{game}</span>
-                            <span className="text-muted-foreground shrink-0">
-                              {count} session{count !== 1 ? 's' : ''}
-                            </span>
-                          </li>
-                        ))}
-                    </ul>
-                  ) : (
-                    <Alert>
-                      <AlertDescription className="font-nunito">
-                        No sessions recorded.
-                      </AlertDescription>
-                    </Alert>
-                  )}
-                </CardContent>
-              </Card>
-
-              <Card className="border-l-4 border-l-[hsl(240,60%,55%)] shadow-lg">
-                <CardHeader>
-                  <CardTitle className="font-quicksand text-xl">Average Scores</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {Object.keys(stats.averageScoresByGame).length > 0 ? (
-                    <ul className="space-y-2 font-nunito">
-                      {Object.entries(stats.averageScoresByGame)
-                        .sort(([, a], [, b]) => b - a)
-                        .map(([game, avg]) => (
-                          <li key={game} className="flex justify-between text-sm items-center">
-                            <span className="truncate mr-2">{game}</span>
-                            <span className="text-muted-foreground shrink-0">
-                              {avg.toFixed(1)} pts
-                            </span>
-                          </li>
-                        ))}
-                    </ul>
-                  ) : (
-                    <Alert>
-                      <AlertDescription className="font-nunito">
-                        No score data recorded.
-                      </AlertDescription>
-                    </Alert>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        )}
-
-        {/* No data state */}
-        {!isLoading && !error && !stats && (
-          <Card>
-            <CardContent className="py-12 text-center text-muted-foreground font-nunito">
-              No statistics available for {playerName}.
-            </CardContent>
-          </Card>
-        )}
-      </DetailPageContainer>
-    </div>
+      {/* No data state */}
+      {!isLoading && !error && !stats && (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground font-nunito">
+            No statistics available for {playerName}.
+          </CardContent>
+        </Card>
+      )}
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/_components/PlayersLibraryView.tsx
+++ b/apps/web/src/app/(authenticated)/players/_components/PlayersLibraryView.tsx
@@ -40,6 +40,7 @@ import {
   type PlayersHeroLabels,
   type PlayersResultsGridLabels,
 } from '@/components/features/players';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { usePlayerStatistics } from '@/hooks/queries/usePlayersFromRecords';
 import { useTranslation } from '@/hooks/useTranslation';
 import {
@@ -76,7 +77,7 @@ function PlayersLoadingSkeleton(): ReactElement {
       aria-label="Caricamento in corso…"
       aria-busy="true"
       aria-live="polite"
-      className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-4 px-4 sm:px-8 max-w-[1280px] mx-auto"
+      className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-4"
     >
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="animate-pulse rounded-2xl border border-border bg-muted/40 h-40" />
@@ -229,7 +230,7 @@ export function PlayersLibraryView(): ReactElement {
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div data-slot="players-library-view" className="flex flex-col gap-6 pb-24">
+    <HubPageContainer data-slot="players-library-view" className="gap-6 pb-24">
       <PlayersHero
         totalSessions={totalSessions}
         distinctGames={distinctGames}
@@ -258,6 +259,6 @@ export function PlayersLibraryView(): ReactElement {
           onRetry={handleRetry}
         />
       )}
-    </div>
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
@@ -41,6 +41,7 @@ import {
   type SessionsFiltersLabels,
   type SessionsHeroLabels,
 } from '@/components/features/sessions';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { useActiveSessions } from '@/hooks/queries/useActiveSessions';
 import { useTranslation } from '@/hooks/useTranslation';
 import {
@@ -292,9 +293,9 @@ export function SessionsLibraryView(): ReactElement {
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div
+    <HubPageContainer
       data-slot="sessions-library-view"
-      className="flex flex-col gap-6 pb-24"
+      className="gap-6 pb-24"
       id="sessions-content"
     >
       <SessionsHero onNewSession={handleNewSession} labels={heroLabels} />
@@ -316,7 +317,7 @@ export function SessionsLibraryView(): ReactElement {
           <div
             role="region"
             aria-label={t('pages.sessions.a11y.resultsLabel')}
-            className="mx-auto grid w-full max-w-[1280px] grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 px-4 sm:px-8"
+            className="grid w-full grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4"
           >
             {filtered.map(item => (
               <SessionCardGrid
@@ -331,7 +332,7 @@ export function SessionsLibraryView(): ReactElement {
           <div
             role="region"
             aria-label={t('pages.sessions.a11y.resultsLabel')}
-            className="mx-auto flex w-full max-w-[1280px] flex-col gap-2 px-4 sm:px-8"
+            className="flex w-full flex-col gap-2"
           >
             {filtered.map(item => (
               <SessionCardList
@@ -358,6 +359,6 @@ export function SessionsLibraryView(): ReactElement {
           }
         />
       )}
-    </div>
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Calendar, Filter, Loader2, Trophy } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { SessionDetailModal } from '@/components/session/SessionDetailModal';
 import type { Session } from '@/components/session/types';
 import { Badge } from '@/components/ui/data-display/badge';
@@ -82,7 +83,7 @@ export default function ToolkitHistoryPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <div className="container mx-auto px-4 py-8 max-w-6xl">
+      <HubPageContainer className="py-8">
         {/* Header */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-purple-100 dark:bg-purple-900">
@@ -91,9 +92,7 @@ export default function ToolkitHistoryPage() {
           <h1 className="text-4xl font-bold mb-2 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
             Session History
           </h1>
-          <p className="text-lg text-muted-foreground">
-            Review past game sessions and statistics
-          </p>
+          <p className="text-lg text-muted-foreground">Review past game sessions and statistics</p>
         </div>
 
         {/* Filters */}
@@ -216,7 +215,7 @@ export default function ToolkitHistoryPage() {
             onOpenChange={setIsModalOpen}
           />
         )}
-      </div>
+      </HubPageContainer>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/upload/upload-client.tsx
+++ b/apps/web/src/app/(authenticated)/upload/upload-client.tsx
@@ -28,6 +28,7 @@ import Link from 'next/link';
 import { MultiDocumentCollectionUpload } from '@/components/documents';
 import { ErrorDisplay } from '@/components/errors';
 import { GamePicker } from '@/components/game/GamePicker';
+import { DetailPageContainer } from '@/components/layout/PageContainer';
 import { LoadingButton, Spinner } from '@/components/loading';
 import { PdfTable } from '@/components/pdf/PdfTable';
 import { PdfUploadForm } from '@/components/pdf/PdfUploadForm';
@@ -299,17 +300,17 @@ export function UploadClient({
   // Show loading state while auth is initializing (after all hooks)
   if (authLoading) {
     return (
-      <div className="p-10 max-w-4xl mx-auto flex flex-col items-center justify-center min-h-[400px]">
+      <DetailPageContainer className="p-10 items-center justify-center min-h-[400px]">
         <Spinner size="lg" />
         <p className="mt-4 text-muted-foreground">Loading...</p>
-      </div>
+      </DetailPageContainer>
     );
   }
 
   const confirmedGame = games.find(g => g.id === confirmedGameId);
 
   return (
-    <div className="p-10 max-w-4xl mx-auto">
+    <DetailPageContainer className="p-10">
       <div className="mb-5">
         <Link href="/" className="text-primary hover:underline">
           ← Back to Home
@@ -602,6 +603,6 @@ export function UploadClient({
           </Card>
         )}
       </main>
-    </div>
+    </DetailPageContainer>
   );
 }

--- a/apps/web/src/app/(authenticated)/versions/page.tsx
+++ b/apps/web/src/app/(authenticated)/versions/page.tsx
@@ -8,6 +8,7 @@ import { useSearchParams } from 'next/navigation';
 
 import { CommentThread } from '@/components/comments';
 import { DiffViewerEnhanced } from '@/components/diff';
+import { HubPageContainer } from '@/components/layout/PageContainer';
 import { VersionTimeline, VersionTimelineFilters } from '@/components/versioning';
 import { api } from '@/lib/api';
 import type { RuleSpecHistory, RuleSpecDiff } from '@/lib/api/schemas';
@@ -220,7 +221,7 @@ function VersionHistoryContent() {
   }
 
   return (
-    <main className="p-6 font-sans max-w-[1600px] mx-auto">
+    <HubPageContainer className="p-6 font-sans">
       <div className="flex justify-between items-center mb-6">
         <div>
           <h1 className="m-0">Storico Versioni RuleSpec</h1>
@@ -318,7 +319,9 @@ function VersionHistoryContent() {
                   <div className="text-xs text-muted-foreground mb-2">
                     {new Date(version.createdAt).toLocaleString()}
                   </div>
-                  <div className="text-xs text-muted-foreground mb-2">{version.atomCount} regole</div>
+                  <div className="text-xs text-muted-foreground mb-2">
+                    {version.atomCount} regole
+                  </div>
                   {authUser.role.toLowerCase() === 'admin' ||
                   authUser.role.toLowerCase() === 'superadmin' ||
                   authUser.role.toLowerCase() === 'editor' ? (
@@ -417,12 +420,14 @@ function VersionHistoryContent() {
                 )}
               </>
             ) : (
-              <p className="text-muted-foreground">Seleziona due versioni per visualizzare le differenze</p>
+              <p className="text-muted-foreground">
+                Seleziona due versioni per visualizzare le differenze
+              </p>
             )}
           </div>
         </div>
       )}
-    </main>
+    </HubPageContainer>
   );
 }
 

--- a/apps/web/src/components/layout/PageContainer/PageContainer.tsx
+++ b/apps/web/src/components/layout/PageContainer/PageContainer.tsx
@@ -1,0 +1,64 @@
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const PADDING_DEFAULT = 'px-4 py-6 sm:px-8 sm:py-8';
+
+interface PageContainerProps extends ComponentPropsWithoutRef<'div'> {
+  children: ReactNode;
+}
+
+const HubPageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
+  ({ className, children, ...rest }, ref) => (
+    <div
+      ref={ref}
+      className={cn('mx-auto flex w-full flex-col max-w-[1440px]', PADDING_DEFAULT, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+);
+HubPageContainer.displayName = 'HubPageContainer';
+
+const DetailPageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
+  ({ className, children, ...rest }, ref) => (
+    <div
+      ref={ref}
+      className={cn('mx-auto flex w-full flex-col max-w-4xl', PADDING_DEFAULT, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+);
+DetailPageContainer.displayName = 'DetailPageContainer';
+
+const FormPageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
+  ({ className, children, ...rest }, ref) => (
+    <div
+      ref={ref}
+      className={cn('mx-auto flex w-full flex-col max-w-2xl', PADDING_DEFAULT, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+);
+FormPageContainer.displayName = 'FormPageContainer';
+
+const SettingsPageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
+  ({ className, children, ...rest }, ref) => (
+    <div
+      ref={ref}
+      className={cn('mx-auto flex w-full flex-col max-w-3xl', PADDING_DEFAULT, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+);
+SettingsPageContainer.displayName = 'SettingsPageContainer';
+
+export { HubPageContainer, DetailPageContainer, FormPageContainer, SettingsPageContainer };
+export type { PageContainerProps };

--- a/apps/web/src/components/layout/PageContainer/__tests__/PageContainer.test.tsx
+++ b/apps/web/src/components/layout/PageContainer/__tests__/PageContainer.test.tsx
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DetailPageContainer,
+  FormPageContainer,
+  HubPageContainer,
+  SettingsPageContainer,
+} from '../PageContainer';
+
+describe('PageContainer primitives', () => {
+  describe('HubPageContainer', () => {
+    it('renders children with max-w-[1440px] default', () => {
+      const { container } = render(
+        <HubPageContainer>
+          <span data-testid="child">hub</span>
+        </HubPageContainer>
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper.className).toContain('max-w-[1440px]');
+      expect(wrapper.className).toContain('mx-auto');
+    });
+
+    it('merges custom className with defaults', () => {
+      const { container } = render(
+        <HubPageContainer className="gap-8 pb-24">
+          <span>x</span>
+        </HubPageContainer>
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toContain('gap-8');
+      expect(wrapper.className).toContain('pb-24');
+      expect(wrapper.className).toContain('max-w-[1440px]');
+    });
+
+    it('passes through HTML attributes (data-slot, id)', () => {
+      const { container } = render(
+        <HubPageContainer data-slot="hub-page" id="my-hub">
+          <span>x</span>
+        </HubPageContainer>
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.getAttribute('data-slot')).toBe('hub-page');
+      expect(wrapper.id).toBe('my-hub');
+    });
+  });
+
+  describe('DetailPageContainer', () => {
+    it('uses max-w-4xl (896px)', () => {
+      const { container } = render(
+        <DetailPageContainer>
+          <span>detail</span>
+        </DetailPageContainer>
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toContain('max-w-4xl');
+    });
+  });
+
+  describe('FormPageContainer', () => {
+    it('uses max-w-2xl (672px)', () => {
+      const { container } = render(
+        <FormPageContainer>
+          <span>form</span>
+        </FormPageContainer>
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toContain('max-w-2xl');
+    });
+  });
+
+  describe('SettingsPageContainer', () => {
+    it('uses max-w-3xl (768px)', () => {
+      const { container } = render(
+        <SettingsPageContainer>
+          <span>settings</span>
+        </SettingsPageContainer>
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toContain('max-w-3xl');
+    });
+  });
+});

--- a/apps/web/src/components/layout/PageContainer/index.ts
+++ b/apps/web/src/components/layout/PageContainer/index.ts
@@ -1,0 +1,7 @@
+export {
+  HubPageContainer,
+  DetailPageContainer,
+  FormPageContainer,
+  SettingsPageContainer,
+} from './PageContainer';
+export type { PageContainerProps } from './PageContainer';


### PR DESCRIPTION
## Summary

Closes #2367. Resolves max-width drift across 38 hub/detail/form/settings pages by introducing 4 semantic primitive container components.

User reported issue: `/library` and `/sessions` were rendering with narrower content area than `/dashboard` (which was using fluid `container`). DOM audit revealed **9 distinct max-w values** in use across `apps/web/src/app/(authenticated)/` (`container`, `max-w-[1280px]`, `max-w-[1440px]`, `max-w-[1400px]`, `max-w-[1600px]`, `max-w-7xl`, `max-w-6xl`, `max-w-4xl`, `max-w-2xl`).

## Primitive architecture

New components in `apps/web/src/components/layout/PageContainer/`:

| Primitive | max-w | Use case |
|-----------|-------|----------|
| `HubPageContainer` | **1440px** (custom) | Hub/list entry pages |
| `DetailPageContainer` | max-w-4xl (896px) | Detail/sub-tabs |
| `FormPageContainer` | max-w-2xl (672px) | Forms/wizards |
| `SettingsPageContainer` | max-w-3xl (768px) | Settings/preferences |

All primitives:
- `<div>`-based with `forwardRef<HTMLDivElement>`
- Extend `ComponentPropsWithoutRef<'div'>` (data-*, id, etc. pass-through)
- Default padding `px-4 py-6 sm:px-8 sm:py-8`
- Custom `className` merged via `twMerge` (overrides defaults correctly)

## Migration breakdown (38 file)

### HubPageContainer (1440px) — 16 callsite
- `/dashboard` `DashboardClient.tsx`
- `/library` `LibraryHub.tsx`
- `/sessions` `SessionsLibraryView.tsx`
- `/players` `PlayersLibraryView.tsx`
- `/gamebook` `page.tsx` + `GamebookIndexView.tsx` (4 FSM states)
- `/editor` `editor-client.tsx`
- `/versions` `page.tsx`
- `/n8n` `page.tsx` (3 FSM states)
- `/library/wishlist` `page.tsx`
- `/knowledge-base/[id]` `page.tsx` (2 FSM states)
- `/toolkit/history` `client.tsx`
- `/game-nights/new` `_content.tsx`
- `/editor/agent-proposals` `client.tsx` (3 FSM states)
- `/editor/agent-proposals/[id]/test` `page.tsx` (5 FSM states)

### DetailPageContainer (896px) — 14 callsite
- `/games/[id]` `GameDetailView.tsx` + 3 sub-tab (rules/faqs/sessions)
- `/players/[id]` `PlayerOverviewRegion.tsx` + 3 panel (Games/Sessions/Toolkits) + 4 sub-tab page (stats/sessions/games/achievements)
- `/agents/[id]` `AgentDetailView.tsx`
- `/upload` `upload-client.tsx` (2 wrappers)
- `/gamebook/upload` `GamebookUploadView.tsx`

### FormPageContainer (672px) — 6 callsite
- `/game-nights/[id]` `GameNightDetailView.tsx` (2 wrappers loading + main)
- `/game-nights/[id]/edit` `page.tsx`
- `/editor/agent-proposals/{create,[id]/edit}` `page.tsx`
- `/play-records/new` `page.tsx`
- `/play-records/[id]/edit` `page.tsx` (3 FSM states)

### SettingsPageContainer (768px) — 2 callsite
- `/notifications` `page.tsx`
- `/notifications/preferences` `page.tsx`

## Eliminated outliers (allineati a 1440)

- `/editor` (era max-w-[1400px])
- `/versions` (era max-w-[1600px])
- `/n8n` (era max-w-7xl=1280)
- `/knowledge-base/[id]` (era max-w-7xl)
- `/toolkit/history` (era max-w-6xl=1152)
- `/editor/agent-proposals` (era max-w-7xl)

## Skipped (follow-up PR)

1. `library/private/add/client.tsx` — conditional className based on `onCancel` prop. Refactor invasivo richiede estrazione di ~148 lines di JSX inline.
2. `game-nights/_components/GameNightForm.tsx` — uses shadcn `Card` primitive con `max-w-2xl mx-auto`. Necessita decisione design (nest Card in FormPageContainer vs. surface variant primitive).

## Test plan

- [x] `pnpm typecheck` green
- [x] Vitest unit per le 4 primitive (`PageContainer.test.tsx`)
- [ ] Visual smoke check `/dashboard`, `/library`, `/sessions` viewport 1920 mostrano stesso max-width 1440px
- [ ] Visual smoke check pagine detail (games/[id]) mantengono max-w-4xl ≈ 896px
- [ ] axe AA pass

## Refs

- Parent: #2367
- Audit DOM: sessione `/sc:spec-panel critique` 2026-06-15 + 5 sub-agent parallel refactor