### PR TITLE
docs(adr): #2344 ratify ADR-079 edit-overlay drawer pattern

### DIFF
--- a/admin-mockups/briefs/SP7-game-night-agent-builder.md
+++ b/admin-mockups/briefs/SP7-game-night-agent-builder.md
@@ -10,7 +10,7 @@
 > §3.5 per il context completo (filename inconsistency gap novel).
 >
 > **Disposizioni Tier 1 pendenti** (decision required):
-> - `sp7-game-night-edit.{html,jsx}` (Wave 1 mockup C) NON esiste sul filesystem — disposition decision in #2344 (Option A dropped scope / B commission / C edit via drawer).
+> - `sp7-game-night-edit.{html,jsx}` (Wave 1 mockup C) **NON commissionato** — ratified Option C in #2344 (CLOSED 2026-06-16). Edit lives as drawer overlay triggered from `sp7-game-night-detail-rsvp` via deep link `?action=edit`. Vedi **ADR-079** (`docs/for-claude/architecture/adr/adr-079-edit-overlay-drawer-pattern.md`) per il pattern canonico applicabile a tutte le future edit operations.
 > - `sp7-game-night-join-public.jsx` orphan JSX senza HTML twin — disposition decision in #2345 (Option A ship HTML twin / B remove / C re-classify component-mock).
 
 ## Stato programma
@@ -63,7 +63,7 @@ Già documentato in [SP6 Capitolo 2](./SP6-libro-game.md#capitolo-2--iter-1-dogf
 |---|------|-------|------|------------------|
 | **A** | `sp7-game-night-new.{html,jsx}` | `/game-nights/new` | US-31 | Multistep wizard 4 step (mobile) / split-form (desktop) |
 | **B** | `sp7-game-night-detail-rsvp.{html,jsx}` | `/game-nights/[id]` | US-31 | Hub detail + RSVP + game voting |
-| **C** | `sp7-game-night-edit.{html,jsx}` | `/game-nights/[id]/edit` | US-31 | Form edit + cancel/reschedule states |
+| **C** | ~~`sp7-game-night-edit.{html,jsx}`~~ — **NOT COMMISSIONED** (ADR-079: drawer overlay) | `/game-nights/[id]?action=edit` | US-31 | Form edit + cancel/reschedule states rendered as drawer overlay from B detail page |
 | **D** | `sp7-agent-proposals-list.{html,jsx}` | `/editor/agent-proposals` | US-33 | Grid + filters + status badge |
 | **E** | `sp7-agent-builder-create.{html,jsx}` | `/editor/agent-proposals/create` | US-33 | Multistep wizard 4 step (KB → prompt → tone → review) |
 | **F** | `sp7-agent-builder-test.{html,jsx}` | `/editor/agent-proposals/[id]/test` | US-33 | Playground chat + feedback annotation |
@@ -74,7 +74,7 @@ Già documentato in [SP6 Capitolo 2](./SP6-libro-game.md#capitolo-2--iter-1-dogf
 
 **Sequence di consegna consigliata** (3 wave, generated 1-by-1 in claude.ai/design):
 
-- **Wave 1 — Game Night Lifecycle**: A → B → C (3 mockup, ~2h totale)
+- **Wave 1 — Game Night Lifecycle**: A → B (2 mockup; C ratified as drawer overlay per ADR-079 in #2344, not commissioned)
 - **Wave 2 — Agent Builder Flow**: D → E → F → G (4 mockup, ~3-4h)
 - **Wave 3 — Agent Inline + Notifications**: H → I → J (3 mockup, ~2h)
 
@@ -352,12 +352,16 @@ US-31: G31.2 (RSVP one-tap), G31.3 (voting active/locked), G31.4 (host modifies)
 
 ---
 
-## C — Game Night Edit (`sp7-game-night-edit`)
+## C — Game Night Edit (drawer overlay, NOT a separate mockup)
 
-**File**: `sp7-game-night-edit.{html,jsx}`
-**Route**: `/game-nights/[id]/edit`
+> **Status 2026-06-16 (#2344 CLOSED, ADR-079 ratified)**: **NOT COMMISSIONED**. Le sezioni qui sotto restano come **spec funzionale del flusso edit** (campi editabili, reschedule warning, cancel section), ma il rendering è una drawer overlay sopra B (`sp7-game-night-detail-rsvp`), NON un mockup standalone. Vedi [ADR-079](../../docs/for-claude/architecture/adr/adr-079-edit-overlay-drawer-pattern.md) per il pattern canonico.
+>
+> Implementation pattern: `GameNightEditDrawer` component mounted in `/game-nights/[id]` detail page, opens when URL has `?action=edit`. Reuses `GameNightDrawerContent` (asse-A asse-C WP6 primitive).
+
+**File**: ~~`sp7-game-night-edit.{html,jsx}`~~ — NOT COMMISSIONED
+**Route**: `/game-nights/[id]?action=edit` (drawer overlay on detail page B)
 **Persona**: host only (Marco). Modifica serata già pianificata.
-**Pattern**: form edit + section delete/cancel modal + reschedule warning
+**Pattern**: drawer overlay con form edit + section delete/cancel modal + reschedule warning. Drawer shipped via asse-B `DrawerStack` cascade-store; visual baseline = B detail page con drawer aperto a destra.
 
 ### Sezione 1: Modifica metadata
 
@@ -998,7 +1002,7 @@ Buon lavoro. SP7 attiva 3 user story P1 dormant — post-merge si passa allo spr
 |------|--------|-------|------|
 | 1 | A `sp7-game-night-new` | ⏳ pending | First della wave |
 | 1 | B `sp7-game-night-detail-rsvp` | ⏳ pending | After A |
-| 1 | C `sp7-game-night-edit` | ⏳ pending | After B |
+| 1 | ~~C `sp7-game-night-edit`~~ | ✅ **NOT COMMISSIONED** (ADR-079) | Drawer overlay on B (`?action=edit`) — no mockup needed |
 | 1+ | K `sp7-game-night-live` | ⏳ pending | Issue #487 — central hub durante serata, embed Diary widget (#7) |
 | 1+ | L `sp7-game-night-transition` | ⏳ pending | Issue #487 — modal recap+preview tra game e game |
 | 1+ | M `sp7-game-night-summary` | ⏳ pending | Issue #487 — recap full-screen post-end |

--- a/docs/for-claude/architecture/adr/adr-079-edit-overlay-drawer-pattern.md
+++ b/docs/for-claude/architecture/adr/adr-079-edit-overlay-drawer-pattern.md
@@ -1,0 +1,128 @@
+# ADR-079 — Edit-overlay drawer pattern for detail routes
+
+**Status**: Accepted
+**Date**: 2026-06-16
+**Deciders**: @badsworm (ratified via [#2344](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344) acceptance 2026-06-16)
+**Tracking**: [#2344](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344) — sp7-game-night-edit disposition decision
+**Related**: ADR-061 (game-detail tab canonical) · `docs/superpowers/plans/2026-06-04-asse-b-ui-shell-pattern.md` (WP3 DrawerStack cascade-store) · `docs/superpowers/plans/2026-06-05-asse-c-dashboard-priority-driven.md` (WP6 GameNightDrawerContent)
+
+## Context
+
+Issue #2344 surfaced a gap in the SP7 Wave 1 mockup commission: `sp7-game-night-edit.{html,jsx}` was referenced by the brief but never shipped during the Claude Design canvas sessions A+B+K+L+M. Filesystem check 2026-06-15 confirmed:
+
+```
+admin-mockups/design_files/sp7-game-night-edit.html → ✗ NOT EXIST
+admin-mockups/design_files/sp7-game-night-edit.jsx  → ✗ NOT EXIST
+```
+
+The disposition was: drop the standalone mockup, commission a missing mockup, or refactor the architectural decision so no standalone mockup is required.
+
+The 2026-06-15 brainstorm in [#2344 comment-4707720729](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344#issuecomment-4707720729) raccomandò **Option C** with multi-axis evidence:
+
+1. **Asse-B `DrawerStack` cascade-store** already shipped (PR sess.33). Generic primitive with `openDrawer(entity, id)` API designed exactly for entity-overlay UX.
+2. **Asse-A `GameNightDrawerContent`** (PR sess.34, dashboard plan WP6) already proves the pattern: edit-style content inside drawer triggered from dashboard cards.
+3. **Next.js 16 App Router**: `/games/[id]/edit` style routes are anti-pattern when the edit content is strictly correlated to the detail view. Deep link `?action=edit` is the canonical alternative.
+4. **A11y baseline already met**: drawer cascade-store has 0-axe-violation baseline (asse-B WP7 test `apps/web/__tests__/asse-b-axe.test.tsx`).
+5. **Effort delta**: Option C ~3gg vs Option B (commission new mockup) ~10gg.
+
+## Decision
+
+**Edit operations on detail routes are rendered as a drawer overlay, NOT a standalone page**. The pattern is canonical for any future detail route that exposes mutation operations.
+
+Concrete instantiation for the original #2344 case:
+
+- Route `/game-nights/[id]/edit` (legacy, never shipped) is replaced by deep link `/game-nights/[id]?action=edit`.
+- A `GameNightEditDrawer` component is mounted in the detail page; it opens when the URL search param `action=edit` is present.
+- The drawer reuses `GameNightDrawerContent` (asse-A primitive) where possible — content composition rather than a new page.
+- Brief SP7 Wave 1 mockup C is marked as "not commissioned (per ADR-079)".
+
+## Pattern (for future detail routes)
+
+When a detail route needs an edit operation:
+
+```
+✅ DO
+  /entity/[id]?action=edit         → opens <EntityEditDrawer> mounted in detail page
+  /entity/[id]?action=invite        → opens <EntityInviteDrawer>
+  /entity/[id]?action=share         → opens <EntityShareDrawer>
+
+❌ DO NOT
+  /entity/[id]/edit                 → standalone page
+  /entity/[id]/invite               → standalone page
+  /entity/[id]/share                → standalone page
+```
+
+Reasons standalone edit pages are anti-pattern:
+
+- Doubles the route tree without adding distinct content (the form fields are largely a subset of the detail view).
+- Forces server-side route group placement decisions (`(public)` vs `(authenticated)` vs `(admin)`) that are already settled by the parent detail route — re-deciding them per action invites drift.
+- Breaks deep-link locality: linking to the edit form requires the user to navigate to the detail page first to grasp context.
+- Multiplies a11y test surface: each new page needs its own axe baseline.
+
+## Exceptions to the pattern
+
+The drawer overlay is **not** appropriate when:
+
+- The edit form is structurally large (>10 fields, multi-step wizard, file upload tab, payment flow). Use a wizard modal (`WizardModal` primitive shipped in asse-B WP4) or a dedicated route.
+- The edit operation has a long-lived state that must survive page reloads (e.g. multi-hour draft of a published article). Use a dedicated route + local storage.
+- The user-flow is conceptually "creating a sibling resource", not "modifying the current resource". Then it's a create flow, not an edit overlay (see SP7-A `sp7-game-night-new` for the create case).
+
+When in doubt, default to drawer overlay. The wizard modal escape hatch is available if the form complexity blows past the drawer's comfortable scope.
+
+## Consequences
+
+### Positive
+
+- **No new mockup commissions** for routine edit flows of existing detail routes. Brief SP7 Wave 1 mockup C is now closed at zero design effort.
+- **Reuse of asse-B `DrawerStack` cascade-store** — a single drawer infrastructure handles edit, invite, share, settings drawers across the app.
+- **Deep link canonical for state** — `?action=edit` lives in the URL, so browser back/forward works correctly, and links shareable into chat/email open the right state.
+- **A11y baseline stays at 0** — no new route, no new axe surface.
+- **Bundle budget**: drawer content is conditionally loaded (`dynamic` import), so the detail page chunk does not grow.
+
+### Negative
+
+- **Mental model shift** for new contributors who expect REST-style `/edit` routes. Mitigated by this ADR + `NotificationRoutes` style codification (separate ADR-075).
+- **Edit form complexity ceiling**: if a future edit grows to wizard-scale (>10 fields, multi-step), the migration from drawer to wizard modal is a refactor. Mitigated by the "exceptions" section above and the wizard modal escape hatch.
+- **Search engines never see edit URLs**: not a concern for authenticated mutation surfaces, but worth flagging if any edit route is ever exposed to a public detail.
+
+### Trade-offs accepted
+
+- The decision is opinionated rather than negotiable per-feature: every detail route in the authenticated surface uses the same pattern. This is intentional — design coherence > local optimization.
+
+## Implementation guidance
+
+For the original #2344 case (`sp7-game-night-edit` ratification):
+
+1. **Spec update** ([`docs/for-developers/specs/2026-06-14-mockup-us-coverage-map.md`](../../../for-developers/specs/2026-06-14-mockup-us-coverage-map.md) §1.2 + §4a US-INT-3c): mark mockup C as "ratified Option C drawer overlay" referencing this ADR. **Done in the same PR as this ADR.**
+2. **Brief update** ([`admin-mockups/briefs/SP7-game-night-agent-builder.md`](../../../../admin-mockups/briefs/SP7-game-night-agent-builder.md) Wave 1 mockup C section): mark as "not commissioned per ADR-079". **Done in the same PR.**
+3. **Redirect rule** (`apps/web/next.config.js`): `/game-nights/:id/edit` → `/game-nights/:id?action=edit` (permanent 301). Safety net for any link that escaped into chat/email before this ADR landed. **Defer to implementation PR** (next session).
+4. **GameNightEditDrawer component** mounted in `/game-nights/[id]` detail page, opened by URL search param `action=edit`. Reuses `GameNightDrawerContent` asse-A primitive. **Defer to implementation PR** (~1gg).
+5. **Close #2344** with link to this ADR + spec update + brief update.
+
+Total implementation effort: ~3gg single FTE (item 3 ~0.5gg, item 4 ~1gg + tests, item 5 trivial). Items 1-2 ship in the ADR PR (this); items 3-5 in a follow-up PR.
+
+## Rollback / reversibility
+
+The ADR is documentation. The actual change at code level is:
+
+- `next.config.js` redirect rule — trivial to remove (single block).
+- `GameNightEditDrawer` mount in detail page — `git revert` the component file + the `?action=edit` handling in the detail page.
+
+If after rollout users (or analytics) demonstrate the drawer pattern is wrong for this case, restore by:
+
+- Commissioning `sp7-game-night-edit` mockup.
+- Adding `/game-nights/[id]/edit` standalone page route in Next.js App Router.
+- Updating brief SP7 Wave 1 to re-include mockup C.
+
+Reverting the ADR itself is a doc-only change.
+
+## References
+
+- Issue #2344 — disposition decision (the source of this ADR)
+- Issue #2344 [comment-4707720729](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344#issuecomment-4707720729) — original Option C recommendation with full multi-axis rationale
+- Issue #2344 [comment-4718607499](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344#issuecomment-4718607499) — status reminder + ratification ask
+- ADR-061 — game-detail tab canonical (similar single-detail-route discipline for tabs)
+- Spec: `docs/superpowers/plans/2026-06-04-asse-b-ui-shell-pattern.md` (WP3 — DrawerStack cascade-store + WP7 axe baseline)
+- Spec: `docs/superpowers/plans/2026-06-05-asse-c-dashboard-priority-driven.md` (WP6 — GameNightDrawerContent props-based asse-B reuse)
+- Brief: `admin-mockups/briefs/SP7-game-night-agent-builder.md` (Wave 1 mockup C section — updated in same PR as this ADR)
+- Memory: `route-group-audience-not-feature.md` (route group discipline that constrains the canonical pattern)

--- a/docs/for-developers/specs/2026-06-14-mockup-us-coverage-map.md
+++ b/docs/for-developers/specs/2026-06-14-mockup-us-coverage-map.md
@@ -101,7 +101,7 @@ Discovery automatica (Grep repo-wide) ha trovato **22 identifier univoci di tipo
 | US-9 Game detail tabs | Marco | `sp4-game-detail.html` | 5 sub-tab `.html` (#2148: rules/reviews/strategies/chat/faqs) | DS-17-13 sp4-content design | ⚠ tabs canonical fixed in ADR-061 |
 | US-10 Library hybrid hub | Marco | `sp4-library-desktop.html` | `sp4-library-mobile.html` (forward-refactor) | DS-17-12 sp4-catalog design | ✅ Wave B.3 shipped |
 | US-13 GameNight create wizard | Marco | `sp7-game-night-new.html` ✅ (filename brief aligned via PR #2351) | — | SP7 brief A | 🚫 NOT IMPLEMENTED (brief ready, FE TODO) |
-| US-15 GameNight detail + RSVP | Marco/Davide | `sp7-game-night-detail-rsvp.html` | `sp7-game-night-edit.html` (disposition #2344) | SP7 brief B+C | 🚫 NOT IMPLEMENTED |
+| US-15 GameNight detail + RSVP | Marco/Davide | `sp7-game-night-detail-rsvp.html` | edit is a drawer overlay (no separate mockup — ratified Option C in #2344) | SP7 brief B+C | 🚫 NOT IMPLEMENTED |
 | US-25 Notifications inbox | Marco | `notifications.html` | (component `sp7-notifications-*.html` to ship) | SP7 brief I+J | ⚠ partial (preferences shipped, hub TODO) |
 | US-26 Profile + achievements | Marco | `sp5-profile-settings.html` | `sp4-player-detail.html` (self-view reuse) | sp5-profile-settings spec + #492 closure | ⚠ achievement detail sheet missing (audit 2026-05-22 §P0) |
 | US-27 AI agent chat | Marco/Aaron | `chat-fullscreen.html` | `sp4-game-chat-tab.html` (composite), `sp7-library-game-agent.html` (game-scoped) | DS-17 Phase B audit | ⚠ scope splittato, chat full-screen desktop residue (audit 2026-05-22 §P0 #491) |
@@ -262,6 +262,9 @@ Legenda colonne:
 >
 > **Nota su `sp7-game-night-edit.html`**: documentato nel brief SP7 Wave 1 mockup C
 > (`sp7-game-night-edit.{html,jsx}`) ma **non presente nel filesystem post-DS-17 Phase B audit**.
+>
+> **DISPOSITION 2026-06-16 (#2344 closed)**: ratificata **Option C — drawer overlay**.
+> Edit non è un mockup separato; vive come drawer triggered da `sp7-game-night-detail-rsvp` via deep link `?action=edit`. Vedi **ADR-079** per il pattern canonico.
 > Le funzionalità di edit risultano consolidate sotto `/game-nights/[id]` (route `[id]/edit` mappa
 > al detail-rsvp page-mock per MOCKUPS_INDEX.md). US-INT-3 cita questo file come "Refs planned" non
 > ancora committato. **Vedi sub-spec US-INT-3c per scope finale.**
@@ -626,7 +629,7 @@ And Roster riceve in-app notif "Serata terminata — vedi riepilogo"
 
 - **US-INT-3a — GameNight create wizard** (SP7-A) — P1 · L (5-7gg) · NEW route create
 - **US-INT-3b — GameNight detail + RSVP** (SP7-B) — P1 · L (5-7gg) · invariante max 1 live
-- **US-INT-3c — GameNight edit + reschedule** (SP7-C) — P2 · M (3gg)
+- **US-INT-3c — GameNight edit + reschedule** (SP7-C) — P2 · M (3gg) · **ratified Option C drawer overlay** (#2344 closed 2026-06-16, see ADR-079) — no standalone `sp7-game-night-edit` mockup commission; edit lives as drawer triggered from `sp7-game-night-detail-rsvp` via `?action=edit` deep link
 - **US-INT-3d — GameNight live hub** (SP7-K, #487) — P1 · L (5-7gg) · 3-pane + diary
 - **US-INT-3e — GameNight transition modal** (SP7-L, #487) — P2 · S (2gg)
 - **US-INT-3f — GameNight summary** (SP7-M, #487) — P1 · M (4gg) · share + archive


### PR DESCRIPTION
## Summary

Closes [#2344](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344) — `sp7-game-night-edit` disposition decision. Ratifies **Option C drawer overlay** as the canonical pattern for edit operations on detail routes (full multi-axis rationale in [#2344 comment-4707720729](https://github.com/meepleAi-app/meepleai-monorepo/issues/2344#issuecomment-4707720729)).

## Changes (docs only)

| File | Change |
|---|---|
| `docs/for-claude/architecture/adr/adr-079-edit-overlay-drawer-pattern.md` | **NEW** — canonical drawer overlay pattern + exceptions + implementation guidance + rollback |
| `docs/for-developers/specs/2026-06-14-mockup-us-coverage-map.md` | §1.2 US-15 row + §3.5 disposition note + §4a US-INT-3c scope — all referencing ADR-079 |
| `admin-mockups/briefs/SP7-game-night-agent-builder.md` | Wave 1 mockup C marked NOT COMMISSIONED + sequence updated A → B (was A → B → C) + mockup C detailed section preserved as functional spec but flagged as drawer overlay |

## What the pattern says

```
✅ /entity/[id]?action=edit  → opens <EntityEditDrawer> in detail page
❌ /entity/[id]/edit         → standalone page (anti-pattern)
```

Reuses `DrawerStack` cascade-store (asse-B WP3 shipped) + `GameNightDrawerContent` (asse-A/asse-C WP6 shipped). Zero new mockups, zero new routes, zero new axe baselines.

**Exceptions** (drawer not appropriate): large forms (>10 fields), long-lived state, sibling-create flows. Wizard modal (`WizardModal` asse-B WP4) is the escape hatch.

## Implementation status

This PR is **docs-only**. Implementation is deferred to a separate PR (~1.5-3gg single-FTE):
- `next.config.js` redirect rule `/game-nights/:id/edit` → `/game-nights/:id?action=edit`
- `GameNightEditDrawer` component mounted in `/game-nights/[id]` detail page, opens on `?action=edit`
- Test coverage (drawer state + axe)

## Test plan

- [x] ADR-079 self-review: real code paths cited (asse-B `DrawerStack`, asse-A `GameNightDrawerContent`), pattern formalized with exceptions
- [x] Spec doc internal consistency: 3 references to mockup C all updated coherently (§1.2 row + §3.5 note + §4a scope)
- [x] Brief internal consistency: 4 references to mockup C all updated (preamble + table + sequence + wave checklist + detailed section)
- [x] Pre-commit hooks pass (after `.next` cache clear — unrelated stale ref to #2316-removed page)
- [ ] CI green

## Refs

- Closes #2344
- ADR-079: `docs/for-claude/architecture/adr/adr-079-edit-overlay-drawer-pattern.md`
- Brainstorm + analysis: #2344 comment-4707720729 (Option C multi-axis rationale) + comment-4718607499 (ratification ask)
- Umbrella parent: #2342

🤖 Generated with [Claude Code](https://claude.com/claude-code)