### PR TITLE
feat(api): #2383 add RsvpDeadline + RsvpClosedAt to GameNightEvent (ADR-074)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -26,6 +26,22 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     public GameNightStatus Status { get; private set; }
     public DateTimeOffset? Reminder24hSentAt { get; private set; }
     public DateTimeOffset? Reminder1hSentAt { get; private set; }
+
+    // RSVP deadline — ADR-074 (#2383 follow-up)
+    /// <summary>
+    /// Optional cutoff after which RSVP submission is rejected by the validator.
+    /// Set by the organiser via <see cref="SetRsvpDeadline"/>. Per ADR-074 Option C
+    /// (lazy validation-time closure check + nullable closed-at timestamp).
+    /// </summary>
+    public DateTimeOffset? RsvpDeadline { get; private set; }
+
+    /// <summary>
+    /// Timestamp at which RSVPs were closed (either by deadline expiry observed at
+    /// validation time, by Hangfire cleanup job, or by manual organiser closure).
+    /// Once set, no further RSVPs are accepted regardless of <see cref="RsvpDeadline"/>.
+    /// </summary>
+    public DateTimeOffset? RsvpClosedAt { get; private set; }
+
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? UpdatedAt { get; private set; }
     public IReadOnlyList<GameNightRsvp> Rsvps => _rsvps.AsReadOnly();
@@ -316,6 +332,55 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     public void MarkReminder1hSent()
     {
         Reminder1hSentAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Sets the RSVP deadline. Organiser-only operation. Per ADR-074 Option C,
+    /// the deadline is consulted at validation time (lazy check); a Hangfire job
+    /// observes expired deadlines and calls <see cref="MarkRsvpClosed"/> for audit.
+    /// Pass null to clear (e.g. organiser extends an indefinitely open RSVP window).
+    /// Throws if RSVP is already closed.
+    /// </summary>
+    public void SetRsvpDeadline(DateTimeOffset? deadline)
+    {
+        if (RsvpClosedAt.HasValue)
+            throw new InvalidOperationException(
+                "Cannot change RSVP deadline after RSVP has been closed");
+
+        if (deadline.HasValue && deadline.Value <= DateTimeOffset.UtcNow)
+            throw new ArgumentException(
+                "RSVP deadline must be in the future",
+                nameof(deadline));
+
+        RsvpDeadline = deadline;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Marks RSVPs as closed. Internal entry point — callable only by the repository
+    /// (during Hangfire cleanup job dispatch) or by validator on first-read deadline
+    /// expiry observation, per ADR-074 Option C. Idempotent: subsequent calls are no-ops.
+    /// </summary>
+    internal void MarkRsvpClosed()
+    {
+        if (RsvpClosedAt.HasValue)
+            return; // idempotent
+
+        RsvpClosedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Returns true if RSVPs are no longer accepted (either explicit close, or
+    /// deadline passed). Validator should call this before persisting a new RSVP.
+    /// </summary>
+    public bool IsRsvpClosed(DateTimeOffset utcNow)
+    {
+        if (RsvpClosedAt.HasValue)
+            return true;
+        if (RsvpDeadline.HasValue && utcNow >= RsvpDeadline.Value)
+            return true;
+        return false;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -209,6 +209,8 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             Status = domain.Status.ToString(),
             Reminder24hSentAt = domain.Reminder24hSentAt,
             Reminder1hSentAt = domain.Reminder1hSentAt,
+            RsvpDeadline = domain.RsvpDeadline,
+            RsvpClosedAt = domain.RsvpClosedAt,
             CreatedAt = domain.CreatedAt,
             UpdatedAt = domain.UpdatedAt
         };
@@ -284,6 +286,12 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
 
         var reminder1hProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.Reminder1hSentAt));
         reminder1hProp?.SetValue(evt, entity.Reminder1hSentAt);
+
+        var rsvpDeadlineProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.RsvpDeadline));
+        rsvpDeadlineProp?.SetValue(evt, entity.RsvpDeadline);
+
+        var rsvpClosedAtProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.RsvpClosedAt));
+        rsvpClosedAtProp?.SetValue(evt, entity.RsvpClosedAt);
 
         // Restore RSVPs
         var rsvps = entity.Rsvps.Select(r => GameNightRsvp.Reconstitute(

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
@@ -52,6 +52,13 @@ public class GameNightEventEntity
     [Column("reminder_1h_sent_at")]
     public DateTimeOffset? Reminder1hSentAt { get; set; }
 
+    // RSVP deadline — ADR-074 (#2383 follow-up)
+    [Column("rsvp_deadline")]
+    public DateTimeOffset? RsvpDeadline { get; set; }
+
+    [Column("rsvp_closed_at")]
+    public DateTimeOffset? RsvpClosedAt { get; set; }
+
     [Required]
     [Column("created_at")]
     public DateTimeOffset CreatedAt { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
@@ -26,6 +26,11 @@ internal class GameNightEventEntityConfiguration : IEntityTypeConfiguration<Game
         builder.Property(e => e.Status).HasColumnName("status").HasMaxLength(20).IsRequired();
         builder.Property(e => e.Reminder24hSentAt).HasColumnName("reminder_24h_sent_at");
         builder.Property(e => e.Reminder1hSentAt).HasColumnName("reminder_1h_sent_at");
+
+        // RSVP deadline — ADR-074 (#2383)
+        builder.Property(e => e.RsvpDeadline).HasColumnName("rsvp_deadline");
+        builder.Property(e => e.RsvpClosedAt).HasColumnName("rsvp_closed_at");
+
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.UpdatedAt).HasColumnName("updated_at");
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260616045908_AddRsvpDeadlineToGameNightEvent.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260616045908_AddRsvpDeadlineToGameNightEvent.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616045908_AddRsvpDeadlineToGameNightEvent")]
+    partial class AddRsvpDeadlineToGameNightEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260616045908_AddRsvpDeadlineToGameNightEvent.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260616045908_AddRsvpDeadlineToGameNightEvent.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRsvpDeadlineToGameNightEvent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "rsvp_closed_at",
+                table: "game_night_events",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "rsvp_deadline",
+                table: "game_night_events",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "rsvp_closed_at",
+                table: "game_night_events");
+
+            migrationBuilder.DropColumn(
+                name: "rsvp_deadline",
+                table: "game_night_events");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventRsvpDeadlineTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventRsvpDeadlineTests.cs
@@ -1,0 +1,138 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+[Trait("Category", "Unit")]
+public class GameNightEventRsvpDeadlineTests
+{
+    private static GameNightEvent CreateEvent() => GameNightEvent.Create(
+        organizerId: Guid.NewGuid(),
+        title: "Test Game Night",
+        scheduledAt: DateTimeOffset.UtcNow.AddDays(7));
+
+    [Fact]
+    public void DefaultEvent_NoRsvpDeadlineNorClosure()
+    {
+        var evt = CreateEvent();
+
+        evt.RsvpDeadline.Should().BeNull();
+        evt.RsvpClosedAt.Should().BeNull();
+        evt.IsRsvpClosed(DateTimeOffset.UtcNow).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetRsvpDeadline_FutureDate_Persists()
+    {
+        var evt = CreateEvent();
+        var deadline = DateTimeOffset.UtcNow.AddDays(3);
+
+        evt.SetRsvpDeadline(deadline);
+
+        evt.RsvpDeadline.Should().Be(deadline);
+        evt.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SetRsvpDeadline_PastDate_Throws()
+    {
+        var evt = CreateEvent();
+        var pastDeadline = DateTimeOffset.UtcNow.AddDays(-1);
+
+        var act = () => evt.SetRsvpDeadline(pastDeadline);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*must be in the future*");
+    }
+
+    [Fact]
+    public void SetRsvpDeadline_Null_ClearsDeadline()
+    {
+        var evt = CreateEvent();
+        evt.SetRsvpDeadline(DateTimeOffset.UtcNow.AddDays(3));
+
+        evt.SetRsvpDeadline(null);
+
+        evt.RsvpDeadline.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetRsvpDeadline_AfterClosure_Throws()
+    {
+        var evt = CreateEvent();
+        evt.MarkRsvpClosed();
+
+        var act = () => evt.SetRsvpDeadline(DateTimeOffset.UtcNow.AddDays(3));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot change RSVP deadline after RSVP has been closed*");
+    }
+
+    [Fact]
+    public void MarkRsvpClosed_SetsTimestamp()
+    {
+        var evt = CreateEvent();
+        var beforeClose = DateTimeOffset.UtcNow;
+
+        evt.MarkRsvpClosed();
+
+        evt.RsvpClosedAt.Should().NotBeNull();
+        evt.RsvpClosedAt!.Value.Should().BeOnOrAfter(beforeClose);
+    }
+
+    [Fact]
+    public void MarkRsvpClosed_Idempotent_DoesNotOverwriteTimestamp()
+    {
+        var evt = CreateEvent();
+        evt.MarkRsvpClosed();
+        var firstClose = evt.RsvpClosedAt!.Value;
+
+        // Wait a tiny bit so a second call would observably differ
+        Thread.Sleep(10);
+        evt.MarkRsvpClosed();
+
+        evt.RsvpClosedAt!.Value.Should().Be(firstClose);
+    }
+
+    [Fact]
+    public void IsRsvpClosed_DeadlineFuture_ReturnsFalse()
+    {
+        var evt = CreateEvent();
+        evt.SetRsvpDeadline(DateTimeOffset.UtcNow.AddDays(3));
+
+        evt.IsRsvpClosed(DateTimeOffset.UtcNow).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRsvpClosed_DeadlinePastButNotMarkedClosed_ReturnsTrue()
+    {
+        var evt = CreateEvent();
+        var deadline = DateTimeOffset.UtcNow.AddHours(1);
+        evt.SetRsvpDeadline(deadline);
+
+        // Caller passes a "now" past the deadline (validator-time check)
+        evt.IsRsvpClosed(deadline.AddMinutes(1)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRsvpClosed_ExplicitClosure_ReturnsTrueRegardlessOfDeadline()
+    {
+        var evt = CreateEvent();
+        evt.SetRsvpDeadline(DateTimeOffset.UtcNow.AddDays(7));
+        evt.MarkRsvpClosed();
+
+        evt.IsRsvpClosed(DateTimeOffset.UtcNow).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRsvpClosed_DeadlineExactlyAtNow_ReturnsTrue()
+    {
+        var evt = CreateEvent();
+        var deadline = DateTimeOffset.UtcNow.AddHours(1);
+        evt.SetRsvpDeadline(deadline);
+
+        // utcNow == deadline → inclusive close
+        evt.IsRsvpClosed(deadline).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Fifth batch of [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383) (ADR follow-up prerequisites umbrella).

Adds **RsvpDeadline + RsvpClosedAt fields** to `GameNightEvent` aggregate + EF migration per ADR-074 (voting closure mechanism, Option C — lazy validation-time closure check + optional deadline + Hangfire cleanup, shipped via PR #2381).

## Domain changes

**New fields**:
| Field | Type | Notes |
|---|---|---|
| `RsvpDeadline` | `DateTimeOffset?` | Organiser-set cutoff; validator rejects past-deadline RSVPs |
| `RsvpClosedAt` | `DateTimeOffset?` | Set by Hangfire cleanup OR validator first-read observation |

**New methods**:
- `SetRsvpDeadline(DateTimeOffset?)` — organiser-only; throws if already closed; throws if past; accepts null
- `MarkRsvpClosed()` — **internal** (DDD-correct: callable only by repository/Hangfire job per ADR-074); idempotent
- `IsRsvpClosed(DateTimeOffset utcNow)` — validator query: true if `RsvpClosedAt` set OR `utcNow >= RsvpDeadline`

## Persistence + migration

- `GameNightEventEntity`: 2 new properties (`rsvp_deadline`, `rsvp_closed_at`)
- EF Configuration: 2 nullable timestamp columns
- Repository `MapToPersistence + MapToDomain`: full round-trip using reflection pattern (matches existing `Reminder24h/1h` field restoration)
- Migration `20260616045908_AddRsvpDeadlineToGameNightEvent`:
  - `Up`: adds 2 nullable timestamp columns (existing rows unaffected — null = no deadline, no closure)
  - `Down`: drops both (safe rollback, no data loss for unused-feature scenarios)

## Test coverage — 11 unit cases in `GameNightEventRsvpDeadlineTests`

1. Default event: no deadline + no closure
2. `SetRsvpDeadline` future date: persists + `UpdatedAt` bumped
3. `SetRsvpDeadline` past date: throws `ArgumentException`
4. `SetRsvpDeadline(null)`: clears deadline
5. `SetRsvpDeadline` after `MarkRsvpClosed`: throws `InvalidOperationException`
6. `MarkRsvpClosed`: sets timestamp
7. `MarkRsvpClosed` idempotent: 10ms sleep + second call leaves timestamp unchanged
8. `IsRsvpClosed` deadline future: false
9. `IsRsvpClosed` deadline past: true (validator-time observation)
10. `IsRsvpClosed` explicit closure overrides deadline (even if future)
11. `IsRsvpClosed` deadline exactly at `now`: true (inclusive close boundary)

## Out of scope (ADR-074 implementation phase, separate PRs)

- **Validator integration**: `CreateRsvpCommand` handler / validator must call `evt.IsRsvpClosed(DateTimeOffset.UtcNow)` and reject if true → 409 Conflict via `MaxLiveSessionsExceededException`-style middleware mapping
- **Hangfire job**: cron tick (e.g. hourly) that scans `GameNightEvent` rows where `RsvpDeadline < now AND RsvpClosedAt IS NULL`, dispatches `MarkRsvpClosed` + organiser notification (`GameNightRsvpClosedEvent` → `INotificationHandler`)
- **API endpoint exposure**: `PATCH /api/v1/game-nights/{id}/rsvp-deadline` for organiser UI
- **FE settings UI**: GameNightEdit drawer section for deadline picker
- **Organiser notification**: post-closure `GameNightRsvpClosedEvent` → in-app + email via `INotificationDispatcher`

## Test plan

- [x] `dotnet build apps/api/src/Api/Api.csproj` (0 errors)
- [x] `dotnet build apps/api/tests/Api.Tests/Api.Tests.csproj` (0 errors)
- [x] Pre-commit hooks pass
- [ ] CI: `Backend Fast (build + unit)` incl. 11 new `GameNightEventRsvpDeadlineTests` cases
- [ ] CI: `Migration Safety Gate` (additive nullable migration — safe)

## Refs

- ADR-074: `docs/for-claude/architecture/adr/adr-074-voting-closure-mechanism.md` (shipped PR #2381)
- Umbrella tracker: #2383
- Domain pattern reference: `GameNightEvent.MarkReminder24hSent` / `MarkReminder1hSent` (same private-setter + repository-reflection approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)