### PR TITLE
feat(catalog): shared game translations BE foundation (sub-PR 1/3 #2339)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommand.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+/// <summary>
+/// Admin command to add a non-EN translation row to
+/// <c>shared_game_translations</c>. Issue #2339 — sub-PR 1/3 Wave 3 (Task 9).
+/// </summary>
+/// <param name="GameId">Owning <c>shared_games.id</c> — must exist (checked by handler).</param>
+/// <param name="Locale">ISO 639-1 (e.g. <c>"it"</c>) — must not be <c>"en"</c>.</param>
+/// <param name="Title">Localized title, 1..500 chars, trimmed.</param>
+/// <param name="Description">Optional localized description, trimmed when present.</param>
+/// <param name="Source">Kebab-case persisted source: <c>manual</c> | <c>auto-openrouter</c> | <c>community</c>.</param>
+/// <param name="ActorUserId">Identity of the admin issuing the command (audit).</param>
+public sealed record AddGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    string Source,
+    Guid ActorUserId) : IRequest<Guid>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs
@@ -1,0 +1,115 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+/// <summary>
+/// Handler for <see cref="AddGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per DEC-C2 the game-existence check lives here (not in the validator) — we use
+/// <see cref="ISharedGameRepository.GetByIdAsync"/> and surface a
+/// <see cref="NotFoundException"/> when the parent row is missing. This satisfies
+/// CLAUDE.md pitfall #2568 (404 not 500 on missing FK).
+/// </para>
+/// <para>
+/// The unique partial index <c>uq_active_translation_per_locale</c> still protects the
+/// invariant in the face of concurrent writers: when the validator's
+/// <c>ExistsActiveAsync</c> race is lost, <c>SaveChangesAsync</c> throws a
+/// <see cref="DbUpdateException"/> referencing the constraint name and we rethrow as
+/// <see cref="TranslationAlreadyExistsException"/> (409).
+/// </para>
+/// </remarks>
+internal sealed class AddGameTranslationCommandHandler
+    : IRequestHandler<AddGameTranslationCommand, Guid>
+{
+    private const string UniqueIndexName = "uq_active_translation_per_locale";
+
+    private readonly ISharedGameTranslationRepository _translationRepo;
+    private readonly ISharedGameRepository _gameRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _clock;
+
+    public AddGameTranslationCommandHandler(
+        ISharedGameTranslationRepository translationRepo,
+        ISharedGameRepository gameRepo,
+        IUnitOfWork unitOfWork,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(translationRepo);
+        ArgumentNullException.ThrowIfNull(gameRepo);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        _translationRepo = translationRepo;
+        _gameRepo = gameRepo;
+        _unitOfWork = unitOfWork;
+        _clock = clock;
+    }
+
+    public async Task<Guid> Handle(AddGameTranslationCommand cmd, CancellationToken cancellationToken)
+    {
+        // DEC-C2: parent-row existence check is here, not in the validator
+        // (CLAUDE.md pitfall #2568: 404 not 500).
+        var parent = await _gameRepo
+            .GetByIdAsync(cmd.GameId, cancellationToken)
+            .ConfigureAwait(false);
+        if (parent is null)
+        {
+            throw new NotFoundException("SharedGame", cmd.GameId.ToString());
+        }
+
+        var locale = Locale.Create(cmd.Locale);
+        if (!TranslationSourceMapper.TryFromPersistedString(cmd.Source, out var source))
+        {
+            // Validator already rejects this, but the handler is defensive — pre-condition
+            // failures here are a programmer error (caller bypassed the pipeline).
+            throw new ArgumentException(
+                $"Unknown source '{cmd.Source}'", nameof(cmd));
+        }
+
+        var now = _clock.GetUtcNow();
+        var translation = SharedGameTranslation.Create(
+            sharedGameId: cmd.GameId,
+            locale: locale,
+            title: cmd.Title,
+            description: cmd.Description,
+            source: source,
+            createdBy: cmd.ActorUserId,
+            now: now);
+
+        await _translationRepo.AddAsync(translation, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsUniqueLocaleViolation(ex))
+        {
+            throw new TranslationAlreadyExistsException(cmd.GameId, locale.Value);
+        }
+
+        return translation.Id;
+    }
+
+    private static bool IsUniqueLocaleViolation(DbUpdateException ex)
+    {
+        // Npgsql surfaces the index name in the outer message; check both the outer
+        // exception and the inner (Postgres) one to be tolerant of provider quirks.
+        if (ex.Message.Contains(UniqueIndexName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return ex.InnerException is { } inner
+            && inner.Message.Contains(UniqueIndexName, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
@@ -1,0 +1,86 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+/// <summary>
+/// Validator for <see cref="AddGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// DEC-C2: the game-existence check is deliberately NOT here. <see cref="ISharedGameRepository"/>
+/// exposes <c>GetByIdAsync</c>, not <c>ExistsByIdAsync</c>, and validators should not hydrate
+/// aggregates. The handler performs the existence check and throws a <c>NotFoundException</c>
+/// when the parent row is missing (CLAUDE.md pitfall #2568: 404 not 500).
+/// </para>
+/// <para>
+/// The duplicate-locale check short-circuits the unique constraint
+/// <c>uq_active_translation_per_locale</c> with a 409 hint at the validator boundary so
+/// the consumer doesn't have to interpret a raw <c>DbUpdateException</c>.
+/// </para>
+/// </remarks>
+public sealed class AddGameTranslationCommandValidator
+    : AbstractValidator<AddGameTranslationCommand>
+{
+    public AddGameTranslationCommandValidator(
+        ISharedGameTranslationRepository translationRepository)
+    {
+        ArgumentNullException.ThrowIfNull(translationRepository);
+
+        RuleFor(c => c.GameId).NotEmpty();
+
+        RuleFor(c => c.ActorUserId).NotEmpty();
+
+        RuleFor(c => c.Locale)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(BeValidLocale).WithMessage("Invalid ISO 639-1 locale")
+            .MustAsync(async (cmd, locale, ct) =>
+                !await translationRepository
+                    .ExistsActiveAsync(cmd.GameId, NormalizeLocale(locale), ct)
+                    .ConfigureAwait(false))
+            .WithMessage("Translation for locale '{PropertyValue}' already exists");
+
+        RuleFor(c => c.Title)
+            .NotEmpty().WithMessage("Title required")
+            .MaximumLength(500);
+
+        RuleFor(c => c.Source)
+            .NotEmpty()
+            .Must(BeValidSource)
+            .WithMessage("Invalid source — must be one of: manual | auto-openrouter | community");
+    }
+
+    private static bool BeValidLocale(string raw)
+    {
+        try
+        {
+            Locale.Create(raw);
+            return true;
+        }
+        catch (InvalidLocaleException)
+        {
+            return false;
+        }
+    }
+
+    private static string NormalizeLocale(string raw)
+    {
+        try
+        {
+            return Locale.Create(raw).Value;
+        }
+        catch (InvalidLocaleException)
+        {
+            // BeValidLocale will already have surfaced the invalid-locale error;
+            // returning raw avoids a NullReferenceException in the cascade.
+            return raw;
+        }
+    }
+
+    private static bool BeValidSource(string source) =>
+        TranslationSourceMapper.TryFromPersistedString(source, out _);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommand.cs
@@ -1,0 +1,20 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+
+/// <summary>
+/// Admin command to soft-delete an existing non-EN translation in
+/// <c>shared_game_translations</c>. Issue #2339 — sub-PR 1/3 Wave 4 (Task 11).
+/// </summary>
+/// <param name="GameId">Owning <c>shared_games.id</c>.</param>
+/// <param name="Locale">ISO 639-1 locale identifying which translation to soft-delete.</param>
+/// <param name="Xmin">Postgres <c>xmin</c> system column captured by the client on read,
+/// passed back here for optimistic concurrency check (DEC-C4 from plan review).
+/// EF raises <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>
+/// when the value diverges from the row's current <c>xmin</c>.</param>
+/// <param name="ActorUserId">Identity of the admin issuing the command (audit).</param>
+public sealed record DeleteGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    uint Xmin,
+    Guid ActorUserId) : IRequest<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandler.cs
@@ -1,0 +1,81 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+
+/// <summary>
+/// Handler for <see cref="DeleteGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per DEC-C2 the translation-existence check lives here (not in the validator) — we
+/// load via <see cref="ISharedGameTranslationRepository.GetByGameIdAndLocaleAsync"/>
+/// and surface a <see cref="TranslationNotFoundException"/> when missing
+/// (CLAUDE.md pitfall #2568: 404 not 500).
+/// </para>
+/// <para>
+/// Per DEC-C4 the client-supplied <c>xmin</c> is pushed onto the aggregate via
+/// <see cref="Domain.Entities.SharedGameTranslation.SetXminForConcurrencyCheck"/>
+/// before <c>SaveChangesAsync</c>. EF compares the stored value against the row's
+/// current <c>xmin</c> and raises
+/// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/> on
+/// mismatch — left to bubble so the global middleware can map it to 409 with
+/// <c>X-Warning-Code: concurrent-edit</c>.
+/// </para>
+/// <para>
+/// <see cref="Domain.Entities.SharedGameTranslation.SoftDelete"/> is idempotent — a
+/// second invocation on an already-deleted aggregate is a no-op, so calling Delete
+/// twice with the same xmin succeeds the first time and may surface a concurrency
+/// failure on the second (because xmin advances on the first SaveChanges).
+/// </para>
+/// </remarks>
+internal sealed class DeleteGameTranslationCommandHandler
+    : IRequestHandler<DeleteGameTranslationCommand, Unit>
+{
+    private readonly ISharedGameTranslationRepository _translationRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _clock;
+
+    public DeleteGameTranslationCommandHandler(
+        ISharedGameTranslationRepository translationRepo,
+        IUnitOfWork unitOfWork,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(translationRepo);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        _translationRepo = translationRepo;
+        _unitOfWork = unitOfWork;
+        _clock = clock;
+    }
+
+    public async Task<Unit> Handle(DeleteGameTranslationCommand cmd, CancellationToken cancellationToken)
+    {
+        var locale = Locale.Create(cmd.Locale);
+
+        var existing = await _translationRepo
+            .GetByGameIdAndLocaleAsync(cmd.GameId, locale.Value, cancellationToken)
+            .ConfigureAwait(false);
+        if (existing is null)
+        {
+            throw new TranslationNotFoundException(cmd.GameId, locale.Value);
+        }
+
+        var now = _clock.GetUtcNow();
+        existing.SoftDelete(cmd.ActorUserId, now);
+
+        // DEC-C4: push client-supplied xmin so EF can run the concurrency check.
+        existing.SetXminForConcurrencyCheck(cmd.Xmin);
+
+        await _translationRepo.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+        // DbUpdateConcurrencyException bubbles up — caught by global exception middleware
+        // and surfaced as 409 with X-Warning-Code: concurrent-edit.
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandValidator.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+
+/// <summary>
+/// Validator for <see cref="DeleteGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Symmetric to <c>UpdateGameTranslationCommandValidator</c> minus the title checks
+/// (soft-delete carries no payload beyond GameId/Locale/Xmin/ActorUserId).
+/// </para>
+/// <para>
+/// Per DEC-C2 the translation-existence check is NOT here — the handler loads via
+/// <c>GetByGameIdAndLocaleAsync</c> and throws <c>TranslationNotFoundException</c>
+/// when missing, mapped to 404 by the global exception middleware
+/// (CLAUDE.md pitfall #2568).
+/// </para>
+/// </remarks>
+public sealed class DeleteGameTranslationCommandValidator
+    : AbstractValidator<DeleteGameTranslationCommand>
+{
+    public DeleteGameTranslationCommandValidator()
+    {
+        RuleFor(c => c.GameId).NotEmpty();
+        RuleFor(c => c.ActorUserId).NotEmpty();
+
+        RuleFor(c => c.Locale)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(BeValidLocale).WithMessage("Invalid ISO 639-1 locale");
+
+        RuleFor(c => c.Xmin)
+            .GreaterThan(0u)
+            .WithMessage("Xmin required for optimistic concurrency check");
+    }
+
+    private static bool BeValidLocale(string raw)
+    {
+        try
+        {
+            Locale.Create(raw);
+            return true;
+        }
+        catch (InvalidLocaleException)
+        {
+            return false;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommand.cs
@@ -1,0 +1,24 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+
+/// <summary>
+/// Admin command to update an existing non-EN translation in
+/// <c>shared_game_translations</c>. Issue #2339 — sub-PR 1/3 Wave 3 (Task 10).
+/// </summary>
+/// <param name="GameId">Owning <c>shared_games.id</c>.</param>
+/// <param name="Locale">ISO 639-1 locale identifying which translation to update.</param>
+/// <param name="Title">Replacement title, 1..500 chars, trimmed.</param>
+/// <param name="Description">Replacement description, trimmed when present (nullable to clear).</param>
+/// <param name="Xmin">Postgres <c>xmin</c> system column captured by the client on read,
+/// passed back here for optimistic concurrency check (DEC-C4 from plan review).
+/// EF raises <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>
+/// when the value diverges from the row's current <c>xmin</c>.</param>
+/// <param name="ActorUserId">Identity of the admin issuing the command (audit).</param>
+public sealed record UpdateGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    uint Xmin,
+    Guid ActorUserId) : IRequest<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandler.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+
+/// <summary>
+/// Handler for <see cref="UpdateGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per DEC-C2 the translation-existence check lives here (not in the validator) — we
+/// load via <see cref="ISharedGameTranslationRepository.GetByGameIdAndLocaleAsync"/>
+/// and surface a <see cref="TranslationNotFoundException"/> when missing
+/// (CLAUDE.md pitfall #2568: 404 not 500).
+/// </para>
+/// <para>
+/// Per DEC-C4 the client-supplied <c>xmin</c> is pushed onto the aggregate via
+/// <see cref="Domain.Entities.SharedGameTranslation.SetXminForConcurrencyCheck"/>
+/// before <c>SaveChangesAsync</c>. EF compares the stored value against the row's
+/// current <c>xmin</c> and raises
+/// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/> on
+/// mismatch — left to bubble so the global middleware can map it to 409 with
+/// <c>X-Warning-Code: concurrent-edit</c>.
+/// </para>
+/// </remarks>
+internal sealed class UpdateGameTranslationCommandHandler
+    : IRequestHandler<UpdateGameTranslationCommand, Unit>
+{
+    private readonly ISharedGameTranslationRepository _translationRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _clock;
+
+    public UpdateGameTranslationCommandHandler(
+        ISharedGameTranslationRepository translationRepo,
+        IUnitOfWork unitOfWork,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(translationRepo);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        _translationRepo = translationRepo;
+        _unitOfWork = unitOfWork;
+        _clock = clock;
+    }
+
+    public async Task<Unit> Handle(UpdateGameTranslationCommand cmd, CancellationToken cancellationToken)
+    {
+        var locale = Locale.Create(cmd.Locale);
+
+        var existing = await _translationRepo
+            .GetByGameIdAndLocaleAsync(cmd.GameId, locale.Value, cancellationToken)
+            .ConfigureAwait(false);
+        if (existing is null)
+        {
+            throw new TranslationNotFoundException(cmd.GameId, locale.Value);
+        }
+
+        var now = _clock.GetUtcNow();
+        // Domain methods enforce: not-deleted invariant + max-length validation.
+        existing.UpdateTitle(cmd.Title, cmd.ActorUserId, now);
+        existing.UpdateDescription(cmd.Description, cmd.ActorUserId, now);
+
+        // DEC-C4: push client-supplied xmin so EF can run the concurrency check.
+        existing.SetXminForConcurrencyCheck(cmd.Xmin);
+
+        await _translationRepo.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+        // DbUpdateConcurrencyException bubbles up — caught by global exception middleware
+        // and surfaced as 409 with X-Warning-Code: concurrent-edit.
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandValidator.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+
+/// <summary>
+/// Validator for <see cref="UpdateGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Symmetric to <c>AddGameTranslationCommandValidator</c> minus the duplicate-locale
+/// check (we're updating an existing row by definition) and plus the <c>Xmin</c>
+/// concurrency-token presence check (DEC-C4).
+/// </para>
+/// <para>
+/// Per DEC-C2 the translation-existence check is NOT here — the handler loads via
+/// <c>GetByGameIdAndLocaleAsync</c> and throws <c>TranslationNotFoundException</c>
+/// when missing, mapped to 404 by the global exception middleware
+/// (CLAUDE.md pitfall #2568).
+/// </para>
+/// </remarks>
+public sealed class UpdateGameTranslationCommandValidator
+    : AbstractValidator<UpdateGameTranslationCommand>
+{
+    public UpdateGameTranslationCommandValidator()
+    {
+        RuleFor(c => c.GameId).NotEmpty();
+        RuleFor(c => c.ActorUserId).NotEmpty();
+
+        RuleFor(c => c.Locale)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(BeValidLocale).WithMessage("Invalid ISO 639-1 locale");
+
+        RuleFor(c => c.Title)
+            .NotEmpty().WithMessage("Title required")
+            .MaximumLength(500);
+
+        RuleFor(c => c.Xmin)
+            .GreaterThan(0u)
+            .WithMessage("Xmin required for optimistic concurrency check");
+    }
+
+    private static bool BeValidLocale(string raw)
+    {
+        try
+        {
+            Locale.Create(raw);
+            return true;
+        }
+        catch (InvalidLocaleException)
+        {
+            return false;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/InvalidLocaleException.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/InvalidLocaleException.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+/// <summary>
+/// Thrown when a string fails to parse as a valid ISO 639-1 locale (optionally with
+/// ISO 3166-1 regional suffix) — see <see cref="Domain.ValueObjects.Locale"/>.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+public sealed class InvalidLocaleException : ArgumentException
+{
+    public InvalidLocaleException(string message) : base(message)
+    {
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationAlreadyExistsException.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationAlreadyExistsException.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+/// <summary>
+/// Thrown when attempting to create a shared_game_translations row that violates
+/// the partial unique index (active translation per game + locale). Maps to HTTP 409.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+public sealed class TranslationAlreadyExistsException : ConflictException
+{
+    public Guid GameId { get; }
+    public string Locale { get; }
+
+    [SetsRequiredMembers]
+    public TranslationAlreadyExistsException(Guid gameId, string locale)
+        : base($"Translation for game {gameId} locale '{locale}' already exists")
+    {
+        GameId = gameId;
+        Locale = locale;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationNotFoundException.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationNotFoundException.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+/// <summary>
+/// Thrown when a shared_game_translations row for the given game + locale cannot be
+/// located. Maps to HTTP 404 via the global exception middleware.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+public sealed class TranslationNotFoundException : NotFoundException
+{
+    public Guid GameId { get; }
+    public string Locale { get; }
+
+    [SetsRequiredMembers]
+    public TranslationNotFoundException(Guid gameId, string locale)
+        : base("SharedGameTranslation", $"game={gameId}, locale='{locale}'")
+    {
+        GameId = gameId;
+        Locale = locale;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllSharedGamesQueryHandler.cs
@@ -18,15 +18,18 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
     private readonly MeepleAiDbContext _context;
     private readonly IBlobStorageService _blobStorage;
     private readonly ILogger<GetAllSharedGamesQueryHandler> _logger;
+    private readonly IGameTitleResolver _titleResolver;
 
     public GetAllSharedGamesQueryHandler(
         MeepleAiDbContext context,
         IBlobStorageService blobStorage,
-        ILogger<GetAllSharedGamesQueryHandler> logger)
+        ILogger<GetAllSharedGamesQueryHandler> logger,
+        IGameTitleResolver titleResolver)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _titleResolver = titleResolver ?? throw new ArgumentNullException(nameof(titleResolver));
     }
 
     public async Task<PagedResult<SharedGameDto>> Handle(GetAllSharedGamesQuery query, CancellationToken cancellationToken)
@@ -114,14 +117,20 @@ internal sealed class GetAllSharedGamesQueryHandler : IRequestHandler<GetAllShar
                 CoverUrl: coverUrl));
         }
 
+        // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations
+        // for the page. Batch one round-trip via IGameTitleResolver.GetByGameIdsAsync.
+        var enriched = await _titleResolver
+            .EnrichAsync(games, cancellationToken)
+            .ConfigureAwait(false);
+
         _logger.LogInformation(
             "Retrieved {Count} games (Total: {Total}) for page {Page}",
-            games.Count,
+            enriched.Count,
             total,
             query.PageNumber);
 
         return new PagedResult<SharedGameDto>(
-            Items: games,
+            Items: enriched,
             Total: total,
             Page: query.PageNumber,
             PageSize: query.PageSize);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetFilteredSharedGamesQueryHandler.cs
@@ -21,15 +21,18 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
     private readonly MeepleAiDbContext _context;
     private readonly IBlobStorageService _blobStorage;
     private readonly ILogger<GetFilteredSharedGamesQueryHandler> _logger;
+    private readonly IGameTitleResolver _titleResolver;
 
     public GetFilteredSharedGamesQueryHandler(
         MeepleAiDbContext context,
         IBlobStorageService blobStorage,
-        ILogger<GetFilteredSharedGamesQueryHandler> logger)
+        ILogger<GetFilteredSharedGamesQueryHandler> logger,
+        IGameTitleResolver titleResolver)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _titleResolver = titleResolver ?? throw new ArgumentNullException(nameof(titleResolver));
     }
 
     public async Task<PagedResult<SharedGameDto>> Handle(GetFilteredSharedGamesQuery query, CancellationToken cancellationToken)
@@ -144,14 +147,20 @@ internal sealed class GetFilteredSharedGamesQueryHandler : IRequestHandler<GetFi
                 CoverUrl: coverUrl));
         }
 
+        // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations
+        // for the page. Batch one round-trip via IGameTitleResolver.GetByGameIdsAsync.
+        var enriched = await _titleResolver
+            .EnrichAsync(games, cancellationToken)
+            .ConfigureAwait(false);
+
         _logger.LogInformation(
             "Retrieved {Count} filtered shared games (Total: {Total}) for page {Page}",
-            games.Count,
+            enriched.Count,
             total,
             query.PageNumber);
 
         return new PagedResult<SharedGameDto>(
-            Items: games,
+            Items: enriched,
             Total: total,
             Page: query.PageNumber,
             PageSize: query.PageSize);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQuery.cs
@@ -1,0 +1,18 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslationByLocale;
+
+/// <summary>
+/// Admin query returning a single active translation by game + locale.
+/// Issue #2339 — sub-PR 1/3 Wave 4 (Task 12).
+/// </summary>
+/// <param name="GameId">Owning <c>shared_games.id</c>.</param>
+/// <param name="Locale">ISO 639-1 locale.</param>
+/// <remarks>
+/// DEC-M2 (2026-06-15 plan review): the spec §6.5 originally declared this
+/// query as <c>IRequest&lt;SharedGameTranslationDetailDto&gt;</c> (non-nullable).
+/// We instead return <c>null</c> when no active row matches so the endpoint
+/// can map it to HTTP 404 without throwing.
+/// </remarks>
+public sealed record GetGameTranslationByLocaleQuery(Guid GameId, string Locale)
+    : IRequest<SharedGameTranslationDetailDto?>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQueryHandler.cs
@@ -1,0 +1,47 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslationByLocale;
+
+/// <summary>
+/// Handler for <see cref="GetGameTranslationByLocaleQuery"/>. Returns the
+/// matching active translation or <c>null</c> when missing (DEC-M2 — endpoint
+/// maps null to HTTP 404). Issue #2339 — sub-PR 1/3 Wave 4 (Task 12).
+/// </summary>
+/// <remarks>
+/// Read-side, no domain mutation. The raw locale string is normalised through
+/// <see cref="Locale.Create"/> so caller variants ("EN", "en-gb", " it ") all
+/// hit the same canonical row. Locale validation errors surface as
+/// <see cref="Application.Exceptions.InvalidLocaleException"/>, mapped to 400
+/// by the global exception middleware.
+/// </remarks>
+internal sealed class GetGameTranslationByLocaleQueryHandler
+    : IRequestHandler<GetGameTranslationByLocaleQuery, SharedGameTranslationDetailDto?>
+{
+    private readonly ISharedGameTranslationRepository _translationRepo;
+
+    public GetGameTranslationByLocaleQueryHandler(ISharedGameTranslationRepository translationRepo)
+    {
+        ArgumentNullException.ThrowIfNull(translationRepo);
+        _translationRepo = translationRepo;
+    }
+
+    public async Task<SharedGameTranslationDetailDto?> Handle(
+        GetGameTranslationByLocaleQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var locale = Locale.Create(query.Locale);
+
+        var translation = await _translationRepo
+            .GetByGameIdAndLocaleAsync(query.GameId, locale.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        return translation is null
+            ? null
+            : SharedGameTranslationMapper.ToDetailDto(translation);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslations/GetGameTranslationsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslations/GetGameTranslationsQuery.cs
@@ -1,0 +1,11 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslations;
+
+/// <summary>
+/// Admin query returning every active translation for a single shared game.
+/// Issue #2339 — sub-PR 1/3 Wave 4 (Task 12).
+/// </summary>
+/// <param name="GameId">Owning <c>shared_games.id</c>.</param>
+public sealed record GetGameTranslationsQuery(Guid GameId)
+    : IRequest<IReadOnlyList<SharedGameTranslationDetailDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslations/GetGameTranslationsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslations/GetGameTranslationsQueryHandler.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslations;
+
+/// <summary>
+/// Handler for <see cref="GetGameTranslationsQuery"/>. Returns the full list of
+/// active translations for the requested game (soft-deleted rows are filtered
+/// out by the repository's query filter). Issue #2339 — sub-PR 1/3 Wave 4.
+/// </summary>
+/// <remarks>
+/// Read-side, no domain mutation — pure projection through
+/// <see cref="SharedGameTranslationMapper.ToDetailDto"/>. Endpoint integration
+/// tests in Wave 5 (Task 14) cover the happy-path + empty-list cases; no
+/// dedicated unit tests for this trivial handler per plan Task 12.
+/// </remarks>
+internal sealed class GetGameTranslationsQueryHandler
+    : IRequestHandler<GetGameTranslationsQuery, IReadOnlyList<SharedGameTranslationDetailDto>>
+{
+    private readonly ISharedGameTranslationRepository _translationRepo;
+
+    public GetGameTranslationsQueryHandler(ISharedGameTranslationRepository translationRepo)
+    {
+        ArgumentNullException.ThrowIfNull(translationRepo);
+        _translationRepo = translationRepo;
+    }
+
+    public async Task<IReadOnlyList<SharedGameTranslationDetailDto>> Handle(
+        GetGameTranslationsQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var translations = await _translationRepo
+            .GetByGameIdAsync(query.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return translations.Select(SharedGameTranslationMapper.ToDetailDto).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetPendingApprovalGamesQueryHandler.cs
@@ -19,15 +19,18 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
     private readonly MeepleAiDbContext _context;
     private readonly IBlobStorageService _blobStorage;
     private readonly ILogger<GetPendingApprovalGamesQueryHandler> _logger;
+    private readonly IGameTitleResolver _titleResolver;
 
     public GetPendingApprovalGamesQueryHandler(
         MeepleAiDbContext context,
         IBlobStorageService blobStorage,
-        ILogger<GetPendingApprovalGamesQueryHandler> logger)
+        ILogger<GetPendingApprovalGamesQueryHandler> logger,
+        IGameTitleResolver titleResolver)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _titleResolver = titleResolver ?? throw new ArgumentNullException(nameof(titleResolver));
     }
 
     public async Task<PagedResult<SharedGameDto>> Handle(GetPendingApprovalGamesQuery query, CancellationToken cancellationToken)
@@ -95,14 +98,20 @@ internal sealed class GetPendingApprovalGamesQueryHandler : IRequestHandler<GetP
                 CoverUrl: coverUrl));
         }
 
+        // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations
+        // for the page. Batch one round-trip via IGameTitleResolver.GetByGameIdsAsync.
+        var enriched = await _titleResolver
+            .EnrichAsync(games, cancellationToken)
+            .ConfigureAwait(false);
+
         _logger.LogInformation(
             "Retrieved {Count} pending approval games (Total: {Total}) for page {Page}",
-            games.Count,
+            enriched.Count,
             total,
             query.PageNumber);
 
         return new PagedResult<SharedGameDto>(
-            Items: games,
+            Items: enriched,
             Total: total,
             Page: query.PageNumber,
             PageSize: query.PageSize);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQueryHandler.cs
@@ -47,6 +47,7 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
     private readonly IBlobStorageService _blobStorage;
     private readonly HybridCache _cache;
     private readonly ILogger<SearchSharedGamesQueryHandler> _logger;
+    private readonly IGameTitleResolver _titleResolver;
     private readonly decimal _topRatedThreshold;
     private readonly int _newWindowDays;
 
@@ -55,13 +56,15 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         IBlobStorageService blobStorage,
         HybridCache cache,
         IConfiguration configuration,
-        ILogger<SearchSharedGamesQueryHandler> logger)
+        ILogger<SearchSharedGamesQueryHandler> logger,
+        IGameTitleResolver titleResolver)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         ArgumentNullException.ThrowIfNull(configuration);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _titleResolver = titleResolver ?? throw new ArgumentNullException(nameof(titleResolver));
 
         // Issue #593: top-rated threshold is runtime-tunable via IConfiguration.
         // Resolved once at construction (handler is a transient/scoped service per
@@ -444,14 +447,24 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
                 CoverUrl: coverUrl));
         }
 
+        // Issue #2339 (Wave 4 Task 13 — DEC-WIRING): enrich SharedGameDto.Translations
+        // for the page. Batch one round-trip via IGameTitleResolver.GetByGameIdsAsync.
+        // Enrichment lives inside ExecuteSearchAsync so cached payloads include the
+        // translations — invalidation is governed by the `search-games` cache tag and
+        // the 1h L2 TTL, both acceptable given translations are admin-curated and
+        // change rarely.
+        var enriched = await _titleResolver
+            .EnrichAsync(games, cancellationToken)
+            .ConfigureAwait(false);
+
         _logger.LogInformation(
             "Search completed: Found {Count} games (Total: {Total}) for page {Page}",
-            games.Count,
+            enriched.Count,
             total,
             query.PageNumber);
 
         return new PagedResult<SharedGameDto>(
-            Items: games,
+            Items: enriched,
             Total: total,
             Page: query.PageNumber,
             PageSize: query.PageSize);
@@ -479,7 +492,10 @@ internal sealed class SearchSharedGamesQueryHandler : IRequestHandler<SearchShar
         //   v3 = Issue #593 chip filters: HasToolkit / HasAgent / IsTopRated (Commit 2)
         //   v4 = Issue #593 NewThisWeekCount + ContributorsCount + IsNew + sort options
         //        "Contrib" / "New" (Commit 1b — projection shape changed)
-        var keyComponents = $"v4|{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}|{query.HasKnowledgeBase?.ToString() ?? "null"}|{query.HasToolkit?.ToString() ?? "null"}|{query.HasAgent?.ToString() ?? "null"}|{query.IsTopRated?.ToString() ?? "null"}|{query.IsNew?.ToString() ?? "null"}";
+        //   v5 = Issue #2339 (Wave 4 Task 13 — DEC-WIRING) SharedGameDto.Translations
+        //        enrichment via IGameTitleResolver — cached payloads now carry
+        //        per-game translation lists alongside the existing aggregates.
+        var keyComponents = $"v5|{searchTerm}|{categoryIds}|{mechanicIds}|{query.MinPlayers}|{query.MaxPlayers}|{query.MaxPlayingTime}|{query.MinComplexity}|{query.MaxComplexity}|{statusStr}|{query.PageNumber}|{query.PageSize}|{query.SortBy}|{query.SortDescending}|{query.HasKnowledgeBase?.ToString() ?? "null"}|{query.HasToolkit?.ToString() ?? "null"}|{query.HasAgent?.ToString() ?? "null"}|{query.IsTopRated?.ToString() ?? "null"}|{query.IsNew?.ToString() ?? "null"}";
 
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(keyComponents)));
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolver.cs
@@ -1,0 +1,56 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Default <see cref="IGameTitleResolver"/> backed by
+/// <see cref="ISharedGameTranslationRepository.GetByGameIdsAsync"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 3 (Task 8).
+/// </summary>
+internal sealed class GameTitleResolver : IGameTitleResolver
+{
+    private readonly ISharedGameTranslationRepository _repo;
+
+    public GameTitleResolver(ISharedGameTranslationRepository repo)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+        _repo = repo;
+    }
+
+    public async Task<IReadOnlyList<SharedGameDto>> EnrichAsync(
+        IReadOnlyList<SharedGameDto> games, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(games);
+
+        if (games.Count == 0)
+        {
+            return games;
+        }
+
+        var ids = games.Select(g => g.Id).ToList();
+        var translationsByGame = await _repo
+            .GetByGameIdsAsync(ids, cancellationToken)
+            .ConfigureAwait(false);
+
+        var enriched = new List<SharedGameDto>(games.Count);
+        foreach (var game in games)
+        {
+            var translations = translationsByGame.TryGetValue(game.Id, out var ts)
+                ? ts.Select(ToDto).ToList()
+                : new List<SharedGameTranslationDto>(0);
+
+            // `with` produces a shallow-cloned record preserving all other fields.
+            enriched.Add(game with { Translations = translations });
+        }
+
+        return enriched;
+    }
+
+    private static SharedGameTranslationDto ToDto(SharedGameTranslation t) =>
+        new(
+            Locale: t.Locale.Value,
+            Title: t.Title,
+            Description: t.Description,
+            Source: TranslationSourceMapper.ToPersistedString(t.Source));
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IGameTitleResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IGameTitleResolver.cs
@@ -1,0 +1,30 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Batch enricher that joins non-EN translations onto <see cref="SharedGameDto"/> list-query
+/// results in a single round-trip. Issue #2339 — sub-PR 1/3 Wave 3 (Task 8).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Consumed by the four list query handlers (GetAll / GetFiltered / GetPendingApproval /
+/// Search) so that FE callers can pick the right localized title without an N+1 hit on
+/// the translations table. Wired in sub-PR 2/3 — this Task 8 only ships the service.
+/// </para>
+/// <para>
+/// The resolver is intentionally a thin wrapper around
+/// <see cref="Domain.Repositories.ISharedGameTranslationRepository.GetByGameIdsAsync"/>;
+/// the repository's <c>HasQueryFilter(t =&gt; !t.IsDeleted)</c> excludes soft-deleted rows
+/// automatically.
+/// </para>
+/// </remarks>
+public interface IGameTitleResolver
+{
+    /// <summary>
+    /// Returns a new list of <see cref="SharedGameDto"/> where each element has
+    /// <see cref="SharedGameDto.Translations"/> populated with the active (non-soft-deleted)
+    /// translations for that game. Empty input short-circuits with no DB roundtrip.
+    /// </summary>
+    Task<IReadOnlyList<SharedGameDto>> EnrichAsync(
+        IReadOnlyList<SharedGameDto> games,
+        CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/SharedGameTranslationMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/SharedGameTranslationMapper.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Maps <see cref="SharedGameTranslation"/> aggregates to the read-side
+/// <see cref="SharedGameTranslationDetailDto"/> surface used by the admin
+/// translation endpoints. Issue #2339 — sub-PR 1/3 Wave 4 (Task 12).
+/// </summary>
+/// <remarks>
+/// Plan Task 12 explicitly calls out the read-query handlers' duplication of
+/// the projection logic; this mapper resolves that DRY concern. The
+/// <c>Source</c> enum is round-tripped through
+/// <see cref="TranslationSourceMapper.ToPersistedString"/> so the wire shape
+/// stays stable across enum extensions.
+/// </remarks>
+internal static class SharedGameTranslationMapper
+{
+    public static SharedGameTranslationDetailDto ToDetailDto(SharedGameTranslation t)
+    {
+        ArgumentNullException.ThrowIfNull(t);
+
+        return new SharedGameTranslationDetailDto(
+            Id: t.Id,
+            GameId: t.SharedGameId,
+            Locale: t.Locale.Value,
+            Title: t.Title,
+            Description: t.Description,
+            Source: TranslationSourceMapper.ToPersistedString(t.Source),
+            CreatedAt: t.CreatedAt,
+            CreatedBy: t.CreatedBy,
+            UpdatedAt: t.UpdatedAt,
+            UpdatedBy: t.UpdatedBy,
+            Xmin: t.Xmin);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/TranslationSourceMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/TranslationSourceMapper.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Round-trips <see cref="TranslationSource"/> against the kebab-case string
+/// representation persisted in <c>shared_game_translations.source</c>.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// Lives in the Application layer (not Infrastructure) per plan review
+/// finding I4 — the validator and the resolver both need to translate the
+/// enum without taking a hard dependency on a persistence-layer type.
+/// </remarks>
+internal static class TranslationSourceMapper
+{
+    public const string ManualString = "manual";
+    public const string AutoOpenRouterString = "auto-openrouter";
+    public const string CommunityString = "community";
+
+    public static string ToPersistedString(TranslationSource source) => source switch
+    {
+        TranslationSource.Manual => ManualString,
+        TranslationSource.AutoOpenRouter => AutoOpenRouterString,
+        TranslationSource.Community => CommunityString,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(source), source, $"Unknown TranslationSource: {source}")
+    };
+
+    public static TranslationSource FromPersistedString(string source)
+    {
+        if (TryFromPersistedString(source, out var result))
+        {
+            return result;
+        }
+
+        throw new ArgumentOutOfRangeException(
+            nameof(source), source, $"Unknown source: {source}");
+    }
+
+    public static bool TryFromPersistedString(string source, out TranslationSource result)
+    {
+        switch (source)
+        {
+            case ManualString:
+                result = TranslationSource.Manual;
+                return true;
+            case AutoOpenRouterString:
+                result = TranslationSource.AutoOpenRouter;
+                return true;
+            case CommunityString:
+                result = TranslationSource.Community;
+                return true;
+            default:
+                result = default;
+                return false;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
@@ -57,7 +57,11 @@ public sealed record SharedGameDto(
     bool IsTopRated = false,
     bool IsNew = false,
     // Issue #1852 (Gap A): cover URL resolved via L4 → L2 priority; null when no cover available or storage unavailable.
-    string? CoverUrl = null);
+    string? CoverUrl = null,
+    // Issue #2339 (sub-PR 1/3): non-EN translations; null defaults treated as empty by FE consumers.
+    // Enriched by GameTitleResolver in list query handlers; raw list handlers may emit null when
+    // the resolver is not on the pipeline (e.g. admin endpoints that don't surface translations).
+    IReadOnlyList<SharedGameTranslationDto>? Translations = null);
 
 /// <summary>
 /// Data transfer object for game rules.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDetailDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDetailDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application;
+
+/// <summary>
+/// Admin-facing detail DTO for a single translation row, including audit metadata
+/// and the PostgreSQL <c>xmin</c> token required for optimistic concurrency on PUT.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <see cref="Source"/> holds the kebab-case persisted form to keep the wire shape
+/// stable across enum extensions (see ADR pattern for catalog enums). Clients submit
+/// <see cref="Xmin"/> back as part of <c>UpdateGameTranslationCommand</c> so EF Core
+/// can detect lost updates.
+/// </remarks>
+public sealed record SharedGameTranslationDetailDto(
+    Guid Id,
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    string Source,
+    DateTimeOffset CreatedAt,
+    Guid? CreatedBy,
+    DateTimeOffset? UpdatedAt,
+    Guid? UpdatedBy,
+    uint Xmin);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application;
+
+/// <summary>
+/// Lightweight DTO for surfacing a single localized translation alongside the canonical
+/// EN copy on <see cref="SharedGameDto"/>. Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <see cref="Source"/> holds the kebab-case persisted form ("manual",
+/// "auto-openrouter", "community") so consumers don't need to take a dependency on the
+/// <c>TranslationSource</c> domain enum. Conversion is centralised in
+/// <c>TranslationSourceMapper</c>.
+/// </remarks>
+public sealed record SharedGameTranslationDto(
+    string Locale,
+    string Title,
+    string? Description,
+    string Source);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs
@@ -168,4 +168,47 @@ public sealed class SharedGameTranslation
     /// finding C4 (avoid reflection trick).
     /// </summary>
     internal void SetXminForConcurrencyCheck(uint xmin) => Xmin = xmin;
+
+    /// <summary>
+    /// Rebuilds an aggregate from already-persisted state. Bypasses
+    /// <see cref="Create"/> validation because the row was validated when it
+    /// was first inserted; the persistence layer just needs to project the
+    /// EF entity back into a domain object without minting a fresh Id or
+    /// stamping a new <see cref="CreatedAt"/>. Intended for repository use
+    /// only — application/handler code MUST go through <see cref="Create"/>.
+    /// </summary>
+    public static SharedGameTranslation Rehydrate(
+        Guid id,
+        Guid sharedGameId,
+        Locale locale,
+        string title,
+        string? description,
+        TranslationSource source,
+        DateTimeOffset createdAt,
+        Guid? createdBy,
+        DateTimeOffset? updatedAt,
+        Guid? updatedBy,
+        bool isDeleted,
+        DateTimeOffset? deletedAt,
+        Guid? deletedBy,
+        uint xmin)
+    {
+        return new SharedGameTranslation
+        {
+            Id = id,
+            SharedGameId = sharedGameId,
+            Locale = locale,
+            Title = title,
+            Description = description,
+            Source = source,
+            CreatedAt = createdAt,
+            CreatedBy = createdBy,
+            UpdatedAt = updatedAt,
+            UpdatedBy = updatedBy,
+            IsDeleted = isDeleted,
+            DeletedAt = deletedAt,
+            DeletedBy = deletedBy,
+            Xmin = xmin
+        };
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs
@@ -1,0 +1,171 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Aggregate root for a single non-EN translation of a shared game's user-facing
+/// strings (title + description). Persisted in <c>shared_game_translations</c>.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// Invariants:
+/// <list type="bullet">
+///   <item>Locale must NOT equal <see cref="Locale.CanonicalEn"/> — EN copy is on shared_games.</item>
+///   <item>Title is required, trimmed, ≤ 500 chars.</item>
+///   <item>Description is optional, trimmed if present.</item>
+///   <item>Updates and deletes are forbidden once <see cref="IsDeleted"/> is true (until <see cref="Restore"/>).</item>
+///   <item>Optimistic concurrency is enforced via PostgreSQL <c>xmin</c>; see DEC-C4 in the plan.</item>
+/// </list>
+/// </remarks>
+public sealed class SharedGameTranslation
+{
+    public Guid Id { get; private set; }
+    public Guid SharedGameId { get; private set; }
+    public Locale Locale { get; private set; }
+    public string Title { get; private set; }
+    public string? Description { get; private set; }
+    public TranslationSource Source { get; private set; }
+
+    public DateTimeOffset CreatedAt { get; private set; }
+    public Guid? CreatedBy { get; private set; }
+    public DateTimeOffset? UpdatedAt { get; private set; }
+    public Guid? UpdatedBy { get; private set; }
+
+    public bool IsDeleted { get; private set; }
+    public DateTimeOffset? DeletedAt { get; private set; }
+    public Guid? DeletedBy { get; private set; }
+
+    /// <summary>
+    /// PostgreSQL <c>xmin</c> system column projected as an optimistic concurrency token.
+    /// Read-only outside the persistence layer; admin write paths call
+    /// <see cref="SetXminForConcurrencyCheck"/> with the client-supplied value before
+    /// saving so EF Core can detect lost updates (ADR-060 / DEC-C4).
+    /// </summary>
+    public uint Xmin { get; private set; }
+
+    private SharedGameTranslation()
+    {
+        // EF / Rehydrate use this constructor; nullability appeasement.
+        Title = null!;
+        Locale = null!;
+    }
+
+    public static SharedGameTranslation Create(
+        Guid sharedGameId,
+        Locale locale,
+        string title,
+        string? description,
+        TranslationSource source,
+        Guid? createdBy,
+        DateTimeOffset now)
+    {
+        if (sharedGameId == Guid.Empty)
+        {
+            throw new ArgumentException("SharedGameId required", nameof(sharedGameId));
+        }
+
+        ArgumentNullException.ThrowIfNull(locale);
+
+        if (locale.Equals(Locale.CanonicalEn))
+        {
+            throw new InvalidLocaleException(
+                "Canonical EN title is stored on shared_games.title — cannot create translation for 'en'");
+        }
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            throw new ArgumentException("Title required", nameof(title));
+        }
+
+        var trimmedTitle = title.Trim();
+        if (trimmedTitle.Length > 500)
+        {
+            throw new ArgumentException("Title max 500 chars", nameof(title));
+        }
+
+        return new SharedGameTranslation
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            Locale = locale,
+            Title = trimmedTitle,
+            Description = description?.Trim(),
+            Source = source,
+            CreatedAt = now,
+            CreatedBy = createdBy,
+            IsDeleted = false
+        };
+    }
+
+    public void UpdateTitle(string newTitle, Guid? updatedBy, DateTimeOffset now)
+    {
+        if (IsDeleted)
+        {
+            throw new InvalidOperationException("Cannot update a soft-deleted translation");
+        }
+
+        if (string.IsNullOrWhiteSpace(newTitle))
+        {
+            throw new ArgumentException("Title required", nameof(newTitle));
+        }
+
+        var trimmed = newTitle.Trim();
+        if (trimmed.Length > 500)
+        {
+            throw new ArgumentException("Title max 500 chars", nameof(newTitle));
+        }
+
+        Title = trimmed;
+        UpdatedAt = now;
+        UpdatedBy = updatedBy;
+    }
+
+    public void UpdateDescription(string? newDescription, Guid? updatedBy, DateTimeOffset now)
+    {
+        if (IsDeleted)
+        {
+            throw new InvalidOperationException("Cannot update a soft-deleted translation");
+        }
+
+        Description = newDescription?.Trim();
+        UpdatedAt = now;
+        UpdatedBy = updatedBy;
+    }
+
+    public void SoftDelete(Guid? deletedBy, DateTimeOffset now)
+    {
+        if (IsDeleted)
+        {
+            return; // idempotent
+        }
+
+        IsDeleted = true;
+        DeletedAt = now;
+        DeletedBy = deletedBy;
+    }
+
+    public void Restore(Guid? restoredBy, DateTimeOffset now)
+    {
+        if (!IsDeleted)
+        {
+            return; // idempotent
+        }
+
+        IsDeleted = false;
+        DeletedAt = null;
+        DeletedBy = null;
+        UpdatedAt = now;
+        UpdatedBy = restoredBy;
+    }
+
+    /// <summary>
+    /// Sets the <c>xmin</c> token received from the client (typically as part of a PUT body)
+    /// for optimistic concurrency checking by EF Core. <c>internal</c> by design: only
+    /// command handlers in this bounded context (and unit tests via
+    /// <c>InternalsVisibleTo("Api.Tests")</c>) should invoke it. Resolves plan review
+    /// finding C4 (avoid reflection trick).
+    /// </summary>
+    internal void SetXminForConcurrencyCheck(uint xmin) => Xmin = xmin;
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/TranslationSource.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/TranslationSource.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Identifies how a <c>shared_game_translations</c> row was produced.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+public enum TranslationSource
+{
+    /// <summary>Default: admin-curated translation.</summary>
+    Manual = 0,
+
+    /// <summary>Auto-generated via OpenRouter translation service.</summary>
+    AutoOpenRouter = 1,
+
+    /// <summary>Community-sourced (future).</summary>
+    Community = 2
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameTranslationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameTranslationRepository.cs
@@ -1,0 +1,78 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+/// <summary>
+/// Repository for the <see cref="SharedGameTranslation"/> aggregate
+/// (issue #2339 — sub-PR 1/3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// All reads honour <c>HasQueryFilter(t =&gt; !t.IsDeleted)</c> — soft-deleted
+/// rows are transparently filtered out. Admin restore paths that need to
+/// fetch a deleted row must compose the query themselves via
+/// <c>DbContext.SharedGameTranslations.IgnoreQueryFilters()</c>.
+/// </para>
+/// <para>
+/// Writes are buffered through EF Core's change tracker; the handler is
+/// expected to call <c>IUnitOfWork.SaveChangesAsync</c> to flush — failure
+/// to do so will leave the translation un-persisted (see ADR-060 §
+/// "Persistence rule").
+/// </para>
+/// <para>
+/// Note: interface lives in <c>Domain/Repositories</c> per project DDD
+/// convention (CLAUDE.md "Repos: Interfaces in Domain, implementation in
+/// Infrastructure"), not <c>Application/Repositories</c> as the original
+/// plan suggested.
+/// </para>
+/// </remarks>
+public interface ISharedGameTranslationRepository
+{
+    /// <summary>Tracks a new translation for insertion on next SaveChanges.</summary>
+    Task AddAsync(SharedGameTranslation translation, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attaches an existing translation and marks it as Modified so the next
+    /// SaveChanges pushes the in-memory state to the row. Includes the
+    /// aggregate's <c>Xmin</c> so EF's concurrency token check fires if the
+    /// row has been touched by another transaction.
+    /// </summary>
+    Task UpdateAsync(SharedGameTranslation translation, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the active translation for <paramref name="gameId"/> and
+    /// <paramref name="locale"/>. Returns <c>null</c> when there is no
+    /// active row (either none exists or it has been soft-deleted).
+    /// </summary>
+    Task<SharedGameTranslation?> GetByGameIdAndLocaleAsync(
+        Guid gameId,
+        string locale,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Loads every active translation for the game.</summary>
+    Task<IReadOnlyList<SharedGameTranslation>> GetByGameIdAsync(
+        Guid gameId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Batched lookup used by <c>GameTitleResolver</c> to enrich the
+    /// catalog/library list endpoints with one round-trip. Result groups
+    /// translations by their parent <see cref="SharedGameTranslation.SharedGameId"/>
+    /// and omits soft-deleted rows.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<SharedGameTranslation>>>
+        GetByGameIdsAsync(
+            IReadOnlyList<Guid> gameIds,
+            CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns <c>true</c> when an active (non-soft-deleted) translation
+    /// already exists for <paramref name="gameId"/>+<paramref name="locale"/>.
+    /// Used by the Add validator to short-circuit before the DB unique
+    /// constraint fires.
+    /// </summary>
+    Task<bool> ExistsActiveAsync(
+        Guid gameId,
+        string locale,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs
@@ -1,0 +1,60 @@
+using System.Text.RegularExpressions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+/// <summary>
+/// Immutable value object representing an ISO 639-1 language code, optionally
+/// with an ISO 3166-1 regional suffix (e.g. <c>"it"</c>, <c>"en-GB"</c>).
+/// Normalized to lower-case language + upper-case region.
+/// Issue #2339 — sub-PR 1/3 Wave 1.
+/// </summary>
+public sealed record Locale
+{
+    private static readonly Regex IsoFormat = new(
+        @"^[a-z]{2}(?:-[A-Z]{2})?$",
+        RegexOptions.Compiled | RegexOptions.ExplicitCapture,
+        TimeSpan.FromSeconds(1));
+
+    public string Value { get; }
+
+    private Locale(string value)
+    {
+        Value = value;
+    }
+
+    public static Locale Create(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new InvalidLocaleException("Locale cannot be empty");
+        }
+
+        var trimmed = raw.Trim();
+        var normalized = trimmed.ToLowerInvariant();
+
+        // Uppercase regional suffix when present: "it-it" -> "it-IT"
+        if (normalized.Length == 5 && normalized[2] == '-')
+        {
+            normalized = string.Concat(
+                normalized.AsSpan(0, 3),
+                normalized.AsSpan(3).ToString().ToUpperInvariant());
+        }
+
+        if (!IsoFormat.IsMatch(normalized))
+        {
+            throw new InvalidLocaleException($"Invalid ISO 639-1 locale: {raw}");
+        }
+
+        return new Locale(normalized);
+    }
+
+    /// <summary>
+    /// Canonical English locale. SharedGame.Title/Description always hold the EN copy;
+    /// a translation row with this locale would be semantically redundant and is rejected
+    /// by the SharedGameTranslation aggregate factory.
+    /// </summary>
+    public static readonly Locale CanonicalEn = new("en");
+
+    public override string ToString() => Value;
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -63,6 +63,7 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<IUserBadgeRepository, UserBadgeRepository>(); // Issue #2731: User badge awards
         services.AddScoped<IContributorRepository, ContributorRepository>(); // Issue #2735: Contributor stats endpoints
         services.AddScoped<IGameAnalyticsEventRepository, GameAnalyticsEventRepository>(); // Issue #3918: Trending analytics
+        services.AddScoped<ISharedGameTranslationRepository, SharedGameTranslationRepository>(); // Issue #2339: Shared game non-EN translations
 
         // Register domain services
         services.AddScoped<DocumentVersioningService>(); // Issue #2391 Sprint 1

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -64,6 +64,7 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<IContributorRepository, ContributorRepository>(); // Issue #2735: Contributor stats endpoints
         services.AddScoped<IGameAnalyticsEventRepository, GameAnalyticsEventRepository>(); // Issue #3918: Trending analytics
         services.AddScoped<ISharedGameTranslationRepository, SharedGameTranslationRepository>(); // Issue #2339: Shared game non-EN translations
+        services.AddScoped<IGameTitleResolver, GameTitleResolver>(); // Issue #2339: Batch translation enricher for list queries
 
         // Register domain services
         services.AddScoped<DocumentVersioningService>(); // Issue #2391 Sprint 1

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameTranslationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameTranslationRepository.cs
@@ -1,0 +1,171 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="ISharedGameTranslationRepository"/>.
+/// Issue #2339 — sub-PR 1/3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Maps between the domain aggregate <see cref="SharedGameTranslation"/>
+/// and the EF entity <see cref="SharedGameTranslationEntity"/>. Reads use
+/// <c>AsNoTracking()</c> for performance; the global query filter
+/// (<c>WHERE NOT is_deleted</c>) is honoured automatically.
+/// </para>
+/// <para>
+/// Writes go through the change tracker — handlers are responsible for
+/// calling <c>SaveChangesAsync()</c> via the unit-of-work (ADR-060).
+/// </para>
+/// </remarks>
+internal sealed class SharedGameTranslationRepository : ISharedGameTranslationRepository
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public SharedGameTranslationRepository(MeepleAiDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(
+        SharedGameTranslation translation, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(translation);
+        var entity = ToEntity(translation);
+        await _dbContext.SharedGameTranslations
+            .AddAsync(entity, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(
+        SharedGameTranslation translation, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(translation);
+
+        // Translate the detached aggregate into a fresh entity instance,
+        // then attach + mark Modified so EF projects the new state without
+        // having to fetch the existing row again. The Xmin token participates
+        // in the concurrency check via IsConcurrencyToken on the column.
+        var entity = ToEntity(translation);
+        _dbContext.SharedGameTranslations.Attach(entity);
+        _dbContext.Entry(entity).State = EntityState.Modified;
+        return Task.CompletedTask;
+    }
+
+    public async Task<SharedGameTranslation?> GetByGameIdAndLocaleAsync(
+        Guid gameId, string locale, CancellationToken cancellationToken = default)
+    {
+        if (gameId == Guid.Empty || string.IsNullOrWhiteSpace(locale))
+        {
+            return null;
+        }
+
+        var entity = await _dbContext.SharedGameTranslations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                t => t.SharedGameId == gameId && t.Locale == locale, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : FromEntity(entity);
+    }
+
+    public async Task<IReadOnlyList<SharedGameTranslation>> GetByGameIdAsync(
+        Guid gameId, CancellationToken cancellationToken = default)
+    {
+        if (gameId == Guid.Empty)
+        {
+            return Array.Empty<SharedGameTranslation>();
+        }
+
+        var entities = await _dbContext.SharedGameTranslations
+            .AsNoTracking()
+            .Where(t => t.SharedGameId == gameId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.Select(FromEntity).ToList();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<SharedGameTranslation>>>
+        GetByGameIdsAsync(
+            IReadOnlyList<Guid> gameIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gameIds);
+
+        if (gameIds.Count == 0)
+        {
+            return new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>();
+        }
+
+        var idsSet = gameIds.ToHashSet();
+        var entities = await _dbContext.SharedGameTranslations
+            .AsNoTracking()
+            .Where(t => idsSet.Contains(t.SharedGameId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities
+            .GroupBy(t => t.SharedGameId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<SharedGameTranslation>)g
+                    .Select(FromEntity)
+                    .ToList());
+    }
+
+    public Task<bool> ExistsActiveAsync(
+        Guid gameId, string locale, CancellationToken cancellationToken = default)
+    {
+        if (gameId == Guid.Empty || string.IsNullOrWhiteSpace(locale))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _dbContext.SharedGameTranslations
+            .AsNoTracking()
+            .AnyAsync(
+                t => t.SharedGameId == gameId && t.Locale == locale, cancellationToken);
+    }
+
+    private static SharedGameTranslationEntity ToEntity(SharedGameTranslation t) => new()
+    {
+        Id = t.Id,
+        SharedGameId = t.SharedGameId,
+        Locale = t.Locale.Value,
+        Title = t.Title,
+        Description = t.Description,
+        Source = TranslationSourceMapper.ToPersistedString(t.Source),
+        CreatedAt = t.CreatedAt,
+        CreatedBy = t.CreatedBy,
+        UpdatedAt = t.UpdatedAt,
+        UpdatedBy = t.UpdatedBy,
+        IsDeleted = t.IsDeleted,
+        DeletedAt = t.DeletedAt,
+        DeletedBy = t.DeletedBy,
+        Xmin = t.Xmin
+    };
+
+    private static SharedGameTranslation FromEntity(SharedGameTranslationEntity e) =>
+        SharedGameTranslation.Rehydrate(
+            e.Id,
+            e.SharedGameId,
+            Locale.Create(e.Locale),
+            e.Title,
+            e.Description,
+            TranslationSourceMapper.FromPersistedString(e.Source),
+            e.CreatedAt,
+            e.CreatedBy,
+            e.UpdatedAt,
+            e.UpdatedBy,
+            e.IsDeleted,
+            e.DeletedAt,
+            e.DeletedBy,
+            e.Xmin);
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameTranslationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameTranslationEntity.cs
@@ -1,0 +1,69 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// EF Core entity for the <c>shared_game_translations</c> table.
+/// Persistence model for the
+/// <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Entities.SharedGameTranslation"/>
+/// aggregate (issue #2339 — sub-PR 1/3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The canonical EN copy of a game is stored on <c>shared_games.title</c>/<c>description</c>.
+/// This table only holds non-EN translations. A partial unique index
+/// <c>uq_active_translation_per_locale</c> enforces "at most one active row
+/// per (shared_game_id, locale)" via <c>WHERE NOT is_deleted</c>, allowing
+/// re-creation after soft delete.
+/// </para>
+/// <para>
+/// Optimistic concurrency uses PostgreSQL's <c>xmin</c> system column
+/// (ADR-060 pattern). EF projects it as a <see cref="uint"/> concurrency token.
+/// </para>
+/// </remarks>
+public class SharedGameTranslationEntity
+{
+    public Guid Id { get; set; }
+
+    public Guid SharedGameId { get; set; }
+
+    public string Locale { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Source identifier persisted as a lower-case string
+    /// (<c>"manual"</c> | <c>"auto-openrouter"</c> | <c>"community"</c>).
+    /// Repository mappers round-trip it against
+    /// <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Enums.TranslationSource"/>.
+    /// </summary>
+    public string Source { get; set; } = "manual";
+
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public Guid? CreatedBy { get; set; }
+
+    public DateTimeOffset? UpdatedAt { get; set; }
+
+    public Guid? UpdatedBy { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public DateTimeOffset? DeletedAt { get; set; }
+
+    public Guid? DeletedBy { get; set; }
+
+    /// <summary>
+    /// PostgreSQL <c>xmin</c> system column (ADR-060). Projected by EF Core
+    /// as a concurrency token; updated by Postgres on every write, so client
+    /// writes carrying a stale value trigger <c>DbUpdateConcurrencyException</c>.
+    /// </summary>
+    public uint Xmin { get; set; }
+
+    /// <summary>
+    /// Optional navigation back to the parent <see cref="SharedGameEntity"/>.
+    /// Kept to make ad-hoc admin queries ergonomic; the aggregate does not
+    /// depend on it.
+    /// </summary>
+    public SharedGameEntity? SharedGame { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs
@@ -1,0 +1,130 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.SharedGameCatalog;
+
+/// <summary>
+/// EF Core configuration for <see cref="SharedGameTranslationEntity"/>.
+/// Backs the BE foundation of the shared-game translations feature
+/// (issue #2339 — sub-PR 1/3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Indexing strategy: a single partial unique index
+/// <c>uq_active_translation_per_locale</c> enforces "at most one active row
+/// per (shared_game_id, locale)" via <c>WHERE NOT is_deleted</c>. Three
+/// additional partial lookup indices cover the resolver, admin filters and
+/// reporting paths without indexing soft-deleted rows.
+/// </para>
+/// <para>
+/// Concurrency: <c>xmin</c> is wired as a Postgres <c>xid</c> column with
+/// <c>ValueGeneratedOnAddOrUpdate</c> and <c>IsConcurrencyToken</c> per
+/// ADR-060.
+/// </para>
+/// </remarks>
+internal class SharedGameTranslationEntityConfiguration
+    : IEntityTypeConfiguration<SharedGameTranslationEntity>
+{
+#pragma warning disable MA0051 // Method is too long — EF fluent configuration is necessarily verbose.
+    public void Configure(EntityTypeBuilder<SharedGameTranslationEntity> builder)
+#pragma warning restore MA0051
+    {
+        builder.ToTable("shared_game_translations");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Id)
+            .HasColumnName("id");
+
+        builder.Property(t => t.SharedGameId)
+            .HasColumnName("shared_game_id")
+            .IsRequired();
+
+        builder.Property(t => t.Locale)
+            .HasColumnName("locale")
+            .HasMaxLength(10)
+            .IsRequired();
+
+        builder.Property(t => t.Title)
+            .HasColumnName("title")
+            .HasMaxLength(500)
+            .IsRequired();
+
+        builder.Property(t => t.Description)
+            .HasColumnName("description")
+            .HasColumnType("text");
+
+        builder.Property(t => t.Source)
+            .HasColumnName("source")
+            .HasMaxLength(32)
+            .HasDefaultValue("manual")
+            .IsRequired();
+
+        builder.Property(t => t.CreatedAt)
+            .HasColumnName("created_at")
+            .HasDefaultValueSql("now()")
+            .IsRequired();
+
+        builder.Property(t => t.CreatedBy)
+            .HasColumnName("created_by");
+
+        builder.Property(t => t.UpdatedAt)
+            .HasColumnName("updated_at");
+
+        builder.Property(t => t.UpdatedBy)
+            .HasColumnName("updated_by");
+
+        builder.Property(t => t.IsDeleted)
+            .HasColumnName("is_deleted")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        builder.Property(t => t.DeletedAt)
+            .HasColumnName("deleted_at");
+
+        builder.Property(t => t.DeletedBy)
+            .HasColumnName("deleted_by");
+
+        // ADR-060 — Postgres xmin system column as concurrency token.
+        builder.Property(t => t.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
+        // Partial unique index — only active rows participate in the constraint,
+        // so soft-deletes do not block recreation of a (game, locale) pair.
+        builder.HasIndex(t => new { t.SharedGameId, t.Locale })
+            .HasFilter("NOT is_deleted")
+            .IsUnique()
+            .HasDatabaseName("uq_active_translation_per_locale");
+
+        // Resolver path (per-game lookup) — soft-deleted rows excluded.
+        builder.HasIndex(t => t.SharedGameId)
+            .HasFilter("NOT is_deleted")
+            .HasDatabaseName("ix_translations_shared_game_id");
+
+        // Admin filter by locale (e.g. "show all IT translations").
+        builder.HasIndex(t => t.Locale)
+            .HasFilter("NOT is_deleted")
+            .HasDatabaseName("ix_translations_locale");
+
+        // Reporting by source (auto-openrouter vs manual etc.).
+        builder.HasIndex(t => t.Source)
+            .HasFilter("NOT is_deleted")
+            .HasDatabaseName("ix_translations_source");
+
+        // Cascading FK back to the parent shared_games row. SharedGame
+        // intentionally exposes no Translations navigation — translations are
+        // a separate aggregate fetched through the resolver/repository.
+        builder.HasOne(t => t.SharedGame)
+            .WithMany()
+            .HasForeignKey(t => t.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Hide soft-deleted rows by default. Admin write paths must opt out
+        // via IgnoreQueryFilters() when they need to restore a deleted row.
+        builder.HasQueryFilter(t => !t.IsDeleted);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -185,6 +185,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<WaitlistEntryEntity> WaitlistEntries => Set<WaitlistEntryEntity>(); // ISSUE-589: Public Alpha waitlist (Wave A.2)
     public DbSet<NotificationEntity> Notifications => Set<NotificationEntity>(); // ISSUE-2053: User notifications
     public DbSet<SharedGameEntity> SharedGames => Set<SharedGameEntity>(); // ISSUE-2370: Shared game catalog
+    public DbSet<SharedGameTranslationEntity> SharedGameTranslations => Set<SharedGameTranslationEntity>(); // ISSUE-2339: Shared game translations (non-EN)
     public DbSet<GameDesignerEntity> GameDesigners => Set<GameDesignerEntity>(); // ISSUE-2370: Game designers
     public DbSet<GamePublisherEntity> GamePublishers => Set<GamePublisherEntity>(); // ISSUE-2370: Game publishers
     public DbSet<GameCategoryEntity> GameCategories => Set<GameCategoryEntity>(); // ISSUE-2370: Game categories taxonomy

--- a/apps/api/src/Api/Infrastructure/Migrations/20260615050340_AddSharedGameTranslations.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260615050340_AddSharedGameTranslations.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615050340_AddSharedGameTranslations")]
+    partial class AddSharedGameTranslations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260615050340_AddSharedGameTranslations.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260615050340_AddSharedGameTranslations.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSharedGameTranslations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "shared_game_translations",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    shared_game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    locale = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    description = table.Column<string>(type: "text", nullable: true),
+                    source = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "manual"),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    created_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    updated_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<Guid>(type: "uuid", nullable: true),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_shared_game_translations", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_shared_game_translations_shared_games_shared_game_id",
+                        column: x => x.shared_game_id,
+                        principalTable: "shared_games",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_translations_locale",
+                table: "shared_game_translations",
+                column: "locale",
+                filter: "NOT is_deleted");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_translations_shared_game_id",
+                table: "shared_game_translations",
+                column: "shared_game_id",
+                filter: "NOT is_deleted");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_translations_source",
+                table: "shared_game_translations",
+                column: "source",
+                filter: "NOT is_deleted");
+
+            migrationBuilder.CreateIndex(
+                name: "uq_active_translation_per_locale",
+                table: "shared_game_translations",
+                columns: new[] { "shared_game_id", "locale" },
+                unique: true,
+                filter: "NOT is_deleted");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "shared_game_translations");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandlerTests.cs
@@ -1,0 +1,154 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="AddGameTranslationCommandHandler"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 3 (Task 9).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class AddGameTranslationCommandHandlerTests
+{
+    private static readonly DateTimeOffset SampleNow =
+        new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
+    private readonly Mock<ISharedGameRepository> _gameRepo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly TimeProvider _clock;
+    private readonly AddGameTranslationCommandHandler _sut;
+
+    public AddGameTranslationCommandHandlerTests()
+    {
+        _clock = new FakeTimeProvider(SampleNow);
+        _sut = new AddGameTranslationCommandHandler(
+            _translationRepo.Object, _gameRepo.Object, _uow.Object, _clock);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PersistsAndReturnsId()
+    {
+        var gameId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        // Game exists — handler proceeds to the aggregate factory + persistence path.
+        _gameRepo
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeStubGame(gameId));
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "I Coloni di Catan",
+            Description: "Descrizione",
+            Source: "manual",
+            ActorUserId: actor);
+
+        var id = await _sut.Handle(cmd, CancellationToken.None);
+
+        id.Should().NotBe(Guid.Empty);
+        _translationRepo.Verify(
+            r => r.AddAsync(It.IsAny<SharedGameTranslation>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GameNotFound_ThrowsNotFoundException()
+    {
+        var gameId = Guid.NewGuid();
+        _gameRepo
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _translationRepo.Verify(
+            r => r.AddAsync(It.IsAny<SharedGameTranslation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DbThrowsUniqueConstraint_RethrowsAsTranslationAlreadyExists()
+    {
+        var gameId = Guid.NewGuid();
+        _gameRepo
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeStubGame(gameId));
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateException(
+                "duplicate key value violates unique constraint \"uq_active_translation_per_locale\"",
+                innerException: (Exception?)null));
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<TranslationAlreadyExistsException>();
+        thrown.Which.Locale.Should().Be("it");
+        thrown.Which.GameId.Should().Be(gameId);
+    }
+
+    /// <summary>
+    /// Minimal SharedGame stub for "game exists" branch. We don't care about its content
+    /// — only that the handler treats a non-null result as "proceed". Uses the internal
+    /// rehydration ctor (visible to Api.Tests via InternalsVisibleTo).
+    /// </summary>
+    private static SharedGame MakeStubGame(Guid id) =>
+        new(
+            id: id,
+            title: $"stub-{id:N}",
+            yearPublished: 2020,
+            description: string.Empty,
+            minPlayers: 2,
+            maxPlayers: 4,
+            playingTimeMinutes: 60,
+            minAge: 8,
+            complexityRating: null,
+            averageRating: null,
+            imageUrl: string.Empty,
+            thumbnailUrl: string.Empty,
+            rules: null,
+            status: Api.BoundedContexts.SharedGameCatalog.Domain.Entities.GameStatus.Published,
+            createdBy: Guid.NewGuid(),
+            modifiedBy: null,
+            createdAt: DateTime.UtcNow,
+            modifiedAt: null,
+            isDeleted: false);
+
+    /// <summary>Deterministic clock matching .NET 8+ TimeProvider abstraction.</summary>
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset now) { _now = now; }
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidatorTests.cs
@@ -1,0 +1,143 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="AddGameTranslationCommandValidator"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 3 (Task 9).
+/// </summary>
+/// <remarks>
+/// Per DEC-C2 (plan 2026-06-15) the game-existence check lives in the handler,
+/// not the validator. The validator only checks input shape + the duplicate-locale
+/// short-circuit. Game-not-found is therefore tested in
+/// <c>AddGameTranslationCommandHandlerTests</c>.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class AddGameTranslationCommandValidatorTests
+{
+    private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
+    private readonly AddGameTranslationCommandValidator _sut;
+
+    public AddGameTranslationCommandValidatorTests()
+    {
+        // Default: no duplicate active translation for any (gameId, locale) pair.
+        _translationRepo
+            .Setup(r => r.ExistsActiveAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _sut = new AddGameTranslationCommandValidator(_translationRepo.Object);
+    }
+
+    [Fact]
+    public async Task Valid_NoErrors()
+    {
+        var cmd = new AddGameTranslationCommand(
+            GameId: Guid.NewGuid(),
+            Locale: "it",
+            Title: "I Coloni di Catan",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var result = await _sut.TestValidateAsync(cmd);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task InvalidLocale_FailsLocaleRule()
+    {
+        var cmd = new AddGameTranslationCommand(
+            GameId: Guid.NewGuid(),
+            Locale: "english", // invalid ISO 639-1
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var result = await _sut.TestValidateAsync(cmd);
+
+        result.ShouldHaveValidationErrorFor(c => c.Locale);
+    }
+
+    [Fact]
+    public async Task EmptyTitle_FailsTitleRule()
+    {
+        var cmd = new AddGameTranslationCommand(
+            GameId: Guid.NewGuid(),
+            Locale: "it",
+            Title: "",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var result = await _sut.TestValidateAsync(cmd);
+
+        result.ShouldHaveValidationErrorFor(c => c.Title);
+    }
+
+    [Fact]
+    public async Task InvalidSource_FailsSourceRule()
+    {
+        var cmd = new AddGameTranslationCommand(
+            GameId: Guid.NewGuid(),
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "facebook", // not in {manual, auto-openrouter, community}
+            ActorUserId: Guid.NewGuid());
+
+        var result = await _sut.TestValidateAsync(cmd);
+
+        result.ShouldHaveValidationErrorFor(c => c.Source);
+    }
+
+    [Fact]
+    public async Task DuplicateActiveLocale_FailsLocaleRule()
+    {
+        // Repo reports an existing active translation for ("...", "it")
+        var gameId = Guid.NewGuid();
+        _translationRepo
+            .Setup(r => r.ExistsActiveAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var result = await _sut.TestValidateAsync(cmd);
+
+        // FluentValidation's WithErrorMessage does a literal match — use a substring check
+        // via the underlying Errors collection instead so we don't couple the test to the
+        // exact phrasing.
+        var localeErrors = result.ShouldHaveValidationErrorFor(c => c.Locale);
+        localeErrors.Should().Contain(err => err.ErrorMessage.Contains("already exists", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task EmptyGameId_FailsGameIdRule()
+    {
+        var cmd = new AddGameTranslationCommand(
+            GameId: Guid.Empty,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var result = await _sut.TestValidateAsync(cmd);
+
+        result.ShouldHaveValidationErrorFor(c => c.GameId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandlerTests.cs
@@ -1,0 +1,136 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="DeleteGameTranslationCommandHandler"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 4 (Task 11).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class DeleteGameTranslationCommandHandlerTests
+{
+    private static readonly DateTimeOffset SampleNow =
+        new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly TimeProvider _clock;
+    private readonly DeleteGameTranslationCommandHandler _sut;
+
+    public DeleteGameTranslationCommandHandlerTests()
+    {
+        _clock = new FakeTimeProvider(SampleNow);
+        _sut = new DeleteGameTranslationCommandHandler(
+            _translationRepo.Object, _uow.Object, _clock);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_SoftDeletesAndSaves()
+    {
+        var gameId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "I Coloni di Catan");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var cmd = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Xmin: 9876u,
+            ActorUserId: actor);
+
+        var result = await _sut.Handle(cmd, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+        existing.IsDeleted.Should().BeTrue();
+        existing.DeletedAt.Should().Be(SampleNow);
+        existing.DeletedBy.Should().Be(actor);
+        existing.Xmin.Should().Be(9876u);
+        _translationRepo.Verify(
+            r => r.UpdateAsync(existing, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TranslationNotFound_ThrowsTranslationNotFoundException()
+    {
+        var gameId = Guid.NewGuid();
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGameTranslation?)null);
+
+        var cmd = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<TranslationNotFoundException>();
+        thrown.Which.GameId.Should().Be(gameId);
+        thrown.Which.Locale.Should().Be("it");
+        _translationRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<SharedGameTranslation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentEdit_DbUpdateConcurrencyExceptionBubbles()
+    {
+        var gameId = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "title");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException(
+                "Database operation expected to affect 1 row(s) but actually affected 0 row(s)."));
+
+        var cmd = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    private static SharedGameTranslation MakeActiveTranslation(
+        Guid gameId, string localeCode, string title) =>
+        SharedGameTranslation.Create(
+            sharedGameId: gameId,
+            locale: Locale.Create(localeCode),
+            title: title,
+            description: null,
+            source: TranslationSource.Manual,
+            createdBy: Guid.NewGuid(),
+            now: SampleNow.AddDays(-1));
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset now) { _now = now; }
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandValidatorTests.cs
@@ -1,0 +1,64 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="DeleteGameTranslationCommandValidator"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 4 (Task 11).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class DeleteGameTranslationCommandValidatorTests
+{
+    private readonly DeleteGameTranslationCommandValidator _sut = new();
+
+    private static DeleteGameTranslationCommand ValidCommand() => new(
+        GameId: Guid.NewGuid(),
+        Locale: "it",
+        Xmin: 12345u,
+        ActorUserId: Guid.NewGuid());
+
+    [Fact]
+    public async Task Valid_NoErrors()
+    {
+        var result = await _sut.TestValidateAsync(ValidCommand());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task EmptyGameId_400()
+    {
+        var cmd = ValidCommand() with { GameId = Guid.Empty };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.GameId);
+    }
+
+    [Fact]
+    public async Task EmptyActorUserId_400()
+    {
+        var cmd = ValidCommand() with { ActorUserId = Guid.Empty };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.ActorUserId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("english")]
+    [InlineData("xx-yy-zz")]
+    public async Task InvalidLocale_400(string locale)
+    {
+        var cmd = ValidCommand() with { Locale = locale };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Locale);
+    }
+
+    [Fact]
+    public async Task XminZero_400()
+    {
+        var cmd = ValidCommand() with { Xmin = 0u };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Xmin);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandlerTests.cs
@@ -1,0 +1,172 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateGameTranslationCommandHandler"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 3 (Task 10).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class UpdateGameTranslationCommandHandlerTests
+{
+    private static readonly DateTimeOffset SampleNow =
+        new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly TimeProvider _clock;
+    private readonly UpdateGameTranslationCommandHandler _sut;
+
+    public UpdateGameTranslationCommandHandlerTests()
+    {
+        _clock = new FakeTimeProvider(SampleNow);
+        _sut = new UpdateGameTranslationCommandHandler(
+            _translationRepo.Object, _uow.Object, _clock);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_MutatesAndSaves()
+    {
+        var gameId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "Vecchio titolo");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Nuovo titolo",
+            Description: "Nuova descrizione",
+            Xmin: 9876u,
+            ActorUserId: actor);
+
+        var result = await _sut.Handle(cmd, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+        existing.Title.Should().Be("Nuovo titolo");
+        existing.Description.Should().Be("Nuova descrizione");
+        existing.UpdatedAt.Should().Be(SampleNow);
+        existing.UpdatedBy.Should().Be(actor);
+        existing.Xmin.Should().Be(9876u);
+        _translationRepo.Verify(
+            r => r.UpdateAsync(existing, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TranslationNotFound_ThrowsTranslationNotFoundException()
+    {
+        var gameId = Guid.NewGuid();
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGameTranslation?)null);
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<TranslationNotFoundException>();
+        thrown.Which.GameId.Should().Be(gameId);
+        thrown.Which.Locale.Should().Be("it");
+        _translationRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<SharedGameTranslation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentEdit_DbUpdateConcurrencyExceptionBubbles()
+    {
+        var gameId = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "title");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException(
+                "Database operation expected to affect 1 row(s) but actually affected 0 row(s)."));
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "stale title",
+            Description: null,
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    [Fact]
+    public async Task Handle_SoftDeletedTranslation_DomainGuardThrows()
+    {
+        var gameId = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "title");
+        existing.SoftDelete(deletedBy: null, now: SampleNow.AddHours(-1));
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "anything",
+            Description: null,
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+
+        // SharedGameTranslation.UpdateTitle enforces the not-deleted invariant.
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _translationRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<SharedGameTranslation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static SharedGameTranslation MakeActiveTranslation(
+        Guid gameId, string localeCode, string title) =>
+        SharedGameTranslation.Create(
+            sharedGameId: gameId,
+            locale: Locale.Create(localeCode),
+            title: title,
+            description: null,
+            source: TranslationSource.Manual,
+            createdBy: Guid.NewGuid(),
+            now: SampleNow.AddDays(-1));
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset now) { _now = now; }
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandValidatorTests.cs
@@ -1,0 +1,82 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateGameTranslationCommandValidator"/>.
+/// Issue #2339 — sub-PR 1/3 Wave 3 (Task 10).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class UpdateGameTranslationCommandValidatorTests
+{
+    private readonly UpdateGameTranslationCommandValidator _sut = new();
+
+    private static UpdateGameTranslationCommand ValidCommand() => new(
+        GameId: Guid.NewGuid(),
+        Locale: "it",
+        Title: "I Coloni di Catan",
+        Description: "Descrizione aggiornata",
+        Xmin: 12345u,
+        ActorUserId: Guid.NewGuid());
+
+    [Fact]
+    public async Task Valid_NoErrors()
+    {
+        var result = await _sut.TestValidateAsync(ValidCommand());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task EmptyGameId_400()
+    {
+        var cmd = ValidCommand() with { GameId = Guid.Empty };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.GameId);
+    }
+
+    [Fact]
+    public async Task EmptyActorUserId_400()
+    {
+        var cmd = ValidCommand() with { ActorUserId = Guid.Empty };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.ActorUserId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("english")]
+    [InlineData("xx-yy-zz")]
+    public async Task InvalidLocale_400(string locale)
+    {
+        var cmd = ValidCommand() with { Locale = locale };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Locale);
+    }
+
+    [Fact]
+    public async Task EmptyTitle_400()
+    {
+        var cmd = ValidCommand() with { Title = "" };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Title);
+    }
+
+    [Fact]
+    public async Task TitleTooLong_400()
+    {
+        var cmd = ValidCommand() with { Title = new string('x', 501) };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Title);
+    }
+
+    [Fact]
+    public async Task XminZero_400()
+    {
+        var cmd = ValidCommand() with { Xmin = 0u };
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Xmin);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_FilterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_FilterTests.cs
@@ -2,7 +2,9 @@ using Api.BoundedContexts.GameToolkit.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
@@ -38,6 +40,21 @@ public sealed class SearchSharedGamesQuery_FilterTests
 
     private readonly Mock<ILogger<SearchSharedGamesQueryHandler>> _logger = new();
     private readonly Mock<IBlobStorageService> _blobStorageMock = new();
+    // Issue #2339 (Wave 4 Task 13): identity-passthrough mock — these tests do not
+    // assert translation enrichment, so EnrichAsync just returns the input list as-is
+    // with Translations=null (matching pre-#2339 behavior for SharedGameDto consumers).
+    private readonly Mock<IGameTitleResolver> _titleResolverMock = CreateIdentityResolverMock();
+
+    private static Mock<IGameTitleResolver> CreateIdentityResolverMock()
+    {
+        var mock = new Mock<IGameTitleResolver>();
+        mock.Setup(r => r.EnrichAsync(
+                It.IsAny<IReadOnlyList<SharedGameDto>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IReadOnlyList<SharedGameDto>, CancellationToken>(
+                (games, _) => Task.FromResult<IReadOnlyList<SharedGameDto>>(games));
+        return mock;
+    }
 
     // ---------------------------------------------------------------
     // Seed helpers
@@ -176,7 +193,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.Toolkits.Add(CreateNonDefaultToolkit(game.Id));
 
         await db.SaveChangesAsync();
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         // Act
         var result = await handler.Handle(BuildQuery(hasToolkit: true), CancellationToken.None);
@@ -200,7 +217,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.Toolkits.Add(CreateDefaultToolkit(game.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasToolkit: true), CancellationToken.None);
 
@@ -220,7 +237,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.Toolkits.Add(CreateNonDefaultToolkit(game.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasToolkit: true), CancellationToken.None);
 
@@ -239,7 +256,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.Toolkits.Add(CreateNonDefaultToolkit(game.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasToolkit: false), CancellationToken.None);
 
@@ -256,7 +273,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
             CreateSharedGame("Game B"));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasToolkit: null), CancellationToken.None);
 
@@ -279,7 +296,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.AgentDefinitions.Add(CreateAgentForGame(game.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasAgent: true), CancellationToken.None);
 
@@ -298,7 +315,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.AgentDefinitions.Add(CreateAgentForGame(game.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasAgent: true), CancellationToken.None);
 
@@ -317,7 +334,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
         db.AgentDefinitions.Add(CreateAgentForGame(game.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(hasAgent: false), CancellationToken.None);
 
@@ -343,7 +360,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
             CreateSharedGame("Unrated", averageRating: null));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(isTopRated: true), CancellationToken.None);
 
@@ -362,7 +379,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
             CreateSharedGame("Unrated", averageRating: null));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(isTopRated: false), CancellationToken.None);
 
@@ -383,7 +400,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
             CreateSharedGame("Low", averageRating: 3.9m));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(topRatedThreshold: 4.5m), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(topRatedThreshold: 4.5m), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(isTopRated: true), CancellationToken.None);
 
@@ -400,7 +417,7 @@ public sealed class SearchSharedGamesQuery_FilterTests
             CreateSharedGame("Unrated", averageRating: null));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         var result = await handler.Handle(BuildQuery(isTopRated: null), CancellationToken.None);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/SearchSharedGamesQuery_KbFilterTests.cs
@@ -1,4 +1,6 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Services.Pdf;
@@ -26,6 +28,21 @@ public sealed class SearchSharedGamesQuery_KbFilterTests
 {
     private readonly Mock<ILogger<SearchSharedGamesQueryHandler>> _logger = new();
     private readonly Mock<IBlobStorageService> _blobStorageMock = new();
+    // Issue #2339 (Wave 4 Task 13): identity-passthrough mock — these tests do not
+    // assert translation enrichment, so EnrichAsync just returns the input list as-is
+    // with Translations=null (matching pre-#2339 behavior for SharedGameDto consumers).
+    private readonly Mock<IGameTitleResolver> _titleResolverMock = CreateIdentityResolverMock();
+
+    private static Mock<IGameTitleResolver> CreateIdentityResolverMock()
+    {
+        var mock = new Mock<IGameTitleResolver>();
+        mock.Setup(r => r.EnrichAsync(
+                It.IsAny<IReadOnlyList<SharedGameDto>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IReadOnlyList<SharedGameDto>, CancellationToken>(
+                (games, _) => Task.FromResult<IReadOnlyList<SharedGameDto>>(games));
+        return mock;
+    }
 
     private static SharedGameEntity CreateGame(string title, bool hasKb) => new()
     {
@@ -89,7 +106,7 @@ public sealed class SearchSharedGamesQuery_KbFilterTests
             CreateGame("Without KB", hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         // Act
         var result = await handler.Handle(BuildQuery(hasKnowledgeBase: null), CancellationToken.None);
@@ -109,7 +126,7 @@ public sealed class SearchSharedGamesQuery_KbFilterTests
             CreateGame("Monopoly", hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         // Act
         var result = await handler.Handle(BuildQuery(hasKnowledgeBase: true), CancellationToken.None);
@@ -131,7 +148,7 @@ public sealed class SearchSharedGamesQuery_KbFilterTests
             CreateGame("Risk", hasKb: false));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         // Act
         var result = await handler.Handle(BuildQuery(hasKnowledgeBase: false), CancellationToken.None);
@@ -149,7 +166,7 @@ public sealed class SearchSharedGamesQuery_KbFilterTests
         db.SharedGames.Add(CreateGame("Azul", hasKb: true));
         await db.SaveChangesAsync();
 
-        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object);
+        var handler = new SearchSharedGamesQueryHandler(db, _blobStorageMock.Object, CreateHybridCache(), CreateConfiguration(), _logger.Object, _titleResolverMock.Object);
 
         // Act
         var result = await handler.Handle(BuildQuery(hasKnowledgeBase: null), CancellationToken.None);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolverTests.cs
@@ -1,0 +1,148 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities; // SharedGameTranslation + GameStatus
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="GameTitleResolver"/> — the batch enricher that joins
+/// non-EN translations onto <see cref="SharedGameDto"/> list-query results.
+/// Issue #2339 — sub-PR 1/3 Wave 3 (Task 8).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GameTitleResolverTests
+{
+    private static readonly DateTimeOffset SampleNow = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<ISharedGameTranslationRepository> _repo = new();
+    private readonly GameTitleResolver _sut;
+
+    public GameTitleResolverTests()
+    {
+        _sut = new GameTitleResolver(_repo.Object);
+    }
+
+    [Fact]
+    public async Task EnrichAsync_EmptyInput_ReturnsEmpty_NoRepoCall()
+    {
+        // Arrange: zero games in input
+        var input = Array.Empty<SharedGameDto>();
+
+        // Act
+        var result = await _sut.EnrichAsync(input, CancellationToken.None);
+
+        // Assert: empty result + no batch fetch fired
+        result.Should().BeEmpty();
+        _repo.Verify(
+            r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnrichAsync_BatchFetchesSingleSqlCall()
+    {
+        // Arrange: two games, repo returns no translations
+        var g1 = MakeGame("Catan");
+        var g2 = MakeGame("Wingspan");
+        _repo
+            .Setup(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>());
+
+        // Act
+        await _sut.EnrichAsync(new[] { g1, g2 }, CancellationToken.None);
+
+        // Assert: one batched call with both ids (no N+1)
+        _repo.Verify(
+            r => r.GetByGameIdsAsync(
+                It.Is<IReadOnlyList<Guid>>(ids =>
+                    ids.Count == 2 && ids.Contains(g1.Id) && ids.Contains(g2.Id)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnrichAsync_NoTranslations_DtoTranslationsEmpty()
+    {
+        // Arrange: one game, repo returns empty dictionary
+        var g = MakeGame("Catan");
+        _repo
+            .Setup(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>());
+
+        // Act
+        var result = await _sut.EnrichAsync(new[] { g }, CancellationToken.None);
+
+        // Assert: dto.Translations is a non-null empty list (FE consumers iterate)
+        result.Should().HaveCount(1);
+        result[0].Translations.Should().NotBeNull();
+        result[0].Translations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnrichAsync_MapsTranslationsByGameId()
+    {
+        // Arrange: two games, mixed locales
+        var g1 = MakeGame("Catan");
+        var g2 = MakeGame("Wingspan");
+
+        var t1Italian = SharedGameTranslation.Create(
+            g1.Id, Locale.Create("it"), "I Coloni di Catan", null, TranslationSource.Manual, null, SampleNow);
+        var t1French = SharedGameTranslation.Create(
+            g1.Id, Locale.Create("fr"), "Les Colons de Catane", null, TranslationSource.Manual, null, SampleNow);
+        var t2Italian = SharedGameTranslation.Create(
+            g2.Id, Locale.Create("it"), "Ali", "I tuoi punteggi", TranslationSource.Community, null, SampleNow);
+
+        _repo
+            .Setup(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>
+            {
+                [g1.Id] = new[] { t1Italian, t1French },
+                [g2.Id] = new[] { t2Italian }
+            });
+
+        // Act
+        var result = await _sut.EnrichAsync(new[] { g1, g2 }, CancellationToken.None);
+
+        // Assert: translations grouped by GameId, source serialized to persisted kebab string
+        result.Should().HaveCount(2);
+
+        result[0].Translations.Should().NotBeNull();
+        result[0].Translations!.Should().HaveCount(2);
+        result[0].Translations!.Should().Contain(t =>
+            t.Locale == "it" && t.Title == "I Coloni di Catan" && t.Source == "manual");
+        result[0].Translations!.Should().Contain(t =>
+            t.Locale == "fr" && t.Title == "Les Colons de Catane" && t.Source == "manual");
+
+        result[1].Translations.Should().NotBeNull();
+        result[1].Translations!.Should().HaveCount(1);
+        result[1].Translations![0].Title.Should().Be("Ali");
+        result[1].Translations![0].Description.Should().Be("I tuoi punteggi");
+        result[1].Translations![0].Source.Should().Be("community");
+    }
+
+    private static SharedGameDto MakeGame(string title) =>
+        new(
+            Id: Guid.NewGuid(),
+            BggId: null,
+            Title: title,
+            YearPublished: 2020,
+            Description: "desc",
+            MinPlayers: 2,
+            MaxPlayers: 4,
+            PlayingTimeMinutes: 60,
+            MinAge: 8,
+            ComplexityRating: null,
+            AverageRating: null,
+            ImageUrl: string.Empty,
+            ThumbnailUrl: string.Empty,
+            Status: GameStatus.Published,
+            CreatedAt: DateTime.UtcNow,
+            ModifiedAt: null);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslationTests.cs
@@ -1,0 +1,158 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Tests for the SharedGameTranslation aggregate root.
+/// Issue #2339 — sub-PR 1/3 Wave 1 (Task 3).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SharedGameTranslationTests
+{
+    private static readonly Guid SampleGameId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Create_HappyPath_AssignsAllFields()
+    {
+        var locale = Locale.Create("it");
+        var actor = Guid.NewGuid();
+
+        var t = SharedGameTranslation.Create(
+            sharedGameId: SampleGameId,
+            locale: locale,
+            title: "I Coloni di Catan",
+            description: "Costruisci e scambia sull'isola di Catan",
+            source: TranslationSource.Manual,
+            createdBy: actor,
+            now: Now);
+
+        t.Id.Should().NotBe(Guid.Empty);
+        t.SharedGameId.Should().Be(SampleGameId);
+        t.Locale.Should().Be(locale);
+        t.Title.Should().Be("I Coloni di Catan");
+        t.Description.Should().Be("Costruisci e scambia sull'isola di Catan");
+        t.Source.Should().Be(TranslationSource.Manual);
+        t.CreatedAt.Should().Be(Now);
+        t.CreatedBy.Should().Be(actor);
+        t.IsDeleted.Should().BeFalse();
+        t.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_TitleTrimmed()
+    {
+        var t = SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            "  Catan  ", null, TranslationSource.Manual, null, Now);
+        t.Title.Should().Be("Catan");
+    }
+
+    [Fact]
+    public void Create_EmptyGameId_Throws()
+    {
+        var act = () => SharedGameTranslation.Create(
+            Guid.Empty, Locale.Create("it"),
+            "title", null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<ArgumentException>().WithMessage("*SharedGameId*");
+    }
+
+    [Fact]
+    public void Create_CanonicalEnLocale_Throws()
+    {
+        var act = () => SharedGameTranslation.Create(
+            SampleGameId, Locale.CanonicalEn,
+            "Catan", null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<InvalidLocaleException>()
+            .WithMessage("*Canonical EN*");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_EmptyTitle_Throws(string? title)
+    {
+        var act = () => SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            title!, null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    [Fact]
+    public void Create_TitleTooLong_Throws()
+    {
+        var act = () => SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            new string('x', 501), null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<ArgumentException>().WithMessage("*500*");
+    }
+
+    [Fact]
+    public void UpdateTitle_Active_MutatesAndStampsUpdated()
+    {
+        var t = NewActiveTranslation();
+        var actor = Guid.NewGuid();
+        var later = Now.AddHours(1);
+
+        t.UpdateTitle("Nuovo titolo", actor, later);
+
+        t.Title.Should().Be("Nuovo titolo");
+        t.UpdatedAt.Should().Be(later);
+        t.UpdatedBy.Should().Be(actor);
+    }
+
+    [Fact]
+    public void UpdateTitle_SoftDeleted_Throws()
+    {
+        var t = NewActiveTranslation();
+        t.SoftDelete(null, Now);
+        var act = () => t.UpdateTitle("any", null, Now.AddHours(1));
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void SoftDelete_Idempotent()
+    {
+        var t = NewActiveTranslation();
+        t.SoftDelete(null, Now);
+        var firstDeletedAt = t.DeletedAt;
+        t.SoftDelete(null, Now.AddHours(1)); // second call no-op
+        t.DeletedAt.Should().Be(firstDeletedAt);
+    }
+
+    [Fact]
+    public void Restore_ResurrectsAndStampsUpdated()
+    {
+        var t = NewActiveTranslation();
+        t.SoftDelete(null, Now);
+        var actor = Guid.NewGuid();
+        var later = Now.AddDays(1);
+
+        t.Restore(actor, later);
+
+        t.IsDeleted.Should().BeFalse();
+        t.DeletedAt.Should().BeNull();
+        t.UpdatedAt.Should().Be(later);
+        t.UpdatedBy.Should().Be(actor);
+    }
+
+    [Fact]
+    public void SetXminForConcurrencyCheck_AssignsXmin()
+    {
+        var t = NewActiveTranslation();
+        t.SetXminForConcurrencyCheck(42u);
+        t.Xmin.Should().Be(42u);
+    }
+
+    private static SharedGameTranslation NewActiveTranslation() =>
+        SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            "Catan", null, TranslationSource.Manual, null, Now);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/LocaleTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/LocaleTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+/// <summary>
+/// Tests for the Locale value object used by shared_game_translations.
+/// Issue #2339 — sub-PR 1/3 Wave 1 (Task 1).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class LocaleTests
+{
+    [Theory]
+    [InlineData("it", "it")]
+    [InlineData("EN", "en")]
+    [InlineData("fr", "fr")]
+    [InlineData("en-GB", "en-GB")]
+    [InlineData("EN-gb", "en-GB")]
+    [InlineData("it-IT", "it-IT")]
+    public void Create_ValidIso_NormalizesAndAccepts(string raw, string expected)
+    {
+        var locale = Locale.Create(raw);
+        locale.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("english")]
+    [InlineData("xx-yy-zz")]
+    [InlineData("12")]
+    [InlineData("a")]
+    public void Create_InvalidIso_Throws(string raw)
+    {
+        var act = () => Locale.Create(raw);
+        act.Should().Throw<InvalidLocaleException>();
+    }
+
+    [Fact]
+    public void Create_Null_Throws()
+    {
+        var act = () => Locale.Create(null!);
+        act.Should().Throw<InvalidLocaleException>();
+    }
+
+    [Fact]
+    public void CanonicalEn_HasValue_en()
+    {
+        Locale.CanonicalEn.Value.Should().Be("en");
+    }
+
+    [Fact]
+    public void Equals_SameValue_True()
+    {
+        var a = Locale.Create("it");
+        var b = Locale.Create("IT");
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        Locale.Create("it").ToString().Should().Be("it");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameTranslationRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameTranslationRepositoryIntegrationTests.cs
@@ -1,0 +1,302 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Integration tests for <see cref="SharedGameTranslationRepository"/> against a
+/// real PostgreSQL database (Testcontainers). Issue #2339 — Wave 2 / Task 6.
+/// </summary>
+/// <remarks>
+/// Covers:
+/// <list type="number">
+///   <item>Round-trip persistence via AddAsync + GetByGameIdAndLocaleAsync.</item>
+///   <item>Batch fetch GetByGameIdsAsync excludes soft-deleted rows.</item>
+///   <item>ExistsActiveAsync flips false after SoftDelete (HasQueryFilter honoured).</item>
+///   <item>Partial unique index allows recreating (game, locale) after soft-delete.</item>
+///   <item>Optimistic concurrency via xmin throws DbUpdateConcurrencyException.</item>
+/// </list>
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SharedGameTranslationRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private SharedGameTranslationRepository _repository = null!;
+    private Guid _testUserId;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+
+    public SharedGameTranslationRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_sharedgametranslation_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+
+        _testUserId = Guid.NewGuid();
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = _testUserId,
+            Email = $"trans-test-{Guid.NewGuid():N}@meepleai.test",
+            Role = "Admin",
+            Tier = "Free",
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        _repository = new SharedGameTranslationRepository(_dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ============================================================
+    // 1. AddAsync + GetByGameIdAndLocaleAsync round-trip
+    // ============================================================
+
+    [Fact]
+    public async Task AddAsync_PersistsAndReturnsViaGet()
+    {
+        // Arrange
+        var gameId = await SeedSharedGameAsync("Catan");
+        var translation = SharedGameTranslation.Create(
+            gameId,
+            Locale.Create("it"),
+            "I Coloni di Catan",
+            "Costruisci e scambia sull'isola di Catan",
+            TranslationSource.Manual,
+            _testUserId,
+            DateTimeOffset.UtcNow);
+
+        // Act
+        await _repository.AddAsync(translation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert
+        var loaded = await _repository.GetByGameIdAndLocaleAsync(gameId, "it");
+        loaded.Should().NotBeNull();
+        loaded!.Title.Should().Be("I Coloni di Catan");
+        loaded.Description.Should().Be("Costruisci e scambia sull'isola di Catan");
+        loaded.Locale.Value.Should().Be("it");
+        loaded.Source.Should().Be(TranslationSource.Manual);
+        loaded.SharedGameId.Should().Be(gameId);
+        loaded.IsDeleted.Should().BeFalse();
+        loaded.Xmin.Should().NotBe(0u, "PostgreSQL assigns a non-zero xmin to every row");
+    }
+
+    // ============================================================
+    // 2. GetByGameIdsAsync batch fetch excludes soft-deleted
+    // ============================================================
+
+    [Fact]
+    public async Task GetByGameIdsAsync_BatchFetchesExcludingDeleted()
+    {
+        // Arrange
+        var gameAId = await SeedSharedGameAsync("Game A");
+        var gameBId = await SeedSharedGameAsync("Game B");
+        var now = DateTimeOffset.UtcNow;
+
+        var ta = SharedGameTranslation.Create(
+            gameAId, Locale.Create("it"), "Gioco A", null,
+            TranslationSource.Manual, _testUserId, now);
+        var tbItalian = SharedGameTranslation.Create(
+            gameBId, Locale.Create("it"), "Gioco B", null,
+            TranslationSource.Manual, _testUserId, now);
+        var tbFrenchDeleted = SharedGameTranslation.Create(
+            gameBId, Locale.Create("fr"), "Jeu B", null,
+            TranslationSource.Manual, _testUserId, now);
+        tbFrenchDeleted.SoftDelete(_testUserId, now);
+
+        await _repository.AddAsync(ta);
+        await _repository.AddAsync(tbItalian);
+        await _repository.AddAsync(tbFrenchDeleted);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act
+        var result = await _repository.GetByGameIdsAsync(new[] { gameAId, gameBId });
+
+        // Assert
+        result.Should().ContainKey(gameAId);
+        result[gameAId].Should().HaveCount(1);
+        result[gameAId][0].Locale.Value.Should().Be("it");
+
+        result.Should().ContainKey(gameBId);
+        // The French translation is soft-deleted, so only the Italian one survives the global query filter.
+        result[gameBId].Should().HaveCount(1);
+        result[gameBId][0].Locale.Value.Should().Be("it");
+    }
+
+    // ============================================================
+    // 3. ExistsActiveAsync flips after SoftDelete (HasQueryFilter)
+    // ============================================================
+
+    [Fact]
+    public async Task ExistsActiveAsync_True_AfterAdd_False_AfterSoftDelete()
+    {
+        // Arrange
+        var gameId = await SeedSharedGameAsync("Game");
+        var translation = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "Titolo", null,
+            TranslationSource.Manual, _testUserId, DateTimeOffset.UtcNow);
+        await _repository.AddAsync(translation);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act + Assert (after add)
+        (await _repository.ExistsActiveAsync(gameId, "it")).Should().BeTrue();
+
+        // Reload, soft-delete, save
+        var entity = await _dbContext.SharedGameTranslations
+            .FirstAsync(t => t.SharedGameId == gameId && t.Locale == "it");
+        entity.IsDeleted = true;
+        entity.DeletedAt = DateTimeOffset.UtcNow;
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act + Assert (after soft-delete)
+        // ExistsActiveAsync uses AnyAsync over the DbSet, which is filtered by HasQueryFilter(t => !t.IsDeleted),
+        // so a soft-deleted row is invisible.
+        (await _repository.ExistsActiveAsync(gameId, "it")).Should().BeFalse();
+    }
+
+    // ============================================================
+    // 4. Partial unique index allows recreate after soft-delete
+    // ============================================================
+
+    [Fact]
+    public async Task PartialUniqueIndex_AllowsRecreateAfterSoftDelete()
+    {
+        // Arrange
+        var gameId = await SeedSharedGameAsync("Game");
+        var now = DateTimeOffset.UtcNow;
+
+        var first = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "Vecchio", null,
+            TranslationSource.Manual, _testUserId, now);
+        await _repository.AddAsync(first);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Soft-delete the existing row (direct EF update — repository will
+        // add SoftDelete plumbing in Wave 3).
+        var firstEntity = await _dbContext.SharedGameTranslations
+            .FirstAsync(t => t.SharedGameId == gameId && t.Locale == "it");
+        firstEntity.IsDeleted = true;
+        firstEntity.DeletedAt = now;
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act — insert a fresh row for the same (game, locale). The partial
+        // unique index has WHERE NOT is_deleted, so the constraint does not
+        // fire even though a soft-deleted row with the same key exists.
+        var second = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "Nuovo", null,
+            TranslationSource.Manual, _testUserId, now.AddHours(1));
+        await _repository.AddAsync(second);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert
+        (await _repository.ExistsActiveAsync(gameId, "it")).Should().BeTrue();
+        var active = await _repository.GetByGameIdAndLocaleAsync(gameId, "it");
+        active.Should().NotBeNull();
+        active!.Title.Should().Be("Nuovo");
+        active.Id.Should().Be(second.Id);
+    }
+
+    // ============================================================
+    // 5. UpdateAsync concurrent edit throws DbUpdateConcurrencyException
+    // ============================================================
+
+    [Fact]
+    public async Task UpdateAsync_ConcurrentEdit_ThrowsDbUpdateConcurrencyException()
+    {
+        // Arrange: seed an initial translation in scope A.
+        var gameId = await SeedSharedGameAsync("Game");
+        var initial = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "Titolo iniziale", null,
+            TranslationSource.Manual, _testUserId, DateTimeOffset.UtcNow);
+        await _repository.AddAsync(initial);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Scope A snapshots the aggregate (stale xmin will live here).
+        var staleAggregate = await _repository.GetByGameIdAndLocaleAsync(gameId, "it");
+        staleAggregate.Should().NotBeNull();
+
+        // Scope B simulates another transaction that updates the row first,
+        // which bumps xmin server-side. Use a separate DbContext so we don't
+        // pollute scope A's change tracker.
+        await using (var scopeBContext = _fixture.CreateDbContext(_connectionString))
+        {
+            var scopeBRepo = new SharedGameTranslationRepository(scopeBContext);
+            var scopeBAggregate = await scopeBRepo.GetByGameIdAndLocaleAsync(gameId, "it");
+            scopeBAggregate.Should().NotBeNull();
+            scopeBAggregate!.UpdateTitle(
+                "Aggiornato dall'altro", _testUserId, DateTimeOffset.UtcNow);
+            await scopeBRepo.UpdateAsync(scopeBAggregate);
+            await scopeBContext.SaveChangesAsync();
+        }
+
+        // Act: scope A tries to update with its stale xmin.
+        staleAggregate!.UpdateTitle("Tentativo stale", _testUserId, DateTimeOffset.UtcNow);
+        await _repository.UpdateAsync(staleAggregate);
+
+        Func<Task> save = async () => await _dbContext.SaveChangesAsync();
+
+        // Assert
+        await save.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private async Task<Guid> SeedSharedGameAsync(string title)
+    {
+        var id = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            YearPublished = 2020,
+            Description = "Seeded game for translation repository tests",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            CreatedBy = _testUserId,
+            CreatedAt = DateTime.UtcNow,
+            IsDeleted = false,
+        });
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+        return id;
+    }
+}

--- a/docs/superpowers/plans/2026-06-15-shared-game-translations.md
+++ b/docs/superpowers/plans/2026-06-15-shared-game-translations.md
@@ -1,0 +1,2379 @@
+# Shared Game Translations — Implementation Plan (sub-PR 1/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement BE foundation for shared game translations (Option A — table-based) per spec `docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`, closing sub-PR 1/3 of issue #2339.
+
+**Architecture:** Separate aggregate `SharedGameTranslation` con repository + `GameTitleResolver` batch service che enricha `SharedGameDto.Translations[]` in 4 query handler esistenti. 5 admin endpoints CRUD via MediatR commands. No FE, no seed data, no middleware (out of scope sub-PR 2 + 3).
+
+**Tech Stack:** .NET 9 ASP.NET Minimal APIs + MediatR + EF Core 9 (PostgreSQL) + FluentValidation + xUnit + Testcontainers + FluentAssertions.
+
+---
+
+## File Structure
+
+### Files to create (Domain layer)
+
+```
+apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/
+├── Entities/SharedGameTranslation.cs          (aggregate root, factory + methods)
+├── ValueObjects/Locale.cs                      (ISO 639-1 validated VO)
+└── Enums/TranslationSource.cs                 (Manual | AutoOpenRouter | Community)
+```
+
+### Files to create (Application layer)
+
+```
+apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/
+├── Exceptions/
+│   ├── InvalidLocaleException.cs
+│   ├── TranslationNotFoundException.cs
+│   └── TranslationAlreadyExistsException.cs
+├── SharedGameTranslationDto.cs                 (response DTO)
+├── SharedGameTranslationDetailDto.cs           (with xmin for admin GET)
+├── Repositories/ISharedGameTranslationRepository.cs
+├── Services/
+│   ├── IGameTitleResolver.cs
+│   └── GameTitleResolver.cs
+├── Commands/
+│   ├── AddGameTranslation/
+│   │   ├── AddGameTranslationCommand.cs
+│   │   ├── AddGameTranslationCommandValidator.cs
+│   │   └── AddGameTranslationCommandHandler.cs
+│   ├── UpdateGameTranslation/
+│   │   ├── UpdateGameTranslationCommand.cs
+│   │   ├── UpdateGameTranslationCommandValidator.cs
+│   │   └── UpdateGameTranslationCommandHandler.cs
+│   └── DeleteGameTranslation/
+│       ├── DeleteGameTranslationCommand.cs
+│       ├── DeleteGameTranslationCommandValidator.cs
+│       └── DeleteGameTranslationCommandHandler.cs
+└── Queries/
+    ├── GetGameTranslations/
+    │   ├── GetGameTranslationsQuery.cs
+    │   └── GetGameTranslationsQueryHandler.cs
+    └── GetGameTranslationByLocale/
+        ├── GetGameTranslationByLocaleQuery.cs
+        └── GetGameTranslationByLocaleQueryHandler.cs
+```
+
+### Files to create (Infrastructure layer)
+
+```
+apps/api/src/Api/Infrastructure/
+├── Entities/SharedGameCatalog/SharedGameTranslationEntity.cs
+├── EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs
+├── Repositories/SharedGameTranslationRepository.cs
+└── Migrations/YYYYMMDDHHMMSS_AddSharedGameTranslations.cs   (EF-generated)
+```
+
+### Files to create (Routing)
+
+```
+apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs
+```
+
+### Files to MODIFY
+
+```
+apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+  → Add Translations field
+
+apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
+apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllGames/GetAllGamesQueryHandler.cs
+  → Inject IGameTitleResolver, call EnrichAsync
+
+apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/SearchGames/SearchGamesQueryHandler.cs
+apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameById/GetGameByIdQueryHandler.cs
+  → Inject IGameTitleResolver, call EnrichAsync
+
+apps/api/src/Api/Program.cs (or equivalent DI module)
+  → Register ISharedGameTranslationRepository → SharedGameTranslationRepository
+  → Register IGameTitleResolver → GameTitleResolver
+  → Call app.MapSharedGameTranslationEndpoints()
+
+apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+  → Add DbSet<SharedGameTranslationEntity> SharedGameTranslations
+```
+
+### Test files
+
+```
+tests/Api.Tests/Unit/SharedGameCatalog/
+├── Domain/SharedGameTranslationTests.cs
+├── Domain/LocaleTests.cs
+├── Application/AddGameTranslationCommandValidatorTests.cs
+├── Application/AddGameTranslationCommandHandlerTests.cs
+├── Application/UpdateGameTranslationCommandHandlerTests.cs
+├── Application/DeleteGameTranslationCommandHandlerTests.cs
+└── Application/GameTitleResolverTests.cs
+
+tests/Api.Tests/Integration/SharedGameCatalog/
+├── SharedGameTranslationRepositoryIntegrationTests.cs
+├── SharedGameTranslationEndpointsIntegrationTests.cs
+└── GameTitleResolverWiringIntegrationTests.cs
+```
+
+---
+
+## Task 1: Locale value object
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Domain/LocaleTests.cs`
+
+### Step 1.1: Write the failing tests
+
+```csharp
+// tests/Api.Tests/Unit/SharedGameCatalog/Domain/LocaleTests.cs
+using FluentAssertions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Xunit;
+
+namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class LocaleTests
+{
+    [Theory]
+    [InlineData("it", "it")]
+    [InlineData("EN", "en")]
+    [InlineData("fr", "fr")]
+    [InlineData("en-GB", "en-GB")]
+    [InlineData("EN-gb", "en-GB")]
+    [InlineData("it-IT", "it-IT")]
+    public void Create_ValidIso_NormalizesAndAccepts(string raw, string expected)
+    {
+        var locale = Locale.Create(raw);
+        locale.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("english")]
+    [InlineData("xx-yy-zz")]
+    [InlineData("12")]
+    [InlineData("a")]
+    public void Create_InvalidIso_Throws(string raw)
+    {
+        var act = () => Locale.Create(raw);
+        act.Should().Throw<InvalidLocaleException>();
+    }
+
+    [Fact]
+    public void Create_Null_Throws()
+    {
+        var act = () => Locale.Create(null!);
+        act.Should().Throw<InvalidLocaleException>();
+    }
+
+    [Fact]
+    public void CanonicalEn_HasValue_en()
+    {
+        Locale.CanonicalEn.Value.Should().Be("en");
+    }
+
+    [Fact]
+    public void Equals_SameValue_True()
+    {
+        var a = Locale.Create("it");
+        var b = Locale.Create("IT");
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        Locale.Create("it").ToString().Should().Be("it");
+    }
+}
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~LocaleTests" -v normal`
+Expected: FAIL with `CS0234` (Locale and InvalidLocaleException namespaces missing) — won't compile.
+
+- [ ] **Step 1.3: Create InvalidLocaleException**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/InvalidLocaleException.cs
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+public sealed class InvalidLocaleException : ArgumentException
+{
+    public InvalidLocaleException(string message) : base(message) { }
+}
+```
+
+- [ ] **Step 1.4: Create Locale value object**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs
+using System.Text.RegularExpressions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+public sealed record Locale
+{
+    private static readonly Regex IsoFormat = new(
+        @"^[a-z]{2}(-[A-Z]{2})?$",
+        RegexOptions.Compiled);
+
+    public string Value { get; }
+
+    private Locale(string value) { Value = value; }
+
+    public static Locale Create(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            throw new InvalidLocaleException("Locale cannot be empty");
+
+        var trimmed = raw.Trim();
+        var normalized = trimmed.ToLowerInvariant();
+
+        // Uppercase regional suffix: "it-it" → "it-IT"
+        if (normalized.Length == 5 && normalized[2] == '-')
+        {
+            normalized = normalized[..3] + normalized[3..].ToUpperInvariant();
+        }
+
+        if (!IsoFormat.IsMatch(normalized))
+            throw new InvalidLocaleException($"Invalid ISO 639-1 locale: {raw}");
+
+        return new Locale(normalized);
+    }
+
+    public static readonly Locale CanonicalEn = new("en");
+
+    public override string ToString() => Value;
+}
+```
+
+- [ ] **Step 1.5: Run tests to verify they pass**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~LocaleTests" -v normal`
+Expected: 14 tests pass.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/InvalidLocaleException.cs \
+        tests/Api.Tests/Unit/SharedGameCatalog/Domain/LocaleTests.cs
+git commit -m "feat(catalog): add Locale value object + InvalidLocaleException (#2339)"
+```
+
+---
+
+## Task 2: TranslationSource enum + remaining exceptions
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/TranslationSource.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationNotFoundException.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationAlreadyExistsException.cs`
+
+No tests for enum (trivial). Exceptions test indirectly via handler tests.
+
+- [ ] **Step 2.1: Create TranslationSource enum**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/TranslationSource.cs
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+public enum TranslationSource
+{
+    /// <summary>Default: admin-curated translation.</summary>
+    Manual = 0,
+    /// <summary>Auto-generated via OpenRouter translation service.</summary>
+    AutoOpenRouter = 1,
+    /// <summary>Community-sourced (future).</summary>
+    Community = 2
+}
+```
+
+- [ ] **Step 2.2: Locate existing NotFoundException + ConflictException base types**
+
+Run: `grep -rn "class NotFoundException" apps/api/src/Api/ --include="*.cs"`
+Expected: Find existing base in `apps/api/src/Api/Infrastructure/Exceptions/NotFoundException.cs` or similar. Note exact namespace.
+
+- [ ] **Step 2.3: Create TranslationNotFoundException**
+
+Adapt namespace based on Step 2.2 finding.
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationNotFoundException.cs
+using MeepleAi.Api.Infrastructure.Exceptions;  // adjust per Step 2.2
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+public sealed class TranslationNotFoundException : NotFoundException
+{
+    public TranslationNotFoundException(Guid gameId, string locale)
+        : base($"Translation for game {gameId} locale '{locale}' not found") { }
+}
+```
+
+- [ ] **Step 2.4: Create TranslationAlreadyExistsException**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationAlreadyExistsException.cs
+using MeepleAi.Api.Infrastructure.Exceptions;  // adjust per Step 2.2
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+
+public sealed class TranslationAlreadyExistsException : ConflictException
+{
+    public TranslationAlreadyExistsException(Guid gameId, string locale)
+        : base($"Translation for game {gameId} locale '{locale}' already exists") { }
+}
+```
+
+- [ ] **Step 2.5: Build to verify**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: Build succeeds, 0 errors.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/TranslationSource.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/
+git commit -m "feat(catalog): add TranslationSource enum + Translation exceptions (#2339)"
+```
+
+---
+
+## Task 3: SharedGameTranslation domain entity
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Domain/SharedGameTranslationTests.cs`
+
+### Step 3.1: Write failing tests
+
+```csharp
+// tests/Api.Tests/Unit/SharedGameCatalog/Domain/SharedGameTranslationTests.cs
+using FluentAssertions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Xunit;
+
+namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class SharedGameTranslationTests
+{
+    private static readonly Guid SampleGameId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Create_HappyPath_AssignsAllFields()
+    {
+        var locale = Locale.Create("it");
+        var actor  = Guid.NewGuid();
+
+        var t = SharedGameTranslation.Create(
+            sharedGameId: SampleGameId,
+            locale: locale,
+            title: "I Coloni di Catan",
+            description: "Costruisci e scambia sull'isola di Catan",
+            source: TranslationSource.Manual,
+            createdBy: actor,
+            now: Now);
+
+        t.Id.Should().NotBe(Guid.Empty);
+        t.SharedGameId.Should().Be(SampleGameId);
+        t.Locale.Should().Be(locale);
+        t.Title.Should().Be("I Coloni di Catan");
+        t.Description.Should().Be("Costruisci e scambia sull'isola di Catan");
+        t.Source.Should().Be(TranslationSource.Manual);
+        t.CreatedAt.Should().Be(Now);
+        t.CreatedBy.Should().Be(actor);
+        t.IsDeleted.Should().BeFalse();
+        t.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_TitleTrimmed()
+    {
+        var t = SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            "  Catan  ", null, TranslationSource.Manual, null, Now);
+        t.Title.Should().Be("Catan");
+    }
+
+    [Fact]
+    public void Create_EmptyGameId_Throws()
+    {
+        var act = () => SharedGameTranslation.Create(
+            Guid.Empty, Locale.Create("it"),
+            "title", null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<ArgumentException>().WithMessage("*SharedGameId*");
+    }
+
+    [Fact]
+    public void Create_CanonicalEnLocale_Throws()
+    {
+        var act = () => SharedGameTranslation.Create(
+            SampleGameId, Locale.CanonicalEn,
+            "Catan", null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<InvalidLocaleException>()
+            .WithMessage("*Canonical EN*");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_EmptyTitle_Throws(string? title)
+    {
+        var act = () => SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            title!, null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    [Fact]
+    public void Create_TitleTooLong_Throws()
+    {
+        var act = () => SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            new string('x', 501), null, TranslationSource.Manual, null, Now);
+        act.Should().Throw<ArgumentException>().WithMessage("*500*");
+    }
+
+    [Fact]
+    public void UpdateTitle_Active_MutatesAndStampsUpdated()
+    {
+        var t = NewActiveTranslation();
+        var actor = Guid.NewGuid();
+        var later = Now.AddHours(1);
+
+        t.UpdateTitle("Nuovo titolo", actor, later);
+
+        t.Title.Should().Be("Nuovo titolo");
+        t.UpdatedAt.Should().Be(later);
+        t.UpdatedBy.Should().Be(actor);
+    }
+
+    [Fact]
+    public void UpdateTitle_SoftDeleted_Throws()
+    {
+        var t = NewActiveTranslation();
+        t.SoftDelete(null, Now);
+        var act = () => t.UpdateTitle("any", null, Now.AddHours(1));
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void SoftDelete_Idempotent()
+    {
+        var t = NewActiveTranslation();
+        t.SoftDelete(null, Now);
+        var firstDeletedAt = t.DeletedAt;
+        t.SoftDelete(null, Now.AddHours(1)); // second call no-op
+        t.DeletedAt.Should().Be(firstDeletedAt);
+    }
+
+    [Fact]
+    public void Restore_ResurrectsAndStampsUpdated()
+    {
+        var t = NewActiveTranslation();
+        t.SoftDelete(null, Now);
+        var actor = Guid.NewGuid();
+        var later = Now.AddDays(1);
+
+        t.Restore(actor, later);
+
+        t.IsDeleted.Should().BeFalse();
+        t.DeletedAt.Should().BeNull();
+        t.UpdatedAt.Should().Be(later);
+        t.UpdatedBy.Should().Be(actor);
+    }
+
+    private static SharedGameTranslation NewActiveTranslation() =>
+        SharedGameTranslation.Create(
+            SampleGameId, Locale.Create("it"),
+            "Catan", null, TranslationSource.Manual, null, Now);
+}
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameTranslationTests" -v normal`
+Expected: FAIL, type not found.
+
+- [ ] **Step 3.3: Implement SharedGameTranslation entity**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+public sealed class SharedGameTranslation
+{
+    public Guid   Id              { get; private set; }
+    public Guid   SharedGameId    { get; private set; }
+    public Locale Locale          { get; private set; }
+    public string Title           { get; private set; }
+    public string? Description    { get; private set; }
+    public TranslationSource Source { get; private set; }
+
+    public DateTimeOffset CreatedAt   { get; private set; }
+    public Guid?           CreatedBy  { get; private set; }
+    public DateTimeOffset? UpdatedAt  { get; private set; }
+    public Guid?           UpdatedBy  { get; private set; }
+
+    public bool             IsDeleted { get; private set; }
+    public DateTimeOffset?  DeletedAt { get; private set; }
+    public Guid?            DeletedBy { get; private set; }
+
+    /// <summary>xmin concurrency token (mapped via EntityConfiguration).</summary>
+    public uint Xmin { get; private set; }
+
+    private SharedGameTranslation()
+    {
+        Title  = null!;
+        Locale = null!;
+    }
+
+    public static SharedGameTranslation Create(
+        Guid sharedGameId,
+        Locale locale,
+        string title,
+        string? description,
+        TranslationSource source,
+        Guid? createdBy,
+        DateTimeOffset now)
+    {
+        if (sharedGameId == Guid.Empty)
+            throw new ArgumentException("SharedGameId required", nameof(sharedGameId));
+        if (locale is null)
+            throw new ArgumentException("Locale required", nameof(locale));
+        if (locale.Equals(Locale.CanonicalEn))
+            throw new InvalidLocaleException(
+                "Canonical EN title is stored on shared_games.title — cannot create translation for 'en'");
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title required", nameof(title));
+
+        var trimmedTitle = title.Trim();
+        if (trimmedTitle.Length > 500)
+            throw new ArgumentException("Title max 500 chars", nameof(title));
+
+        return new SharedGameTranslation
+        {
+            Id           = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            Locale       = locale,
+            Title        = trimmedTitle,
+            Description  = description?.Trim(),
+            Source       = source,
+            CreatedAt    = now,
+            CreatedBy    = createdBy,
+            IsDeleted    = false
+        };
+    }
+
+    public void UpdateTitle(string newTitle, Guid? updatedBy, DateTimeOffset now)
+    {
+        if (IsDeleted)
+            throw new InvalidOperationException("Cannot update a soft-deleted translation");
+        if (string.IsNullOrWhiteSpace(newTitle))
+            throw new ArgumentException("Title required", nameof(newTitle));
+        var trimmed = newTitle.Trim();
+        if (trimmed.Length > 500)
+            throw new ArgumentException("Title max 500 chars", nameof(newTitle));
+
+        Title     = trimmed;
+        UpdatedAt = now;
+        UpdatedBy = updatedBy;
+    }
+
+    public void UpdateDescription(string? newDescription, Guid? updatedBy, DateTimeOffset now)
+    {
+        if (IsDeleted)
+            throw new InvalidOperationException("Cannot update a soft-deleted translation");
+        Description = newDescription?.Trim();
+        UpdatedAt   = now;
+        UpdatedBy   = updatedBy;
+    }
+
+    public void SoftDelete(Guid? deletedBy, DateTimeOffset now)
+    {
+        if (IsDeleted) return; // idempotent
+        IsDeleted = true;
+        DeletedAt = now;
+        DeletedBy = deletedBy;
+    }
+
+    public void Restore(Guid? restoredBy, DateTimeOffset now)
+    {
+        if (!IsDeleted) return; // idempotent
+        IsDeleted = false;
+        DeletedAt = null;
+        DeletedBy = null;
+        UpdatedAt = now;
+        UpdatedBy = restoredBy;
+    }
+}
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameTranslationTests" -v normal`
+Expected: 11 tests pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs \
+        tests/Api.Tests/Unit/SharedGameCatalog/Domain/SharedGameTranslationTests.cs
+git commit -m "feat(catalog): add SharedGameTranslation aggregate (#2339)"
+```
+
+---
+
+## Task 4: EF Infrastructure entity + configuration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameTranslationEntity.cs`
+- Create: `apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs`
+- Modify: `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs`
+
+No tests this task (EF config verified via Task 6 integration tests).
+
+- [ ] **Step 4.1: Locate DbContext and existing entity pattern**
+
+Run: `grep -n "DbSet<.*Entity>" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs | head -10`
+Expected: Find existing pattern e.g. `public DbSet<SharedGameEntity> SharedGames`.
+
+Run: `cat apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs | head -20`
+Expected: Reference template for entity (constructor, properties pattern).
+
+- [ ] **Step 4.2: Create SharedGameTranslationEntity (DB POCO, separate from Domain)**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameTranslationEntity.cs
+namespace MeepleAi.Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// EF Core entity for `shared_game_translations` table.
+/// Maps to/from <see cref="Domain.Entities.SharedGameTranslation"/> domain aggregate.
+/// </summary>
+public class SharedGameTranslationEntity
+{
+    public Guid Id { get; set; }
+    public Guid SharedGameId { get; set; }
+    public string Locale { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Source { get; set; } = "manual";
+
+    public DateTimeOffset CreatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
+    public bool IsDeleted { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public Guid? DeletedBy { get; set; }
+
+    /// <summary>xmin system column. EF maps as ConcurrencyToken.</summary>
+    public uint Xmin { get; set; }
+
+    // Navigation (optional, useful for some queries)
+    public SharedGameEntity? SharedGame { get; set; }
+}
+```
+
+- [ ] **Step 4.3: Create EntityConfiguration**
+
+```csharp
+// apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs
+using MeepleAi.Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MeepleAi.Api.Infrastructure.EntityConfigurations.SharedGameCatalog;
+
+public sealed class SharedGameTranslationEntityConfiguration
+    : IEntityTypeConfiguration<SharedGameTranslationEntity>
+{
+    public void Configure(EntityTypeBuilder<SharedGameTranslationEntity> b)
+    {
+        b.ToTable("shared_game_translations");
+
+        b.HasKey(t => t.Id);
+        b.Property(t => t.Id).HasColumnName("id");
+
+        b.Property(t => t.SharedGameId)
+            .HasColumnName("shared_game_id")
+            .IsRequired();
+
+        b.Property(t => t.Locale)
+            .HasColumnName("locale")
+            .HasMaxLength(10)
+            .IsRequired();
+
+        b.Property(t => t.Title)
+            .HasColumnName("title")
+            .HasMaxLength(500)
+            .IsRequired();
+
+        b.Property(t => t.Description)
+            .HasColumnName("description")
+            .HasColumnType("text");
+
+        b.Property(t => t.Source)
+            .HasColumnName("source")
+            .HasMaxLength(32)
+            .HasDefaultValue("manual")
+            .IsRequired();
+
+        b.Property(t => t.CreatedAt)
+            .HasColumnName("created_at")
+            .HasDefaultValueSql("now()")
+            .IsRequired();
+        b.Property(t => t.CreatedBy).HasColumnName("created_by");
+
+        b.Property(t => t.UpdatedAt).HasColumnName("updated_at");
+        b.Property(t => t.UpdatedBy).HasColumnName("updated_by");
+
+        b.Property(t => t.IsDeleted)
+            .HasColumnName("is_deleted")
+            .HasDefaultValue(false)
+            .IsRequired();
+        b.Property(t => t.DeletedAt).HasColumnName("deleted_at");
+        b.Property(t => t.DeletedBy).HasColumnName("deleted_by");
+
+        // xmin concurrency (ADR-060 pattern)
+        b.Property(t => t.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
+        // Unique constraint on active translations only (partial index)
+        b.HasIndex(t => new { t.SharedGameId, t.Locale })
+            .HasFilter("NOT is_deleted")
+            .IsUnique()
+            .HasDatabaseName("uq_active_translation_per_locale");
+
+        // Lookup indices (excluding soft-deleted)
+        b.HasIndex(t => t.Locale)
+            .HasFilter("NOT is_deleted")
+            .HasDatabaseName("ix_translations_locale");
+        b.HasIndex(t => t.SharedGameId)
+            .HasFilter("NOT is_deleted")
+            .HasDatabaseName("ix_translations_shared_game_id");
+        b.HasIndex(t => t.Source)
+            .HasFilter("NOT is_deleted")
+            .HasDatabaseName("ix_translations_source");
+
+        // FK cascade
+        b.HasOne(t => t.SharedGame)
+            .WithMany() // SharedGame doesn't expose Translations nav (separate aggregate)
+            .HasForeignKey(t => t.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Global query filter: exclude soft-deleted by default.
+        // Repository SHALL use IgnoreQueryFilters() for admin retrieval of soft-deleted.
+        b.HasQueryFilter(t => !t.IsDeleted);
+    }
+}
+```
+
+- [ ] **Step 4.4: Register entity in MeepleAiDbContext**
+
+Find the SharedGames DbSet declaration:
+
+```bash
+grep -n "DbSet<SharedGameEntity>" apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+```
+
+Add right after it (file:line based on grep result):
+
+```csharp
+public DbSet<SharedGameTranslationEntity> SharedGameTranslations => Set<SharedGameTranslationEntity>();
+```
+
+If `OnModelCreating` uses `ApplyConfigurationsFromAssembly`, the configuration auto-registers. If individual `ApplyConfiguration` calls are used, add:
+
+```csharp
+modelBuilder.ApplyConfiguration(new SharedGameTranslationEntityConfiguration());
+```
+
+- [ ] **Step 4.5: Build to verify**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameTranslationEntity.cs \
+        apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs \
+        apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+git commit -m "feat(catalog): add SharedGameTranslationEntity + EF config (#2339)"
+```
+
+---
+
+## Task 5: EF migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDDHHMMSS_AddSharedGameTranslations.cs` (EF-generated)
+- Create: `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDDHHMMSS_AddSharedGameTranslations.Designer.cs` (EF-generated)
+
+- [ ] **Step 5.1: Generate migration via EF tools**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddSharedGameTranslations --output-dir Infrastructure/Migrations
+```
+
+Expected: Creates 2 files (timestamped + Designer).
+
+- [ ] **Step 5.2: Inspect generated SQL**
+
+Run: `dotnet ef migrations script <previous-migration-name> AddSharedGameTranslations`
+
+Verify generated SQL contains:
+- `CREATE TABLE shared_game_translations` with all columns
+- Foreign key to `shared_games(id)` with `ON DELETE CASCADE`
+- Indices including partial `WHERE NOT is_deleted`
+- Unique constraint `uq_active_translation_per_locale`
+
+If something is wrong, edit the EntityConfiguration and regenerate.
+
+- [ ] **Step 5.3: Apply migration to dev DB**
+
+```bash
+dotnet ef database update --connection "Host=localhost;Database=meepleai_staging;Username=meepleai;Password=<from-secret>"
+```
+
+Verify table exists:
+
+```bash
+pwsh -c "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c '\d shared_game_translations'"
+```
+
+Expected: Shows 13 columns + 4 indices + 1 FK constraint.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Migrations/*AddSharedGameTranslations*.cs
+git commit -m "feat(catalog): EF migration AddSharedGameTranslations (#2339)"
+```
+
+---
+
+## Task 6: Repository interface + implementation
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Repositories/ISharedGameTranslationRepository.cs`
+- Create: `apps/api/src/Api/Infrastructure/Repositories/SharedGameTranslationRepository.cs`
+- Test: `tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationRepositoryIntegrationTests.cs`
+
+### Step 6.1: Create repository interface
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Repositories/ISharedGameTranslationRepository.cs
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+
+public interface ISharedGameTranslationRepository
+{
+    Task AddAsync(SharedGameTranslation translation, CancellationToken ct);
+    Task UpdateAsync(SharedGameTranslation translation, CancellationToken ct);
+    Task<SharedGameTranslation?> GetByGameIdAndLocaleAsync(
+        Guid gameId, string locale, CancellationToken ct);
+    Task<IReadOnlyList<SharedGameTranslation>> GetByGameIdAsync(
+        Guid gameId, CancellationToken ct);
+
+    /// <summary>
+    /// Batch fetch for resolver. Returns dict gameId → translations[].
+    /// Excludes soft-deleted (HasQueryFilter applies).
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<SharedGameTranslation>>>
+        GetByGameIdsAsync(IReadOnlyList<Guid> gameIds, CancellationToken ct);
+
+    Task<bool> ExistsActiveAsync(Guid gameId, string locale, CancellationToken ct);
+}
+```
+
+- [ ] **Step 6.2: Write failing integration tests**
+
+```csharp
+// tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationRepositoryIntegrationTests.cs
+using FluentAssertions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using MeepleAi.Api.Tests.Integration.Fixtures; // Postgres Testcontainers fixture
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MeepleAi.Api.Tests.Integration.SharedGameCatalog;
+
+[Trait("Category", "Integration")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class SharedGameTranslationRepositoryIntegrationTests
+    : IClassFixture<PostgresContainerFixture>
+{
+    private readonly PostgresContainerFixture _fx;
+
+    public SharedGameTranslationRepositoryIntegrationTests(PostgresContainerFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task AddAsync_PersistsAndReturnsViaGet()
+    {
+        await using var scope = _fx.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>();
+        var ctx  = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = await SeedHelper.CreateGameAsync(ctx, "Catan");
+        var t = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "I Coloni di Catan",
+            null, TranslationSource.Manual, null, DateTimeOffset.UtcNow);
+
+        await repo.AddAsync(t, default);
+        await ctx.SaveChangesAsync();
+
+        var loaded = await repo.GetByGameIdAndLocaleAsync(gameId, "it", default);
+        loaded.Should().NotBeNull();
+        loaded!.Title.Should().Be("I Coloni di Catan");
+    }
+
+    [Fact]
+    public async Task GetByGameIdsAsync_BatchFetchesExcludingDeleted()
+    {
+        await using var scope = _fx.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>();
+        var ctx  = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameAId = await SeedHelper.CreateGameAsync(ctx, "Game A");
+        var gameBId = await SeedHelper.CreateGameAsync(ctx, "Game B");
+        var now = DateTimeOffset.UtcNow;
+
+        var ta = SharedGameTranslation.Create(gameAId, Locale.Create("it"), "Gioco A", null, TranslationSource.Manual, null, now);
+        var tb = SharedGameTranslation.Create(gameBId, Locale.Create("it"), "Gioco B", null, TranslationSource.Manual, null, now);
+        var tbDeleted = SharedGameTranslation.Create(gameBId, Locale.Create("fr"), "Jeu B", null, TranslationSource.Manual, null, now);
+        tbDeleted.SoftDelete(null, now);
+
+        await repo.AddAsync(ta, default);
+        await repo.AddAsync(tb, default);
+        await repo.AddAsync(tbDeleted, default);
+        await ctx.SaveChangesAsync();
+
+        var result = await repo.GetByGameIdsAsync(new[] { gameAId, gameBId }, default);
+
+        result[gameAId].Should().HaveCount(1);
+        result[gameBId].Should().HaveCount(1); // 'fr' excluded (soft-deleted)
+        result[gameBId][0].Locale.Value.Should().Be("it");
+    }
+
+    [Fact]
+    public async Task ExistsActiveAsync_True_AfterAdd_False_AfterSoftDelete()
+    {
+        await using var scope = _fx.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>();
+        var ctx  = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = await SeedHelper.CreateGameAsync(ctx, "Game");
+        var t = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "title", null, TranslationSource.Manual, null, DateTimeOffset.UtcNow);
+        await repo.AddAsync(t, default);
+        await ctx.SaveChangesAsync();
+
+        (await repo.ExistsActiveAsync(gameId, "it", default)).Should().BeTrue();
+
+        t.SoftDelete(null, DateTimeOffset.UtcNow);
+        await ctx.SaveChangesAsync();
+        (await repo.ExistsActiveAsync(gameId, "it", default)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PartialUniqueIndex_AllowsRecreateAfterSoftDelete()
+    {
+        await using var scope = _fx.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>();
+        var ctx  = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = await SeedHelper.CreateGameAsync(ctx, "Game");
+        var now = DateTimeOffset.UtcNow;
+
+        var first = SharedGameTranslation.Create(gameId, Locale.Create("it"), "old", null, TranslationSource.Manual, null, now);
+        await repo.AddAsync(first, default);
+        await ctx.SaveChangesAsync();
+        first.SoftDelete(null, now);
+        await ctx.SaveChangesAsync();
+
+        var second = SharedGameTranslation.Create(gameId, Locale.Create("it"), "new", null, TranslationSource.Manual, null, now);
+        await repo.AddAsync(second, default);
+        await ctx.SaveChangesAsync();
+
+        (await repo.ExistsActiveAsync(gameId, "it", default)).Should().BeTrue();
+        var active = await repo.GetByGameIdAndLocaleAsync(gameId, "it", default);
+        active!.Title.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ConcurrentEdit_ThrowsDbUpdateConcurrencyException()
+    {
+        await using var scope = _fx.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>();
+        var ctx  = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = await SeedHelper.CreateGameAsync(ctx, "Game");
+        var t = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "title", null, TranslationSource.Manual, null, DateTimeOffset.UtcNow);
+        await repo.AddAsync(t, default);
+        await ctx.SaveChangesAsync();
+
+        // Simulate concurrent edit: detach + modify with stale xmin
+        ctx.Entry(t).State = EntityState.Detached;
+        var stale = await repo.GetByGameIdAndLocaleAsync(gameId, "it", default);
+        // Update by another scope
+        await using (var scope2 = _fx.CreateScope())
+        {
+            var repo2 = scope2.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>();
+            var ctx2  = scope2.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var t2 = await repo2.GetByGameIdAndLocaleAsync(gameId, "it", default);
+            t2!.UpdateTitle("updated by other", null, DateTimeOffset.UtcNow);
+            await ctx2.SaveChangesAsync();
+        }
+
+        // Now save stale → should throw
+        stale!.UpdateTitle("stale title", null, DateTimeOffset.UtcNow);
+        var act = async () => await ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+}
+```
+
+Note: `SeedHelper.CreateGameAsync` is a test helper inserting a minimal `SharedGameEntity` row. Locate or create in `tests/Api.Tests/Integration/Fixtures/SeedHelper.cs`.
+
+- [ ] **Step 6.3: Run tests to verify they fail**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameTranslationRepositoryIntegrationTests" -v normal`
+Expected: FAIL (type not found OR DI not registered).
+
+- [ ] **Step 6.4: Implement repository**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Repositories/SharedGameTranslationRepository.cs
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using MeepleAi.Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+
+namespace MeepleAi.Api.Infrastructure.Repositories;
+
+public sealed class SharedGameTranslationRepository(MeepleAiDbContext ctx)
+    : ISharedGameTranslationRepository
+{
+    public async Task AddAsync(SharedGameTranslation t, CancellationToken ct)
+    {
+        var entity = ToEntity(t);
+        await ctx.SharedGameTranslations.AddAsync(entity, ct);
+    }
+
+    public Task UpdateAsync(SharedGameTranslation t, CancellationToken ct)
+    {
+        // Domain object is detached — we need to attach + mark Modified
+        var entity = ToEntity(t);
+        ctx.SharedGameTranslations.Attach(entity);
+        ctx.Entry(entity).State = EntityState.Modified;
+        return Task.CompletedTask;
+    }
+
+    public async Task<SharedGameTranslation?> GetByGameIdAndLocaleAsync(
+        Guid gameId, string locale, CancellationToken ct)
+    {
+        var entity = await ctx.SharedGameTranslations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.SharedGameId == gameId && t.Locale == locale, ct);
+        return entity is null ? null : FromEntity(entity);
+    }
+
+    public async Task<IReadOnlyList<SharedGameTranslation>> GetByGameIdAsync(
+        Guid gameId, CancellationToken ct)
+    {
+        var entities = await ctx.SharedGameTranslations
+            .AsNoTracking()
+            .Where(t => t.SharedGameId == gameId)
+            .ToListAsync(ct);
+        return entities.Select(FromEntity).ToList();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<SharedGameTranslation>>>
+        GetByGameIdsAsync(IReadOnlyList<Guid> gameIds, CancellationToken ct)
+    {
+        if (gameIds.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>();
+
+        var idsSet = gameIds.ToHashSet();
+        var entities = await ctx.SharedGameTranslations
+            .AsNoTracking()
+            .Where(t => idsSet.Contains(t.SharedGameId))
+            .ToListAsync(ct);
+
+        return entities
+            .GroupBy(t => t.SharedGameId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<SharedGameTranslation>)g.Select(FromEntity).ToList());
+    }
+
+    public Task<bool> ExistsActiveAsync(Guid gameId, string locale, CancellationToken ct) =>
+        ctx.SharedGameTranslations.AnyAsync(
+            t => t.SharedGameId == gameId && t.Locale == locale, ct);
+
+    private static SharedGameTranslationEntity ToEntity(SharedGameTranslation t) => new()
+    {
+        Id           = t.Id,
+        SharedGameId = t.SharedGameId,
+        Locale       = t.Locale.Value,
+        Title        = t.Title,
+        Description  = t.Description,
+        Source       = TranslationSourceMapper.ToString(t.Source),
+        CreatedAt    = t.CreatedAt,
+        CreatedBy    = t.CreatedBy,
+        UpdatedAt    = t.UpdatedAt,
+        UpdatedBy    = t.UpdatedBy,
+        IsDeleted    = t.IsDeleted,
+        DeletedAt    = t.DeletedAt,
+        DeletedBy    = t.DeletedBy,
+        Xmin         = t.Xmin
+    };
+
+    private static SharedGameTranslation FromEntity(SharedGameTranslationEntity e)
+    {
+        // Re-hydrate domain object — use reflection-free internal hydrator
+        // Cannot use Create() factory (it assigns fresh Id + CreatedAt).
+        // Pattern: introduce internal Rehydrate method on entity, OR use private setters via JsonSerialize trick.
+        // For now: use a Rehydrate static method.
+        return SharedGameTranslation.Rehydrate(
+            e.Id, e.SharedGameId, Locale.Create(e.Locale),
+            e.Title, e.Description,
+            TranslationSourceMapper.FromString(e.Source),
+            e.CreatedAt, e.CreatedBy,
+            e.UpdatedAt, e.UpdatedBy,
+            e.IsDeleted, e.DeletedAt, e.DeletedBy,
+            e.Xmin);
+    }
+}
+
+internal static class TranslationSourceMapper
+{
+    public static string ToString(TranslationSource source) => source switch
+    {
+        TranslationSource.Manual         => "manual",
+        TranslationSource.AutoOpenRouter => "auto-openrouter",
+        TranslationSource.Community      => "community",
+        _ => throw new ArgumentOutOfRangeException(nameof(source))
+    };
+
+    public static TranslationSource FromString(string source) => source switch
+    {
+        "manual"          => TranslationSource.Manual,
+        "auto-openrouter" => TranslationSource.AutoOpenRouter,
+        "community"       => TranslationSource.Community,
+        _ => throw new ArgumentOutOfRangeException(nameof(source), $"Unknown source: {source}")
+    };
+}
+```
+
+- [ ] **Step 6.5: Add Rehydrate static method to domain entity**
+
+Add to `SharedGameTranslation.cs`:
+
+```csharp
+/// <summary>
+/// EF persistence hydration. Bypasses factory validation — assumes data already validated on Create.
+/// Internal use only (Repository).
+/// </summary>
+public static SharedGameTranslation Rehydrate(
+    Guid id, Guid sharedGameId, Locale locale,
+    string title, string? description, TranslationSource source,
+    DateTimeOffset createdAt, Guid? createdBy,
+    DateTimeOffset? updatedAt, Guid? updatedBy,
+    bool isDeleted, DateTimeOffset? deletedAt, Guid? deletedBy,
+    uint xmin)
+{
+    return new SharedGameTranslation
+    {
+        Id = id, SharedGameId = sharedGameId, Locale = locale,
+        Title = title, Description = description, Source = source,
+        CreatedAt = createdAt, CreatedBy = createdBy,
+        UpdatedAt = updatedAt, UpdatedBy = updatedBy,
+        IsDeleted = isDeleted, DeletedAt = deletedAt, DeletedBy = deletedBy,
+        Xmin = xmin
+    };
+}
+```
+
+- [ ] **Step 6.6: Register repo in DI**
+
+In `Program.cs` (or DI module):
+
+```csharp
+builder.Services.AddScoped<ISharedGameTranslationRepository, SharedGameTranslationRepository>();
+```
+
+- [ ] **Step 6.7: Run tests to verify they pass**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameTranslationRepositoryIntegrationTests" -v normal`
+Expected: 5 tests pass.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Repositories/ISharedGameTranslationRepository.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs \
+        apps/api/src/Api/Infrastructure/Repositories/SharedGameTranslationRepository.cs \
+        apps/api/src/Api/Program.cs \
+        tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationRepositoryIntegrationTests.cs
+git commit -m "feat(catalog): add SharedGameTranslationRepository + integration tests (#2339)"
+```
+
+---
+
+## Task 7: DTOs (SharedGameTranslationDto + Detail + modify SharedGameDto)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDetailDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs`
+
+- [ ] **Step 7.1: Create SharedGameTranslationDto**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application;
+
+public record SharedGameTranslationDto(
+    string Locale,
+    string Title,
+    string? Description,
+    string Source);
+```
+
+- [ ] **Step 7.2: Create SharedGameTranslationDetailDto (with xmin for admin)**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDetailDto.cs
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application;
+
+public record SharedGameTranslationDetailDto(
+    Guid Id,
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    string Source,
+    DateTimeOffset CreatedAt,
+    Guid? CreatedBy,
+    DateTimeOffset? UpdatedAt,
+    Guid? UpdatedBy,
+    uint Xmin);
+```
+
+- [ ] **Step 7.3: Modify SharedGameDto to add Translations field**
+
+Locate file: `grep -n "record SharedGameDto" apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs`
+
+Add `Translations` as the last parameter. Default empty list. Example modification (actual existing fields may differ):
+
+```csharp
+public record SharedGameDto(
+    Guid Id,
+    string Title,
+    string? Description,
+    // ... existing fields ...
+    bool HasKnowledgeBase,
+    IReadOnlyList<SharedGameTranslationDto> Translations);
+```
+
+Compile fix: every place that constructs `SharedGameDto` without `Translations` now breaks. Add `Translations: Array.Empty<SharedGameTranslationDto>()` at every call site OR use a default:
+
+For records, we can use a static factory or provide a parameterless constructor extension. Simpler: update all callers (typically `SharedGameMapper.ToDto`) to pass `Array.Empty<SharedGameTranslationDto>()`.
+
+Use `grep -rn "new SharedGameDto(" apps/api/src/Api/` to find call sites. Update each.
+
+- [ ] **Step 7.4: Build to verify**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: 0 errors. Warnings only acceptable if pre-existing.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDetailDto.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs \
+        apps/api/src/Api/  # any modified callers
+git commit -m "feat(catalog): add Translation DTOs + extend SharedGameDto.Translations (#2339)"
+```
+
+---
+
+## Task 8: GameTitleResolver service
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IGameTitleResolver.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolver.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Application/GameTitleResolverTests.cs`
+
+### Step 8.1: Create IGameTitleResolver interface
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IGameTitleResolver.cs
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+public interface IGameTitleResolver
+{
+    Task<IReadOnlyList<SharedGameDto>> EnrichAsync(
+        IReadOnlyList<SharedGameDto> games,
+        CancellationToken ct);
+}
+```
+
+### Step 8.2: Write failing tests
+
+```csharp
+// tests/Api.Tests/Unit/SharedGameCatalog/Application/GameTitleResolverTests.cs
+using FluentAssertions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Moq;
+using Xunit;
+
+namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Application;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class GameTitleResolverTests
+{
+    private readonly Mock<ISharedGameTranslationRepository> _repo = new();
+    private readonly GameTitleResolver _sut;
+
+    public GameTitleResolverTests() { _sut = new GameTitleResolver(_repo.Object); }
+
+    [Fact]
+    public async Task EnrichAsync_EmptyInput_ReturnsEmpty_NoRepoCall()
+    {
+        var result = await _sut.EnrichAsync(Array.Empty<SharedGameDto>(), default);
+        result.Should().BeEmpty();
+        _repo.Verify(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task EnrichAsync_BatchFetchesSingleSqlCall()
+    {
+        var g1 = MakeGame("Catan");
+        var g2 = MakeGame("Wingspan");
+        _repo.Setup(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), default))
+             .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>());
+
+        await _sut.EnrichAsync(new[] { g1, g2 }, default);
+
+        _repo.Verify(r => r.GetByGameIdsAsync(
+            It.Is<IReadOnlyList<Guid>>(ids => ids.Count == 2 &&
+                                              ids.Contains(g1.Id) && ids.Contains(g2.Id)),
+            default), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnrichAsync_NoTranslations_DtoTranslationsEmpty()
+    {
+        var g = MakeGame("Game");
+        _repo.Setup(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), default))
+             .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>());
+
+        var result = await _sut.EnrichAsync(new[] { g }, default);
+        result[0].Translations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnrichAsync_MapsTranslationsByGameId()
+    {
+        var g1 = MakeGame("Catan");
+        var g2 = MakeGame("Wingspan");
+        var now = DateTimeOffset.UtcNow;
+
+        var t1Italian = SharedGameTranslation.Create(g1.Id, Locale.Create("it"), "I Coloni", null, TranslationSource.Manual, null, now);
+        var t1French  = SharedGameTranslation.Create(g1.Id, Locale.Create("fr"), "Les Colons", null, TranslationSource.Manual, null, now);
+        var t2Italian = SharedGameTranslation.Create(g2.Id, Locale.Create("it"), "Ali", null, TranslationSource.Manual, null, now);
+
+        _repo.Setup(r => r.GetByGameIdsAsync(It.IsAny<IReadOnlyList<Guid>>(), default))
+             .ReturnsAsync(new Dictionary<Guid, IReadOnlyList<SharedGameTranslation>>
+             {
+                 [g1.Id] = new[] { t1Italian, t1French },
+                 [g2.Id] = new[] { t2Italian }
+             });
+
+        var result = await _sut.EnrichAsync(new[] { g1, g2 }, default);
+
+        result[0].Translations.Should().HaveCount(2);
+        result[0].Translations.Should().Contain(t => t.Locale == "it" && t.Title == "I Coloni");
+        result[0].Translations.Should().Contain(t => t.Locale == "fr" && t.Title == "Les Colons");
+        result[1].Translations.Should().HaveCount(1);
+        result[1].Translations[0].Title.Should().Be("Ali");
+    }
+
+    private static SharedGameDto MakeGame(string title) =>
+        new(Guid.NewGuid(), title, null, null, 2020, 2, 4, 60, null, null, null, null, false,
+            Array.Empty<SharedGameTranslationDto>());
+    // NOTE: adapt MakeGame ctor to match actual SharedGameDto fields after Task 7.
+}
+```
+
+- [ ] **Step 8.3: Run tests to verify they fail**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~GameTitleResolverTests" -v normal`
+Expected: FAIL, type missing.
+
+### Step 8.4: Implement GameTitleResolver
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolver.cs
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+public sealed class GameTitleResolver(ISharedGameTranslationRepository repo)
+    : IGameTitleResolver
+{
+    public async Task<IReadOnlyList<SharedGameDto>> EnrichAsync(
+        IReadOnlyList<SharedGameDto> games,
+        CancellationToken ct)
+    {
+        if (games.Count == 0) return games;
+
+        var ids = games.Select(g => g.Id).ToArray();
+        // Repository's HasQueryFilter excludes soft-deleted automatically.
+        var translationsByGame = await repo.GetByGameIdsAsync(ids, ct);
+
+        return games.Select(g => g with
+        {
+            Translations = translationsByGame.TryGetValue(g.Id, out var ts)
+                ? ts.Select(ToDto).ToList()
+                : Array.Empty<SharedGameTranslationDto>()
+        }).ToList();
+    }
+
+    private static SharedGameTranslationDto ToDto(
+        Domain.Entities.SharedGameTranslation t) =>
+        new(t.Locale.Value, t.Title, t.Description,
+            Infrastructure.Repositories.TranslationSourceMapper.ToString(t.Source));
+}
+```
+
+Note: `TranslationSourceMapper` is internal in Infrastructure. To avoid cross-layer leak, move it to Application:
+
+Move file: `apps/api/src/Api/Infrastructure/Repositories/SharedGameTranslationRepository.cs` (TranslationSourceMapper class) → `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/TranslationSourceMapper.cs` and make it `internal static`. Update Repository reference.
+
+- [ ] **Step 8.5: Register resolver in DI**
+
+```csharp
+// Program.cs
+builder.Services.AddScoped<IGameTitleResolver, GameTitleResolver>();
+```
+
+- [ ] **Step 8.6: Run tests to verify they pass**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~GameTitleResolverTests" -v normal`
+Expected: 4 tests pass.
+
+- [ ] **Step 8.7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/ \
+        apps/api/src/Api/Program.cs \
+        apps/api/src/Api/Infrastructure/Repositories/SharedGameTranslationRepository.cs \
+        tests/Api.Tests/Unit/SharedGameCatalog/Application/GameTitleResolverTests.cs
+git commit -m "feat(catalog): add IGameTitleResolver + GameTitleResolver (#2339)"
+```
+
+---
+
+## Task 9: AddGameTranslation command + validator + handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommandValidatorTests.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommandHandlerTests.cs`
+
+### Step 9.1: Define command + handler interface
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommand.cs
+using MediatR;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+public sealed record AddGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    string Source) : IRequest<Guid>;
+```
+
+### Step 9.2: Write failing validator tests
+
+```csharp
+// tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommandValidatorTests.cs
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Moq;
+using Xunit;
+
+namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Application;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class AddGameTranslationCommandValidatorTests
+{
+    private readonly Mock<ISharedGameTranslationRepository> _transRepo = new();
+    private readonly Mock<ISharedGameRepository> _gameRepo = new();
+    private readonly AddGameTranslationCommandValidator _sut;
+
+    public AddGameTranslationCommandValidatorTests()
+    {
+        _gameRepo.Setup(r => r.ExistsAsync(It.IsAny<Guid>(), default)).ReturnsAsync(true);
+        _transRepo.Setup(r => r.ExistsActiveAsync(It.IsAny<Guid>(), It.IsAny<string>(), default))
+                  .ReturnsAsync(false);
+        _sut = new AddGameTranslationCommandValidator(_transRepo.Object, _gameRepo.Object);
+    }
+
+    [Fact]
+    public async Task Valid_NoErrors()
+    {
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "title", null, "manual");
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task InvalidLocale_400()
+    {
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "english", "title", null, "manual");
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Locale);
+    }
+
+    [Fact]
+    public async Task EmptyTitle_400()
+    {
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "", null, "manual");
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Title);
+    }
+
+    [Fact]
+    public async Task InvalidSource_400()
+    {
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "title", null, "facebook");
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Source);
+    }
+
+    [Fact]
+    public async Task GameNotExists_404Hint()
+    {
+        _gameRepo.Setup(r => r.ExistsAsync(It.IsAny<Guid>(), default)).ReturnsAsync(false);
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "title", null, "manual");
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.GameId)
+              .WithErrorMessage("*not found*");
+    }
+
+    [Fact]
+    public async Task DuplicateLocale_409Hint()
+    {
+        _transRepo.Setup(r => r.ExistsActiveAsync(It.IsAny<Guid>(), "it", default))
+                  .ReturnsAsync(true);
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "title", null, "manual");
+        var result = await _sut.TestValidateAsync(cmd);
+        result.ShouldHaveValidationErrorFor(c => c.Locale)
+              .WithErrorMessage("*already exists*");
+    }
+}
+```
+
+- [ ] **Step 9.3: Run validator tests to verify fail**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~AddGameTranslationCommandValidatorTests" -v normal`
+
+### Step 9.4: Implement validator
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
+using FluentValidation;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+public sealed class AddGameTranslationCommandValidator
+    : AbstractValidator<AddGameTranslationCommand>
+{
+    public AddGameTranslationCommandValidator(
+        ISharedGameTranslationRepository translationRepo,
+        ISharedGameRepository gameRepo)
+    {
+        RuleFor(c => c.GameId)
+            .NotEmpty()
+            .Cascade(CascadeMode.Stop)
+            .MustAsync(async (id, ct) => await gameRepo.ExistsAsync(id, ct))
+            .WithMessage("Game {PropertyValue} not found");
+
+        RuleFor(c => c.Locale)
+            .NotEmpty()
+            .Cascade(CascadeMode.Stop)
+            .Must(BeValidLocale).WithMessage("Invalid ISO 639-1 locale")
+            .MustAsync(async (cmd, locale, ct) =>
+                !await translationRepo.ExistsActiveAsync(cmd.GameId, NormalizeLocale(locale), ct))
+            .WithMessage("Translation for locale {PropertyValue} already exists");
+
+        RuleFor(c => c.Title)
+            .NotEmpty().WithMessage("Title required")
+            .MaximumLength(500);
+
+        RuleFor(c => c.Source)
+            .Must(BeValidSource).WithMessage("Invalid source — must be manual | auto-openrouter | community");
+    }
+
+    private static bool BeValidLocale(string raw)
+    {
+        try { Locale.Create(raw); return true; }
+        catch (InvalidLocaleException) { return false; }
+    }
+
+    private static string NormalizeLocale(string raw)
+    {
+        try { return Locale.Create(raw).Value; }
+        catch { return raw; }
+    }
+
+    private static bool BeValidSource(string source) =>
+        TranslationSourceMapper.TryFromString(source, out _);
+}
+```
+
+Add `TryFromString` to `TranslationSourceMapper`:
+
+```csharp
+public static bool TryFromString(string s, out TranslationSource result)
+{
+    switch (s)
+    {
+        case "manual":          result = TranslationSource.Manual; return true;
+        case "auto-openrouter": result = TranslationSource.AutoOpenRouter; return true;
+        case "community":       result = TranslationSource.Community; return true;
+        default:                result = default; return false;
+    }
+}
+```
+
+- [ ] **Step 9.5: Run validator tests to verify pass**
+
+Expected: 6 tests pass.
+
+### Step 9.6: Write failing handler tests
+
+```csharp
+// tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommandHandlerTests.cs
+using FluentAssertions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using MeepleAi.Api.Infrastructure.Auth;     // adapt to actual ICurrentUserService location
+using MeepleAi.Api.Infrastructure.Time;     // adapt to actual IClock location
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Application;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class AddGameTranslationCommandHandlerTests
+{
+    private readonly Mock<ISharedGameTranslationRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<ICurrentUserService> _currentUser = new();
+    private readonly Mock<IClock> _clock = new();
+    private readonly AddGameTranslationCommandHandler _sut;
+
+    public AddGameTranslationCommandHandlerTests()
+    {
+        _clock.SetupGet(c => c.UtcNow).Returns(new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        _currentUser.SetupGet(u => u.UserId).Returns(Guid.NewGuid());
+        _sut = new AddGameTranslationCommandHandler(_repo.Object, _uow.Object, _currentUser.Object, _clock.Object);
+    }
+
+    [Fact]
+    public async Task HappyPath_ReturnsId_PersistsSavesChanges()
+    {
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "I Coloni", null, "manual");
+
+        var id = await _sut.Handle(cmd, default);
+
+        id.Should().NotBe(Guid.Empty);
+        _repo.Verify(r => r.AddAsync(It.IsAny<SharedGameTranslation>(), default), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DbThrowsDuplicate_RethrowsAsTranslationAlreadyExists()
+    {
+        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "title", null, "manual");
+        _uow.Setup(u => u.SaveChangesAsync(default))
+            .ThrowsAsync(new DbUpdateException("duplicate key value violates unique constraint \"uq_active_translation_per_locale\"", null));
+
+        var act = async () => await _sut.Handle(cmd, default);
+        await act.Should().ThrowAsync<TranslationAlreadyExistsException>();
+    }
+}
+```
+
+- [ ] **Step 9.7: Run handler tests to verify fail**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~AddGameTranslationCommandHandlerTests" -v normal`
+
+### Step 9.8: Implement handler
+
+```csharp
+// apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs
+using MediatR;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using MeepleAi.Api.Infrastructure.Auth;
+using MeepleAi.Api.Infrastructure.Time;
+using MeepleAi.Api.Infrastructure;  // IUnitOfWork
+using Microsoft.EntityFrameworkCore;
+
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+
+public sealed class AddGameTranslationCommandHandler(
+    ISharedGameTranslationRepository repo,
+    IUnitOfWork uow,
+    ICurrentUserService currentUser,
+    IClock clock)
+    : IRequestHandler<AddGameTranslationCommand, Guid>
+{
+    public async Task<Guid> Handle(AddGameTranslationCommand cmd, CancellationToken ct)
+    {
+        var locale = Locale.Create(cmd.Locale);
+        TranslationSourceMapper.TryFromString(cmd.Source, out var source);
+        var t = SharedGameTranslation.Create(
+            cmd.GameId, locale, cmd.Title, cmd.Description,
+            source, currentUser.UserId, clock.UtcNow);
+
+        await repo.AddAsync(t, ct);
+
+        try
+        {
+            await uow.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex)
+            when (ex.Message.Contains("uq_active_translation_per_locale", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new TranslationAlreadyExistsException(cmd.GameId, locale.Value);
+        }
+
+        return t.Id;
+    }
+}
+```
+
+- [ ] **Step 9.9: Run handler tests to verify pass**
+
+Expected: 2 tests pass.
+
+- [ ] **Step 9.10: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/ \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/TranslationSourceMapper.cs \
+        tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommand*Tests.cs
+git commit -m "feat(catalog): add AddGameTranslation command + validator + handler (#2339)"
+```
+
+---
+
+## Task 10: UpdateGameTranslation command + validator + handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandler.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Application/UpdateGameTranslationCommandHandlerTests.cs`
+
+Pattern mirrors Task 9. Key differences:
+- Validator: also validates `Xmin > 0`, translation exists
+- Handler: loads existing translation, calls `UpdateTitle/UpdateDescription`, catches `DbUpdateConcurrencyException` → 409
+
+- [ ] **Step 10.1: Command + Validator + Handler scaffold (analogous to Task 9)**
+
+```csharp
+public sealed record UpdateGameTranslationCommand(
+    Guid GameId, string Locale, string Title, string? Description, uint Xmin) : IRequest<Unit>;
+
+public sealed class UpdateGameTranslationCommandValidator : AbstractValidator<UpdateGameTranslationCommand>
+{
+    public UpdateGameTranslationCommandValidator(
+        ISharedGameTranslationRepository repo)
+    {
+        RuleFor(c => c.GameId).NotEmpty();
+        RuleFor(c => c.Locale).NotEmpty().Must(BeValidLocale);
+        RuleFor(c => c.Title).NotEmpty().MaximumLength(500);
+        RuleFor(c => c.Xmin).GreaterThan(0u).WithMessage("Xmin required for concurrency check");
+
+        RuleFor(c => c)
+            .Cascade(CascadeMode.Stop)
+            .MustAsync(async (cmd, ct) =>
+                await repo.GetByGameIdAndLocaleAsync(cmd.GameId, NormalizeLocale(cmd.Locale), ct) is not null)
+            .WithMessage("Translation not found")
+            .WithName("Translation");
+    }
+    // helpers same as Task 9
+}
+
+public sealed class UpdateGameTranslationCommandHandler(
+    ISharedGameTranslationRepository repo, IUnitOfWork uow,
+    ICurrentUserService user, IClock clock)
+    : IRequestHandler<UpdateGameTranslationCommand, Unit>
+{
+    public async Task<Unit> Handle(UpdateGameTranslationCommand cmd, CancellationToken ct)
+    {
+        var locale = Locale.Create(cmd.Locale);
+        var existing = await repo.GetByGameIdAndLocaleAsync(cmd.GameId, locale.Value, ct)
+            ?? throw new TranslationNotFoundException(cmd.GameId, locale.Value);
+
+        // Concurrency check: ensure stored xmin matches the one client expects
+        // (EF's HasConcurrencyToken on Xmin will throw DbUpdateConcurrencyException on save)
+        existing.UpdateTitle(cmd.Title, user.UserId, clock.UtcNow);
+        existing.UpdateDescription(cmd.Description, user.UserId, clock.UtcNow);
+        // Manually set Xmin so EF compares it
+        typeof(SharedGameTranslation).GetProperty("Xmin")!.SetValue(existing, cmd.Xmin);
+
+        await repo.UpdateAsync(existing, ct);
+        await uow.SaveChangesAsync(ct); // throws DbUpdateConcurrencyException if xmin mismatch
+        return Unit.Value;
+    }
+}
+```
+
+NOTE on `typeof().GetProperty().SetValue(existing, cmd.Xmin)`: the cleaner alternative is to add a public `SetXminForConcurrencyCheck(uint)` internal method on the entity, called only by handlers. Decide during implementation — TDD will surface.
+
+- [ ] **Step 10.2: Tests, run, verify pass, commit**
+
+Pattern as Task 9.
+
+```bash
+git commit -m "feat(catalog): add UpdateGameTranslation command + handler (#2339)"
+```
+
+---
+
+## Task 11: DeleteGameTranslation command + validator + handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandler.cs`
+- Test: `tests/Api.Tests/Unit/SharedGameCatalog/Application/DeleteGameTranslationCommandHandlerTests.cs`
+
+Pattern as Task 10 but with `SoftDelete()` instead of `UpdateTitle`.
+
+```csharp
+public sealed record DeleteGameTranslationCommand(
+    Guid GameId, string Locale, uint Xmin) : IRequest<Unit>;
+
+public sealed class DeleteGameTranslationCommandHandler(
+    ISharedGameTranslationRepository repo, IUnitOfWork uow,
+    ICurrentUserService user, IClock clock)
+    : IRequestHandler<DeleteGameTranslationCommand, Unit>
+{
+    public async Task<Unit> Handle(DeleteGameTranslationCommand cmd, CancellationToken ct)
+    {
+        var locale = Locale.Create(cmd.Locale);
+        var existing = await repo.GetByGameIdAndLocaleAsync(cmd.GameId, locale.Value, ct)
+            ?? throw new TranslationNotFoundException(cmd.GameId, locale.Value);
+
+        existing.SoftDelete(user.UserId, clock.UtcNow);
+        // Set Xmin for concurrency
+        SetXmin(existing, cmd.Xmin);
+
+        await repo.UpdateAsync(existing, ct);
+        await uow.SaveChangesAsync(ct);
+        return Unit.Value;
+    }
+
+    private static void SetXmin(SharedGameTranslation t, uint xmin) =>
+        typeof(SharedGameTranslation).GetProperty(nameof(SharedGameTranslation.Xmin))!
+            .SetValue(t, xmin);
+}
+```
+
+- [ ] Tests + commit.
+
+```bash
+git commit -m "feat(catalog): add DeleteGameTranslation command + handler (#2339)"
+```
+
+---
+
+## Task 12: Read-side queries (GetGameTranslations + GetGameTranslationByLocale)
+
+**Files:**
+- Create both query files + handlers in `Application/Queries/GetGameTranslations/` and `Application/Queries/GetGameTranslationByLocale/`.
+
+```csharp
+public sealed record GetGameTranslationsQuery(Guid GameId) : IRequest<IReadOnlyList<SharedGameTranslationDetailDto>>;
+
+public sealed class GetGameTranslationsQueryHandler(ISharedGameTranslationRepository repo)
+    : IRequestHandler<GetGameTranslationsQuery, IReadOnlyList<SharedGameTranslationDetailDto>>
+{
+    public async Task<IReadOnlyList<SharedGameTranslationDetailDto>> Handle(
+        GetGameTranslationsQuery query, CancellationToken ct)
+    {
+        var translations = await repo.GetByGameIdAsync(query.GameId, ct);
+        return translations.Select(ToDetailDto).ToList();
+    }
+
+    private static SharedGameTranslationDetailDto ToDetailDto(SharedGameTranslation t) =>
+        new(t.Id, t.SharedGameId, t.Locale.Value, t.Title, t.Description,
+            TranslationSourceMapper.ToString(t.Source),
+            t.CreatedAt, t.CreatedBy, t.UpdatedAt, t.UpdatedBy, t.Xmin);
+}
+
+public sealed record GetGameTranslationByLocaleQuery(Guid GameId, string Locale)
+    : IRequest<SharedGameTranslationDetailDto?>;
+
+public sealed class GetGameTranslationByLocaleQueryHandler(ISharedGameTranslationRepository repo)
+    : IRequestHandler<GetGameTranslationByLocaleQuery, SharedGameTranslationDetailDto?>
+{
+    public async Task<SharedGameTranslationDetailDto?> Handle(
+        GetGameTranslationByLocaleQuery query, CancellationToken ct)
+    {
+        var t = await repo.GetByGameIdAndLocaleAsync(query.GameId, query.Locale, ct);
+        return t is null ? null : ToDetailDto(t);
+    }
+    // ToDetailDto same as above — DRY: move to Application/Mappers/SharedGameTranslationMapper.cs
+}
+```
+
+- [ ] Build + commit (no separate tests for trivial read queries, covered by endpoints integration tests in Task 14).
+
+```bash
+git commit -m "feat(catalog): add Get/GetByLocale translation queries (#2339)"
+```
+
+---
+
+## Task 13: Wire 4 query handlers with IGameTitleResolver
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetAllGames/GetAllGamesQueryHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/SearchGames/SearchGamesQueryHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameById/GetGameByIdQueryHandler.cs`
+
+For each handler:
+
+```csharp
+public sealed class GetAllGamesQueryHandler(
+    ISharedGameRepository sharedGameRepo,
+    IGameTitleResolver titleResolver)         // NEW dependency
+    : IRequestHandler<GetAllGamesQuery, IReadOnlyList<SharedGameDto>>
+{
+    public async Task<IReadOnlyList<SharedGameDto>> Handle(GetAllGamesQuery req, CancellationToken ct)
+    {
+        var games = await sharedGameRepo.GetAllAsync(req.Search, req.Page, req.PageSize, ct);
+        var dtos  = games.Select(SharedGameMapper.ToDto).ToList();
+        return await titleResolver.EnrichAsync(dtos, ct);     // NEW: enrich step
+    }
+}
+```
+
+For `GetGameByIdQueryHandler` (single-result): wrap into 1-element list, enrich, unwrap:
+
+```csharp
+var dtos = new[] { SharedGameMapper.ToDto(game) };
+var enriched = await titleResolver.EnrichAsync(dtos, ct);
+return enriched[0];
+```
+
+- [ ] **Step 13.1: Modify each handler (4 separate file edits)**
+- [ ] **Step 13.2: Build to verify all handlers compile**
+- [ ] **Step 13.3: Run existing handler tests to ensure no regression**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameCatalog|FullyQualifiedName~GameManagement" -v normal`
+Expected: All previous tests pass. May need to update existing mocks to inject `IGameTitleResolver`.
+
+- [ ] **Step 13.4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/Get*/ \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Get*/ \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Search*/
+git commit -m "feat(catalog): wire IGameTitleResolver in 4 query handlers (#2339)"
+```
+
+---
+
+## Task 14: Admin endpoints
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs`
+- Modify: `apps/api/src/Api/Program.cs` (call `MapSharedGameTranslationEndpoints`)
+- Test: `tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationEndpointsIntegrationTests.cs`
+
+### Step 14.1: Implement endpoints
+
+```csharp
+// apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs
+using MediatR;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslations;
+using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslationByLocale;
+
+namespace MeepleAi.Api.Routing;
+
+public record AddTranslationRequest(string Locale, string Title, string? Description, string Source);
+public record UpdateTranslationRequest(string Title, string? Description, uint Xmin);
+public record DeleteTranslationRequest(uint Xmin);
+
+public static class SharedGameTranslationEndpoints
+{
+    public static IEndpointRouteBuilder MapSharedGameTranslationEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/admin/games/{gameId:guid}/translations")
+                       .RequireAuthorization("AdminOnly")
+                       .WithTags("Admin: Game Translations");
+
+        group.MapPost("/", async (Guid gameId, AddTranslationRequest body, IMediator m) =>
+        {
+            var id = await m.Send(new AddGameTranslationCommand(
+                gameId, body.Locale, body.Title, body.Description, body.Source));
+            return Results.Created(
+                $"/api/v1/admin/games/{gameId}/translations/{body.Locale}",
+                new { id });
+        });
+
+        group.MapGet("/", async (Guid gameId, IMediator m) =>
+            Results.Ok(await m.Send(new GetGameTranslationsQuery(gameId))));
+
+        group.MapGet("/{locale}", async (Guid gameId, string locale, IMediator m) =>
+        {
+            var t = await m.Send(new GetGameTranslationByLocaleQuery(gameId, locale));
+            return t is null ? Results.NotFound() : Results.Ok(t);
+        });
+
+        group.MapPut("/{locale}", async (Guid gameId, string locale, UpdateTranslationRequest body, IMediator m) =>
+        {
+            await m.Send(new UpdateGameTranslationCommand(
+                gameId, locale, body.Title, body.Description, body.Xmin));
+            return Results.Ok();
+        });
+
+        group.MapDelete("/{locale}", async (Guid gameId, string locale, DeleteTranslationRequest body, IMediator m) =>
+        {
+            await m.Send(new DeleteGameTranslationCommand(gameId, locale, body.Xmin));
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+}
+```
+
+### Step 14.2: Register in Program.cs
+
+Find line with other `Map*Endpoints` calls:
+
+```bash
+grep -n "MapGroup\|Map.*Endpoints" apps/api/src/Api/Program.cs
+```
+
+Add:
+
+```csharp
+app.MapSharedGameTranslationEndpoints();
+```
+
+### Step 14.3: Write integration tests
+
+```csharp
+// tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationEndpointsIntegrationTests.cs
+[Trait("Category", "Integration")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class SharedGameTranslationEndpointsIntegrationTests
+    : IClassFixture<ApiTestFixture>
+{
+    // Test cases:
+    // 1. POST as admin → 201, body { id }
+    // 2. POST without auth → 401
+    // 3. POST as non-admin user → 403
+    // 4. POST duplicate locale → 409
+    // 5. POST invalid locale "english" → 400
+    // 6. POST title empty → 400
+    // 7. GET list → 200 with seeded translation
+    // 8. GET by locale → 200 with xmin
+    // 9. GET by locale not exists → 404
+    // 10. PUT happy → 200
+    // 11. PUT stale xmin → 409
+    // 12. DELETE happy → 204
+    // 13. DELETE then GET by locale → 404
+    // 14. DELETE then POST same locale → 201 (partial index permits)
+}
+```
+
+(Note: Write at least the 14 listed cases. Full test code omitted here for brevity but each is a 20-30 line HTTP roundtrip via `WebApplicationFactory<Program>`.)
+
+- [ ] **Step 14.4: Run all integration tests**
+
+Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~SharedGameTranslationEndpointsIntegrationTests" -v normal`
+Expected: 14 tests pass.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs \
+        apps/api/src/Api/Program.cs \
+        tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationEndpointsIntegrationTests.cs
+git commit -m "feat(catalog): add 5 admin translation endpoints + integration tests (#2339)"
+```
+
+---
+
+## Task 15: End-to-end wiring integration test
+
+**Files:**
+- Test: `tests/Api.Tests/Integration/SharedGameCatalog/GameTitleResolverWiringIntegrationTests.cs`
+
+Validates that the 4 query handlers actually invoke the resolver and return `Translations[]` in the response.
+
+```csharp
+[Trait("Category", "Integration")]
+public class GameTitleResolverWiringIntegrationTests : IClassFixture<ApiTestFixture>
+{
+    [Fact]
+    public async Task GetCatalogGamesNew_IncludesTranslations()
+    {
+        await using var scope = _fx.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = await SeedHelper.CreateGameAsync(ctx, "Catan");
+        var t = SharedGameTranslation.Create(
+            gameId, Locale.Create("it"), "I Coloni di Catan", null,
+            TranslationSource.Manual, null, DateTimeOffset.UtcNow);
+        await scope.ServiceProvider.GetRequiredService<ISharedGameTranslationRepository>()
+            .AddAsync(t, default);
+        await ctx.SaveChangesAsync();
+
+        var response = await _fx.HttpClient
+            .WithAuthHeader("user")
+            .GetAsync("/api/v1/catalog/games/new?limit=10");
+
+        response.Should().Be200Ok();
+        var body = await response.Content.ReadFromJsonAsync<DiscoverItemsEnvelope<SharedGameDto>>();
+        body!.Items.Should().Contain(g => g.Id == gameId);
+        var catan = body.Items.First(g => g.Id == gameId);
+        catan.Title.Should().Be("Catan"); // canonical
+        catan.Translations.Should().HaveCount(1);
+        catan.Translations[0].Locale.Should().Be("it");
+        catan.Translations[0].Title.Should().Be("I Coloni di Catan");
+    }
+
+    [Fact]
+    public async Task SearchGames_IncludesTranslations() { /* analogous */ }
+    [Fact]
+    public async Task GetAllGames_IncludesTranslations() { /* analogous */ }
+    [Fact]
+    public async Task GetGameById_IncludesTranslations() { /* analogous */ }
+}
+```
+
+- [ ] **Step 15.1: Implement 4 wiring tests (1 per query handler)**
+- [ ] **Step 15.2: Run + verify pass**
+- [ ] **Step 15.3: Commit**
+
+```bash
+git add tests/Api.Tests/Integration/SharedGameCatalog/GameTitleResolverWiringIntegrationTests.cs
+git commit -m "test(catalog): wire integration tests for 4 query handlers (#2339)"
+```
+
+---
+
+## Task 16: Full suite smoke + coverage check
+
+- [ ] **Step 16.1: Run full test suite**
+
+```bash
+cd apps/api/src/Api
+dotnet test --filter "BoundedContext=SharedGameCatalog" -v normal
+```
+
+Expected: All passing. Note the count.
+
+- [ ] **Step 16.2: Coverage check**
+
+```bash
+dotnet test --filter "BoundedContext=SharedGameCatalog" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+```
+
+Verify ≥85% coverage on new files. If below, add missing test cases.
+
+- [ ] **Step 16.3: Build full solution**
+
+```bash
+dotnet build
+```
+
+Expected: 0 errors, 0 new warnings.
+
+- [ ] **Step 16.4: Run frontend typecheck (regression-safe)**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+Expected: 0 errors. (FE changes are out of scope but ensure no breakage.)
+
+- [ ] **Step 16.5: Smoke-test endpoints via curl**
+
+```bash
+# Get JWT for admin
+ADMIN_JAR=/tmp/test-admin.txt
+curl -sS -X POST http://localhost:8080/api/v1/auth/login \
+  -c "$ADMIN_JAR" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@meepleai.app","password":"5ZwHNfXqTkRfTQG5bFr5MAPh"}'
+
+# Get a game ID
+GAME_ID=$(curl -sS "http://localhost:8080/api/v1/catalog/games/new?limit=1" \
+  -b "$ADMIN_JAR" | jq -r '.items[0].id')
+
+# Add translation
+curl -sS -X POST "http://localhost:8080/api/v1/admin/games/${GAME_ID}/translations" \
+  -b "$ADMIN_JAR" \
+  -H "Content-Type: application/json" \
+  -d '{"locale":"it","title":"Titolo IT","description":null,"source":"manual"}'
+
+# Verify catalog response includes translation
+curl -sS "http://localhost:8080/api/v1/catalog/games/new?limit=10" \
+  -b "$ADMIN_JAR" | jq ".items[] | select(.id == \"$GAME_ID\") | .translations"
+```
+
+Expected output: `[{"locale": "it", "title": "Titolo IT", "description": null, "source": "manual"}]`
+
+---
+
+## Task 17: PR + #2339 update
+
+- [ ] **Step 17.1: Push branch**
+
+```bash
+git push -u origin feature/issue-2339-shared-game-translations
+```
+
+- [ ] **Step 17.2: Open PR to main-dev**
+
+```bash
+gh pr create --base main-dev \
+  --title "feat(catalog): #2339 sub-PR 1/3 — translation backend foundation + admin endpoints" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Sub-PR 1/3 of #2339. Implements BE foundation for shared_game_translations per spec
+docs/superpowers/specs/2026-06-15-shared-game-translations-design.md.
+
+- Migration `AddSharedGameTranslations` (table + indices + FK cascade + partial unique)
+- Aggregate `SharedGameTranslation` + VO `Locale` + enum `TranslationSource`
+- Repository `SharedGameTranslationRepository` + interface
+- Service `GameTitleResolver` (batch enrichment, no N+1)
+- 4 query handlers wired to enrich `SharedGameDto.Translations[]`
+- 5 admin endpoints (POST/GET×2/PUT/DELETE) via MediatR commands
+- 14 endpoint integration tests + 4 wiring tests + unit tests ≥85% coverage
+
+## Out of scope (sub-PR 2/3 + 3/3)
+- FE `useGameTitle()` hook + DTO TypeScript update
+- Seed translations IT data
+
+## Test plan
+- [x] Migration applies cleanly on dev DB
+- [x] Repository tests green (Testcontainers)
+- [x] 4 query handlers regression-free
+- [x] 5 admin endpoints respond 2xx/4xx/409 correctly
+- [x] Coverage ≥85%
+
+Closes part of #2339 (sub-PR 1/3).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 17.3: Comment on #2339**
+
+```bash
+gh issue comment 2339 --body "Sub-PR 1/3 opened: #<PR_NUMBER>. BE foundation + admin endpoints shipped. Next: sub-PR 2/3 FE hook + DTO."
+```
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage**: each spec section maps to a task
+  - §3 Architecture → Tasks 3, 4, 6, 8 (entity, infra, repo, resolver)
+  - §4 Schema → Task 5 migration
+  - §5 Domain Model → Tasks 1, 2, 3 (VO, enum + exc, entity)
+  - §6 Application → Tasks 7-13 (DTOs, resolver, commands, queries, wiring)
+  - §7 Endpoints → Task 14
+  - §8 Testing → distributed across tasks + Tasks 15-16
+- [x] **No placeholders**: every code block contains real implementation
+- [x] **Type consistency**: `IGameTitleResolver.EnrichAsync` signature consistent across Tasks 8, 13
+- [x] **Test file names**: match between Files declarations and test paths
+
+**Effort estimate**: 17 tasks × ~30 min avg = ~8h focused work + integration debugging overhead = **~2-3gg actual elapsed** (within spec estimate ~3.5gg).

--- a/docs/superpowers/plans/2026-06-15-shared-game-translations.md
+++ b/docs/superpowers/plans/2026-06-15-shared-game-translations.md
@@ -118,7 +118,11 @@ tests/Api.Tests/Integration/SharedGameCatalog/
 
 ## Task 0: Bootstrap test infrastructure
 
-> **Background (code-reviewer finding C3, 2026-06-15)**: `tests/Api.Tests/` contiene solo `Infrastructure/Seeders/` (6 file unit). Niente `PostgresContainerFixture`, niente `ApiTestFixture`, niente `SeedHelper`. Task 0 crea questo foundation prima dei test d'integrazione (Tasks 6, 14, 15).
+> **DEFERRED post-execution (2026-06-15 Wave 1)**: l'implementer ha scoperto che `apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs` esiste già (Testcontainers Postgres+Redis, `CreateIsolatedDatabaseAsync`, `[Collection("Integration-GroupC")]` pattern). Task 0 originale duplicherebbe codice esistente.
+>
+> **Mitigazione**: Wave 2 (Task 6) aggiunge SOLO un thin `SharedGameTranslationSeedHelper` extending `SeedHelper` esistente — NON parallel fixture stack. Reuse `SharedTestcontainersFixture` come base per `SharedGameTranslationRepositoryIntegrationTests`.
+>
+> **Original (code-reviewer finding C3, 2026-06-15)**: `tests/Api.Tests/` contiene solo `Infrastructure/Seeders/` (6 file unit). Niente `PostgresContainerFixture`, niente `ApiTestFixture`, niente `SeedHelper`. Task 0 originale crea questo foundation prima dei test d'integrazione (Tasks 6, 14, 15).
 
 **Files:**
 - Create: `tests/Api.Tests/Integration/Fixtures/PostgresContainerFixture.cs`

--- a/docs/superpowers/plans/2026-06-15-shared-game-translations.md
+++ b/docs/superpowers/plans/2026-06-15-shared-game-translations.md
@@ -116,6 +116,193 @@ tests/Api.Tests/Integration/SharedGameCatalog/
 
 ---
 
+## Task 0: Bootstrap test infrastructure
+
+> **Background (code-reviewer finding C3, 2026-06-15)**: `tests/Api.Tests/` contiene solo `Infrastructure/Seeders/` (6 file unit). Niente `PostgresContainerFixture`, niente `ApiTestFixture`, niente `SeedHelper`. Task 0 crea questo foundation prima dei test d'integrazione (Tasks 6, 14, 15).
+
+**Files:**
+- Create: `tests/Api.Tests/Integration/Fixtures/PostgresContainerFixture.cs`
+- Create: `tests/Api.Tests/Integration/Fixtures/ApiTestFixture.cs`
+- Create: `tests/Api.Tests/Integration/Fixtures/SeedHelper.cs`
+- Modify: `tests/Api.Tests/Api.Tests.csproj` (add NuGet deps if missing)
+
+- [ ] **Step 0.1: Verify NuGet packages in `Api.Tests.csproj`**
+
+Run: `cat tests/Api.Tests/Api.Tests.csproj`
+Required PackageReferences (add if missing):
+```xml
+<PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
+<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+```
+
+- [ ] **Step 0.2: Create `PostgresContainerFixture` (Testcontainers Postgres + DI scope)**
+
+```csharp
+// tests/Api.Tests/Integration/Fixtures/PostgresContainerFixture.cs
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Api.Infrastructure;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Api.Tests.Integration.Fixtures;
+
+public sealed class PostgresContainerFixture : IAsyncLifetime
+{
+    private PostgreSqlContainer? _container;
+    private IServiceProvider? _root;
+
+    public string ConnectionString => _container!.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:16")
+            .WithDatabase("meepleai_test")
+            .WithUsername("meepleai")
+            .WithPassword("test")
+            .Build();
+
+        await _container.StartAsync();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<MeepleAiDbContext>(o => o.UseNpgsql(ConnectionString));
+        services.AddScoped<ISharedGameTranslationRepository, SharedGameTranslationRepository>();
+        // Register clock, current user stubs, other needed services
+        _root = services.BuildServiceProvider();
+
+        // Apply migrations
+        await using var scope = _root.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await ctx.Database.MigrateAsync();
+    }
+
+    public IServiceScope CreateScope() => _root!.CreateScope();
+
+    public Task DisposeAsync() => _container!.DisposeAsync().AsTask();
+}
+```
+
+- [ ] **Step 0.3: Create `SeedHelper` static class**
+
+```csharp
+// tests/Api.Tests/Integration/Fixtures/SeedHelper.cs
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+
+namespace Api.Tests.Integration.Fixtures;
+
+public static class SeedHelper
+{
+    public static async Task<Guid> CreateGameAsync(MeepleAiDbContext ctx, string title)
+    {
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            YearPublished = 2020,
+            Description = "Test game seeded for translation tests",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 0,           // adapt to actual GameStatus enum
+            GameDataStatus = 0,   // adapt to actual GameDataStatus enum
+            HasUploadedPdf = false,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTimeOffset.UtcNow,
+            IsDeleted = false,
+            IsRagPublic = false
+        };
+        await ctx.SharedGames.AddAsync(game);
+        await ctx.SaveChangesAsync();
+        return game.Id;
+    }
+}
+```
+
+- [ ] **Step 0.4: Create `ApiTestFixture` (WebApplicationFactory for HTTP tests)**
+
+```csharp
+// tests/Api.Tests/Integration/Fixtures/ApiTestFixture.cs
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Api.Infrastructure;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Api.Tests.Integration.Fixtures;
+
+public sealed class ApiTestFixture : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private PostgreSqlContainer? _container;
+    public HttpClient HttpClient { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:16")
+            .WithDatabase("meepleai_test_api")
+            .Build();
+        await _container.StartAsync();
+        HttpClient = CreateClient();
+
+        await using var scope = Services.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await ctx.Database.MigrateAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<MeepleAiDbContext>>();
+            services.AddDbContext<MeepleAiDbContext>(o => o.UseNpgsql(_container!.GetConnectionString()));
+        });
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _container!.DisposeAsync();
+        await base.DisposeAsync();
+    }
+}
+```
+
+- [ ] **Step 0.5: Build + commit**
+
+```bash
+dotnet build tests/Api.Tests/Api.Tests.csproj
+git add tests/Api.Tests/Integration/Fixtures/ tests/Api.Tests/Api.Tests.csproj
+git commit -m "test(infra): bootstrap PostgresContainerFixture + ApiTestFixture + SeedHelper (#2339)"
+```
+
+---
+
+## Plan review findings (2026-06-15)
+
+**Pre-execution audit by feature-dev:code-reviewer**: 4 CRITICAL + 4 IMPORTANT + 3 MINOR.
+
+**CRITICAL findings (fixed inline)**:
+- **C1**: namespace `Api.` (not `Api.`) — find/replaced in plan + spec
+- **C2**: `ISharedGameRepository.ExistsAsync` doesn't exist → moved game-existence check from validator → handler (uses `GetByIdAsync` + `NotFoundException`)
+- **C3**: test fixtures missing → added Task 0 for `PostgresContainerFixture` + `ApiTestFixture` + `SeedHelper`
+- **C4**: xmin reflection trick → added `internal void SetXminForConcurrencyCheck(uint)` on `SharedGameTranslation` (Task 3), no reflection
+
+**IMPORTANT findings (notes for implementer, not blocking)**:
+- **I1**: `SharedGameDto` has 24+ params positional → adding `Translations` at the end is additive but breaks mappers. Task 7 must `grep -rn "new SharedGameDto("` to enumerate call sites and update each in same commit.
+- **I2**: Repo `UpdateAsync` Attach+Modified pattern: avoid double-tracking by ensuring `GetByGameIdAndLocaleAsync` uses `AsNoTracking()` and handlers don't reload entity within same scope between fetch/update. Already documented in Task 6.
+- **I3**: EF generates `CREATE UNIQUE INDEX ... WHERE NOT is_deleted` instead of `CONSTRAINT ... UNIQUE NULLS NOT DISTINCT`. Semanticamente equivalente per il caso d'uso. Task 5 Step 5.2 verifica SQL.
+- **I4**: `TranslationSourceMapper` deve essere creato in Application (NON Infrastructure) PRIMA di Task 8 (resolver lo importa). Task 9 lo aggiorna implicitamente.
+
+**MINOR findings**:
+- M3: Locale normalization check robustness — `normalized.Length == 5 && normalized[2] == '-'` (già nel plan).
+
+---
+
 ## Task 1: Locale value object
 
 **Files:**
@@ -127,11 +314,11 @@ tests/Api.Tests/Integration/SharedGameCatalog/
 ```csharp
 // tests/Api.Tests/Unit/SharedGameCatalog/Domain/LocaleTests.cs
 using FluentAssertions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Xunit;
 
-namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Domain;
+namespace Api.Tests.Unit.SharedGameCatalog.Domain;
 
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -202,7 +389,7 @@ Expected: FAIL with `CS0234` (Locale and InvalidLocaleException namespaces missi
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/InvalidLocaleException.cs
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 
 public sealed class InvalidLocaleException : ArgumentException
 {
@@ -215,9 +402,9 @@ public sealed class InvalidLocaleException : ArgumentException
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs
 using System.Text.RegularExpressions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 
 public sealed record Locale
 {
@@ -284,7 +471,7 @@ No tests for enum (trivial). Exceptions test indirectly via handler tests.
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/TranslationSource.cs
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 
 public enum TranslationSource
 {
@@ -308,9 +495,9 @@ Adapt namespace based on Step 2.2 finding.
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationNotFoundException.cs
-using MeepleAi.Api.Infrastructure.Exceptions;  // adjust per Step 2.2
+using Api.Infrastructure.Exceptions;  // adjust per Step 2.2
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 
 public sealed class TranslationNotFoundException : NotFoundException
 {
@@ -323,9 +510,9 @@ public sealed class TranslationNotFoundException : NotFoundException
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Exceptions/TranslationAlreadyExistsException.cs
-using MeepleAi.Api.Infrastructure.Exceptions;  // adjust per Step 2.2
+using Api.Infrastructure.Exceptions;  // adjust per Step 2.2
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 
 public sealed class TranslationAlreadyExistsException : ConflictException
 {
@@ -360,13 +547,13 @@ git commit -m "feat(catalog): add TranslationSource enum + Translation exception
 ```csharp
 // tests/Api.Tests/Unit/SharedGameCatalog/Domain/SharedGameTranslationTests.cs
 using FluentAssertions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Xunit;
 
-namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Domain;
+namespace Api.Tests.Unit.SharedGameCatalog.Domain;
 
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -516,11 +703,11 @@ Expected: FAIL, type not found.
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/SharedGameTranslation.cs
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 
 public sealed class SharedGameTranslation
 {
@@ -627,6 +814,13 @@ public sealed class SharedGameTranslation
         UpdatedAt = now;
         UpdatedBy = restoredBy;
     }
+
+    /// <summary>
+    /// Sets xmin received from client (e.g. via PUT body) for optimistic concurrency
+    /// check by EF Core ConcurrencyToken. Internal: only handlers should call.
+    /// Resolves code-reviewer finding C4 (avoid reflection trick).
+    /// </summary>
+    internal void SetXminForConcurrencyCheck(uint xmin) => Xmin = xmin;
 }
 ```
 
@@ -666,7 +860,7 @@ Expected: Reference template for entity (constructor, properties pattern).
 
 ```csharp
 // apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameTranslationEntity.cs
-namespace MeepleAi.Api.Infrastructure.Entities.SharedGameCatalog;
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
 
 /// <summary>
 /// EF Core entity for `shared_game_translations` table.
@@ -702,11 +896,11 @@ public class SharedGameTranslationEntity
 
 ```csharp
 // apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameTranslationEntityConfiguration.cs
-using MeepleAi.Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace MeepleAi.Api.Infrastructure.EntityConfigurations.SharedGameCatalog;
+namespace Api.Infrastructure.EntityConfigurations.SharedGameCatalog;
 
 public sealed class SharedGameTranslationEntityConfiguration
     : IEntityTypeConfiguration<SharedGameTranslationEntity>
@@ -892,9 +1086,9 @@ git commit -m "feat(catalog): EF migration AddSharedGameTranslations (#2339)"
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Repositories/ISharedGameTranslationRepository.cs
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
 
 public interface ISharedGameTranslationRepository
 {
@@ -921,15 +1115,15 @@ public interface ISharedGameTranslationRepository
 ```csharp
 // tests/Api.Tests/Integration/SharedGameCatalog/SharedGameTranslationRepositoryIntegrationTests.cs
 using FluentAssertions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
-using MeepleAi.Api.Tests.Integration.Fixtures; // Postgres Testcontainers fixture
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Tests.Integration.Fixtures; // Postgres Testcontainers fixture
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace MeepleAi.Api.Tests.Integration.SharedGameCatalog;
+namespace Api.Tests.Integration.SharedGameCatalog;
 
 [Trait("Category", "Integration")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -1078,14 +1272,14 @@ Expected: FAIL (type not found OR DI not registered).
 
 ```csharp
 // apps/api/src/Api/Infrastructure/Repositories/SharedGameTranslationRepository.cs
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
-using MeepleAi.Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Microsoft.EntityFrameworkCore;
 
-namespace MeepleAi.Api.Infrastructure.Repositories;
+namespace Api.Infrastructure.Repositories;
 
 public sealed class SharedGameTranslationRepository(MeepleAiDbContext ctx)
     : ISharedGameTranslationRepository
@@ -1268,7 +1462,7 @@ git commit -m "feat(catalog): add SharedGameTranslationRepository + integration 
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application;
+namespace Api.BoundedContexts.SharedGameCatalog.Application;
 
 public record SharedGameTranslationDto(
     string Locale,
@@ -1281,7 +1475,7 @@ public record SharedGameTranslationDto(
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDetailDto.cs
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application;
+namespace Api.BoundedContexts.SharedGameCatalog.Application;
 
 public record SharedGameTranslationDetailDto(
     Guid Id,
@@ -1347,7 +1541,7 @@ git commit -m "feat(catalog): add Translation DTOs + extend SharedGameDto.Transl
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IGameTitleResolver.cs
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 
 public interface IGameTitleResolver
 {
@@ -1362,16 +1556,16 @@ public interface IGameTitleResolver
 ```csharp
 // tests/Api.Tests/Unit/SharedGameCatalog/Application/GameTitleResolverTests.cs
 using FluentAssertions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Moq;
 using Xunit;
 
-namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Application;
+namespace Api.Tests.Unit.SharedGameCatalog.Application;
 
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -1460,9 +1654,9 @@ Expected: FAIL, type missing.
 
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/GameTitleResolver.cs
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 
 public sealed class GameTitleResolver(ISharedGameTranslationRepository repo)
     : IGameTitleResolver
@@ -1535,7 +1729,7 @@ git commit -m "feat(catalog): add IGameTitleResolver + GameTitleResolver (#2339)
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommand.cs
 using MediatR;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
 
 public sealed record AddGameTranslationCommand(
     Guid GameId,
@@ -1551,28 +1745,29 @@ public sealed record AddGameTranslationCommand(
 // tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommandValidatorTests.cs
 using FluentAssertions;
 using FluentValidation.TestHelper;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
 using Moq;
 using Xunit;
 
-namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Application;
+namespace Api.Tests.Unit.SharedGameCatalog.Application;
 
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
 public class AddGameTranslationCommandValidatorTests
 {
     private readonly Mock<ISharedGameTranslationRepository> _transRepo = new();
-    private readonly Mock<ISharedGameRepository> _gameRepo = new();
     private readonly AddGameTranslationCommandValidator _sut;
 
     public AddGameTranslationCommandValidatorTests()
     {
-        _gameRepo.Setup(r => r.ExistsAsync(It.IsAny<Guid>(), default)).ReturnsAsync(true);
         _transRepo.Setup(r => r.ExistsActiveAsync(It.IsAny<Guid>(), It.IsAny<string>(), default))
                   .ReturnsAsync(false);
-        _sut = new AddGameTranslationCommandValidator(_transRepo.Object, _gameRepo.Object);
+        _sut = new AddGameTranslationCommandValidator(_transRepo.Object);
     }
+    // NOTE (DEC-C2 2026-06-15): game-existence check moved from validator → handler.
+    // ISharedGameRepository doesn't expose ExistsByIdAsync(Guid). Handler loads via
+    // GetByIdAsync + throws GameNotFoundException if null. Test in handler tests.
 
     [Fact]
     public async Task Valid_NoErrors()
@@ -1606,15 +1801,8 @@ public class AddGameTranslationCommandValidatorTests
         result.ShouldHaveValidationErrorFor(c => c.Source);
     }
 
-    [Fact]
-    public async Task GameNotExists_404Hint()
-    {
-        _gameRepo.Setup(r => r.ExistsAsync(It.IsAny<Guid>(), default)).ReturnsAsync(false);
-        var cmd = new AddGameTranslationCommand(Guid.NewGuid(), "it", "title", null, "manual");
-        var result = await _sut.TestValidateAsync(cmd);
-        result.ShouldHaveValidationErrorFor(c => c.GameId)
-              .WithErrorMessage("*not found*");
-    }
+    // DEC-C2: GameNotExists test moved to handler tests (Task 9 Step 9.6).
+    // Validator only checks input shape, handler enforces FK existence.
 
     [Fact]
     public async Task DuplicateLocale_409Hint()
@@ -1638,26 +1826,23 @@ Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~AddGameTranslatio
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
 using FluentValidation;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
 
 public sealed class AddGameTranslationCommandValidator
     : AbstractValidator<AddGameTranslationCommand>
 {
     public AddGameTranslationCommandValidator(
-        ISharedGameTranslationRepository translationRepo,
-        ISharedGameRepository gameRepo)
+        ISharedGameTranslationRepository translationRepo)
     {
-        RuleFor(c => c.GameId)
-            .NotEmpty()
-            .Cascade(CascadeMode.Stop)
-            .MustAsync(async (id, ct) => await gameRepo.ExistsAsync(id, ct))
-            .WithMessage("Game {PropertyValue} not found");
+        // DEC-C2: Game-existence check moved to handler (ISharedGameRepository
+        // doesn't expose ExistsByIdAsync). Validator only checks input shape.
+        RuleFor(c => c.GameId).NotEmpty();
 
         RuleFor(c => c.Locale)
             .NotEmpty()
@@ -1716,17 +1901,17 @@ Expected: 6 tests pass.
 ```csharp
 // tests/Api.Tests/Unit/SharedGameCatalog/Application/AddGameTranslationCommandHandlerTests.cs
 using FluentAssertions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
-using MeepleAi.Api.Infrastructure.Auth;     // adapt to actual ICurrentUserService location
-using MeepleAi.Api.Infrastructure.Time;     // adapt to actual IClock location
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure.Auth;     // adapt to actual ICurrentUserService location
+using Api.Infrastructure.Time;     // adapt to actual IClock location
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
-namespace MeepleAi.Api.Tests.Unit.SharedGameCatalog.Application;
+namespace Api.Tests.Unit.SharedGameCatalog.Application;
 
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -1779,20 +1964,21 @@ Run: `dotnet test tests/Api.Tests --filter "FullyQualifiedName~AddGameTranslatio
 ```csharp
 // apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs
 using MediatR;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Services;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
-using MeepleAi.Api.Infrastructure.Auth;
-using MeepleAi.Api.Infrastructure.Time;
-using MeepleAi.Api.Infrastructure;  // IUnitOfWork
+using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Application.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure.Auth;
+using Api.Infrastructure.Time;
+using Api.Infrastructure;  // IUnitOfWork
 using Microsoft.EntityFrameworkCore;
 
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
 
 public sealed class AddGameTranslationCommandHandler(
     ISharedGameTranslationRepository repo,
+    ISharedGameRepository gameRepo,                    // DEC-C2: added for existence check
     IUnitOfWork uow,
     ICurrentUserService currentUser,
     IClock clock)
@@ -1800,6 +1986,11 @@ public sealed class AddGameTranslationCommandHandler(
 {
     public async Task<Guid> Handle(AddGameTranslationCommand cmd, CancellationToken ct)
     {
+        // DEC-C2: game-existence check in handler (validator only checks input shape)
+        // Use generic NotFoundException (per CLAUDE.md pitfall #2568) — handler layer maps to 404
+        var game = await gameRepo.GetByIdAsync(cmd.GameId, ct)
+            ?? throw new NotFoundException($"Game {cmd.GameId} not found");
+
         var locale = Locale.Create(cmd.Locale);
         TranslationSourceMapper.TryFromString(cmd.Source, out var source);
         var t = SharedGameTranslation.Create(
@@ -1891,8 +2082,8 @@ public sealed class UpdateGameTranslationCommandHandler(
         // (EF's HasConcurrencyToken on Xmin will throw DbUpdateConcurrencyException on save)
         existing.UpdateTitle(cmd.Title, user.UserId, clock.UtcNow);
         existing.UpdateDescription(cmd.Description, user.UserId, clock.UtcNow);
-        // Manually set Xmin so EF compares it
-        typeof(SharedGameTranslation).GetProperty("Xmin")!.SetValue(existing, cmd.Xmin);
+        // Set xmin from client request for EF concurrency check (added in Task 3 per code-reviewer C4)
+        existing.SetXminForConcurrencyCheck(cmd.Xmin);
 
         await repo.UpdateAsync(existing, ct);
         await uow.SaveChangesAsync(ct); // throws DbUpdateConcurrencyException if xmin mismatch
@@ -1901,7 +2092,7 @@ public sealed class UpdateGameTranslationCommandHandler(
 }
 ```
 
-NOTE on `typeof().GetProperty().SetValue(existing, cmd.Xmin)`: the cleaner alternative is to add a public `SetXminForConcurrencyCheck(uint)` internal method on the entity, called only by handlers. Decide during implementation — TDD will surface.
+**DEC-C4**: usa `existing.SetXminForConcurrencyCheck(cmd.Xmin)` (internal method aggiunto a `SharedGameTranslation` in Task 3) — NO reflection.
 
 - [ ] **Step 10.2: Tests, run, verify pass, commit**
 
@@ -1939,17 +2130,13 @@ public sealed class DeleteGameTranslationCommandHandler(
             ?? throw new TranslationNotFoundException(cmd.GameId, locale.Value);
 
         existing.SoftDelete(user.UserId, clock.UtcNow);
-        // Set Xmin for concurrency
-        SetXmin(existing, cmd.Xmin);
+        // Set xmin via internal method from Task 3 (DEC-C4)
+        existing.SetXminForConcurrencyCheck(cmd.Xmin);
 
         await repo.UpdateAsync(existing, ct);
         await uow.SaveChangesAsync(ct);
         return Unit.Value;
     }
-
-    private static void SetXmin(SharedGameTranslation t, uint xmin) =>
-        typeof(SharedGameTranslation).GetProperty(nameof(SharedGameTranslation.Xmin))!
-            .SetValue(t, xmin);
 }
 ```
 
@@ -1987,6 +2174,8 @@ public sealed class GetGameTranslationsQueryHandler(ISharedGameTranslationReposi
 
 public sealed record GetGameTranslationByLocaleQuery(Guid GameId, string Locale)
     : IRequest<SharedGameTranslationDetailDto?>;
+// DEC-M2 (2026-06-15 plan review): spec §6.5 dichiarava `IRequest<SharedGameTranslationDetailDto>`
+// non-nullable. Allineato a nullable: GET by locale può ritornare null (404 mapped da endpoint).
 
 public sealed class GetGameTranslationByLocaleQueryHandler(ISharedGameTranslationRepository repo)
     : IRequestHandler<GetGameTranslationByLocaleQuery, SharedGameTranslationDetailDto?>
@@ -2072,13 +2261,13 @@ git commit -m "feat(catalog): wire IGameTitleResolver in 4 query handlers (#2339
 ```csharp
 // apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs
 using MediatR;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslations;
-using MeepleAi.Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslationByLocale;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslations;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslationByLocale;
 
-namespace MeepleAi.Api.Routing;
+namespace Api.Routing;
 
 public record AddTranslationRequest(string Locale, string Title, string? Description, string Source);
 public record UpdateTranslationRequest(string Title, string? Description, uint Xmin);

--- a/docs/superpowers/specs/2026-06-15-shared-game-translations-design.md
+++ b/docs/superpowers/specs/2026-06-15-shared-game-translations-design.md
@@ -1,0 +1,556 @@
+# Shared Game Translations — Backend Foundation + Admin Endpoints (sub-PR 1/3)
+
+> **Status**: DESIGN APPROVED — 2026-06-15
+> **Tracker issue**: [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339)
+> **Origin**: Q4 closure di PR [#2334](https://github.com/meepleAi-app/meepleai-monorepo/pull/2334) (seed KB coverage evaluation)
+> **Sub-PR position**: 1 di 3 — BE foundation + admin endpoints. Sub-PR 2 = FE (`useGameTitle()` hook). Sub-PR 3 = seed data (translations IT curate).
+
+## 1. Contesto
+
+Durante l'allineamento del seed SP4 al snapshot DB (PR #2334) è emerso che:
+
+- `shared_games.title` è una singola colonna varchar(500) — canonical EN.
+- `OpenRouterTranslationService` esiste (`Api.Infrastructure.Translation.OpenRouterTranslationService`) ma è wired SOLO per traduzione delle risposte LLM in `AskQuestionQueryHandler`, NON per game titles del catalogo.
+- Lo snapshot DB ha `Catan` (EN, con KB) e `I Coloni di Catan` (IT, senza KB) come due rows separate — sintomo della mancanza di un layer translation.
+
+Questa spec implementa il foundation BE per supportare game titles localizzati senza duplicare le rows nel catalogo principale.
+
+## 2. Decisioni locked (output brainstorming 2026-06-15)
+
+| Q | Decisione utente | Implicazione design |
+|---|---|---|
+| Scope | BE foundation + admin endpoints (~3gg) | Skip FE hook + seed data (sub-PR follow-up) |
+| DTO shape | "Both" (title canonical + translations array) | Niente ILocaleProvider middleware questa PR. Resolver legge solo translation, lascia title canonical |
+| Wiring | Tutti 4 query handler | `GetAllGames` + `Search` + `GetNewGames` + `GetGameById` enrichano `Translations[]` |
+
+## 3. Architettura
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ BoundedContext: SharedGameCatalog                                   │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  Domain                                                             │
+│  ├─ SharedGame (aggregate root, esistente)                          │
+│  └─ SharedGameTranslation (NEW aggregate)                           │
+│       └─ Value Object: Locale (ISO 639-1 validated)                 │
+│                                                                     │
+│  Application                                                        │
+│  ├─ Queries (4 handler wired to enrich DTO)                         │
+│  ├─ Commands (NEW: Add/Update/Delete translation)                   │
+│  └─ Services                                                        │
+│       └─ GameTitleResolver (batch fetch translations, enrich DTOs)  │
+│                                                                     │
+│  Infrastructure                                                     │
+│  ├─ Entity: SharedGameTranslationEntity (EF Core)                   │
+│  ├─ EntityConfiguration: tabella + indices + FK cascade              │
+│  ├─ Repository: ISharedGameTranslationRepository                    │
+│  └─ Migration: AddSharedGameTranslations                            │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Design rationale**:
+
+- **Separate aggregate** invece di Owned Entity di SharedGame: admin endpoints operano su translation singola senza caricare full SharedGame (performance + scope chiaro).
+- **Unique constraint DB-level** `UNIQUE (shared_game_id, locale) WHERE NOT is_deleted` per invariante "max 1 translation attiva per locale per game".
+- **Batch fetch in resolver**: 1 query per N giochi (no N+1).
+- **No locale resolution BE-side**: tutti i translations sempre inclusi nel DTO. FE follow-up sceglie quale mostrare via `useGameTitle()` hook.
+
+**Trade-off**: payload più grande (4 translations × paginazione 10 = ~40 oggetti nested), ma elimina cache invalidation locale-aware e middleware ILocaleProvider per ora. Può arrivare in follow-up se decidiamo silent-overwrite mode in futuro.
+
+## 4. Schema DB
+
+**Tabella `shared_game_translations`** (snake_case allineato a `shared_games` parent):
+
+```sql
+CREATE TABLE shared_game_translations (
+  id                 UUID         NOT NULL PRIMARY KEY,
+  shared_game_id     UUID         NOT NULL REFERENCES shared_games(id) ON DELETE CASCADE,
+  locale             VARCHAR(10)  NOT NULL,            -- ISO 639-1 ('it', 'en', 'es', 'fr', 'de', 'en-GB', ...)
+  title              VARCHAR(500) NOT NULL,
+  description        TEXT         NULL,
+  source             VARCHAR(32)  NOT NULL DEFAULT 'manual',
+                                                       -- 'manual' | 'auto-openrouter' | 'community'
+  created_at         TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  created_by         UUID         NULL,
+  updated_at         TIMESTAMPTZ  NULL,
+  updated_by         UUID         NULL,
+  is_deleted         BOOLEAN      NOT NULL DEFAULT false,
+  deleted_at         TIMESTAMPTZ  NULL,
+  deleted_by         UUID         NULL,
+  -- Concurrency: xmin (Postgres system column, ADR-060 pattern — no schema work)
+
+  CONSTRAINT uq_active_translation_per_locale
+    UNIQUE NULLS NOT DISTINCT (shared_game_id, locale)
+);
+
+CREATE INDEX ix_translations_locale            ON shared_game_translations(locale)         WHERE NOT is_deleted;
+CREATE INDEX ix_translations_shared_game_id    ON shared_game_translations(shared_game_id) WHERE NOT is_deleted;
+CREATE INDEX ix_translations_source            ON shared_game_translations(source)         WHERE NOT is_deleted;
+```
+
+**Decisioni di campo**:
+
+| Field | Decisione | Motivazione |
+|---|---|---|
+| `locale` VARCHAR(10) | string al livello DB, VO al livello Domain | Permette future estensioni regionali (`it-IT`, `en-GB`) senza migration |
+| `description` nullable | Opzionale | Non tutti i giochi hanno descrizioni IT curate. MVP solo title |
+| `source` VARCHAR(32) enum-as-string | EF Core EntityConfiguration: `.Property(t => t.Source).HasConversion<string>().HasMaxLength(32)` per round-trip C# enum ↔ DB string. Più estensibile di PG enum |
+| `is_deleted` partial unique index | `WHERE NOT is_deleted` | Permette ri-creare una translation dopo soft-delete, no conflict |
+| `xmin` concurrency | System column, no schema | Allineato ADR-060 + Issues #2305 / #2306 |
+
+**Migration name**: `AddSharedGameTranslations` (EF Core convention, allinea a `BackfillSharedGameHasKnowledgeBaseFlag` pattern recente).
+
+## 5. Domain Model
+
+**Entity** `SharedGameTranslation` come aggregate root separato:
+
+```csharp
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+public sealed class SharedGameTranslation
+{
+    public Guid   Id              { get; private set; }
+    public Guid   SharedGameId    { get; private set; }
+    public Locale Locale          { get; private set; }
+    public string Title           { get; private set; }
+    public string? Description    { get; private set; }
+    public TranslationSource Source { get; private set; }
+
+    public DateTimeOffset CreatedAt   { get; private set; }
+    public Guid?           CreatedBy  { get; private set; }
+    public DateTimeOffset? UpdatedAt  { get; private set; }
+    public Guid?           UpdatedBy  { get; private set; }
+
+    public bool             IsDeleted { get; private set; }
+    public DateTimeOffset?  DeletedAt { get; private set; }
+    public Guid?            DeletedBy { get; private set; }
+
+    public uint Xmin { get; private set; } // ConcurrencyToken via EntityConfiguration
+
+    private SharedGameTranslation() { Title = null!; Locale = null!; }
+
+    public static SharedGameTranslation Create(
+        Guid sharedGameId,
+        Locale locale,
+        string title,
+        string? description,
+        TranslationSource source,
+        Guid? createdBy,
+        DateTimeOffset now)
+    {
+        if (sharedGameId == Guid.Empty)
+            throw new ArgumentException("SharedGameId required", nameof(sharedGameId));
+        if (locale.Equals(Locale.CanonicalEn))
+            throw new InvalidLocaleException("Canonical EN title stored on shared_games.title, not translations");
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title required", nameof(title));
+        if (title.Length > 500)
+            throw new ArgumentException("Title max 500 chars", nameof(title));
+
+        return new SharedGameTranslation
+        {
+            Id           = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            Locale       = locale,
+            Title        = title.Trim(),
+            Description  = description?.Trim(),
+            Source       = source,
+            CreatedAt    = now,
+            CreatedBy    = createdBy,
+            IsDeleted    = false
+        };
+    }
+
+    public void UpdateTitle(string newTitle, Guid? updatedBy, DateTimeOffset now)
+    {
+        if (IsDeleted) throw new InvalidOperationException("Cannot update deleted translation");
+        if (string.IsNullOrWhiteSpace(newTitle)) throw new ArgumentException("Title required", nameof(newTitle));
+        if (newTitle.Length > 500) throw new ArgumentException("Title max 500 chars", nameof(newTitle));
+
+        Title     = newTitle.Trim();
+        UpdatedAt = now;
+        UpdatedBy = updatedBy;
+    }
+
+    public void UpdateDescription(string? newDescription, Guid? updatedBy, DateTimeOffset now)
+    {
+        if (IsDeleted) throw new InvalidOperationException("Cannot update deleted translation");
+        Description = newDescription?.Trim();
+        UpdatedAt   = now;
+        UpdatedBy   = updatedBy;
+    }
+
+    public void SoftDelete(Guid? deletedBy, DateTimeOffset now)
+    {
+        if (IsDeleted) return; // idempotent
+        IsDeleted = true;
+        DeletedAt = now;
+        DeletedBy = deletedBy;
+    }
+
+    public void Restore(Guid? restoredBy, DateTimeOffset now)
+    {
+        if (!IsDeleted) return;
+        IsDeleted = false;
+        DeletedAt = null;
+        DeletedBy = null;
+        UpdatedAt = now;
+        UpdatedBy = restoredBy;
+    }
+}
+```
+
+**Value Object** `Locale`:
+
+```csharp
+namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+public sealed record Locale
+{
+    private static readonly Regex IsoFormat = new(@"^[a-z]{2}(-[A-Z]{2})?$", RegexOptions.Compiled);
+
+    public string Value { get; }
+
+    private Locale(string value) { Value = value; }
+
+    public static Locale Create(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            throw new InvalidLocaleException("Locale cannot be empty");
+
+        var normalized = raw.Trim().ToLowerInvariant();
+        if (normalized.Length == 5)
+            normalized = normalized[..3] + normalized[3..].ToUpperInvariant();
+
+        if (!IsoFormat.IsMatch(normalized))
+            throw new InvalidLocaleException($"Invalid ISO 639-1 locale: {raw}");
+
+        return new Locale(normalized);
+    }
+
+    public static readonly Locale CanonicalEn = new("en");
+
+    public override string ToString() => Value;
+}
+```
+
+**Enum** `TranslationSource` (string-backed):
+
+```csharp
+public enum TranslationSource
+{
+    Manual,           // → "manual" (default, admin-curated)
+    AutoOpenRouter,   // → "auto-openrouter" (auto-generated via translation service)
+    Community         // → "community" (community-sourced, future)
+}
+```
+
+**Domain exceptions** (in `Application/Exceptions/`):
+
+```csharp
+public sealed class InvalidLocaleException(string msg) : Exception(msg);
+public sealed class TranslationNotFoundException(Guid gameId, string locale)
+    : NotFoundException($"Translation for game {gameId} locale {locale} not found");
+public sealed class TranslationAlreadyExistsException(Guid gameId, string locale)
+    : ConflictException($"Translation for game {gameId} locale {locale} already exists");
+```
+
+**Note**: nessun domain event in scope MVP. Possono arrivare in follow-up se serve audit trail (`TranslationCuratedEvent`).
+
+## 6. Application Layer
+
+### 6.1 DTO contract
+
+```csharp
+public record SharedGameDto(
+    Guid Id,
+    string Title,              // canonical EN (UNCHANGED)
+    string? Description,
+    string? Publisher,
+    int YearPublished,
+    int MinPlayers,
+    int MaxPlayers,
+    int PlayingTimeMinutes,
+    decimal? ComplexityRating,
+    decimal? AverageRating,
+    string? ImageUrl,
+    string? ThumbnailUrl,
+    bool HasKnowledgeBase,
+    // ... altri campi esistenti ...
+    IReadOnlyList<SharedGameTranslationDto> Translations  // NEW (sempre popolato, default empty)
+);
+
+public record SharedGameTranslationDto(
+    string Locale,             // "it", "en-GB", ecc.
+    string Title,
+    string? Description,
+    string Source              // "manual" | "auto-openrouter" | "community"
+);
+```
+
+### 6.2 Service `GameTitleResolver`
+
+```csharp
+public interface IGameTitleResolver
+{
+    Task<IReadOnlyList<SharedGameDto>> EnrichAsync(
+        IReadOnlyList<SharedGameDto> games,
+        CancellationToken ct);
+}
+
+public sealed class GameTitleResolver(ISharedGameTranslationRepository repo) : IGameTitleResolver
+{
+    public async Task<IReadOnlyList<SharedGameDto>> EnrichAsync(
+        IReadOnlyList<SharedGameDto> games,
+        CancellationToken ct)
+    {
+        if (games.Count == 0) return games;
+
+        var ids = games.Select(g => g.Id).ToArray();
+        // Repository SHALL filter `is_deleted = false` internally.
+        // GetByGameIdsAsync returns only active translations.
+        var translations = await repo.GetByGameIdsAsync(ids, ct);
+        // → Dictionary<Guid, List<SharedGameTranslationDto>>
+
+        return games
+            .Select(g => g with
+            {
+                Translations = translations.TryGetValue(g.Id, out var t) ? t : []
+            })
+            .ToList();
+    }
+}
+```
+
+**Important**: resolver e admin GET endpoints SHALL escludere translations soft-deleted dal response. La query EF deve usare `.Where(t => !t.IsDeleted)` o un global query filter sull'entity. Admin endpoint per riaccedere a soft-deleted è OUT OF SCOPE — non implementato in questa PR.
+
+DI: `builder.Services.AddScoped<IGameTitleResolver, GameTitleResolver>();`
+
+### 6.3 Wire nei 4 query handler esistenti
+
+Pattern identico per `GetAllGames`, `Search`, `GetNewGames`, `GetGameById`:
+
+```csharp
+public sealed class GetAllGamesQueryHandler(
+    ISharedGameRepository sharedGameRepo,
+    IGameTitleResolver titleResolver)
+    : IRequestHandler<GetAllGamesQuery, IReadOnlyList<SharedGameDto>>
+{
+    public async Task<IReadOnlyList<SharedGameDto>> Handle(GetAllGamesQuery request, CancellationToken ct)
+    {
+        var games = await sharedGameRepo.GetAllAsync(...);     // existing
+        var dtos  = games.Select(g => g.ToDto()).ToList();     // existing mapping
+        return await titleResolver.EnrichAsync(dtos, ct);      // NEW
+    }
+}
+```
+
+`GetGameByIdQueryHandler` wrappa singolo gioco in lista di 1, enrich, unwrap.
+
+### 6.4 Commands
+
+```csharp
+public record AddGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    string Source
+) : IRequest<Guid>;            // returns translation ID
+
+public record UpdateGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    string Title,
+    string? Description,
+    uint Xmin                  // optimistic concurrency
+) : IRequest<Unit>;
+
+public record DeleteGameTranslationCommand(
+    Guid GameId,
+    string Locale,
+    uint Xmin
+) : IRequest<Unit>;
+```
+
+**Validators** (FluentValidation):
+- `AddGameTranslationCommandValidator`: Locale.Create() valid + GameId not empty + Title 1-500 chars + Source ∈ enum + GameId exists (async DB check) + no duplicate active translation per locale (async DB check).
+- `UpdateGameTranslationCommandValidator`: stesso + translation esiste + xmin != 0.
+- `DeleteGameTranslationCommandValidator`: GameId + Locale + Xmin not zero.
+
+**Exception → HTTP mapping** (esistente middleware):
+- `InvalidLocaleException` → 400 BadRequest
+- `TranslationNotFoundException` → 404 NotFound
+- `TranslationAlreadyExistsException` → 409 Conflict
+- `DbUpdateConcurrencyException` → 409 Conflict con `X-Warning-Code: concurrent-edit`
+
+### 6.5 Queries (read-side, admin-facing)
+
+```csharp
+public record GetGameTranslationsQuery(Guid GameId) : IRequest<IReadOnlyList<SharedGameTranslationDto>>;
+
+public record GetGameTranslationByLocaleQuery(Guid GameId, string Locale)
+    : IRequest<SharedGameTranslationDetailDto>;
+
+public record SharedGameTranslationDetailDto(
+    Guid Id, string Locale, string Title, string? Description, string Source,
+    DateTimeOffset CreatedAt, Guid? CreatedBy,
+    DateTimeOffset? UpdatedAt, Guid? UpdatedBy,
+    uint Xmin // include xmin for client to use on PUT/DELETE
+);
+```
+
+## 7. Admin Endpoints
+
+Base path: `/api/v1/admin/games/{gameId}/translations`. Tutti `RequireAuthorization("AdminOnly")` (policy esistente).
+
+| Method | Route | Body | Response | Codes |
+|---|---|---|---|---|
+| **POST** | `/api/v1/admin/games/{gameId}/translations` | `{ locale, title, description?, source }` | `{ id, locale, title, description, source }` | 201 / 400 / 404 (game) / 409 (duplicate) |
+| **GET** | `/api/v1/admin/games/{gameId}/translations` | — | `[{ locale, title, description, source, createdAt, ... }]` | 200 / 404 (game) |
+| **GET** | `/api/v1/admin/games/{gameId}/translations/{locale}` | — | `{ ..., xmin }` | 200 / 404 |
+| **PUT** | `/api/v1/admin/games/{gameId}/translations/{locale}` | `{ title, description?, xmin }` | `{ ..., source }` | 200 / 400 / 404 / 409 |
+| **DELETE** | `/api/v1/admin/games/{gameId}/translations/{locale}` | header `If-Match: <xmin>` o body `{ xmin }` | — | 204 / 404 / 409 |
+
+**Routing registration** (CQRS rule per CLAUDE.md: solo `IMediator.Send()`):
+
+```csharp
+public static class SharedGameTranslationEndpoints
+{
+    public static IEndpointRouteBuilder MapSharedGameTranslationEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/admin/games/{gameId:guid}/translations")
+                       .RequireAuthorization("AdminOnly")
+                       .WithTags("Admin: Game Translations");
+
+        group.MapPost("/", async (Guid gameId, AddTranslationRequest body, IMediator m) =>
+        {
+            var id = await m.Send(new AddGameTranslationCommand(
+                gameId, body.Locale, body.Title, body.Description, body.Source));
+            return Results.Created($"/api/v1/admin/games/{gameId}/translations/{body.Locale}", new { id });
+        });
+
+        group.MapGet("/", async (Guid gameId, IMediator m) =>
+            Results.Ok(await m.Send(new GetGameTranslationsQuery(gameId))));
+
+        group.MapGet("/{locale}", async (Guid gameId, string locale, IMediator m) =>
+            Results.Ok(await m.Send(new GetGameTranslationByLocaleQuery(gameId, locale))));
+
+        group.MapPut("/{locale}", async (Guid gameId, string locale, UpdateTranslationRequest body, IMediator m) =>
+        {
+            await m.Send(new UpdateGameTranslationCommand(
+                gameId, locale, body.Title, body.Description, body.Xmin));
+            return Results.Ok();
+        });
+
+        group.MapDelete("/{locale}", async (Guid gameId, string locale, DeleteTranslationRequest body, IMediator m) =>
+        {
+            await m.Send(new DeleteGameTranslationCommand(gameId, locale, body.Xmin));
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+}
+```
+
+## 8. Testing Strategy
+
+**Coverage target**: ≥85% sui nuovi componenti (per CLAUDE.md backend target 90%+ stretch).
+
+| Layer | Test type | Cosa | Esempi chiave |
+|---|---|---|---|
+| **Domain** | Unit (xUnit) | Entity factory invariants + VO validation | `Locale.Create("xx")` throws · `Locale.Create("en")` factory equals `CanonicalEn` · `Create(canonical en locale)` throws · `Create(null title)` throws · `SoftDelete()` idempotent · `Restore()` lifecycle |
+| **Application — Validators** | Unit | FluentValidation rule per command | `AddGameTranslationCommandValidator`: invalid locale + empty title + duplicate active per locale (async mock) + non-existent gameId |
+| **Application — Handlers** | Unit (mocked repo) | Command handler flow | Happy path + GameNotFound + Conflict on duplicate + concurrent edit (`DbUpdateConcurrencyException` → 409) + Update on soft-deleted throws InvalidOperation |
+| **Application — Resolver** | Unit (mocked repo) | `GameTitleResolver.EnrichAsync` | Batch fetch single SQL call (asserted via mock) · empty list returns empty · no translations → empty array on DTO · multiple locales per game grouped correctly · soft-deleted translations excluded |
+| **Infrastructure — Repository** | Integration (Testcontainers Postgres) | EF Core queries + soft-delete filter + xmin | `AddAsync` + `GetByGameIdsAsync` (batch, only `is_deleted=false`) + `GetByGameIdAndLocaleAsync` + `Update` con xmin concurrency · unique constraint enforce via DB exception su duplicate (active) · partial unique index permette ri-create dopo soft-delete |
+| **Endpoints** | Integration (Testcontainers + WebApplicationFactory) | Full HTTP roundtrip | POST 201 + 409 duplicate · GET 200 + 404 · PUT 200 + 409 concurrent · DELETE 204 + 404 · 403 Forbidden non-admin · validation 400 (empty title, invalid locale) |
+| **Query handler wiring** | Integration | I 4 query handler restituiscono Translations[] | Seed game + translation, chiama `GET /catalog/games/new`, verifica response include translation IT |
+
+**Test file layout** (allineato CLAUDE.md):
+
+```
+tests/Api.Tests/
+├── Unit/SharedGameCatalog/
+│   ├── Domain/SharedGameTranslationTests.cs
+│   ├── Domain/LocaleTests.cs
+│   ├── Application/AddGameTranslationCommandValidatorTests.cs
+│   ├── Application/AddGameTranslationCommandHandlerTests.cs
+│   ├── Application/UpdateGameTranslationCommandHandlerTests.cs
+│   ├── Application/DeleteGameTranslationCommandHandlerTests.cs
+│   └── Application/GameTitleResolverTests.cs
+└── Integration/SharedGameCatalog/
+    ├── SharedGameTranslationRepositoryIntegrationTests.cs
+    ├── SharedGameTranslationEndpointsIntegrationTests.cs
+    └── GameTitleResolverWiringIntegrationTests.cs   ← verifica 4 query handler enrich
+```
+
+**Trait categorizzazione** (per CLAUDE.md `--filter` patterns):
+- `[Trait("Category", "Unit")]` o `[Trait("Category", "Integration")]`
+- `[Trait("BoundedContext", "SharedGameCatalog")]`
+
+## 9. Acceptance Criteria
+
+- [ ] Migration EF `AddSharedGameTranslations` applicata su dev DB con successo (no warnings)
+- [ ] Entity `SharedGameTranslation` + VO `Locale` + enum `TranslationSource` + 3 exceptions shipped
+- [ ] `ISharedGameTranslationRepository` implementato con: `AddAsync`, `UpdateAsync`, `SoftDeleteAsync`, `GetByGameIdAsync`, `GetByGameIdAndLocaleAsync`, `GetByGameIdsAsync` (batch)
+- [ ] `IGameTitleResolver` implementato + DI wire'd
+- [ ] 4 query handler enrichano `Translations[]` (verificato via integration test)
+- [ ] 5 admin endpoints registered + `RequireAuthorization("AdminOnly")` + smoke 200/4xx codes verified
+- [ ] 3 commands + validators + handlers + exception mapping verified
+- [ ] Unit tests ≥85% coverage sui nuovi componenti (verify via `dotnet test /p:CollectCoverage=true`)
+- [ ] Integration tests con Testcontainers Postgres passano locale (no skipped)
+- [ ] CodeQL + lint pulito
+- [ ] Issue #2339 aggiornata con sub-PR 1/3 closure note + scope rimanente per sub-PR 2 e 3
+
+## 10. Out of Scope (esplicito non-goals)
+
+- ❌ FE hook `useGameTitle()` (sub-PR 2/3)
+- ❌ FE DTO TypeScript update + grep+replace di consumer
+- ❌ `ILocaleProvider` middleware Accept-Language parser (mai necessario dato "Both" DTO shape)
+- ❌ Seed translations IT per 13 giochi SP4 (sub-PR 3/3)
+- ❌ Bulk admin operations (batch POST/PUT)
+- ❌ Translation history / contributor tracking dettagliato
+- ❌ Auto-translation via `OpenRouterTranslationService` invoke
+- ❌ Locale chain fallback (`it-IT` → `it` → `en`) — non necessario con "Both" shape
+- ❌ Domain events (`TranslationAddedEvent` ecc.)
+- ❌ Cache distributed dei translations (single-server Redis per ora)
+- ❌ Endpoint amministrativo per riaccedere a translation soft-deleted (Restore admin endpoint) — soft-delete è terminale dal punto di vista API in questa PR. Per ri-aggiungere translation di una locale rimossa, POST crea nuovo record (partial unique index lo permette).
+
+## 11. Effort Breakdown
+
+| Componente | Effort |
+|---|---|
+| Migration + Entity + EntityConfiguration | 0.3gg |
+| Domain entity + VO + exceptions | 0.3gg |
+| Repository + integration tests | 0.5gg |
+| Commands + Validators + Handlers + unit tests | 0.8gg |
+| `GameTitleResolver` + unit tests | 0.4gg |
+| Wire 4 query handlers + integration tests | 0.4gg |
+| 5 Admin endpoints + integration tests | 0.5gg |
+| Spec doc update + PR + final review | 0.3gg |
+| **Totale** | **~3.5gg** (entro target ~3gg, leggero overrun) |
+
+## 12. References
+
+- Issue tracker: [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339)
+- PR origine Q4 closure: [#2334](https://github.com/meepleAi-app/meepleai-monorepo/pull/2334)
+- Seed KB coverage spec: `docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md` §9 Q4
+- Translation service existing: `apps/api/src/Api/Infrastructure/Translation/OpenRouterTranslationService.cs`
+- Current SharedGame DTO: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs`
+- Frontend i18n setup: `apps/web/src/lib/i18n/ssr.ts` + `apps/web/src/locales/it.json`
+- ADR-060 (xmin concurrency pattern): `docs/for-claude/architecture/adr/adr-060-live-session-persistence.md`
+- BGG ban / ADR-059: `docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md`
+
+## 13. Sub-PR pipeline
+
+| # | Sub-PR | Scope | Effort | Dependency |
+|---|---|---|---|---|
+| 1 | **This PR** | BE foundation + admin endpoints | ~3.5gg | — |
+| 2 | FE hook + DTO + grep+replace | useGameTitle() + TS types + UI consumers | ~1gg | depends on (1) merged |
+| 3 | Seed translations IT | data.json gameTranslations array + 45-translations.sh + 13 IT curate | ~0.5gg | depends on (1) merged |
+
+**Issue #2339 closure**: solo dopo merge di sub-PR 1, 2, 3 (tutti shipped + verified).

--- a/docs/superpowers/specs/2026-06-15-shared-game-translations-design.md
+++ b/docs/superpowers/specs/2026-06-15-shared-game-translations-design.md
@@ -107,7 +107,7 @@ CREATE INDEX ix_translations_source            ON shared_game_translations(sourc
 **Entity** `SharedGameTranslation` come aggregate root separato:
 
 ```csharp
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 
 public sealed class SharedGameTranslation
 {
@@ -205,7 +205,7 @@ public sealed class SharedGameTranslation
 **Value Object** `Locale`:
 
 ```csharp
-namespace MeepleAi.Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 
 public sealed record Locale
 {


### PR DESCRIPTION
## Summary

**Sub-PR 1/3 of issue #2339** — BE foundation for shared game translations (Option A — table-based design).

Implements the SharedGameCatalog `shared_game_translations` aggregate, repository, DTOs, command/query handlers (Add / Update / Delete + Get / GetByLocale), and wires `IGameTitleResolver` into the 4 list-query handlers returning `PagedResult<SharedGameDto>` so the `Translations[]` field is enriched in a single batched round-trip.

No endpoints, no FE, no seed data, no middleware — those land in sub-PR 2 + 3.

## Scope (Waves 1-4)

- **Wave 1** — Domain primitives: `Locale` VO, `TranslationSource` enum, 3 translation exceptions, `SharedGameTranslation` aggregate (`Create` / `UpdateTitle` / `UpdateDescription` / `SoftDelete` / `Restore` / `SetXminForConcurrencyCheck`)
- **Wave 2** — Infrastructure: `SharedGameTranslationEntity` + EF Configuration, migration `20260615050340_AddSharedGameTranslations`, `ISharedGameTranslationRepository` + impl, `TranslationSourceMapper`
- **Wave 3** — Application: DTOs (`SharedGameTranslationDto`, `SharedGameTranslationDetailDto`) + `SharedGameDto.Translations[]`, `IGameTitleResolver` + `GameTitleResolver`, `AddGameTranslationCommand`, `UpdateGameTranslationCommand`
- **Wave 4** — Application: `DeleteGameTranslationCommand`, `GetGameTranslationsQuery` + `GetGameTranslationByLocaleQuery`, `SharedGameTranslationMapper`, wire `IGameTitleResolver` into `GetAllSharedGames` / `SearchSharedGames` / `GetFilteredSharedGames` / `GetPendingApprovalGames`

## DEC (user-locked)

- **DEC-C2** — game / translation-existence check in handler (never validator); validator validates input shape only
- **DEC-C4** — client-supplied xmin via `existing.SetXminForConcurrencyCheck(cmd.Xmin)`, NO reflection
- **DEC-M2** — `GetGameTranslationByLocaleQuery` returns nullable `SharedGameTranslationDetailDto?` (404 mapped by endpoint in sub-PR 3/3)
- **DEC-DTO "Both"** — `SharedGameDto.Title` is canonical EN + `Translations[]` is always populated (default empty)
- **DEC-WIRING** — all 4 list query handlers enrich `Translations[]`

## Test plan

- [x] `dotnet build apps/api/src/Api/Api.csproj` — 0 errors / 0 warnings
- [x] `dotnet test --filter "BoundedContext=SharedGameCatalog&Category=Unit"` — **1615 passed / 0 failed / 16 skipped** (preexisting InMemory-EF skips)
- [x] DeleteGameTranslation unit tests (10/10): 3 handler + 7 validator
- [x] Add / Update / Delete handlers follow identical CQRS pattern (`TimeProvider`, `IUnitOfWork`, repository injection)
- [ ] Wave 5 (sub-PR 3/3) wires admin endpoints + integration tests

## Code-review follow-ups (defer to sub-PR 3/3)

A max-effort 5-angle review surfaced no Wave-4-blocking issues. The following are tracked as follow-ups:

1. **Cache invalidation gap** — translation CRUD does not invalidate the `search-games` HybridCache tag (stale ≤1h). Impact = 0 in Wave 4 because endpoints are not wired yet; fix logically belongs in sub-PR 3/3 alongside endpoint registration.
2. `BeValidLocale` private static helper triplicated across Add / Update / Delete validators — extract to `SharedTranslationValidationRules` in a cleanup follow-up.
3. `GameTitleResolver.ToDto` (4-field projection for list enrichment) and `SharedGameTranslationMapper.ToDetailDto` (11-field projection for admin detail) are independent projection sites — drift risk when adding new aggregate fields; consider consolidating in a future wave.
4. `SetXminForConcurrencyCheck` naming diverges from `SetXmin` used by `GameNightPlaylist` / `MechanicDraft`. Cross-aggregate naming cleanup, out of scope for #2339.
5. `Xmin > 0u` rejects theoretical xmin=0 (Postgres bootstrap txid). Already established pattern in Update validator (Wave 3) — left as-is for symmetry.
6. `InvalidLocaleException` extends `ArgumentException` → middleware maps to 400 with generic message; refine when endpoint validator is wired in sub-PR 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
