### PR TITLE
build(api): #2383 add TimeZoneConverter NuGet (ADR-076 prerequisite)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -128,6 +128,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.1-beta.1" />
+    <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
     <PackageReference Include="WebPush" Version="1.0.13" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

First batch of [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383) (ADR follow-up prerequisites umbrella). 

Adds `TimeZoneConverter 7.2.0` NuGet package as **prerequisite for ADR-076** (quiet hours hybrid timezone, Option C — shipped via PR #2381).

## Why

`ADR-076 Decision §6` mandates `TimeZoneInfo.FindSystemTimeZoneById(user.TimeZone)` for server-side quiet-hours gating on email/Slack channels. On **Linux container host** (production deploy target), `TimeZoneInfo` ONLY recognizes Windows timezone names by default — IANA strings (`Europe/Rome`, `America/New_York`, etc) throw `TimeZoneNotFoundException`.

`TimeZoneConverter` bridges the gap: `TZConvert.GetTimeZoneInfo("Europe/Rome")` returns a `TimeZoneInfo` regardless of host OS.

## Why now (vs at implementation time)

Per ADR-076 open question #5 surfaced in PR #2381 body:
> ADR-076 — Linux deployment risk: `TimeZoneConverter` NuGet package MUST be added before implementation (Linux container host).

Adding it now in isolation (zero risk, zero behavior change) decouples the ADR implementation PR from infrastructure setup and reduces friction when the NotificationPreferences `TimeZone` field migration lands.

## Diff

```diff
+    <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
```

Single line added to `apps/api/src/Api/Api.csproj` between `OpenTelemetry.Exporter.Prometheus.AspNetCore` and `WebPush` (alphabetical position).

## Test plan

- [x] `dotnet restore apps/api/src/Api/Api.csproj` succeeds (verified locally)
- [x] No source code references `TimeZoneConverter` yet (package is dormant until ADR-076 impl PR uses it)
- [x] No security vulnerabilities reported (NuGet vulnerability scan clean per `dotnet add` output)

## What's NOT in this PR (out of scope)

- `NotificationPreferences.TimeZone: string` field (deferred — separate batch 3 PR per #2383)
- `NotificationPreferences.QuietHoursStart/End: TimeOnly?` fields (same)
- `NotificationDispatcher` channel gating logic per ADR-076 Option C (same)
- `User.TimeZone` field migration (verify if exists or needs adding — investigate during impl PR)

## Refs

- ADR-076: `docs/for-claude/architecture/adr/adr-076-quiet-hours-timezone.md` (shipped PR #2381)
- Umbrella tracker: #2383
- Memory hooks applicable: `dotnet-ef-nuget-pitfall.md` (verified `dotnet restore` after `dotnet add` to avoid downstream EF migration failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)