### PR TITLE
fix(notifications): #2383 swallow 23505 race-window in dispatcher via AddAndCommitAsync

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
@@ -42,4 +42,20 @@ internal interface INotificationRepository : IRepository<Notification, Guid>
     /// — see <c>NotificationMessage.SourceEventId</c>.
     /// </summary>
     Task<bool> ExistsBySourceEventIdAsync(Guid userId, Guid sourceEventId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomic add-and-commit for in-app notifications guarded by the
+    /// <c>(user_id, source_event_id)</c> UNIQUE pair (issue #2383 / ADR-068/072
+    /// follow-up). Mirrors <c>LedgerEntryRepository.AddAndCommitAsync</c>
+    /// (CF-2 #1938): tracks the entity, calls <c>SaveChangesAsync</c>, and
+    /// catches the Postgres <c>23505 unique_violation</c> race-window so the
+    /// caller doesn't have to wrap every <c>INotificationHandler</c>
+    /// invocation in a try/catch (10 of 25 handlers have no catch-all).
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the notification was persisted; <c>false</c> when a
+    /// concurrent caller already inserted a row with the same source event id
+    /// (dedup-by-race — the in-app row exists, just under the other caller).
+    /// </returns>
+    Task<bool> AddAndCommitAsync(Notification notification, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
@@ -103,6 +103,16 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
 
         // Broadcast to connected SSE clients (Issue #5005).
         // Fires before UnitOfWork.SaveChangesAsync — matches metric recording pattern.
+        //
+        // Phantom-broadcast risk (acknowledged): if the caller's external
+        // SaveChangesAsync subsequently throws (e.g. FK violation on a sibling
+        // entity, deadlock, late constraint check), the metric is already
+        // counted and the SSE frame has already shipped for a notification
+        // that was never durably stored. Affects the 12 non-dispatcher callers
+        // (Hangfire jobs + command handlers + non-dispatcher event handlers).
+        // The dispatcher path (#2383) routes through AddAndCommitAsync below,
+        // which emits these side-effects only after a successful save. A
+        // follow-up will migrate the remaining callers; see #2383 umbrella.
         _broadcaster.Publish(notification.UserId, MapToDto(notification));
     }
 

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
@@ -8,6 +8,7 @@ using Api.Infrastructure.Entities.UserNotifications;
 using Api.Observability;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
@@ -103,6 +104,39 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
         // Broadcast to connected SSE clients (Issue #5005).
         // Fires before UnitOfWork.SaveChangesAsync — matches metric recording pattern.
         _broadcaster.Publish(notification.UserId, MapToDto(notification));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AddAndCommitAsync(Notification notification, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        CollectDomainEvents(notification);
+
+        var notificationEntity = MapToPersistence(notification);
+        await DbContext.Set<NotificationEntity>().AddAsync(notificationEntity, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (CounterTableIdempotency.IsUniqueViolation(ex))
+        {
+            // Race-window: concurrent caller already inserted a row with the same
+            // (user_id, source_event_id) UNIQUE pair (issue #2383). Detach the
+            // unsaved entity so it isn't retried on a later SaveChangesAsync,
+            // and signal the caller (dispatcher) to skip channel queue items —
+            // the in-app row exists already, just under the other caller's CorrelationId.
+            DbContext.Entry(notificationEntity).State = EntityState.Detached;
+            return false;
+        }
+
+        // Side-effects fire only after the row is durably persisted so a lost
+        // race doesn't leave a phantom metric/SSE broadcast for a notification
+        // that was never committed.
+        MeepleAiMetrics.RecordNotificationCreated(notification.Type.Value, notification.Severity.Value);
+        _broadcaster.Publish(notification.UserId, MapToDto(notification));
+
+        return true;
     }
 
     public async Task UpdateAsync(Notification notification, CancellationToken cancellationToken = default)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -78,7 +78,22 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             correlationId: correlationId,
             sourceEventId: message.SourceEventId);
 
-        await _notificationRepository.AddAsync(notification, ct).ConfigureAwait(false);
+        // Issue #2383 / ADR-068/072 follow-up: route the in-app insert through
+        // an atomic add-and-commit so the Postgres 23505 unique_violation that
+        // surfaces when ExistsBySourceEventIdAsync false-negatives under
+        // concurrent dispatch is caught at the repository boundary (mirrors
+        // LedgerEntryRepository.AddAndCommitAsync, CF-2 #1938). 10 of 25
+        // INotificationHandler implementations have no catch-all, so a
+        // bubbling DbUpdateException would surface as an unhandled exception
+        // in the MediatR pipeline.
+        var committed = await _notificationRepository.AddAndCommitAsync(notification, ct).ConfigureAwait(false);
+        if (!committed)
+        {
+            _logger.LogInformation(
+                "Skipping channel dispatch for race-window dedup: user={UserId}, type={Type}, sourceEventId={SourceEventId} (concurrent caller already persisted the in-app row)",
+                message.RecipientUserId, message.Type, message.SourceEventId);
+            return;
+        }
 
         _logger.LogInformation(
             "Created in-app notification {NotificationId} for user {UserId}, type={Type}, correlationId={CorrelationId}",

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
@@ -23,6 +23,18 @@ public class NotificationDispatcherTests
     private readonly Mock<ILogger<NotificationDispatcher>> _loggerMock = new();
     private readonly SlackNotificationConfiguration _slackConfig = new();
 
+    public NotificationDispatcherTests()
+    {
+        // Default to the "won the race" path so existing happy-path tests don't have
+        // to opt in; tests that exercise the lost-race / dedup branch override this
+        // with .ReturnsAsync(false). Mirrors LedgerTrackingServiceTests's default.
+        // Lives here (not in CreateSut) so per-test Setup overrides win — Moq applies
+        // the last matching Setup, and xUnit instantiates this class per test.
+        _notificationRepoMock
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
     private NotificationDispatcher CreateSut()
     {
         return new NotificationDispatcher(
@@ -60,7 +72,7 @@ public class NotificationDispatcherTests
 
         // Assert
         _notificationRepoMock.Verify(
-            r => r.AddAsync(It.Is<Notification>(n =>
+            r => r.AddAndCommitAsync(It.Is<Notification>(n =>
                 n.UserId == message.RecipientUserId &&
                 n.Type == message.Type &&
                 n.Link == "/test/path"),
@@ -175,7 +187,7 @@ public class NotificationDispatcherTests
 
         // Assert — in-app notification always created
         _notificationRepoMock.Verify(
-            r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Email queue item should be added (null preferences defaults to email enabled)
@@ -290,9 +302,9 @@ public class NotificationDispatcherTests
 
         Notification? captured = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
             .Callback<Notification, CancellationToken>((n, _) => captured = n)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         var sut = CreateSut();
 
@@ -322,9 +334,9 @@ public class NotificationDispatcherTests
 
         Notification? captured = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
             .Callback<Notification, CancellationToken>((n, _) => captured = n)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
 
         var sut = CreateSut();
 
@@ -409,9 +421,9 @@ public class NotificationDispatcherTests
         // Act
         await sut.DispatchAsync(message);
 
-        // Assert — no AddAsync, no AddRangeAsync (dispatcher short-circuited)
+        // Assert — no AddAndCommitAsync, no AddRangeAsync (dispatcher short-circuited)
         _notificationRepoMock.Verify(
-            r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _queueRepoMock.Verify(
             r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()),
@@ -436,7 +448,7 @@ public class NotificationDispatcherTests
 
         // Assert — Notification persisted with SourceEventId = the one from the message
         _notificationRepoMock.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.Is<Notification>(n => n.SourceEventId == sourceEventId),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -490,9 +502,114 @@ public class NotificationDispatcherTests
             r => r.ExistsBySourceEventIdAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _notificationRepoMock.Verify(
-            r => r.AddAsync(
+            r => r.AddAndCommitAsync(
                 It.Is<Notification>(n => n.SourceEventId == null),
                 It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ----- Race-window dedup (#2383 P1) ---------------------------------------
+    //
+    // Issue #2383 / ADR-068/072 follow-up: when the pre-check
+    // ExistsBySourceEventIdAsync returns false but a concurrent caller wins the
+    // INSERT race, EF SaveChangesAsync surfaces a Postgres 23505 unique-violation.
+    // The dispatcher MUST detect this signal and swallow it (dedup is the intent),
+    // not let the exception bubble up through the MediatR notification pipeline
+    // where 10 of 25 INotificationHandler implementations have no catch-all.
+    //
+    // The fix routes the in-app insert through the repository's atomic
+    // AddAndCommitAsync entry point (same pattern as
+    // LedgerEntryRepository.AddAndCommitAsync, CF-2 #1938). It returns:
+    //   - true  → row committed; proceed with channel queue items
+    //   - false → race detected; log Information, skip queue items, return cleanly
+
+    [Fact]
+    public async Task DispatchAsync_WhenAddAndCommitWinsRace_ProcessesChannelQueueItems()
+    {
+        // Arrange — happy path: AddAndCommitAsync returns true (we committed first)
+        var userId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+        var message = CreateMessage(recipientUserId: userId) with { SourceEventId = sourceEventId };
+
+        _notificationRepoMock
+            .Setup(r => r.ExistsBySourceEventIdAsync(userId, sourceEventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _notificationRepoMock
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — AddAndCommitAsync called once, queue items added (we won the race)
+        _notificationRepoMock.Verify(
+            r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _queueRepoMock.Verify(
+            r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenAddAndCommitLosesRace_SwallowsAndSkipsQueueItems()
+    {
+        // Arrange — race-window: pre-check passes, but a concurrent caller commits
+        // first; AddAndCommitAsync detects 23505 internally and returns false.
+        var userId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+        var message = CreateMessage(recipientUserId: userId) with { SourceEventId = sourceEventId };
+
+        _notificationRepoMock
+            .Setup(r => r.ExistsBySourceEventIdAsync(userId, sourceEventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _notificationRepoMock
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = CreateSut();
+
+        // Act — MUST NOT throw; the lost race is the intended dedup outcome
+        var act = async () => await sut.DispatchAsync(message);
+        await act.Should().NotThrowAsync(
+            "23505 surfacing in the calling MediatR handler is exactly the bug we are fixing");
+
+        // Assert — channel queue items skipped (no notification was committed for this caller)
+        _queueRepoMock.Verify(
+            r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenAddAndCommitLosesRace_LogsDedupReasonAtInformation()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+        var message = CreateMessage(recipientUserId: userId) with { SourceEventId = sourceEventId };
+
+        _notificationRepoMock
+            .Setup(r => r.ExistsBySourceEventIdAsync(userId, sourceEventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _notificationRepoMock
+            .Setup(r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — a single Information-level log entry mentions the race-window
+        // reason so operators can distinguish this from a normal dedup short-circuit.
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("race-window")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationRepositoryAddAndCommitIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationRepositoryAddAndCommitIntegrationTests.cs
@@ -1,0 +1,190 @@
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.UserNotifications;
+
+/// <summary>
+/// Integration tests for <see cref="NotificationRepository.AddAndCommitAsync"/>
+/// using a real Testcontainers PostgreSQL instance (issue #2383 — ADR-068/072
+/// follow-up).
+///
+/// Covers the race-window the dispatcher pre-check
+/// <c>ExistsBySourceEventIdAsync</c> can't fully close: when two MediatR event
+/// handlers race past the pre-check, the second SaveChangesAsync hits the
+/// partial UNIQUE index <c>UX_notifications_user_source_event_id</c> on
+/// <c>(user_id, source_event_id) WHERE source_event_id IS NOT NULL</c> and
+/// Postgres emits SqlState 23505. AddAndCommitAsync must catch it, detach the
+/// unsaved entity, and return false — the in-app row already exists under the
+/// winning caller's CorrelationId.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "UserNotifications")]
+[Trait("Issue", "2383")]
+public sealed class NotificationRepositoryAddAndCommitIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private INotificationRepository? _repository;
+    private IServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public NotificationRepositoryAddAndCommitIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_notifrepoaddcommit_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+
+        // NotificationRepository depends on IUserNotificationBroadcaster (SSE).
+        // No-op mock keeps the broadcast side-effect inert during persistence tests.
+        services.AddScoped(_ => Mock.Of<IUserNotificationBroadcaster>());
+        services.AddScoped<INotificationRepository, NotificationRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _repository = _serviceProvider.GetRequiredService<INotificationRepository>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(TestConstants.Timing.RetryDelay, TestCancellationToken);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch (NpgsqlException)
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task AddAndCommitAsync_FirstInsertWithSourceEventId_ReturnsTrueAndPersistsRow()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+        var notification = BuildNotification(userId, sourceEventId);
+
+        // Act
+        var committed = await _repository!.AddAndCommitAsync(notification, TestCancellationToken);
+
+        // Assert — repository signals success
+        committed.Should().BeTrue("the first insert wins the race and persists the row");
+
+        // And the row is durably stored
+        var persisted = await _dbContext!.Set<NotificationEntity>()
+            .AsNoTracking()
+            .Where(n => n.UserId == userId)
+            .ToListAsync(TestCancellationToken);
+
+        persisted.Should().ContainSingle(n => n.SourceEventId == sourceEventId);
+    }
+
+    [Fact]
+    public async Task AddAndCommitAsync_SecondInsertWithSameSourceEventId_ReturnsFalseAndDoesNotDuplicateRow()
+    {
+        // Arrange — first insert simulates the winning caller
+        var userId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+        var first = BuildNotification(userId, sourceEventId);
+        var initialCommit = await _repository!.AddAndCommitAsync(first, TestCancellationToken);
+        initialCommit.Should().BeTrue("baseline: the first caller must succeed for this test to be meaningful");
+
+        // Act — second insert mimics the losing caller in the race: same
+        // (user_id, source_event_id) UNIQUE pair, new aggregate id (different
+        // CorrelationId). The partial UNIQUE index on
+        // (user_id, source_event_id) WHERE source_event_id IS NOT NULL must trip
+        // Postgres SqlState 23505, which AddAndCommitAsync must catch.
+        var second = BuildNotification(userId, sourceEventId);
+        var raceCommit = await _repository!.AddAndCommitAsync(second, TestCancellationToken);
+
+        // Assert — race detected without surfacing DbUpdateException to the caller
+        raceCommit.Should().BeFalse(
+            "the dispatcher relies on this signal to skip channel queue items "
+            + "instead of letting 23505 bubble up through MediatR (issue #2383)");
+
+        // And the table still contains exactly one row for that pair
+        var rowsForPair = await _dbContext!.Set<NotificationEntity>()
+            .AsNoTracking()
+            .CountAsync(n => n.UserId == userId && n.SourceEventId == sourceEventId, TestCancellationToken);
+
+        rowsForPair.Should().Be(1, "the partial UNIQUE index prevents duplicates");
+    }
+
+    [Fact]
+    public async Task AddAndCommitAsync_NullSourceEventId_AllowsMultipleRowsForSameUser()
+    {
+        // Arrange — legacy / hand-triggered admin notifications have no source
+        // event id, so the partial UNIQUE index does NOT apply. AddAndCommitAsync
+        // must let both rows persist (returns true twice).
+        var userId = Guid.NewGuid();
+
+        // Act
+        var first = await _repository!.AddAndCommitAsync(BuildNotification(userId, sourceEventId: null), TestCancellationToken);
+        var second = await _repository!.AddAndCommitAsync(BuildNotification(userId, sourceEventId: null), TestCancellationToken);
+
+        // Assert
+        first.Should().BeTrue();
+        second.Should().BeTrue();
+
+        var rowsForUser = await _dbContext!.Set<NotificationEntity>()
+            .AsNoTracking()
+            .CountAsync(n => n.UserId == userId && n.SourceEventId == null, TestCancellationToken);
+
+        rowsForUser.Should().Be(2,
+            "the UNIQUE index has 'WHERE source_event_id IS NOT NULL', so null-id rows are unconstrained");
+    }
+
+    private static Notification BuildNotification(Guid userId, Guid? sourceEventId)
+    {
+        return new Notification(
+            id: Guid.NewGuid(),
+            userId: userId,
+            type: NotificationType.ShareRequestCreated,
+            severity: NotificationSeverity.Info,
+            title: "Race-window dedup test",
+            message: "issue #2383 integration regression",
+            correlationId: Guid.NewGuid(),
+            sourceEventId: sourceEventId);
+    }
+}


### PR DESCRIPTION
## Summary

First checkbox of umbrella [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383) (ADR-068/072 P1 bug). Concurrent `INotificationHandler<TEvent>` dispatches that pass the `ExistsBySourceEventIdAsync` pre-check but lose the INSERT race on `UX_notifications_user_source_event_id` (partial UNIQUE on `(user_id, source_event_id) WHERE source_event_id IS NOT NULL`) currently surface a `DbUpdateException` (Postgres SqlState 23505) into the MediatR pipeline. 10 of the 25 `INotificationHandler` impls have no catch-all, so the exception escapes as an unhandled handler failure even though dedup is the intent.

This PR routes the in-app insert through a new atomic `INotificationRepository.AddAndCommitAsync` that catches 23505 at the repository boundary, detaches the unsaved entity, and returns `false`. The dispatcher reads the signal, logs `Information` with the race-window reason for ops triage, and skips channel queue items (Email/Slack DM/Slack team). Mirrors `LedgerEntryRepository.AddAndCommitAsync` (CF-2 #1938) and reuses `CounterTableIdempotency.IsUniqueViolation`.

## Why

- Without the guard, ops dashboards see the race log as `Error` (unhandled exception) rather than `Information` (intended dedup) — false alerts.
- Metric `meepleai_notifications_created_total` and SSE broadcast moved INSIDE `AddAndCommitAsync` AFTER save so a lost race no longer leaves a phantom metric / SSE push for a row that was never persisted.

## What changed

- `INotificationRepository.AddAndCommitAsync(Notification, ct) → Task<bool>` — new atomic method
- `NotificationRepository.AddAndCommitAsync` — implementation w/ try/catch on `CounterTableIdempotency.IsUniqueViolation`; metrics + broadcaster fire only on `true`
- `NotificationDispatcher.DispatchAsync` — uses `AddAndCommitAsync` (was `AddAsync`); early-returns with `LogInformation("race-window…")` on `false`
- `NotificationRepository.AddAsync` — UNCHANGED (12 other callers unaffected: command handlers + Quartz jobs + non-dispatcher event handlers)

## Test plan

- [x] **3 new unit tests** (`NotificationDispatcherTests`): `WhenAddAndCommitWinsRace_ProcessesChannelQueueItems`, `WhenAddAndCommitLosesRace_SwallowsAndSkipsQueueItems`, `WhenAddAndCommitLosesRace_LogsDedupReasonAtInformation`
- [x] **3 new integration tests** (`NotificationRepositoryAddAndCommitIntegrationTests`, Testcontainers Postgres): first insert persists, second insert with same `(userId, sourceEventId)` returns false + no duplicate, null `sourceEventId` is unconstrained
- [x] **132 existing UserNotifications BC tests** still green (138/138 total post-fix)
- [x] Side-effects (metric + SSE) verified to fire AFTER save inside `AddAndCommitAsync` (no phantom metric on lost race)

## Refs

- Umbrella: [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383) (item 1 of P1 bugs — leaves 4 P1 prereq + 4 P2 discussion items open)
- Pattern source: `LedgerEntryRepository.AddAndCommitAsync` (CF-2 #1938)
- Helper reused: `CounterTableIdempotency.IsUniqueViolation` (SharedKernel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)