### PR TITLE
feat(session-live): #2375 G3 ChatAgent always-visible accordion + smart scroll

### DIFF
--- a/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
+++ b/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * #2375 G3 — axe AA test for ChatAgentPanel + LiveAgentChat (expanded + collapsed).
+ *
+ * Renders the panel in isolation with IntlProvider and IntersectionObserver
+ * mock, then runs axe-core on both states.
+ *
+ * Spec: docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §7.4
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { IntlProvider } from 'react-intl';
+
+import { ChatAgentPanel } from '@/components/features/session-live/ChatAgentPanel';
+
+// toHaveNoViolations is extended globally in vitest.setup.tsx
+
+const messages = {
+  'pages.sessionLive.chat.newMessagesToast':
+    '{count, plural, one {# new message} other {# new messages}}',
+};
+
+const labels = {
+  title: 'ChatAgent',
+  agentNameAriaLabel: 'Agent name MeepleAI',
+  onlineLabel: 'Online',
+  latencyAriaLabel: 'Latency 42ms',
+  chatPanelLabels: {
+    title: 'Chat',
+    inputAriaLabel: 'Write a message',
+    sendAriaLabel: 'Send message',
+    visibilityPrivate: 'Private',
+    visibilityShared: 'Shared',
+    emptyMessage: 'No messages yet.',
+    newMessagesToastAriaLabel: 'New messages — click to scroll',
+  },
+};
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(function (this: unknown, cb: IntersectionObserverCallback) {
+      return {
+        callback: cb,
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      } as unknown as IntersectionObserver;
+    })
+  );
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderPanel(collapsed: boolean) {
+  return render(
+    <IntlProvider locale="en" messages={messages}>
+      <ChatAgentPanel
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        agentName="MeepleAI"
+        agentEmoji="🤖"
+        latencyMs={42}
+        collapsed={collapsed}
+        onHeaderClick={() => {}}
+        labels={labels}
+      />
+    </IntlProvider>
+  );
+}
+
+describe('#2375 G3 — ChatAgentPanel axe AA', () => {
+  it('expanded state: 0 violations', async () => {
+    const { container } = renderPanel(false);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('collapsed state: 0 violations', async () => {
+    const { container } = renderPanel(true);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('aria-expanded reflects !collapsed on header button when expanded', () => {
+    const { container } = renderPanel(false);
+    const button = container.querySelector('button[aria-expanded]');
+    expect(button?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('aria-expanded reflects !collapsed on header button when collapsed', () => {
+    const { container } = renderPanel(true);
+    const button = container.querySelector('button[aria-expanded]');
+    expect(button?.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/apps/web/e2e/session-live-chat-agent-g3.spec.ts
+++ b/apps/web/e2e/session-live-chat-agent-g3.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * E2E — #2375 G3 ChatAgent always-visible accordion FSM.
+ *
+ * Covers 8 scenarios from spec §7.3:
+ *   1. Default render: ChatAgent expanded (no ?chat param)
+ *   2. Click header → ?chat=collapsed URL written + body hidden
+ *   3. Reload preserves collapsed state (URL is SSOT)
+ *   4. Click again removes ?chat param (toggle back to expanded)
+ *   5. Draft persists across reload (sessionStorage-backed)
+ *   6. Send clears draft + input, draft absent after reload
+ *   7. data-at-bottom attribute reflects scroll anchor state
+ *   8. axe AA — 0 violations on expanded + collapsed states
+ *
+ * Uses the visual-test fixture (?fixture=host) so SSE is mocked and
+ * the page renders deterministically without a running backend.
+ * The fixture activates only when STATE_OVERRIDE_ENABLED=true
+ * (NODE_ENV !== 'production'), which is always the case in E2E dev mode.
+ *
+ * Auth bypass: triple helper (seedAuthSession + seedCookieConsent +
+ * mockAuthEndpoints) required for `(authenticated)` routes
+ * (Wave B.1 lesson #633 — mirrors session-live-mobile.spec.ts pattern).
+ */
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+import { mockAuthEndpoints, seedAuthSession } from './_helpers/seedAuthSession';
+import { seedCookieConsent } from './_helpers/seedCookieConsent';
+
+// SessionLiveView hardcodes data-theme="dark" on its root div.
+// next-themes also applies .dark class from colorScheme preference.
+test.use({ colorScheme: 'dark' });
+
+/** Sentinel UUID matching VISUAL_TEST_FIXTURE_SESSION.id. */
+const FIXTURE_SESSION_ID = '00000000-0000-4000-8000-000000000d20';
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedAuth(page: Page): Promise<void> {
+  await seedAuthSession(page);
+  await seedCookieConsent(page);
+  await mockAuthEndpoints(page);
+}
+
+/**
+ * Navigate to the session-live page with the host fixture active.
+ * `search` is appended verbatim after `?fixture=host` (use `&foo=bar`).
+ *
+ * Waits for `data-ui-state="default"` — the fixture-loaded state.
+ * Without this, the page may be stuck in `loading` waiting for
+ * the backend (which is not running during E2E tests).
+ * Mirrors the `?fixture=host` pattern in `a11y/session-live.spec.ts:438`.
+ */
+async function gotoSessionLive(page: Page, search = ''): Promise<void> {
+  await seedAuth(page);
+  await page.goto(`/sessions/${FIXTURE_SESSION_ID}/live?fixture=host${search}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  // Wait for the fixture to load and render the default shell.
+  // data-ui-state="default" is set by SessionLiveView when the fixture
+  // resolves — equivalent to the session being live and renderable.
+  await page.waitForSelector('[data-slot="session-live-view"][data-ui-state="default"]', {
+    timeout: 30_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('#2375 G3 ChatAgent accordion + draft + smart scroll', () => {
+  // ── 1. Default render ─────────────────────────────────────────────────────
+
+  test('1. default render: ChatAgentPanel expanded (no ?chat param)', async ({ page }) => {
+    await gotoSessionLive(page);
+
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await expect(panel).toBeVisible();
+
+    // data-collapsed must be absent (not set to 'true') when expanded.
+    await expect(panel).not.toHaveAttribute('data-collapsed', 'true');
+
+    // Body (LiveAgentChat) is mounted when expanded.
+    await expect(panel.locator('[data-slot="live-agent-chat"]')).toBeVisible();
+  });
+
+  // ── 2. Click header → collapsed URL + body hidden ─────────────────────────
+
+  test('2. click header → URL becomes ?chat=collapsed, body hidden', async ({ page }) => {
+    await gotoSessionLive(page);
+
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+
+    // Header is a <button> when onHeaderClick is wired (§5 contract).
+    const header = panel.locator('button[aria-expanded]').first();
+    await header.click();
+
+    // URL must contain ?chat=collapsed (router.replace via handleChatCollapsedChange).
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toMatch(/[?&]chat=collapsed/);
+
+    // data-collapsed="true" set on section root.
+    await expect(panel).toHaveAttribute('data-collapsed', 'true');
+
+    // Body unmounts when collapsed=true (§5: no hidden focus traps).
+    await expect(panel.locator('[data-slot="live-agent-chat"]')).toHaveCount(0);
+  });
+
+  // ── 3. Reload preserves collapsed state ───────────────────────────────────
+
+  test('3. reload preserves collapsed state (URL is SSOT)', async ({ page }) => {
+    await gotoSessionLive(page, '&chat=collapsed');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-slot="session-live-view"][data-ui-state="default"]', {
+      timeout: 30_000,
+    });
+
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await expect(panel).toHaveAttribute('data-collapsed', 'true');
+    await expect(panel.locator('[data-slot="live-agent-chat"]')).toHaveCount(0);
+  });
+
+  // ── 4. Click again removes ?chat param ────────────────────────────────────
+
+  test('4. click again removes ?chat=collapsed param (toggle back)', async ({ page }) => {
+    await gotoSessionLive(page, '&chat=collapsed');
+
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await expect(panel).toHaveAttribute('data-collapsed', 'true');
+
+    const header = panel.locator('button[aria-expanded]').first();
+    await header.click();
+
+    // ?chat=collapsed must be removed from URL.
+    await expect.poll(() => page.url(), { timeout: 5_000 }).not.toMatch(/[?&]chat=collapsed/);
+
+    await expect(panel).not.toHaveAttribute('data-collapsed', 'true');
+    await expect(panel.locator('[data-slot="live-agent-chat"]')).toBeVisible();
+  });
+
+  // ── 5. Draft persists across reload (sessionStorage) ─────────────────────
+
+  test('5. draft persists across reload (sessionStorage)', async ({ page }) => {
+    await gotoSessionLive(page);
+
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await page.waitForSelector('[data-slot="chat-agent-panel"] [data-slot="live-agent-chat"]', {
+      timeout: 15_000,
+    });
+
+    const input = panel.locator('input[type="text"]').first();
+    await input.fill('borrador');
+
+    // Wait for sessionStorage write (useChatDraft: onChange debounced).
+    await expect(input).toHaveValue('borrador');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-slot="session-live-view"][data-ui-state="default"]', {
+      timeout: 30_000,
+    });
+    await page.waitForSelector('[data-slot="chat-agent-panel"] [data-slot="live-agent-chat"]', {
+      timeout: 15_000,
+    });
+
+    const inputAfter = page
+      .locator('[data-slot="chat-agent-panel"]')
+      .first()
+      .locator('input[type="text"]')
+      .first();
+    await expect(inputAfter).toHaveValue('borrador');
+  });
+
+  // ── 6. Send clears draft + input ──────────────────────────────────────────
+
+  test('6. send clears draft + input; draft absent after reload', async ({ page }) => {
+    await gotoSessionLive(page);
+
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await page.waitForSelector('[data-slot="chat-agent-panel"] [data-slot="live-agent-chat"]', {
+      timeout: 15_000,
+    });
+
+    const input = panel.locator('input[type="text"]').first();
+    await input.fill('hello');
+    await expect(input).toHaveValue('hello');
+
+    // Submit via button[type="submit"] inside the form.
+    const sendBtn = panel.locator('button[type="submit"]').first();
+    await sendBtn.click();
+
+    // Input cleared immediately after send.
+    await expect(input).toHaveValue('');
+
+    // After reload, sessionStorage draft also cleared (clearDraft called).
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-slot="session-live-view"][data-ui-state="default"]', {
+      timeout: 30_000,
+    });
+    await page.waitForSelector('[data-slot="chat-agent-panel"] [data-slot="live-agent-chat"]', {
+      timeout: 15_000,
+    });
+
+    const inputAfter = page
+      .locator('[data-slot="chat-agent-panel"]')
+      .first()
+      .locator('input[type="text"]')
+      .first();
+    await expect(inputAfter).toHaveValue('');
+  });
+
+  // ── 7. data-at-bottom reflects scroll anchor ──────────────────────────────
+
+  test('7. data-at-bottom="true" on initial mount (no overflow)', async ({ page }) => {
+    await gotoSessionLive(page);
+
+    await page.waitForSelector('[data-slot="chat-agent-panel"] [data-slot="live-agent-chat"]', {
+      timeout: 15_000,
+    });
+
+    const chat = page
+      .locator('[data-slot="chat-agent-panel"]')
+      .first()
+      .locator('[data-slot="live-agent-chat"]')
+      .first();
+
+    // On initial mount with fixture messages, scroll anchor is at bottom.
+    await expect(chat).toHaveAttribute('data-at-bottom', 'true');
+  });
+
+  // ── 8. axe AA — expanded + collapsed states ───────────────────────────────
+
+  test('8. axe AA — 0 WCAG 2.1 AA violations on expanded + collapsed states', async ({ page }) => {
+    // Disable animations so axe sees stable final colours
+    // (mirrors session-live-mobile.spec.ts pattern).
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+
+    // ── State 1: expanded (default) ──────────────────────────────────────────
+    await gotoSessionLive(page);
+    await page.waitForSelector('[data-slot="chat-agent-panel"] [data-slot="live-agent-chat"]', {
+      timeout: 15_000,
+    });
+
+    const expandedResults = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .exclude('#webpack-dev-server-client-overlay')
+      .analyze();
+
+    if (expandedResults.violations.length > 0) {
+      const summary = expandedResults.violations
+        .map(v => `[${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} nodes)`)
+        .join('\n');
+      console.error('axe violations (expanded):\n' + summary);
+    }
+    expect(expandedResults.violations).toEqual([]);
+
+    // ── State 2: collapsed ───────────────────────────────────────────────────
+    const header = page
+      .locator('[data-slot="chat-agent-panel"]')
+      .first()
+      .locator('button[aria-expanded]')
+      .first();
+    await header.click();
+
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toMatch(/[?&]chat=collapsed/);
+
+    const collapsedResults = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .exclude('#webpack-dev-server-client-overlay')
+      .analyze();
+
+    if (collapsedResults.violations.length > 0) {
+      const summary = collapsedResults.violations
+        .map(v => `[${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} nodes)`)
+        .join('\n');
+      console.error('axe violations (collapsed):\n' + summary);
+    }
+    expect(collapsedResults.violations).toEqual([]);
+  });
+});

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -187,6 +187,11 @@ function parseMobileSheetOpen(raw: string | null): boolean {
   return raw === 'open';
 }
 
+// G3 #2375 — shared accordion FSM URL parser
+function parseCollapsed(raw: string | null): boolean {
+  return raw === 'collapsed';
+}
+
 // ─── Skeleton shell components ────────────────────────────────────────────────
 // Foundation: simple inline skeletons — no external component dependency.
 
@@ -293,6 +298,8 @@ export function SessionLiveView(): ReactElement {
   const tab = parseLiveTab(searchParams.get('tab'));
   const mobileTab = parseMobileTab(searchParams.get('mtab'));
   const mobileSheetOpen = parseMobileSheetOpen(searchParams.get('msheet'));
+  const chatCollapsed = parseCollapsed(searchParams.get('chat'));
+  const mobileChatCollapsed = parseCollapsed(searchParams.get('mchat'));
   const fixtureVariantParam = searchParams.get('fixture');
 
   // State override hatch (dev/visual-test builds only)
@@ -433,6 +440,35 @@ export function SessionLiveView(): ReactElement {
       router.replace(`${pathname}${buildQuery({ msheet: val })}`, { scroll: false });
     },
     [router, pathname, buildQuery]
+  );
+
+  // G3 #2375 — accordion FSM handlers (DEC-1: ?chat desktop, ?mchat mobile, separate params).
+  // Default expanded (param omitted) per DEC-4 / mockup canonical.
+  const handleChatCollapsedChange = useCallback(
+    (collapsed: boolean) => {
+      const val = collapsed ? 'collapsed' : null;
+      router.replace(`${pathname}${buildQuery({ chat: val })}`, { scroll: false });
+    },
+    [router, pathname, buildQuery]
+  );
+
+  const handleMobileChatCollapsedChange = useCallback(
+    (collapsed: boolean) => {
+      const val = collapsed ? 'collapsed' : null;
+      router.replace(`${pathname}${buildQuery({ mchat: val })}`, { scroll: false });
+    },
+    [router, pathname, buildQuery]
+  );
+
+  // G3 #2375 — stable header-click handlers (avoids new closure every render).
+  const handleChatHeaderClick = useCallback(
+    () => handleChatCollapsedChange(!chatCollapsed),
+    [handleChatCollapsedChange, chatCollapsed]
+  );
+
+  const handleMobileChatHeaderClick = useCallback(
+    () => handleMobileChatCollapsedChange(!mobileChatCollapsed),
+    [handleMobileChatCollapsedChange, mobileChatCollapsed]
   );
 
   /** Dialog dismiss/open handler — updates ?dialog= URL param.
@@ -898,6 +934,7 @@ export function SessionLiveView(): ReactElement {
     return (
       <div className="flex flex-col gap-3">
         <ChatAgentPanel
+          sessionId={sessionId}
           messages={chatMessages}
           viewerRole={activeSession.viewerRole}
           viewerId={activeSession.viewerId}
@@ -905,13 +942,24 @@ export function SessionLiveView(): ReactElement {
           agentName="MeepleAI"
           agentEmoji="🤖"
           latencyMs={42}
+          collapsed={mobileChatCollapsed}
+          onHeaderClick={handleMobileChatHeaderClick}
           labels={chatAgentLabels}
           compact
         />
         <ActionLogTimeline entries={activeSession.actionLog} labels={actionLogLabels} compact />
       </div>
     );
-  }, [activeSession, chatMessages, handleSendMessage, chatAgentLabels, actionLogLabels]);
+  }, [
+    activeSession,
+    sessionId,
+    chatMessages,
+    handleSendMessage,
+    chatAgentLabels,
+    actionLogLabels,
+    mobileChatCollapsed,
+    handleMobileChatHeaderClick,
+  ]);
 
   // ── Mobile bottom-sheet content (G1 #2374 T9 sess.46r) ───────────────────
   // Same switch as desktopRightColumn (DRY): score / turn / widget / notes.
@@ -1072,6 +1120,7 @@ export function SessionLiveView(): ReactElement {
   const desktopMainColumn = (
     <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3">
       <ChatAgentPanel
+        sessionId={sessionId}
         messages={chatMessages}
         viewerRole={activeSession.viewerRole}
         viewerId={activeSession.viewerId}
@@ -1079,6 +1128,8 @@ export function SessionLiveView(): ReactElement {
         agentName="MeepleAI"
         agentEmoji="🤖"
         latencyMs={42}
+        collapsed={chatCollapsed}
+        onHeaderClick={handleChatHeaderClick}
         labels={chatAgentLabels}
       />
       <ActionLogTimeline entries={activeSession.actionLog} labels={actionLogLabels} />

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -776,6 +776,7 @@ export function SessionLiveView(): ReactElement {
       visibilityPrivate: t('pages.sessionLive.chat.visibilityPrivate'),
       visibilityShared: t('pages.sessionLive.chat.visibilityShared'),
       emptyMessage: t('pages.sessionLive.chat.emptyMessage'),
+      newMessagesToastAriaLabel: t('pages.sessionLive.chat.newMessagesToastAriaLabel'),
     }),
     [t]
   );

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -951,3 +951,97 @@ describe('SessionLiveView (Wave D.2 Interactions — Task 3)', () => {
     expect(() => renderWithIntl(<SessionLiveView />)).not.toThrow();
   });
 });
+
+// ─── #2375 G3 — accordion FSM URL SSOT ──────────────────────────────────────
+
+describe('SessionLiveView (#2375 G3 — accordion FSM URL SSOT)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    mockParamsId = 'session-abc-123';
+    IS_VISUAL_TEST_BUILD_MOCK = false;
+    useSessionMock.mockReturnValue({
+      data: MOCK_SESSION_DTO,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+  });
+
+  it('G3-1: renders ChatAgentPanel expanded by default (no ?chat param)', () => {
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Desktop ChatAgentPanel — no ?chat param → data-collapsed attribute absent (expanded).
+    const desktopBody = container.querySelector('[data-slot="desktop-body"]');
+    expect(desktopBody).toBeInTheDocument();
+    const panels = desktopBody?.querySelectorAll('[data-slot="chat-agent-panel"]');
+    expect(panels).toBeTruthy();
+    expect(panels!.length).toBeGreaterThanOrEqual(1);
+    // No data-collapsed="true" when expanded (attribute is absent per ChatAgentPanel contract).
+    expect(panels![0]).not.toHaveAttribute('data-collapsed', 'true');
+  });
+
+  it('G3-2: ?chat=collapsed → desktop ChatAgentPanel has data-collapsed="true"', () => {
+    searchParamsMap['chat'] = 'collapsed';
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const desktopBody = container.querySelector('[data-slot="desktop-body"]');
+    expect(desktopBody).toBeInTheDocument();
+    const panels = desktopBody?.querySelectorAll('[data-slot="chat-agent-panel"]');
+    expect(panels).toBeTruthy();
+    expect(panels![0]).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  it('G3-3: ?mchat=collapsed → mobile ChatAgentPanel has data-collapsed="true"', () => {
+    searchParamsMap['mchat'] = 'collapsed';
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const mobileBody = container.querySelector('[data-slot="mobile-body"]');
+    expect(mobileBody).toBeInTheDocument();
+    const panels = mobileBody?.querySelectorAll('[data-slot="chat-agent-panel"]');
+    expect(panels).toBeTruthy();
+    expect(panels!.length).toBeGreaterThanOrEqual(1);
+    expect(panels![0]).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  it('G3-4: ?chat=collapsed&mchat=collapsed → both desktop and mobile ChatAgentPanel collapsed', () => {
+    searchParamsMap['chat'] = 'collapsed';
+    searchParamsMap['mchat'] = 'collapsed';
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const desktopBody = container.querySelector('[data-slot="desktop-body"]');
+    const mobileBody = container.querySelector('[data-slot="mobile-body"]');
+    const desktopPanels = desktopBody?.querySelectorAll('[data-slot="chat-agent-panel"]');
+    const mobilePanels = mobileBody?.querySelectorAll('[data-slot="chat-agent-panel"]');
+    expect(desktopPanels![0]).toHaveAttribute('data-collapsed', 'true');
+    expect(mobilePanels![0]).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  it('G3-5: clicking desktop ChatAgentPanel header calls router.replace with ?chat=collapsed', () => {
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const desktopBody = container.querySelector('[data-slot="desktop-body"]');
+    // Header is a <button> (a11y) when onHeaderClick is provided (§5 contract).
+    const headerBtn = desktopBody?.querySelector(
+      '[data-slot="chat-agent-panel"] button[aria-expanded]'
+    ) as HTMLButtonElement | null;
+    expect(headerBtn).not.toBeNull();
+    fireEvent.click(headerBtn!);
+    expect(routerReplace).toHaveBeenCalled();
+    const callArg = routerReplace.mock.calls[0]?.[0] as string;
+    expect(callArg).toContain('chat=collapsed');
+  });
+
+  it('G3-6: clicking header when ?chat=collapsed calls router.replace WITHOUT chat param (toggle expand)', () => {
+    searchParamsMap['chat'] = 'collapsed';
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const desktopBody = container.querySelector('[data-slot="desktop-body"]');
+    const headerBtn = desktopBody?.querySelector(
+      '[data-slot="chat-agent-panel"] button[aria-expanded]'
+    ) as HTMLButtonElement | null;
+    expect(headerBtn).not.toBeNull();
+    fireEvent.click(headerBtn!);
+    expect(routerReplace).toHaveBeenCalled();
+    const callArg = routerReplace.mock.calls[0]?.[0] as string;
+    // When expanding, 'chat' param is removed (null → deleted from query string).
+    expect(callArg).not.toContain('chat=collapsed');
+  });
+});

--- a/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+++ b/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
@@ -15,6 +15,8 @@
  *   - header is a <button> (a11y) when onHeaderClick provided, else <div>
  *   - body unmounts when collapsed=true (no hidden focus traps)
  *   - no SSE state inside the primitive (parent owns the stream)
+ *   - sessionId is forwarded transparently to LiveAgentChat;
+ *     it does NOT change the panel's data-slot/collapsed/header semantics.
  *
  * Token discipline (§3 D-4):
  *   - semantic tokens: bg-card / text-foreground / text-muted-foreground /
@@ -52,6 +54,9 @@ export interface ChatAgentPanelLabels {
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface ChatAgentPanelProps {
+  /** #2375 G3 — forwarded to LiveAgentChat for sessionStorage draft persistence.
+   *  Optional: when omitted or null, draft persistence is disabled (no-op). */
+  readonly sessionId?: string | null;
   readonly messages: ReadonlyArray<ChatMessage>;
   readonly viewerRole: ParticipantRole;
   readonly viewerId: string;
@@ -75,6 +80,7 @@ export interface ChatAgentPanelProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ChatAgentPanel({
+  sessionId,
   messages,
   viewerRole,
   viewerId,
@@ -174,7 +180,7 @@ export function ChatAgentPanel({
       {!collapsed && (
         <div className="flex min-h-0 flex-1 flex-col p-3">
           <LiveAgentChat
-            sessionId={null} // TODO Task 5: wire real sessionId from SessionLiveView
+            sessionId={sessionId ?? null}
             messages={messages}
             viewerRole={viewerRole}
             viewerId={viewerId}

--- a/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+++ b/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
@@ -174,6 +174,7 @@ export function ChatAgentPanel({
       {!collapsed && (
         <div className="flex min-h-0 flex-1 flex-col p-3">
           <LiveAgentChat
+            sessionId={null} // TODO Task 5: wire real sessionId from SessionLiveView
             messages={messages}
             viewerRole={viewerRole}
             viewerId={viewerId}

--- a/apps/web/src/components/features/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/features/session-live/LiveAgentChat.tsx
@@ -2,24 +2,32 @@
 
 /**
  * LiveAgentChat — Wave D.2 Interactions sub-PR (Issue #750).
- *
- * Chat panel with messages list and send form.
+ * Extended by Issue #2375 G3 with sessionStorage draft + smart auto-scroll.
  *
  * Role variants:
  *   Spectator: visibility forced 'shared' (no private toggle visible)
  *   Player+Host: both visibility options (private/shared toggle)
  *
+ * #2375 G3:
+ *   - sessionId prop → useChatDraft persists input across collapse/expand cycles
+ *   - useScrollAnchor → smart auto-scroll: auto when at bottom, toast when scrolled up
+ *   - data-at-bottom attribute reflects current anchor state (E2E selector)
+ *
  * Gate C: DIVERGES from MeepleCard — live chat panel, not a card pattern.
  *
  * data-slot="live-agent-chat" — required by unit tests.
  * data-viewer-role={viewerRole} — role variant assertion in unit tests.
+ * data-at-bottom={isAtBottom ? 'true' : 'false'} — #2375 G3 scroll anchor state.
  */
 
-import { type ReactElement, useState, useRef, useEffect } from 'react';
+import { type ReactElement, useEffect, useRef, useState, type RefObject } from 'react';
 
 import { Send } from 'lucide-react';
+import { useIntl } from 'react-intl';
 
 import type { ParticipantRole } from '@/lib/session-live/participant-role';
+import { useChatDraft } from '@/lib/session-live/use-chat-draft';
+import { useScrollAnchor } from '@/lib/session-live/use-scroll-anchor';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -41,11 +49,15 @@ export interface LiveAgentChatLabels {
   readonly visibilityPrivate: string;
   readonly visibilityShared: string;
   readonly emptyMessage: string;
+  /** #2375 G3: aria-label on the "N nuovi messaggi" toast button. */
+  readonly newMessagesToastAriaLabel: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface LiveAgentChatProps {
+  /** #2375 G3: sessionId used as sessionStorage key for draft persistence. */
+  readonly sessionId: string | null;
   readonly messages: ReadonlyArray<ChatMessage>;
   readonly viewerRole: ParticipantRole;
   readonly viewerId: string;
@@ -58,6 +70,7 @@ export interface LiveAgentChatProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function LiveAgentChat({
+  sessionId,
   messages,
   viewerRole,
   viewerId,
@@ -66,31 +79,74 @@ export function LiveAgentChat({
   labels,
   className,
 }: LiveAgentChatProps): ReactElement {
-  const [inputValue, setInputValue] = useState('');
+  const intl = useIntl();
+  const { draft, setDraft, clearDraft } = useChatDraft({ sessionId });
+
   // Spectator forced to 'shared'; Player+Host can toggle
   const [visibility, setVisibility] = useState<'private' | 'shared'>('shared');
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const { isAtBottom, scrollToBottom } = useScrollAnchor({
+    // Cast: HTMLDivElement extends HTMLElement; hook only reads .current via null guard.
+    containerRef: containerRef as RefObject<HTMLElement | null>,
+    bottomRef: bottomRef as RefObject<HTMLElement | null>,
+    trigger: messages.length,
+  });
+
+  // Track new arrivals while scrolled up to display "N nuovi messaggi" toast.
+  const [newMessageCount, setNewMessageCount] = useState<number>(0);
+  const prevMessageCountRef = useRef<number>(messages.length);
+
+  useEffect(() => {
+    const prev = prevMessageCountRef.current;
+    const next = messages.length;
+    if (next > prev) {
+      if (isAtBottom) {
+        scrollToBottom();
+        setNewMessageCount(0);
+      } else {
+        setNewMessageCount(c => c + (next - prev));
+      }
+    }
+    prevMessageCountRef.current = next;
+  }, [messages.length, isAtBottom, scrollToBottom]);
+
+  // C1 fix: reset counter when user manually scrolls to bottom (isAtBottom flips true
+  // without a new message arrival — the counter-increment branch above is not taken,
+  // so we need a dedicated effect to clear the stale count).
+  useEffect(() => {
+    if (isAtBottom) {
+      setNewMessageCount(0);
+    }
+  }, [isAtBottom]);
 
   const isSpectator = viewerRole === 'Spectator';
 
-  // Auto-scroll to bottom on new messages
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages.length]);
+  const toastLabel = intl.formatMessage(
+    { id: 'pages.sessionLive.chat.newMessagesToast' },
+    { count: newMessageCount }
+  );
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent): void => {
     e.preventDefault();
-    const trimmed = inputValue.trim();
+    const trimmed = draft.trim();
     if (!trimmed) return;
-    // Spectator always sends as shared
     onSendMessage(trimmed, isSpectator ? 'shared' : visibility);
-    setInputValue('');
+    clearDraft();
+  };
+
+  const handleToastClick = (): void => {
+    scrollToBottom();
+    setNewMessageCount(0);
   };
 
   return (
     <section
       data-slot="live-agent-chat"
       data-viewer-role={viewerRole}
+      data-at-bottom={isAtBottom ? 'true' : 'false'}
       aria-label={labels.title}
       className={`flex flex-col ${compact ? 'gap-2' : 'gap-3'} ${className ?? ''}`}
     >
@@ -100,7 +156,8 @@ export function LiveAgentChat({
 
       {/* Messages list */}
       <div
-        className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto"
+        ref={containerRef}
+        className="relative flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto"
         aria-live="polite"
         aria-atomic="false"
         aria-relevant="additions"
@@ -120,9 +177,9 @@ export function LiveAgentChat({
               >
                 {!isOwn && <span className="text-xs text-muted-foreground">{msg.senderName}</span>}
                 <div
-                  className={`max-w-[85%] rounded-lg px-3 py-1.5 text-sm ${
-                    isOwn ? 'bg-card text-foreground' : 'bg-card text-foreground'
-                  } ${isPrivate ? 'border border-amber-700/40' : ''}`}
+                  className={`max-w-[85%] rounded-lg px-3 py-1.5 text-sm bg-card text-foreground ${
+                    isPrivate ? 'border border-amber-700/40' : ''
+                  }`}
                 >
                   {msg.content}
                   {isPrivate && (
@@ -135,7 +192,25 @@ export function LiveAgentChat({
             );
           })
         )}
-        <div ref={messagesEndRef} />
+        <div ref={bottomRef} aria-hidden="true" data-slot="chat-bottom-sentinel" />
+
+        {/* #2375 G3 — "N nuovi messaggi" pill, shown when scrolled up + new arrivals */}
+        {!isAtBottom && newMessageCount > 0 && (
+          <div className="sticky bottom-2 flex justify-center">
+            <button
+              type="button"
+              onClick={handleToastClick}
+              aria-label={labels.newMessagesToastAriaLabel}
+              data-slot="chat-new-messages-toast"
+              className="rounded-full border border-entity-agent/40 bg-entity-agent/15
+                px-3 py-1 text-xs font-semibold text-entity-agent shadow-sm
+                hover:bg-entity-agent/25 focus-visible:outline-none
+                focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {toastLabel}
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Send form */}
@@ -173,8 +248,8 @@ export function LiveAgentChat({
         <div className="flex gap-2">
           <input
             type="text"
-            value={inputValue}
-            onChange={e => setInputValue(e.target.value)}
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
             aria-label={labels.inputAriaLabel}
             placeholder={labels.inputAriaLabel}
             className="min-w-0 flex-1 rounded-lg border border-border/60 bg-card
@@ -184,7 +259,7 @@ export function LiveAgentChat({
           <button
             type="submit"
             aria-label={labels.sendAriaLabel}
-            disabled={!inputValue.trim()}
+            disabled={!draft.trim()}
             className="flex shrink-0 items-center justify-center rounded-lg border
               border-border/60 bg-card px-3 py-2 text-foreground
               transition-colors hover:bg-muted

--- a/apps/web/src/components/features/session-live/__tests__/ChatAgentPanel.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/ChatAgentPanel.test.tsx
@@ -14,13 +14,28 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IntlProvider } from 'react-intl';
 
 import type { ChatAgentPanelLabels, ChatAgentPanelProps } from '../ChatAgentPanel';
 import { ChatAgentPanel } from '../ChatAgentPanel';
 import type { ChatMessage, LiveAgentChatLabels } from '../LiveAgentChat';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+// i18n messages needed by LiveAgentChat's useIntl call (toast ICU plural)
+const INTL_MESSAGES = {
+  'pages.sessionLive.chat.newMessagesToast':
+    '{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}',
+};
+
+function wrapIntl(ui: React.ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={INTL_MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
 
 const CHAT_PANEL_LABELS: LiveAgentChatLabels = {
   title: 'Chat AI',
@@ -29,6 +44,7 @@ const CHAT_PANEL_LABELS: LiveAgentChatLabels = {
   visibilityPrivate: 'Privato',
   visibilityShared: 'Condiviso',
   emptyMessage: 'Nessun messaggio',
+  newMessagesToastAriaLabel: 'Nuovi messaggi — clic per scorrere',
 };
 
 const LABELS: ChatAgentPanelLabels = {
@@ -64,9 +80,29 @@ function renderPanel(overrides: Partial<ChatAgentPanelProps> = {}) {
     onHeaderClick,
     ...overrides,
   };
-  const result = render(<ChatAgentPanel {...props} />);
+  const result = wrapIntl(<ChatAgentPanel {...props} />);
   return { ...result, onSendMessage, onHeaderClick };
 }
+
+// ─── Shared IntersectionObserver stub (mirrors LiveAgentChat.test.tsx) ────────
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(function (this: unknown, cb: IntersectionObserverCallback) {
+      return {
+        callback: cb,
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      } as unknown as IntersectionObserver;
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+});
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -135,7 +171,7 @@ describe('ChatAgentPanel — header interactions', () => {
 
   it('header is a <div> (not <button>) when onHeaderClick is undefined', () => {
     // Override default fixture by explicitly passing onHeaderClick=undefined
-    const { container } = render(
+    const { container } = wrapIntl(
       <ChatAgentPanel
         messages={[]}
         viewerRole="Player"

--- a/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
@@ -1,5 +1,6 @@
 /**
  * LiveAgentChat unit tests — Wave D.2 Interactions sub-PR (Issue #750)
+ * Extended by Issue #2375 G3 — draft persistence + smart scroll
  *
  * Coverage:
  * - Render shape (data-slot, messages, empty state)
@@ -8,14 +9,25 @@
  * - Spectator forced to 'shared' visibility
  * - Input form state (disabled submit when empty)
  * - aria attributes
+ * - #2375 G3: draft persistence (sessionStorage read/write/clear)
+ * - #2375 G3: data-at-bottom attribute reflecting scroll anchor state
  */
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { IntlProvider } from 'react-intl';
 
 import type { LiveAgentChatLabels, LiveAgentChatProps, ChatMessage } from '../LiveAgentChat';
 import { LiveAgentChat } from '../LiveAgentChat';
+import { CHAT_DRAFT_KEY_PREFIX } from '@/lib/session-live/use-chat-draft';
+
+// ─── i18n messages used by the component ──────────────────────────────────────
+
+const INTL_MESSAGES = {
+  'pages.sessionLive.chat.newMessagesToast':
+    '{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}',
+};
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -26,6 +38,7 @@ const LABELS: LiveAgentChatLabels = {
   visibilityPrivate: 'Privato',
   visibilityShared: 'Condiviso',
   emptyMessage: 'Nessun messaggio',
+  newMessagesToastAriaLabel: 'Nuovi messaggi — clic per scorrere',
 };
 
 const MESSAGES: ReadonlyArray<ChatMessage> = [
@@ -47,9 +60,20 @@ const MESSAGES: ReadonlyArray<ChatMessage> = [
   },
 ];
 
+// ─── Render helper (wraps with IntlProvider for useIntl compatibility) ────────
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={INTL_MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
+
 function renderChat(overrides: Partial<LiveAgentChatProps> = {}) {
   const onSendMessage = vi.fn();
   const props: LiveAgentChatProps = {
+    sessionId: 'sess-test',
     messages: [],
     viewerRole: 'Player',
     viewerId: 'viewer-id',
@@ -57,9 +81,29 @@ function renderChat(overrides: Partial<LiveAgentChatProps> = {}) {
     labels: LABELS,
     ...overrides,
   };
-  const result = render(<LiveAgentChat {...props} />);
+  const result = renderWithIntl(<LiveAgentChat {...props} />);
   return { ...result, onSendMessage };
 }
+
+// ─── Shared IntersectionObserver stub ─────────────────────────────────────────
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(function (this: unknown, cb: IntersectionObserverCallback) {
+      return {
+        callback: cb,
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      } as unknown as IntersectionObserver;
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+});
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -198,5 +242,159 @@ describe('LiveAgentChat — aria attributes', () => {
     const privateBtn = screen.getByRole('button', { name: /Privato/i });
     await user.click(privateBtn);
     expect(privateBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+// ─── #2375 G3 — draft persistence + smart scroll ──────────────────────────────
+
+describe('#2375 G3 — draft + smart scroll', () => {
+  const baseLabels: LiveAgentChatLabels = {
+    title: 'Chat',
+    inputAriaLabel: 'Scrivi',
+    sendAriaLabel: 'Invia',
+    visibilityPrivate: 'Privato',
+    visibilityShared: 'Condiviso',
+    emptyMessage: 'Vuoto',
+    newMessagesToastAriaLabel: 'Nuovi messaggi — clic per scorrere',
+  };
+
+  it('loads draft from sessionStorage on mount', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`, 'in-progress draft');
+
+    renderWithIntl(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    const input = screen.getByLabelText('Scrivi') as HTMLInputElement;
+    expect(input.value).toBe('in-progress draft');
+  });
+
+  it('writes input changes to sessionStorage as draft', () => {
+    renderWithIntl(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    const input = screen.getByLabelText('Scrivi') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'typing' } });
+
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe('typing');
+  });
+
+  it('clears draft from sessionStorage after successful send', () => {
+    const onSend = vi.fn();
+    renderWithIntl(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={onSend}
+        labels={baseLabels}
+      />
+    );
+
+    const input = screen.getByLabelText('Scrivi') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'hi' } });
+    fireEvent.click(screen.getByLabelText('Invia'));
+
+    expect(onSend).toHaveBeenCalledWith('hi', 'shared');
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe(null);
+    expect(input.value).toBe('');
+  });
+
+  it('renders data-at-bottom attribute reflecting scroll anchor state', () => {
+    const { container } = renderWithIntl(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    const root = container.querySelector('[data-slot="live-agent-chat"]');
+    expect(root).not.toBeNull();
+    expect(root?.getAttribute('data-at-bottom')).toBe('true');
+  });
+
+  it('resets newMessageCount when isAtBottom flips to true (manual scroll)', () => {
+    // Capture IntersectionObserver callbacks for manual firing
+    const observers: IntersectionObserverCallback[] = [];
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(function (this: unknown, cb: IntersectionObserverCallback) {
+        observers.push(cb);
+        return { observe: vi.fn(), disconnect: vi.fn() } as unknown as IntersectionObserver;
+      })
+    );
+
+    function fire(isIntersecting: boolean) {
+      act(() => {
+        for (const cb of observers) {
+          cb([{ isIntersecting } as IntersectionObserverEntry], {} as IntersectionObserver);
+        }
+      });
+    }
+
+    const { rerender, queryByLabelText } = renderWithIntl(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    // Step 1: simulate user scrolled up (not at bottom)
+    fire(false);
+
+    // Step 2: new message arrives while scrolled up → counter increments → toast visible
+    rerender(
+      <IntlProvider locale="it" messages={INTL_MESSAGES}>
+        <LiveAgentChat
+          sessionId="sess-1"
+          messages={[
+            {
+              id: 'm1',
+              senderId: 'other',
+              senderName: 'Other',
+              content: 'hi',
+              visibility: 'shared',
+              timestamp: '2026-01-01T00:00:00Z',
+            },
+          ]}
+          viewerRole="Player"
+          viewerId="me"
+          onSendMessage={() => {}}
+          labels={baseLabels}
+        />
+      </IntlProvider>
+    );
+
+    expect(queryByLabelText(baseLabels.newMessagesToastAriaLabel)).not.toBeNull();
+
+    // Step 3: user manually scrolls to bottom (isAtBottom flips true, no new messages)
+    fire(true);
+
+    // Toast should disappear (guarded by !isAtBottom) AND counter reset to 0
+    expect(queryByLabelText(baseLabels.newMessagesToastAriaLabel)).toBeNull();
   });
 });

--- a/apps/web/src/lib/session-live/__tests__/use-chat-draft.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/use-chat-draft.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useChatDraft, CHAT_DRAFT_KEY_PREFIX } from '../use-chat-draft';
+
+describe('useChatDraft', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  // I3 fix: suite-level safety net — restores all spies/mocks even if assertions throw.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty draft when no value persisted', () => {
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    expect(result.current.draft).toBe('');
+  });
+
+  it('reads existing draft from sessionStorage on mount', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`, 'hello world');
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    expect(result.current.draft).toBe('hello world');
+  });
+
+  it('setDraft writes to sessionStorage', () => {
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    act(() => result.current.setDraft('typing...'));
+    expect(result.current.draft).toBe('typing...');
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe('typing...');
+  });
+
+  it('clearDraft removes from sessionStorage', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`, 'existing');
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    act(() => result.current.clearDraft());
+    expect(result.current.draft).toBe('');
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe(null);
+  });
+
+  it('sessionId=null → no-op (no sessionStorage access)', () => {
+    const setSpy = vi.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useChatDraft({ sessionId: null }));
+    act(() => result.current.setDraft('ignored'));
+    expect(result.current.draft).toBe('');
+    expect(setSpy).not.toHaveBeenCalled();
+    setSpy.mockRestore();
+  });
+
+  it('distinct sessionId values use distinct keys', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-a`, 'draft a');
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-b`, 'draft b');
+
+    const { result: a } = renderHook(() => useChatDraft({ sessionId: 'sess-a' }));
+    const { result: b } = renderHook(() => useChatDraft({ sessionId: 'sess-b' }));
+
+    expect(a.current.draft).toBe('draft a');
+    expect(b.current.draft).toBe('draft b');
+  });
+
+  it('swallows quota-exceeded errors with warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    expect(() => act(() => result.current.setDraft('won-t-fit'))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+
+    setItemSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  // I2 fix: clearDraft must be a no-op when sessionId is null (C1 guard symmetry).
+  it('clearDraft is no-op when sessionId is null', () => {
+    const removeSpy = vi.spyOn(Storage.prototype, 'removeItem');
+    const { result } = renderHook(() => useChatDraft({ sessionId: null }));
+    act(() => result.current.clearDraft());
+    expect(result.current.draft).toBe('');
+    expect(removeSpy).not.toHaveBeenCalled();
+    removeSpy.mockRestore();
+  });
+
+  // I3 / I1 fix: re-reads stored draft when sessionId transitions null → string.
+  it('re-reads draft from sessionStorage when sessionId transitions from null', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-late`, 'late draft');
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string | null }) => useChatDraft({ sessionId }),
+      { initialProps: { sessionId: null as string | null } }
+    );
+
+    expect(result.current.draft).toBe('');
+
+    rerender({ sessionId: 'sess-late' });
+
+    expect(result.current.draft).toBe('late draft');
+  });
+});

--- a/apps/web/src/lib/session-live/__tests__/use-scroll-anchor.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/use-scroll-anchor.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React, { useRef } from 'react';
+
+import { useScrollAnchor } from '../use-scroll-anchor';
+
+interface FakeObserver {
+  callback: IntersectionObserverCallback;
+  observe: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+let fakeObservers: FakeObserver[] = [];
+
+function installIntersectionObserverMock(): void {
+  fakeObservers = [];
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(function (this: unknown, cb: IntersectionObserverCallback) {
+      const observer: FakeObserver = {
+        callback: cb,
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      fakeObservers.push(observer);
+      // When called with `new`, the constructor return value must be an object.
+      return observer as unknown as IntersectionObserver;
+    })
+  );
+}
+
+function fireIntersection(isIntersecting: boolean): void {
+  for (const obs of fakeObservers) {
+    act(() => {
+      obs.callback(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        obs as unknown as IntersectionObserver
+      );
+    });
+  }
+}
+
+describe('useScrollAnchor', () => {
+  beforeEach(() => {
+    installIntersectionObserverMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts with isAtBottom=true (default optimistic)', () => {
+    const { result } = renderHook(() => {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    });
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
+  it('flips isAtBottom to false when sentinel leaves viewport', () => {
+    const { result } = renderHook(() => {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+
+      // Provide a non-null sentinel so the effect does not exit early.
+      if (bottomRef.current === null) {
+        (bottomRef as React.MutableRefObject<HTMLDivElement>).current =
+          document.createElement('div');
+      }
+
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    });
+
+    fireIntersection(false);
+    expect(result.current.isAtBottom).toBe(false);
+
+    fireIntersection(true);
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
+  it('scrollToBottom calls scrollIntoView on bottomRef', () => {
+    const scrollIntoView = vi.fn();
+
+    function TestHook() {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+
+      if (bottomRef.current === null) {
+        (bottomRef as React.MutableRefObject<HTMLDivElement>).current = {
+          scrollIntoView,
+        } as unknown as HTMLDivElement;
+      }
+
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    }
+
+    const { result } = renderHook(TestHook);
+
+    act(() => {
+      result.current.scrollToBottom();
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('falls back to isAtBottom=true when IntersectionObserver is undefined', () => {
+    vi.unstubAllGlobals();
+    // @ts-expect-error — deleting global for fallback path
+    delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
+
+    const { result } = renderHook(() => {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    });
+
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
+  it('re-registers observer when trigger changes (e.g. messages.length grows)', () => {
+    const sentinel = document.createElement('div');
+
+    function TestHook({ trigger }: { trigger: number }) {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+
+      if (bottomRef.current === null) {
+        (bottomRef as React.MutableRefObject<HTMLDivElement>).current = sentinel;
+      }
+
+      return useScrollAnchor({ containerRef, bottomRef, trigger });
+    }
+
+    const { rerender } = renderHook(({ trigger }) => TestHook({ trigger }), {
+      initialProps: { trigger: 0 },
+    });
+
+    // First observer registered on initial render
+    expect(fakeObservers.length).toBe(1);
+    const firstObserver = fakeObservers[0];
+
+    // trigger change → effect re-runs → old observer disconnected + new one created
+    rerender({ trigger: 1 });
+
+    expect(firstObserver!.disconnect).toHaveBeenCalled();
+    expect(fakeObservers.length).toBe(2);
+  });
+});

--- a/apps/web/src/lib/session-live/use-chat-draft.ts
+++ b/apps/web/src/lib/session-live/use-chat-draft.ts
@@ -1,0 +1,81 @@
+'use client';
+
+/**
+ * useChatDraft — Issue #2375 G3.
+ *
+ * sessionStorage-backed draft persistence per session. Allows the chat input
+ * to survive collapse/expand cycles of the ChatAgentPanel (§5 contract:
+ * body unmounts when collapsed=true).
+ *
+ * Key format: `meepleai.chat-draft.${sessionId}`.
+ *
+ * - SSR-safe: returns empty string when `window` is undefined.
+ * - sessionId=null → all operations no-op (no sessionStorage access).
+ * - Quota exceeded / sessionStorage unavailable (Safari private mode) →
+ *   console.warn + swallow. Component stays functional with no persistence.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §4.2
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+export const CHAT_DRAFT_KEY_PREFIX = 'meepleai.chat-draft.';
+
+export interface UseChatDraftOptions {
+  readonly sessionId: string | null;
+}
+
+export interface UseChatDraftReturn {
+  readonly draft: string;
+  readonly setDraft: (next: string) => void;
+  readonly clearDraft: () => void;
+}
+
+function readDraft(sessionId: string | null): string {
+  if (sessionId == null) return '';
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}${sessionId}`) ?? '';
+  } catch (err) {
+    console.warn('[useChatDraft] sessionStorage.getItem failed:', err);
+    return '';
+  }
+}
+
+export function useChatDraft({ sessionId }: UseChatDraftOptions): UseChatDraftReturn {
+  const [draft, setDraftState] = useState<string>(() => readDraft(sessionId));
+
+  // I1 fix: re-read from storage when sessionId transitions null → string (post-hydration).
+  useEffect(() => {
+    if (sessionId == null) return;
+    const stored = readDraft(sessionId);
+    if (stored) setDraftState(stored);
+  }, [sessionId]);
+
+  const setDraft = useCallback(
+    (next: string) => {
+      if (sessionId == null) return;
+      setDraftState(next);
+      if (typeof window === 'undefined') return;
+      try {
+        window.sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}${sessionId}`, next);
+      } catch (err) {
+        console.warn('[useChatDraft] sessionStorage.setItem failed:', err);
+      }
+    },
+    [sessionId]
+  );
+
+  const clearDraft = useCallback(() => {
+    if (sessionId == null) return; // C1 fix: guard FIRST, mirroring setDraft
+    setDraftState('');
+    if (typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.removeItem(`${CHAT_DRAFT_KEY_PREFIX}${sessionId}`);
+    } catch (err) {
+      console.warn('[useChatDraft] sessionStorage.removeItem failed:', err);
+    }
+  }, [sessionId]);
+
+  return { draft, setDraft, clearDraft };
+}

--- a/apps/web/src/lib/session-live/use-scroll-anchor.ts
+++ b/apps/web/src/lib/session-live/use-scroll-anchor.ts
@@ -22,8 +22,8 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react';
 
 export interface UseScrollAnchorOptions {
-  readonly containerRef: RefObject<HTMLElement>;
-  readonly bottomRef: RefObject<HTMLElement>;
+  readonly containerRef: RefObject<HTMLElement | null>;
+  readonly bottomRef: RefObject<HTMLElement | null>;
   /** Trigger to keep observer reactive (e.g. messages.length). */
   readonly trigger: unknown;
 }

--- a/apps/web/src/lib/session-live/use-scroll-anchor.ts
+++ b/apps/web/src/lib/session-live/use-scroll-anchor.ts
@@ -1,0 +1,74 @@
+'use client';
+
+/**
+ * useScrollAnchor — Issue #2375 G3.
+ *
+ * IntersectionObserver-based smart scroll anchor for chat messages.
+ *
+ * Returns:
+ *   isAtBottom — true when bottomRef intersects the viewport (last message visible)
+ *   scrollToBottom — programmatic scroll-to-bottom (smooth)
+ *
+ * Fallback: when `IntersectionObserver` is `undefined`, isAtBottom stays `true`
+ * (naive auto-scroll on every new message — degraded UX for <1% of browsers).
+ *
+ * Caller is responsible for using `trigger` (e.g., messages.length) to decide
+ * whether to auto-scroll (`isAtBottom=true`) or show a "N nuovi messaggi" toast
+ * (`isAtBottom=false`).
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §4.1
+ */
+
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+
+export interface UseScrollAnchorOptions {
+  readonly containerRef: RefObject<HTMLElement>;
+  readonly bottomRef: RefObject<HTMLElement>;
+  /** Trigger to keep observer reactive (e.g. messages.length). */
+  readonly trigger: unknown;
+}
+
+export interface UseScrollAnchorReturn {
+  readonly isAtBottom: boolean;
+  readonly scrollToBottom: () => void;
+}
+
+export function useScrollAnchor({
+  containerRef,
+  bottomRef,
+  trigger,
+}: UseScrollAnchorOptions): UseScrollAnchorReturn {
+  const [isAtBottom, setIsAtBottom] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') {
+      setIsAtBottom(true);
+      return undefined;
+    }
+
+    const sentinel = bottomRef.current;
+    if (sentinel == null) return undefined;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (entry != null) {
+          setIsAtBottom(entry.isIntersecting);
+        }
+      },
+      { root: containerRef.current ?? null, threshold: 0.1 }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [containerRef, bottomRef, trigger]);
+
+  const scrollToBottom = useCallback(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [bottomRef]);
+
+  return { isAtBottom, scrollToBottom };
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3154,13 +3154,17 @@
         "sendAriaLabel": "Send message",
         "visibilityPrivate": "Private",
         "visibilityShared": "Shared",
-        "emptyMessage": "No messages yet."
+        "emptyMessage": "No messages yet.",
+        "newMessagesToast": "{count, plural, one {# new message} other {# new messages}}",
+        "newMessagesToastAriaLabel": "New messages available — click to scroll to bottom"
       },
       "chatAgent": {
         "title": "ChatAgent",
         "onlineLabel": "Online",
         "latencyAriaLabel": "Latency {ms}ms",
-        "agentNameAriaLabel": "Agent name {name}"
+        "agentNameAriaLabel": "Agent name {name}",
+        "collapsedAriaLabel": "ChatAgent collapsed — click to expand",
+        "expandedAriaLabel": "ChatAgent expanded — click to collapse"
       },
       "mobile": {
         "openSheetCta": "Open panel",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3261,13 +3261,17 @@
         "sendAriaLabel": "Invia messaggio",
         "visibilityPrivate": "Privato",
         "visibilityShared": "Condiviso",
-        "emptyMessage": "Nessun messaggio ancora."
+        "emptyMessage": "Nessun messaggio ancora.",
+        "newMessagesToast": "{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}",
+        "newMessagesToastAriaLabel": "Nuovi messaggi disponibili — clic per scorrere in fondo"
       },
       "chatAgent": {
         "title": "ChatAgent",
         "onlineLabel": "Online",
         "latencyAriaLabel": "Latenza {ms}ms",
-        "agentNameAriaLabel": "Nome agente {name}"
+        "agentNameAriaLabel": "Nome agente {name}",
+        "collapsedAriaLabel": "ChatAgent collassato — clic per espandere",
+        "expandedAriaLabel": "ChatAgent espanso — clic per collassare"
       },
       "mobile": {
         "openSheetCta": "Apri pannello",

--- a/docs/superpowers/plans/2026-06-16-issue-2375-g3-chatagent-always-visible.md
+++ b/docs/superpowers/plans/2026-06-16-issue-2375-g3-chatagent-always-visible.md
@@ -1,0 +1,1856 @@
+# #2375 G3 ChatAgent always-visible — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the accordion FSM on the ChatAgentPanel primitive (§5 contract preserved), add smart auto-scroll + draft persistence to LiveAgentChat, and ship E2E + axe AA coverage to close the remaining acceptance criteria from #2375.
+
+**Architecture:** Two new hooks (`useScrollAnchor` IntersectionObserver + `useChatDraft` sessionStorage) plug into existing `LiveAgentChat`. Parent `SessionLiveView` owns URL SSOT (`?chat`/`?mchat`) and forwards `collapsed`/`onHeaderClick` to `ChatAgentPanel`. No changes to the §5-frozen `ChatAgentPanel.tsx`.
+
+**Tech Stack:** Next.js App Router, React 19, Zustand, Vitest + Testing Library, Playwright, axe-core, react-intl (ICU plural).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md`
+
+**Branch:** `feature/issue-2375-g3-chat-agent-always-visible` (parent: `main-dev`)
+
+**4 DEC user-locked:** (1) URL SSOT separati `?chat`/`?mchat` · (2) IntersectionObserver smart auto-scroll + "N nuovi messaggi" toast · (3) sessionStorage draft per sessionId · (4) Default expanded.
+
+---
+
+## File Structure
+
+**New files (4):**
+
+- `apps/web/src/lib/session-live/use-scroll-anchor.ts` — IntersectionObserver hook (returns `isAtBottom` + `scrollToBottom`).
+- `apps/web/src/lib/session-live/__tests__/use-scroll-anchor.test.ts` — unit test suite.
+- `apps/web/src/lib/session-live/use-chat-draft.ts` — sessionStorage draft hook keyed by sessionId.
+- `apps/web/src/lib/session-live/__tests__/use-chat-draft.test.ts` — unit test suite.
+- `apps/web/e2e/session-live-chat-agent-g3.spec.ts` — Playwright spec (8 scenarios).
+- `apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx` — axe AA test.
+
+**Modified files (5):**
+
+- `apps/web/src/components/features/session-live/LiveAgentChat.tsx` — extend with `sessionId` prop, wire `useChatDraft` + `useScrollAnchor`, render "N nuovi messaggi" pill, add `data-at-bottom` selector.
+- `apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx` — extend existing tests for draft + smart scroll + toast.
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` — add URL parsers, handlers, wire `collapsed`/`onHeaderClick` on both desktop + mobile `ChatAgentPanel`, pass `sessionId` to `LiveAgentChat`.
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx` — extend existing tests for `?chat`/`?mchat` URL SSOT.
+- `apps/web/src/locales/it.json` + `apps/web/src/locales/en.json` — add 3 new keys (collapsedAriaLabel, expandedAriaLabel, newMessagesToast).
+
+**Unchanged:** `apps/web/src/components/features/session-live/ChatAgentPanel.tsx` (§5 frozen contract preserved).
+
+---
+
+## Task 1: `useScrollAnchor` hook
+
+**Files:**
+- Create: `apps/web/src/lib/session-live/use-scroll-anchor.ts`
+- Create: `apps/web/src/lib/session-live/__tests__/use-scroll-anchor.test.ts`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+Create `apps/web/src/lib/session-live/__tests__/use-scroll-anchor.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef } from 'react';
+
+import { useScrollAnchor } from '../use-scroll-anchor';
+
+// ── IntersectionObserver mock ─────────────────────────────────────────────────
+// Vitest jsdom doesn't ship IntersectionObserver. We mock with a controllable
+// observer so the test can flip isAtBottom on demand.
+
+interface FakeObserver {
+  callback: IntersectionObserverCallback;
+  observe: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+let fakeObservers: FakeObserver[] = [];
+
+function installIntersectionObserverMock(): void {
+  fakeObservers = [];
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn((cb: IntersectionObserverCallback) => {
+      const observer: FakeObserver = {
+        callback: cb,
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      fakeObservers.push(observer);
+      return observer as unknown as IntersectionObserver;
+    })
+  );
+}
+
+function fireIntersection(isIntersecting: boolean): void {
+  for (const obs of fakeObservers) {
+    act(() => {
+      obs.callback(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        obs as unknown as IntersectionObserver
+      );
+    });
+  }
+}
+
+describe('useScrollAnchor', () => {
+  beforeEach(() => {
+    installIntersectionObserverMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts with isAtBottom=true (default optimistic)', () => {
+    const { result } = renderHook(() => {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    });
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
+  it('flips isAtBottom to false when sentinel leaves viewport', () => {
+    const { result } = renderHook(() => {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    });
+
+    fireIntersection(false);
+    expect(result.current.isAtBottom).toBe(false);
+
+    fireIntersection(true);
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
+  it('scrollToBottom calls scrollIntoView on bottomRef', () => {
+    const scrollIntoView = vi.fn();
+
+    function TestHook() {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+
+      // Inject a fake element with scrollIntoView
+      if (bottomRef.current === null) {
+        (bottomRef as React.MutableRefObject<HTMLDivElement>).current = {
+          scrollIntoView,
+        } as unknown as HTMLDivElement;
+      }
+
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    }
+
+    const { result } = renderHook(TestHook);
+
+    act(() => {
+      result.current.scrollToBottom();
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('falls back to isAtBottom=true when IntersectionObserver is undefined', () => {
+    vi.unstubAllGlobals();
+    // No global IntersectionObserver — jsdom default state after unstub.
+    // Ensure the global is gone:
+    // @ts-expect-error — deleting global for fallback path
+    delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
+
+    const { result } = renderHook(() => {
+      const containerRef = useRef<HTMLDivElement>(null);
+      const bottomRef = useRef<HTMLDivElement>(null);
+      return useScrollAnchor({ containerRef, bottomRef, trigger: 0 });
+    });
+
+    expect(result.current.isAtBottom).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify failure**
+
+```bash
+cd apps/web && pnpm test src/lib/session-live/__tests__/use-scroll-anchor.test.ts --run
+```
+
+Expected: 4 tests FAIL (module not found `../use-scroll-anchor`).
+
+- [ ] **Step 1.3: Create the hook file**
+
+Create `apps/web/src/lib/session-live/use-scroll-anchor.ts`:
+
+```ts
+'use client';
+
+/**
+ * useScrollAnchor — Issue #2375 G3.
+ *
+ * IntersectionObserver-based smart scroll anchor for chat messages.
+ *
+ * Returns:
+ *   isAtBottom — true when bottomRef intersects the viewport (last message visible)
+ *   scrollToBottom — programmatic scroll-to-bottom (smooth)
+ *
+ * Fallback: when `IntersectionObserver` is `undefined`, isAtBottom stays `true`
+ * (naive auto-scroll on every new message — degraded UX for <1% of browsers).
+ *
+ * Caller is responsible for using `trigger` (e.g., messages.length) to decide
+ * whether to auto-scroll (`isAtBottom=true`) or show a "N nuovi messaggi" toast
+ * (`isAtBottom=false`).
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §4.1
+ */
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+export interface UseScrollAnchorOptions {
+  readonly containerRef: RefObject<HTMLElement>;
+  readonly bottomRef: RefObject<HTMLElement>;
+  /** Trigger to keep observer reactive (e.g. messages.length). */
+  readonly trigger: unknown;
+}
+
+export interface UseScrollAnchorReturn {
+  readonly isAtBottom: boolean;
+  readonly scrollToBottom: () => void;
+}
+
+export function useScrollAnchor({
+  containerRef,
+  bottomRef,
+  trigger,
+}: UseScrollAnchorOptions): UseScrollAnchorReturn {
+  const [isAtBottom, setIsAtBottom] = useState<boolean>(true);
+  const isAtBottomRef = useRef<boolean>(true);
+
+  // Keep ref in sync with state so callers reading inside effects see the
+  // freshest value. (state updates batch; ref doesn't.)
+  isAtBottomRef.current = isAtBottom;
+
+  useEffect(() => {
+    // Fallback: no IntersectionObserver → stay isAtBottom=true (naive).
+    if (typeof IntersectionObserver === 'undefined') {
+      setIsAtBottom(true);
+      return undefined;
+    }
+
+    const sentinel = bottomRef.current;
+    if (sentinel == null) return undefined;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (entry != null) {
+          setIsAtBottom(entry.isIntersecting);
+        }
+      },
+      { root: containerRef.current ?? null, threshold: 0.1 }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+    // `trigger` is intentional — when message list grows the sentinel ref may
+    // change identity and we need to re-observe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerRef, bottomRef, trigger]);
+
+  const scrollToBottom = useCallback(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [bottomRef]);
+
+  return { isAtBottom, scrollToBottom };
+}
+```
+
+- [ ] **Step 1.4: Run test to verify pass**
+
+```bash
+cd apps/web && pnpm test src/lib/session-live/__tests__/use-scroll-anchor.test.ts --run
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add apps/web/src/lib/session-live/use-scroll-anchor.ts \
+        apps/web/src/lib/session-live/__tests__/use-scroll-anchor.test.ts
+git commit -m "feat(session-live): #2375 useScrollAnchor hook (IntersectionObserver)
+
+TDD: 4 unit tests cover happy path, isAtBottom flip, scrollToBottom call,
+and IntersectionObserver-undefined fallback (degraded UX naive auto-scroll).
+
+Spec: docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §4.1
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `useChatDraft` hook
+
+**Files:**
+- Create: `apps/web/src/lib/session-live/use-chat-draft.ts`
+- Create: `apps/web/src/lib/session-live/__tests__/use-chat-draft.test.ts`
+
+- [ ] **Step 2.1: Write the failing test file**
+
+Create `apps/web/src/lib/session-live/__tests__/use-chat-draft.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useChatDraft, CHAT_DRAFT_KEY_PREFIX } from '../use-chat-draft';
+
+describe('useChatDraft', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns empty draft when no value persisted', () => {
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    expect(result.current.draft).toBe('');
+  });
+
+  it('reads existing draft from sessionStorage on mount', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`, 'hello world');
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    expect(result.current.draft).toBe('hello world');
+  });
+
+  it('setDraft writes to sessionStorage', () => {
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    act(() => result.current.setDraft('typing...'));
+    expect(result.current.draft).toBe('typing...');
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe('typing...');
+  });
+
+  it('clearDraft removes from sessionStorage', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`, 'existing');
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    act(() => result.current.clearDraft());
+    expect(result.current.draft).toBe('');
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe(null);
+  });
+
+  it('sessionId=null → no-op (no sessionStorage access)', () => {
+    const setSpy = vi.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useChatDraft({ sessionId: null }));
+    act(() => result.current.setDraft('ignored'));
+    expect(result.current.draft).toBe('');
+    expect(setSpy).not.toHaveBeenCalled();
+    setSpy.mockRestore();
+  });
+
+  it('distinct sessionId values use distinct keys', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-a`, 'draft a');
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-b`, 'draft b');
+
+    const { result: a } = renderHook(() => useChatDraft({ sessionId: 'sess-a' }));
+    const { result: b } = renderHook(() => useChatDraft({ sessionId: 'sess-b' }));
+
+    expect(a.current.draft).toBe('draft a');
+    expect(b.current.draft).toBe('draft b');
+  });
+
+  it('swallows quota-exceeded errors with warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useChatDraft({ sessionId: 'sess-1' }));
+    expect(() => act(() => result.current.setDraft('won-t-fit'))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+
+    setItemSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run test to verify failure**
+
+```bash
+cd apps/web && pnpm test src/lib/session-live/__tests__/use-chat-draft.test.ts --run
+```
+
+Expected: 7 tests FAIL (module not found `../use-chat-draft`).
+
+- [ ] **Step 2.3: Create the hook file**
+
+Create `apps/web/src/lib/session-live/use-chat-draft.ts`:
+
+```ts
+'use client';
+
+/**
+ * useChatDraft — Issue #2375 G3.
+ *
+ * sessionStorage-backed draft persistence per session. Allows the chat input
+ * to survive collapse/expand cycles of the ChatAgentPanel (§5 contract:
+ * body unmounts when collapsed=true).
+ *
+ * Key format: `meepleai.chat-draft.${sessionId}`.
+ *
+ * - SSR-safe: returns empty string when `window` is undefined.
+ * - sessionId=null → all operations no-op (no sessionStorage access).
+ * - Quota exceeded / sessionStorage unavailable (Safari private mode) →
+ *   console.warn + swallow. Component stays functional with no persistence.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §4.2
+ */
+
+import { useCallback, useState } from 'react';
+
+export const CHAT_DRAFT_KEY_PREFIX = 'meepleai.chat-draft.';
+
+export interface UseChatDraftOptions {
+  readonly sessionId: string | null;
+}
+
+export interface UseChatDraftReturn {
+  readonly draft: string;
+  readonly setDraft: (next: string) => void;
+  readonly clearDraft: () => void;
+}
+
+function readDraft(sessionId: string | null): string {
+  if (sessionId == null) return '';
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}${sessionId}`) ?? '';
+  } catch (err) {
+    console.warn('[useChatDraft] sessionStorage.getItem failed:', err);
+    return '';
+  }
+}
+
+export function useChatDraft({ sessionId }: UseChatDraftOptions): UseChatDraftReturn {
+  const [draft, setDraftState] = useState<string>(() => readDraft(sessionId));
+
+  const setDraft = useCallback(
+    (next: string) => {
+      setDraftState(next);
+      if (sessionId == null) return;
+      if (typeof window === 'undefined') return;
+      try {
+        window.sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}${sessionId}`, next);
+      } catch (err) {
+        console.warn('[useChatDraft] sessionStorage.setItem failed:', err);
+      }
+    },
+    [sessionId]
+  );
+
+  const clearDraft = useCallback(() => {
+    setDraftState('');
+    if (sessionId == null) return;
+    if (typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.removeItem(`${CHAT_DRAFT_KEY_PREFIX}${sessionId}`);
+    } catch (err) {
+      console.warn('[useChatDraft] sessionStorage.removeItem failed:', err);
+    }
+  }, [sessionId]);
+
+  return { draft, setDraft, clearDraft };
+}
+```
+
+- [ ] **Step 2.4: Run test to verify pass**
+
+```bash
+cd apps/web && pnpm test src/lib/session-live/__tests__/use-chat-draft.test.ts --run
+```
+
+Expected: 7 tests PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add apps/web/src/lib/session-live/use-chat-draft.ts \
+        apps/web/src/lib/session-live/__tests__/use-chat-draft.test.ts
+git commit -m "feat(session-live): #2375 useChatDraft sessionStorage persistence
+
+TDD: 7 unit tests cover empty default, mount-read, set/clear roundtrip,
+sessionId=null no-op, distinct sessionId isolation, quota-exceeded swallow.
+
+Key: meepleai.chat-draft.\${sessionId}. SSR-safe. Falls back to in-memory
+state when sessionStorage unavailable (Safari private mode).
+
+Spec: docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md §4.2
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: i18n keys (it.json + en.json)
+
+**Files:**
+- Modify: `apps/web/src/locales/it.json` (existing `chatAgent` block + new `chat.newMessagesToast`)
+- Modify: `apps/web/src/locales/en.json` (mirror)
+
+- [ ] **Step 3.1: Add new keys to it.json**
+
+Find the `chatAgent` block around line 3266 and add 2 keys; find the `chat` block around line 3258 and add 1 key. Use the Edit tool.
+
+Edit `apps/web/src/locales/it.json` — replace the `chatAgent` block:
+
+```json
+"chatAgent": {
+  "title": "ChatAgent",
+  "onlineLabel": "Online",
+  "latencyAriaLabel": "Latenza {ms}ms",
+  "agentNameAriaLabel": "Nome agente {name}",
+  "collapsedAriaLabel": "ChatAgent collassato — clic per espandere",
+  "expandedAriaLabel": "ChatAgent espanso — clic per collassare"
+},
+```
+
+Edit the same file — find the `chat` block (the one containing `inputAriaLabel`, NOT `chatAgent`) and add `newMessagesToast` and `newMessagesToastAriaLabel` at the end of that block:
+
+```json
+"chat": {
+  "title": "Chat",
+  "inputAriaLabel": "Scrivi un messaggio",
+  "sendAriaLabel": "Invia messaggio",
+  "visibilityPrivate": "Privato",
+  "visibilityShared": "Condiviso",
+  "emptyMessage": "Nessun messaggio ancora.",
+  "newMessagesToast": "{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}",
+  "newMessagesToastAriaLabel": "Nuovi messaggi disponibili — clic per scorrere in fondo"
+},
+```
+
+- [ ] **Step 3.2: Mirror in en.json**
+
+Edit `apps/web/src/locales/en.json` — locate the same `chatAgent` block (use `grep -n chatAgent apps/web/src/locales/en.json` to find the line) and the `chat` block. Add the same 3 keys, translated:
+
+```json
+"chatAgent": {
+  ...existing...
+  "collapsedAriaLabel": "ChatAgent collapsed — click to expand",
+  "expandedAriaLabel": "ChatAgent expanded — click to collapse"
+},
+```
+
+```json
+"chat": {
+  ...existing...
+  "newMessagesToast": "{count, plural, one {# new message} other {# new messages}}",
+  "newMessagesToastAriaLabel": "New messages available — click to scroll to bottom"
+},
+```
+
+- [ ] **Step 3.3: Run typecheck**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+Expected: 0 errors (JSON edits are typechecked at runtime via the intl loader, but typecheck must still pass for all `.ts`/`.tsx`).
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add apps/web/src/locales/it.json apps/web/src/locales/en.json
+git commit -m "feat(i18n): #2375 add chatAgent collapsedAriaLabel + chat newMessagesToast (ICU plural)
+
+3 new keys in it.json + en.json:
+- pages.sessionLive.chatAgent.collapsedAriaLabel
+- pages.sessionLive.chatAgent.expandedAriaLabel
+- pages.sessionLive.chat.newMessagesToast (ICU plural)
+- pages.sessionLive.chat.newMessagesToastAriaLabel
+
+Resolved Gate A in SessionLiveView per pattern §6.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `LiveAgentChat` extension
+
+**Files:**
+- Modify: `apps/web/src/components/features/session-live/LiveAgentChat.tsx`
+- Modify: `apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx`
+
+- [ ] **Step 4.1: Read current test file to learn patterns**
+
+```bash
+cat apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx | head -50
+```
+
+Note the existing import style, the `renderWithIntl` helper if any, the labels fixture.
+
+- [ ] **Step 4.2: Add failing tests for draft + smart scroll + toast**
+
+Append new `describe('#2375 G3 — draft + smart scroll', ...)` block to `apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// (existing imports above)
+
+import { LiveAgentChat } from '../LiveAgentChat';
+import { CHAT_DRAFT_KEY_PREFIX } from '@/lib/session-live/use-chat-draft';
+
+// ... existing tests ...
+
+describe('#2375 G3 — draft + smart scroll', () => {
+  const baseLabels = {
+    title: 'Chat',
+    inputAriaLabel: 'Scrivi',
+    sendAriaLabel: 'Invia',
+    visibilityPrivate: 'Privato',
+    visibilityShared: 'Condiviso',
+    emptyMessage: 'Vuoto',
+    newMessagesToast: '1 nuovo messaggio',
+    newMessagesToastAriaLabel: 'Nuovi messaggi — clic per scorrere',
+  };
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    // Re-install IntersectionObserver mock that starts intersecting=true
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(() => ({
+        observe: vi.fn(),
+        disconnect: vi.fn(),
+      }))
+    );
+  });
+
+  it('loads draft from sessionStorage on mount', () => {
+    sessionStorage.setItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`, 'in-progress draft');
+
+    render(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    const input = screen.getByLabelText('Scrivi') as HTMLInputElement;
+    expect(input.value).toBe('in-progress draft');
+  });
+
+  it('writes input changes to sessionStorage as draft', () => {
+    render(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    const input = screen.getByLabelText('Scrivi') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'typing' } });
+
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe('typing');
+  });
+
+  it('clears draft from sessionStorage after successful send', () => {
+    const onSend = vi.fn();
+    render(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={onSend}
+        labels={baseLabels}
+      />
+    );
+
+    const input = screen.getByLabelText('Scrivi') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'hi' } });
+    fireEvent.click(screen.getByLabelText('Invia'));
+
+    expect(onSend).toHaveBeenCalledWith('hi', 'shared');
+    expect(sessionStorage.getItem(`${CHAT_DRAFT_KEY_PREFIX}sess-1`)).toBe(null);
+    expect(input.value).toBe('');
+  });
+
+  it('renders data-at-bottom attribute reflecting scroll anchor state', () => {
+    const { container } = render(
+      <LiveAgentChat
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        labels={baseLabels}
+      />
+    );
+
+    const root = container.querySelector('[data-slot="live-agent-chat"]');
+    expect(root).not.toBeNull();
+    expect(root?.getAttribute('data-at-bottom')).toBe('true');
+  });
+});
+```
+
+- [ ] **Step 4.3: Run failing tests**
+
+```bash
+cd apps/web && pnpm test src/components/features/session-live/__tests__/LiveAgentChat.test.tsx --run
+```
+
+Expected: 4 new tests FAIL (`sessionId` prop not yet accepted, draft not loaded, etc.).
+
+- [ ] **Step 4.4: Modify `LiveAgentChat.tsx` — extend props + wire hooks**
+
+Replace the existing component body in `apps/web/src/components/features/session-live/LiveAgentChat.tsx` with:
+
+```tsx
+'use client';
+
+/**
+ * LiveAgentChat — Wave D.2 Interactions sub-PR (Issue #750).
+ * Extended by Issue #2375 G3 with sessionStorage draft + smart auto-scroll.
+ *
+ * Role variants:
+ *   Spectator: visibility forced 'shared' (no private toggle visible)
+ *   Player+Host: both visibility options (private/shared toggle)
+ *
+ * #2375 G3:
+ *   - sessionId prop → useChatDraft persists input across collapse/expand cycles
+ *   - useScrollAnchor → smart auto-scroll: auto when at bottom, toast when scrolled up
+ *   - data-at-bottom attribute reflects current anchor state (E2E selector)
+ *
+ * Gate C: DIVERGES from MeepleCard — live chat panel, not a card pattern.
+ *
+ * data-slot="live-agent-chat" — required by unit tests.
+ * data-viewer-role={viewerRole} — role variant assertion in unit tests.
+ * data-at-bottom={isAtBottom ? 'true' : 'false'} — #2375 G3 scroll anchor state.
+ */
+
+import { type ReactElement, useEffect, useRef, useState } from 'react';
+
+import { Send } from 'lucide-react';
+
+import { useChatDraft } from '@/lib/session-live/use-chat-draft';
+import { useScrollAnchor } from '@/lib/session-live/use-scroll-anchor';
+import type { ParticipantRole } from '@/lib/session-live/participant-role';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ChatMessage {
+  readonly id: string;
+  readonly senderId: string;
+  readonly senderName: string;
+  readonly content: string;
+  readonly visibility: 'private' | 'shared';
+  readonly timestamp: string;
+}
+
+// ─── Labels ───────────────────────────────────────────────────────────────────
+
+export interface LiveAgentChatLabels {
+  readonly title: string;
+  readonly inputAriaLabel: string;
+  readonly sendAriaLabel: string;
+  readonly visibilityPrivate: string;
+  readonly visibilityShared: string;
+  readonly emptyMessage: string;
+  /** #2375 G3: pre-resolved ICU plural for "N nuovi messaggi" pill. */
+  readonly newMessagesToast: string;
+  /** #2375 G3: aria-label on the toast button. */
+  readonly newMessagesToastAriaLabel: string;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface LiveAgentChatProps {
+  /** #2375 G3: sessionId used as sessionStorage key for draft persistence. */
+  readonly sessionId: string | null;
+  readonly messages: ReadonlyArray<ChatMessage>;
+  readonly viewerRole: ParticipantRole;
+  readonly viewerId: string;
+  readonly onSendMessage: (content: string, visibility: 'private' | 'shared') => void;
+  readonly compact?: boolean;
+  readonly labels: LiveAgentChatLabels;
+  readonly className?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function LiveAgentChat({
+  sessionId,
+  messages,
+  viewerRole,
+  viewerId,
+  onSendMessage,
+  compact = false,
+  labels,
+  className,
+}: LiveAgentChatProps): ReactElement {
+  const { draft, setDraft, clearDraft } = useChatDraft({ sessionId });
+
+  // Spectator forced to 'shared'; Player+Host can toggle
+  const [visibility, setVisibility] = useState<'private' | 'shared'>('shared');
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const { isAtBottom, scrollToBottom } = useScrollAnchor({
+    containerRef,
+    bottomRef,
+    trigger: messages.length,
+  });
+
+  // Counter for "N nuovi messaggi" toast — reset to 0 whenever isAtBottom flips
+  // to true (caller scrolled back down or auto-scroll engaged).
+  const [newMessageCount, setNewMessageCount] = useState<number>(0);
+  const prevMessageCountRef = useRef<number>(messages.length);
+
+  useEffect(() => {
+    const prev = prevMessageCountRef.current;
+    const next = messages.length;
+    prevMessageCountRef.current = next;
+
+    if (next <= prev) return;
+
+    if (isAtBottom) {
+      scrollToBottom();
+      setNewMessageCount(0);
+    } else {
+      setNewMessageCount(prev => prev + (next - prevMessageCountRef.current + 1));
+      // Note: prevMessageCountRef.current already moved to `next`; (next - next + 1) is wrong.
+      // We need to use the captured `prev` from the closure, not the ref.
+    }
+  }, [messages.length, isAtBottom, scrollToBottom]);
+
+  const isSpectator = viewerRole === 'Spectator';
+
+  const handleSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    // Spectator always sends as shared
+    onSendMessage(trimmed, isSpectator ? 'shared' : visibility);
+    clearDraft();
+  };
+
+  const handleToastClick = (): void => {
+    scrollToBottom();
+    setNewMessageCount(0);
+  };
+
+  return (
+    <section
+      data-slot="live-agent-chat"
+      data-viewer-role={viewerRole}
+      data-at-bottom={isAtBottom ? 'true' : 'false'}
+      aria-label={labels.title}
+      className={`flex flex-col ${compact ? 'gap-2' : 'gap-3'} ${className ?? ''}`}
+    >
+      <h3 className="shrink-0 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {labels.title}
+      </h3>
+
+      {/* Messages list */}
+      <div
+        ref={containerRef}
+        className="relative flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto"
+        aria-live="polite"
+        aria-atomic="false"
+        aria-relevant="additions"
+      >
+        {messages.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">{labels.emptyMessage}</p>
+        ) : (
+          messages.map(msg => {
+            const isOwn = msg.senderId === viewerId;
+            const isPrivate = msg.visibility === 'private';
+            return (
+              <div
+                key={msg.id}
+                className={`flex flex-col gap-0.5 ${isOwn ? 'items-end' : 'items-start'}`}
+                data-message-id={msg.id}
+                data-visibility={msg.visibility}
+              >
+                {!isOwn && <span className="text-xs text-muted-foreground">{msg.senderName}</span>}
+                <div
+                  className={`max-w-[85%] rounded-lg px-3 py-1.5 text-sm bg-card text-foreground ${
+                    isPrivate ? 'border border-amber-700/40' : ''
+                  }`}
+                >
+                  {msg.content}
+                  {isPrivate && (
+                    <span className="ml-2 text-xs text-amber-400/70">
+                      {labels.visibilityPrivate}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+        <div ref={bottomRef} aria-hidden="true" data-slot="chat-bottom-sentinel" />
+
+        {/* #2375 G3 — "N nuovi messaggi" pill, shown when scrolled up + new arrivals */}
+        {!isAtBottom && newMessageCount > 0 && (
+          <div className="sticky bottom-2 flex justify-center" aria-live="polite">
+            <button
+              type="button"
+              onClick={handleToastClick}
+              aria-label={labels.newMessagesToastAriaLabel}
+              data-slot="chat-new-messages-toast"
+              className="rounded-full border border-entity-agent/40 bg-entity-agent/15
+                px-3 py-1 text-xs font-semibold text-entity-agent shadow-sm
+                hover:bg-entity-agent/25 focus-visible:outline-none
+                focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {labels.newMessagesToast}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Send form */}
+      <form onSubmit={handleSubmit} className="flex shrink-0 flex-col gap-2">
+        {/* Visibility toggle — hidden for Spectator */}
+        {!isSpectator && (
+          <div className="flex gap-2" role="group" aria-label="Visibilità messaggio">
+            <button
+              type="button"
+              aria-pressed={visibility === 'shared'}
+              onClick={() => setVisibility('shared')}
+              className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                visibility === 'shared'
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {labels.visibilityShared}
+            </button>
+            <button
+              type="button"
+              aria-pressed={visibility === 'private'}
+              onClick={() => setVisibility('private')}
+              className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                visibility === 'private'
+                  ? 'bg-amber-700/60 text-amber-100'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {labels.visibilityPrivate}
+            </button>
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            aria-label={labels.inputAriaLabel}
+            placeholder={labels.inputAriaLabel}
+            className="min-w-0 flex-1 rounded-lg border border-border/60 bg-card
+              px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <button
+            type="submit"
+            aria-label={labels.sendAriaLabel}
+            disabled={!draft.trim()}
+            className="flex shrink-0 items-center justify-center rounded-lg border
+              border-border/60 bg-card px-3 py-2 text-foreground
+              transition-colors hover:bg-muted
+              disabled:cursor-not-allowed disabled:opacity-40
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Send className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+```
+
+**Note on the counter increment bug.** The version above uses `prevMessageCountRef` incorrectly inside the `useEffect`. Fix by capturing `prev` before the ref assignment:
+
+```tsx
+useEffect(() => {
+  const prev = prevMessageCountRef.current;
+  const next = messages.length;
+  if (next > prev) {
+    if (isAtBottom) {
+      scrollToBottom();
+      setNewMessageCount(0);
+    } else {
+      setNewMessageCount(c => c + (next - prev));
+    }
+  }
+  prevMessageCountRef.current = next;
+}, [messages.length, isAtBottom, scrollToBottom]);
+```
+
+Replace the `useEffect` block in `LiveAgentChat.tsx` with this corrected version.
+
+- [ ] **Step 4.5: Run tests**
+
+```bash
+cd apps/web && pnpm test src/components/features/session-live/__tests__/LiveAgentChat.test.tsx --run
+```
+
+Expected: All existing + 4 new tests PASS.
+
+- [ ] **Step 4.6: Update `SessionLiveView.tsx` chatAgentLabels memo to include new fields**
+
+Find `chatAgentLabels` (~line 783) and update `chatLabels` (~line 771) to add the 2 new chat keys and 2 new chatAgent keys. The exact line numbers may have drifted — use `grep -n "chatLabels = useMemo" apps/web/src/app/\(authenticated\)/sessions/\[id\]/live/_components/SessionLiveView.tsx` to locate.
+
+Replace the `chatLabels` memo:
+
+```tsx
+const chatLabels = useMemo<LiveAgentChatLabels>(
+  (): LiveAgentChatLabels => ({
+    title: t('pages.sessionLive.chat.title'),
+    inputAriaLabel: t('pages.sessionLive.chat.inputAriaLabel'),
+    sendAriaLabel: t('pages.sessionLive.chat.sendAriaLabel'),
+    visibilityPrivate: t('pages.sessionLive.chat.visibilityPrivate'),
+    visibilityShared: t('pages.sessionLive.chat.visibilityShared'),
+    emptyMessage: t('pages.sessionLive.chat.emptyMessage'),
+    // #2375 G3 ICU plural resolved here; count wired in Task 5 via separate prop, see note.
+    newMessagesToast: '', // placeholder — resolved per render in LiveAgentChat (count unknown here)
+    newMessagesToastAriaLabel: t('pages.sessionLive.chat.newMessagesToastAriaLabel'),
+  }),
+  [t]
+);
+```
+
+**WAIT — placeholder is wrong.** ICU plural with dynamic `count` can't be pre-resolved when the count is local component state. We have two options:
+
+(a) Resolve `newMessagesToast` inside `LiveAgentChat` using `useIntl`.
+(b) Lift `newMessageCount` to `SessionLiveView`.
+
+**Decision: option (a)** — local state stays local; we add an `intl` import inside `LiveAgentChat` and call `intl.formatMessage(...)` for the plural. This is the ONE Gate A violation we accept because the count is component-private.
+
+Update `LiveAgentChat.tsx`:
+
+```tsx
+import { useIntl } from 'react-intl';
+// (top of file)
+
+// inside component, after the `newMessageCount` state declaration:
+const intl = useIntl();
+const toastLabel = intl.formatMessage(
+  { id: 'pages.sessionLive.chat.newMessagesToast' },
+  { count: newMessageCount }
+);
+```
+
+And in the JSX, replace `{labels.newMessagesToast}` with `{toastLabel}`.
+
+Also REMOVE `newMessagesToast` from the `LiveAgentChatLabels` interface and from the `chatLabels` memo in `SessionLiveView` (keep `newMessagesToastAriaLabel`). Update the test fixture in Step 4.2 by removing the `newMessagesToast` key — the JSX no longer reads it from `labels`.
+
+Re-run Step 4.5 tests to verify they still pass after this refactor (the toast text will now come from the IntlProvider — Step 4.2 test wraps without IntlProvider, so render under `<IntlProvider locale="en" messages={{ ...test fixture... }}>` if not already).
+
+Check the existing test file: if it uses `renderWithIntl` helper, follow that pattern. If not, wrap with `IntlProvider` from `react-intl`:
+
+```tsx
+import { IntlProvider } from 'react-intl';
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <IntlProvider
+      locale="it"
+      messages={{
+        'pages.sessionLive.chat.newMessagesToast': '{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}',
+      }}
+    >
+      {ui}
+    </IntlProvider>
+  );
+}
+```
+
+Use `renderWithIntl(...)` in the new `describe('#2375 G3...')` tests.
+
+- [ ] **Step 4.7: Run tests again to verify pass with IntlProvider**
+
+```bash
+cd apps/web && pnpm test src/components/features/session-live/__tests__/LiveAgentChat.test.tsx --run
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add apps/web/src/components/features/session-live/LiveAgentChat.tsx \
+        apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
+git commit -m "feat(session-live): #2375 LiveAgentChat draft + smart scroll + N nuovi messaggi
+
+- New sessionId prop wires useChatDraft (sessionStorage per session)
+- useScrollAnchor IntersectionObserver: smart auto-scroll when at bottom
+- 'N nuovi messaggi' toast appears when scrolled up + new arrivals
+- data-at-bottom attribute exposed for E2E
+- ICU plural for toast resolved locally via useIntl (count is component-private)
+
+4 new unit tests cover: mount-load draft, change-write draft, send-clear draft,
+data-at-bottom attribute.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `SessionLiveView` accordion FSM wire
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx`
+
+- [ ] **Step 5.1: Add failing tests for ?chat / ?mchat URL SSOT**
+
+Append a new `describe('#2375 G3 — accordion FSM URL SSOT', ...)` block to `SessionLiveView.test.tsx`:
+
+```tsx
+describe('#2375 G3 — accordion FSM URL SSOT', () => {
+  it('renders ChatAgentPanel expanded by default (no ?chat param)', () => {
+    // Uses existing test harness with searchParams empty
+    // Assert: section[data-slot=chat-agent-panel] has no data-collapsed attribute
+    // (or data-collapsed is undefined per §5 contract: only set when truthy)
+    // Both desktop AND mobile rendered (matchMedia mock may need attention)
+  });
+
+  it('?chat=collapsed → desktop ChatAgentPanel collapsed=true', () => {
+    // Mock useSearchParams to return ?chat=collapsed
+    // Assert: desktop panel has data-collapsed="true"
+    // Assert: mobile panel does NOT have data-collapsed (mchat omitted)
+  });
+
+  it('?mchat=collapsed → mobile ChatAgentPanel collapsed=true', () => {
+    // Mock useSearchParams to return ?mchat=collapsed
+    // Assert: mobile panel has data-collapsed="true"
+    // Assert: desktop panel does NOT have data-collapsed
+  });
+
+  it('?chat=collapsed&mchat=collapsed → both collapsed', () => {
+    // Assert both data-collapsed="true"
+  });
+
+  it('clicking desktop ChatAgentPanel header pushes ?chat=collapsed to URL', async () => {
+    // render with empty search; click the chat-agent-panel button header on desktop
+    // assert router.replace called with /sessions/X/live?chat=collapsed (or similar)
+  });
+
+  it('clicking again when ?chat=collapsed removes the param', async () => {
+    // initial ?chat=collapsed; click header
+    // assert router.replace called with URL minus ?chat
+  });
+
+  // Mirror for mobile if matchMedia testable; otherwise skip mobile-specific
+  // click tests and rely on E2E coverage.
+});
+```
+
+**Important:** Read the existing test file to mirror its router/searchParams mocking style. The existing tests already cover `?tab=` / `?mtab=` behaviour so the harness is in place — copy the pattern verbatim.
+
+- [ ] **Step 5.2: Run failing tests**
+
+```bash
+cd apps/web && pnpm test \
+  src/app/\(authenticated\)/sessions/\[id\]/live/_components/__tests__/SessionLiveView.test.tsx \
+  --run
+```
+
+Expected: 6 new tests FAIL.
+
+- [ ] **Step 5.3: Wire URL parsers + handlers in `SessionLiveView.tsx`**
+
+Add **after** the existing `parseMobileSheetOpen` function (~line 186):
+
+```tsx
+// G3 #2375 — accordion FSM URL parsers
+function parseChatCollapsed(raw: string | null): boolean {
+  return raw === 'collapsed';
+}
+
+function parseMobileChatCollapsed(raw: string | null): boolean {
+  return raw === 'collapsed';
+}
+```
+
+Add **after** `const mobileSheetOpen = parseMobileSheetOpen(...)` (~line 295):
+
+```tsx
+const chatCollapsed = parseChatCollapsed(searchParams.get('chat'));
+const mobileChatCollapsed = parseMobileChatCollapsed(searchParams.get('mchat'));
+```
+
+Add **after** `handleMobileSheetOpenChange` (~line 436):
+
+```tsx
+const handleChatCollapsedChange = useCallback(
+  (collapsed: boolean) => {
+    const val = collapsed ? 'collapsed' : null;
+    router.replace(`${pathname}${buildQuery({ chat: val })}`, { scroll: false });
+  },
+  [router, pathname, buildQuery]
+);
+
+const handleMobileChatCollapsedChange = useCallback(
+  (collapsed: boolean) => {
+    const val = collapsed ? 'collapsed' : null;
+    router.replace(`${pathname}${buildQuery({ mchat: val })}`, { scroll: false });
+  },
+  [router, pathname, buildQuery]
+);
+```
+
+- [ ] **Step 5.4: Wire props on desktop `ChatAgentPanel`**
+
+Find `desktopMainColumn` (~line 1071) and update the `<ChatAgentPanel>` call:
+
+```tsx
+const desktopMainColumn = (
+  <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3">
+    <ChatAgentPanel
+      messages={chatMessages}
+      viewerRole={activeSession.viewerRole}
+      viewerId={activeSession.viewerId}
+      onSendMessage={handleSendMessage}
+      agentName="MeepleAI"
+      agentEmoji="🤖"
+      latencyMs={42}
+      collapsed={chatCollapsed}
+      onHeaderClick={() => handleChatCollapsedChange(!chatCollapsed)}
+      labels={chatAgentLabels}
+    />
+    <ActionLogTimeline entries={activeSession.actionLog} labels={actionLogLabels} />
+  </div>
+);
+```
+
+- [ ] **Step 5.5: Wire props on mobile `ChatAgentPanel` (mobileMainContent)**
+
+Find `mobileMainContent` (~line 895) and update:
+
+```tsx
+const mobileMainContent = useMemo<React.ReactNode>(() => {
+  if (activeSession == null) return null;
+  return (
+    <div className="flex flex-col gap-3">
+      <ChatAgentPanel
+        messages={chatMessages}
+        viewerRole={activeSession.viewerRole}
+        viewerId={activeSession.viewerId}
+        onSendMessage={handleSendMessage}
+        agentName="MeepleAI"
+        agentEmoji="🤖"
+        latencyMs={42}
+        collapsed={mobileChatCollapsed}
+        onHeaderClick={() => handleMobileChatCollapsedChange(!mobileChatCollapsed)}
+        labels={chatAgentLabels}
+        compact
+      />
+      <ActionLogTimeline entries={activeSession.actionLog} labels={actionLogLabels} compact />
+    </div>
+  );
+}, [
+  activeSession,
+  chatMessages,
+  handleSendMessage,
+  chatAgentLabels,
+  actionLogLabels,
+  mobileChatCollapsed,
+  handleMobileChatCollapsedChange,
+]);
+```
+
+- [ ] **Step 5.6: Pass `sessionId` prop to LiveAgentChat consumers**
+
+`LiveAgentChat` is consumed by `ChatAgentPanel` internally; the `ChatAgentPanel` primitive does NOT yet forward `sessionId`. Per §5 contract preservation we must add a non-breaking optional prop.
+
+Update `apps/web/src/components/features/session-live/ChatAgentPanel.tsx` props interface (NOT the component contract — just propagate the prop):
+
+```tsx
+export interface ChatAgentPanelProps {
+  readonly messages: ReadonlyArray<ChatMessage>;
+  readonly viewerRole: ParticipantRole;
+  readonly viewerId: string;
+  /** #2375 G3 — forwarded to LiveAgentChat for draft persistence. */
+  readonly sessionId?: string | null;
+  readonly onSendMessage: (
+    content: string,
+    visibility: 'private' | 'shared'
+  ) => Promise<void> | void;
+  // ...existing fields unchanged...
+}
+```
+
+And inside the component body, forward to `LiveAgentChat`:
+
+```tsx
+<LiveAgentChat
+  sessionId={sessionId ?? null}
+  messages={messages}
+  viewerRole={viewerRole}
+  viewerId={viewerId}
+  onSendMessage={handleSendMessage}
+  compact={compact}
+  labels={labels.chatPanelLabels}
+/>
+```
+
+**§5 contract clarification:** this is an additive optional prop. The `data-slot`, `data-collapsed`, header button semantics, and body-unmount behaviour are unchanged. Update the JSDoc to note: "§5 contract: sessionId is forwarded transparently to LiveAgentChat; it does NOT change the panel's data-slot/collapsed/header semantics."
+
+Finally, in `SessionLiveView.tsx` pass `sessionId` on both desktop and mobile `ChatAgentPanel` usages:
+
+```tsx
+<ChatAgentPanel
+  sessionId={sessionId}
+  ...
+/>
+```
+
+- [ ] **Step 5.7: Run all session-live tests**
+
+```bash
+cd apps/web && pnpm test src/app/\(authenticated\)/sessions/\[id\]/live --run
+```
+
+Expected: All existing + 6 new SessionLiveView tests PASS.
+
+- [ ] **Step 5.8: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/sessions/\[id\]/live/_components/SessionLiveView.tsx \
+        apps/web/src/app/\(authenticated\)/sessions/\[id\]/live/_components/__tests__/SessionLiveView.test.tsx \
+        apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+git commit -m "feat(session-live): #2375 wire accordion FSM (?chat/?mchat URL SSOT)
+
+- parseChatCollapsed + parseMobileChatCollapsed parsers
+- handleChatCollapsedChange + handleMobileChatCollapsedChange handlers
+- Desktop ChatAgentPanel: collapsed + onHeaderClick wired
+- Mobile ChatAgentPanel: collapsed + onHeaderClick wired (independent ?mchat)
+- ChatAgentPanel: additive optional sessionId prop forwarded to LiveAgentChat
+  (§5 contract preserved — no data-slot/collapsed/header semantics change)
+
+DEC-1 lock: ?chat (desktop) + ?mchat (mobile) separate, mirror ?tab/?mtab.
+DEC-4 lock: default expanded (param omitted), match mockup canonical.
+
+6 new SessionLiveView tests cover URL parse + handler dispatch + prop wiring.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Playwright E2E spec
+
+**Files:**
+- Create: `apps/web/e2e/session-live-chat-agent-g3.spec.ts`
+
+- [ ] **Step 6.1: Read an existing session-live e2e spec for pattern**
+
+```bash
+cat apps/web/e2e/session-live-mobile.spec.ts | head -60
+```
+
+Note the fixture URL pattern (`?fixture=host|player|spectator|paused`), helper imports from `e2e/_helpers`, and `test.describe` structure.
+
+- [ ] **Step 6.2: Create the E2E spec**
+
+Create `apps/web/e2e/session-live-chat-agent-g3.spec.ts`:
+
+```ts
+import { expect, test } from '@playwright/test';
+
+/**
+ * #2375 G3 — ChatAgent always-visible accordion FSM E2E.
+ *
+ * Covers 8 scenarios from spec §7.3.
+ *
+ * Uses visual-test fixture (?fixture=host) so SSE is mocked and we can
+ * deterministically assert without backend dependency.
+ */
+
+const FIXTURE_URL = '/sessions/fixture-host/live?fixture=host';
+
+test.describe('#2375 G3 ChatAgent accordion + smart scroll', () => {
+  test('1. default render: ChatAgent expanded (no ?chat param)', async ({ page }) => {
+    await page.goto(FIXTURE_URL);
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await expect(panel).toBeVisible();
+    await expect(panel).not.toHaveAttribute('data-collapsed', 'true');
+  });
+
+  test('2. click header → URL becomes ?chat=collapsed, body hidden', async ({ page }) => {
+    await page.goto(FIXTURE_URL);
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    const header = panel.locator('button').first();
+    await header.click();
+
+    await expect(page).toHaveURL(/[?&]chat=collapsed/);
+    await expect(panel).toHaveAttribute('data-collapsed', 'true');
+    await expect(panel.locator('[data-slot="live-agent-chat"]')).toHaveCount(0);
+  });
+
+  test('3. reload preserves collapsed state (URL is SSOT)', async ({ page }) => {
+    await page.goto(`${FIXTURE_URL}&chat=collapsed`);
+    await page.reload();
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    await expect(panel).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  test('4. click again removes ?chat param', async ({ page }) => {
+    await page.goto(`${FIXTURE_URL}&chat=collapsed`);
+    const panel = page.locator('[data-slot="chat-agent-panel"]').first();
+    const header = panel.locator('button').first();
+    await header.click();
+
+    await expect(page).not.toHaveURL(/[?&]chat=collapsed/);
+    await expect(panel).not.toHaveAttribute('data-collapsed', 'true');
+  });
+
+  test('5. draft persistence across reload (sessionStorage)', async ({ page }) => {
+    await page.goto(FIXTURE_URL);
+    const input = page.locator(
+      '[data-slot="chat-agent-panel"] input[type="text"]'
+    ).first();
+    await input.fill('borrador');
+
+    await page.reload();
+    const inputAfter = page.locator(
+      '[data-slot="chat-agent-panel"] input[type="text"]'
+    ).first();
+    await expect(inputAfter).toHaveValue('borrador');
+  });
+
+  test('6. send clears draft + input', async ({ page }) => {
+    await page.goto(FIXTURE_URL);
+    const input = page.locator(
+      '[data-slot="chat-agent-panel"] input[type="text"]'
+    ).first();
+    await input.fill('hello');
+    const send = page.locator(
+      '[data-slot="chat-agent-panel"] button[type="submit"]'
+    ).first();
+    await send.click();
+
+    await expect(input).toHaveValue('');
+
+    // Reload should NOT restore (cleared on send)
+    await page.reload();
+    const inputAfter = page.locator(
+      '[data-slot="chat-agent-panel"] input[type="text"]'
+    ).first();
+    await expect(inputAfter).toHaveValue('');
+  });
+
+  test('7. data-at-bottom toggles as user scrolls', async ({ page }) => {
+    await page.goto(FIXTURE_URL);
+    const chat = page.locator('[data-slot="live-agent-chat"]').first();
+    await expect(chat).toHaveAttribute('data-at-bottom', 'true');
+
+    // We can't deterministically scroll without populated messages in fixture;
+    // this assertion just verifies the attribute is rendered. Full smart-scroll
+    // behaviour is covered by unit tests; the E2E asserts the wiring exists.
+  });
+
+  test('8. axe AA — collapsed + expanded states pass', async ({ page }) => {
+    await page.goto(FIXTURE_URL);
+    // Default expanded
+    let violations = await page.evaluate(async () => {
+      // @ts-expect-error — axe injected by accessibility.spec helper
+      if (typeof window.axe === 'undefined') return [];
+      // @ts-expect-error
+      const results = await window.axe.run();
+      return results.violations;
+    });
+    expect(violations).toEqual([]);
+
+    // Toggle to collapsed
+    const header = page
+      .locator('[data-slot="chat-agent-panel"] button')
+      .first();
+    await header.click();
+
+    violations = await page.evaluate(async () => {
+      // @ts-expect-error
+      if (typeof window.axe === 'undefined') return [];
+      // @ts-expect-error
+      const results = await window.axe.run();
+      return results.violations;
+    });
+    expect(violations).toEqual([]);
+  });
+});
+```
+
+**Note on test 8 (axe):** if `accessibility.spec.ts` provides a helper for axe injection, use that instead of the inline `evaluate`. Check:
+
+```bash
+grep -l "axe-core\|window.axe" apps/web/e2e/_helpers/ 2>/dev/null
+```
+
+Replace test 8 with the helper-based version if available.
+
+- [ ] **Step 6.3: Run E2E in headless mode (sanity)**
+
+```bash
+cd apps/web && pnpm exec playwright test session-live-chat-agent-g3 --reporter=line
+```
+
+Expected: 8 tests PASS. If the dev server is not running, Playwright will likely fail with `ECONNREFUSED` — start the dev server first (`pnpm dev`) or use the project's pre-configured webServer in `playwright.config.ts`.
+
+If tests fail because the fixture URL is wrong (look at `IS_VISUAL_TEST_BUILD` gating), inspect `apps/web/src/lib/session-live/session-live-visual-test-fixture.ts` and adjust the URL to match the visual-test build flag.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add apps/web/e2e/session-live-chat-agent-g3.spec.ts
+git commit -m "test(e2e): #2375 G3 ChatAgent accordion + draft + smart scroll (8 scenarios)
+
+Playwright spec covers:
+1. Default render expanded
+2. Click header → ?chat=collapsed URL + body hidden
+3. Reload preserves collapsed state
+4. Click again → ?chat removed
+5. Draft persists across reload (sessionStorage)
+6. Send clears draft + input
+7. data-at-bottom attribute wired
+8. axe AA passes on both expanded + collapsed states
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: axe AA component test
+
+**Files:**
+- Create: `apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx`
+
+- [ ] **Step 7.1: Locate the existing axe pattern**
+
+```bash
+ls apps/web/__tests__/ | grep -i axe
+# or
+grep -rl "axe-core\|@axe-core/react" apps/web/__tests__ 2>/dev/null | head -3
+```
+
+Read one of the existing files to learn the import + `await axe(container)` pattern used in this repo.
+
+- [ ] **Step 7.2: Create the axe test**
+
+Create `apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx`:
+
+```tsx
+/**
+ * #2375 G3 — axe AA test for ChatAgentPanel + LiveAgentChat (expanded + collapsed).
+ *
+ * Renders the panel in isolation with IntlProvider and IntersectionObserver
+ * mock, then runs axe-core on both states.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { IntlProvider } from 'react-intl';
+
+import { ChatAgentPanel } from '@/components/features/session-live/ChatAgentPanel';
+
+expect.extend(toHaveNoViolations);
+
+const messages = {
+  'pages.sessionLive.chat.newMessagesToast':
+    '{count, plural, one {# new message} other {# new messages}}',
+};
+
+const labels = {
+  title: 'ChatAgent',
+  agentNameAriaLabel: 'Agent name MeepleAI',
+  onlineLabel: 'Online',
+  latencyAriaLabel: 'Latency 42ms',
+  chatPanelLabels: {
+    title: 'Chat',
+    inputAriaLabel: 'Write a message',
+    sendAriaLabel: 'Send message',
+    visibilityPrivate: 'Private',
+    visibilityShared: 'Shared',
+    emptyMessage: 'No messages yet.',
+    newMessagesToastAriaLabel: 'New messages — click to scroll',
+  },
+};
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(() => ({ observe: vi.fn(), disconnect: vi.fn() }))
+  );
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderPanel(collapsed: boolean) {
+  return render(
+    <IntlProvider locale="en" messages={messages}>
+      <ChatAgentPanel
+        sessionId="sess-1"
+        messages={[]}
+        viewerRole="Player"
+        viewerId="me"
+        onSendMessage={() => {}}
+        agentName="MeepleAI"
+        agentEmoji="🤖"
+        latencyMs={42}
+        collapsed={collapsed}
+        onHeaderClick={() => {}}
+        labels={labels}
+      />
+    </IntlProvider>
+  );
+}
+
+describe('#2375 G3 — ChatAgentPanel axe AA', () => {
+  it('expanded state: 0 violations', async () => {
+    const { container } = renderPanel(false);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('collapsed state: 0 violations', async () => {
+    const { container } = renderPanel(true);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('aria-expanded reflects !collapsed on header button', () => {
+    const { container } = renderPanel(false);
+    const button = container.querySelector('button[aria-expanded]');
+    expect(button?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('aria-expanded reflects !collapsed when collapsed', () => {
+    const { container } = renderPanel(true);
+    const button = container.querySelector('button[aria-expanded]');
+    expect(button?.getAttribute('aria-expanded')).toBe('false');
+  });
+});
+```
+
+If `jest-axe` is not installed in this monorepo, swap to `@axe-core/react` or the existing axe helper used by other tests in this repo. Check:
+
+```bash
+grep -E "jest-axe|@axe-core/react" apps/web/package.json
+```
+
+- [ ] **Step 7.3: Install jest-axe if missing**
+
+```bash
+cd apps/web && pnpm add -D jest-axe @types/jest-axe
+```
+
+(Skip if already present.)
+
+- [ ] **Step 7.4: Run the axe test**
+
+```bash
+cd apps/web && pnpm test __tests__/session-live-chat-agent-g3-axe.test.tsx --run
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx apps/web/package.json apps/web/pnpm-lock.yaml
+git commit -m "test(a11y): #2375 G3 ChatAgentPanel axe AA expanded + collapsed (4 tests)
+
+Covers spec §7.4:
+- Expanded state: 0 axe AA violations
+- Collapsed state: 0 axe AA violations
+- aria-expanded=true when expanded
+- aria-expanded=false when collapsed
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Final verification + PR creation
+
+- [ ] **Step 8.1: Run full typecheck**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 8.2: Run full lint (including BGG ban + token guards)**
+
+```bash
+cd apps/web && pnpm lint && pnpm lint:bgg && pnpm lint:tokens
+```
+
+Expected: 0 violations across all three lints.
+
+- [ ] **Step 8.3: Run all session-live unit + integration tests**
+
+```bash
+cd apps/web && pnpm test session-live --run
+```
+
+Expected: All tests PASS (existing + 4 useScrollAnchor + 7 useChatDraft + 4 LiveAgentChat new + 6 SessionLiveView new = ~21 new + existing baseline).
+
+- [ ] **Step 8.4: Run axe AA test**
+
+```bash
+cd apps/web && pnpm test session-live-chat-agent-g3-axe --run
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 8.5: Run E2E (if dev server available)**
+
+```bash
+cd apps/web && pnpm exec playwright test session-live-chat-agent-g3 --reporter=line
+```
+
+Expected: 8 PASS. If skipped (no dev server in CI), note in PR body that E2E will run on CI.
+
+- [ ] **Step 8.6: Verify CLAUDE.md flaky baseline is empty**
+
+```bash
+grep -A 3 "Known Flaky Tests" CLAUDE.md | head -20
+```
+
+Expected: "baseline currently clean". No new entries needed unless something flakes during the PR run.
+
+- [ ] **Step 8.7: Push branch**
+
+```bash
+git push -u origin feature/issue-2375-g3-chat-agent-always-visible
+```
+
+- [ ] **Step 8.8: Create PR targeting `main-dev`**
+
+```bash
+gh pr create --base main-dev --title "feat(session-live): #2375 G3 ChatAgent always-visible accordion + smart scroll" --body "$(cat <<'EOF'
+## Summary
+- Wires accordion FSM on ChatAgentPanel (§5 contract preserved — no primitive changes)
+- Adds `useScrollAnchor` (IntersectionObserver) + `useChatDraft` (sessionStorage) hooks
+- "N nuovi messaggi" toast when user is scrolled up + new SSE arrivals
+- URL SSOT separati `?chat` (desktop) + `?mchat` (mobile), default expanded
+- Draft persists across collapse/expand cycles via sessionStorage per sessionId
+- Playwright E2E + axe AA coverage closes remaining #2375 acceptance criteria
+
+## Refs
+- Issue: #2375 (epic #2354 Session live shell)
+- Spec: `docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md`
+- Plan: `docs/superpowers/plans/2026-06-16-issue-2375-g3-chatagent-always-visible.md`
+- G1 prerequisite shipped: PR #2393 (`5ad149ea0` sess.46r)
+
+## 4 DEC user-locked
+- DEC-1 URL SSOT separati `?chat` + `?mchat` (mirror `?tab`/`?mtab`)
+- DEC-2 Smart auto-scroll via IntersectionObserver + "N nuovi messaggi" toast
+- DEC-3 Draft persistence in sessionStorage per sessionId
+- DEC-4 Default expanded (no URL param)
+
+## Test plan
+- [x] Unit `useScrollAnchor` (4 tests) — happy path + flip + scrollToBottom + fallback
+- [x] Unit `useChatDraft` (7 tests) — mount/set/clear roundtrip + isolation + quota
+- [x] Integration `LiveAgentChat` (4 new tests) — draft + send-clear + at-bottom attr
+- [x] Integration `SessionLiveView` (6 new tests) — `?chat`/`?mchat` URL SSOT + handlers
+- [x] E2E `session-live-chat-agent-g3.spec.ts` (8 scenarios)
+- [x] Axe AA `session-live-chat-agent-g3-axe.test.tsx` (4 tests, expanded + collapsed)
+- [x] Typecheck + lint + lint:bgg + lint:tokens pass
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8.9: Wait for CI green, then merge**
+
+Check PR status:
+
+```bash
+gh pr view --json url,statusCheckRollup
+```
+
+Once all checks pass (or admin-squash decision approved by user), merge with squash:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 8.10: Close issue #2375 with comment + verify epic #2354 progress**
+
+```bash
+gh issue close 2375 -r completed -c "Shipped via PR #<PR-number>. All AC verified:
+- ChatAgent visible LEFT 60% ✅
+- No tab switching ✅
+- SSE scroll preservation via useScrollAnchor (IntersectionObserver) ✅
+- axe AA 0 violations on expanded + collapsed ✅
+- E2E typing + send + receive (8 scenarios) ✅
+
+Accordion FSM bonus (DEC scope C):
+- ?chat / ?mchat URL SSOT
+- sessionStorage draft persistence
+
+Spec: docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md
+Plan: docs/superpowers/plans/2026-06-16-issue-2375-g3-chatagent-always-visible.md"
+
+gh issue view 2354 --json title,body,state | head
+```
+
+Expected: issue #2375 closed completed; epic #2354 unchanged (G3 was a sub-issue).
+
+---
+
+## Self-Review
+
+**Spec coverage:** All 4 DEC locks have a task:
+- DEC-1 URL SSOT → Task 5
+- DEC-2 IntersectionObserver scroll anchor → Tasks 1 + 4
+- DEC-3 sessionStorage draft → Tasks 2 + 4
+- DEC-4 Default expanded → Tasks 5 (parser returns false when param absent)
+
+All 5 spec acceptance criteria (§8) covered:
+- "ChatAgent visible LEFT 60%" → preserved by G1, Task 5 wires panel
+- "No tab switching" → preserved by G1
+- "SSE scroll preservation" → Tasks 1 + 4
+- "axe AA 0 violations" → Task 7
+- "E2E typing + send + receive" → Task 6
+
+**Placeholder scan:** No "TBD"/"TODO". Step 4.6 originally included a placeholder fallback for the ICU plural — corrected inline to use `useIntl` directly.
+
+**Type consistency:** `useScrollAnchor` returns `isAtBottom` + `scrollToBottom`; used identically in Task 4. `useChatDraft` returns `draft` + `setDraft` + `clearDraft`; used identically in Task 4. `CHAT_DRAFT_KEY_PREFIX` exported from `use-chat-draft.ts` (Task 2) + imported in Task 4 test. `LiveAgentChatLabels` interface gains `newMessagesToastAriaLabel` but NOT `newMessagesToast` (Task 4 Step 4.6 decision — count is component-private).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-16-issue-2375-g3-chatagent-always-visible.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. ~6-8 subagent dispatches (1 per task, Task 4+5 may need 2 each).
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.

--- a/docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md
+++ b/docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md
@@ -1,0 +1,300 @@
+# Issue #2375 G3 — ChatAgent always-visible primitive (design)
+
+**Date**: 2026-06-16
+**Parent epic**: [#2354 Session live shell](https://github.com/meepleAi-app/meepleai-monorepo/issues/2354)
+**Sub-issue**: [#2375](https://github.com/meepleAi-app/meepleai-monorepo/issues/2375)
+**Scope**: C (combined verify-and-close + accordion FSM wire)
+**Effort estimate**: ~2-3gg
+
+## 1. Context
+
+G1 (`#2374`, PR `#2393`, sess.46r) shipped the 2-col 60/40 desktop layout + mobile
+bottom-sheet for `/sessions/[id]/live`. The `ChatAgentPanel` primitive landed
+with a frozen §5 contract that supports `collapsed`/`onHeaderClick` props for
+G3, but the parent `SessionLiveView` does **not** wire the accordion FSM yet.
+The LEFT 60% column currently stacks `ChatAgentPanel` (always-expanded) on top
+of `ActionLogTimeline`, matching the canonical mockup
+`admin-mockups/design_files/sp4-session-skeleton-live.{html,jsx}`.
+
+This spec covers two combined deliverables:
+
+- **(A) Verify-and-close**: audit the current G1 implementation for the
+  remaining `#2375` acceptance criteria (SSE scroll preservation, axe AA,
+  Playwright E2E for typing + send + receive) and ship the missing tests +
+  fixes.
+- **(B) Accordion FSM wire**: parent `SessionLiveView` consumes
+  `collapsed`/`onHeaderClick` props, exposes URL SSOT for the collapse state,
+  preserves the chat draft across collapse cycles, and gracefully manages
+  scroll position when SSE delivers new messages.
+
+The §5 frozen contract on `ChatAgentPanel` is **preserved verbatim**: no prop
+rename, no body-mount semantics change, no SSE state moved inside the primitive.
+
+## 2. Decisions locked (brainstorming session)
+
+| ID | Decision | Rationale |
+|---|---|---|
+| DEC-1 | URL SSOT separati `?chat` (desktop) + `?mchat` (mobile) | Mirror del pattern esistente `?tab` / `?mtab`. Permette state divergente cross-device. |
+| DEC-2 | Smart auto-scroll via `IntersectionObserver` + "N nuovi messaggi" toast quando utente è scrolled up | UX-friendly per chat live; pattern industry-standard. |
+| DEC-3 | Draft persistence in `sessionStorage` con key `meepleai.chat-draft.${sessionId}` | Zero data loss + zero friction. Restored on re-expand. |
+| DEC-4 | Default state expanded (no URL param) on first render | Match mockup canonical "sempre visibile". |
+
+## 3. FSM + URL contract
+
+```
+URL params (NEW G3 additions, no rename of existing):
+  ?chat=collapsed      desktop accordion state
+  ?mchat=collapsed     mobile accordion state
+
+Default = param omitted → expanded (DEC-4).
+Any value other than the literal string `collapsed` → expanded (defensive
+parser).
+
+Parsers (SessionLiveView):
+  parseChatCollapsed(raw)        → raw === 'collapsed'
+  parseMobileChatCollapsed(raw)  → raw === 'collapsed'
+
+Handlers (SessionLiveView):
+  handleChatCollapsedChange(c)       → router.replace(buildQuery({ chat:  c ? 'collapsed' : null }))
+  handleMobileChatCollapsedChange(c) → router.replace(buildQuery({ mchat: c ? 'collapsed' : null }))
+```
+
+§5 contract preserved on `ChatAgentPanel`:
+
+- `onHeaderClick` provided → header rendered as `<button aria-expanded={!collapsed}>`.
+- `collapsed=true` → body unmounts (no hidden focus traps).
+- `data-collapsed="true"` attribute reflects current state (E2E selector).
+
+Back-compat:
+
+- Existing bookmarks without `?chat`/`?mchat` continue to render the chat
+  expanded (current G1 behavior).
+- No legacy aliases needed — these are net-new params.
+
+## 4. Components + hooks API
+
+### 4.1 `useScrollAnchor` (new)
+
+`apps/web/src/lib/session-live/use-scroll-anchor.ts`
+
+```ts
+interface UseScrollAnchorOptions {
+  containerRef: RefObject<HTMLElement>;
+  bottomRef: RefObject<HTMLElement>;
+  trigger: unknown; // e.g. messages.length
+}
+
+interface UseScrollAnchorReturn {
+  isAtBottom: boolean;
+  scrollToBottom: () => void;
+}
+
+export function useScrollAnchor(opts: UseScrollAnchorOptions): UseScrollAnchorReturn;
+```
+
+Behavior:
+
+- Mounts an `IntersectionObserver` on `bottomRef` with `root = containerRef`.
+- `isAtBottom` flips to `true` when the bottom sentinel intersects the viewport
+  (last message visible).
+- `scrollToBottom()` calls `bottomRef.current?.scrollIntoView({ behavior: 'smooth' })`.
+- Fallback: when `IntersectionObserver` is undefined, `isAtBottom` stays `true`
+  (naive auto-scroll on every new message — degraded UX for ≤1% of browsers).
+
+### 4.2 `useChatDraft` (new)
+
+`apps/web/src/lib/session-live/use-chat-draft.ts`
+
+```ts
+interface UseChatDraftOptions {
+  sessionId: string | null;
+}
+
+interface UseChatDraftReturn {
+  draft: string;
+  setDraft: (next: string) => void;
+  clearDraft: () => void;
+}
+
+export function useChatDraft(opts: UseChatDraftOptions): UseChatDraftReturn;
+```
+
+Behavior:
+
+- Key: `meepleai.chat-draft.${sessionId}`.
+- Mount → read `sessionStorage[key]` (SSR-safe: returns `""` when
+  `typeof window === 'undefined'`).
+- `setDraft` writes synchronously to `sessionStorage`.
+- `clearDraft` removes the key.
+- `sessionId=null` → all operations are no-ops (`draft=""`).
+- Quota exceeded / sessionStorage unavailable → `console.warn` + swallow
+  (component still functional, just no persistence).
+
+### 4.3 `LiveAgentChat` modifications
+
+The existing `LiveAgentChat` component is extended (not rewritten):
+
+- Mount `containerRef` on the inner messages-list `<div>` carrying
+  `overflow-y: auto` (the actual scroll container, not the outer panel).
+- Mount `bottomRef` as an `aria-hidden` empty `<div>` rendered immediately
+  after the last message item.
+- Wire `useChatDraft({ sessionId })`: the input is now controlled by `draft`,
+  `setDraft` on change, `clearDraft` after a successful send.
+- Wire `useScrollAnchor({ containerRef, bottomRef, trigger: messages.length })`.
+- On `messages.length` increase:
+  - `isAtBottom=true` → call `scrollToBottom()` (auto-scroll).
+  - `isAtBottom=false` → increment local `newMessageCount`, render a "N nuovi
+    messaggi" button that on click calls `scrollToBottom()` and resets the
+    counter.
+
+### 4.4 `SessionLiveView` wiring delta
+
+```tsx
+const chatCollapsed       = parseChatCollapsed(searchParams.get('chat'));
+const mobileChatCollapsed = parseMobileChatCollapsed(searchParams.get('mchat'));
+
+const handleChatCollapsedChange = useCallback((c: boolean) => {
+  router.replace(`${pathname}${buildQuery({ chat: c ? 'collapsed' : null })}`,
+    { scroll: false });
+}, [router, pathname, buildQuery]);
+// (mirror for mobile)
+
+// desktopMainColumn:
+<ChatAgentPanel
+  …
+  collapsed={chatCollapsed}
+  onHeaderClick={() => handleChatCollapsedChange(!chatCollapsed)}
+  labels={chatAgentLabels}
+/>
+
+// mobileMainContent (mirror):
+<ChatAgentPanel
+  …
+  collapsed={mobileChatCollapsed}
+  onHeaderClick={() => handleMobileChatCollapsedChange(!mobileChatCollapsed)}
+  labels={chatAgentLabels}
+  compact
+/>
+```
+
+## 5. Error handling + edge cases
+
+| Scenario | Behavior |
+|---|---|
+| `sessionStorage` unavailable (Safari private, quota exceeded) | `useChatDraft` swallows error in `console.warn`; user can still send, no persistence. |
+| `IntersectionObserver` unsupported | `useScrollAnchor.isAtBottom=true` always → naive auto-scroll fallback. |
+| `sessionId=null` (pre-hydration race) | `useChatDraft` no-ops; collapse handlers still work (URL is independent). Chat is already locked out by existing send guard. |
+| Collapse during inflight SSE event | Body unmounts but parent owns the stream (§5 contract); on re-expand the full `messages` array is replayed into a fresh `LiveAgentChat`. |
+| Concurrent desktop+mobile state divergence | `?chat` and `?mchat` are independent — desired by DEC-1. URL can encode both. |
+| Mobile `?msheet=open` + `?mchat=collapsed` | Independent params. Drawer covers the main column; chat header remains visible underneath when sheet closes. |
+| Pre-G3 bookmarks (e.g., `?tab=score`) | No `?chat`/`?mchat` → expanded by default. Bookmark continues to work. |
+
+## 6. Accessibility (axe AA)
+
+- Header `<button>` carries `aria-expanded={!collapsed}` (already in §5 contract).
+- Body unmount when collapsed → no hidden focus traps.
+- "N nuovi messaggi" button: `aria-live="polite"` on its parent region so AT
+  announces the count change without spamming on every message.
+- Auto-scroll path: no `aria-live` (avoid AT spam when user is at bottom).
+- New i18n keys (Gate A — resolved in `SessionLiveView` via `useTranslation`,
+  passed to `ChatAgentPanel`/`LiveAgentChat` pre-formatted; no ICU templates in
+  child components):
+
+```
+pages.sessionLive.chatAgent.collapsedAriaLabel  "ChatAgent collassato — clic per espandere"
+pages.sessionLive.chatAgent.expandedAriaLabel   "ChatAgent espanso — clic per collassare"
+pages.sessionLive.chat.newMessagesToast         "{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}"
+```
+
+## 7. Testing strategy
+
+### 7.1 Unit (Vitest)
+
+`use-scroll-anchor.test.ts`:
+
+- `isAtBottom=true` when bottom sentinel intersects (mock `IntersectionObserver`).
+- `isAtBottom=false` when scrolled up.
+- `scrollToBottom()` calls `scrollIntoView({ behavior: 'smooth' })`.
+- Fallback `isAtBottom=true` when `IntersectionObserver` is `undefined`.
+
+`use-chat-draft.test.ts`:
+
+- Draft loaded from `sessionStorage` on mount.
+- `setDraft` writes to `sessionStorage`.
+- `clearDraft` removes the key.
+- `sessionId=null` → no `sessionStorage` access.
+- Quota exceeded → warn + swallow.
+- Distinct `sessionId` values → distinct keys.
+
+### 7.2 Integration (Vitest + Testing Library)
+
+`SessionLiveView.test.tsx` (extend):
+
+- `?chat=collapsed` → `ChatAgentPanel` rendered with `collapsed=true`,
+  `data-collapsed="true"`.
+- Click header → URL becomes `?chat=collapsed`.
+- Click header again → `?chat` param removed.
+- Mirror behavior for `?mchat`.
+- No `?chat` → expanded default (DEC-4).
+- Combined `?chat=collapsed&mchat=collapsed` → both sides collapsed.
+
+`LiveAgentChat.test.tsx` (extend):
+
+- Draft loaded from `sessionStorage` on mount.
+- Send → `clearDraft` called.
+- Input change → `setDraft` called.
+- New message when `isAtBottom=false` → "N nuovi messaggi" button visible.
+- Click toast → `scrollToBottom` called, counter reset.
+- New message when `isAtBottom=true` → auto-scroll, no toast.
+
+### 7.3 E2E (Playwright)
+
+`apps/web/e2e/session-live-chat-agent-g3.spec.ts` (NEW):
+
+1. Open `/sessions/{id}/live` → `ChatAgentPanel` expanded (no `?chat`).
+2. Click header → URL becomes `?chat=collapsed`, body hidden.
+3. Reload → still collapsed (URL is SSOT).
+4. Click header again → `?chat` removed, body visible.
+5. Type message in input → reload → input retains draft.
+6. Send → input cleared, sessionStorage cleared.
+7. Scroll up → new SSE message arrives → "N nuovi messaggi" toast.
+8. Click toast → auto-scroll, toast gone.
+
+### 7.4 Accessibility (axe-core)
+
+`apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx` (NEW):
+
+- Default expanded → 0 violations.
+- Collapsed state → 0 violations.
+- `aria-expanded` matches `!collapsed`.
+- "N nuovi messaggi" button → `aria-live="polite"` on parent.
+- Header button → discernible label.
+
+## 8. Acceptance criteria (issue body)
+
+- [x] **ChatAgent visible LEFT 60%** — shipped in G1, preserved.
+- [x] **No tab switching** — chat is no longer a tab (G1).
+- [ ] **SSE updates non disturbano scroll** — implemented via `useScrollAnchor`
+  (smart auto-scroll + toast).
+- [ ] **axe AA 0 violations** — new axe test suite (§7.4).
+- [ ] **E2E typing + send + receive** — new Playwright spec (§7.3).
+
+## 9. Out of scope (for #2375)
+
+- G5 polymorphic renderers (#2373 / #2376 / #2378) — separate sub-issues.
+- `useLiveSessionStore.scoringType` / `displayName` wiring (#2389) — separate
+  follow-up.
+- Per-game extensions (#2377 G6 umbrella).
+- Refactoring `LiveAgentChat` SSE consumption (parent still owns the stream).
+
+## 10. Refs
+
+- Epic parent: [#2354](https://github.com/meepleAi-app/meepleai-monorepo/issues/2354).
+- G1 shipped: PR [#2393](https://github.com/meepleAi-app/meepleai-monorepo/pull/2393)
+  (`5ad149ea0`, sess.46r).
+- §5 frozen contract: `apps/web/src/components/features/session-live/ChatAgentPanel.tsx:12-17`.
+- Mockup canonical: `admin-mockups/design_files/sp4-session-skeleton-live.{html,jsx}`.
+- Sibling G5 specs: not yet specced — `#2373`, `#2378`, `#2376` to be brainstormed
+  separately.
+
+🤖 Brainstormed via `superpowers:brainstorming` skill — 4 DEC user-locked.


### PR DESCRIPTION
## Summary
- Wires accordion FSM on ChatAgentPanel (§5 contract preserved — no primitive contract changes)
- Adds `useScrollAnchor` (IntersectionObserver) + `useChatDraft` (sessionStorage) hooks
- "N nuovi messaggi" toast when user is scrolled up + new SSE arrivals
- URL SSOT separati `?chat` (desktop) + `?mchat` (mobile), default expanded
- Draft persists across collapse/expand cycles via sessionStorage per sessionId
- Playwright E2E (8 scenarios) + axe AA (4 tests) component coverage closes remaining #2375 acceptance criteria

## Refs
- Issue: #2375 (epic #2354 Session live shell)
- Spec: `docs/superpowers/specs/2026-06-16-issue-2375-g3-chatagent-always-visible-design.md`
- Plan: `docs/superpowers/plans/2026-06-16-issue-2375-g3-chatagent-always-visible.md`
- G1 prerequisite shipped: PR #2393 (`5ad149ea0` sess.46r)

## 4 DEC user-locked
- DEC-1 URL SSOT separati `?chat` + `?mchat` (mirror `?tab`/`?mtab`)
- DEC-2 Smart auto-scroll via IntersectionObserver + "N nuovi messaggi" toast
- DEC-3 Draft persistence in sessionStorage per sessionId
- DEC-4 Default expanded (no URL param)

## Test plan
- [x] Unit `useScrollAnchor` (5 tests) — happy path + flip + scrollToBottom + fallback + trigger re-observe
- [x] Unit `useChatDraft` (9 tests) — mount/set/clear + isolation + quota + sessionId transition + clearDraft no-op
- [x] Integration `LiveAgentChat` (4 new + manual-scroll reset = 5 G3 tests) — draft + send-clear + at-bottom + counter reset
- [x] Integration `SessionLiveView` (6 new G3 tests) — `?chat`/`?mchat` URL SSOT + handler dispatch
- [x] E2E `session-live-chat-agent-g3.spec.ts` (8 scenarios, runs on CI with NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1)
- [x] axe AA `session-live-chat-agent-g3-axe.test.tsx` (4 tests, expanded + collapsed)
- [x] Typecheck pass
- [x] Lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)