### PR TITLE
docs(adr): #2363 Wave 3+4 — 7 ADRs close tracker (072-078)

### DIFF
--- a/docs/for-claude/architecture/adr/adr-072-notification-dedup-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-072-notification-dedup-strategy.md
@@ -1,0 +1,162 @@
+# ADR-072 — Notification Deduplication Strategy
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 3 — US-INT-5 (notifications & deep links)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · ADR-068 (RSVP delivery pipeline) · issue #1937 (CF-1 dedup contract)
+
+## Context
+
+The `UserNotifications` bounded context already exposes a `SourceEventId: Guid?` field on the `Notification` aggregate (`Domain/Aggregates/Notification.cs:30`) and on the `NotificationQueueItem` entity. ADR-068 flagged that "the `INotificationRepository.SourceEventId` dedup contract was NOT FOUND" at the time of drafting — meaning the **enforcement mechanism** for the CF-1 contract had not yet been decided. This ADR closes that gap.
+
+The existing codebase has now shipped the following dedup infrastructure as part of issue #1937:
+
+- **DB partial unique index** `UX_notifications_user_source_event_id` on `(user_id, source_event_id) WHERE source_event_id IS NOT NULL` — configured in `NotificationEntityConfiguration.cs:45-48`.
+- **Application-level check**: `NotificationDispatcher.DispatchAsync` calls `INotificationRepository.ExistsBySourceEventIdAsync(userId, sourceEventId)` before inserting, short-circuiting on `true` (`NotificationDispatcher.cs:51-59`).
+- **Repository method**: `NotificationRepository.ExistsBySourceEventIdAsync` executes `AnyAsync(n => n.UserId == userId && n.SourceEventId == sourceEventId)` (`NotificationRepository.cs:136-140`).
+- **Parallel queue dedup**: `UX_notification_queue_items_channel_recipient_source_event` partial unique on `(channel_type, recipient_user_id, source_event_id)` (`NotificationQueueEntityConfiguration.cs:57-59`).
+
+Multiple existing event handlers already propagate `SourceEventId` from the originating domain event: `PdfNotificationEventHandler`, `VectorDocumentReadyNotificationHandler`, `GameNightPublishedNotificationHandler`, `ShareRequestApprovedNotificationHandler`, and others.
+
+ADR-068's RSVP handler pattern (recommended Option C) relies on this dedup mechanism to prevent double-notification on MediatR retry. The design decision in this ADR is therefore **which layer is the authoritative dedup enforcement point**, and whether the current dual-layer (application check + DB constraint) approach should be the canonical pattern going forward.
+
+**What is NOT yet settled**: new event handlers are not consistently setting `SourceEventId`. Several handlers that create notifications through `INotificationDispatcher` omit the field, falling back to "legacy behavior (no dedup)" per the `NotificationDispatcher` inline comment (`NotificationDispatcher.cs:49`). The dedup strategy must be clearly specified so future handlers follow the same pattern.
+
+## Problem
+
+The specific architectural question: **what is the authoritative layer for `(userId, sourceEventId)` dedup enforcement — application-level check, DB unique constraint, or both — and what is the mandatory contract for new event handlers?**
+
+Sub-decisions:
+1. **In-memory cache** (`IMemoryCache` keyed by `(userId, sourceEventId)`) — fast, per-process only.
+2. **Redis TTL cache** — works across pods, requires Redis dependency on the notification path.
+3. **DB unique constraint** (already in place as `UX_notifications_user_source_event_id`) — strongest guarantee, catches races.
+4. **Application-level pre-check** (already in `NotificationDispatcher`) — eliminates unnecessary DB write attempts, reduces constraint-violation exceptions in logs.
+
+## Options Considered
+
+### Option A — In-Memory Cache (IMemoryCache)
+
+Key `(userId, sourceEventId)` with a sliding TTL (e.g. 30 minutes) in `IMemoryCache`. `NotificationDispatcher` checks the cache before any DB access.
+
+**Pros**:
+- Sub-millisecond cache hit — no DB round-trip for the common case (handler retry within the same process lifetime).
+- Already registered in DI (`Microsoft.Extensions.Caching.Memory` is present via the hosting infrastructure).
+
+**Cons**:
+- Per-process only: in a multi-pod deployment, `NotificationDispatcher` on Pod A cannot see that Pod B already created a notification for `(userId, sourceEventId)`. Cache miss → duplicate write attempt → caught only by DB constraint (race window exists within the constraint's atomicity, but Postgres serializes concurrent inserts on the unique index).
+- Cache entry eviction on process restart loses dedup state for in-flight retries longer than the TTL.
+- Does not replace the DB constraint: a cache miss always triggers a DB write, so the constraint still needs to exist for correctness. Adds a cache layer without removing DB dependency.
+
+**Risks**: Duplicate notifications in multi-pod scenarios between cache miss and DB insert (Postgres constraint prevents the insert but a logged `UniqueKeyViolationException` appears in the error logs — misleading for on-call ops).
+
+**Impact**: ~1 day. New cache lookup + eviction logic in `NotificationDispatcher`.
+
+---
+
+### Option B — Redis TTL Cache
+
+Replace the application-level `ExistsBySourceEventIdAsync` check with a Redis `SET NX EX <ttl>` operation. Cache key: `notif-dedup:{userId}:{sourceEventId}`. TTL = 24h (covers retry windows up to one day).
+
+**Pros**:
+- Shared across all pods — no cross-pod race window.
+- Atomic `SET NX EX` eliminates the check-then-act race that exists in Option C's `ExistsBySourceEventId → AddAsync` sequence.
+- Redis is already used in the infrastructure (`StackExchange.Redis` is in `apps/api/` — `docker-compose.yml` includes Redis service).
+
+**Cons**:
+- Adds Redis as a hard dependency on the notification write path. If Redis is down, the dispatcher must decide: fail the notification dispatch, or fall back to DB-only (re-introducing duplicates). Neither is clean.
+- The DB unique constraint **must** be retained regardless: Redis TTL expiry (or a Redis flush) could allow duplicate inserts after the TTL window. Two layers required.
+- 24h TTL is arbitrary: legitimate re-notification after a full day of inactivity (e.g., a second invite to a rescheduled game night) would be incorrectly suppressed if the same domain event ID is reused (which it should not be, but human error in testing can cause it).
+- Introduces a new pattern not currently used on any notification path in the codebase.
+
+**Risks**: Redis unavailability = notification dispatch degrades. Operational complexity (cache TTL tuning, Redis monitoring, flush-on-deploy guard).
+
+**Impact**: ~2.5 days. New Redis client usage in `UserNotifications`, fallback logic, monitoring.
+
+---
+
+### Option C — DB Unique Constraint as Primary + Application Pre-Check (recommended)
+
+Retain the existing architecture: the DB partial unique constraint `UX_notifications_user_source_event_id` is the **authoritative enforcement** mechanism. The application-level `ExistsBySourceEventIdAsync` pre-check in `NotificationDispatcher` is a **best-effort optimistic guard** that reduces unnecessary write attempts and cleans up log noise — not the primary correctness guarantee.
+
+This is the architecture **already shipped** as issue #1937. This ADR formalises it as the canonical pattern and mandates the `SourceEventId` contract for all new event handlers.
+
+**Canonical contract for new handlers**:
+1. Every `INotificationHandler<TDomainEvent>` that dispatches via `INotificationDispatcher` **must** set `SourceEventId = domainEvent.EventId` (or equivalent domain event identifier) on the `NotificationMessage`.
+2. Handlers that use `IMediator.Send(new CreateNotificationCommand(...))` directly must also pass `sourceEventId: domainEvent.EventId`.
+3. Admin-triggered notifications without an originating domain event (e.g. `SendManualNotificationCommand`) may omit `SourceEventId` (null = no dedup, as documented in `NotificationDispatcher.cs:49`).
+
+**Pros**:
+- Zero additional infrastructure dependency. DB is always available on the notification path.
+- Partial unique constraint is tight: per `(user_id, source_event_id)` pair; fan-out events (one domain event → N users) are correctly allowed (each `(user_id, event_id)` pair is distinct).
+- `ExistsBySourceEventIdAsync` eliminates most write attempts before they reach the constraint — reduces noisy `UniqueKeyViolationException` entries in Postgres logs.
+- Pattern is already in production and tested (`UX_notifications_user_source_event_id` is in the EF Core snapshot and applied migrations).
+- No TTL ambiguity: the dedup window is permanent (notification row exists forever unless deleted).
+
+**Cons**:
+- `ExistsBySourceEventIdAsync` adds one `SELECT` round-trip before each notification insert when `SourceEventId` is set. Under high notification volume, this doubles DB round-trips. Mitigated by the partial index efficiency.
+- The pre-check + insert sequence has a theoretical race window: between `ExistsBySourceEventIdAsync` returning `false` and `AddAsync` completing, a parallel handler replica could insert the same `(user_id, source_event_id)`. Postgres catches this with a `UniqueKeyViolationException` at the DB layer. `NotificationDispatcher` must catch this exception and swallow it (log as `Information`, not `Error`).
+
+**Risks**: Low. The existing infrastructure is correct by construction. The main gap is handler compliance — some handlers do not set `SourceEventId`, leaving them without dedup protection.
+
+**Impact**: ~0.5 days. Add `UniqueKeyViolationException` catch + swallow in `NotificationDispatcher.AddAsync` path; document the handler contract; audit existing handlers for compliance.
+
+---
+
+### Option D — Event Sourcing / Idempotency Key Table
+
+A dedicated `notification_idempotency_keys(id, user_id, source_event_id, created_at)` table, inserted atomically alongside the notification in the same transaction. The unique index is on this table rather than on `notifications`.
+
+**Pros**: Clean separation of dedup concern from notification data.
+
+**Cons**: Two-table write in every transaction. The existing `UX_notifications_user_source_event_id` constraint already serves this purpose with zero extra table. Option D would be a pure overhead increase with no benefit for the current scale.
+
+**Impact**: ~3 days. Out of scope.
+
+## Decision
+
+**Adopt Option C**: DB partial unique constraint `UX_notifications_user_source_event_id` is the authoritative dedup enforcement mechanism. The application-level `ExistsBySourceEventIdAsync` pre-check is retained as an optimistic guard. `SourceEventId` propagation from domain event handlers is **mandatory** for all new handlers.
+
+**Rationale**: The architecture is already in place and correct. The decision resolves the ambiguity flagged in ADR-068 by formally naming the DB constraint as the canonical enforcement layer. Option A (in-memory) would fail across pods. Option B (Redis) adds a hard runtime dependency without removing the DB constraint requirement. Option D is pure overhead.
+
+## Consequences
+
+**Positive**:
+- All future event handlers have a clear, enforceable contract for `SourceEventId` propagation.
+- The partial unique index is lightweight (Postgres `WHERE source_event_id IS NOT NULL` means null-`SourceEventId` admin notifications incur no index overhead).
+- Multi-pod safety: the DB constraint is the single point of truth, visible to all instances.
+- Existing handlers (`PdfNotificationEventHandler`, `GameNightPublishedNotificationHandler`, etc.) are already compliant; only new handlers need onboarding.
+
+**Negative**:
+- One `SELECT` per notification dispatch when `SourceEventId` is set (the `ExistsBySourceEventIdAsync` round-trip). Acceptable at current scale; revisit if notification volume exceeds ~10k/min.
+- `UniqueKeyViolationException` from the DB constraint (when the pre-check race window is lost) must be explicitly caught and suppressed in `NotificationDispatcher` — currently this is a gap that causes an unhandled DB exception to propagate to the calling event handler.
+
+**Trade-offs**:
+- Permanent dedup window (no TTL expiry) means a re-triggered notification for an event that legitimately repeats (e.g. a retried workflow with a new domain event ID) will work correctly only if the retry generates a new `EventId`. Handlers must never reuse `EventId` across retry attempts — this is consistent with MediatR domain event semantics (each `AddDomainEvent` call creates a new event object with a new `EventId`).
+
+## Implementation Guidance
+
+1. **Catch `UniqueKeyViolationException` in `NotificationDispatcher.DispatchAsync`**: after `_notificationRepository.AddAsync(notification, ct)`, wrap the call in a try/catch for `PostgresException` with `SqlState == "23505"`. Log at `Information` level: "Duplicate notification insert caught by DB constraint: user={UserId}, sourceEventId={SourceEventId} — idempotent skip". This prevents a spurious `Error`-level log from alerting on-call for an expected idempotency scenario.
+
+2. **Handler contract documentation**: add XML doc to `INotificationDispatcher.DispatchAsync`:
+   > **Required**: set `NotificationMessage.SourceEventId = domainEvent.EventId` for all event-driven dispatches. Omit only for manually-triggered admin notifications without a domain event origin.
+
+3. **Compliance audit**: grep for `INotificationDispatcher.DispatchAsync` callers and verify `SourceEventId` is set. As of 2026-06-15, compliant handlers include `PdfNotificationEventHandler`, `VectorDocumentReadyNotificationHandler`, `GameNightPublishedNotificationHandler`, `GameNightCancelledNotificationHandler`, `ShareRequestApprovedNotificationHandler`, `NewShareRequestAdminAlertHandler`, `SharedGameIndexingAdminNotificationHandler`, `ProcessingJobNotificationEventHandler`. Non-compliant handlers (if any) should be patched in the same PR that introduces the new handler.
+
+4. **New handler template**: `GameNightRsvpNotificationHandler` (per ADR-068 Option C) is the reference implementation — set `SourceEventId = domainEvent.EventId` on both the organizer and invitee `NotificationMessage` objects.
+
+5. **No schema migration needed**: `UX_notifications_user_source_event_id` is already applied (EF Core snapshot confirmed at `Infrastructure/Migrations/MeepleAiDbContextModelSnapshot.cs:1005`).
+
+## Rollback / Reversibility
+
+The DB constraint and application-level check are independently reversible. Removing `ExistsBySourceEventIdAsync` from `NotificationDispatcher` reverts to DB-constraint-only enforcement (silent `UniqueKeyViolationException` on retry). Dropping the DB index would remove dedup entirely — this is a schema migration that requires a new EF Core migration. No rollback of the dedup mechanism is anticipated; this is a permanent correctness guarantee.
+
+## References
+
+- `Notification.SourceEventId` — `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs:30`
+- `NotificationEntityConfiguration` (partial unique index) — `apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs:45-48`
+- `NotificationDispatcher.DispatchAsync` (pre-check) — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs:51-59`
+- `INotificationRepository.ExistsBySourceEventIdAsync` — `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs:44`
+- `NotificationRepository.ExistsBySourceEventIdAsync` — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs:136-140`
+- ADR-068 — RSVP delivery pipeline (flagged the dedup gap)
+- Issue #1937 — CF-1 dedup contract (original implementation)

--- a/docs/for-claude/architecture/adr/adr-073-playrecord-stats-aggregation.md
+++ b/docs/for-claude/architecture/adr/adr-073-playrecord-stats-aggregation.md
@@ -1,0 +1,166 @@
+# ADR-073 — PlayRecord Stats Aggregation Refresh Strategy
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-2 (PlayRecord stats surface)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · mockup `sp4-play-records-stats.html` · issue #3890 (CQRS play record queries)
+
+## Context
+
+The `GameManagement` bounded context contains the `PlayRecord` aggregate (`Domain/Entities/PlayRecord.cs`) and a `GetPlayerStatisticsQueryHandler` (`Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs`) that already implements per-user statistics aggregation over completed play records.
+
+**Current implementation** of `GetPlayerStatisticsQueryHandler`:
+- Fetches all completed play records for a user via `_context.PlayRecords.AsNoTracking().Include(r => r.Players).ThenInclude(p => p.Scores).Where(r => r.Status == Completed)` — a full table scan over the user's records, loaded in-memory.
+- Performs in-memory LINQ aggregation: `totalSessions`, `totalWins`, `gamePlayCounts`, `averageScoresByGame`, `totalDurationMinutes`, `winByGame`, `mostPlayedGames`, `leaderboardRank`, `favoriteAgentName`, `winRateTrend`.
+- `leaderboardRank` additionally executes a cross-user aggregate SQL query (`CountAsync`) over all completed records.
+- Contains an inline scale note: "Acceptable for community scale < 100k users; revisit with a materialized leaderboard view when scale demands."
+
+The `sp4-play-records-stats.fidelity.json` mockup (`design_intent: "current"`) defines a stats dashboard that includes total sessions, win rate, average duration, most-played games, and the win-rate trend chart — all derived from completed `PlayRecord` rows.
+
+**Key constraints**:
+- `PlayRecord.UpdatedAt` and `PlayRecord.Status` are updated by command handlers (`CompletePlayRecordCommandHandler`). These raise `PlayRecordCompletedEvent` domain events.
+- The domain entity uses private setters + factory methods — any stats materialisation must read from the EF entity model, not the domain aggregate (per DDD infrastructure pattern: entities are reconstituted from EF, not from domain aggregate directly).
+- Memory pitfall `notracking-default-update-gotcha.md`: always use `AsNoTracking()` for read-only stats queries — this is already in place in the current handler.
+- The `MeepleAiDbContext` is used directly in `GetPlayerStatisticsQueryHandler` (via `_context.PlayRecords`), which is the accepted cross-context pattern for complex read queries in this codebase.
+
+**Volume estimate**: the play records feature is MVP-stage. The community is invite-only with a small user base. However, a per-user stats page load that executes a full cross-user `CountAsync` for leaderboard rank will not scale past ~10k records without index support.
+
+## Problem
+
+The specific architectural question: **how should per-user play record statistics be refreshed — real-time on every `/stats` GET, via Redis TTL cache, via nightly batch into a materialised table, or via event-driven invalidation — given MVP scale constraints and the mockup's requirement for stats currency?**
+
+The stats dashboard is user-facing (not admin-only) and expected to be checked after each game session. Staleness tolerance must be defined.
+
+## Options Considered
+
+### Option A — Real-Time Aggregate Query on Every GET (current behaviour)
+
+Every `GET /api/v1/play-records/stats` executes `GetPlayerStatisticsQueryHandler.Handle()` — full in-memory aggregation over all completed play records plus the cross-user leaderboard rank query.
+
+**Pros**:
+- Always fresh — reflects the latest completed play record immediately.
+- Zero infrastructure dependency beyond the DB.
+- Already implemented and in production (`GetPlayerStatisticsQueryHandler` is wired via CQRS routing).
+
+**Cons**:
+- `_context.PlayRecords.Include(Players).ThenInclude(Scores)` loads all player/score rows for every stats request. For a user with 500 play records × 4 players × 3 score dimensions = 6,000 rows loaded per request. O(n) in play record count.
+- The cross-user leaderboard `CountAsync` is a full scan of all completed records for all users — no per-user index on `(status, created_by_user_id)`. Degrades O(N_total_records) with community growth.
+- Repeated identical queries on the same data (stats don't change between game sessions) waste DB I/O.
+
+**Risks**: Performance degrades predictably as play record volume grows. Acceptable at MVP scale (<1,000 records per user, <10k total); unacceptable at 100k+ total records without index additions.
+
+**Impact**: 0 additional implementation. Already live.
+
+---
+
+### Option B — Redis TTL Cache (5-minute window)
+
+`GetPlayerStatisticsQueryHandler` checks a Redis key `play-stats:{userId}` before executing the DB query. On cache miss, execute the query, cache the result as JSON with TTL = 5 minutes. Invalidate on `PlayRecordCompletedEvent` if Redis is available.
+
+**Pros**:
+- Dramatically reduces DB load for users who check their stats repeatedly within a session (common pattern: play a game → immediately check stats → share screenshot).
+- Redis is already present in the infrastructure (`docker-compose.yml` includes `redis` service; `StackExchange.Redis` is a dependency).
+- 5-minute staleness is acceptable for a game-night stats dashboard.
+
+**Cons**:
+- Redis adds a hard runtime dependency to the stats read path. If Redis is down, the handler must fall back to DB query (adding fallback logic complexity).
+- TTL-based staleness: after completing a play record, the stats cache will show the old data for up to 5 minutes unless explicitly invalidated. Users who complete a game and immediately check stats may see stale data — confusing UX.
+- Explicit invalidation on `PlayRecordCompletedEvent` requires an `INotificationHandler` that calls Redis — cross-cutting infrastructure concern added to the GameManagement bounded context.
+- Cache key must be scoped to query parameters (`userId`, `startDate`, `endDate`) — cache key explosion if date filters are varied.
+
+**Risks**: Redis downtime = stats endpoint degrades to real-time query (Option A fallback). Cache invalidation complexity on query-parameter variations.
+
+**Impact**: ~2 days. Redis caching in `GetPlayerStatisticsQueryHandler` + invalidation handler.
+
+---
+
+### Option C — Nightly Batch + Materialised View
+
+A scheduled job (Hangfire/Quartz, or a GHA cron workflow) runs nightly at 02:00 UTC, computing per-user aggregates and writing to a `play_record_stats` denormalisation table. `GetPlayerStatisticsQueryHandler` reads from this table instead of computing live.
+
+**Pros**:
+- Fastest possible read: a single-row lookup by `user_id`.
+- Eliminates the leaderboard cross-user scan from the stats request path — the rank is pre-computed.
+
+**Cons**:
+- Stats are up to 23h stale. A user who completes a game at 20:00 and checks stats at 21:00 sees yesterday's data — unacceptable for a feature marketed as "track your progress".
+- Requires a new `play_record_stats` table + migration + nightly job infrastructure.
+- The existing codebase uses Hangfire for scheduled jobs (`CooldownEndReminderJob`, `StaleShareRequestWarningJob`) but adding a stats materialisation job increases job scheduler complexity.
+- Invalidation on-demand (user clicks "refresh") bypasses the batch job, requiring a live fallback anyway.
+
+**Risks**: Staleness unacceptable for post-session stats review. The mockup's stats dashboard is expected to be consulted immediately after a game — a 23h stale result would be misleading.
+
+**Impact**: ~3 days. New migration + Hangfire job + fallback for live refresh. Out of scope for US-INT-2 MVP.
+
+---
+
+### Option D — Hybrid: Redis Cache + Explicit Invalidation on Write (recommended)
+
+Extend Option A with targeted cache invalidation: when `CompletePlayRecordCommandHandler` completes (post `SaveChangesAsync`), publish a `PlayRecordCompletedEvent`. A `PlayRecordStatsInvalidationHandler : INotificationHandler<PlayRecordCompletedEvent>` calls `IDistributedCache.RemoveAsync($"play-stats:{userId}")`.
+
+`GetPlayerStatisticsQueryHandler` uses `IDistributedCache.GetOrCreateAsync($"play-stats:{userId}", async () => { <execute DB query> }, absoluteExpiration: TimeSpan.FromMinutes(30))`.
+
+On cache miss (first request, or post-completion): full DB query. On cache hit: JSON deserialise (sub-millisecond). On completion event: Redis key removed immediately, next request re-populates.
+
+**Pros**:
+- Stats are always fresh immediately after a play record completion: the invalidation handler removes the cache key in the same MediatR publish cycle as the completion event.
+- 30-minute TTL is a safety net against leaked cache entries (e.g. if the invalidation handler throws and the key is never cleared).
+- Reduces DB round-trips for users who view stats multiple times between sessions (most common case: check stats once after a game, then again an hour later — second request is cache hit).
+- `IDistributedCache` is an abstraction layer that can use Redis in staging/prod and `IMemoryCache`-backed in dev/test without changing handler code.
+- Avoids the leaderboard scan staleness issue (invalidation ensures the rank recalculates on next request).
+
+**Cons**:
+- `IDistributedCache` adds a dependency to `GetPlayerStatisticsQueryHandler` (currently depends only on `MeepleAiDbContext`). Small scope increase.
+- Cache invalidation handler (`PlayRecordStatsInvalidationHandler`) is a new event handler class.
+- JSON serialisation round-trip for `PlayerStatisticsDto` (which contains nested collections) requires explicit `System.Text.Json` configuration (record types with `IReadOnlyList` must be serialisable).
+
+**Risks**: Low. `IDistributedCache` uses Redis in production (already available) and in-memory in test environments. If Redis is unavailable, `GetOrCreateAsync` throws and must be caught — fall back to direct DB query.
+
+**Impact**: ~1.5 days. `IDistributedCache` injection in the query handler, `PlayRecordStatsInvalidationHandler`, JSON serialisation config for `PlayerStatisticsDto`.
+
+## Decision
+
+**Adopt Option D**: hybrid Redis cache with explicit invalidation on `PlayRecordCompletedEvent`, with a 30-minute TTL safety net.
+
+**Rationale**: Option A's real-time approach is acceptable at MVP scale but has a documented scaling concern (the inline comment in `GetPlayerStatisticsQueryHandler:123` acknowledges this). Option D extends the existing architecture minimally (one new event handler, one `IDistributedCache` injection) while providing immediate freshness after game completion — the most important user-facing freshness requirement. Option C's 23h staleness is incompatible with the post-session use case. Option B's TTL-only approach would show stale data immediately after a game is completed.
+
+## Consequences
+
+**Positive**:
+- Stats always reflect the most recently completed play record within the same MediatR publish cycle.
+- DB query frequency drops from "every page load" to "once after each game completion + first load after 30 minutes of inactivity".
+- The `leaderboardRank` cross-user scan is amortised over cache hits — the expensive query runs at most once per completion event per user.
+
+**Negative**:
+- `PlayerStatisticsDto` must be JSON-serialisable. The DTO uses C# records with `IReadOnlyList<GameWinStats>`, `IReadOnlyList<GamePlayCount>`, `IReadOnlyList<MonthlyWinRate>` — these require `System.Text.Json` source generation or explicit converter configuration to avoid runtime `JsonException` on complex nested types.
+- The invalidation handler (`PlayRecordStatsInvalidationHandler`) runs in the same MediatR pipeline as the completion event — if it throws, the exception propagates to the command caller. Must be wrapped in a try/catch with `LogWarning` (cache invalidation failure is non-fatal; the 30-minute TTL covers it).
+
+**Trade-offs**:
+- Date-filtered stats (`startDate`/`endDate` query parameters) cannot be efficiently cached with a single `play-stats:{userId}` key — the cache key must include the filter parameters. For the MVP stats dashboard (no date filter), this is not an issue. If date-filtered stats are added later, the cache key schema must be updated.
+
+## Implementation Guidance
+
+1. **Cache injection**: add `IDistributedCache _cache` to `GetPlayerStatisticsQueryHandler` constructor. Wrap the existing LINQ aggregation in `GetOrCreateAsync($"play-stats:{query.UserId}", async () => { ... }, new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30) })`.
+
+2. **Invalidation handler**: `PlayRecordStatsInvalidationHandler : INotificationHandler<PlayRecordCompletedEvent>` at `apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsInvalidationHandler.cs`. Calls `_cache.RemoveAsync($"play-stats:{evt.UserId}", ct)`. Wrap in try/catch — cache miss on key removal is not an error (key may have already expired).
+
+3. **Serialisation**: annotate `PlayerStatisticsDto` and its nested records (`GameWinStats`, `GamePlayCount`, `MonthlyWinRate`) with `[JsonSerializable]` in a `PlayRecordsJsonContext : JsonSerializerContext` source-generation context. Use `JsonSerializer.Serialize(dto, PlayRecordsJsonContext.Default.PlayerStatisticsDto)` for cache write and `JsonSerializer.Deserialize` for cache read.
+
+4. **Dev environment**: in `appsettings.Development.json`, `IDistributedCache` resolves to the in-memory distributed cache (`services.AddDistributedMemoryCache()` — already registered in `Program.cs` for dev). No Redis required in dev.
+
+5. **Scale note update**: remove or update the comment in `GetPlayerStatisticsQueryHandler:123` after this ADR is implemented to reflect the caching strategy.
+
+## Rollback / Reversibility
+
+Removing `IDistributedCache` injection and the `PlayRecordStatsInvalidationHandler` reverts to the current real-time Option A behaviour. No schema migration is involved. Cache entries expire naturally after 30 minutes. The rollback is fully additive (add/remove a handler class and a cache injection).
+
+## References
+
+- `GetPlayerStatisticsQueryHandler` — `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs`
+- `PlayRecordCompletedEvent` — `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/PlayRecordCompletedEvent.cs`
+- `PlayRecord` aggregate — `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs`
+- `IPlayRecordRepository` — `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPlayRecordRepository.cs`
+- Mockup `sp4-play-records-stats.fidelity.json` (`design_intent: "current"`)
+- Memory: `notracking-default-update-gotcha.md` (always `AsNoTracking()` on read queries)
+- ADR-060: `SaveChangesAsync`-then-publish contract governs when `PlayRecordCompletedEvent` fires

--- a/docs/for-claude/architecture/adr/adr-074-voting-closure-mechanism.md
+++ b/docs/for-claude/architecture/adr/adr-074-voting-closure-mechanism.md
@@ -1,0 +1,158 @@
+# ADR-074 — Voting Closure Mechanism (GameNight RSVP)
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-3 (GameNight invitations & voting flow)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · ADR-068 (RSVP delivery pipeline) · domain model spec `2026-06-04-gamenight-session-domain-model.md`
+
+## Context
+
+The `GameNightEvent` aggregate (`Domain/Entities/GameNightEvent/GameNightEvent.cs`) tracks the full lifecycle of a game night: `Draft → Published → (InProgress | Completed | Cancelled)`. The `GameNightRsvp` entity (`Domain/Entities/GameNightEvent/GameNightRsvp.cs`) captures per-invitee responses (`Pending | Accepted | Declined | Maybe`).
+
+**Current state**: the `GameNightEvent` aggregate has `ScheduledAt: DateTimeOffset` (the event date/time) and status flags for reminders (`Reminder24hSentAt`, `Reminder1hSentAt`). There is **no `RsvpDeadline` field** on `GameNightEvent` in the current domain model — the aggregate and its EF entity do not yet have a concept of "voting closed" or an RSVP cutoff time. Searching for `RsvpDeadline`, `VotingClosed`, `ClosesAt`, and `VotingDeadline` across `BoundedContexts/GameManagement/Domain` returns no matches.
+
+**What US-INT-3 requires** (per the domain model spec §Tagging vs RSVP): the RSVP phase has a cutoff — after the organiser publishes and sends invitations, there is an expected window during which invitees respond. The spec defines 5 phases (tag silente → "Invia inviti" esplicito → pending → confermato). The "voting closed" concept is the transition from the pending/response window to a finalised attendee list.
+
+The voting closure mechanism must answer: **when can an organiser no longer accept new RSVPs, and how is that enforced?**
+
+**Scheduling context**: the project currently uses Hangfire for lightweight scheduled jobs (`CooldownEndReminderJob`, `StaleShareRequestWarningJob`). A Hangfire scheduler context is therefore available. The reminder jobs (`Reminder24hSentAt`, `Reminder1hSentAt`) are time-based — they fire when `ScheduledAt - now < 24h` (or 1h), checking via scheduled polling.
+
+## Problem
+
+The specific architectural question: **should RSVP voting closure be enforced by a scheduled job that transitions the aggregate state explicitly, or by a lazy read-time check that derives "closed" status on query projection?**
+
+Sub-decision: whether a new `RsvpDeadline: DateTimeOffset?` field is added to `GameNightEvent` or whether closure is derived implicitly from `ScheduledAt` (e.g. "RSVP closes 2h before the event").
+
+## Options Considered
+
+### Option A — Scheduled Job (Hangfire cron, explicit closure event)
+
+A Hangfire recurring job polls every 5 minutes for `GameNightEvent` records where `Status == Published`, `RsvpDeadline <= now`, and no `RsvpClosedAt` timestamp. For matching records, the job calls a `CloseRsvpCommand` which transitions the aggregate to a "RSVP closed" sub-state and raises a `GameNightRsvpClosedEvent` domain event. Notifications are sent to the organiser ("RSVP period ended; N players confirmed").
+
+**Pros**:
+- Explicit domain event: `GameNightRsvpClosedEvent` is raised, enabling downstream reactions (send organiser summary email, lock new RSVPs at the aggregate level, update the UI state).
+- Aggregate state reflects closure: `RsvpClosedAt` timestamp is set on the entity — readable in any query without recalculating.
+- Consistent with the existing reminder job pattern (`Reminder24hSentAt` / `Reminder1hSentAt` set by similar cron-triggered jobs).
+- Deterministic: organiser can see exactly when RSVP closed, and the timeline is auditable.
+
+**Cons**:
+- Polling granularity: a 5-minute tick means closure can lag up to 5 minutes past `RsvpDeadline`. For a 18:00 event with a 16:00 deadline, a new RSVP submitted at 15:58 is accepted; the aggregate closes at 16:01-16:05 depending on tick timing. Acceptable for a social game app.
+- Requires adding `RsvpDeadline: DateTimeOffset?` and `RsvpClosedAt: DateTimeOffset?` to `GameNightEvent` + migration.
+- Adds a new Hangfire job to the scheduler — minor operational complexity.
+- `CloseRsvpCommand` + handler + validator: ~150 LOC new code.
+
+**Risks**: Moderate. Hangfire tick failure (if the scheduler is down) could delay closure. `ConflictException` if `CloseRsvpCommand` is replayed for an already-closed event (must be idempotent — check `RsvpClosedAt != null` and short-circuit).
+
+**Impact**: ~3 days. New domain fields + migration + Hangfire job + command/handler/notification.
+
+---
+
+### Option B — Lazy Check on Read (projection-time derivation)
+
+No new domain field or scheduled job. `RsvpDeadline` is derived: `RsvpClosedAt = ScheduledAt - configured_offset` (e.g. 2h before the event). Every read-path projection (DTOs, query handlers) checks `if (now > event.ScheduledAt - deadlineOffset) => IsRsvpClosed = true`. The `RecordRsvpCommand` validator checks the same condition and returns a `ConflictException("RSVP period has closed")` if closure is detected.
+
+**Pros**:
+- Zero new infrastructure: no Hangfire job, no new migration columns.
+- Always "live": the closure condition reflects the current server time at the moment of the request — no polling lag.
+- Implementation is a pure expression in the validator and projection: `event.ScheduledAt.AddHours(-2) < DateTimeOffset.UtcNow`.
+
+**Cons**:
+- No explicit domain event: there is no `GameNightRsvpClosedEvent` to trigger organiser notifications, UI state updates, or audit entries. The organiser must discover closure by observing the UI change, not by receiving a notification.
+- The `deadlineOffset` (2h) is a hardcoded convention not surfaced in the domain model — not configurable per event.
+- Timeline is not auditable: no timestamp records when the RSVP period actually ended for a given event.
+- Inconsistent with the reminder job pattern: the existing `Reminder24hSentAt` / `Reminder1hSentAt` pattern uses explicit timestamps set when the domain transition occurs, not derived projections.
+
+**Risks**: Low implementation risk; but missing notification on closure is a UX gap — the organiser receives no closure summary email (violates the intent of US-INT-3's organiser notification requirement).
+
+**Impact**: ~0.5 days. Validator guard + DTO projection field.
+
+---
+
+### Option C — Lazy Check + Nightly Cleanup Batch (recommended)
+
+Hybrid approach: the read-path uses a lazy `IsRsvpClosed` derived property (`ScheduledAt <= DateTimeOffset.UtcNow || (RsvpDeadline.HasValue && RsvpDeadline.Value <= DateTimeOffset.UtcNow)`) for immediate closure enforcement in the `RecordRsvpCommand` validator. Separately, a lightweight Hangfire job runs once nightly (or every hour) to find `GameNightEvent` records whose implicit or explicit closure condition has passed and updates their `RsvpClosedAt` timestamp + dispatches the organiser summary notification.
+
+Add a **lightweight `RsvpDeadline: DateTimeOffset?`** field to `GameNightEvent`: optional, organiser-configurable. Defaults to `null` (meaning: RSVP closes when the event starts, i.e. `ScheduledAt`).
+
+**Closure rule**:
+- If `RsvpDeadline != null`: closed when `RsvpDeadline <= now`.
+- If `RsvpDeadline == null`: closed when `ScheduledAt <= now` (event has started — no point accepting RSVPs).
+
+**Pros**:
+- Immediate enforcement: the `RecordRsvpCommand` validator checks the derived closure condition — no polling lag for blocking new RSVPs.
+- Explicit audit trail: the Hangfire job sets `RsvpClosedAt` once, after the closure condition is met, giving an auditable timestamp.
+- Organiser notification: the Hangfire job dispatches the closure summary notification (`EnqueueEmailCommand` for "RSVP period ended: N confirmed, M declined, K no-response").
+- Flexible: organiser can set an early `RsvpDeadline` (e.g. 48h before the event for catering planning) or leave it null for the default "closes when event starts" behaviour.
+- Minimal new fields: only `RsvpDeadline: DateTimeOffset?` and `RsvpClosedAt: DateTimeOffset?` — single migration.
+
+**Cons**:
+- Two-layer approach (lazy check + scheduled cleanup) introduces duplication of the closure condition logic (validator and job both evaluate it). Extract to a domain method `GameNightEvent.IsRsvpClosed(DateTimeOffset now)` to avoid divergence.
+- Hangfire job still has polling lag for setting `RsvpClosedAt` (up to 1h if job runs hourly). The organiser may receive the closure notification up to 1h after the actual closure. Acceptable for a social app.
+- One new Hangfire job added to the scheduler.
+
+**Risks**: Low. The domain method `IsRsvpClosed` is a pure function that both the validator and the job delegate to. Divergence risk is eliminated if the domain method is the single source of truth.
+
+**Impact**: ~2 days. `RsvpDeadline` + `RsvpClosedAt` fields + migration + domain method + Hangfire job + closure notification.
+
+---
+
+### Option D — Event-Sourced Closure via ScheduledAt Trigger Only
+
+Force closure exclusively through the `GameNightEvent.Publish()` → organiser sets `ScheduledAt` → no RSVPs after `ScheduledAt`. No new fields. No job. The `RecordRsvpCommand` validator simply checks `event.ScheduledAt <= DateTimeOffset.UtcNow`.
+
+**Pros**: Zero-overhead simplicity.
+
+**Cons**: No per-event configurable deadline. No organiser closure notification. Inconsistent with the 5-phase RSVP model (organiser may want RSVPs to close days before the event, not at start time). Subset of Option B with less flexibility.
+
+**Impact**: Lowest. Out of scope for the RSVP closure feature.
+
+## Decision
+
+**Adopt Option C**: lazy validation-time closure check + optional `RsvpDeadline` field + Hangfire hourly cleanup job for `RsvpClosedAt` timestamp and organiser notification.
+
+**Rationale**: Option B alone provides no organiser notification and no audit trail. Option A adds a 5-minute-tick job with full implementation cost but no improvement over Option C for the user-facing experience (the validator catches new RSVPs immediately in both). Option C captures the best outcome: immediate enforcement (no RSVP accepted after closure), auditable timestamp, and organiser notification — with a minimal new domain model change (two nullable fields). Option D is too restrictive for the MVP use case.
+
+## Consequences
+
+**Positive**:
+- `RecordRsvpCommand` validation immediately rejects RSVPs past the closure point — no polling lag for the user-facing action.
+- Organiser receives a "RSVP period closed: N confirmed" notification through the existing `EnqueueEmailCommand` path (per ADR-068 Option C).
+- The `RsvpDeadline` field is organiser-configurable — supports catering/planning workflows that need an early cutoff.
+- Domain method `GameNightEvent.IsRsvpClosed(DateTimeOffset now)` is the single source of truth for closure state — validator, job, and DTOs all delegate to it.
+
+**Negative**:
+- One new migration required (`RsvpDeadline: DateTimeOffset?`, `RsvpClosedAt: DateTimeOffset?`, added to `game_night_events` table).
+- Hangfire job adds an operational dependency. If the job stalls, `RsvpClosedAt` is never set (organiser does not receive closure notification), but new RSVPs are still rejected by the validator. The functional impact is notification delay only.
+
+**Trade-offs**:
+- The Hangfire job runs hourly — organiser closure notification may be delayed up to 1 hour past actual closure. Acceptable for a social game-night app (organisers are not making time-sensitive catering calls based on this notification).
+- The `RsvpDeadline == null` default (closure at `ScheduledAt`) is the least surprising behaviour for organisers who don't configure a deadline.
+
+## Implementation Guidance
+
+1. **Domain model changes** (`GameNightEvent.cs`):
+   - Add `RsvpDeadline: DateTimeOffset?` — set via `SetRsvpDeadline(DateTimeOffset deadline)` domain method with guard (`deadline < ScheduledAt` required).
+   - Add `RsvpClosedAt: DateTimeOffset?` — set by the Hangfire job via `MarkRsvpClosed(DateTimeOffset closedAt)` internal method.
+   - Add `bool IsRsvpClosed(DateTimeOffset now) => RsvpClosedAt.HasValue || (RsvpDeadline.HasValue ? RsvpDeadline.Value <= now : ScheduledAt <= now)`.
+
+2. **Migration**: `dotnet ef migrations add AddGameNightRsvpClosureFields` — adds nullable `rsvp_deadline` and `rsvp_closed_at` columns to `game_night_events`.
+
+3. **Validator guard** (`RecordRsvpCommandValidator`): add rule `RuleFor(cmd => cmd).Must(cmd => !gameNightEvent.IsRsvpClosed(DateTimeOffset.UtcNow)).WithMessage("RSVP period has closed for this event").WithErrorCode("RSVP_CLOSED")`.
+
+4. **Hangfire job**: `GameNightRsvpClosureJob` at `UserNotifications/Infrastructure/Scheduling/` — runs hourly. Queries `game_night_events WHERE status = 'Published' AND rsvp_closed_at IS NULL AND (rsvp_deadline <= NOW() OR scheduled_at <= NOW())`. For each: calls `MarkRsvpClosed(now)`, saves via `IUnitOfWork.SaveChangesAsync`, dispatches closure notification via `INotificationDispatcher`.
+
+5. **DTO projection**: `GameNightEventDto` adds `IsRsvpClosed: bool` derived from `event.IsRsvpClosed(DateTimeOffset.UtcNow)` in the query handler mapping.
+
+## Rollback / Reversibility
+
+The new domain fields (`RsvpDeadline`, `RsvpClosedAt`) are nullable — existing events without these fields behave as before. Removing the Hangfire job stops the closure notification but does not break existing RSVPs. The validator guard can be removed to re-allow post-deadline RSVPs. Rolling back the migration requires dropping the two nullable columns (data-safe since no values existed before the migration).
+
+## References
+
+- `GameNightEvent` aggregate — `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs`
+- `GameNightRsvp` entity — `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightRsvp.cs`
+- `CooldownEndReminderJob` (reference Hangfire job) — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/CooldownEndReminderJob.cs`
+- `StaleShareRequestWarningJob` (reference Hangfire pattern) — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/StaleShareRequestWarningJob.cs`
+- ADR-068 (RSVP delivery pipeline + `EnqueueEmailCommand` pattern)
+- Domain model spec — `docs/for-developers/specs/2026-06-04-gamenight-session-domain-model.md` § Tagging vs RSVP (5-phase model)

--- a/docs/for-claude/architecture/adr/adr-075-deep-link-versioning.md
+++ b/docs/for-claude/architecture/adr/adr-075-deep-link-versioning.md
@@ -1,0 +1,193 @@
+# ADR-075 — Deep Link Versioning and Backward Compatibility
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-5 (notifications & deep links)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · `apps/web/next.config.js` (redirects block) · issue #897 (branch retirement + route consolidation)
+
+## Context
+
+MeepleAI's frontend uses Next.js App Router with a well-established `next.config.js` `redirects()` block for managing route renames. As of 2026-06-15, the redirect block contains **19+ permanent 301 redirect rules** handling at least three distinct historical route migrations:
+
+- **Issue #5039** — User route consolidation: `/library/games/:id/:tab` → `/library/:id?tab=:tab` (7 rules).
+- **Issue #871** — SP6 play routes: `/library/games/:id/play/**` → `/library/:id/play/**` (3 rules).
+- **Issue #1672 / #1004** — Profile/settings consolidation: `/settings/notifications` → `/profile?tab=settings&section=notifications`, `/profile/settings/**` → `/profile?tab=settings`, `/settings` → `/profile?tab=settings`.
+- **Discover hub** (Asse D P2, issue #2309): old `/discover` routes preserved as aliases of the new `/games?tab=discover` hub.
+
+Additionally, the `Notification` aggregate has a `Link: string?` field (the deep link path, stored in the `notifications.link` column as a relative path like `/library/abc123/play/xyz`). **Notification deep links are stored at dispatch time** — a notification dispatched before a route migration retains the old path in the DB forever. If the old path is not redirected in `next.config.js`, clicking the notification opens a 404.
+
+**Route group discipline** (memory: `route-group-audience-not-feature.md`): `(public)/(authenticated)/(admin)` segments define who accesses a route, not what feature it belongs to. The route `(authenticated)/games/[id]` and `(authenticated)/library/[id]` share the same authenticated audience group. Route group changes do not change the visible URL.
+
+**BGG asset ban** (CLAUDE.md, issue #2123): `/discover` routes were affected by the BGG ban migration. The `next.config.js` redirect logic for discover routes is already in place.
+
+**Issue #897 note**: `frontend-dev` and `backend-dev` branches were retired; all routes now target `main-dev`. This is a branch-level change, not a URL route change, and does not affect deep links.
+
+The `Notification.Link` field is populated by event handlers at dispatch time (e.g. `GameNightPublishedNotificationHandler` sets `DeepLinkPath = $"/game-nights/{eventId}"`). These paths are stored in the `notifications` table and never updated post-dispatch. If the route `/game-nights/{id}` is later renamed to `/events/{id}`, all existing notification links become stale.
+
+## Problem
+
+The specific architectural question: **how should deep links embedded in notifications remain valid as the Next.js route structure evolves, without requiring retroactive DB updates to stored notification links?**
+
+Sub-decisions:
+1. Should deep link paths be versioned (`/v1/game-nights/:id` → `/v2/game-nights/:id`)?
+2. Should redirect rules cover all stored link patterns, or only "shared" paths (those embedded in emails)?
+3. Should notification deep links be stored as absolute paths or as semantic identifiers (`entity:type:id`) resolved at render time?
+
+## Options Considered
+
+### Option A — 301 Redirects in next.config.js (current pattern, formalised)
+
+For every route rename that affects a deep-linked surface, add a `permanent: true` redirect entry in `next.config.js`. The rule maps the old URL to the new canonical URL. Existing notification `Link` values in the DB remain unchanged; the browser follows the redirect transparently.
+
+**Pros**:
+- Already the established pattern in the codebase (19+ redirect rules in production). No new infrastructure.
+- Transparent to users: clicking a notification link follows the 301 redirect to the new canonical URL — the user sees the correct page.
+- No DB migration: notification link values are preserved as-is.
+- Next.js `redirects()` supports dynamic segments (`:id`, `:campaignId`, `*` wildcards) — complex route renames are expressible.
+- SEO-safe: 301 is a permanent redirect that search engines honour.
+
+**Cons**:
+- Redirect table grows with each route migration. After many migrations, the table becomes a historical log of every route rename — maintenance overhead.
+- Redirect chains: if `/old-1` → `/new-1` and later `/new-1` → `/new-2`, Next.js does not automatically collapse the chain. Each intermediate hop requires an explicit rule, or the chain adds latency for clients following multiple 301s.
+- Does not cover email-embedded deep links if email contains a fully-qualified URL (`https://meepleai.app/game-nights/abc`) and the route rename happens after the email is sent — the 301 redirect handles this correctly, but the email content shows the old path in the link text.
+- Requires a deploy to activate new redirects — zero-downtime concern if the route rename and redirect ship in the same PR (they must).
+
+**Risks**: Low. The existing redirect infrastructure is tested and operational. Risk is mainly **missing a redirect** when a route is renamed — this leaves old notification links as 404s until discovered and fixed. A lint rule or test checking that all notification `DeepLinkPath` patterns have corresponding redirect coverage would mitigate this.
+
+**Impact**: ~0 additional infrastructure. Operational discipline required: every route rename PR must include the corresponding redirect rule in `next.config.js`.
+
+---
+
+### Option B — Versioned URL Prefix (/v1/x → /v2/x)
+
+All deep-linked notification URLs use a version prefix: `/v1/game-nights/:id`. When the route is redesigned, the new URL is `/v2/game-nights/:id`. The API version prefix disambiguates old and new clients.
+
+**Pros**:
+- Explicit versioning: clients that stored `/v1/` links always get the v1 route; new links use `/v2/`. No implicit redirect needed between versions.
+- Clear contract: the version number signals which route schema applies.
+
+**Cons**:
+- This pattern is from REST API versioning, not frontend URL design. Next.js App Router routes are not versioned in the MeepleAI codebase — the existing canonical routes are `/library/:id`, `/game-nights/:id`, `/games/:id`, none of which have a `/v1/` prefix.
+- Retroactively adding `/v1/` prefixes to all existing notification deep link paths would require a DB migration across all stored `notifications.link` values — high risk of data corruption if any path does not match expected patterns.
+- Creates a confusing multi-version URL space: users see `/v1/game-nights/abc` in their browser address bar — unprofessional and confusing.
+- Incompatible with Next.js App Router conventions and the existing route group discipline (memory: `route-group-audience-not-feature.md`).
+
+**Risks**: High adoption friction. Not recommended.
+
+**Impact**: ~5 days. DB migration + Next.js route group refactor + all notification handler updates. Out of scope.
+
+---
+
+### Option C — Catch-All Middleware with Route Alias Map
+
+A Next.js `middleware.ts` intercepts all requests and consults a `routeAliasMap` (a JSON map of `{old: string, new: string}[]` loaded at middleware startup). On match, the middleware issues a `NextResponse.redirect()` to the new canonical URL.
+
+**Pros**:
+- Runtime-configurable: the alias map can be updated without a Next.js deploy (if loaded from a config API or environment variable at runtime).
+- Handles complex pattern matching (regex, wildcard) not easily expressible in `next.config.js` static redirects.
+
+**Cons**:
+- Middleware runs on every request, including API routes and static assets — performance impact unless carefully filtered with `config.matcher`.
+- `next.config.js` `redirects()` already runs at the CDN edge before middleware — adding a middleware layer for the same purpose duplicates the concern.
+- The alias map is a new config artifact that must be maintained in sync with `next.config.js`. Two sources of truth for redirect logic.
+- Not needed: the existing `next.config.js` redirect approach handles all current migration patterns without middleware.
+
+**Risks**: Middleware edge cases (auth redirects, API routes, `_next` static) require careful matcher exclusions. Adds operational complexity without benefit over Option A.
+
+**Impact**: ~2 days. New middleware file + route alias map management. Not recommended.
+
+---
+
+### Option D — Shared Deep Links Only (pragmatic scope, recommended)
+
+Formalise a policy: **only notification deep link paths that are embedded in outbound emails** (i.e. "shared" links that cannot be retrieved from the DB to update) require a redirect rule in `next.config.js`. In-app notification links (stored in `notifications.link`) are **retroactively updatable** by a DB migration when a route is renamed, because they are not cached in email inboxes.
+
+**Two-tier strategy**:
+1. **Email-embedded links** (sent via Resend, stored in email body): always add a `permanent: true` redirect for any renamed route that was embedded in a sent email. These cannot be updated post-dispatch.
+2. **In-app notification links** (`notifications.link` DB column): add a redirect rule (preferred, zero risk) OR run a targeted DB update (`UPDATE notifications SET link = replace(link, '/old-path/', '/new-path/')`) at migration time (for high-confidence, scope-limited updates).
+
+**Additionally**: notification event handlers must use **relative path constants** (e.g. `NotificationRoutes.GameNight(eventId)` → `$"/game-nights/{eventId}"`) defined in a central `NotificationRoutes` static class. When a route changes, updating `NotificationRoutes` is the single-location change, and the compiler flags all usages. Old stored links are covered by a redirect rule or DB migration.
+
+**Pros**:
+- Pragmatic: distinguishes "links we can fix" (in-app, DB-updatable) from "links we cannot fix" (emails, already delivered).
+- `NotificationRoutes` static class acts as a compile-time contract for deep link patterns — reduces ad-hoc string construction in handlers.
+- Consistent with the existing redirect approach (Option A) for email links, while offering a DB migration escape hatch for in-app links.
+- No new infrastructure.
+
+**Cons**:
+- The DB update approach for in-app links carries risk if the path pattern is not unique or if the `replace()` function matches unintended substrings. Must be scoped carefully (e.g. `WHERE link LIKE '/game-nights/%'` to limit scope).
+- The `NotificationRoutes` static class is a new convention — existing handlers must be updated to use it (10+ event handlers reference deep link paths as inline strings today).
+
+**Risks**: Low if the `NotificationRoutes` static class is introduced carefully. DB path updates are reversible (the old path can be restored from audit logs or a DB snapshot).
+
+**Impact**: ~1.5 days. `NotificationRoutes` static class + handlers updated + redirect-rule discipline documented.
+
+## Decision
+
+**Adopt Option D**: two-tier deep link strategy with `NotificationRoutes` static class. Email-embedded links always get a `next.config.js` redirect on route rename. In-app notification links are covered by either a redirect rule (preferred) or a scoped DB update when the redirect would be impractical.
+
+**Rationale**: Option A alone (pure redirect table growth) is viable but does not address the root cause — ad-hoc string construction in handlers creates a maintenance blind spot when routes change. Option D adds `NotificationRoutes` as a compile-time guard that makes route changes visible at the point of handler authoring, while keeping the redirect-rule discipline for email links. Options B and C are over-engineered for the current scale and team size.
+
+## Consequences
+
+**Positive**:
+- `NotificationRoutes.GameNight(id)`, `NotificationRoutes.Library(id)`, `NotificationRoutes.Session(id)` etc. are the single place to update when routes change.
+- Email deep links are guaranteed to redirect correctly via `next.config.js` entries — same guarantee as the existing 19+ redirect rules.
+- In-app notification links can be surgically repaired by a DB migration when a route rename occurs — no stale 404 links accumulate.
+
+**Negative**:
+- Existing handlers use inline string construction (`$"/game-nights/{eventId}"`) — migrating them to `NotificationRoutes` is a refactor effort.
+- Two-tier logic (redirect vs DB update) adds decision overhead when a route rename occurs: engineers must check whether the old path appears in email bodies or only in in-app notifications.
+
+**Trade-offs**:
+- The `next.config.js` redirect table will continue to grow with each route rename. This is an accepted trade-off: the table is the historical record of route aliases, and Next.js compiles it into the edge runtime efficiently. A comment lint rule or CI test that warns when the redirect count exceeds a threshold (e.g. 40 rules) can prompt periodic consolidation.
+
+## Implementation Guidance
+
+1. **`NotificationRoutes` static class**: create `apps/web/src/lib/notifications/notification-routes.ts` with typed path constructors:
+   ```typescript
+   export const NotificationRoutes = {
+     gameNight: (id: string) => `/game-nights/${id}`,
+     library: (id: string) => `/library/${id}`,
+     session: (id: string) => `/sessions/${id}`,
+     discover: () => `/games?tab=discover`,
+     kbDetail: (id: string) => `/knowledge-base/${id}`,
+   } as const;
+   ```
+   C# equivalent in `apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/NotificationRoutes.cs`:
+   ```csharp
+   internal static class NotificationRoutes
+   {
+       public static string GameNight(Guid id) => $"/game-nights/{id}";
+       public static string Library(Guid id) => $"/library/{id}";
+       public static string Session(Guid id) => $"/sessions/{id}";
+       public static string KnowledgeBase(Guid id) => $"/knowledge-base/{id}";
+   }
+   ```
+
+2. **Redirect rule discipline**: every PR that renames a route that is used in at least one notification handler must include a `next.config.js` redirect entry. The PR checklist in `CONTRIBUTING.md` should include: "If this PR renames a user-facing route, add a `permanent: true` redirect in `next.config.js`."
+
+3. **Existing handler migration**: update the 5 highest-traffic notification event handlers to use `NotificationRoutes` in the same PR as the static class introduction: `GameNightPublishedNotificationHandler`, `PdfNotificationEventHandler`, `VectorDocumentReadyNotificationHandler`, `ShareRequestApprovedNotificationHandler`, `GameNightCancelledNotificationHandler`.
+
+4. **DB update pattern**: when a route rename is small-scope and only affects in-app notifications (not emails), the `down migration` SQL:
+   ```sql
+   UPDATE notifications
+   SET link = replace(link, '/old-route/', '/new-route/')
+   WHERE link LIKE '/old-route/%';
+   ```
+   Include this in the EF Core migration's `migrationBuilder.Sql(...)` block.
+
+## Rollback / Reversibility
+
+`NotificationRoutes` is an additive refactor — removing it reverts handlers to inline string construction. `next.config.js` redirect rules can be removed if the old route is restored. DB `replace()` updates can be reversed by applying the inverse pattern. No breaking schema changes.
+
+## References
+
+- `next.config.js` redirects block — `apps/web/next.config.js:164-290` (19+ redirect rules)
+- `Notification.Link` — `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs:17`
+- `NotificationEntity.Link` — `apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationEntity.cs:62`
+- `NotificationDispatcher.DeepLinkPath` — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs:73`
+- `GameNightPublishedNotificationHandler` (example handler with inline deep link path)
+- Memory: `route-group-audience-not-feature.md` (audience vs feature routing discipline)
+- Issue #897 (route consolidation precedent — `frontend-dev`/`backend-dev` retirement)

--- a/docs/for-claude/architecture/adr/adr-076-quiet-hours-timezone.md
+++ b/docs/for-claude/architecture/adr/adr-076-quiet-hours-timezone.md
@@ -1,0 +1,182 @@
+# ADR-076 — Quiet Hours Timezone Enforcement
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-5 (notifications & deep links)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · `NotificationPreferences` aggregate · Resend email provider (issue #1632)
+
+## Context
+
+The `NotificationPreferences` aggregate (`Domain/Aggregates/NotificationPreferences.cs`) manages per-user notification channel preferences (email, push, Slack). As of 2026-06-15, it supports boolean flags per channel per notification type (`EmailOnDocumentReady`, `SlackOnGameNightInvitation`, etc.) but **has no quiet hours concept** — no `QuietHoursStart`, `QuietHoursEnd`, or `Timezone` fields.
+
+The `NotificationDispatcher.DispatchAsync` (`Infrastructure/Services/NotificationDispatcher.cs`) loads `NotificationPreferences` and checks channel flags. Email delivery is synchronous to the handler (`NotificationQueueItem` enqueued for async processing), push delivery uses the Web Push API subscription, and Slack uses the `SlackNotificationProcessorJob`.
+
+The email dispatch path uses Resend (memory: `resend-email-provider-setup.md`) — transactional emails are delivered immediately after `EmailQueueItem` is processed by the background job. There is currently no time-of-day gating in the `NotificationDispatcher` or the queue processor.
+
+**Relevant channel characteristics**:
+- **In-app notifications**: shown on next app open. Time of delivery is irrelevant — the user sees them when they check the app.
+- **Email**: delivered to inbox immediately. A 02:00 UTC game night reminder email is disruptive for users in UTC+1 (03:00 local).
+- **Push (Web Push API)**: delivered to device immediately if subscribed. Can wake a phone at night.
+- **Slack DM**: delivered to the Slack client immediately, triggers a notification sound/badge.
+
+"Quiet hours" means: suppress time-sensitive channels (email, push, Slack) during a user-defined window such as 22:00–08:00 local time. In-app notifications are never suppressed.
+
+**Current `User` model**: no `TimeZone` field exists in the `Authentication` bounded context or the `Administration` bounded context user entity — confirmed by absence of `TimeZone`, `timezone`, `quiet_hours` in the codebase search.
+
+## Problem
+
+The specific architectural question: **where should quiet hours enforcement live — server-side using a `User.TimeZone` field for UTC-offset calculation, or client-side where the browser suppresses display of in-app notifications during the user's local quiet hours?**
+
+Sub-decision: whether quiet hours should gate server-side channels (email, push, Slack) at the dispatch layer or the queue-processing layer.
+
+## Options Considered
+
+### Option A — Server-Side Enforcement Using `User.TimeZone`
+
+Add a `TimeZone: string?` field to the `NotificationPreferences` aggregate (or the `User` entity in `Administration`) storing an IANA timezone string (e.g. `"Europe/Rome"`). Add `QuietHoursStart: TimeOnly?` and `QuietHoursEnd: TimeOnly?` to `NotificationPreferences`.
+
+`NotificationDispatcher.DispatchAsync` checks, before enqueuing email/push/Slack: `IsInQuietHours(preferences, DateTimeOffset.UtcNow)`. If true, suppress email/push/Slack enqueue (in-app notification still created).
+
+**IsInQuietHours** logic:
+```csharp
+var userTz = TimeZoneInfo.FindSystemTimeZoneById(preferences.TimeZone ?? "UTC");
+var localNow = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, userTz);
+var localTime = TimeOnly.FromTimeSpan(localNow.TimeOfDay);
+return localTime >= preferences.QuietHoursStart && localTime < preferences.QuietHoursEnd;
+// Handles midnight wrap-around: if Start > End (e.g. 22:00 - 08:00): 
+//   localTime >= Start || localTime < End
+```
+
+**Pros**:
+- Gates all push channels at the source: no Resend API call, no push notification, no Slack DM during quiet hours — user's phone does not wake.
+- Server is authoritative: consistent behaviour regardless of whether the user's device is active.
+- Works for email: even if the device is offline, the email is not sent.
+- The `NotificationPreferences` aggregate is already the central opt-in/opt-out hub — adding quiet hours here is the natural extension.
+
+**Cons**:
+- Requires a `User.TimeZone` or `NotificationPreferences.TimeZone` field — new DB column + migration.
+- IANA timezone handling in .NET requires `TimeZoneInfo.FindSystemTimeZoneById` which uses OS timezone data. On Linux containers, the `tzdata` package must be installed (standard on Debian/Ubuntu base images). Windows ↔ Linux timezone name differences must be handled (use `TimeZoneConverter` NuGet package for cross-platform IANA ↔ Windows compatibility).
+- Suppressed notifications are lost: there is no "deferred queue" — the email that was suppressed during quiet hours is simply not sent. The user misses the notification until the next relevant event triggers a new dispatch. For a game night reminder, this means the 08:00 "wake-up" send never happens automatically.
+- The user must configure their timezone in their profile settings — adds friction for users who do not bother configuring it. Default = UTC, which may mis-gate non-UTC users.
+
+**Risks**: Moderate. Timezone handling edge cases (DST transitions, ambiguous local times at DST boundary) require careful implementation. Suppressed notifications are irreversibly lost without a deferral queue.
+
+**Impact**: ~2.5 days. New `NotificationPreferences` fields + migration + quiet hours check + timezone converter + unit tests for DST edge cases.
+
+---
+
+### Option B — Client-Side Suppression (in-app only)
+
+The server dispatches all notifications on schedule (no server-side quiet hours gating). The frontend reads `NotificationPreferences.QuietHoursStart` / `QuietHoursEnd` from the API and suppresses:
+- **In-app notification badge/popup**: during quiet hours, do not show notification toasts; show a "quiet hours active" indicator instead.
+- **Push notifications**: the Service Worker registration can use `Notification.requestPermission()` with a custom suppression check, but the Web Push payload is still delivered by the push service — the browser can show/hide the notification based on local DND settings, but the app cannot reliably suppress delivery after the payload is dispatched from the server.
+
+**Pros**:
+- Zero server-side infrastructure change: no timezone field, no DB migration.
+- The user's device already knows the local time — no timezone string required.
+- In-app suppression is accurate to the millisecond (device clock, no UTC offset calculation).
+
+**Cons**:
+- Does not suppress email or Slack DM. A 02:00 game night invitation email is still sent to the user's inbox — quiet hours does not protect email recipients.
+- Does not suppress push notifications: the Web Push payload is delivered to the push service (FCM/Apple APNs) which delivers it immediately — the browser can suppress display only if the tab is active, but a push notification to a closed browser is delivered regardless.
+- Client-side suppression requires the client to be running (the web app must be open to intercept the notification toast). A PWA Service Worker can handle push suppression, but this requires careful SW lifecycle management.
+- Breaks for email: the primary user complaint for quiet hours features is unwanted emails at night — this option does not solve that.
+- Multiple clients (web, mobile): each client must independently implement suppression.
+
+**Risks**: High for email. Email is the most disruptive quiet-hours violation, and this option provides zero email protection.
+
+**Impact**: ~1 day (frontend only). Does not address the core use case.
+
+---
+
+### Option C — Hybrid: Server-Side for Email/Slack, Client-Side for In-App/Push (recommended)
+
+**Server-side** (in `NotificationDispatcher`): gate email and Slack DM dispatch during quiet hours using the `User.TimeZone` + `QuietHoursStart`/`QuietHoursEnd` fields on `NotificationPreferences`. If the user has quiet hours configured and the current server time falls within the window (in user's local timezone), suppress email and Slack enqueue. Log the suppression at `Debug` level.
+
+**Client-side** (in-app + push): the frontend checks quiet hours locally for in-app notification toasts — suppress the toast popup during quiet hours, but do not suppress the notification record (it remains in the `notifications` table as unread). Push notification suppression is delegated to the device DND / Focus mode — the app does not attempt to suppress push delivery, which is outside app control.
+
+**In-app notifications**: always created in the DB regardless of quiet hours. The user sees them when they open the app. The `IsRead` flag and `CreatedAt` timestamp are preserved. Quiet hours does not apply to persistent in-app notification records.
+
+**Deferred send (optional future enhancement)**: email suppressed during quiet hours could be enqueued to a `QuietHours` queue and released at `QuietHoursEnd`. This is explicitly deferred — the MVP ships suppression-only (email not sent, not deferred).
+
+**Pros**:
+- Email and Slack DM are the most disruptive channels — both gated server-side.
+- In-app notifications remain fully functional (no suppression of the notification record).
+- The client-side check for toast popups uses the device clock — accurate, no server round-trip.
+- Push is acknowledged as out of app control — documented expectation, not a bug.
+
+**Cons**:
+- Requires `NotificationPreferences.TimeZone: string?` + `QuietHoursStart: TimeOnly?` + `QuietHoursEnd: TimeOnly?` — new fields + migration.
+- Server-side check adds latency to `NotificationDispatcher.DispatchAsync` (one extra preference check — already loaded, so no extra DB round-trip).
+- Default `TimeZone == null` → defaults to UTC → may suppress emails for non-UTC users at wrong hours if they don't configure their timezone. **Mitigation**: when `TimeZone` is null, disable server-side quiet hours check entirely (treat as "no quiet hours configured"). Only apply when the user has explicitly configured both timezone and quiet hours window.
+- MVP: suppressed emails are lost (not deferred). The 08:00 "quiet hours end" automatic send is a follow-up feature (requires a Hangfire job to re-dispatch suppressed items).
+
+**Risks**: Low. The timezone calculation is a standard `.NET TimeZoneInfo` operation. DST is handled by `TimeZoneInfo.ConvertTime`. The null-timezone guard eliminates the mis-gate risk for unconfigured users.
+
+**Impact**: ~2 days. `NotificationPreferences` new fields + migration + server-side quiet hours check in `NotificationDispatcher` + frontend toast suppression hook.
+
+## Decision
+
+**Adopt Option C**: hybrid quiet hours — server-side for email and Slack, client-side toast suppression for in-app notifications. Push suppression is delegated to device DND.
+
+**Rationale**: Option B alone is insufficient for email gating (the primary driver). Option A alone adds unnecessary server complexity for in-app notifications (which are persistent in the DB and not disruptive when delivered late at night). Option C provides the right protection at the right layer: server controls the channels it controls (email, Slack), client controls the channels it renders (in-app toasts), and device OS controls the channel it owns (push DND).
+
+## Consequences
+
+**Positive**:
+- Users in European timezones (the primary MeepleAI market) will not receive 02:00 game night invitation emails if they configure their quiet hours.
+- `NotificationPreferences` already handles all channel opt-in/opt-out — quiet hours is a natural extension to the same aggregate.
+- The `QuietHoursStart`/`QuietHoursEnd` null check means unconfigured users are unaffected by this change — zero regression risk on existing users.
+
+**Negative**:
+- MVP ships suppression-only: emails suppressed during quiet hours are not deferred to `QuietHoursEnd`. The organiser of a late-night game night invitation may not trigger a notification until the next game night action — acceptable for MVP.
+- `TimeZoneConverter` NuGet package dependency may be needed for cross-platform IANA timezone compatibility (Linux containers use IANA names; Windows timezone IDs differ).
+
+**Trade-offs**:
+- The deferred-send queue (`email sent at QuietHoursEnd`) is a significant additional feature. It requires a Hangfire job that queries `notification_queue_items WHERE suppressed_until IS NOT NULL AND suppressed_until <= NOW()`. Deferred to a post-MVP issue.
+- Push suppression at the server level (not dispatching the push payload when quiet hours are active) is technically feasible but would require the app to re-dispatch the push when quiet hours end — same complexity as deferred email. Deferred.
+
+## Implementation Guidance
+
+1. **`NotificationPreferences` domain changes**:
+   - Add `TimeZone: string?` (IANA identifier, e.g. `"Europe/Rome"`).
+   - Add `QuietHoursStart: TimeOnly?` and `QuietHoursEnd: TimeOnly?`.
+   - Add domain method `bool IsInQuietHours(DateTimeOffset utcNow)`:
+     ```csharp
+     if (TimeZone is null || QuietHoursStart is null || QuietHoursEnd is null) return false;
+     var tz = TimeZoneInfo.FindSystemTimeZoneById(TimeZone);
+     var local = TimeOnly.FromTimeSpan(TimeZoneInfo.ConvertTime(utcNow, tz).TimeOfDay);
+     return QuietHoursEnd > QuietHoursStart
+         ? local >= QuietHoursStart && local < QuietHoursEnd          // same-day window
+         : local >= QuietHoursStart || local < QuietHoursEnd;         // midnight wrap
+     ```
+
+2. **Migration**: `dotnet ef migrations add AddNotificationPreferencesQuietHours` — adds nullable `timezone`, `quiet_hours_start` (`time` type), `quiet_hours_end` (`time` type) to `notification_preferences`.
+
+3. **`NotificationDispatcher` guard**: after loading `preferences`, before building `queueItems`:
+   ```csharp
+   var inQuietHours = preferences?.IsInQuietHours(DateTimeOffset.UtcNow) ?? false;
+   // In email channel check (line ~103):
+   if (!inQuietHours && (preferences == null || IsEmailEnabledForType(preferences, message.Type)))
+   // In Slack channel check (line ~130):
+   if (!inQuietHours && preferences is { SlackEnabled: true } && ...)
+   ```
+   Push is not server-gated in MVP.
+
+4. **Frontend toast suppression**: in the `useNotificationsCounter` hook (Asse B, `apps/web/src/`), add a local `isInQuietHours()` utility using `new Date().getHours()` vs the user's `quietHoursStart`/`quietHoursEnd` from the preferences API response. If in quiet hours, suppress the notification toast popup but do not suppress the badge count or the notification list.
+
+5. **Profile settings UI**: add a "Quiet Hours" section in `/profile?tab=settings&section=notifications` with: timezone selector (IANA timezone picker, defaulting to `Intl.DateTimeFormat().resolvedOptions().timeZone` on first load) + time range picker for start/end.
+
+## Rollback / Reversibility
+
+New `NotificationPreferences` fields are nullable — existing users without quiet hours configured are unaffected. Removing the `IsInQuietHours` guard from `NotificationDispatcher` reverts to always-dispatch behaviour. Rolling back the migration drops the three nullable columns (data-safe). The frontend toast suppression is a purely additive check that can be removed independently.
+
+## References
+
+- `NotificationPreferences` aggregate — `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs`
+- `NotificationDispatcher.DispatchAsync` — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs`
+- `NotificationPreferencesEntity` — `apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs`
+- Resend email provider (memory: `resend-email-provider-setup.md` — issue #1632)
+- Mailpit dev email (memory: `dev-email-uses-mailpit.md`)
+- `SlackNotificationProcessorJob` — `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs`

--- a/docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md
+++ b/docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md
@@ -1,0 +1,192 @@
+# ADR-077 — Designer Signoff CI Gate
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-6 (CI/CD quality gates)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · mockup audit DS-17 Phase B (#2127) · fidelity.json pattern · `ci.yml`
+
+## Context
+
+The MeepleAI design system (DS-17) introduced `*.fidelity.json` files alongside each mockup in `admin-mockups/design_files/`. Each fidelity file carries a `designer_approved_by` and `designer_approved_on` field:
+
+```json
+{
+  "acceptance": {
+    "designer_approved_by": "",
+    "designer_approved_on": ""
+  }
+}
+```
+
+The `generate-deliverables.mjs` script populates these as empty strings by default. The mockup audit pattern (CLAUDE.md § Mockup audit — DS-17 Phase B) requires that new mockups carry a `design_intent` ∈ `{current, forward-refactor, forward-refactor-obsolete}`. The `pnpm lint:fidelity` gate validates the schema but does not currently enforce `designer_approved_by` being non-empty.
+
+**P250 self-waiver pattern**: the project has an established single-person team exception. Several `fidelity.json` files in the audit queue contain or anticipate a value like:
+```json
+"designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)"
+```
+This pattern acknowledges that the developer and the designer are the same person — the "designer review" is the developer reviewing their own mockup against the design intent.
+
+**Current CI gates** (`ci.yml`):
+- `pnpm lint:tokens` — blocking (token canonicalization).
+- `pnpm mockup-annotations:audit --threshold 80` — blocking (mockup annotation coverage).
+- `pnpm lint:bgg` — blocking (BGG URL guard).
+- `pnpm lint:fidelity` — runs but validates schema only, not approval status.
+- `Frontend - A11y E2E` — blocking (0 axe AA violations required).
+
+The `designer_approved_by` field has no current CI enforcement. Mockups flow through the audit queue (`docs/for-developers/frontend/mockup-designer-review-queue.md`) but there is no mechanical gate preventing a PR from merging a new `design_intent: "current"` component without setting `designer_approved_by`.
+
+**Design surface definition**: "designer review" applies to PRs that modify `apps/web/src/` components tagged with `area/frontend` **and** that implement or modify a user-facing UI surface mapped in `admin-mockups/MOCKUPS_INDEX.md`. Infrastructure-only, backend-only, and documentation PRs are explicitly excluded.
+
+## Problem
+
+The specific architectural question: **should `designer_approved_by` enforcement be a hard CI blocker, an advisory annotation, or a time-boxed default-approve gate — and how does this interact with the solo-maintainer P250 self-waiver pattern?**
+
+## Options Considered
+
+### Option A — Blocking Gate (hard CI block until signoff label added)
+
+A new CI check `Designer Signoff` runs on all PRs that touch `apps/web/src/components/**` or `apps/web/src/app/**` (path filter). The check:
+1. Identifies all `*.fidelity.json` files modified or added in the PR diff.
+2. Checks `designer_approved_by` is non-empty for each.
+3. Fails the check if any fidelity file lacks an approval.
+
+Alternatively, implemented via a GitHub branch protection rule requiring a label `designer-approved` before merge.
+
+**Pros**:
+- Strongest enforcement: no component reaches production without explicit signoff.
+- Prevents design debt accumulation — the cost of deferring signoff is immediate (PR cannot merge).
+
+**Cons**:
+- Blocks developer velocity for every frontend PR, even trivial ones (e.g. fixing a typo in a label). Not all frontend changes require a design review.
+- The P250 self-waiver pattern means the developer must manually add the self-waiver string before each merge — a CI-unfriendly ceremony that adds friction without real quality value in a solo-maintainer context.
+- False blocking: a PR that modifies a backend-side component handler (e.g. a `.tsx` file inside `app/(authenticated)/sessions/[id]/live/_components/`) may not have a corresponding fidelity file but would trigger the check by path filter.
+- A blocked PR that has been reviewed and merged in the development workflow (developer self-reviewed as P250) creates a ghost blocker that must be manually cleared.
+
+**Risks**: Frequent block → developers learn to always pre-populate `designer_approved_by` before opening a PR, which defeats the purpose of the gate (if approval is automatic, it carries no review signal). The gate becomes a rubber-stamp ceremony.
+
+**Impact**: ~1 day. New GHA workflow step or label-required branch protection.
+
+---
+
+### Option B — Advisory (CI check runs but does not block merge)
+
+The `pnpm lint:fidelity` gate is extended to also check `designer_approved_by` and emit a `warning` annotation (not a failure) when empty. The PR summary comment (posted by CI) includes a section: "⚠️ Pending designer signoff: `sp4-play-records-stats.fidelity.json`". The developer sees the warning but can merge.
+
+**Pros**:
+- Zero velocity impact: developer and reviewer are aware of missing signoffs without being blocked.
+- Visible in PR: the warning comment creates a conversation anchor for the designer review.
+- Compatible with P250 self-waiver: the developer can fill in the self-waiver field at any time and the warning clears on the next CI run (or the reviewer can accept the warning as understood).
+
+**Cons**:
+- No enforcement: if the warning is consistently ignored (which it will be in a solo-maintainer context where the developer is also the designer), it becomes noise.
+- The design review queue (`mockup-designer-review-queue.md`) may fall behind as warnings accumulate without resolution.
+- Advisory warnings that are consistently non-blocking tend to be ignored system-wide — a well-studied problem in CI warning fatigue.
+
+**Risks**: Low — no blocking risk. The primary risk is the warning becoming invisible noise over time.
+
+**Impact**: ~0.5 days. Extend `pnpm lint:fidelity` to emit warning annotations.
+
+---
+
+### Option C — Timeout-Default-Approve (blocking for 48h, then auto-approves)
+
+A GHA workflow posts a "designer review pending" label on a PR when frontend-UI changes are detected. If the label has not been replaced by `designer-approved` within 48h, a bot (GHA `workflow_dispatch` cron + GH API call) auto-applies `designer-approved` and the blocking check clears. This models "if no designer responds in 48h, the change is implicitly approved."
+
+**Pros**:
+- Forces at least a 48h design review window — creates space for a real review if a designer is available.
+- Self-heals for solo-maintainer: after 48h, the PR can merge without manual ceremony.
+- Auditable: the auto-approve event is logged in the PR timeline.
+
+**Cons**:
+- GHA bot requires `issues:write` and `pull-requests:write` permissions — a `GITHUB_TOKEN` with elevated scope.
+- The 48h window is arbitrary: a trivial frontend fix (correcting a token name) is blocked for 48h even if no design review is needed.
+- Complexity: a new GHA cron workflow + label management + PR detection logic. More moving parts than Option B or D.
+- Solo-maintainer reality: the developer will simply wait 48h for the auto-approve. The gate becomes a time tax, not a quality gate.
+
+**Risks**: Bot workflow failures (see memory: `gh-pr-merge-auto-stale-sha.md`) — auto-merge bots can be unreliable. Label management in GHA has known edge cases.
+
+**Impact**: ~2 days. New GHA cron workflow + bot permissions + label logic.
+
+---
+
+### Option D — Per-Area Blocking, with Explicit P250 Self-Waiver as a Valid Approval (recommended)
+
+Extend `pnpm lint:fidelity` to check `designer_approved_by` for fidelity files with `design_intent == "current"` (not `forward-refactor` or `forward-refactor-obsolete`). The check **blocks** the CI on PRs that:
+1. Add or modify a `design_intent: "current"` fidelity file **and**
+2. Have `designer_approved_by` empty.
+
+The check explicitly **accepts** the P250 self-waiver pattern — if `designer_approved_by` contains the substring `"self-waiver P250"`, the check passes.
+
+**For PRs with no fidelity file changes**: the check trivially passes (no fidelity files in diff → not a frontend-UI surface PR, by definition).
+
+**For PRs changing `forward-refactor` or `forward-refactor-obsolete` fidelity files**: advisory warning only, not blocking. These files are not yet approved for implementation.
+
+This maps the P250 pattern from an informal convention to a formally recognised CI-accepted token. The developer fills in `"user@meepleAi (self-waiver P250, single-person team)"` before opening a PR — a 5-second ceremony — and the gate passes.
+
+**Pros**:
+- Only blocks when a `design_intent: "current"` surface is added/modified without signoff. Trivial frontend PRs (label fixes, token corrections) that do not add or modify fidelity files are not blocked.
+- P250 self-waiver is explicit CI documentation of the solo-maintainer exception — not a workaround but a first-class approved pattern.
+- Scoped: `forward-refactor` and `forward-refactor-obsolete` files are advisory-only — they are design aspirations, not current surfaces, and do not need blocking enforcement.
+- No new GHA workflow complexity: `pnpm lint:fidelity` is extended in the existing `ci.yml` frontend job.
+
+**Cons**:
+- Requires every `design_intent: "current"` fidelity file to have `designer_approved_by` filled before PR open — minor discipline required.
+- If the solo-maintainer team grows and a real designer is hired, the P250 pattern must be retired and replaced with a genuine design review workflow. The `pnpm lint:fidelity` check will need to be updated to reject `self-waiver P250` tokens at that point.
+- The fidelity file may not be modified in the same PR as the component implementation — if the developer modifies a `.tsx` file without touching the `.fidelity.json`, the check does not fire. Fidelity files are only checked when they appear in the PR diff.
+
+**Risks**: Low. The check is scoped to diff-changed fidelity files and accepts an explicit waiver string. No false positives for infrastructure/backend PRs. The P250 acceptance string is documented here and in the relevant spec files.
+
+**Impact**: ~0.5 days. Extend `pnpm lint:fidelity` script to check `designer_approved_by` for `design_intent: "current"` files and accept `self-waiver P250`.
+
+## Decision
+
+**Adopt Option D**: per-area blocking gate scoped to `design_intent: "current"` fidelity files, with `self-waiver P250` as a formally accepted approval token.
+
+**Rationale**: Option A blocks too broadly (all frontend PRs, not just mockup-surface changes). Option B provides no enforcement signal. Option C adds 48h time tax + GHA bot complexity without quality benefit. Option D is surgical: it blocks only when a current-design surface is added or modified without documented approval, and explicitly codifies the solo-maintainer exception without blocking velocity.
+
+## Consequences
+
+**Positive**:
+- Developers cannot accidentally ship a `design_intent: "current"` surface without deliberately setting `designer_approved_by` — even if only with the P250 self-waiver.
+- The `pnpm lint:fidelity` gate becomes a complete schema + approval validator — one command covers both concerns.
+- The P250 self-waiver pattern is CI-documented, reducing confusion about when the exception applies.
+- `forward-refactor` and `forward-refactor-obsolete` files remain advisory — no friction for speculative design work.
+
+**Negative**:
+- Requires existing `design_intent: "current"` fidelity files with empty `designer_approved_by` to be backfilled (either with the P250 waiver or with a genuine approval) before the gate is enabled. Audit scope: ~38 `design_intent: "current"` fidelity files (per DS-17 Phase B audit count).
+- If the gate is enabled before backfill, any PR that touches a fidelity file with empty `designer_approved_by` will fail CI — gate should be enabled only after the backfill PR merges.
+
+**Trade-offs**:
+- The gate does not prevent a developer from pre-filling the self-waiver without actually reviewing the design. The gate is a documentation discipline tool, not a proof-of-review mechanism. In a solo-maintainer context, this is the correct trade-off: the waiver documents the exception, not bypasses a real review.
+
+## Implementation Guidance
+
+1. **Extend `pnpm lint:fidelity`** (`apps/web/scripts/audit-mockups/` or the `pnpm` script target in `package.json`):
+   - For each `.fidelity.json` in the PR diff with `design_intent == "current"`:
+     - If `designer_approved_by` is empty → fail with message: `"ERROR: sp4-play-records-stats.fidelity.json (design_intent: current) is missing designer_approved_by. Fill in the signoff or use 'self-waiver P250' for solo-maintainer context."`.
+     - If `designer_approved_by` contains `"self-waiver P250"` → pass (emit `INFO: accepted P250 self-waiver`).
+     - Otherwise (real approver name) → pass.
+   - For `design_intent != "current"`: emit advisory warning only, do not fail.
+
+2. **Backfill PR**: before enabling the check, submit a single PR that populates `designer_approved_by: "badsworm@gmail.com (self-waiver P250, single-person team)"` and `designer_approved_on: "2026-06-15"` on all existing `design_intent: "current"` fidelity files with empty approval fields.
+
+3. **CI integration** (`ci.yml`): add `pnpm lint:fidelity:approvals` (or extend the existing `pnpm lint:fidelity` script) as a step in the frontend job, after the existing `pnpm lint:fidelity` schema validation. Gate on `if: steps.changes.outputs.frontend == 'true'` (same condition as other frontend checks).
+
+4. **Future team growth**: when a second designer joins the team, remove the P250 waiver acceptance from `pnpm lint:fidelity` and require `designer_approved_by` to match a configured list of approved designer email addresses. This is a one-line config change in the lint script.
+
+5. **Documentation**: update `docs/for-developers/frontend/mockup-annotation-pattern.md` to document the `designer_approved_by` field requirement and the P250 self-waiver pattern.
+
+## Rollback / Reversibility
+
+Removing the `designer_approved_by` check from `pnpm lint:fidelity` reverts to schema-only validation (Option B advisory). No schema or migration changes are involved. The backfill PR is additive (fidelity JSON field values) and can be reverted if needed.
+
+## References
+
+- Fidelity JSON pattern — `admin-mockups/design_files/sp4-play-records-stats.fidelity.json` (example)
+- `generate-deliverables.mjs` — `apps/web/scripts/audit-mockups/generate-deliverables.mjs:50` (`designer_approved_by: ''` default)
+- Mockup annotation pattern — `docs/for-developers/frontend/mockup-annotation-pattern.md`
+- CLAUDE.md § Mockup audit — DS-17 Phase B (#2127) (P250 self-waiver pattern documented)
+- `ci.yml` — `.github/workflows/ci.yml` (frontend job with existing lint gates)
+- `pnpm lint:fidelity` — defined in `apps/web/package.json`
+- Designer review queue — `docs/for-developers/frontend/mockup-designer-review-queue.md`

--- a/docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md
+++ b/docs/for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md
@@ -1,0 +1,221 @@
+# ADR-078 — Auto-Issue Noise Thresholds and Batch Grouping Policy
+
+**Status**: Proposed
+**Date**: 2026-06-15
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-6 (CI/CD quality gates)
+**Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · `spec-debt-false-positive-handler.yml` · `dev-auto-revert.yml` · issue #1071 (WS-E.2b false-positive override)
+
+## Context
+
+MeepleAI's CI/CD infrastructure includes several automated workflows that create GitHub issues based on detected conditions:
+
+**Existing auto-issue workflows (evidenced in `.github/workflows/`)**:
+
+1. **`spec-debt-false-positive-handler.yml`** (issue #1071, WS-E.2b): Creates auto-PRs and updates an allowlist (`spec-debt-false-positive-allowlist.json`) when a `mockup-spec-debt` issue receives the `spec-debt-false-positive` label. Uses a `dedup_key` hash in the issue body marker (`<!-- spec-debt-key: {key}; -->`) to prevent re-opening the same issue.
+
+2. **`dev-auto-revert.yml`** (ADR-055, issue #843): A Phase 1 shadow-mode bot that classifies main-dev failures every 15 minutes. Emits Slack alerts when `verdict=real-failure` crosses a threshold. In Phase 2 (not yet active), it would open revert PRs. Uses a failure-mode catalog (8 categories: `success`, `real-failure`, `infra-flake`, `concurrency-cancelled`, etc.) to classify before acting.
+
+3. **`ci-minutes-digest.yml`**: Presumably creates or updates a digest issue with CI minute consumption.
+
+4. **`runner-health-check.yml`** and **`monitor-runner-queue.yml`**: Runner health monitoring — likely emit issues or Slack alerts on runner anomalies.
+
+5. **`validate-secrets.yml`**: Validates secrets configuration — could emit issues on secret drift.
+
+6. **`docs-linkcheck.yml`**: Link checking — could emit issues on broken links.
+
+**Current noise management evidence**:
+- The `dedup_key` pattern in `spec-debt-false-positive-handler.yml` shows that at least one workflow uses content-hash fingerprinting to prevent duplicate issue creation.
+- The `dev-auto-revert.yml` uses a failure-mode classification with threshold logic ("would-revert only after 30min continuous red") before taking action — a noise-reduction strategy.
+- The `spec-debt-false-positive-allowlist.json` is an explicit allowlist pattern for suppressing known-false-positive auto-issues.
+
+**Problem space**: as the number of automated monitors grows (security scans, dependency drift, spec debt, seed snapshot freshness, runner health), each generating potential issues, the GitHub issue tracker can be polluted with:
+- **Noise issues** (same condition detected on consecutive scans, creating N identical issues).
+- **Burst issues** (a single root cause — e.g. a network blip — causing 10 simultaneous "health check failed" issues across 10 monitors).
+- **Stale issues** (a condition that auto-resolved but the issue remains open, accumulating false backlog).
+
+The existing codebase has partial solutions (`dedup_key`, threshold checks) but no unified cross-workflow policy for noise management.
+
+## Problem
+
+The specific architectural question: **what is the canonical policy for auto-issue creation across all MeepleAI automated monitors — including thresholds, batch grouping, deduplication strategy, and escalation tiers — such that the GitHub issue tracker reflects actionable signal rather than automated noise?**
+
+## Options Considered
+
+### Option A — Hard Daily Cap (max 1 issue per day per workflow)
+
+Each auto-issue workflow reads a `last_issue_created_at` value (stored as a workflow output, a GH variable, or a file in the repo) and skips issue creation if one was already created within the past 24h.
+
+**Pros**:
+- Simple and predictable: each monitor can create at most 1 issue per day.
+- Reduces backlog growth rate to O(monitors × days).
+
+**Cons**:
+- Misses a P1 burst: if a security vulnerability is detected at 11:00 and the cap was already used at 09:00 for a different occurrence of the same monitor, the P1 is silently dropped until the next day.
+- The 24h window is arbitrary: a monitor that fires on a 5-minute schedule has a 288x reduction in sensitivity.
+- Does not help with stale issues: the cap prevents creation but does not manage issue lifecycle (reopen vs close).
+- State storage for `last_issue_created_at` across GHA workflow runs requires a GitHub Actions variable or a file commit — operational complexity.
+
+**Risks**: Silent drops of P1 issues. Not recommended as the sole mechanism.
+
+**Impact**: ~1 day per workflow adoption. Fragile state management.
+
+---
+
+### Option B — Batch Grouping (1 issue per scan, N findings as bullet list)
+
+Each scan cycle (cron run) produces a single issue containing all findings as bullet points:
+```
+## Scan findings: 2026-06-15 02:00 UTC
+- [ ] Broken doc link: `docs/for-developers/ops/manual.md:42` → 404
+- [ ] Broken doc link: `docs/for-developers/api/ref.md:17` → 404
+- [ ] Stale secret: `OPENROUTER_API_KEY` not found in vault
+```
+
+Issue title: `[auto] Scan findings — 2026-06-15` — one issue per day per scan type.
+
+**Pros**:
+- Linear issue growth: 1 issue per day per scan type, regardless of finding count.
+- Findings are co-located: the reviewer sees all issues in one place for triage.
+- Natural batch for a single CI run — each scan run owns its issues.
+
+**Cons**:
+- Issue granularity is lost: the batch issue cannot be labelled, assigned, or tracked per finding. Assigning "broken link in API ref" to a specific developer is awkward if it's item 7 in a 15-item list.
+- Progress tracking per finding requires checkbox state in the issue body — GitHub doesn't track individual checkboxes as sub-tasks.
+- If the scan finds 0 issues, no issue is created but the previous batch issue remains open (stale backlog problem).
+- "N findings in 1 issue" can mask escalation: if the finding count doubles from 5 to 50 between scans, the issue count stays at 1 — the severity increase is invisible without reading the body.
+
+**Risks**: Triage complexity. Sub-optimal for large batches (>10 findings).
+
+**Impact**: ~1.5 days per workflow to implement batch aggregation.
+
+---
+
+### Option C — Deduplication via Fingerprint Hash + Reopen-Old (recommended as primary mechanism)
+
+Each auto-issue carries a `dedup_key` in the issue body (HTML comment marker, per the existing `spec-debt-false-positive-handler.yml` pattern): `<!-- auto-issue-key: {sha256_fingerprint}; -->`. The fingerprint is derived from the finding's stable attributes (e.g. `sha256(monitor_name + finding_id + affected_path)`).
+
+Before creating a new issue, the workflow uses the GH API to search for open issues with the same `dedup_key` body marker. If found: update the existing issue (add a comment "re-detected: {timestamp}") and skip creation. If not found: create a new issue.
+
+When the condition auto-resolves (monitor next scan returns clean), the workflow closes the old issue: `github.rest.issues.update({ state: 'closed', state_reason: 'completed' })`.
+
+**Pros**:
+- Prevents duplicate issue creation for the same condition across scan cycles — the key pattern is already proven in `spec-debt-false-positive-handler.yml`.
+- Issues remain open exactly as long as the condition exists — lifecycle follows the actual problem, not the scan schedule.
+- Reopening an existing issue (vs creating a new one) preserves the issue history (comments, assignment, labels) — useful for conditions that flap.
+- Compatible with the existing `spec-debt-false-positive-allowlist.json` pattern: allowlisted keys are skipped at the search step.
+
+**Cons**:
+- GH API search for `dedup_key` is a GitHub Issues Search API call — subject to GH API rate limits (1,000 search requests/hour per workflow). With many monitors running in parallel, this could be constrained.
+- The fingerprint must be stable across scan runs: if the finding description includes unstable attributes (e.g. a line number that shifts with code changes), the fingerprint changes on every scan and dedup fails. Fingerprint design is critical.
+- `is:open` search is not instant — the GH API has up to 30s indexing lag for newly created issues. A race condition exists if two monitor runs start simultaneously (both see `is:open count=0` and both create a new issue).
+
+**Risks**: Fingerprint instability → dedup failure → duplicate issues. API rate limits under burst conditions. Race condition on simultaneous parallel monitors (rare, mitigated by `concurrency` group settings already used in the codebase).
+
+**Impact**: ~2 days. Shared GHA action (`auto-issue-dedup`) that all monitors call, implementing the search + create-or-update-or-close logic.
+
+---
+
+### Option D — Threshold + Escalation Tiers (recommended as escalation layer, combined with Option C)
+
+Build on the existing `dev-auto-revert.yml` pattern: classify findings by severity before deciding the response:
+
+```
+Tier 0 (advisory):  finding count ≤ 2        → no issue (log to workflow summary only)
+Tier 1 (tracking):  finding count 3-9         → create/update deduplicated issue (Option C)
+Tier 2 (alert):     finding count 10-24       → issue + Slack DM to @badsworm
+Tier 3 (P1):        finding count ≥ 25        → issue + Slack @channel + block merge
+```
+
+Additionally, some findings are P1 regardless of count (e.g. leaked secret, failing auth, production 500): these bypass the threshold and always create an issue + Slack alert.
+
+**Combined with Option C**: the dedup hash prevents duplicate issues; the tier system determines response intensity.
+
+**Pros**:
+- Low-count noise is suppressed at Tier 0 (advisory log only): common transient conditions (1 flaky test, 1 stale link) do not generate issues.
+- High-count bursts are escalated: 25 simultaneous failures indicate a systemic problem, not random noise — the P1 tier ensures immediate response.
+- P1 bypass for specific finding types (leaked secrets) ensures critical issues are never suppressed by thresholds.
+- Mirrors the `dev-auto-revert.yml` classification approach already proven in production.
+
+**Cons**:
+- Per-monitor threshold calibration required: the threshold for "alert on doc link failures" (Tier 1: ≥ 3) differs from "alert on flaky tests" (Tier 0: advisory always, since 1 flaky test is already a regression per CLAUDE.md Known Flaky Tests policy).
+- The tier thresholds (3, 10, 25) are suggested defaults and may need tuning per monitor type.
+- Combining with Option C adds complexity: the workflow must implement both the dedup hash check and the tier classification — more logic per workflow.
+
+**Risks**: Threshold mis-calibration → either too noisy (threshold too low) or missed fires (threshold too high). Requires per-monitor configuration.
+
+**Impact**: ~3 days for the shared escalation framework + per-monitor threshold configuration. Higher implementation cost, higher value.
+
+## Decision
+
+**Adopt Option C as the deduplication primitive, combined with Option D's tier system as the escalation layer.** Together, these form the canonical auto-issue policy.
+
+**Canonical auto-issue creation policy**:
+1. **Fingerprint every finding**: SHA-256 of `{monitor_name}:{stable_finding_id}`. Stable finding IDs are path-based (file path, issue ID) not line-number-based.
+2. **Search for open issue with `dedup_key`** before creating. On match: add a re-detection comment; skip creation.
+3. **Tier classification** (per-monitor configurable defaults: Tier 0 ≤ 2, Tier 1 3-9, Tier 2 10-24, Tier 3 ≥ 25). P1 finding types bypass all thresholds.
+4. **Auto-close** when the condition resolves on next scan: `state_reason: 'completed'`.
+5. **Allowlist integration**: check the `spec-debt-false-positive-allowlist.json` pattern before creating — if `dedup_key` is in the allowlist, skip (no issue, no comment).
+
+**P1 bypass types** (issue always created regardless of count, no Tier 0 suppression):
+- Leaked secret detected (`validate-secrets.yml`).
+- Production auth failure.
+- DB migration conflict.
+- Dependency with known CVE (CVSS ≥ 7.0).
+
+**Rationale**: Option A (daily cap) risks silent drops of P1 findings. Option B (batch grouping) reduces issue count but loses per-finding granularity and assignment capability. Options C+D provide maximum signal quality: dedup prevents noise accumulation, tiers ensure response proportional to severity, and auto-close maintains backlog hygiene without manual intervention.
+
+## Consequences
+
+**Positive**:
+- Issue tracker reflects only active, actionable problems — resolved conditions are auto-closed.
+- P1 conditions always surface regardless of threshold settings.
+- The `dedup_key` pattern is consistent with `spec-debt-false-positive-handler.yml` — no new issue body conventions are introduced.
+- Auto-close on resolution eliminates the "stale open issue" category of backlog debt.
+
+**Negative**:
+- Tier 0 suppression means 1-2 instances of a condition are logged only to workflow summaries — a developer must actively check workflow runs to discover Tier-0 conditions. This is the intended trade-off (Tier 0 = expected transient noise).
+- GH API search latency and rate limits must be managed per the constraint above. Recommendation: all monitors use a shared `concurrency` group name `auto-issue-{monitor_type}` with `cancel-in-progress: false` to prevent parallel searches from the same monitor.
+- Per-monitor threshold configuration must be maintained as a `workflow_inputs` or a centralised JSON config file.
+
+**Trade-offs**:
+- The race condition in Option C (two parallel monitors both see 0 open issues and both create one) is mitigated but not eliminated by the `concurrency` group. If it occurs, the duplicate is detected on the next scan run and the extra issue is auto-closed with a `state_reason: 'not_planned'` comment. Acceptable residual risk.
+
+## Implementation Guidance
+
+1. **Shared GHA action**: create `.github/actions/auto-issue-dedup/action.yml` with inputs: `monitor_name`, `finding_id`, `finding_title`, `finding_body`, `tier_threshold` (JSON: `{"warn":3,"alert":10,"p1":25}`), `is_p1` (boolean), `allowlist_path`. Outputs: `action` (`created | updated | skipped | allowlisted`), `issue_number`.
+
+2. **Fingerprint generation**:
+   ```javascript
+   const crypto = require('node:crypto');
+   const dedupKey = crypto.createHash('sha256')
+     .update(`${monitorName}:${findingId}`)
+     .digest('hex')
+     .substring(0, 16); // 16-char prefix sufficient for uniqueness
+   ```
+   Embed in issue body: `<!-- auto-issue-key: ${dedupKey}; -->`.
+
+3. **Search query**: `repo:meepleAi-app/meepleai-monorepo is:issue is:open body:"auto-issue-key: ${dedupKey};"` — uses GH Issues Search API.
+
+4. **Auto-close on resolution**: each monitor workflow has a "check if condition still exists" step. If the condition is resolved and an open issue with matching `dedup_key` is found, close it: `github.rest.issues.update({ issue_number, state: 'closed', state_reason: 'completed' })` + comment "Auto-resolved: {condition} not detected on scan at {timestamp}".
+
+5. **Adopt in existing workflows**: 
+   - `dev-auto-revert.yml` Phase 2: add `dedup_key` to would-revert issues + auto-close when main-dev goes green.
+   - `docs-linkcheck.yml`: use the shared action with `tier_threshold: {"warn":3,"alert":15,"p1":999}` (no P1 for doc links).
+   - `validate-secrets.yml`: use with `is_p1: true` for leaked secret findings.
+
+6. **Monitoring**: add a `ci-minutes-digest.yml`-style weekly digest that reports: open auto-issues by monitor type, auto-closes in the past 7 days, dedup hits (re-detections without new issue creation). This gives visibility into noise reduction effectiveness.
+
+## Rollback / Reversibility
+
+The shared `auto-issue-dedup` action is consumed by each monitor workflow independently. Removing the action from a workflow reverts that monitor to its pre-ADR behaviour (typically: always create a new issue, no dedup). The `spec-debt-false-positive-allowlist.json` format is unchanged. No schema or DB changes.
+
+## References
+
+- `spec-debt-false-positive-handler.yml` — `.github/workflows/spec-debt-false-positive-handler.yml` (existing `dedup_key` pattern)
+- `dev-auto-revert.yml` — `.github/workflows/dev-auto-revert.yml` (failure-mode classification + threshold + shadow-mode pattern)
+- `spec-debt-false-positive-allowlist.json` — `docs/for-developers/audits/spec-debt-false-positive-allowlist.json` (allowlist pattern)
+- CLAUDE.md § Known Flaky Tests (0-baseline policy: flaky tests = regression, not noise)
+- CLAUDE.md § Active Freezes (existing P1 conditions: BGG asset ban, token canonicalization)
+- `ci.yml` — `.github/workflows/ci.yml` (reference for `concurrency` group pattern used across CI)
+- Issue #1071 (WS-E.2b false-positive handler), issue #843 (dev-auto-revert ADR-055)


### PR DESCRIPTION
## Summary

**Final wave** of umbrella [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363). After merge, all 13 ADRs are ✅ shipped and the architectural gate for umbrella #2342 Tier 2-6 implementation is fully unblocked.

| ADR | Title | Parent US | Priority | Tracker row |
|-----|-------|-----------|----------|-------------|
| 072 | Notification dedup strategy | US-INT-5 | P1 | #9 |
| 073 | PlayRecord stats aggregation refresh | US-INT-2 | P2 | #3 |
| 074 | Voting closure mechanism | US-INT-3 | P2 | #5 |
| 075 | Deep link versioning | US-INT-5 | P2 | #10 |
| 076 | Quiet hours timezone | US-INT-5 | P2 | #11 |
| 077 | Designer signoff CI gate | US-INT-6 | P2 | #12 |
| 078 | Auto-issue noise thresholds | US-INT-6 | P3 | #13 |

7 commits (1 per ADR), 1274 LOC total, all docs-only.

## Decisions chosen (one-line each)

- **ADR-072**: Option C — DB partial unique constraint as authoritative + application pre-check as optimistic guard. Formalises the `UX_notifications_user_source_event_id` already shipped via #1937; closes the dedup gap flagged by ADR-068.
- **ADR-073**: Option D — Redis cache + explicit invalidation on `PlayRecordCompletedEvent`. 30-min TTL with explicit invalidation ensures stats fresh post-write.
- **ADR-074**: Option C — Lazy validation-time closure check + optional `RsvpDeadline` field + Hangfire hourly cleanup for `RsvpClosedAt` + organiser notification.
- **ADR-075**: Option D — Two-tier: email-embedded links use `next.config.js` 301 redirects; in-app `notifications.link` values DB-updated at migration time + `NotificationRoutes` static class.
- **ADR-076**: Option C — Hybrid: server-side gating for email/Slack, client-side toast suppression for in-app; push delegated to device DND.
- **ADR-077**: Option D — Per-area blocking scoped to `design_intent: "current"` fidelity files, with `self-waiver P250` formally accepted as CI approval token (solo-maintainer context).
- **ADR-078**: Options C+D combined — fingerprint-hash dedup (consistent with `spec-debt-false-positive-handler.yml`) + 4-tier escalation (log-only / issue / Slack DM / P1 @channel) + P1 bypass for leaked secrets.

## ⚠️ Open questions per ADR (require user attention before implementation)

1. **ADR-072 — code bug to patch**: `UniqueKeyViolationException` catch-and-swallow gap in `NotificationDispatcher` — race-window DB constraint violation would propagate as unhandled exception. Fix in implementation PR.

2. **ADR-073 — STJ serialisation check**: `PlayerStatisticsDto` records with `IReadOnlyList<T>` nested types require explicit `System.Text.Json` configuration or `[JsonSerializable]` source generation. If STJ cannot roundtrip the DTO, cache approach fails silently.

3. **ADR-074 — domain method visibility**: `MarkRsvpClosed()` MUST be `internal` (callable only by repository/job), consistent with private-setter + factory-method DDD pattern.

4. **ADR-075 — codegen drift risk**: `NotificationRoutes` static class requires C# + TypeScript parallel definitions. Long-term solution: single JSON source of truth consumed by both. OUT OF SCOPE this ADR.

5. **ADR-076 — Linux deployment risk**: `TimeZoneInfo.FindSystemTimeZoneById` throws on Linux if IANA timezone string unknown. **`TimeZoneConverter` NuGet package MUST be added before implementation** (Linux container host).

6. **ADR-077 — backfill prerequisite**: ~38 `design_intent: "current"` fidelity files need `designer_approved_by` backfill BEFORE enabling CI gate. Cross-reference `audits/2026-06-10-mockup-design-intent-audit.json`.

7. **ADR-078 — rate-limit mitigation**: GH Issues Search API limit (1k req/h) means >16 simultaneous monitors approach the cap. Recommend shared `concurrency` group per monitor type (discipline for future workflow authors).

## Self-review evidence

All ADRs cite real code paths verified by grep/read:
- ADR-072: `NotificationEntityConfiguration.cs:45-48`, `NotificationDispatcher.cs:51-59`, `NotificationRepository.cs:136-140`
- ADR-073: `GetPlayerStatisticsQueryHandler.cs:123` (scale note), `PlayRecordCompletedEvent`
- ADR-074: `GameNightEvent.cs` (no RsvpDeadline today), `CooldownEndReminderJob`, `StaleShareRequestWarningJob`
- ADR-075: `next.config.js:164-290` (19+ redirects), `Notification.Link` field, 5 event handlers with inline link strings
- ADR-076: `NotificationPreferences.cs` (no TimeZone/QuietHours today), `NotificationDispatcher.DispatchAsync`
- ADR-077: `sp4-play-records-stats.fidelity.json`, `generate-deliverables.mjs:50`, P250 waiver pattern from CLAUDE.md
- ADR-078: `spec-debt-false-positive-handler.yml` (dedup_key pattern), `dev-auto-revert.yml` (8-category, 30-min threshold)

## Tracker closure

After merge, the [#2363 body](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) table updated to mark rows #3, #5, #9, #10, #11, #12, #13 as ✅ shipped. **All 13/13 ADRs complete → close tracker #2363** with summary comment.

## Cumulative #2363 Wave summary (this PR + predecessors)

| Wave | PR | ADRs | Rows |
|------|-----|------|------|
| 1 | #2371 | 066, 067 | #1, #2 |
| 2 | #2380 | 068, 069, 070, 071 | #4, #6, #7, #8 |
| **3+4** | **THIS PR** | **072, 073, 074, 075, 076, 077, 078** | **#3, #5, #9, #10, #11, #12, #13** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)