### PR TITLE
refactor(catalog): #2399 Locale.TryCreate — eliminate exception-as-control-flow

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
@@ -54,8 +54,11 @@ public sealed class AddGameTranslationCommandValidator
     }
 
     // BeValidLocale (via Cascade(CascadeMode.Stop)) guarantees this is only called
-    // on a Locale.Create-accepting string, so the constructor cannot throw.
-    private static string NormalizeLocale(string raw) => Locale.Create(raw).Value;
+    // on a TryCreate-accepting string. Issue #2399 — TryCreate consolidates the
+    // exception-free parser; if BeValidLocale fired Stop, we never reach the
+    // fallback branch below.
+    private static string NormalizeLocale(string raw) =>
+        Locale.TryCreate(raw, out var locale) ? locale.Value : raw;
 
     private static bool BeValidSource(string source) =>
         TranslationSourceMapper.TryFromPersistedString(source, out _);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddGameTranslation/AddGameTranslationCommandValidator.cs
@@ -53,12 +53,14 @@ public sealed class AddGameTranslationCommandValidator
             .WithMessage("Invalid source — must be one of: manual | auto-openrouter | community");
     }
 
-    // BeValidLocale (via Cascade(CascadeMode.Stop)) guarantees this is only called
-    // on a TryCreate-accepting string. Issue #2399 — TryCreate consolidates the
-    // exception-free parser; if BeValidLocale fired Stop, we never reach the
-    // fallback branch below.
-    private static string NormalizeLocale(string raw) =>
-        Locale.TryCreate(raw, out var locale) ? locale.Value : raw;
+    // BeValidLocale (via Cascade(CascadeMode.Stop)) guarantees this is only
+    // called on a TryCreate-accepting string. If a future refactor reorders
+    // the rules or drops Cascade.Stop, we WANT the failure to be loud at the
+    // validator boundary (InvalidLocaleException → middleware 400) rather
+    // than silently feeding un-normalised input to ExistsActiveAsync which
+    // would do a case-sensitive miss and let the command proceed until the
+    // DB unique-constraint surface as 5xx. Issue #2399 PR #2414 code-review.
+    private static string NormalizeLocale(string raw) => Locale.Create(raw).Value;
 
     private static bool BeValidSource(string source) =>
         TranslationSourceMapper.TryFromPersistedString(source, out _);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQueryHandler.cs
@@ -12,12 +12,13 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTrans
 /// </summary>
 /// <remarks>
 /// Read-side, no domain mutation. The raw locale string is normalised through
-/// <see cref="Locale.Create"/> so caller variants ("EN", "en-gb", " it ") all
-/// hit the same canonical row. Locale validation runs upstream via
+/// <see cref="Locale.TryCreate"/> so caller variants ("EN", "en-gb", " it ")
+/// all hit the same canonical row. Locale validation runs upstream via
 /// <see cref="GetGameTranslationByLocaleQueryValidator"/> (FluentValidation →
-/// HTTP 422 with "Invalid ISO 639-1 locale"); the <c>Locale.Create</c> call
-/// here is defense-in-depth for direct <c>IMediator.Send</c> paths that may
-/// bypass <c>ValidationBehavior</c>.
+/// HTTP 422 with "Invalid ISO 639-1 locale"). Issue #2399: handler trusts the
+/// validator and degrades gracefully via <c>TryCreate</c> if a direct
+/// <c>IMediator.Send</c> bypasses <c>ValidationBehavior</c> (returns null
+/// instead of throwing — same shape as a missing translation row).
 /// </remarks>
 internal sealed class GetGameTranslationByLocaleQueryHandler
     : IRequestHandler<GetGameTranslationByLocaleQuery, SharedGameTranslationDetailDto?>
@@ -36,7 +37,14 @@ internal sealed class GetGameTranslationByLocaleQueryHandler
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var locale = Locale.Create(query.Locale);
+        // Issue #2399: validator already rejected invalid locales with 422.
+        // TryCreate keeps the handler exception-free even if ValidationBehavior
+        // is bypassed (defense-in-depth) — returns null, same shape as the
+        // "no row matches" path below, so the endpoint maps it to HTTP 404.
+        if (!Locale.TryCreate(query.Locale, out var locale))
+        {
+            return null;
+        }
 
         var translation = await _translationRepo
             .GetByGameIdAndLocaleAsync(query.GameId, locale.Value, cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameTranslationByLocale/GetGameTranslationByLocaleQueryValidator.cs
@@ -7,12 +7,12 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTrans
 /// Validator for <see cref="GetGameTranslationByLocaleQuery"/>. Issue #2379 (F5).
 /// </summary>
 /// <remarks>
-/// Without this validator the handler's call to <c>Locale.Create(query.Locale)</c>
-/// throws <c>InvalidLocaleException</c> (an <c>ArgumentException</c>), which the
-/// global exception middleware maps to HTTP 400 with the generic
-/// "Invalid request parameters" body — losing the locale-specific detail. Routing
-/// the check through FluentValidation surfaces the more informative
-/// "Invalid ISO 639-1 locale" message via HTTP 422.
+/// Issue #2399 update: the handler now calls <c>Locale.TryCreate</c> and
+/// degrades gracefully to <c>null</c> on bypass (mapped to HTTP 404 by the
+/// endpoint, same shape as "no row matches"). Routing the locale check
+/// through FluentValidation here surfaces the more informative
+/// "Invalid ISO 639-1 locale" message via HTTP 422 instead of the
+/// indistinguishable 404, so callers can tell "bad input" from "missing row".
 /// </remarks>
 public sealed class GetGameTranslationByLocaleQueryValidator
     : AbstractValidator<GetGameTranslationByLocaleQuery>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/SharedTranslationValidationRules.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/SharedTranslationValidationRules.cs
@@ -1,4 +1,3 @@
-using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
@@ -12,26 +11,10 @@ internal static class SharedTranslationValidationRules
 {
     /// <summary>
     /// Returns <c>true</c> when <paramref name="raw"/> parses as a normalised
-    /// ISO 639-1 locale (optionally with an ISO 3166-1 regional suffix). Wraps
-    /// <see cref="Locale.Create(string)"/> to translate
-    /// <see cref="InvalidLocaleException"/> into a boolean rule predicate
-    /// suitable for <c>RuleFor(x => x.Locale).Must(BeValidLocale)</c>.
+    /// ISO 639-1 locale (optionally with an ISO 3166-1 regional suffix). Delegates
+    /// to <see cref="Locale.TryCreate"/> so the happy path stays exception-free
+    /// (issue #2399 — drops the previous try/catch <c>Create</c> wrapper).
+    /// Suitable for <c>RuleFor(x => x.Locale).Must(BeValidLocale)</c>.
     /// </summary>
-    public static bool BeValidLocale(string? raw)
-    {
-        if (raw is null)
-        {
-            return false;
-        }
-
-        try
-        {
-            Locale.Create(raw);
-            return true;
-        }
-        catch (InvalidLocaleException)
-        {
-            return false;
-        }
-    }
+    public static bool BeValidLocale(string? raw) => Locale.TryCreate(raw, out _);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions;
 
@@ -23,11 +24,46 @@ public sealed record Locale
         Value = value;
     }
 
+    /// <summary>
+    /// Throwing constructor. Use <see cref="TryCreate"/> when the caller wants
+    /// to avoid exception-as-control-flow (FluentValidation predicates, batch
+    /// imports). Issue #2399.
+    /// </summary>
+    /// <exception cref="InvalidLocaleException">
+    /// Thrown when <paramref name="raw"/> is null, empty, whitespace, or does
+    /// not match the canonical ISO 639-1 (+ optional 3166-1 region) shape.
+    /// </exception>
     public static Locale Create(string raw)
     {
+        if (TryCreate(raw, out var locale))
+        {
+            return locale;
+        }
+
         if (string.IsNullOrWhiteSpace(raw))
         {
             throw new InvalidLocaleException("Locale cannot be empty");
+        }
+
+        throw new InvalidLocaleException($"Invalid ISO 639-1 locale: {raw}");
+    }
+
+    /// <summary>
+    /// Non-throwing parse. Returns <c>true</c> with the normalised value when
+    /// <paramref name="raw"/> matches the canonical ISO 639-1 (+ optional
+    /// 3166-1 region) shape, otherwise <c>false</c> with <paramref name="value"/>
+    /// set to <c>null</c>. Issue #2399 — replaces the
+    /// <c>try { Create(...); } catch { … }</c> pattern in
+    /// <see cref="Api.BoundedContexts.SharedGameCatalog.Application.Services.SharedTranslationValidationRules.BeValidLocale"/>
+    /// and other parser callers so the happy path costs zero exception
+    /// allocations.
+    /// </summary>
+    public static bool TryCreate(string? raw, [NotNullWhen(true)] out Locale? value)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            value = null;
+            return false;
         }
 
         var trimmed = raw.Trim();
@@ -43,10 +79,12 @@ public sealed record Locale
 
         if (!IsoFormat.IsMatch(normalized))
         {
-            throw new InvalidLocaleException($"Invalid ISO 639-1 locale: {raw}");
+            value = null;
+            return false;
         }
 
-        return new Locale(normalized);
+        value = new Locale(normalized);
+        return true;
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/LocaleTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/LocaleTests.cs
@@ -66,4 +66,56 @@ public sealed class LocaleTests
     {
         Locale.Create("it").ToString().Should().Be("it");
     }
+
+    // ─── TryCreate (non-throwing — issue #2399) ──────────────────────────────
+
+    [Theory]
+    [InlineData("it", "it")]
+    [InlineData("EN", "en")]
+    [InlineData("  fr  ", "fr")]
+    [InlineData("en-GB", "en-GB")]
+    [InlineData("EN-gb", "en-GB")]
+    public void TryCreate_AcceptsAndNormalizesIso(string raw, string expected)
+    {
+        var success = Locale.TryCreate(raw, out var locale);
+
+        success.Should().BeTrue();
+        locale.Should().NotBeNull();
+        locale!.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("english")]
+    [InlineData("1234")]
+    [InlineData("e")]
+    [InlineData("en-G")]
+    [InlineData("en-GBR")]
+    public void TryCreate_RejectsMalformedAndNullWithoutThrowing(string? raw)
+    {
+        var success = Locale.TryCreate(raw, out var locale);
+
+        success.Should().BeFalse();
+        locale.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("it")]
+    [InlineData("en-GB")]
+    [InlineData("EN-gb")]
+    [InlineData("  fr  ")]
+    public void Create_AndTryCreate_YieldEqualLocalesForValidInput(string raw)
+    {
+        // Parity check: Create (throwing) and TryCreate (non-throwing) must
+        // agree on every input shape — same normalisation, same equality.
+        // Issue #2399.
+        var thrown = Locale.Create(raw);
+        var success = Locale.TryCreate(raw, out var tryCreated);
+
+        success.Should().BeTrue();
+        tryCreated.Should().NotBeNull();
+        tryCreated!.Should().Be(thrown);
+    }
 }


### PR DESCRIPTION
## Summary

Consolida 3 finding del code-review max-effort di PR #2398 (#2379) con stesso root cause: \`Locale.Create\` lancia \`InvalidLocaleException\` su input invalidi, costringendo callers a try/catch come control flow.

## Changes

**\`Locale.cs\`** (value object):
- Nuovo \`TryCreate(string?, [NotNullWhen(true)] out Locale?)\` — non-throwing primary parser
- \`Create(string)\` delegate a TryCreate + throw on fail (back-compat)

**\`SharedTranslationValidationRules.BeValidLocale\`**:
- Da 16 righe try/catch wrapper → \`public static bool BeValidLocale(string? raw) => Locale.TryCreate(raw, out _);\`
- Drop \`using Api.BoundedContexts.SharedGameCatalog.Application.Exceptions\` (non più referenziato)

**\`AddGameTranslationCommandValidator.NormalizeLocale\`**:
- \`Locale.Create(raw).Value\` → \`Locale.TryCreate(raw, out var l) ? l.Value : raw\` (parity con BeValidLocale, cascade Stop guarantee)

**\`GetGameTranslationByLocaleQueryHandler\`**:
- Da throwing \`Locale.Create(query.Locale)\` → non-throwing \`if (!Locale.TryCreate(...)) return null\`
- Handler ora trusts validator upstream (HTTP 422)
- Se ValidationBehavior bypassed (direct \`IMediator.Send\`), TryCreate degrada a null → endpoint mappa HTTP 404 (no più 400-vs-422 inconsistency)

## Test plan

- [x] \`dotnet build src/Api/Api.csproj\` → 0 errori 0 warning
- [x] \`dotnet test --filter "BoundedContext=SharedGameCatalog&Category=Unit"\` → **1668/1668 verde** (+17 nuovi TryCreate test)
- [ ] CI green
- [ ] Code-review subagent

## 17 nuovi test in LocaleTests.cs

- \`TryCreate_AcceptsAndNormalizesIso\` × 5 (it, EN, fr trimmed, en-GB, EN-gb→en-GB)
- \`TryCreate_RejectsMalformedAndNullWithoutThrowing\` × 8 (null/empty/whitespace/english/1234/e/en-G/en-GBR)
- \`Create_AndTryCreate_YieldEqualLocalesForValidInput\` × 4 (parity check structural equality)

## Refs

- Closes #2399
- Source code-review: PR #2398 finding C1 + C3 + S6
- Parent issue: #2379 (closed via PR #2398)

🤖 Generated with [Claude Code](https://claude.com/claude-code)