### PR TITLE
docs(fidelity): #2383 backfill 134 current-intent fidelity files (ADR-077)

### DIFF
--- a/admin-mockups/design_files/00-hub.fidelity.json
+++ b/admin-mockups/design_files/00-hub.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/01-screens.fidelity.json
+++ b/admin-mockups/design_files/01-screens.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/02-desktop-patterns.fidelity.json
+++ b/admin-mockups/design_files/02-desktop-patterns.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/03-drawer-variants.fidelity.json
+++ b/admin-mockups/design_files/03-drawer-variants.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/04-design-system.fidelity.json
+++ b/admin-mockups/design_files/04-design-system.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/05-dark-mode.fidelity.json
+++ b/admin-mockups/design_files/05-dark-mode.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/chat-fullscreen.fidelity.json
+++ b/admin-mockups/design_files/chat-fullscreen.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/components.fidelity.json
+++ b/admin-mockups/design_files/components.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/data.fidelity.json
+++ b/admin-mockups/design_files/data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/index.fidelity.json
+++ b/admin-mockups/design_files/index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json
+++ b/admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-encounter-cheatsheet.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-encounter-cheatsheet.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-error-states.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-error-states.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-game-detail.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-game-detail.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-game-onboarding.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-game-onboarding.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-glossary-editor.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-glossary-editor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-library-search.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-library-search.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-play-session.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-play-session.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-quota-credits.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-quota-credits.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-resume-picker.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-resume-picker.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-session-end.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-session-end.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-setup-chat.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-setup-chat.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-setup-wizard.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-setup-wizard.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/librogame-runthrough-translate-viewer.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-translate-viewer.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/mobile-app.fidelity.json
+++ b/admin-mockups/design_files/mobile-app.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/onboarding.fidelity.json
+++ b/admin-mockups/design_files/onboarding.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/onboarding/onboarding.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/auth/onboarding.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/pr-form-core.fidelity.json
+++ b/admin-mockups/design_files/pr-form-core.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/primitive-nav-bottom-mobile.fidelity.json
+++ b/admin-mockups/design_files/primitive-nav-bottom-mobile.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/primitive-nav-topbar.fidelity.json
+++ b/admin-mockups/design_files/primitive-nav-topbar.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/public.fidelity.json
+++ b/admin-mockups/design_files/public.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/components/landing/public-landing.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/auth/public.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/scaffold.fidelity.json
+++ b/admin-mockups/design_files/scaffold.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/settings.fidelity.json
+++ b/admin-mockups/design_files/settings.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/components/features/settings/settings.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/auth/settings.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-accept-invite.fidelity.json
+++ b/admin-mockups/design_files/sp3-accept-invite.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-faq-enhanced.fidelity.json
+++ b/admin-mockups/design_files/sp3-faq-enhanced.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-how-it-works.fidelity.json
+++ b/admin-mockups/design_files/sp3-how-it-works.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-join.fidelity.json
+++ b/admin-mockups/design_files/sp3-join.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-legal.fidelity.json
+++ b/admin-mockups/design_files/sp3-legal.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-shared-game-detail.fidelity.json
+++ b/admin-mockups/design_files/sp3-shared-game-detail.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp3-shared-games.fidelity.json
+++ b/admin-mockups/design_files/sp3-shared-games.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-add-game-drawer.fidelity.json
+++ b/admin-mockups/design_files/sp4-add-game-drawer.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/library/AddGameDrawer.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-add-game-pdf-dedup.fidelity.json
+++ b/admin-mockups/design_files/sp4-add-game-pdf-dedup.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-agent-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-agent-detail.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-agents-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-agents-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-citation-pdf-viewer.fidelity.json
+++ b/admin-mockups/design_files/sp4-citation-pdf-viewer.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-discover.fidelity.json
+++ b/admin-mockups/design_files/sp4-discover.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-editor-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-editor-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-editor-proposals-edit.fidelity.json
+++ b/admin-mockups/design_files/sp4-editor-proposals-edit.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-editor-proposals-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-editor-proposals-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-editor-proposals-new.fidelity.json
+++ b/admin-mockups/design_files/sp4-editor-proposals-new.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-editor-proposals-test.fidelity.json
+++ b/admin-mockups/design_files/sp4-editor-proposals-test.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-game-chat-tab.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-chat-tab.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-game-nights-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-nights-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-games-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-games-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-kb-global.fidelity.json
+++ b/admin-mockups/design_files/sp4-kb-global.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/knowledge-base/global/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-kb-hub.fidelity.json
+++ b/admin-mockups/design_files/sp4-kb-hub.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-library-desktop.fidelity.json
+++ b/admin-mockups/design_files/sp4-library-desktop.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-library-wishlist-ui.fidelity.json
+++ b/admin-mockups/design_files/sp4-library-wishlist-ui.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-library-wishlist.fidelity.json
+++ b/admin-mockups/design_files/sp4-library-wishlist.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/library/wishlist/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-parts-common.fidelity.json
+++ b/admin-mockups/design_files/sp4-parts-common.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-play-records-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-play-records-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-detail.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-play-records-edit.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-edit.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-play-records-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-play-records-new.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-new.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-play-records-stats.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-stats.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-player-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-player-detail.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-players-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-players-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-catan-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-catan-flavor.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-flavor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-catan-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-catan-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-catan-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-codenames-bodies.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-bodies.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-codenames-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-codenames-flavor.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-flavor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-codenames-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-codenames-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-codenames-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-paleo-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-paleo-flavor.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-flavor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-paleo-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-paleo-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-paleo-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-play-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-play-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-play-ui.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-play-ui.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-play.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-play.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-power-grid-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-power-grid-flavor.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-flavor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-power-grid-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-power-grid-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-power-grid-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-puerto-rico-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-puerto-rico-flavor.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-flavor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-puerto-rico-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-puerto-rico-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-puerto-rico-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-skeleton-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-skeleton-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-skeleton-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-skeleton-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-skeleton-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-skeleton-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-skeleton-renderers.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-skeleton-renderers.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-summary-skeleton.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-summary-skeleton.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-live-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-live-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-live-tabs.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-live-tabs.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-summary-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-summary-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-summary-sections.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-summary-sections.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-summary-tabs.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-summary-tabs.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-wingspan-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-zombicide-data.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-data.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-zombicide-flavor.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-flavor.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-zombicide-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-zombicide-parts.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-parts.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-session-zombicide-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-sessions-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-sessions-index.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-detail.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/toolkit/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-history-ui.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-history-ui.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-history.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-history.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-play-dice.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-play-dice.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-play-tools.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-play-tools.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-play-ui.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-play-ui.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-play.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-play.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-stats.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-stats.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-templates-ui.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-templates-ui.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-toolkit-templates.fidelity.json
+++ b/admin-mockups/design_files/sp4-toolkit-templates.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp4-upload-wizard-extended.fidelity.json
+++ b/admin-mockups/design_files/sp4-upload-wizard-extended.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/gamebook/upload/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp5-profile-settings.fidelity.json
+++ b/admin-mockups/design_files/sp5-profile-settings.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/profile/_components/sp5-profile-settings.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/auth/sp5-profile-settings.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp7-game-night-detail-rsvp.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-detail-rsvp.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/game-nights/[id]/game-night-detail-rsvp.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-detail-rsvp.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp7-game-night-join-public.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-join-public.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp7-game-night-live.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-live.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/game-nights/[id]/live/game-night-live.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-live.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp7-game-night-new.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-new.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/game-nights/new/game-night-create.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-create.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp7-game-night-summary.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-summary.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "apps/web/src/app/(authenticated)/game-nights/[id]/summary/game-night-summary.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-summary.ts",
     "design_intent": "current",

--- a/admin-mockups/design_files/sp7-game-night-transition.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-transition.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/state-matrix.fidelity.json
+++ b/admin-mockups/design_files/state-matrix.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",

--- a/admin-mockups/design_files/tokens.fidelity.json
+++ b/admin-mockups/design_files/tokens.fidelity.json
@@ -22,8 +22,8 @@
       1024,
       1440
     ],
-    "designer_approved_by": "",
-    "designer_approved_on": "",
+    "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
+    "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
     "design_intent": "current",


### PR DESCRIPTION
## Summary

Second batch of [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383) (ADR follow-up prerequisites umbrella).

**Backfills `designer_approved_by` + `designer_approved_on` for 134 fidelity.json files** where `design_intent = "current"` and these fields were empty. Required prerequisite for ADR-077 (designer signoff CI gate, Option D per-area scoped) before the blocking rule can be enabled.

## Backfill convention

Self-waiver P250 token applied per solo-maintainer mode (CLAUDE.md § Mockup audit DS-17 Phase B):

```json
"designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
"designer_approved_on": "2026-06-15"
```

This matches the existing pattern already used in shipped fidelity files (e.g. `sp4-library-desktop.fidelity.json`, `sp4-kb-detail.fidelity.json`).

## Coverage

| Bucket | Count | Action |
|---|---|---|
| `design_intent: "current"` + empty approval | **134** | ✅ Backfilled (this PR) |
| `design_intent: "current"` + already-filled approval | 0 | — |
| `design_intent: "forward-refactor"` or `"forward-refactor-obsolete"` | 13 | ⏭ Skipped (ADR-077 Option D — non-current intent exempt from gate) |
| **Total fidelity files** | **147** | — |

## Files changed

134 fidelity.json files (`admin-mockups/design_files/*.fidelity.json`). Atomic 2-line patch per file: `designer_approved_by` + `designer_approved_on` fields.

## Validation

- [x] `pnpm lint:fidelity` PASS 100% post-backfill (147/147 files OK)
- [x] No semantic content changed (only previously-empty signoff fields populated)
- [x] No `design_intent` field touched (forward-refactor files preserved)
- [x] CRLF→LF normalization handled by git `text=auto`

## Why now (vs at ADR-077 implementation time)

Per ADR-077 open question #6 in PR #2381 body:
> ADR-077 prerequisite: ~38 `design_intent: "current"` fidelity files need `designer_approved_by` backfill BEFORE enabling CI gate.

Note: actual count is **134** (not 38 — the subagent estimate was based on a subset; full repo scan via `grep -l '"design_intent": "current"'` returned 134). Backfilling now unblocks the ADR-077 implementation PR from data prep.

## Out of scope

- The actual CI gate implementation (separate PR per ADR-077 Option D — needs the `ci.yml` rule + branch protection update). This PR only does data backfill.
- Updating CLAUDE.md to mention the P250 waiver count growth (deferred — already mentions the pattern, count update is cosmetic).

## Refs

- ADR-077: `docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md` (shipped PR #2381)
- Umbrella tracker: #2383
- Pattern reference: CLAUDE.md § Mockup audit DS-17 Phase B (#2127)
- Audit lineage: `audits/2026-06-10-mockup-design-intent-audit.{json,md}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)