### PR TITLE
refactor(session-live): #2383 remove sse-disconnect state (ADR-071 Option B)

### DIFF
--- a/apps/web/src/components/features/session-live/SessionStateRenderer.tsx
+++ b/apps/web/src/components/features/session-live/SessionStateRenderer.tsx
@@ -1,20 +1,26 @@
 /**
  * SessionStateRenderer — G7 polymorphic discriminated-union primitive.
  *
- * Renders one of 5 canonical session-live states (per spec
+ * Renders one of 4 canonical panel-local session-live states (per spec
  * `2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md` §G7):
  *
- *   - default        → children passthrough (no wrapper)
- *   - empty          → existing `EmptyState` component
- *   - loading        → minimal inline skeleton
- *   - error          → minimal inline error banner + retry CTA
- *   - sse-disconnect → existing `ConnectionLostBanner` kind='failed'
+ *   - default → children passthrough (no wrapper)
+ *   - empty   → existing `EmptyState` component
+ *   - loading → minimal inline skeleton
+ *   - error   → minimal inline error banner + retry CTA
  *
- * Exhaustiveness is enforced by TypeScript: adding a 6th state requires
+ * SSE connection lost is **NOT** a panel state — per ADR-071 follow-up (#2383),
+ * the SSE disconnect banner is rendered at orchestrator level (see
+ * `SessionLiveView.tsx` `showConnectionBanner` flag + `ConnectionLostBanner`
+ * page-level mount). Splitting the banner across panels would multiply sources
+ * of truth for `ConnectionLostBannerLabels` (label prop drilling).
+ *
+ * Exhaustiveness is enforced by TypeScript: adding a 5th state requires
  * a code change AND a type change (the `assertNever` default catches drift).
  *
  * @see docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md §G7
- * @see Issue #2356 (G7 primitive), parent #2342 (umbrella)
+ * @see docs/for-claude/architecture/adr/adr-071-live-session-5-state-fsm.md (Option B)
+ * @see Issue #2356 (G7 primitive), #2383 (ADR-071 refactor), parent #2342 (umbrella)
  */
 
 import type { ReactElement, ReactNode } from 'react';
@@ -22,8 +28,6 @@ import type { ReactElement, ReactNode } from 'react';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 
 import { EmptyState } from '@/components/empty-state/EmptyState';
-
-import { ConnectionLostBanner, type ConnectionLostBannerLabels } from './ConnectionLostBanner';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -42,8 +46,7 @@ export type SessionLiveState =
       onRetry: () => void;
       errorTitle: string;
       retryLabel: string;
-    }
-  | { kind: 'sse-disconnect'; connectionLabels: ConnectionLostBannerLabels };
+    };
 
 export interface SessionStateRendererProps {
   readonly state: SessionLiveState;
@@ -110,13 +113,6 @@ export function SessionStateRenderer({ state }: SessionStateRendererProps): Reac
             <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
             {state.retryLabel}
           </button>
-        </div>
-      );
-
-    case 'sse-disconnect':
-      return (
-        <div data-slot="session-state-sse-disconnect">
-          <ConnectionLostBanner kind="failed" labels={state.connectionLabels} />
         </div>
       );
 

--- a/apps/web/src/components/features/session-live/__tests__/SessionStateRenderer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/SessionStateRenderer.test.tsx
@@ -6,28 +6,22 @@
  * - empty: delegates to EmptyState (title + description + action)
  * - loading: skeleton with aria-live polite + aria-label
  * - error: inline banner with title + message + retry CTA
- * - sse-disconnect: delegates to ConnectionLostBanner kind='failed'
  * - exhaustiveness: assertNever throws on unknown kind (runtime defense)
  *
+ * Note: `sse-disconnect` was removed from the discriminated union per ADR-071
+ * follow-up (#2383). The SSE disconnect banner is now rendered at orchestrator
+ * level (`SessionLiveView.tsx` `showConnectionBanner` flag), not as a panel
+ * state — eliminates `ConnectionLostBannerLabels` prop drilling.
+ *
  * @see docs/superpowers/specs/2026-06-14-issue-2281-session-skeleton-g2-g4-g7-scope.md §G7
+ * @see docs/for-claude/architecture/adr/adr-071-live-session-5-state-fsm.md (Option B)
  */
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ConnectionLostBannerLabels } from '../ConnectionLostBanner';
 import { SessionStateRenderer, type SessionLiveState } from '../SessionStateRenderer';
-
-// ─── Fixtures ─────────────────────────────────────────────────────────────────
-
-const CONNECTION_LABELS: ConnectionLostBannerLabels = {
-  retryCountResolved: 'Tentativo 1/5',
-  reconnecting: 'Riconnessione in corso',
-  degradedPolling: 'Aggiornamenti ogni 5s',
-  failed: 'Connessione persa',
-  manualRetryLabel: 'Riprova',
-};
 
 // ─── default ──────────────────────────────────────────────────────────────────
 
@@ -122,23 +116,6 @@ describe('SessionStateRenderer — error', () => {
     const button = screen.getByRole('button', { name: /Riprova/ });
     await userEvent.click(button);
     expect(onRetry).toHaveBeenCalledTimes(1);
-  });
-});
-
-// ─── sse-disconnect ───────────────────────────────────────────────────────────
-
-describe('SessionStateRenderer — sse-disconnect', () => {
-  it('delegates to ConnectionLostBanner kind="failed"', () => {
-    const state: SessionLiveState = {
-      kind: 'sse-disconnect',
-      connectionLabels: CONNECTION_LABELS,
-    };
-    render(<SessionStateRenderer state={state} />);
-    expect(document.querySelector('[data-slot="session-state-sse-disconnect"]')).not.toBeNull();
-    expect(document.querySelector('[data-slot="connection-lost-banner"]')).not.toBeNull();
-    expect(
-      document.querySelector('[data-slot="connection-lost-banner"]')?.getAttribute('data-kind')
-    ).toBe('failed');
   });
 });
 


### PR DESCRIPTION
## Summary

Seventh batch of [#2383](https://github.com/meepleAi-app/meepleai-monorepo/issues/2383). Resolves ADR-071 open question #4: removes `kind: 'sse-disconnect'` from `SessionLiveState` discriminated union per ADR-071 Option B (orchestrator-level banner).

## Why

`SessionLiveView.tsx` ALREADY renders `ConnectionLostBanner` at page level via `showConnectionBanner` flag with `ConnectionLostBannerLabels` as single source of truth. Adding `sse-disconnect` as a panel state would:
- Multiply sources of truth for the label string
- Risk conflict with orchestrator-level banner (2 banners simultaneously)
- Add prop drilling to 8+ panels

`SessionStateRenderer` now correctly handles only **panel-local states**: `default | empty | loading | error`.

## Production impact: zero

No production caller used `kind: 'sse-disconnect'`. `ScoreboardPage.tsx` uses only `loading`/`error`. Removed `describe('SessionStateRenderer — sse-disconnect', ...)` test block.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run SessionStateRenderer.test.tsx`: 7/7 pass
- [x] Pre-commit hooks pass

## Refs

- ADR-071, umbrella #2383 (analysis comment-4715365924), Issue #2356 (G7 primitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)