### PR TITLE
feat(notifications): #2392 migrate 9 of 10 AddAsync callers — phantom-broadcast follow-up

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameSessionTerminatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameSessionTerminatedEventHandler.cs
@@ -50,10 +50,13 @@ internal sealed class GameSessionTerminatedEventHandler : DomainEventHandlerBase
                         terminatedAt = domainEvent.TerminatedAt
                     }));
 
-                await _notificationRepository.AddAsync(notification, cancellationToken)
+                // Issue #2392: AddAndCommitAsync commits the notification row first,
+                // then fires the metric + SSE broadcast. The main GameSession transaction
+                // is already committed by the time this MediatR handler runs (Hybrid /
+                // OutboxOnly dispatch — see MeepleAiDbContext.SaveChangesAsyncCore step 5),
+                // so a separate notification commit can't orphan the parent.
+                await _notificationRepository.AddAndCommitAsync(notification, cancellationToken)
                     .ConfigureAwait(false);
-
-                // SaveChanges will be called by the unit of work after all event handlers complete
 
                 Logger.LogInformation(
                     "Created session termination notification for user {UserId}, session {SessionId}",

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameSessionTerminatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/GameSessionTerminatedEventHandler.cs
@@ -54,7 +54,11 @@ internal sealed class GameSessionTerminatedEventHandler : DomainEventHandlerBase
                 // then fires the metric + SSE broadcast. The main GameSession transaction
                 // is already committed by the time this MediatR handler runs (Hybrid /
                 // OutboxOnly dispatch — see MeepleAiDbContext.SaveChangesAsyncCore step 5),
-                // so a separate notification commit can't orphan the parent.
+                // so a separate notification commit can't orphan the parent. Note: under
+                // Hybrid mode the handler still shares the request-scoped DbContext, so
+                // upstream tracked-but-unsaved entities would commit alongside the
+                // notification — callers in the pipeline are expected to flush their own
+                // mutations before raising the GameSessionTerminatedEvent.
                 await _notificationRepository.AddAndCommitAsync(notification, cancellationToken)
                     .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/Gamification/Application/Jobs/AchievementEvaluationJob.cs
+++ b/apps/api/src/Api/BoundedContexts/Gamification/Application/Jobs/AchievementEvaluationJob.cs
@@ -90,6 +90,8 @@ internal sealed class AchievementEvaluationJob : IJob
             await _unitOfWork.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
 
             // Step 2: commit notifications and fire post-save side-effects.
+            // Notification count matches new-unlock count by construction
+            // (one Notification queued per newly-unlocked achievement, lines below).
             var totalUnlocks = await _notificationRepository
                 .AddBatchAndCommitAsync(pendingNotifications, context.CancellationToken)
                 .ConfigureAwait(false);
@@ -117,7 +119,7 @@ internal sealed class AchievementEvaluationJob : IJob
 #pragma warning restore CA1031
     }
 
-    private async Task<int> EvaluateUserAchievementsAsync(
+    private async Task EvaluateUserAchievementsAsync(
         Guid userId,
         IReadOnlyList<Domain.Entities.Achievement> achievements,
         List<Notification> pendingNotifications,
@@ -127,7 +129,6 @@ internal sealed class AchievementEvaluationJob : IJob
             .GetByUserIdAsync(userId, cancellationToken).ConfigureAwait(false);
 
         var userAchievementMap = userAchievements.ToDictionary(ua => ua.AchievementId);
-        var unlockCount = 0;
 
         foreach (var achievement in achievements)
         {
@@ -150,7 +151,6 @@ internal sealed class AchievementEvaluationJob : IJob
                     _logger.LogInformation(
                         "Achievement unlocked: {Code} for user {UserId} (+{Points} pts)",
                         achievement.Code, userId, achievement.Points);
-                    unlockCount++;
                 }
             }
             else
@@ -166,12 +166,9 @@ internal sealed class AchievementEvaluationJob : IJob
                     _logger.LogInformation(
                         "Achievement unlocked: {Code} for user {UserId} (+{Points} pts)",
                         achievement.Code, userId, achievement.Points);
-                    unlockCount++;
                 }
             }
         }
-
-        return unlockCount;
     }
 
     private static Notification BuildAchievementNotification(

--- a/apps/api/src/Api/BoundedContexts/Gamification/Application/Jobs/AchievementEvaluationJob.cs
+++ b/apps/api/src/Api/BoundedContexts/Gamification/Application/Jobs/AchievementEvaluationJob.cs
@@ -75,17 +75,24 @@ internal sealed class AchievementEvaluationJob : IJob
             _logger.LogInformation("Evaluating {AchievementCount} achievements for {UserCount} users",
                 achievements.Count, userIds.Count);
 
-            var totalUnlocks = 0;
+            // Issue #2392: accumulate unlocks-side notifications outside the loop so
+            // we can commit them via AddBatchAndCommitAsync (POST-save metric + SSE),
+            // separated from the achievement aggregate save below.
+            var pendingNotifications = new List<Notification>();
 
             foreach (var userId in userIds)
             {
-                var unlocks = await EvaluateUserAchievementsAsync(
-                    userId, achievements, context.CancellationToken).ConfigureAwait(false);
-
-                totalUnlocks += unlocks;
+                await EvaluateUserAchievementsAsync(
+                    userId, achievements, pendingNotifications, context.CancellationToken).ConfigureAwait(false);
             }
 
+            // Step 1: commit achievement aggregate state via the unit of work.
             await _unitOfWork.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+
+            // Step 2: commit notifications and fire post-save side-effects.
+            var totalUnlocks = await _notificationRepository
+                .AddBatchAndCommitAsync(pendingNotifications, context.CancellationToken)
+                .ConfigureAwait(false);
 
             // Invalidate cache for affected users
             await _cache.RemoveByTagAsync("achievements", context.CancellationToken).ConfigureAwait(false);
@@ -113,6 +120,7 @@ internal sealed class AchievementEvaluationJob : IJob
     private async Task<int> EvaluateUserAchievementsAsync(
         Guid userId,
         IReadOnlyList<Domain.Entities.Achievement> achievements,
+        List<Notification> pendingNotifications,
         CancellationToken cancellationToken)
     {
         var userAchievements = await _userAchievementRepository
@@ -138,7 +146,10 @@ internal sealed class AchievementEvaluationJob : IJob
 
                 if (newlyUnlocked)
                 {
-                    await SendAchievementNotificationAsync(userId, achievement, cancellationToken).ConfigureAwait(false);
+                    pendingNotifications.Add(BuildAchievementNotification(userId, achievement));
+                    _logger.LogInformation(
+                        "Achievement unlocked: {Code} for user {UserId} (+{Points} pts)",
+                        achievement.Code, userId, achievement.Points);
                     unlockCount++;
                 }
             }
@@ -151,7 +162,10 @@ internal sealed class AchievementEvaluationJob : IJob
 
                 if (newlyUnlocked)
                 {
-                    await SendAchievementNotificationAsync(userId, achievement, cancellationToken).ConfigureAwait(false);
+                    pendingNotifications.Add(BuildAchievementNotification(userId, achievement));
+                    _logger.LogInformation(
+                        "Achievement unlocked: {Code} for user {UserId} (+{Points} pts)",
+                        achievement.Code, userId, achievement.Points);
                     unlockCount++;
                 }
             }
@@ -160,12 +174,11 @@ internal sealed class AchievementEvaluationJob : IJob
         return unlockCount;
     }
 
-    private async Task SendAchievementNotificationAsync(
+    private static Notification BuildAchievementNotification(
         Guid userId,
-        Domain.Entities.Achievement achievement,
-        CancellationToken cancellationToken)
+        Domain.Entities.Achievement achievement)
     {
-        var notification = new Notification(
+        return new Notification(
             id: Guid.NewGuid(),
             userId: userId,
             type: NotificationType.FromString("achievement_unlocked"),
@@ -180,11 +193,5 @@ internal sealed class AchievementEvaluationJob : IJob
                 points = achievement.Points,
                 rarity = achievement.Rarity.ToString()
             }));
-
-        await _notificationRepository.AddAsync(notification, cancellationToken).ConfigureAwait(false);
-
-        _logger.LogInformation(
-            "Achievement unlocked: {Code} for user {UserId} (+{Points} pts)",
-            achievement.Code, userId, achievement.Points);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/CircuitBreakerStateChangedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/CircuitBreakerStateChangedEventHandler.cs
@@ -76,9 +76,12 @@ internal sealed class CircuitBreakerStateChangedEventHandler
                 occurredAt = notification.OccurredAt
             });
 
-            foreach (var adminId in adminIds)
-            {
-                var n = new Notification(
+            // Issue #2392: collect notifications and commit them atomically with
+            // POST-save side-effects, replacing the previous foreach-AddAsync + manual
+            // SaveChangesAsync pair (which broadcast/recorded the metric BEFORE the
+            // rows were durably stored — phantom-broadcast risk if SaveChanges failed).
+            var notifications = adminIds
+                .Select(adminId => new Notification(
                     id: Guid.NewGuid(),
                     userId: adminId,
                     type: NotificationType.AdminSystemHealthAlert,
@@ -86,12 +89,10 @@ internal sealed class CircuitBreakerStateChangedEventHandler
                     title: title,
                     message: notification.Reason,
                     link: "/admin/agents/usage",
-                    metadata: metadata);
+                    metadata: metadata))
+                .ToList();
 
-                await _notificationRepository.AddAsync(n, cancellationToken).ConfigureAwait(false);
-            }
-
-            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _notificationRepository.AddBatchAndCommitAsync(notifications, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "CircuitBreakerStateChangedEvent: notified {Count} admins — {Provider} {Prev}→{New}",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedAutoFallbackHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedAutoFallbackHandler.cs
@@ -129,9 +129,14 @@ internal sealed class ModelDeprecatedAutoFallbackHandler
                     }).ToArray(),
                 });
 
-                foreach (var adminId in adminIds)
-                {
-                    var n = new Notification(
+                // Issue #2392: commit mapping + log changes first, then commit the
+                // notification batch separately so the metric/SSE side-effects fire
+                // AFTER the rows are durably stored (previously AddAsync + manual save
+                // broadcast pre-commit, risking phantom frames on SaveChanges failure).
+                await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                var notifications = adminIds
+                    .Select(adminId => new Notification(
                         id: Guid.NewGuid(),
                         userId: adminId,
                         type: NotificationType.AdminModelStatusChanged,
@@ -139,13 +144,16 @@ internal sealed class ModelDeprecatedAutoFallbackHandler
                         title: title,
                         message: message,
                         link: "/admin/agents/strategy",
-                        metadata: metadata);
+                        metadata: metadata))
+                    .ToList();
 
-                    await _notificationRepository.AddAsync(n, cancellationToken).ConfigureAwait(false);
-                }
+                await _notificationRepository.AddBatchAndCommitAsync(notifications, cancellationToken).ConfigureAwait(false);
             }
-
-            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            else
+            {
+                // No admins to notify, but the mapping + log changes still need to commit.
+                await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             _logger.LogInformation(
                 "ModelDeprecatedAutoFallback: switched {Count} strategies for {ModelId}, notified {AdminCount} admins",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedAutoFallbackHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedAutoFallbackHandler.cs
@@ -129,10 +129,12 @@ internal sealed class ModelDeprecatedAutoFallbackHandler
                     }).ToArray(),
                 });
 
-                // Issue #2392: commit mapping + log changes first, then commit the
-                // notification batch separately so the metric/SSE side-effects fire
-                // AFTER the rows are durably stored (previously AddAsync + manual save
-                // broadcast pre-commit, risking phantom frames on SaveChanges failure).
+                // Issue #2392: belt-and-braces SaveChanges after the per-iteration
+                // LogChangeAsync flushes inside the foreach above (each LogChangeAsync
+                // commits its own row), then commit the notification batch separately
+                // so the metric/SSE side-effects fire AFTER the rows are durably
+                // stored. Previously AddAsync + manual save broadcast pre-commit,
+                // risking phantom frames on SaveChanges failure.
                 await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
                 var notifications = adminIds

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedNotificationHandler.cs
@@ -76,9 +76,11 @@ internal sealed class ModelDeprecatedNotificationHandler
                 detectedAt = notification.DetectedAt,
             });
 
-            foreach (var adminId in adminIds)
-            {
-                var n = new Notification(
+            // Issue #2392: collect notifications + AddBatchAndCommitAsync ensures
+            // POST-save metric + SSE broadcast discipline (was AddAsync + manual save
+            // → phantom broadcast risk if SaveChanges failed after fan-out).
+            var notifications = adminIds
+                .Select(adminId => new Notification(
                     id: Guid.NewGuid(),
                     userId: adminId,
                     type: NotificationType.AdminModelStatusChanged,
@@ -86,12 +88,10 @@ internal sealed class ModelDeprecatedNotificationHandler
                     title: title,
                     message: message,
                     link: "/admin/agents/usage",
-                    metadata: metadata);
+                    metadata: metadata))
+                .ToList();
 
-                await _notificationRepository.AddAsync(n, cancellationToken).ConfigureAwait(false);
-            }
-
-            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _notificationRepository.AddBatchAndCommitAsync(notifications, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "ModelDeprecatedEvent: notified {Count} admins — {ModelId} affects [{Strategies}], replacement: {Replacement}",

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/SendLoanReminderCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/SendLoanReminderCommandHandler.cs
@@ -6,7 +6,6 @@ using Api.BoundedContexts.UserNotifications.Domain.Repositories;
 using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
-using Api.SharedKernel.Infrastructure.Persistence;
 
 namespace Api.BoundedContexts.UserLibrary.Application.Commands;
 
@@ -18,18 +17,15 @@ internal class SendLoanReminderCommandHandler : ICommandHandler<SendLoanReminder
 {
     private readonly IUserLibraryRepository _libraryRepository;
     private readonly INotificationRepository _notificationRepository;
-    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<SendLoanReminderCommandHandler> _logger;
 
     public SendLoanReminderCommandHandler(
         IUserLibraryRepository libraryRepository,
         INotificationRepository notificationRepository,
-        IUnitOfWork unitOfWork,
         ILogger<SendLoanReminderCommandHandler> logger)
     {
         _libraryRepository = libraryRepository ?? throw new ArgumentNullException(nameof(libraryRepository));
         _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
-        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -82,8 +78,10 @@ internal class SendLoanReminderCommandHandler : ICommandHandler<SendLoanReminder
             metadata: $"{{\"gameId\":\"{command.GameId}\",\"type\":\"loan-reminder\"}}"
         );
 
-        await _notificationRepository.AddAsync(notification, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        // Issue #2392: AddAndCommitAsync commits + fires post-save side-effects in
+        // one step, replacing the previous AddAsync + external SaveChangesAsync pair
+        // (which broadcast/recorded the metric BEFORE the row was durably stored).
+        await _notificationRepository.AddAndCommitAsync(notification, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation("Sent loan reminder for game {GameId} to user {UserId}",
             command.GameId, command.UserId);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/CreateN8nNotificationCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/CreateN8nNotificationCommand.cs
@@ -48,7 +48,11 @@ internal sealed class CreateN8nNotificationCommandHandler : ICommandHandler<Crea
             link: request.Link
         );
 
-        await _notificationRepository.AddAsync(notification, cancellationToken).ConfigureAwait(false);
+        // Issue #2392: AddAndCommitAsync commits the row first, then publishes the
+        // metric + SSE broadcast — the previous AddAsync path fired side-effects
+        // pre-save, risking a phantom broadcast if the n8n webhook caller's outer
+        // pipeline rolled back the transaction.
+        await _notificationRepository.AddAndCommitAsync(notification, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "n8n webhook: notification created for user {UserId}, type={Type}",

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
@@ -58,4 +58,20 @@ internal interface INotificationRepository : IRepository<Notification, Guid>
     /// (dedup-by-race — the in-app row exists, just under the other caller).
     /// </returns>
     Task<bool> AddAndCommitAsync(Notification notification, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Batch add-and-commit for fan-out notification callers (admin alerts,
+    /// achievement unlocks, scheduled jobs that emit one row per user). Issue
+    /// #2392 (phantom-broadcast follow-up): tracks every <paramref name="notifications"/>
+    /// row, calls a single <c>SaveChangesAsync</c>, then fires side-effects
+    /// (metric + SSE broadcast) AFTER the durable commit. Replaces the
+    /// <c>foreach { AddAsync } + SaveChanges</c> pattern in 6 loop callers.
+    /// </summary>
+    /// <remarks>
+    /// No 23505 race-window catch — batch callers don't set
+    /// <c>SourceEventId</c>, so the partial UNIQUE index doesn't apply.
+    /// Any <c>DbUpdateException</c> rolls back the entire batch.
+    /// </remarks>
+    /// <returns>Number of rows persisted (0 when input is empty).</returns>
+    Task<int> AddBatchAndCommitAsync(IEnumerable<Notification> notifications, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationRepository.cs
@@ -68,9 +68,18 @@ internal interface INotificationRepository : IRepository<Notification, Guid>
     /// <c>foreach { AddAsync } + SaveChanges</c> pattern in 6 loop callers.
     /// </summary>
     /// <remarks>
-    /// No 23505 race-window catch — batch callers don't set
-    /// <c>SourceEventId</c>, so the partial UNIQUE index doesn't apply.
-    /// Any <c>DbUpdateException</c> rolls back the entire batch.
+    /// <para><b>Caller preconditions</b>:</para>
+    /// <list type="bullet">
+    ///   <item>Notifications MUST NOT set <c>SourceEventId</c>. The partial
+    ///   UNIQUE index <c>UX_notifications_user_source_event_id</c> only
+    ///   applies to non-null source event ids; one duplicate would roll back
+    ///   the ENTIRE batch with no graceful dedup. Use <see cref="AddAndCommitAsync"/>
+    ///   for dedup-guarded inserts.</item>
+    ///   <item>Notification ids MUST be unique within the batch (callers use
+    ///   <c>Guid.NewGuid()</c> per row). A duplicate id throws
+    ///   <c>InvalidOperationException</c> from the EF change tracker.</item>
+    /// </list>
+    /// <para>Any <c>DbUpdateException</c> rolls back the entire batch.</para>
     /// </remarks>
     /// <returns>Number of rows persisted (0 when input is empty).</returns>
     Task<int> AddBatchAndCommitAsync(IEnumerable<Notification> notifications, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
@@ -105,15 +105,55 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
         // Fires before UnitOfWork.SaveChangesAsync — matches metric recording pattern.
         //
         // Phantom-broadcast risk (acknowledged): if the caller's external
-        // SaveChangesAsync subsequently throws (e.g. FK violation on a sibling
-        // entity, deadlock, late constraint check), the metric is already
-        // counted and the SSE frame has already shipped for a notification
-        // that was never durably stored. Affects the 12 non-dispatcher callers
-        // (Hangfire jobs + command handlers + non-dispatcher event handlers).
-        // The dispatcher path (#2383) routes through AddAndCommitAsync below,
-        // which emits these side-effects only after a successful save. A
-        // follow-up will migrate the remaining callers; see #2383 umbrella.
+        // SaveChangesAsync subsequently throws (FK violation on a sibling entity,
+        // deadlock, late constraint check), the metric is already counted and
+        // the SSE frame has already shipped for a notification that was never
+        // durably stored. Issue #2392 migrated 9 of 10 callers to
+        // <see cref="AddAndCommitAsync"/> (single-row) / <see cref="AddBatchAndCommitAsync"/>
+        // (fan-out batch). The one remaining call site —
+        // <c>SlackNotificationProcessorJob.HandleTokenRevocationAsync</c> — keeps
+        // <c>AddAsync</c> on purpose: its outer save deactivates the Slack
+        // connection AND inserts the notification atomically, and splitting
+        // them would create a worse failure mode (deactivated connection with
+        // no user notification) than the residual phantom risk. New callers
+        // SHOULD prefer the AddAndCommit variants.
         _broadcaster.Publish(notification.UserId, MapToDto(notification));
+    }
+
+    /// <inheritdoc />
+    public async Task<int> AddBatchAndCommitAsync(IEnumerable<Notification> notifications, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notifications);
+
+        var list = notifications.ToList();
+        if (list.Count == 0)
+        {
+            return 0;
+        }
+
+        foreach (var n in list)
+        {
+            CollectDomainEvents(n);
+            var entity = MapToPersistence(n);
+            await DbContext.Set<NotificationEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Single SaveChangesAsync for the whole batch — preserves atomicity
+        // (all rows persist together or none do via Postgres transaction).
+        // Any DbUpdateException bubbles up unchanged; side-effects below
+        // are skipped, so no phantom broadcast / metric fires.
+        await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // POST-save side-effects (issue #2392): once persisted, fire the
+        // metric counter and SSE frame for each row. Iteration order matches
+        // the input list so callers can reason about per-row notification.
+        foreach (var n in list)
+        {
+            MeepleAiMetrics.RecordNotificationCreated(n.Type.Value, n.Severity.Value);
+            _broadcaster.Publish(n.UserId, MapToDto(n));
+        }
+
+        return list.Count;
     }
 
     /// <inheritdoc />

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/CooldownEndReminderJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/CooldownEndReminderJob.cs
@@ -4,8 +4,6 @@ using Api.BoundedContexts.SystemConfiguration.Domain.Services;
 using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
 using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
-using Api.Infrastructure;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Quartz;
 
@@ -21,7 +19,6 @@ internal sealed class CooldownEndReminderJob : IJob
     private readonly IShareRequestRepository _shareRequestRepository;
     private readonly IRateLimitEvaluator _rateLimitEvaluator;
     private readonly INotificationRepository _notificationRepository;
-    private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<CooldownEndReminderJob> _logger;
 
     // Look ahead window - notify users whose cooldown ends within this timeframe
@@ -31,13 +28,11 @@ internal sealed class CooldownEndReminderJob : IJob
         IShareRequestRepository shareRequestRepository,
         IRateLimitEvaluator rateLimitEvaluator,
         INotificationRepository notificationRepository,
-        MeepleAiDbContext dbContext,
         ILogger<CooldownEndReminderJob> logger)
     {
         _shareRequestRepository = shareRequestRepository ?? throw new ArgumentNullException(nameof(shareRequestRepository));
         _rateLimitEvaluator = rateLimitEvaluator ?? throw new ArgumentNullException(nameof(rateLimitEvaluator));
         _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
-        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -68,7 +63,9 @@ internal sealed class CooldownEndReminderJob : IJob
                 })
                 .ToList();
 
-            var remindersCreated = 0;
+            // Issue #2392: collect reminders then commit as one batch with POST-save
+            // side-effects, replacing the previous foreach-AddAsync + conditional save.
+            var pendingReminders = new List<Notification>();
 
             foreach (var userInfo in usersWithRecentRejections)
             {
@@ -85,8 +82,7 @@ internal sealed class CooldownEndReminderJob : IJob
                 // Check if cooldown ends within the look-ahead window
                 if (status.CooldownEndsAt.Value > now && status.CooldownEndsAt.Value <= windowEnd)
                 {
-                    // Cooldown is about to end - create reminder notification
-                    var notification = new Notification(
+                    pendingReminders.Add(new Notification(
                         id: Guid.NewGuid(),
                         userId: userInfo.UserId,
                         type: NotificationType.CooldownEnded,
@@ -100,24 +96,18 @@ internal sealed class CooldownEndReminderJob : IJob
                             remainingMonthly = status.RemainingMonthlyRequests,
                             remainingPending = status.RemainingPendingRequests,
                             tier = status.Tier.ToString()
-                        }));
-
-                    await _notificationRepository.AddAsync(notification, cancellationToken)
-                        .ConfigureAwait(false);
-
-                    remindersCreated++;
+                        })));
 
                     _logger.LogInformation(
-                        "Created cooldown end reminder for user {UserId}. Cooldown ends at {CooldownEndsAt}",
+                        "Queued cooldown end reminder for user {UserId}. Cooldown ends at {CooldownEndsAt}",
                         userInfo.UserId,
                         status.CooldownEndsAt.Value);
                 }
             }
 
-            if (remindersCreated > 0)
-            {
-                await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            }
+            var remindersCreated = await _notificationRepository
+                .AddBatchAndCommitAsync(pendingReminders, cancellationToken)
+                .ConfigureAwait(false);
 
             _logger.LogInformation(
                 "CooldownEndReminderJob completed. Created {Count} reminders",

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/SlackNotificationProcessorJob.cs
@@ -356,7 +356,15 @@ internal sealed class SlackNotificationProcessorJob : IJob
                         connection.Id, item.RecipientUserId);
                 }
 
-                // Create in-app notification about the disconnection
+                // Create in-app notification about the disconnection.
+                //
+                // Issue #2392 KEEP rationale: this path intentionally keeps the
+                // legacy AddAsync + manual SaveChanges pattern because the outer
+                // SaveChanges (line below) atomically commits BOTH the Slack
+                // connection deactivation AND the in-app notification. Splitting
+                // them via AddAndCommitAsync would risk a worse failure mode
+                // (connection deactivated, user never notified) than the residual
+                // phantom-broadcast risk we accept here.
                 var notification = new Notification(
                     id: Guid.NewGuid(),
                     userId: item.RecipientUserId.Value,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/StaleShareRequestWarningJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/StaleShareRequestWarningJob.cs
@@ -85,10 +85,11 @@ internal sealed class StaleShareRequestWarningJob : IJob
             var oldestDays = staleRequests
                 .Max(r => (DateTime.UtcNow - r.CreatedAt).Days);
 
-            // Create high-priority notification for each admin
-            foreach (var adminId in admins)
-            {
-                var warning = new Notification(
+            // Issue #2392: batch-commit admin notifications so the metric + SSE
+            // broadcast fire AFTER the rows are durably persisted (previously
+            // foreach-AddAsync + manual SaveChanges → phantom broadcast risk).
+            var notifications = admins
+                .Select(adminId => new Notification(
                     id: Guid.NewGuid(),
                     userId: adminId,
                     type: NotificationType.AdminStaleShareRequests,
@@ -101,12 +102,12 @@ internal sealed class StaleShareRequestWarningJob : IJob
                         staleCount = staleRequests.Count,
                         oldestDays,
                         thresholdDays = staleDays
-                    }));
+                    })))
+                .ToList();
 
-                await _notificationRepository.AddAsync(warning, context.CancellationToken).ConfigureAwait(false);
-            }
-
-            await _dbContext.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+            await _notificationRepository
+                .AddBatchAndCommitAsync(notifications, context.CancellationToken)
+                .ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Stale share request warning job completed: StaleCount={StaleCount}, OldestDays={OldestDays}, AdminsNotified={AdminCount}",

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/CircuitBreakerStateChangedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/CircuitBreakerStateChangedEventHandlerTests.cs
@@ -44,8 +44,8 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
         _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
         _notificationRepoMock = new Mock<INotificationRepository>();
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
 
         _handler = new CircuitBreakerStateChangedEventHandler(
             _notificationRepoMock.Object,
@@ -88,7 +88,7 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
 
         // Assert
         _notificationRepoMock.Verify(
-            r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -101,18 +101,19 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
         await SeedAdminAsync();
         var evt = MakeEvent(newState);
 
-        Notification? captured = null;
+        List<Notification>? captured = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => captured = n)
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => captured = ns.ToList())
+            .ReturnsAsync(1);
 
         await _handler.Handle(evt, CancellationToken.None);
 
         captured.Should().NotBeNull();
-        captured!.Severity.Should().Be(expectedSeverity);
-        captured.Type.Should().Be(NotificationType.AdminSystemHealthAlert);
-        captured.Link.Should().Be("/admin/agents/usage");
+        captured!.Should().ContainSingle();
+        captured[0].Severity.Should().Be(expectedSeverity);
+        captured[0].Type.Should().Be(NotificationType.AdminSystemHealthAlert);
+        captured[0].Link.Should().Be("/admin/agents/usage");
     }
 
     [Fact]
@@ -136,18 +137,19 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
         await SeedAdminAsync();
         var evt = MakeEvent(CircuitState.Open, provider: "openrouter");
 
-        Notification? captured = null;
+        List<Notification>? captured = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => captured = n)
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => captured = ns.ToList())
+            .ReturnsAsync(1);
 
         // Act
         await _handler.Handle(evt, CancellationToken.None);
 
         // Assert
-        captured!.Title.Should().Contain("OPENED");
-        captured.Title.Should().Contain("openrouter");
+        captured!.Should().ContainSingle();
+        captured[0].Title.Should().Contain("OPENED");
+        captured[0].Title.Should().Contain("openrouter");
     }
 
     [Fact]
@@ -157,18 +159,19 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
         await SeedAdminAsync();
         var evt = MakeEvent(CircuitState.Closed, provider: "ollama");
 
-        Notification? captured = null;
+        List<Notification>? captured = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => captured = n)
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => captured = ns.ToList())
+            .ReturnsAsync(1);
 
         // Act
         await _handler.Handle(evt, CancellationToken.None);
 
         // Assert
-        captured!.Title.Should().ContainEquivalentOf("recovered");
-        captured.Title.Should().Contain("ollama");
+        captured!.Should().ContainSingle();
+        captured[0].Title.Should().ContainEquivalentOf("recovered");
+        captured[0].Title.Should().Contain("ollama");
     }
 
     // ── Message equals reason ─────────────────────────────────────────────────
@@ -181,17 +184,18 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
         const string reason = "Provider returned 503 three consecutive times";
         var evt = MakeEvent(CircuitState.Open, reason: reason);
 
-        Notification? captured = null;
+        List<Notification>? captured = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => captured = n)
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => captured = ns.ToList())
+            .ReturnsAsync(1);
 
         // Act
         await _handler.Handle(evt, CancellationToken.None);
 
         // Assert
-        captured!.Message.Should().Be(reason);
+        captured!.Should().ContainSingle();
+        captured[0].Message.Should().Be(reason);
     }
 
     // ── Multiple admins ────────────────────────────────────────────────────────
@@ -206,13 +210,17 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
 
         var evt = MakeEvent(CircuitState.Open);
 
+        List<Notification>? captured = null;
+        _notificationRepoMock
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => captured = ns.ToList())
+            .ReturnsAsync(2);
+
         // Act
         await _handler.Handle(evt, CancellationToken.None);
 
         // Assert
-        _notificationRepoMock.Verify(
-            r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
-            Times.Exactly(2));
+        captured!.Should().HaveCount(2);
     }
 
     [Fact]
@@ -225,11 +233,11 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
 
         var evt = MakeEvent(CircuitState.Open);
 
-        var capturedUserIds = new List<Guid>();
+        List<Guid>? capturedUserIds = null;
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => capturedUserIds.Add(n.UserId))
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => capturedUserIds = ns.Select(n => n.UserId).ToList())
+            .ReturnsAsync(2);
 
         // Act
         await _handler.Handle(evt, CancellationToken.None);
@@ -247,7 +255,7 @@ public sealed class CircuitBreakerStateChangedEventHandlerTests : IDisposable
         // Arrange
         await SeedAdminAsync();
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("DB failure"));
 
         var evt = MakeEvent(CircuitState.Open);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedAutoFallbackHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedAutoFallbackHandlerTests.cs
@@ -47,9 +47,9 @@ public sealed class ModelDeprecatedAutoFallbackHandlerTests : IDisposable
         _notificationRepoMock = new Mock<INotificationRepository>();
 
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => _capturedNotifications.Add(n))
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => _capturedNotifications.AddRange(ns))
+            .ReturnsAsync((IEnumerable<Notification> ns, CancellationToken _) => ns.Count());
 
         _handler = new ModelDeprecatedAutoFallbackHandler(
             _dbContext,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedNotificationHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/ModelDeprecatedNotificationHandlerTests.cs
@@ -44,9 +44,9 @@ public sealed class ModelDeprecatedNotificationHandlerTests : IDisposable
             new DomainEventCollector());
 
         _notificationRepoMock
-            .Setup(r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
-            .Callback<Notification, CancellationToken>((n, _) => _capturedNotifications.Add(n))
-            .Returns(Task.CompletedTask);
+            .Setup(r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Notification>, CancellationToken>((ns, _) => _capturedNotifications.AddRange(ns))
+            .ReturnsAsync((IEnumerable<Notification> ns, CancellationToken _) => ns.Count());
 
         _handler = new ModelDeprecatedNotificationHandler(
             _notificationRepoMock.Object,
@@ -192,7 +192,7 @@ public sealed class ModelDeprecatedNotificationHandlerTests : IDisposable
 
         // Assert
         _notificationRepoMock.Verify(
-            r => r.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            r => r.AddBatchAndCommitAsync(It.IsAny<IEnumerable<Notification>>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationRepositoryAddAndCommitIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationRepositoryAddAndCommitIntegrationTests.cs
@@ -175,6 +175,71 @@ public sealed class NotificationRepositoryAddAndCommitIntegrationTests : IAsyncL
             "the UNIQUE index has 'WHERE source_event_id IS NOT NULL', so null-id rows are unconstrained");
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // AddBatchAndCommitAsync — issue #2392 (phantom-broadcast follow-up)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddBatchAndCommitAsync_PersistsAllRowsAndPublishesPostSave()
+    {
+        // Arrange — three notifications (different users, no source event id)
+        // mirror the loop callers (admin fan-out, achievement evaluation, etc.)
+        // that previously used `AddAsync` + external `SaveChangesAsync`.
+        var broadcasterMock = new Mock<IUserNotificationBroadcaster>();
+        var repo = BuildRepositoryWithBroadcaster(broadcasterMock.Object);
+
+        var batch = new[]
+        {
+            BuildNotification(Guid.NewGuid(), sourceEventId: null),
+            BuildNotification(Guid.NewGuid(), sourceEventId: null),
+            BuildNotification(Guid.NewGuid(), sourceEventId: null),
+        };
+
+        // Act
+        var persisted = await repo.AddBatchAndCommitAsync(batch, TestCancellationToken);
+
+        // Assert — all rows persisted, broadcaster invoked exactly once per row
+        persisted.Should().Be(3);
+
+        var rowsCommitted = await _dbContext!.Set<NotificationEntity>()
+            .AsNoTracking()
+            .CountAsync(TestCancellationToken);
+        rowsCommitted.Should().Be(3);
+
+        broadcasterMock.Verify(
+            b => b.Publish(It.IsAny<Guid>(), It.IsAny<Api.BoundedContexts.UserNotifications.Application.DTOs.NotificationDto>()),
+            Times.Exactly(3),
+            "POST-save side-effects must fire once per persisted row");
+    }
+
+    [Fact]
+    public async Task AddBatchAndCommitAsync_EmptyEnumerable_IsNoOp()
+    {
+        var broadcasterMock = new Mock<IUserNotificationBroadcaster>();
+        var repo = BuildRepositoryWithBroadcaster(broadcasterMock.Object);
+
+        var persisted = await repo.AddBatchAndCommitAsync(Array.Empty<Notification>(), TestCancellationToken);
+
+        persisted.Should().Be(0);
+        broadcasterMock.Verify(
+            b => b.Publish(It.IsAny<Guid>(), It.IsAny<Api.BoundedContexts.UserNotifications.Application.DTOs.NotificationDto>()),
+            Times.Never,
+            "empty batch must not invoke side-effects");
+    }
+
+    private INotificationRepository BuildRepositoryWithBroadcaster(IUserNotificationBroadcaster broadcaster)
+    {
+        // Override the default no-op broadcaster registration with a caller-supplied
+        // Mock so per-test assertions on Publish() are possible.
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        services.AddScoped(_ => broadcaster);
+        services.AddScoped<INotificationRepository, NotificationRepository>();
+
+        var sp = services.BuildServiceProvider();
+        _dbContext = sp.GetRequiredService<MeepleAiDbContext>();
+        return sp.GetRequiredService<INotificationRepository>();
+    }
+
     private static Notification BuildNotification(Guid userId, Guid? sourceEventId)
     {
         return new Notification(


### PR DESCRIPTION
## Summary

Eliminates phantom-broadcast risk for 9 of the 10 \`AddAsync\` callers flagged by code-review of PR #2391 (umbrella #2383).

### What changed

- **NEW** \`INotificationRepository.AddBatchAndCommitAsync(IEnumerable<Notification>, CT)\`: single SaveChanges for the whole batch then fires metric + broadcast.Publish POST-save. Mirrors \`AddAndCommitAsync\` contract for fan-out callers. No 23505 catch (batch callers don't set SourceEventId).
- **MIGRATE** 3 single-row callers → \`AddAndCommitAsync\`
- **REFACTOR LOOP** 6 fan-out callers → \`AddBatchAndCommitAsync\` (collect-then-batch pattern)
- **KEEP** 1 caller documented (\`SlackNotificationProcessorJob\`): atomicity with Slack-connection deactivation is more important than the residual phantom risk.

### Caller-by-caller

| # | File | Decision | Why |
|---|------|----------|-----|
| 1 | AchievementEvaluationJob | LOOP refactor | Collect into pending list, save achievements via UoW, then AddBatchAndCommit |
| 2 | GameSessionTerminatedEventHandler | MIGRATE | MediatR handler post-commit per MeepleAiDbContext.SaveChangesAsyncCore step 5 |
| 3 | CircuitBreakerStateChangedEventHandler | LOOP refactor | Admin fan-out |
| 4 | ModelDeprecatedAutoFallbackHandler | LOOP refactor | Save mapping changes first, then batch |
| 5 | ModelDeprecatedNotificationHandler | LOOP refactor | Admin fan-out |
| 6 | SendLoanReminderCommandHandler | MIGRATE | Single notification + drops \`_unitOfWork\` injection |
| 7 | CreateN8nNotificationCommandHandler | MIGRATE | n8n webhook callback |
| 8 | CooldownEndReminderJob | LOOP refactor | Drops unused \`_dbContext\` |
| 9 | SlackNotificationProcessorJob | **KEEP** | Atomic batch with Slack connection deactivation |
| 10 | StaleShareRequestWarningJob | LOOP refactor | Admin fan-out |

### Test plan

- [x] \`dotnet build src/Api/Api.csproj\` → 0 warning, 0 error
- [x] Unit tests across 5 impacted BCs → **4325/4325 verde** (UserNotifications + Gamification + KnowledgeBase + UserLibrary + GameManagement)
- [x] 2 new integration tests in \`NotificationRepositoryAddAndCommitIntegrationTests\` (batch happy-path + empty no-op)
- [ ] CI integration tests (local Testcontainers Postgres didn't init — affects every Integration suite uniformly, not specific to this diff)
- [ ] CI green
- [ ] Code-review subagent ≤2 nuovi finding

### Repository \`AddAsync\` xmldoc updated

The explanatory comment block now documents: 9 migrated + 1 intentional KEEP. New callers SHOULD prefer the AddAndCommit variants.

## Refs

- Closes #2392
- Umbrella: #2383
- Source PR: #2391 (race-window swallow in dispatcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)