### PR TITLE
feat(api): #2383 add quiet hours fields to NotificationPreferences (ADR-076 step 2)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs
@@ -1,4 +1,5 @@
 using Api.SharedKernel.Domain.Entities;
+using TimeZoneConverter;
 
 namespace Api.BoundedContexts.UserNotifications.Domain.Aggregates;
 
@@ -37,6 +38,27 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
     public bool EmailOnGameNightReminder { get; private set; } = true;
     public bool PushOnGameNightReminder { get; private set; } = true;
 
+    // Quiet hours - ADR-076 (#2383 follow-up)
+    /// <summary>
+    /// IANA timezone identifier (e.g. "Europe/Rome", "America/New_York") used to
+    /// compute local time for quiet-hours gating. Defaults to "UTC".
+    /// Resolved cross-platform via <see cref="TimeZoneConverter"/> on Linux hosts.
+    /// </summary>
+    public string TimeZone { get; private set; } = "UTC";
+
+    /// <summary>
+    /// Optional start of daily quiet-hours window (local time per <see cref="TimeZone"/>).
+    /// When set together with <see cref="QuietHoursEnd"/>, email + Slack channels
+    /// are gated server-side. In-app channels are NEVER suppressed (records persisted).
+    /// </summary>
+    public TimeOnly? QuietHoursStart { get; private set; }
+
+    /// <summary>
+    /// Optional end of daily quiet-hours window. May be earlier than <see cref="QuietHoursStart"/>
+    /// (window crosses midnight, e.g. 22:00 → 08:00).
+    /// </summary>
+    public TimeOnly? QuietHoursEnd { get; private set; }
+
     // Slack - Issue #slack-notification-system
     public bool SlackEnabled { get; private set; } = true;
     public bool SlackOnDocumentReady { get; private set; } = true;
@@ -72,12 +94,16 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
         bool slackEnabled = true, bool slackOnDocumentReady = true, bool slackOnDocumentFailed = true,
         bool slackOnRetryAvailable = false, bool slackOnGameNightInvitation = true,
         bool slackOnGameNightReminder = true, bool slackOnShareRequestCreated = true,
-        bool slackOnShareRequestApproved = true, bool slackOnBadgeEarned = true)
+        bool slackOnShareRequestApproved = true, bool slackOnBadgeEarned = true,
+        string timeZone = "UTC", TimeOnly? quietHoursStart = null, TimeOnly? quietHoursEnd = null)
     {
         return new NotificationPreferences
         {
             Id = id,
             UserId = userId,
+            TimeZone = string.IsNullOrWhiteSpace(timeZone) ? "UTC" : timeZone,
+            QuietHoursStart = quietHoursStart,
+            QuietHoursEnd = quietHoursEnd,
             EmailOnDocumentReady = emailReady,
             EmailOnDocumentFailed = emailFailed,
             EmailOnRetryAvailable = emailRetry,
@@ -178,5 +204,50 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
         UpdateEmailPreferences(emailReady, emailFailed, emailRetry);
         UpdatePushPreferences(pushReady, pushFailed, pushRetry);
         UpdateInAppPreferences(inAppReady, inAppFailed, inAppRetry);
+    }
+
+    /// <summary>
+    /// Updates timezone + quiet-hours window. Per ADR-076, gating applies only to
+    /// email + Slack channels server-side. In-app records persist regardless.
+    /// Pass null start/end to disable quiet hours.
+    /// </summary>
+    public void UpdateQuietHours(string timeZone, TimeOnly? start, TimeOnly? end)
+    {
+        if (string.IsNullOrWhiteSpace(timeZone))
+            throw new ArgumentException("Time zone cannot be empty", nameof(timeZone));
+
+        if (start.HasValue != end.HasValue)
+            throw new ArgumentException(
+                "Quiet hours start and end must both be set or both be null",
+                nameof(start));
+
+        TimeZone = timeZone;
+        QuietHoursStart = start;
+        QuietHoursEnd = end;
+    }
+
+    /// <summary>
+    /// Returns true if the given UTC timestamp falls inside the user's quiet-hours
+    /// window. Window may cross midnight (start > end, e.g. 22:00 → 08:00 local).
+    /// Returns false if quiet hours not configured.
+    /// </summary>
+    public bool IsQuietHoursActive(DateTimeOffset utcNow)
+    {
+        if (!QuietHoursStart.HasValue || !QuietHoursEnd.HasValue)
+            return false;
+
+        var tzInfo = TZConvert.GetTimeZoneInfo(TimeZone);
+        var localNow = TimeOnly.FromDateTime(
+            TimeZoneInfo.ConvertTimeFromUtc(utcNow.UtcDateTime, tzInfo));
+
+        var start = QuietHoursStart.Value;
+        var end = QuietHoursEnd.Value;
+
+        // Window crosses midnight (e.g. 22:00 → 08:00): active if localNow >= start OR localNow < end
+        if (start > end)
+            return localNow >= start || localNow < end;
+
+        // Normal window (e.g. 09:00 → 17:00): active if start <= localNow < end
+        return localNow >= start && localNow < end;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs
@@ -75,7 +75,8 @@ internal class NotificationPreferencesRepository : RepositoryBase, INotification
             entity.SlackEnabled, entity.SlackOnDocumentReady, entity.SlackOnDocumentFailed,
             entity.SlackOnRetryAvailable, entity.SlackOnGameNightInvitation,
             entity.SlackOnGameNightReminder, entity.SlackOnShareRequestCreated,
-            entity.SlackOnShareRequestApproved, entity.SlackOnBadgeEarned
+            entity.SlackOnShareRequestApproved, entity.SlackOnBadgeEarned,
+            entity.TimeZone, entity.QuietHoursStart, entity.QuietHoursEnd
         );
     }
 
@@ -110,7 +111,10 @@ internal class NotificationPreferencesRepository : RepositoryBase, INotification
             SlackOnGameNightReminder = domain.SlackOnGameNightReminder,
             SlackOnShareRequestCreated = domain.SlackOnShareRequestCreated,
             SlackOnShareRequestApproved = domain.SlackOnShareRequestApproved,
-            SlackOnBadgeEarned = domain.SlackOnBadgeEarned
+            SlackOnBadgeEarned = domain.SlackOnBadgeEarned,
+            TimeZone = domain.TimeZone,
+            QuietHoursStart = domain.QuietHoursStart,
+            QuietHoursEnd = domain.QuietHoursEnd
         };
     }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs
@@ -24,6 +24,11 @@ public class NotificationPreferencesEntity
     public bool EmailOnGameNightReminder { get; set; } = true;
     public bool PushOnGameNightReminder { get; set; } = true;
 
+    // Quiet hours - ADR-076 (#2383 follow-up)
+    public string TimeZone { get; set; } = "UTC";
+    public TimeOnly? QuietHoursStart { get; set; }
+    public TimeOnly? QuietHoursEnd { get; set; }
+
     // Slack - Issue #slack-notification-system
     public bool SlackEnabled { get; set; } = true;
     public bool SlackOnDocumentReady { get; set; } = true;

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationPreferencesEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationPreferencesEntityConfiguration.cs
@@ -25,6 +25,19 @@ internal class NotificationPreferencesEntityConfiguration : IEntityTypeConfigura
         builder.Property(e => e.InAppOnDocumentFailed).IsRequired().HasDefaultValue(true);
         builder.Property(e => e.InAppOnRetryAvailable).IsRequired().HasDefaultValue(true);
 
+        // Quiet hours - ADR-076 (#2383)
+        builder.Property(e => e.TimeZone)
+            .HasColumnName("time_zone")
+            .IsRequired()
+            .HasMaxLength(64)
+            .HasDefaultValue("UTC");
+        builder.Property(e => e.QuietHoursStart)
+            .HasColumnName("quiet_hours_start")
+            .HasColumnType("time");
+        builder.Property(e => e.QuietHoursEnd)
+            .HasColumnName("quiet_hours_end")
+            .HasColumnType("time");
+
         // Slack notification preferences
         builder.Property(e => e.SlackEnabled).IsRequired().HasDefaultValue(true);
         builder.Property(e => e.SlackOnDocumentReady).IsRequired().HasDefaultValue(true);

--- a/apps/api/src/Api/Infrastructure/Migrations/20260615171430_AddQuietHoursToNotificationPreferences.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260615171430_AddQuietHoursToNotificationPreferences.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615171430_AddQuietHoursToNotificationPreferences")]
+    partial class AddQuietHoursToNotificationPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260615171430_AddQuietHoursToNotificationPreferences.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260615171430_AddQuietHoursToNotificationPreferences.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuietHoursToNotificationPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<TimeOnly>(
+                name: "quiet_hours_end",
+                table: "notification_preferences",
+                type: "time",
+                nullable: true);
+
+            migrationBuilder.AddColumn<TimeOnly>(
+                name: "quiet_hours_start",
+                table: "notification_preferences",
+                type: "time",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "time_zone",
+                table: "notification_preferences",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "UTC");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "quiet_hours_end",
+                table: "notification_preferences");
+
+            migrationBuilder.DropColumn(
+                name: "quiet_hours_start",
+                table: "notification_preferences");
+
+            migrationBuilder.DropColumn(
+                name: "time_zone",
+                table: "notification_preferences");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferencesQuietHoursTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferencesQuietHoursTests.cs
@@ -1,0 +1,132 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Domain.Aggregates;
+
+[Trait("Category", "Unit")]
+public class NotificationPreferencesQuietHoursTests
+{
+    private static NotificationPreferences CreatePrefs() => new(Guid.NewGuid());
+
+    [Fact]
+    public void DefaultPrefs_QuietHoursNotActive()
+    {
+        var prefs = CreatePrefs();
+
+        prefs.TimeZone.Should().Be("UTC");
+        prefs.QuietHoursStart.Should().BeNull();
+        prefs.QuietHoursEnd.Should().BeNull();
+        prefs.IsQuietHoursActive(DateTimeOffset.UtcNow).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpdateQuietHours_ValidWindow_PersistsFields()
+    {
+        var prefs = CreatePrefs();
+
+        prefs.UpdateQuietHours("Europe/Rome", new TimeOnly(22, 0), new TimeOnly(8, 0));
+
+        prefs.TimeZone.Should().Be("Europe/Rome");
+        prefs.QuietHoursStart.Should().Be(new TimeOnly(22, 0));
+        prefs.QuietHoursEnd.Should().Be(new TimeOnly(8, 0));
+    }
+
+    [Fact]
+    public void UpdateQuietHours_NullStartAndEnd_ClearsWindow()
+    {
+        var prefs = CreatePrefs();
+        prefs.UpdateQuietHours("Europe/Rome", new TimeOnly(22, 0), new TimeOnly(8, 0));
+
+        prefs.UpdateQuietHours("Europe/Rome", null, null);
+
+        prefs.QuietHoursStart.Should().BeNull();
+        prefs.QuietHoursEnd.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateQuietHours_OnlyStartSet_Throws()
+    {
+        var prefs = CreatePrefs();
+
+        var act = () => prefs.UpdateQuietHours("UTC", new TimeOnly(22, 0), null);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*both be set or both be null*");
+    }
+
+    [Fact]
+    public void UpdateQuietHours_EmptyTimeZone_Throws()
+    {
+        var prefs = CreatePrefs();
+
+        var act = () => prefs.UpdateQuietHours("", new TimeOnly(22, 0), new TimeOnly(8, 0));
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Time zone cannot be empty*");
+    }
+
+    [Fact]
+    public void IsQuietHoursActive_NormalWindow_ActiveDuring()
+    {
+        var prefs = CreatePrefs();
+        prefs.UpdateQuietHours("UTC", new TimeOnly(9, 0), new TimeOnly(17, 0));
+
+        // 12:00 UTC is inside [09:00, 17:00)
+        var insideWindow = new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(insideWindow).Should().BeTrue();
+
+        // 08:00 UTC is BEFORE window start
+        var beforeWindow = new DateTimeOffset(2026, 6, 15, 8, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(beforeWindow).Should().BeFalse();
+
+        // 17:00 UTC is at window end (exclusive)
+        var atWindowEnd = new DateTimeOffset(2026, 6, 15, 17, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(atWindowEnd).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsQuietHoursActive_CrossMidnightWindow_ActiveOvernight()
+    {
+        var prefs = CreatePrefs();
+        prefs.UpdateQuietHours("UTC", new TimeOnly(22, 0), new TimeOnly(8, 0));
+
+        // 23:00 UTC (after start, before midnight)
+        var lateNight = new DateTimeOffset(2026, 6, 15, 23, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(lateNight).Should().BeTrue();
+
+        // 03:00 UTC (after midnight, before end)
+        var earlyMorning = new DateTimeOffset(2026, 6, 16, 3, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(earlyMorning).Should().BeTrue();
+
+        // 12:00 UTC (well outside window)
+        var midday = new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(midday).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsQuietHoursActive_TimeZoneAwareness_ConvertsUtcCorrectly()
+    {
+        // Quiet hours 22:00-08:00 LOCAL Europe/Rome (UTC+2 in summer, UTC+1 in winter)
+        var prefs = CreatePrefs();
+        prefs.UpdateQuietHours("Europe/Rome", new TimeOnly(22, 0), new TimeOnly(8, 0));
+
+        // 20:30 UTC on 2026-06-15 (summer time CEST UTC+2) = 22:30 local Rome → inside window
+        var utcInsideRomeWindow = new DateTimeOffset(2026, 6, 15, 20, 30, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(utcInsideRomeWindow).Should().BeTrue();
+
+        // 12:00 UTC on 2026-06-15 = 14:00 local Rome → outside window
+        var utcOutsideRomeWindow = new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        prefs.IsQuietHoursActive(utcOutsideRomeWindow).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpdateQuietHours_WhitespaceTimeZone_Throws()
+    {
+        var prefs = CreatePrefs();
+
+        var act = () => prefs.UpdateQuietHours("   ", new TimeOnly(22, 0), new TimeOnly(8, 0));
+
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Summary

Fourth batch of [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383) (ADR follow-up prerequisites umbrella).

Adds **TimeZone + QuietHoursStart/End fields** to `NotificationPreferences` aggregate + EF migration per ADR-076 (quiet hours hybrid timezone, Option C — shipped via PR #2381). Closes the prerequisite gap for `NotificationDispatcher` server-side quiet-hours gating.

## Domain changes (NotificationPreferences aggregate)

| Field | Type | Default | Notes |
|---|---|---|---|
| `TimeZone` | `string` | `"UTC"` | IANA timezone name; required, max 64 chars |
| `QuietHoursStart` | `TimeOnly?` | `null` | Local time per `TimeZone` |
| `QuietHoursEnd` | `TimeOnly?` | `null` | May be < Start (window crosses midnight) |

**New methods**:
- `UpdateQuietHours(string timeZone, TimeOnly? start, TimeOnly? end)` — validates both start+end set OR both null
- `IsQuietHoursActive(DateTimeOffset utcNow)` — handles cross-midnight + timezone conversion via `TimeZoneConverter` (shipped PR #2385)

**Reconstitute() factory**: 3 new optional params with defaults (additive, backward-compat with existing call sites).

## Persistence + migration

- `NotificationPreferencesEntity`: 3 new properties matching domain
- EF Configuration: column mappings (`time_zone` NOT NULL DEFAULT 'UTC', `quiet_hours_start/end` nullable `TIME`)
- `NotificationPreferencesRepository.MapToDomain + MapToPersistence`: full round-trip
- Migration `20260615171430_AddQuietHoursToNotificationPreferences`:
  - `Up`: adds 3 columns (existing rows: TimeZone="UTC", quiet hours null)
  - `Down`: drops 3 columns (safe rollback, no data loss for quiet-hours-unused scenarios)

## Test coverage

9 unit test cases in `NotificationPreferencesQuietHoursTests`:

1. **Default prefs**: TimeZone="UTC", quiet hours null, `IsQuietHoursActive(now)` returns false
2. **UpdateQuietHours valid**: persists timezone + start + end
3. **UpdateQuietHours null+null**: clears window
4. **UpdateQuietHours only-start-set**: throws `ArgumentException` (invariant: both or neither)
5. **UpdateQuietHours empty timezone**: throws
6. **UpdateQuietHours whitespace timezone**: throws
7. **IsQuietHoursActive normal window** (09:00→17:00 UTC): active inside, inactive at exact end (exclusive)
8. **IsQuietHoursActive cross-midnight window** (22:00→08:00 UTC): active late-night + early-morning, inactive midday
9. **IsQuietHoursActive Europe/Rome CEST UTC+2**: 20:30 UTC = 22:30 local → inside window; 12:00 UTC = 14:00 local → outside

## Out of scope (deferred to ADR-076 implementation phase)

- **NotificationDispatcher integration**: gating email/Slack channels at dispatch time via `prefs.IsQuietHoursActive(DateTimeOffset.UtcNow)` check. Separate PR per ADR-076 Option C §3 (Implementation guidance).
- **API endpoint exposure**: GET/PATCH `/api/v1/users/{userId}/notification-preferences/quiet-hours` for user-facing UI. Separate PR.
- **In-app channel suppression**: per ADR-076 Option C decision, in-app records persist regardless of quiet hours — only email/Slack are gated.
- **Quiet hours UI** (FE): settings page section for timezone + quiet hours window. Separate PR.

## Test plan

- [x] `dotnet build` BE: 0 errors
- [x] `dotnet build` tests: 0 errors
- [x] Pre-commit hooks pass (lint-staged + typecheck)
- [ ] CI: `Backend Fast (build + unit)` incl. 9 new `NotificationPreferencesQuietHoursTests` cases
- [ ] CI: migration applies clean (no schema drift)

## Refs

- ADR-076: `docs/for-claude/architecture/adr/adr-076-quiet-hours-timezone.md` (shipped PR #2381)
- Umbrella tracker: #2383
- Prerequisite: PR #2385 (TimeZoneConverter NuGet — enables IANA timezone strings cross-platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)