### PR TITLE
fix(catalog): #2372 invalidate search-games HybridCache on translation CRUD

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -12,6 +13,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTran
 
 /// <summary>
 /// Handler for <see cref="AddGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// Issue #2372 — closes the cache-invalidation gap so Wave 5 endpoints can ship.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -27,6 +29,15 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTran
 /// <see cref="DbUpdateException"/> referencing the constraint name and we rethrow as
 /// <see cref="TranslationAlreadyExistsException"/> (409).
 /// </para>
+/// <para>
+/// After a successful save, the handler invalidates the two HybridCache tags that wrap
+/// <see cref="SharedGameCatalog.Application.Queries.SearchSharedGamesQueryHandler"/> and
+/// <see cref="SharedGameCatalog.Application.Queries.GetSharedGameByIdQueryHandler"/> so
+/// the read-model stops serving stale <c>SharedGameDto.Translations</c> payloads for up
+/// to 60 minutes (L2 TTL). Tag fan-out across replicas follows the ADR-062 contract
+/// (Pub/Sub + retry policy). Invalidation runs only on the GREEN path: NotFound and
+/// unique-constraint violations short-circuit before the invalidation block.
+/// </para>
 /// </remarks>
 internal sealed class AddGameTranslationCommandHandler
     : IRequestHandler<AddGameTranslationCommand, Guid>
@@ -36,22 +47,30 @@ internal sealed class AddGameTranslationCommandHandler
     private readonly ISharedGameTranslationRepository _translationRepo;
     private readonly ISharedGameRepository _gameRepo;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly TimeProvider _clock;
 
     public AddGameTranslationCommandHandler(
         ISharedGameTranslationRepository translationRepo,
         ISharedGameRepository gameRepo,
         IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         TimeProvider clock)
     {
         ArgumentNullException.ThrowIfNull(translationRepo);
         ArgumentNullException.ThrowIfNull(gameRepo);
         ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(retryPolicy);
         ArgumentNullException.ThrowIfNull(clock);
 
         _translationRepo = translationRepo;
         _gameRepo = gameRepo;
         _unitOfWork = unitOfWork;
+        _cache = cache;
+        _retryPolicy = retryPolicy;
         _clock = clock;
     }
 
@@ -97,7 +116,27 @@ internal sealed class AddGameTranslationCommandHandler
             throw new TranslationAlreadyExistsException(cmd.GameId, locale.Value);
         }
 
+        // Issue #2372: invalidate catalog read-model on the GREEN path only.
+        await InvalidateCatalogCacheAsync(cmd.GameId, cancellationToken).ConfigureAwait(false);
+
         return translation.Id;
+    }
+
+    private async Task InvalidateCatalogCacheAsync(Guid sharedGameId, CancellationToken ct)
+    {
+        // Mirrors VectorDocumentIndexedForKbFlagHandler invalidation pattern (ADR-062):
+        // "search-games" evicts SearchSharedGamesQueryHandler cache, "shared-game:{id}"
+        // evicts GetSharedGameByIdQueryHandler cache. The retry policy guards against
+        // transient Redis Pub/Sub failures and bounds wall-time to ~4s worst case.
+        await _retryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
+            "shared-games.list",
+            ct).ConfigureAwait(false);
+
+        await _retryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", token)),
+            "shared-games.detail",
+            ct).ConfigureAwait(false);
     }
 
     private static bool IsUniqueLocaleViolation(DbUpdateException ex)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 
@@ -8,6 +9,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameT
 
 /// <summary>
 /// Handler for <see cref="DeleteGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// Issue #2372 — closes the cache-invalidation gap so Wave 5 endpoints can ship.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -31,25 +33,38 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameT
 /// twice with the same xmin succeeds the first time and may surface a concurrency
 /// failure on the second (because xmin advances on the first SaveChanges).
 /// </para>
+/// <para>
+/// After a successful save the handler invalidates the "search-games" + "shared-game:{id}"
+/// HybridCache tags (ADR-062 cross-replica pattern) so the catalog read-model stops
+/// serving stale <c>SharedGameDto.Translations</c> payloads within L2 TTL (60 min).
+/// </para>
 /// </remarks>
 internal sealed class DeleteGameTranslationCommandHandler
     : IRequestHandler<DeleteGameTranslationCommand, Unit>
 {
     private readonly ISharedGameTranslationRepository _translationRepo;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly TimeProvider _clock;
 
     public DeleteGameTranslationCommandHandler(
         ISharedGameTranslationRepository translationRepo,
         IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         TimeProvider clock)
     {
         ArgumentNullException.ThrowIfNull(translationRepo);
         ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(retryPolicy);
         ArgumentNullException.ThrowIfNull(clock);
 
         _translationRepo = translationRepo;
         _unitOfWork = unitOfWork;
+        _cache = cache;
+        _retryPolicy = retryPolicy;
         _clock = clock;
     }
 
@@ -76,6 +91,22 @@ internal sealed class DeleteGameTranslationCommandHandler
         // and surfaced as 409 with X-Warning-Code: concurrent-edit.
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+        // Issue #2372: invalidate catalog read-model on the GREEN path only.
+        await InvalidateCatalogCacheAsync(existing.SharedGameId, cancellationToken).ConfigureAwait(false);
+
         return Unit.Value;
+    }
+
+    private async Task InvalidateCatalogCacheAsync(Guid sharedGameId, CancellationToken ct)
+    {
+        await _retryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
+            "shared-games.list",
+            ct).ConfigureAwait(false);
+
+        await _retryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", token)),
+            "shared-games.detail",
+            ct).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 
@@ -8,6 +9,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameT
 
 /// <summary>
 /// Handler for <see cref="UpdateGameTranslationCommand"/>. Issue #2339 — sub-PR 1/3.
+/// Issue #2372 — closes the cache-invalidation gap so Wave 5 endpoints can ship.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -25,25 +27,40 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameT
 /// mismatch — left to bubble so the global middleware can map it to 409 with
 /// <c>X-Warning-Code: concurrent-edit</c>.
 /// </para>
+/// <para>
+/// After a successful save the handler invalidates the "search-games" + "shared-game:{id}"
+/// HybridCache tags (ADR-062 cross-replica pattern) so the catalog read-model stops
+/// serving stale <c>SharedGameDto.Translations</c> payloads within L2 TTL (60 min).
+/// The concurrent-edit branch shorts out before invalidation because
+/// <c>DbUpdateConcurrencyException</c> propagates from SaveChangesAsync.
+/// </para>
 /// </remarks>
 internal sealed class UpdateGameTranslationCommandHandler
     : IRequestHandler<UpdateGameTranslationCommand, Unit>
 {
     private readonly ISharedGameTranslationRepository _translationRepo;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly TimeProvider _clock;
 
     public UpdateGameTranslationCommandHandler(
         ISharedGameTranslationRepository translationRepo,
         IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         TimeProvider clock)
     {
         ArgumentNullException.ThrowIfNull(translationRepo);
         ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(retryPolicy);
         ArgumentNullException.ThrowIfNull(clock);
 
         _translationRepo = translationRepo;
         _unitOfWork = unitOfWork;
+        _cache = cache;
+        _retryPolicy = retryPolicy;
         _clock = clock;
     }
 
@@ -72,6 +89,22 @@ internal sealed class UpdateGameTranslationCommandHandler
         // and surfaced as 409 with X-Warning-Code: concurrent-edit.
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+        // Issue #2372: invalidate catalog read-model on the GREEN path only.
+        await InvalidateCatalogCacheAsync(existing.SharedGameId, cancellationToken).ConfigureAwait(false);
+
         return Unit.Value;
+    }
+
+    private async Task InvalidateCatalogCacheAsync(Guid sharedGameId, CancellationToken ct)
+    {
+        await _retryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
+            "shared-games.list",
+            ct).ConfigureAwait(false);
+
+        await _retryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", token)),
+            "shared-games.detail",
+            ct).ConfigureAwait(false);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.AddGa
 /// <summary>
 /// Unit tests for <see cref="AddGameTranslationCommandHandler"/>.
 /// Issue #2339 — sub-PR 1/3 Wave 3 (Task 9).
+/// Issue #2372 — added cache-invalidation guards (Wave 5 blocker fix).
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -26,14 +28,33 @@ public sealed class AddGameTranslationCommandHandlerTests
     private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
     private readonly Mock<ISharedGameRepository> _gameRepo = new();
     private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _retryPolicy = new();
     private readonly TimeProvider _clock;
     private readonly AddGameTranslationCommandHandler _sut;
 
     public AddGameTranslationCommandHandlerTests()
     {
         _clock = new FakeTimeProvider(SampleNow);
+
+        // Identity passthrough: invoke the operation delegate inline so the unit test
+        // can verify the inner _cache.RemoveByTagAcrossReplicasAsync calls. Matches
+        // the production CacheInvalidationRetryPolicy contract (no retry on first attempt).
+        _retryPolicy
+            .Setup(p => p.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, ValueTask>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) =>
+                op(ct).AsTask());
+
         _sut = new AddGameTranslationCommandHandler(
-            _translationRepo.Object, _gameRepo.Object, _uow.Object, _clock);
+            _translationRepo.Object,
+            _gameRepo.Object,
+            _uow.Object,
+            _cache.Object,
+            _retryPolicy.Object,
+            _clock);
     }
 
     [Fact]
@@ -115,6 +136,109 @@ public sealed class AddGameTranslationCommandHandlerTests
         var thrown = await act.Should().ThrowAsync<TranslationAlreadyExistsException>();
         thrown.Which.Locale.Should().Be("it");
         thrown.Which.GameId.Should().Be(gameId);
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #2372 — cache invalidation regression guards.
+    //
+    // SearchSharedGamesQueryHandler caches SharedGameDto (including its
+    // Translations enrichment payload) under the "search-games" tag with
+    // L1 15min / L2 1h TTL. Without explicit invalidation on Add/Update/Delete
+    // of a translation, the read-model serves stale SharedGameDto.Translations
+    // for up to 60 minutes after CRUD — the bug that #2372 closes.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_HappyPath_InvalidatesSearchGamesAndDetailTags()
+    {
+        var gameId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        _gameRepo
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeStubGame(gameId));
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "I Coloni di Catan",
+            Description: null,
+            Source: "manual",
+            ActorUserId: actor);
+
+        await _sut.Handle(cmd, CancellationToken.None);
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{gameId}", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _retryPolicy.Verify(
+            p => p.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, ValueTask>>(),
+                "shared-games.list",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _retryPolicy.Verify(
+            p => p.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, ValueTask>>(),
+                "shared-games.detail",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GameNotFound_DoesNotInvalidateCache()
+    {
+        var gameId = Guid.NewGuid();
+        _gameRepo
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UniqueConstraintViolation_DoesNotInvalidateCache()
+    {
+        var gameId = Guid.NewGuid();
+        _gameRepo
+            .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeStubGame(gameId));
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateException(
+                "duplicate key value violates unique constraint \"uq_active_translation_per_locale\"",
+                innerException: (Exception?)null));
+
+        var cmd = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Source: "manual",
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<TranslationAlreadyExistsException>();
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/DeleteGameTranslation/DeleteGameTranslationCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.Delet
 /// <summary>
 /// Unit tests for <see cref="DeleteGameTranslationCommandHandler"/>.
 /// Issue #2339 — sub-PR 1/3 Wave 4 (Task 11).
+/// Issue #2372 — added cache-invalidation guards (Wave 5 blocker fix).
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -25,14 +27,31 @@ public sealed class DeleteGameTranslationCommandHandlerTests
 
     private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
     private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _retryPolicy = new();
     private readonly TimeProvider _clock;
     private readonly DeleteGameTranslationCommandHandler _sut;
 
     public DeleteGameTranslationCommandHandlerTests()
     {
         _clock = new FakeTimeProvider(SampleNow);
+
+        // Identity passthrough: invoke the operation delegate inline so the unit test
+        // can verify the inner _cache.RemoveByTagAcrossReplicasAsync calls.
+        _retryPolicy
+            .Setup(p => p.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, ValueTask>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) =>
+                op(ct).AsTask());
+
         _sut = new DeleteGameTranslationCommandHandler(
-            _translationRepo.Object, _uow.Object, _clock);
+            _translationRepo.Object,
+            _uow.Object,
+            _cache.Object,
+            _retryPolicy.Object,
+            _clock);
     }
 
     [Fact]
@@ -114,6 +133,89 @@ public sealed class DeleteGameTranslationCommandHandlerTests
         var act = async () => await _sut.Handle(cmd, CancellationToken.None);
 
         await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #2372 — cache invalidation regression guards (see Add handler
+    // tests for full rationale).
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_HappyPath_InvalidatesSearchGamesAndDetailTags()
+    {
+        var gameId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "I Coloni di Catan");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var cmd = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Xmin: 1u,
+            ActorUserId: actor);
+
+        await _sut.Handle(cmd, CancellationToken.None);
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{gameId}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TranslationNotFound_DoesNotInvalidateCache()
+    {
+        var gameId = Guid.NewGuid();
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGameTranslation?)null);
+
+        var cmd = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<TranslationNotFoundException>();
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentEdit_DoesNotInvalidateCache()
+    {
+        var gameId = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "title");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException(
+                "Database operation expected to affect 1 row(s) but actually affected 0 row(s)."));
+
+        var cmd = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private static SharedGameTranslation MakeActiveTranslation(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/UpdateGameTranslation/UpdateGameTranslationCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.Updat
 /// <summary>
 /// Unit tests for <see cref="UpdateGameTranslationCommandHandler"/>.
 /// Issue #2339 — sub-PR 1/3 Wave 3 (Task 10).
+/// Issue #2372 — added cache-invalidation guards (Wave 5 blocker fix).
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SharedGameCatalog")]
@@ -25,14 +27,31 @@ public sealed class UpdateGameTranslationCommandHandlerTests
 
     private readonly Mock<ISharedGameTranslationRepository> _translationRepo = new();
     private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _retryPolicy = new();
     private readonly TimeProvider _clock;
     private readonly UpdateGameTranslationCommandHandler _sut;
 
     public UpdateGameTranslationCommandHandlerTests()
     {
         _clock = new FakeTimeProvider(SampleNow);
+
+        // Identity passthrough: invoke the operation delegate inline so the unit test
+        // can verify the inner _cache.RemoveByTagAcrossReplicasAsync calls.
+        _retryPolicy
+            .Setup(p => p.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, ValueTask>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((Func<CancellationToken, ValueTask> op, string _, CancellationToken ct) =>
+                op(ct).AsTask());
+
         _sut = new UpdateGameTranslationCommandHandler(
-            _translationRepo.Object, _uow.Object, _clock);
+            _translationRepo.Object,
+            _uow.Object,
+            _cache.Object,
+            _retryPolicy.Object,
+            _clock);
     }
 
     [Fact]
@@ -150,6 +169,95 @@ public sealed class UpdateGameTranslationCommandHandlerTests
             r => r.UpdateAsync(It.IsAny<SharedGameTranslation>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #2372 — cache invalidation regression guards (see Add handler
+    // tests for full rationale).
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_HappyPath_InvalidatesSearchGamesAndDetailTags()
+    {
+        var gameId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "Vecchio titolo");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Nuovo titolo",
+            Description: null,
+            Xmin: 1u,
+            ActorUserId: actor);
+
+        await _sut.Handle(cmd, CancellationToken.None);
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{gameId}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TranslationNotFound_DoesNotInvalidateCache()
+    {
+        var gameId = Guid.NewGuid();
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGameTranslation?)null);
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "Foo",
+            Description: null,
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<TranslationNotFoundException>();
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentEdit_DoesNotInvalidateCache()
+    {
+        var gameId = Guid.NewGuid();
+        var existing = MakeActiveTranslation(gameId, "it", "title");
+
+        _translationRepo
+            .Setup(r => r.GetByGameIdAndLocaleAsync(gameId, "it", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException(
+                "Database operation expected to affect 1 row(s) but actually affected 0 row(s)."));
+
+        var cmd = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: "it",
+            Title: "stale title",
+            Description: null,
+            Xmin: 1u,
+            ActorUserId: Guid.NewGuid());
+
+        var act = async () => await _sut.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private static SharedGameTranslation MakeActiveTranslation(


### PR DESCRIPTION
## Summary

Closes #2372 — Wave 5 blocker cache-invalidation gap on the 3 `GameTranslation` handlers identified during PR #2370 code-review max-effort (3 of 5 angle convergent finding).

- ✅ `AddGameTranslationCommandHandler` invalidates `search-games` + `shared-game:{id}` post-save
- ✅ `UpdateGameTranslationCommandHandler` invalidates `search-games` + `shared-game:{id}` post-save
- ✅ `DeleteGameTranslationCommandHandler` invalidates `search-games` + `shared-game:{id}` post-save
- ✅ All failure paths (NotFound / TranslationNotFound / unique-constraint / DbUpdateConcurrency) short-circuit BEFORE the invalidation block — verified via negative-case tests

## Pattern

Mirrors `VectorDocumentIndexedForKbFlagHandler` (ADR-062):

```csharp
await _retryPolicy.ExecuteAsync(
    token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
    "shared-games.list", ct);

await _retryPolicy.ExecuteAsync(
    token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", token)),
    "shared-games.detail", ct);
```

Two-tag fan-out covers both `SearchSharedGamesQueryHandler` and `GetSharedGameByIdQueryHandler` caches. Cross-replica eviction via Redis Pub/Sub (ADR-062). Bounded retry guards transient failures (≤4s wall-clock).

## Why now

**Impact today**: zero — Wave 5 endpoints (`POST/PUT/DELETE /api/v1/admin/games/{id}/translations/{locale}`) are not yet wired. Without this fix, the moment those endpoints ship in sub-PR 2/3 of #2339, admins editing a translation would see stale `SharedGameDto.Translations` for up to 60min (L2 TTL).

**Why merge before Wave 5**: ships the safety net so sub-PR 2/3 doesn't introduce stale-read regressions on day-1.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~SharedGameCatalog.Application.Commands"` → **176/176 passing in 680ms**
- [x] Build clean (0 errors, 0 warnings on modified files)
- [x] Identity-passthrough mock pattern (`_retryPolicy.Setup(...).Returns(op => op(ct).AsTask())`) lets unit tests observe inner `_cache.RemoveByTagAcrossReplicasAsync` calls
- [x] 3 happy-path tests (one per handler) verify both tags invalidated exactly once
- [x] 6 negative-case tests verify cache NOT invalidated on failure paths

## Files changed

| File | Δ LOC |
|------|-------|
| `AddGameTranslationCommandHandler.cs` | +39 |
| `UpdateGameTranslationCommandHandler.cs` | +33 |
| `DeleteGameTranslationCommandHandler.cs` | +31 |
| `AddGameTranslationCommandHandlerTests.cs` | +123 |
| `UpdateGameTranslationCommandHandlerTests.cs` | +107 |
| `DeleteGameTranslationCommandHandlerTests.cs` | +101 |
| **Total** | **+440 / -3** |

## Refs

- Closes: #2372 (Wave 5 blocker, identified via `/sc:code-review` max effort on PR #2370)
- Parent epic: #2339 (shared game translations Option A)
- Pattern source: `VectorDocumentIndexedForKbFlagHandler.cs`
- ADR: `docs/for-claude/architecture/adr/adr-062-kb-flag-cache-strategy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
