### PR TITLE
fix(metrics): #2383 PR #2409 cardinality + transaction safety doc

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
@@ -93,17 +93,17 @@ internal class GenerateToolkitFromKbHandler
                 if (cached is not null)
                 {
                     _logger.LogInformation("AiToolkit cache HIT for game {GameId}", command.GameId);
-                    MeepleAiMetrics.RecordAiToolkitCacheHit(command.GameId);
+                    MeepleAiMetrics.RecordAiToolkitCacheHit();
                     return JsonSerializer.Deserialize<AiToolkitSuggestionDto>(cached.SuggestionJson, CacheJsonOptions)!;
                 }
-                MeepleAiMetrics.RecordAiToolkitCacheMiss(command.GameId);
+                MeepleAiMetrics.RecordAiToolkitCacheMiss();
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex,
                     "AiToolkit cache GET failed for game {GameId}; falling back to LLM",
                     command.GameId);
-                MeepleAiMetrics.RecordAiToolkitCacheMiss(command.GameId);
+                MeepleAiMetrics.RecordAiToolkitCacheMiss();
             }
         }
 
@@ -216,6 +216,18 @@ internal class GenerateToolkitFromKbHandler
 
         // ADR-069 (#2383): Cache write-back. Errors are swallowed — the caller
         // must receive the generated result even when the cache layer is unavailable.
+        //
+        // PR #2409 open question #2 resolution (transaction safety, brainstorm 2026-06-16):
+        // The SaveChangesAsync call below commits the cache entry. This handler is a pure
+        // read+generate flow: it does not stage any other writes to the UoW prior to this
+        // point, so the SaveChangesAsync commits ONLY the cache entry — no risk of
+        // committing partial outer-transaction state.
+        //
+        // INVARIANT: do NOT add any AddAsync / UpdateAsync calls earlier in this Handle
+        // method without also moving the cache write-back into a separate transaction
+        // (or refactoring to a domain-event-driven write-back). Adding new writes earlier
+        // would cause the SaveChangesAsync here to commit them too, breaking the
+        // "cache failure doesn't affect business state" guarantee.
         if (_cacheRepository is not null)
         {
             try

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/EventHandlers/InvalidateToolkitSuggestionCacheOnKbDocIndexedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/EventHandlers/InvalidateToolkitSuggestionCacheOnKbDocIndexedHandler.cs
@@ -52,7 +52,7 @@ internal sealed class InvalidateToolkitSuggestionCacheOnKbDocIndexedHandler
         try
         {
             await _cacheRepo.DeleteByGameIdAsync(gameId, cancellationToken).ConfigureAwait(false);
-            MeepleAiMetrics.RecordAiToolkitCacheInvalidated(gameId);
+            MeepleAiMetrics.RecordAiToolkitCacheInvalidated();
             _logger.LogInformation(
                 "Invalidated AiToolkit cache for game {GameId} post-KB-doc-index (file: {FileName})",
                 gameId, notification.FileName);

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AiToolkitCache.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AiToolkitCache.cs
@@ -1,4 +1,12 @@
-// ADR-069 follow-up (#2383): AiToolkit suggestion cache observability
+// ADR-069 follow-up (#2383): AiToolkit suggestion cache observability.
+//
+// Cardinality policy (matches MeepleAiMetrics.SharedGameDetail pattern, #614):
+// counters are aggregate (no per-game-id label) to keep the metric cardinality
+// bounded. Per-game breakdown is available via the structured-log entries fired
+// by the handler/event-handler at the same call sites (game_id is logged via
+// LogInformation, not via Prometheus label).
+//
+// PR #2409 open question #1 resolution (#2383 brainstorm 2026-06-16).
 using System.Diagnostics.Metrics;
 
 namespace Api.Observability;
@@ -17,15 +25,21 @@ internal static partial class MeepleAiMetrics
         name: "meepleai_aitoolkit_cache_invalidated_total",
         description: "AiToolkit suggestion cache entries invalidated by KbDocIndexedEvent — ADR-069 #2383");
 
-    /// <summary>Records a cache hit for the AiToolkit suggestion of the given game.</summary>
-    public static void RecordAiToolkitCacheHit(Guid gameId) =>
-        AiToolkitCacheHits.Add(1, new KeyValuePair<string, object?>("game_id", gameId));
+    /// <summary>Records a cache hit for the AiToolkit suggestion.</summary>
+    /// <remarks>
+    /// Aggregate counter (no per-game label per #614 cardinality policy).
+    /// Per-game breakdown is available via structured logs at the call site.
+    /// </remarks>
+    public static void RecordAiToolkitCacheHit() =>
+        AiToolkitCacheHits.Add(1);
 
-    /// <summary>Records a cache miss (LLM pipeline will run) for the given game.</summary>
-    public static void RecordAiToolkitCacheMiss(Guid gameId) =>
-        AiToolkitCacheMisses.Add(1, new KeyValuePair<string, object?>("game_id", gameId));
+    /// <summary>Records a cache miss (LLM pipeline will run).</summary>
+    /// <remarks>Aggregate counter; see <see cref="RecordAiToolkitCacheHit"/> for cardinality rationale.</remarks>
+    public static void RecordAiToolkitCacheMiss() =>
+        AiToolkitCacheMisses.Add(1);
 
-    /// <summary>Records a cache invalidation triggered by <c>KbDocIndexedEvent</c> for the given game.</summary>
-    public static void RecordAiToolkitCacheInvalidated(Guid gameId) =>
-        AiToolkitCacheInvalidations.Add(1, new KeyValuePair<string, object?>("game_id", gameId));
+    /// <summary>Records a cache invalidation triggered by <c>KbDocIndexedEvent</c>.</summary>
+    /// <remarks>Aggregate counter; see <see cref="RecordAiToolkitCacheHit"/> for cardinality rationale.</remarks>
+    public static void RecordAiToolkitCacheInvalidated() =>
+        AiToolkitCacheInvalidations.Add(1);
 }


### PR DESCRIPTION
## Summary

PR #2409 follow-up resolving 2 non-blocking open questions:

| # | Concern | Resolution |
|---|---|---|
| 1 | **Cardinality**: `game_id` label on AiToolkit cache counters → high cardinality | Remove label; aggregate counters only (matches `SharedGameDetail` #614 policy) |
| 2 | **Transaction safety**: `SaveChangesAsync` in handler write-back could commit outer transaction state | Add INVARIANT doc block flagging the safety contract for future maintainers |

## Files

- `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AiToolkitCache.cs` — 3 methods zero-arg + header doc on cardinality policy
- `apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs` — 3 caller sites + 20-line INVARIANT doc block before cache write-back
- `apps/api/src/Api/BoundedContexts/GameToolkit/Application/EventHandlers/InvalidateToolkitSuggestionCacheOnKbDocIndexedHandler.cs` — 1 caller site

## Cardinality rationale

Pattern reference: `MeepleAiMetrics.SharedGameDetail` (#614) uses low-cardinality labels (`result` ∈ {success, not_found, error}, `source` ∈ {hit, origin}) — never per-game-id. Per-game observability is available via structured logs (`LogInformation` with `GameId` field at every cache hit/miss/invalidation site).

## Transaction safety rationale

The handler write-back block (`apps/api/src/Api/.../GenerateToolkitFromKbHandler.cs:217-244`) calls `_unitOfWork.SaveChangesAsync` to commit the cache entry. Today this commits ONLY the cache entry because the handler is pure read+generate (no `AddAsync`/`UpdateAsync` calls earlier in `Handle`). The new INVARIANT comment documents this contract — future maintainers adding writes earlier in `Handle` must move the cache write-back to a separate transaction (or refactor to event-driven write-back).

## Test plan

- [x] BE build clean (0 errors)
- [x] Zero test impact (no test verified per-game label — confirmed via `grep -rn "RecordAiToolkitCache" apps/api/tests`)
- [ ] CI: Backend Fast green

## Refs

- PR #2409 §"For controller to verify before opening PR" items 1 + 2
- Pattern: `MeepleAiMetrics.SharedGameDetail` (#614)
- Brainstorm: 2026-06-16 (#2383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)