### PR TITLE
docs(superpowers): plans for #2373 G5a renderer + #2374 G1 layout (epic #2354)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-issue-2373-scoring-panel-renderer.md
+++ b/docs/superpowers/plans/2026-06-15-issue-2373-scoring-panel-renderer.md
@@ -1,0 +1,393 @@
+# Plan: Issue #2373 — ScoringPanelRenderer Polymorphic Dispatch (G5a)
+
+> Generated 2026-06-15 via `Plan` subagent dispatched during `/sc:spec-panel "find next 5 issues"` session. Sub-issue G5a of epic #2354 (Session live shell). Parallel to #2374 (G1 layout) — renderer is layout-agnostic.
+
+## §1 Context + spec links
+
+- **Issue**: [#2373](https://github.com/meepleAi-app/meepleai-monorepo/issues/2373) — `feat(session-live): ScoringPanelRenderer polymorphic dispatch (4 ScoreType variants)`
+- **Epic**: [#2354](https://github.com/meepleAi-app/meepleai-monorepo/issues/2354) — Session live shell (sub-issue G5a)
+- **Sibling G1**: #2374 (layout). G5a is layout-agnostic.
+- **Canonical mockup**: `admin-mockups/design_files/sp4-session-skeleton-renderers.jsx` (Panel-based dispatch on `data.scoring.scoreType` — Points / Ranking / BinaryWin / Objectives variants, lines 100–286).
+- **Backend asse A v2.1**: SHIPPED (PR #1917) — `ScoreType.cs` enum, `IScoringStrategy`, `ScoringStrategyFactory`, `UpdateSessionScoresCommand`, `MAX_LIVE_SESSIONS_EXCEEDED`. Per epic body, asse-A polymorphic Score wiring landed via PR #1896 sess.32 (`c1efb4fb6`).
+- **Asse D P1 (FE editor) — SHIPPED sess.35**: `apps/web/src/components/sessions/PolymorphicScoreEditor.tsx`, the 4 strategy editors, `useUpdateSessionScores` mutation hook with `UpdateSessionScoresError` tagged union (`forbidden|validation|server`). Plan at `docs/superpowers/plans/2026-06-05-asse-d-p1-polymorphic-score-editor.md`.
+- **Token discipline**: `CLAUDE.md` § Token Canonicalization — only semantic tokens (`bg-card`, `bg-muted`, `text-foreground`, `border-border`, `text-muted-foreground`) + entity utilities (`bg-entity-session`, `text-entity-toolkit`); ESLint `local/no-hardcoded-color-utility` is **error** since DS-15.
+- **Asse A semantic alignment**: `docs/superpowers/plans/2026-06-04-asse-a-semantic-alignment.md`.
+- **Issue #2281 / sister scope**: `docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md`.
+
+## §2 Discovery notes (what's already shipped vs the gap)
+
+### BE shipped (mirror checkpoint — no FE-side blocker)
+
+- `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/ScoreType.cs` — 4 variants.
+- `ScoringStrategyFactory.cs` + 4 strategies (`Points|Ranking|BinaryWin|Objectives`).
+- `UpdateSessionScoresCommand` ready end-to-end (per epic body, commit `c1efb4fb6`).
+
+### FE primitives shipped (sess.35, asse D P1)
+
+| Concern | File | Notes |
+|---|---|---|
+| Editor dispatcher (WRITE) | `apps/web/src/components/sessions/PolymorphicScoreEditor.tsx` | Exhaustive `switch` over `ScoreType`; throws on missing `availableObjectives`; emits `ScoreChangePayload` tagged union. |
+| Editor strategies (4) | `apps/web/src/components/sessions/score-strategies/{Points,BinaryWin,Objectives,Ranking}Editor.tsx` | DnD ranking via `@dnd-kit`. |
+| Type contract | `apps/web/src/components/sessions/score-strategies/types.ts` (lines 19, 24–58) | `ScoreType = 'Points' \| 'BinaryWin' \| 'Objectives' \| 'Ranking'`, `ScoreDataByType` map, `PlayerOption { id, displayName, avatar? }`. |
+| Mutation hook | `apps/web/src/hooks/use-update-session-scores.ts` | Returns `UpdateSessionScoresError { kind: 'forbidden'\|'validation'\|'server' }`. Invalidates `['session', id]` + `['live-session', id]`. |
+| Schemas | `apps/web/src/lib/api/schemas/toolkit.schemas.ts` (line 137) | `ScoreTypeSchema = z.enum(['Points','Ranking','BinaryWin','Objectives'])` — order differs from `score-strategies/types.ts` but value set is identical. |
+
+### Pre-existing read-side renderer (toolkit context — DO NOT reuse directly)
+
+- `apps/web/src/components/toolkit/ScoringPanelRenderer.tsx` (issue #1749 B19-4a) already dispatches on `AiScoringTemplateSuggestion.scoreType` (Points/Ranking/BinaryWin/Objectives) for the **toolkit template preview**. Its data shape is `template + scores: Record<string, number>`. It is a **read-only chip/list display** with no host vs viewer differentiation, no edit handles, and no live-session store coupling.
+- Tests at `apps/web/src/components/toolkit/__tests__/ScoringPanelRenderer.test.tsx` lock its current contract.
+- **Conclusion**: Move the toolkit renderer to a feature-specific session-live renderer is wrong — the toolkit one is consumed by toolkit dashboard preview UX. The G5a renderer is a SIBLING surface; it consumes live session data (player roster + per-player `scoreData` + `viewerRole`), not toolkit template metadata.
+
+### Existing surface to refactor / displace
+
+- `apps/web/src/components/features/session-live/LiveScoringPanel.tsx` — hard-codes Points-only numeric scoreboard with `scores: ReadonlyArray<{ playerId, playerName, score, isWinner }>`. Used in:
+  - `apps/web/src/components/features/session-live/index.ts:35`
+  - `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx:54, 848, 973`
+  - `apps/web/src/components/features/session-live/MobileBody.tsx` (via `MobileTab='score'`)
+- Legacy `apps/web/src/components/session/live/ScoreBoard.tsx` — Zustand-driven Points-only with host proposal approve/reject. Per epic note: `Points` + non-host → legacy `ScoreBoard`; host or non-`Points` → `PolymorphicScoreEditor`. **Decision below in §3 supersedes this branching.**
+
+### Known gap (per epic #2354 G5a body)
+
+- `apps/web/src/lib/stores/live-session-store.ts` (lines 13–67):
+  - `PlayerInfo { id, name, isHost, isOnline }` — **no `displayName`**, **no `scoringType`** selector at store level.
+  - `scores: Record<string, number>` — Points-only legacy shape; no per-variant payload.
+  - T6 in the epic hardcodes 'Points' currently. Confirmed: `live-session-store.ts` has no `scoringType` field anywhere.
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx:340` builds `LiveSessionFixture.players` with `{ id, name, role, score, isOnline }` — also no `scoringType` / `displayName`.
+- `apps/web/src/lib/session-live/session-live-visual-test-fixture.ts:74-81` — `LiveSessionFixturePlayer { id, name, role, score, isOnline }`.
+
+### Conclusion
+
+A new `apps/web/src/components/features/session-live/scoring/ScoringPanelRenderer.tsx` directory is needed:
+- Distinct from toolkit renderer (different data contract).
+- Wraps existing editor primitives for host-write mode.
+- Renders a polymorphic **read-side display** for spectator/non-host (and the Points-fast-path retains legacy `LiveScoringPanel` behaviour for back-compat).
+
+## §3 Architectural decisions
+
+### D1 — New feature-local sub-package `session-live/scoring/`
+
+Create:
+```
+apps/web/src/components/features/session-live/scoring/
+  ScoringPanelRenderer.tsx        (top-level dispatcher)
+  variants/
+    PointsPanel.tsx               (live leaderboard + categories breakdown)
+    RankingPanel.tsx              (ordered 1st/2nd/3rd with rank pills)
+    BinaryWinPanel.tsx            (collective win/lose toggle)
+    ObjectivesPanel.tsx           (checklist progress meter)
+  ScoringPanelEmpty.tsx           (shared `Trophy` empty state)
+  __tests__/
+    ScoringPanelRenderer.test.tsx
+    variants/{Points,Ranking,BinaryWin,Objectives}Panel.test.tsx
+  index.ts
+```
+
+Rationale: keeps session-live a self-contained feature folder (matches `LiveScoringPanel`, `LiveAgentChat`, `PlayerRosterLive` siblings). Avoids polluting toolkit's `ScoringPanelRenderer` (different consumer, different schema). Re-uses the polymorphic editor primitives from `components/sessions/score-strategies/*` rather than reimplementing them.
+
+### D2 — Renderer-vs-Editor dispatch boundary
+
+The renderer's job is **layout + viewer adaptation**:
+- Spectator / Player-viewing-other / Player-viewing-own-read-only → read-side display (variant panels with progress bars, ranks, checklists from the mockup).
+- Host (or current Player when grant is `MIN_ROLE_PLAYER_ACTIONS` for own score in Points) → embed `PolymorphicScoreEditor` for that ScoreType, wired to `useUpdateSessionScores`.
+
+This means `ScoringPanelRenderer` owns the **viewer/role gate** + **scoreType selector + dispatch**; `PolymorphicScoreEditor` remains the write primitive that the renderer composes when the role gate opens.
+
+### D3 — Host-vs-Viewer dispatch rule
+
+```
+canEdit(viewerRole, scoringType) =
+  viewerRole === 'Host'
+  || (viewerRole === 'Player' && scoringType === 'Points')   // legacy carve-out; matches existing LiveScoringPanel
+```
+
+- `Spectator` → always read-only.
+- `Host` → always editable (any ScoreType).
+- `Player` + Points → can edit OWN score only (preserves current `LiveScoringPanel` Player+Host carve at line 62–74).
+- `Player` + Ranking/BinaryWin/Objectives → read-only (mockup intent: these are host-resolved at game end).
+
+### D4 — Backward compatibility with hardcoded Points
+
+While the store gap (T6 hardcodes `'Points'`) is open, the renderer accepts a `scoringType?: ScoreType` prop with **default `'Points'`**. The orchestrator (`SessionLiveView`) keeps passing the current Points-flavour data via a thin adapter (see Task T7), so this PR ships incrementally without depending on the store schema migration.
+
+A separate follow-up issue (recommended title: `chore(session-live): wire useLiveSessionStore.scoringType + displayName for G5a renderer`) tracks the store-shape gap (§6 risk R2).
+
+### D5 — Token discipline
+
+All variants use ONLY semantic tokens (`bg-card`, `bg-muted`, `border-border`, `text-foreground`, `text-muted-foreground`) + entity utilities (`bg-entity-toolkit/10`, `text-entity-session`, `ring-entity-event/30`). Avoid mockup's `var(--bg-card)` inline-style pattern. The leader gold accent uses `text-entity-toolkit` not `text-amber-*`.
+
+### D6 — Data contract (DTO between orchestrator and renderer)
+
+```ts
+type ScoringPanelData =
+  | { scoringType: 'Points';     payload: PointsPanelData     }
+  | { scoringType: 'Ranking';    payload: RankingPanelData    }
+  | { scoringType: 'BinaryWin'; payload: BinaryWinPanelData  }
+  | { scoringType: 'Objectives'; payload: ObjectivesPanelData };
+```
+
+The renderer reads the discriminator (mirror of the editor's `ScoreChangePayload`) and dispatches. Read shape is a SIBLING discriminated union — see §5.
+
+### D7 — i18n labels passed via `labels` prop
+
+Mirror the existing `LiveScoringPanelLabels` convention (`SessionLiveView.tsx:627`): all strings come from `useTranslation` upstream, never raw ICU in the component. ICU plural is pre-resolved.
+
+## §4 Task breakdown (TDD, test → impl → commit)
+
+| # | WP | Task | Files | Type | Effort |
+|---|---|---|---|---|---|
+| T0 | WP0 | Plan land + scaffold barrel | `scoring/index.ts` | impl | 10m |
+| T1 | WP1 | Type contract + dispatch table | `scoring/types.ts` | test+impl | 30m |
+| T2 | WP2 | `PointsPanel` (read-side) | `variants/PointsPanel.{tsx,test.tsx}` | TDD | 1.5h |
+| T3 | WP2 | `RankingPanel` (read-side) | `variants/RankingPanel.{tsx,test.tsx}` | TDD | 1.5h |
+| T4 | WP2 | `BinaryWinPanel` (read-side) | `variants/BinaryWinPanel.{tsx,test.tsx}` | TDD | 1h |
+| T5 | WP2 | `ObjectivesPanel` (read-side) | `variants/ObjectivesPanel.{tsx,test.tsx}` | TDD | 1h |
+| T6 | WP3 | `ScoringPanelRenderer` dispatcher + role gate + empty | `ScoringPanelRenderer.{tsx,test.tsx}` | TDD | 1.5h |
+| T7 | WP4 | Orchestrator wiring + Points fast-path adapter | `SessionLiveView.tsx`, `index.ts` | impl + integration test | 1h |
+| T8 | WP5 | Visual-test fixture variants (per-ScoreType) | `session-live-visual-test-fixture.ts` (extend, do NOT mutate existing keys) | impl | 45m |
+| T9 | WP5 | Storybook/Playwright smoke (4 baselines) | `tests/visual/session-live-scoring.spec.ts` | E2E | 1h |
+| T10 | WP6 | Follow-up issue: store schema migration | (no code — github issue body draft only in this plan) | doc | 15m |
+
+**Estimate**: ≈9.5h focused; with TDD ceremony + PR review buffer → **2 dev-days realistic** (revised down from 3-5; see §7).
+
+### TDD detail per task
+
+#### T1 — Type contract
+
+- **Test**: Asserts `ScoringPanelData` discriminator switch is exhaustive (compile-time `never` in `default`). Asserts `PointsPanelData.players[number]` has `{ id, displayName, score, isWinner }`.
+- **Impl**: define `ScoringPanelData` (see §5), re-export `ScoreType` from `score-strategies/types` to avoid drift.
+- **Commit**: `feat(session-live): scoring renderer type contract + dispatch discriminator (T1)`
+
+#### T2 — `PointsPanel`
+
+- **Tests (TDD red first)**:
+  - Renders ranked list desc by `score`.
+  - First entry gets leader styling (`data-leader="true"` attr + `text-entity-toolkit` text class).
+  - Renders score number with `tabular-nums`.
+  - Optional `turnDelta` shows as `+N` with entity-toolkit accent.
+  - Empty `players[]` → fallback to `ScoringPanelEmpty`.
+  - Category breakdown table when `categories.length > 0`.
+- **Commit**: `feat(session-live): PointsPanel read-side leaderboard with category breakdown (T2)`
+
+#### T3 — `RankingPanel`
+
+- **Tests**: Renders rank pill `1..N` (sorted by `rank` asc). Leader pill has `bg-entity-toolkit text-primary-foreground`. Trophy icon on rank=1. `sub` line under name. Empty → `ScoringPanelEmpty`.
+- **Commit**: `feat(session-live): RankingPanel ordered list with rank pills (T3)`
+
+#### T4 — `BinaryWinPanel`
+
+- **Tests**: Collective outcome banner. Goal meter using entity-toolkit. Fail meter using `bg-entity-event`. Conditions list with weight badge.
+- **Commit**: `feat(session-live): BinaryWinPanel collective outcome + meters (T4)`
+
+#### T5 — `ObjectivesPanel`
+
+- **Tests**: `Completati N/M` counter + progress meter. Each objective row: checkbox icon + label + optional `progress` mono text. Completed rows strikethrough.
+- **Commit**: `feat(session-live): ObjectivesPanel checklist with progress meter (T5)`
+
+#### T6 — `ScoringPanelRenderer` dispatcher (the centerpiece)
+
+- **Tests**:
+  - Renders `<ScoringPanelEmpty>` when `data == null`.
+  - Switches to `<{Points,Ranking,BinaryWin,Objectives}Panel>` per discriminator.
+  - **Host gate**: when `viewerRole === 'Host'`, embeds `PolymorphicScoreEditor` AND read-side panel.
+  - **Player-Points carve-out**: when `viewerRole === 'Player'` AND `scoringType === 'Points'`, embeds Points editor scoped to own player.
+  - **Spectator/Player-non-Points**: NO editor rendered.
+  - Unknown scoreType: runtime fallback renders `ScoringPanelEmpty` with `data-score-type` debug attr.
+  - `data-testid="scoring-panel"` + `data-score-type` + `aria-label="Scoring panel"` on root section.
+- **Commit**: `feat(session-live): ScoringPanelRenderer polymorphic dispatch with host/viewer gate (T6, closes #2373)`
+
+#### T7 — Orchestrator wiring + adapter
+
+- **Tests**: Renders Points variant by default. Switching fixture variant via `?fixture=ranking` renders Ranking panel. Host fixture renders editor + panel.
+- **Impl**: Build `ScoringPanelData` from current `scores` + `activeSession.players` (default `scoringType: 'Points'`). Replace `<LiveScoringPanel>` usages at lines 848 and 973 with `<ScoringPanelRenderer>`.
+- **Commit**: `feat(session-live): SessionLiveView wires ScoringPanelRenderer with Points fast-path (T7)`
+
+#### T8 — Visual-test fixtures per ScoreType
+
+- Extend `session-live-visual-test-fixture.ts` with `VISUAL_TEST_FIXTURE_SESSION_RANKING`, `_BINARY_WIN`, `_OBJECTIVES`.
+- **Commit**: `test(session-live): visual-test fixtures for 4 ScoreType variants (T8)`
+
+#### T9 — Playwright visual smoke
+
+- Add `tests/visual/session-live-scoring.spec.ts` taking baseline screenshots per variant.
+- **Commit**: `test(session-live): Playwright visual baselines for ScoringPanelRenderer (T9)`
+
+#### T10 — Follow-up issue for store schema gap
+
+- Draft issue body in §6 R2 (do not file from this PR).
+- **Commit**: `docs(superpowers): file follow-up #TBD for useLiveSessionStore.scoringType wiring (T10)`
+
+## §5 Type contract — `ScoringPanelData` discriminated union
+
+```ts
+// apps/web/src/components/features/session-live/scoring/types.ts
+
+import type {
+  ScoreType,
+  PointsScoreData,
+  BinaryWinScoreData,
+  ObjectivesScoreData,
+  RankingScoreData,
+  PlayerOption,
+} from '@/components/sessions/score-strategies/types';
+
+/** Read-side player view — mirrors mockup data.players shape. */
+export interface ScoringPlayerView {
+  readonly id: string;
+  readonly displayName: string;
+  /** Used by Points/Ranking variants. */
+  readonly score?: number;
+  /** Optional rank pill input (Ranking variant). */
+  readonly rank?: number;
+  /** Last-turn delta indicator (Points variant; mockup `turnDelta`). */
+  readonly turnDelta?: number;
+  /** Subtitle line under name (Ranking variant `sub`). */
+  readonly sub?: string;
+  /** Avatar hue (matches mockup MAI palette via entity tokens). */
+  readonly hue?: number;
+}
+
+export interface PointsPanelData {
+  readonly scoringType: 'Points';
+  readonly players: ReadonlyArray<ScoringPlayerView>;
+  readonly categories?: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly computation: 'Count' | 'Sum' | 'RankBased' | 'Custom';
+    readonly description?: string;
+  }>;
+  readonly breakdown?: Readonly<Record<string, Readonly<Record<string, number>>>>;
+  readonly editorData?: PointsScoreData;
+}
+
+export interface RankingPanelData {
+  readonly scoringType: 'Ranking';
+  readonly meta?: string;
+  readonly ranking: ReadonlyArray<ScoringPlayerView & { readonly rank: number }>;
+  readonly editorData?: RankingScoreData;
+}
+
+export interface BinaryWinPanelData {
+  readonly scoringType: 'BinaryWin';
+  readonly collective: {
+    readonly goalLabel: string;
+    readonly goalValue: number;
+    readonly goalMax: number;
+    readonly goalHint?: string;
+    readonly failLabel: string;
+    readonly failValue: number;
+    readonly failMax: number;
+    readonly failHint?: string;
+  };
+  readonly categories: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly computation: 'Count' | 'Sum' | 'RankBased' | 'Custom';
+    readonly weight: number; // > 0 = win, < 0 = lose, 0 = neutral
+    readonly description?: string;
+  }>;
+  readonly editorData?: BinaryWinScoreData;
+}
+
+export interface ObjectivesPanelData {
+  readonly scoringType: 'Objectives';
+  readonly meta?: string;
+  readonly objectives: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly done: boolean;
+    readonly progress?: string;
+  }>;
+  readonly editorData?: ObjectivesScoreData;
+}
+
+export type ScoringPanelData =
+  | PointsPanelData
+  | RankingPanelData
+  | BinaryWinPanelData
+  | ObjectivesPanelData;
+```
+
+### Dispatch table
+
+| `data.scoringType` | Render component (read) | Render editor (write, host or own-Points) |
+|---|---|---|
+| `Points` | `PointsPanel` | `PolymorphicScoreEditor scoringType='Points'` |
+| `Ranking` | `RankingPanel` | `PolymorphicScoreEditor scoringType='Ranking'` (host only) |
+| `BinaryWin` | `BinaryWinPanel` | `PolymorphicScoreEditor scoringType='BinaryWin'` (host only) |
+| `Objectives` | `ObjectivesPanel` | `PolymorphicScoreEditor scoringType='Objectives'` (host only; `availableObjectives` required) |
+| `null` | `ScoringPanelEmpty` | — |
+
+## §6 Risks + mitigations
+
+### R1 — Backward compatibility with legacy `ScoreBoard`
+
+- **Risk**: `apps/web/src/components/session/live/ScoreBoard.tsx` (Zustand-driven, Points-only with host approve/reject) — confirmed lives at `apps/web/src/app/(authenticated)/sessions/[id]/scoreboard/` (sister surface).
+- **Mitigation**: ScoringPanelRenderer does NOT touch `session/live/ScoreBoard.tsx`. The "Points + non-host → legacy ScoreBoard" branching in epic body is **superseded**: with the renderer's role gate, the non-host Points path renders a fresh read-side `PointsPanel`. File a deprecation note in `session/live/ScoreBoard.tsx` header (Task T7 side-effect).
+
+### R2 — `useLiveSessionStore` schema gap (`scoringType` + `displayName`)
+
+- **Risk** (per epic): store has no `scoringType` selector and `PlayerInfo` lacks `displayName`. T6 in the epic hardcodes `'Points'` currently.
+- **Mitigation A (this PR)**: Renderer accepts `ScoringPanelData` via props. The orchestrator (`SessionLiveView`) defaults `scoringType: 'Points'` and synthesises `displayName = playerName`. Renderer is SHIPPABLE without store changes.
+- **Mitigation B (follow-up)**: File issue `chore(session-live): wire useLiveSessionStore.scoringType + displayName + per-variant scoreData payload`.
+
+### R3 — Mockup fidelity vs token discipline
+
+- **Risk**: Mockup uses `var(--bg-card)`, `var(--text-muted)`, inline style props with `eHsl('toolkit')`. ESLint `local/no-hardcoded-color-utility` rejects raw color utilities at error level.
+- **Mitigation**: Map mockup CSS-var calls to semantic Tailwind tokens (`bg-card`, `text-foreground`, `border-border`, `text-entity-toolkit`, `bg-entity-session/10`, `text-entity-event`, `rounded-full`, `rounded-lg`, `font-display`, `font-mono`). Avatar's `linear-gradient(135deg, hsl(${p.hue}…))` — use CSS custom property `style={{ '--avatar-hue': p.hue }}` (allowed by ESLint when property name is `--avatar-*`).
+
+### R4 — `PolymorphicScoreEditor` Objectives requires `availableObjectives`
+
+- **Risk**: Editor throws when Objectives + missing list.
+- **Mitigation**: `ObjectivesPanelData.objectives[]` carries `{ id, label }` — the renderer derives `availableObjectives = data.objectives.map(o => o.label)` before mounting the editor. Defensive guard test (T6).
+
+### R5 — Double-source-of-truth between read panel and editor
+
+- **Risk**: When host edits, the read-side panel could go stale until the mutation invalidates queries.
+- **Mitigation**: `useUpdateSessionScores` already invalidates `['session', sessionId]` AND `['live-session', sessionId]`. Editor `onChange` updates local editor state; the renderer's read-side panel re-reads from props after invalidation refetch.
+
+### R6 — `useUpdateSessionScores` 403 forbidden when viewer is non-host
+
+- **Risk**: Player editing own Points triggers 403 because backend `UpdateSessionScoresCommand` IDOR-guards host-only.
+- **Mitigation (in scope)**: For `Player + Points` carve-out, the renderer routes the score update through the **legacy** `PUT /api/v1/game-sessions/{id}/participants/{playerId}/score` endpoint (already wired in `SessionLiveView` `_handleScoreUpdate` at line 432), NOT through `useUpdateSessionScores`. The polymorphic mutation is host-only.
+
+## §7 Effort estimate breakdown
+
+| Bucket | Subtask | Hours |
+|---|---|---|
+| Type contract (T1) | discriminated union + dispatch table | 0.5 |
+| 4 read-side variants (T2-T5) | TDD per panel | 5 (≈1.25 each) |
+| Dispatcher + role gate (T6) | most complex; 8 test cases | 1.5 |
+| Orchestrator wiring (T7) | adapter + replace LiveScoringPanel calls | 1 |
+| Visual fixtures (T8) | 3 new fixtures + parse cases | 0.75 |
+| Playwright baselines (T9) | 4 screenshots | 1 |
+| Follow-up issue doc (T10) | doc only | 0.25 |
+| **Pure dev sum** | | **~10h** |
+| TDD red-cycle ceremony | +20% on TDD tasks | +1.5h |
+| PR review + lint:tokens loop | | +1h |
+| **Buffered** | | **~12.5h ≈ 1.5-2 dev days** |
+
+### Revised vs original 3-5 day estimate
+
+**Revised estimate: 2 dev-days.**
+
+Rationale for revision down:
+- BE shipped (no integration unknowns).
+- `PolymorphicScoreEditor` shipped (no editor reimplementation).
+- `useUpdateSessionScores` shipped with `UpdateSessionScoresError` tagged union.
+- Mockup is concrete reference.
+- Type contract aligns with existing `ScoreDataByType`.
+- Existing toolkit `ScoringPanelRenderer` test file is a strong template to mirror.
+
+Remaining risk to estimate:
+- Token discipline ESLint may need ~1h to resolve gradient + dark-bg variants.
+- Visual baselines require pixel-perfect chase + may add 1-2h.
+
+## Critical Files for Implementation
+
+- `apps/web/src/components/features/session-live/LiveScoringPanel.tsx` (the surface to displace)
+- `apps/web/src/components/sessions/PolymorphicScoreEditor.tsx` (write primitive to compose for host mode)
+- `apps/web/src/components/sessions/score-strategies/types.ts` (source-of-truth ScoreType + ScoreDataByType + PlayerOption)
+- `apps/web/src/hooks/use-update-session-scores.ts` (mutation hook + UpdateSessionScoresError tagged union)
+- `admin-mockups/design_files/sp4-session-skeleton-renderers.jsx` (visual spec)
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` (orchestrator wiring point)
+- `apps/web/src/components/toolkit/__tests__/ScoringPanelRenderer.test.tsx` (test template to mirror)

--- a/docs/superpowers/plans/2026-06-15-issue-2374-session-live-g1-3-col-layout.md
+++ b/docs/superpowers/plans/2026-06-15-issue-2374-session-live-g1-3-col-layout.md
@@ -1,0 +1,371 @@
+# Plan: Issue #2374 — Session-Live G1 (3-col 60/40 layout + polymorphic tabs)
+
+> Generated 2026-06-15 via `Plan` subagent dispatched during `/sc:spec-panel "find next 5 issues"` session. Sub-issue G1 (foundation) of epic #2354 (Session live shell). HARD DEP downstream: #2375 (G3 ChatAgent always-visible). Parallel to #2373 (G5a renderer).
+
+## §1 Context + spec links
+
+- **Issue:** #2374 — `feat(session-live): 3-col desktop layout (60/40 chat+log / polymorphic tabs)` (G1 of epic #2354)
+- **Estimate:** 4–6 days
+- **Hard dep downstream:** #2375 (G3 ChatAgent always-visible) consumes the LEFT-column primitive shipped here
+- **Mockup (canonical):**
+  - `admin-mockups/design_files/sp4-session-skeleton-live.html`
+  - `admin-mockups/design_files/sp4-session-skeleton-live.jsx`
+  - `admin-mockups/design_files/sp4-session-skeleton-parts.jsx` (the load-bearing `DesktopSessionBody` + `RightColumnTabs` definitions)
+  - `admin-mockups/design_files/sp4-session-skeleton-live.fidelity.json` (`design_intent: current`, viewports: `desktop`)
+- **Architectural anchors:**
+  - ADR-071 (Live Session 5-state FSM, PR #2380 shipped 2026-06-15)
+  - ADR-060 (LiveSession persistence xmin, #2097 → #2305)
+  - Asse B sidebar/topbar (sess.33, #1897) — `useMiniNavConfig` registered in parent layout
+  - Asse A polymorphic `ScoreType` BE (sess.32, c1efb4fb6)
+  - `PolymorphicScoreEditor` (sess.35) lives at `apps/web/src/components/sessions/PolymorphicScoreEditor.tsx` (NOT under `features/session-live/scoring/...` as the issue body states; flag for correction in the issue)
+  - Token canonicalization Tier 1–4 complete (CLAUDE.md §306); `local/no-hardcoded-color-utility` is **error**
+
+## §2 Discovery notes (current state)
+
+### 2.1 Current `SessionLiveView` 3-column wiring
+`apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`:
+- L949–969 `desktopLeftSidebar`: `TurnIndicator` + `PlayerRosterLive`
+- L971–981 `desktopCenterColumn`: `LiveScoringPanel` + `ActionLogTimeline`
+- L984–1013 `desktopRightColumn`: `RightColumnTabs` with `tools|chat|notes`
+- L1055–1060 `<DesktopBody>` composition
+
+### 2.2 Current `DesktopBody` widths
+`apps/web/src/components/features/session-live/DesktopBody.tsx`:
+- L40–45 left aside: **`w-[280px]` fixed**
+- L48 center: `flex-1`
+- L51–54 right aside: **`w-[340px]` fixed**
+- Uses raw `bg-[hsl(240,40%,10%)]` (token-discipline violation — needs replacement)
+
+### 2.3 Current `RightColumnTabs` tab keys
+`apps/web/src/components/features/session-live/RightColumnTabs.tsx`:
+- L31 `LiveTab = 'tools' | 'chat' | 'notes'` (only 3 tabs)
+- L33 `ORDERED_TABS` defines order
+- Roving tabindex via `useTablistKeyboardNav` is already correct
+
+### 2.4 Gap vs canonical mockup
+| Aspect | Current | Mockup spec |
+|---|---|---|
+| Desktop columns | LEFT 280px / CENTER flex / RIGHT 340px (3 zones) | LEFT 60% (chat+log) / RIGHT 40% (tabs) — only 2 zones at the body level |
+| Tab keys | `tools \| chat \| notes` | `scoring \| turn \| widget \| notes` (per mockup: Score / Turni / Widget / Note) |
+| LEFT content | `LiveScoringPanel + ActionLogTimeline` in CENTER, roster+turn in LEFT | `ChatAgentPanel + ActionLogTimeline` stacked, **with expanded/collapsed accordion behaviour** (see parts.jsx L252–263) |
+| ChatAgent visibility | Lives inside RIGHT tab `chat` (not always visible) | "Magnete" — always visible in LEFT |
+| Background tokens | `bg-[hsl(240,40%,10%)]` raw HSL | `bg-card` / `bg-background` semantic tokens |
+| Mobile | bottom-nav 4 tabs (`score\|log\|tools\|chat`) | LEFT same stack full-width, RIGHT becomes bottom-sheet drawer (parts.jsx L266–286) |
+
+### 2.5 Existing primitives reusable
+- `LiveAgentChat` (`features/session-live/LiveAgentChat.tsx`) — full chat panel, accepts `compact`, has `data-slot="live-agent-chat"`. Will become the body of new `ChatAgentPanel` primitive (G3 will hoist this).
+- `ActionLogTimeline` (`features/session-live/ActionLogTimeline.tsx`) — append-only timeline with `compact` prop and labels.
+- `LiveScoringPanel` (`features/session-live/LiveScoringPanel.tsx`) — read-only scoreboard (no polymorphic dispatch yet).
+- `PolymorphicScoreEditor` (`components/sessions/PolymorphicScoreEditor.tsx`) + `score-strategies/*` (BinaryWinEditor, ObjectivesEditor, PointsEditor, RankingEditor). **Existing**, but currently used in summary route, not in live.
+- `TurnIndicator` (`features/session-live/TurnIndicator.tsx`) — single-shape turn display.
+- `LiveSessionNotes` (`features/session-live/LiveSessionNotes.tsx`) — notes with private/shared toggle.
+- `SessionToolsRail` (`features/session-live/SessionToolsRail.tsx`) — kept for backward compat; relabelled "Widget" in new tab key.
+- `useTablistKeyboardNav` — keyboard navigation hook used by `RightColumnTabs`.
+- Asse B `useMiniNavConfig` (parent `layout.tsx` L58) — already registers a session-level tab strip on the desktop topbar. **NOT to be touched** in this scope.
+
+### 2.6 Existing tests
+- `apps/web/src/components/features/session-live/__tests__/RightColumnTabs.test.tsx` — 14 tests covering tablist contract; will be **rewritten** (tab keys change tools→score/turn/widget/notes).
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx` — 40+ tests; tabs in T3.2a–e need new tab key values.
+- `apps/web/e2e/a11y/session-live.spec.ts` — axe-AA scan; ensures we keep 0 violations after refactor.
+- `apps/web/e2e/smoke-real-backend/session-live.smoke.spec.ts` — smoke probe (basic data-slots).
+- No dedicated `DesktopBody.test.tsx` exists today — we add one in Task 2.
+
+### 2.7 i18n
+- `apps/web/src/locales/it.json` L3241–3246 has only `tabTools | tabChat | tabNotes`. Needs `tabScore | tabTurn | tabWidget | tabNotes` (with backwards-compat alias for `tabTools→tabWidget`).
+- Mirror in `apps/web/src/locales/en.json` L3138.
+
+## §3 Architectural decisions
+
+### D-1 Layout topology — refactor in place, no new files for `DesktopBody`
+The mockup uses **2 body zones** (LEFT 60% / RIGHT 40%). The existing `DesktopBody` already accepts `leftSidebar | centerColumn | rightColumn` — too many slots. We **rename slot semantics** rather than rewrite the file path:
+
+- `leftSidebar` (DEPRECATED) → still supported, default `undefined`. Kept to avoid breaking any callers.
+- New props: `mainColumn` (LEFT 60% — chat+log stacked) + `rightColumn` (RIGHT 40% — polymorphic tabs).
+- Grid template: `grid-template-columns: minmax(0, 3fr) minmax(0, 2fr)` (60/40 ratio, fluid; min-width guards against squish).
+- Roster + Turn indicator absorbed into the RIGHT `turn` tab content.
+
+Rationale: the issue is "refactor in place"; mockup explicitly drops the 3rd sidebar zone. Single component, additive props with deprecation.
+
+### D-2 Polymorphic tab keys (new `LiveTab` union)
+New union: `'score' | 'turn' | 'widget' | 'notes'` (default `'score'`, per mockup).
+- BREAKING for URL: `?tab=tools|chat|notes` → `?tab=score|turn|widget|notes`. Add a one-pass migration in `parseLiveTab`:
+  - `tools` → `widget` (semantic equivalent — `SessionToolsRail`)
+  - `chat` → `score` (chat is no longer a tab; it's always-visible in LEFT; falling back to default is safest)
+  - `notes` → `notes` (unchanged)
+
+### D-3 ChatAgent panel primitive (the G3 contract)
+G1 introduces a thin **wrapper primitive** `ChatAgentPanel` (new file under `features/session-live/`) that:
+- Wraps `LiveAgentChat` with a header (avatar, name, "Online" pip, "ChatAgent" pill) — see mockup parts.jsx L91–135.
+- Accepts `collapsed: boolean` + `onHeaderClick: () => void` for the accordion behaviour shown in mockup `DesktopSessionBody` L253.
+- Default uncollapsed in G1 (no accordion logic wired here); the `collapsed` prop is exposed so G3 (#2375) can wire the expand/collapse FSM without touching this file again.
+
+**Exposed contract for #2375:**
+```ts
+export interface ChatAgentPanelProps {
+  readonly messages: ReadonlyArray<ChatMessage>;
+  readonly viewerRole: ParticipantRole;
+  readonly viewerId: string;
+  readonly onSendMessage: (content: string, visibility: 'private' | 'shared') => void;
+  readonly agentName: string;
+  readonly agentEmoji: string;
+  readonly latencyMs: number;
+  readonly collapsed?: boolean;
+  readonly onHeaderClick?: () => void;
+  readonly compact?: boolean;
+  readonly labels: ChatAgentPanelLabels;
+}
+```
+
+### D-4 Token discipline
+- Drop **every** `bg-[hsl(240,40%,8%)]` / `bg-[hsl(240,40%,10%)]` in `SessionLiveView.tsx` + `DesktopBody.tsx`; use `bg-background` / `bg-card`.
+- Keep `data-theme="dark"` on the root (intentional dark default).
+- ChatAgentPanel header uses `bg-entity-agent/10` + `text-entity-agent`.
+- Active tab uses `border-entity-session` per mockup `eHsl(t.entity)` mapping: Score→session, Turn→player, Widget→toolkit, Notes→kb.
+
+### D-5 Mobile fallback (deferred but scoped)
+G1 only adds the desktop 60/40. Mobile (`MobileBody`) keeps current bottom-nav. The mockup's bottom-sheet drawer pattern (parts.jsx L266–286) is **out of scope** here.
+
+### D-6 Polymorphic Score/Turn renderers
+G1 introduces the **tab plumbing** (Score/Turn/Widget/Notes), not the polymorphic renderer interiors:
+- `Score` tab: renders existing `LiveScoringPanel` (G5 will replace with polymorphic dispatcher).
+- `Turn` tab: renders `TurnIndicator` + `PlayerRosterLive` (currently in LEFT sidebar).
+- `Widget` tab: renders existing `SessionToolsRail` (G5: `ToolkitRenderer` dispatcher).
+- `Notes` tab: renders existing `LiveSessionNotes`.
+
+This isolates layout work from polymorphic-dispatch work and unblocks the 4-6 day budget.
+
+## §4 Task breakdown (TDD-ordered)
+
+### T1 — Update `RightColumnTabs` tab keys (Score/Turn/Widget/Notes)
+**Test changes** (`__tests__/RightColumnTabs.test.tsx`):
+1. Rename `LABELS` to use `tabScore | tabTurn | tabWidget | tabNotes`.
+2. Replace `activeTab: 'tools'` defaults with `'score'`.
+3. Update keyboard nav test ordering (score → turn → widget → notes; ArrowRight from `notes` wraps to `score`).
+4. Add **new** test "tab buttons render in mockup order".
+**Impl changes** (`RightColumnTabs.tsx`):
+- L31 `LiveTab = 'score' | 'turn' | 'widget' | 'notes'`
+- L33 `ORDERED_TABS = ['score', 'turn', 'widget', 'notes'] as const`
+- L37–42 `RightColumnTabsLabels`: rename fields.
+- L66–73 `tabLabels` map: new keys.
+
+**Effort:** 0.5 day.
+
+### T2 — Add `DesktopBody.test.tsx` + refactor for 60/40 + `mainColumn`
+**New test file** (`__tests__/DesktopBody.test.tsx`):
+1. `renders data-slot="desktop-body"` (regression).
+2. `renders mainColumn + rightColumn slots` (new contract).
+3. `applies 60/40 grid template` — inspect computed `gridTemplateColumns` includes `3fr` and `2fr`.
+4. `omits leftSidebar slot when undefined (back-compat path)`.
+5. `still mounts leftSidebar when provided (legacy callers)`.
+6. `root uses bg-background (no raw HSL)` — assert `className` does not contain `bg-[hsl(`.
+7. `hidden on mobile (< lg)` — assert `hidden lg:grid`.
+
+**Impl** (`DesktopBody.tsx`):
+- Add `mainColumn?: ReactNode` (new) AND keep `centerColumn?: ReactNode` (alias). When `mainColumn` provided, use the 2-zone grid; when only `centerColumn`, fall back to existing 3-zone flex (deprecation soft-landing).
+- Switch root to `grid grid-cols-[minmax(0,3fr)_minmax(0,2fr)]` when 2-zone path is active.
+- Replace `bg-[hsl(240,40%,10%)]` → `bg-card border-border/60`.
+- JSDoc update: mark `leftSidebar` + `centerColumn` `@deprecated — use mainColumn for 60/40 layout (G1 #2374)`.
+
+**Effort:** 0.5 day.
+
+### T3 — Create `ChatAgentPanel` primitive
+**New test** (`__tests__/ChatAgentPanel.test.tsx`):
+1. `renders data-slot="chat-agent-panel"`.
+2. `header shows agent name + emoji + Online pip`.
+3. `header has "ChatAgent" pill (mockup magnet semantic)`.
+4. `body renders LiveAgentChat with same data-slot`.
+5. `collapsed=true hides body, shows expanded=false aria`.
+6. `clicking header fires onHeaderClick (when provided)`.
+7. `compact prop forwards to LiveAgentChat`.
+8. `Gate A ICU: latency label uses pre-resolved string`.
+9. `respects token discipline: no raw HSL; uses bg-entity-agent/* + text-entity-agent`.
+
+**Impl** (new `ChatAgentPanel.tsx`):
+- Functional component matching mockup parts.jsx L91–135 (header layout + emoji avatar + pulse pip + ChatAgent pill).
+- Body delegates to `<LiveAgentChat />` (no duplication).
+- Export from `index.ts` barrel.
+
+**Effort:** 1 day.
+
+### T4 — Refactor `SessionLiveView` to 60/40 + new tabs
+**Test changes** (`__tests__/SessionLiveView.test.tsx`):
+1. Tests T3.2a–e (L600–634): change expected `data-active-tab` values from `'tools'` → `'score'`, etc.
+2. **New test:** `default ?tab is "score" (not "tools")`.
+3. **New test:** `legacy ?tab=tools is treated as widget (back-compat)`.
+4. **New test:** `Cell 5 default desktop renders <ChatAgentPanel /> in LEFT (60%)`.
+5. **New test:** `Cell 5 default desktop renders <RightColumnTabs /> in RIGHT (40%)`.
+6. **New test:** `LEFT column also renders ActionLogTimeline stacked below ChatAgent`.
+7. **New test:** `RIGHT column "turn" tab renders TurnIndicator + PlayerRosterLive (moved from sidebar)`.
+8. **New test:** `desktopBody has data-layout="2col-60-40"` (added attribute for E2E selectors).
+9. Mobile tab routing tests: keep existing — mobile out-of-scope.
+10. i18n: extend MESSAGES dict with `pages.sessionLive.rightColumn.tabScore | tabTurn | tabWidget | tabNotes` keys.
+
+**Impl** (`SessionLiveView.tsx`):
+- L135 `LiveTab = 'score' | 'turn' | 'widget' | 'notes'`.
+- L137 `parseLiveTab`: map legacy `tools|chat|notes` → `widget|score|notes`.
+- L687–695 `rightColumnTabsLabels` → use new label keys.
+- L949–969 DELETE `desktopLeftSidebar`.
+- L971–981 RENAME `desktopCenterColumn` → `desktopMainColumn`; replace contents:
+  ```tsx
+  <div className="flex flex-col gap-3 p-3 min-h-0 flex-1 overflow-hidden">
+    <ChatAgentPanel messages={chatMessages} ... labels={chatAgentLabels} />
+    <ActionLogTimeline entries={activeSession.actionLog} labels={actionLogLabels} />
+  </div>
+  ```
+- L984–1013 `desktopRightColumn` switch (`score`/`turn`/`widget`/`notes` cases). The `turn` case mounts `<TurnIndicator />` + `<PlayerRosterLive />`. The `widget` case mounts `<SessionToolsRail />`.
+- L1055 `<DesktopBody mainColumn={desktopMainColumn} rightColumn={desktopRightColumn} />`.
+- Add new `chatAgentLabels` memo block.
+- Replace `bg-[hsl(240,40%,8%)]` root background → `bg-background` (4 occurrences L886, L900, L919, L939, L1020).
+
+**Effort:** 1.5 days.
+
+### T5 — i18n keys + locale parity
+**Impl** (`locales/it.json` + `en.json`):
+- Add `pages.sessionLive.rightColumn.tabScore`, `tabTurn`, `tabWidget`. KEEP `tabTools | tabChat | tabNotes` for back-compat.
+- Add `pages.sessionLive.chatAgent.title | onlineLabel | latencyAriaLabel | offlineLabel | …` for new `ChatAgentPanel`.
+
+**Effort:** 0.25 day.
+
+### T6 — Playwright a11y refresh (`session-live.spec.ts`)
+**Test changes**:
+- `axe-core default state` should still pass with 0 violations (regression).
+- Add **new test:** `desktop 60/40 layout — both columns have correct role/landmarks`.
+- Add **new test:** `RightColumnTabs has 4 tab buttons after refactor`.
+- Add **new test:** `LEFT column is keyboard-traversable: Tab order ChatAgentPanel → ActionLogTimeline → RightColumnTabs`.
+
+**Effort:** 0.5 day.
+
+### T7 — Playwright visual baseline + designer review prep
+Per CLAUDE.md L302: "Visual Gate REMOVED 2026-05-20 — replacement = manual designer review on PRs".
+- Capture before/after screenshots.
+- Update mockup fidelity meta: `sp4-session-skeleton-live.fidelity.json` → `designer_approved_by: "<designer>"` after review.
+
+**Effort:** 0.25 day.
+
+### T8 — Update SessionLiveView JSDoc + emit ADR breadcrumb
+**Impl:** Update JSDoc at L1–42 of `SessionLiveView.tsx` to mention G1 (#2374). Optionally drop a one-paragraph ADR-072-stub note in CLAUDE.md.
+
+**Effort:** 0.25 day.
+
+### Sequencing
+T1 → T2 (parallel-safe) → T3 → T5 → T4 → T6 → T7 → T8.
+T1 and T2 are independent; T3 must precede T4 (T4 imports `ChatAgentPanel`); T6 needs T4 deployed; T7 captures the final state.
+
+### Commits / PR strategy
+One PR per task is overkill at 4-6 day total; **single feature branch** `feature/issue-2374-session-live-g1-3col-layout` with **8 logical commits**:
+1. `test(session-live): T1 RightColumnTabs new tab keys (score/turn/widget/notes)`
+2. `feat(session-live): T1 update RightColumnTabs tab keys`
+3. `test(session-live): T2 DesktopBody 60/40 grid contract`
+4. `feat(session-live): T2 DesktopBody mainColumn + 60/40 grid`
+5. `test(session-live): T3 ChatAgentPanel primitive`
+6. `feat(session-live): T3 ChatAgentPanel primitive`
+7. `feat(session-live): T4 refactor SessionLiveView to 60/40 + new tabs (with back-compat)`
+8. `feat(i18n): T5 polymorphic tab keys + chatAgent labels` + `test(e2e): T6 a11y + JSDoc T8`
+
+## §5 Primitive contract for #2375 G3 (HARD DEP downstream)
+
+`ChatAgentPanel` exposes the stable surface #2375 will lean on. Frozen contract:
+
+```ts
+// apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+export interface ChatAgentPanelLabels {
+  readonly title: string;            // "ChatAgent"
+  readonly agentNameAriaLabel: string;
+  readonly onlineLabel: string;      // "Online"
+  readonly latencyAriaLabel: string; // "Latenza {ms}ms" (Gate A pre-resolved)
+  readonly chatPanelLabels: LiveAgentChatLabels;
+}
+
+export interface ChatAgentPanelProps {
+  readonly messages: ReadonlyArray<ChatMessage>;
+  readonly viewerRole: ParticipantRole;
+  readonly viewerId: string;
+  readonly onSendMessage: (content: string, visibility: 'private' | 'shared') => void;
+  readonly agentName: string;
+  readonly agentEmoji?: string;       // default '🤖'
+  readonly latencyMs: number;
+  readonly collapsed?: boolean;       // default false; G3 controls
+  readonly onHeaderClick?: () => void; // G3 wires accordion FSM
+  readonly compact?: boolean;
+  readonly labels: ChatAgentPanelLabels;
+  readonly className?: string;
+}
+```
+
+### Guarantees to #2375
+1. **Data-slot stable**: `data-slot="chat-agent-panel"` will be the E2E selector forever (do not rename).
+2. **Always-visible by default**: G3 only adds the collapsed=true semantics + URL state SSOT (`?chat=collapsed|expanded`), never moves the component to a tab.
+3. **Header is a `<button>` when `onHeaderClick` provided**: A11y contract = `aria-expanded={!collapsed}` and proper Enter/Space activation.
+4. **Body unmounts when `collapsed=true`** to avoid hidden focus traps.
+5. **No SSE state** inside the primitive; messages flow in via prop (parent owns the stream).
+6. **Token classes are entity-agent based** — G3 must not override colours.
+
+### Co-owned dataset (left for #2375 to extend)
+- `expanded: 'chat' | 'log'` accordion state lives in `SessionLiveView` (URL SSOT). G1 ships with both panels uncollapsed; G3 will introduce the toggle.
+
+## §6 Risks + mitigations
+
+### R-1 (HIGH) — Back-compat URL `?tab=tools|chat|notes`
+**Risk:** Existing bookmarks + deep links to `?tab=chat` would 404-render the wrong panel.
+**Mitigation:** `parseLiveTab` legacy alias map (D-2). Add explicit Vitest test (T4.3) to lock the mapping. Watch for breakage in `apps/web/e2e/a11y/session-live.spec.ts`.
+
+### R-2 (HIGH) — Mobile layout drift
+**Risk:** Mockup defines a bottom-sheet drawer for RIGHT on mobile; current `MobileBody` uses bottom-nav with 4 tabs. Refactor LEFT/RIGHT semantics on desktop must NOT regress mobile.
+**Mitigation:**
+- Keep `MobileBody` untouched in G1.
+- `SessionLiveView` continues to pass `mobileContent` independent of desktop changes.
+- Note in PR description: bottom-sheet drawer parity is **deferred** to a follow-up G-issue (open after G1 merge).
+
+### R-3 (HIGH) — Asse B `useMiniNavConfig` collision
+**Risk:** Parent layout (`sessions/[id]/layout.tsx` L58) registers a top-level tab bar on the Asse B mini-nav slot. The new RIGHT-column tabs sit ABOVE the same surface, which the user may experience as duplicate navigation on the `/live` route.
+**Mitigation:**
+- Inspect during T4: if the mini-nav tabs render on `/live` route, conditionally hide them via `useMiniNavConfig({ tabs: [] })`.
+- Add Playwright assertion in T6: only ONE tablist rendered above-the-fold on `/live` page.
+- Escalate to design if the duplicate looks intentional.
+
+### R-4 (MEDIUM) — Token discipline regression
+**Risk:** `SessionLiveView` currently has a file-level `eslint-disable local/no-hardcoded-color-utility` directive (L1). Token-canonicalization mode is **error**.
+**Mitigation:**
+- T4 explicitly replaces all `bg-[hsl(240,40%,8%)]` → `bg-background` (CLAUDE.md L313).
+- After refactor, attempt to remove the file-level disable; if still needed, narrow to line-level. Run `pnpm lint:tokens` and update `audits/2026-05-12-token-violations.md`.
+
+### R-5 (MEDIUM) — Test breakage cascade in `SessionLiveView.test.tsx`
+**Risk:** 40+ tests reference current tab keys. Mass-rename will silently miss assertions.
+**Mitigation:** Run Vitest in watch mode during T1–T4; explicit search-and-replace of `'tab=chat'`, `'tab=tools'`, `tabTools`, etc. as a single grep PR pass.
+
+### R-6 (MEDIUM) — `data-theme="dark"` hardcoded
+**Risk:** Mockup is dark default; SessionLiveView L886 hardcodes `data-theme="dark"`. A11y a11y/session-live.spec.ts L23 already documents the gap.
+**Mitigation:** Use semantic tokens (`bg-card`/`text-foreground`) — they already react to `[data-theme]`. No new hardcoded dark colors introduced by G1.
+
+### R-7 (LOW) — Mockup primitive `PolymorphicScoreEditor` mis-pathed
+**Risk:** Issue body claims `apps/web/src/components/features/session-live/scoring/PolymorphicScoreEditor.tsx`; actual location is `apps/web/src/components/sessions/PolymorphicScoreEditor.tsx`.
+**Mitigation:** Surface in PR description; not blocking for G1. Open follow-up `chore: move PolymorphicScoreEditor under features/session-live`.
+
+### R-8 (LOW) — Fidelity meta has `viewports: ["desktop"]`
+**Risk:** Mockup spec is desktop-only; mobile layout has no canonical reference image.
+**Mitigation:** Note in PR description that mobile is unchanged; designer reviews desktop only against `sp4-session-skeleton-live.html`.
+
+## §7 Effort estimate breakdown
+
+| Task | Description | Effort |
+|---|---|---|
+| T1 | RightColumnTabs tab keys refactor + tests | 0.5 d |
+| T2 | DesktopBody 60/40 grid + tests | 0.5 d |
+| T3 | ChatAgentPanel primitive + tests | 1.0 d |
+| T4 | SessionLiveView refactor + tests + back-compat | 1.5 d |
+| T5 | i18n keys it/en parity | 0.25 d |
+| T6 | Playwright a11y refresh | 0.5 d |
+| T7 | Visual baseline + designer review prep | 0.25 d |
+| T8 | JSDoc + ADR breadcrumb | 0.25 d |
+| **Subtotal** | | **4.75 d** |
+| Buffer (15%) | Risk R-1, R-3 mitigation refinement | 0.75 d |
+| **Total** | | **~5.5 days** |
+
+Falls within issue estimate of 4–6 days.
+
+## Critical Files for Implementation
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`
+- `apps/web/src/components/features/session-live/DesktopBody.tsx`
+- `apps/web/src/components/features/session-live/RightColumnTabs.tsx`
+- `apps/web/src/components/features/session-live/ChatAgentPanel.tsx` (NEW)
+- `apps/web/src/components/features/session-live/index.ts` (barrel update)


### PR DESCRIPTION
## Summary

Docs-only PR that lands two implementation plans produced during a `/sc:spec-panel "find next 5 issues"` session on 2026-06-15:

- **`2026-06-15-issue-2373-scoring-panel-renderer.md`** — G5a polymorphic dispatch plan, **11 tasks · ~2 dev-days**
- **`2026-06-15-issue-2374-session-live-g1-3-col-layout.md`** — G1 3-col 60/40 layout plan, **8 tasks · ~5.5 dev-days**

Both target sub-issues of epic **#2354** (Session live shell) and are designed to ship in parallel — the renderer is layout-agnostic.

## Why now

The spec-panel review identified these two issues as Track A priorities (foundation + parallelizable). The plans are the artifact required before dispatching implementation agents per superpowers `writing-plans` → `executing-plans` workflow. Landing them as a small standalone PR keeps them on `main-dev` so:

- Future implementation PRs can reference them by path
- Reviewers can read the architectural decisions without checking out a WIP branch
- The plans become discoverable to anyone running `ls docs/superpowers/plans/`

## Plan highlights

### #2373 G5a — ScoringPanelRenderer
- **Discovery savings**: revised down from 3-5 days to ~2 because BE (`UpdateSessionScoresCommand`), `PolymorphicScoreEditor`, and `useUpdateSessionScores` are all already shipped.
- **New folder**: `apps/web/src/components/features/session-live/scoring/` with 4 read-side variant panels + dispatcher.
- **Architectural anchor**: `ScoringPanelRenderer` owns the viewer/role gate and composes `PolymorphicScoreEditor` for host editing — never reimplements editing logic.
- **Top risks**: `useLiveSessionStore` lacks `scoringType` + `displayName` (orchestrator-side default mitigation), mockup CSS-var → semantic token mapping, host-only IDOR guard requires legacy participant endpoint for `Player + Points` carve-out.

### #2374 G1 — 3-col desktop layout
- **In-place refactor**: `DesktopBody` gains additive `mainColumn` prop, switches to `grid-cols-[minmax(0,3fr)_minmax(0,2fr)]`. Legacy `centerColumn` + `leftSidebar` kept with `@deprecated` JSDoc.
- **New primitive**: `ChatAgentPanel` (wraps `LiveAgentChat`) — frozen contract for downstream **#2375 G3** always-visible work.
- **Polymorphic tabs**: `LiveTab` union refactors from `'tools|chat|notes'` → `'score|turn|widget|notes'` with URL back-compat alias (`tools→widget`, `chat→score`).
- **Top risks**: legacy `?tab=` URL back-compat, mobile bottom-sheet drift (deferred), Asse B `useMiniNavConfig` duplicate-tablist collision on `/live`.

## Test plan

- [x] Plans render correctly in markdown viewers
- [x] No broken cross-references in `docs/superpowers/plans/`
- [x] No code changes — pure docs PR

## Refs

- Epic: #2354 Session live shell (G1/G3/G5/G6)
- Sub-issues: #2373 G5a + #2374 G1
- Downstream HARD DEP: #2375 G3 (consumes `ChatAgentPanel` contract from #2374)
- Mockups: `admin-mockups/design_files/sp4-session-skeleton-{live,renderers,parts}.{html,jsx}`
- BE anchors: ADR-071 5-state FSM (PR #2380 2026-06-15), Asse A `ScoreType` polymorphic BE (sess.32, `c1efb4fb6`)
- FE anchors: `PolymorphicScoreEditor` + `useUpdateSessionScores` (sess.35, asse-D P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
