### PR TITLE
feat(session-live): #2376 G5c ToolkitRenderer polymorphic dispatch (6 widget types)

### DIFF
--- a/apps/web/__tests__/session-live-toolkit-renderer-axe.test.tsx
+++ b/apps/web/__tests__/session-live-toolkit-renderer-axe.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * #2376 G5c — axe AA test for ToolkitRenderer covering all 6 widget types
+ * + Unknown + empty state.
+ *
+ * Spec: docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §6
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { ToolkitRenderer } from '@/components/features/session-live';
+import type { ToolkitRendererLabels } from '@/components/features/session-live';
+import type { ParsedWidget } from '@/lib/session-live/widget-state';
+import { defaultConfigFor } from '@/lib/session-live/widget-state';
+
+// toHaveNoViolations is extended globally in vitest.setup.tsx
+
+const LABELS: ToolkitRendererLabels = {
+  title: 'Tools',
+  emptyTitle: 'Empty',
+  emptyBody: 'Enable widgets',
+  unknownTitle: 'Unsupported',
+  unknownBody: 'Update',
+  expandAriaTemplate: 'Expand {name}',
+  collapseAriaTemplate: 'Collapse {name}',
+  randomGenerator: { heading: 'Random', rollLabel: 'Roll', lastLabel: 'Last' },
+  turnManager: {
+    heading: 'Turn',
+    prevLabel: 'Prev',
+    nextLabel: 'Next',
+    turnOfLabel: 'Turn of',
+    phaseLabel: 'Phase',
+  },
+  scoreTracker: {
+    heading: 'Score',
+    incrementAriaTemplate: 'Increment {name}',
+    decrementAriaTemplate: 'Decrement {name}',
+  },
+  resourceManager: {
+    heading: 'Resources',
+    sharedHeading: 'Shared',
+    incrementAriaTemplate: 'Increment {label}',
+    decrementAriaTemplate: 'Decrement {label}',
+  },
+  noteManager: {
+    heading: 'Notes',
+    inputAriaLabel: 'Write',
+    savingLabel: 'Saving',
+    savedLabel: 'Saved',
+  },
+  whiteboard: {
+    heading: 'Board',
+    toolPenLabel: 'Pen',
+    toolEraserLabel: 'Eraser',
+    toolCircleLabel: 'Circle',
+    placeholderLabel: 'Draw',
+  },
+};
+
+const PLAYERS = [
+  { id: 'p1', name: 'Marco' },
+  { id: 'p2', name: 'Sara' },
+];
+
+function makeWidget<T extends ParsedWidget['type']>(type: T, id = 'w1'): ParsedWidget {
+  return {
+    id,
+    type,
+    isEnabled: true,
+    displayOrder: 0,
+    config: defaultConfigFor(type),
+  } as ParsedWidget;
+}
+
+beforeAll(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRenderer(widgets: ReadonlyArray<ParsedWidget>) {
+  return render(
+    <ToolkitRenderer
+      widgets={widgets}
+      openWidgetId="w1"
+      onOpenWidgetChange={() => {}}
+      onWidgetConfigChange={() => {}}
+      players={PLAYERS}
+      labels={LABELS}
+    />
+  );
+}
+
+const TYPES = [
+  'RandomGenerator',
+  'TurnManager',
+  'ScoreTracker',
+  'ResourceManager',
+  'NoteManager',
+  'Whiteboard',
+] as const;
+
+describe('#2376 G5c — ToolkitRenderer axe AA', () => {
+  for (const type of TYPES) {
+    it(`${type}: 0 axe AA violations (expanded)`, async () => {
+      const { container } = renderRenderer([makeWidget(type)]);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  }
+
+  it('empty state: 0 axe AA violations', async () => {
+    const { container } = renderRenderer([]);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Unknown widget: 0 axe AA violations', async () => {
+    const w = {
+      id: 'w1',
+      type: 'BogusType',
+      isEnabled: true,
+      displayOrder: 0,
+      config: {},
+    } as unknown as ParsedWidget;
+    const { container } = renderRenderer([w]);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -95,12 +95,12 @@ import {
   ConnectionLostBanner,
   LiveSessionNotes,
   RightColumnTabs,
-  SessionToolsRail,
+  ToolkitRenderer,
   type ConnectionLostBannerLabels,
   type LiveAgentChatLabels,
   type LiveSessionNotesLabels,
   type RightColumnTabsLabels,
-  type SessionToolsRailLabels,
+  type ToolkitRendererLabels,
 } from '@/components/features/session-live';
 import { useSession } from '@/hooks/queries/useActiveSessions';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -125,6 +125,7 @@ import {
 } from '@/lib/session-live/session-live-visual-test-fixture';
 import { useElapsedTime } from '@/lib/session-live/use-elapsed-time';
 import { useSessionLiveStream } from '@/lib/session-live/use-session-live-stream';
+import { useToolkitRendererStore } from '@/lib/stores/toolkit-renderer-store';
 
 // ─── Lazy dialogs (orchestrator-side lazy import per Task 3 spec) ──────────────
 
@@ -578,24 +579,6 @@ export function SessionLiveView(): ReactElement {
   );
   void _handleScoreUpdate;
 
-  const handleToolExecute = useCallback(
-    async (toolId: string): Promise<void> => {
-      if (sessionId == null) return;
-      if (activeSession == null) return;
-      if (!hasRequiredRole(activeSession.viewerRole, 'Player')) return;
-
-      try {
-        await fetch(`/api/v1/game-sessions/${sessionId}/tools/${toolId}/execute`, {
-          method: 'POST',
-          credentials: 'include',
-        });
-      } catch {
-        // Fail silently — SSE event confirms or not
-      }
-    },
-    [sessionId, activeSession]
-  );
-
   const handleSendMessage = useCallback(
     async (content: string, visibility: 'private' | 'shared'): Promise<void> => {
       if (sessionId == null) return;
@@ -790,16 +773,71 @@ export function SessionLiveView(): ReactElement {
     [t]
   );
 
-  const toolsRailLabels = useMemo<SessionToolsRailLabels>(
-    (): SessionToolsRailLabels => ({
-      title: t('pages.sessionLive.tools.title'),
-      toolDiceLabel: t('pages.sessionLive.tools.toolDiceLabel'),
-      toolTimerLabel: t('pages.sessionLive.tools.toolTimerLabel'),
-      toolCardLabel: t('pages.sessionLive.tools.toolCardLabel'),
-      executeAriaTemplate:
-        (intl.messages['pages.sessionLive.tools.executeAriaTemplate'] as string) ??
-        'Esegui {toolName}',
-      disabledSpectatorTooltip: t('pages.sessionLive.tools.disabledSpectatorTooltip'),
+  // G5c #2376 — ToolkitRenderer labels (all 6 widget sub-namespaces).
+  // Gate A: aria templates that use ICU-like {name}/{label} placeholders are
+  // pulled from intl.messages directly (they are not ICU plural — just runtime
+  // string-replace in each widget component) to avoid double-escaping.
+  const toolkitRendererLabels = useMemo<ToolkitRendererLabels>(
+    (): ToolkitRendererLabels => ({
+      title: t('pages.sessionLive.toolkitRenderer.title'),
+      emptyTitle: t('pages.sessionLive.toolkitRenderer.emptyTitle'),
+      emptyBody: t('pages.sessionLive.toolkitRenderer.emptyBody'),
+      unknownTitle: t('pages.sessionLive.toolkitRenderer.unknownTitle'),
+      unknownBody: t('pages.sessionLive.toolkitRenderer.unknownBody'),
+      expandAriaTemplate:
+        (intl.messages['pages.sessionLive.toolkitRenderer.expandAriaTemplate'] as string) ??
+        'Espandi widget {name}',
+      collapseAriaTemplate:
+        (intl.messages['pages.sessionLive.toolkitRenderer.collapseAriaTemplate'] as string) ??
+        'Collassa widget {name}',
+      randomGenerator: {
+        heading: t('pages.sessionLive.toolkitRenderer.randomGenerator.heading'),
+        rollLabel: t('pages.sessionLive.toolkitRenderer.randomGenerator.rollLabel'),
+        lastLabel: t('pages.sessionLive.toolkitRenderer.randomGenerator.lastLabel'),
+      },
+      turnManager: {
+        heading: t('pages.sessionLive.toolkitRenderer.turnManager.heading'),
+        prevLabel: t('pages.sessionLive.toolkitRenderer.turnManager.prevLabel'),
+        nextLabel: t('pages.sessionLive.toolkitRenderer.turnManager.nextLabel'),
+        turnOfLabel: t('pages.sessionLive.toolkitRenderer.turnManager.turnOfLabel'),
+        phaseLabel: t('pages.sessionLive.toolkitRenderer.turnManager.phaseLabel'),
+      },
+      scoreTracker: {
+        heading: t('pages.sessionLive.toolkitRenderer.scoreTracker.heading'),
+        incrementAriaTemplate:
+          (intl.messages[
+            'pages.sessionLive.toolkitRenderer.scoreTracker.incrementAriaTemplate'
+          ] as string) ?? 'Aumenta punteggio {name}',
+        decrementAriaTemplate:
+          (intl.messages[
+            'pages.sessionLive.toolkitRenderer.scoreTracker.decrementAriaTemplate'
+          ] as string) ?? 'Diminuisci punteggio {name}',
+      },
+      resourceManager: {
+        heading: t('pages.sessionLive.toolkitRenderer.resourceManager.heading'),
+        sharedHeading: t('pages.sessionLive.toolkitRenderer.resourceManager.sharedHeading'),
+        incrementAriaTemplate:
+          (intl.messages[
+            'pages.sessionLive.toolkitRenderer.resourceManager.incrementAriaTemplate'
+          ] as string) ?? 'Aumenta {label}',
+        decrementAriaTemplate:
+          (intl.messages[
+            'pages.sessionLive.toolkitRenderer.resourceManager.decrementAriaTemplate'
+          ] as string) ?? 'Diminuisci {label}',
+      },
+      noteManager: {
+        heading: t('pages.sessionLive.toolkitRenderer.noteManager.heading'),
+        inputAriaLabel: t('pages.sessionLive.toolkitRenderer.noteManager.inputAriaLabel'),
+        savingLabel: t('pages.sessionLive.toolkitRenderer.noteManager.savingLabel'),
+        savedLabel: t('pages.sessionLive.toolkitRenderer.noteManager.savedLabel'),
+      },
+      whiteboard: {
+        heading: t('pages.sessionLive.toolkitRenderer.whiteboard.heading'),
+        toolPenLabel: t('pages.sessionLive.toolkitRenderer.whiteboard.toolPenLabel'),
+        toolEraserLabel: t('pages.sessionLive.toolkitRenderer.whiteboard.toolEraserLabel'),
+        toolCircleLabel: t('pages.sessionLive.toolkitRenderer.whiteboard.toolCircleLabel'),
+        placeholderLabel: t('pages.sessionLive.toolkitRenderer.whiteboard.placeholderLabel'),
+      },
     }),
     [t, intl.messages]
   );
@@ -867,15 +905,18 @@ export function SessionLiveView(): ReactElement {
     return active?.name ?? '';
   }, [activeSession]);
 
-  // ── Default tools list ────────────────────────────────────────────────────
-  // Foundation: standard 3 tools. Real tools come from session DTO in future.
-  const toolsList = useMemo(
-    () => [
-      { id: 'dice', name: toolsRailLabels.toolDiceLabel, icon: 'dice' as const },
-      { id: 'timer', name: toolsRailLabels.toolTimerLabel, icon: 'timer' as const },
-      { id: 'card', name: toolsRailLabels.toolCardLabel, icon: 'card' as const },
-    ],
-    [toolsRailLabels]
+  // ── G5c #2376: Zustand toolkit renderer store ─────────────────────────────
+  // Store starts empty; real hydration via useQuery(['toolkit', sessionId]) is a
+  // follow-up PR that wires GET /api/v1/toolkits/{toolkitId}/widgets.
+  const toolkitWidgets = useToolkitRendererStore(s => s.widgets);
+  const toolkitOpenId = useToolkitRendererStore(s => s.openWidgetId);
+  const setToolkitOpen = useToolkitRendererStore(s => s.setOpenWidget);
+  const updateToolkitConfig = useToolkitRendererStore(s => s.updateWidgetConfig);
+
+  // Map active session players for ScoreTracker widget
+  const toolkitPlayers = useMemo(
+    () => activeSession?.players.map(p => ({ id: p.id, name: p.name })) ?? [],
+    [activeSession]
   );
 
   // ── Chat messages from SSE events ────────────────────────────────────────
@@ -987,11 +1028,13 @@ export function SessionLiveView(): ReactElement {
         );
       case 'widget':
         return (
-          <SessionToolsRail
-            tools={toolsList}
-            viewerRole={activeSession.viewerRole}
-            onToolExecute={handleToolExecute}
-            labels={toolsRailLabels}
+          <ToolkitRenderer
+            widgets={toolkitWidgets}
+            openWidgetId={toolkitOpenId}
+            onOpenWidgetChange={setToolkitOpen}
+            onWidgetConfigChange={(id, cfg) => void updateToolkitConfig(id, cfg)}
+            players={toolkitPlayers}
+            labels={toolkitRendererLabels}
           />
         );
       case 'notes':
@@ -1024,9 +1067,12 @@ export function SessionLiveView(): ReactElement {
     isMyTurn,
     turnIndicatorLabels,
     rosterLabels,
-    toolsList,
-    toolsRailLabels,
-    handleToolExecute,
+    toolkitWidgets,
+    toolkitOpenId,
+    setToolkitOpen,
+    updateToolkitConfig,
+    toolkitPlayers,
+    toolkitRendererLabels,
     noteEntries,
     handleAddNote,
     notesLabels,
@@ -1167,11 +1213,13 @@ export function SessionLiveView(): ReactElement {
         </div>
       )}
       {tab === 'widget' && (
-        <SessionToolsRail
-          tools={toolsList}
-          viewerRole={activeSession.viewerRole}
-          onToolExecute={handleToolExecute}
-          labels={toolsRailLabels}
+        <ToolkitRenderer
+          widgets={toolkitWidgets}
+          openWidgetId={toolkitOpenId}
+          onOpenWidgetChange={setToolkitOpen}
+          onWidgetConfigChange={(id, cfg) => void updateToolkitConfig(id, cfg)}
+          players={toolkitPlayers}
+          labels={toolkitRendererLabels}
         />
       )}
       {tab === 'notes' && (

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -18,7 +18,7 @@
  *   - useSessionLiveStream NOT called in IS_VISUAL_TEST_BUILD mode
  *   - Dialog state from URL: ?dialog=pause mounts PauseOverlay, ?dialog=endgame mounts EndgameDialog
  *   - ConnectionLostBanner renders for reconnecting / degraded-polling / failed states
- *   - Mobile tab routing: chat tab renders LiveAgentChat, tools tab renders SessionToolsRail
+ *   - Mobile tab routing: chat tab renders LiveAgentChat, tools/widget tab renders ToolkitRenderer (G5c #2376)
  *   - Desktop right column: RightColumnTabs mounted with correct activeTab
  *   - Desktop tab change calls router.replace with ?tab= param
  *   - Optimistic score update via liveStream events
@@ -769,10 +769,12 @@ describe('SessionLiveView (Wave D.2 Interactions — Task 3)', () => {
     expect(container.querySelector('[data-slot="player-roster-live"]')).toBeInTheDocument();
   });
 
-  it('T4.9: RIGHT tab=widget renders SessionToolsRail (legacy tools renamed)', () => {
+  it('T4.9: RIGHT tab=widget renders ToolkitRenderer (G5c #2376, replaces SessionToolsRail)', () => {
     searchParamsMap['tab'] = 'widget';
     const { container } = renderWithIntl(<SessionLiveView />);
-    expect(container.querySelector('[data-slot="session-tools-rail"]')).toBeInTheDocument();
+    // G5c swap: ToolkitRenderer replaces SessionToolsRail in the 'widget' tab.
+    // Empty store → empty state renders the region with data-empty="true".
+    expect(container.querySelector('[data-slot="toolkit-renderer"]')).toBeInTheDocument();
   });
 
   it('T4.10: RIGHT tab=notes renders LiveSessionNotes', () => {
@@ -797,14 +799,14 @@ describe('SessionLiveView (Wave D.2 Interactions — Task 3)', () => {
     expect(mobileBody?.querySelector('[data-slot="live-agent-chat"]')).not.toBeNull();
   });
 
-  it('T3.3b: ?msheet=open + ?mtab=widget mounts SessionToolsRail in drawer (Player role)', () => {
-    // Default fixture role is Player, so tools rail is visible inside the drawer.
+  it('T3.3b: ?msheet=open + ?mtab=widget mounts ToolkitRenderer in drawer (G5c #2376)', () => {
+    // G5c swap: ToolkitRenderer replaces SessionToolsRail in the mobile 'widget' tab.
     searchParamsMap['msheet'] = 'open';
     searchParamsMap['mtab'] = 'widget';
     const { container } = renderWithIntl(<SessionLiveView />);
-    // Drawer mounted with SessionToolsRail inside.
+    // Drawer mounted with ToolkitRenderer inside (empty store → data-empty="true").
     expect(document.querySelector('[data-slot="mobile-bottom-sheet"]')).not.toBeNull();
-    // Whether SessionToolsRail renders depends on viewer role (Player/Host yes, Spectator no).
+    expect(document.querySelector('[data-slot="toolkit-renderer"]')).not.toBeNull();
     // Assert no crash + drawer mounted with widget tab selected.
     expect(container.querySelector('[data-slot="session-live-view"]')).toBeInTheDocument();
   });

--- a/apps/web/src/components/features/session-live/index.ts
+++ b/apps/web/src/components/features/session-live/index.ts
@@ -131,3 +131,11 @@ export type {
   SessionToolsRailLabels,
   SessionToolsRailProps,
 } from '@/components/features/session-live/SessionToolsRail';
+
+// ─── G5c #2376 ToolkitRenderer ────────────────────────────────────────────────
+
+export { ToolkitRenderer } from '@/components/features/session-live/toolkit-renderer/ToolkitRenderer';
+export type {
+  ToolkitRendererLabels,
+  ToolkitRendererProps,
+} from '@/components/features/session-live/toolkit-renderer/ToolkitRenderer';

--- a/apps/web/src/components/features/session-live/toolkit-renderer/ToolkitRenderer.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/ToolkitRenderer.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+/**
+ * ToolkitRenderer — Issue #2376 G5c polymorphic dispatcher.
+ *
+ * Switches on widget.type and renders one of 6 widget components, or an
+ * UnknownWidget fallback for unregistered values.
+ *
+ * Accordion FSM: single-expanded (DEC-5). Click header to toggle.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §3
+ */
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType, WidgetType } from '@/lib/session-live/widget-state';
+
+import { NoteManagerWidget } from './widgets/NoteManagerWidget';
+import { RandomGeneratorWidget } from './widgets/RandomGeneratorWidget';
+import { ResourceManagerWidget } from './widgets/ResourceManagerWidget';
+import { ScoreTrackerWidget } from './widgets/ScoreTrackerWidget';
+import { TurnManagerWidget } from './widgets/TurnManagerWidget';
+import { UnknownWidget } from './widgets/UnknownWidget';
+import { WhiteboardWidget } from './widgets/WhiteboardWidget';
+
+import type { ToolkitRendererLabels } from './labels';
+
+export type { ToolkitRendererLabels };
+
+export interface ToolkitRendererProps {
+  readonly widgets: ReadonlyArray<ParsedWidget>;
+  readonly openWidgetId: string | null;
+  readonly onOpenWidgetChange: (id: string | null) => void;
+  readonly onWidgetConfigChange: <T extends WidgetType>(
+    widgetId: string,
+    nextConfig: WidgetConfigByType[T]
+  ) => void;
+  readonly players?: ReadonlyArray<{ id: string; name: string }>;
+  readonly labels: ToolkitRendererLabels;
+}
+
+const KNOWN_TYPES: ReadonlySet<WidgetType> = new Set([
+  'RandomGenerator',
+  'TurnManager',
+  'ScoreTracker',
+  'ResourceManager',
+  'NoteManager',
+  'Whiteboard',
+]);
+
+export function ToolkitRenderer({
+  widgets,
+  openWidgetId,
+  onOpenWidgetChange,
+  onWidgetConfigChange,
+  players,
+  labels,
+}: ToolkitRendererProps): ReactElement {
+  const enabled = widgets.filter(w => w.isEnabled).sort((a, b) => a.displayOrder - b.displayOrder);
+
+  if (enabled.length === 0) {
+    return (
+      <section
+        data-slot="toolkit-renderer"
+        data-empty="true"
+        role="region"
+        aria-label={labels.title}
+        className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-muted/10 p-6 text-center"
+      >
+        <p className="text-sm font-bold text-foreground">{labels.emptyTitle}</p>
+        <p className="text-xs text-muted-foreground">{labels.emptyBody}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      data-slot="toolkit-renderer"
+      role="region"
+      aria-label={labels.title}
+      className="flex flex-col gap-2"
+    >
+      {enabled.map(w => {
+        const collapsed = w.id !== openWidgetId;
+        const onHeaderClick = (): void => {
+          onOpenWidgetChange(collapsed ? w.id : null);
+        };
+
+        if (!KNOWN_TYPES.has(w.type as WidgetType)) {
+          console.warn('[ToolkitRenderer] Unknown widget type:', (w as { type: string }).type);
+          return <UnknownWidget key={w.id} widget={w} labels={labels} />;
+        }
+
+        switch (w.type) {
+          case 'RandomGenerator':
+            return (
+              <div key={w.id} data-widget-type={w.type}>
+                <RandomGeneratorWidget
+                  widget={w}
+                  collapsed={collapsed}
+                  onHeaderClick={onHeaderClick}
+                  onConfigChange={cfg => onWidgetConfigChange(w.id, cfg)}
+                  labels={labels}
+                />
+              </div>
+            );
+          case 'TurnManager':
+            return (
+              <div key={w.id} data-widget-type={w.type}>
+                <TurnManagerWidget
+                  widget={w}
+                  collapsed={collapsed}
+                  onHeaderClick={onHeaderClick}
+                  onConfigChange={cfg => onWidgetConfigChange(w.id, cfg)}
+                  labels={labels}
+                />
+              </div>
+            );
+          case 'ScoreTracker':
+            return (
+              <div key={w.id} data-widget-type={w.type}>
+                <ScoreTrackerWidget
+                  widget={w}
+                  players={players}
+                  collapsed={collapsed}
+                  onHeaderClick={onHeaderClick}
+                  onConfigChange={cfg => onWidgetConfigChange(w.id, cfg)}
+                  labels={labels}
+                />
+              </div>
+            );
+          case 'ResourceManager':
+            return (
+              <div key={w.id} data-widget-type={w.type}>
+                <ResourceManagerWidget
+                  widget={w}
+                  collapsed={collapsed}
+                  onHeaderClick={onHeaderClick}
+                  onConfigChange={cfg => onWidgetConfigChange(w.id, cfg)}
+                  labels={labels}
+                />
+              </div>
+            );
+          case 'NoteManager':
+            return (
+              <div key={w.id} data-widget-type={w.type}>
+                <NoteManagerWidget
+                  widget={w}
+                  collapsed={collapsed}
+                  onHeaderClick={onHeaderClick}
+                  onConfigChange={cfg => onWidgetConfigChange(w.id, cfg)}
+                  labels={labels}
+                />
+              </div>
+            );
+          case 'Whiteboard':
+            return (
+              <div key={w.id} data-widget-type={w.type}>
+                <WhiteboardWidget
+                  widget={w}
+                  collapsed={collapsed}
+                  onHeaderClick={onHeaderClick}
+                  onConfigChange={cfg => onWidgetConfigChange(w.id, cfg)}
+                  labels={labels}
+                />
+              </div>
+            );
+        }
+      })}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/__tests__/ToolkitRenderer.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/__tests__/ToolkitRenderer.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { ToolkitRenderer } from '../ToolkitRenderer';
+import type { ToolkitRendererLabels } from '../labels';
+import type { ParsedWidget } from '@/lib/session-live/widget-state';
+import { defaultConfigFor } from '@/lib/session-live/widget-state';
+
+const LABELS: ToolkitRendererLabels = {
+  title: 'Toolkit',
+  emptyTitle: 'Empty',
+  emptyBody: 'Body',
+  unknownTitle: 'Unknown',
+  unknownBody: 'Update',
+  expandAriaTemplate: 'Expand {name}',
+  collapseAriaTemplate: 'Collapse {name}',
+  randomGenerator: { heading: 'Random', rollLabel: 'Roll', lastLabel: 'Last' },
+  turnManager: {
+    heading: 'Turn',
+    prevLabel: 'Prev',
+    nextLabel: 'Next',
+    turnOfLabel: 'Turn of',
+    phaseLabel: 'Phase',
+  },
+  scoreTracker: {
+    heading: 'Score',
+    incrementAriaTemplate: '+{name}',
+    decrementAriaTemplate: '-{name}',
+  },
+  resourceManager: {
+    heading: 'Res',
+    sharedHeading: 'Shared Res',
+    incrementAriaTemplate: '+{label}',
+    decrementAriaTemplate: '-{label}',
+  },
+  noteManager: {
+    heading: 'Notes',
+    inputAriaLabel: 'Write',
+    savingLabel: 'Saving',
+    savedLabel: 'Saved',
+  },
+  whiteboard: {
+    heading: 'Board',
+    toolPenLabel: 'Pen',
+    toolEraserLabel: 'Eraser',
+    toolCircleLabel: 'Circle',
+    placeholderLabel: 'Draw',
+  },
+};
+
+function makeWidget<T extends ParsedWidget['type']>(
+  type: T,
+  id: string,
+  isEnabled = true,
+  displayOrder = 0
+): ParsedWidget {
+  return {
+    id,
+    type,
+    isEnabled,
+    displayOrder,
+    config: defaultConfigFor(type),
+  } as ParsedWidget;
+}
+
+describe('ToolkitRenderer dispatch', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it.each([
+    ['RandomGenerator', 'widget-random-generator'],
+    ['TurnManager', 'widget-turn-manager'],
+    ['ScoreTracker', 'widget-score-tracker'],
+    ['ResourceManager', 'widget-resource-manager'],
+    ['NoteManager', 'widget-note-manager'],
+    ['Whiteboard', 'widget-whiteboard'],
+  ] as const)('dispatches %s widget', (type, slot) => {
+    const { container } = render(
+      <ToolkitRenderer
+        widgets={[makeWidget(type, 'w1')]}
+        openWidgetId="w1"
+        onOpenWidgetChange={() => {}}
+        onWidgetConfigChange={() => {}}
+        labels={LABELS}
+      />
+    );
+    expect(container.querySelector(`[data-slot="${slot}"]`)).not.toBeNull();
+  });
+
+  it('renders Unknown widget for unregistered type + warns', () => {
+    const w = {
+      id: 'w1',
+      type: 'BogusType',
+      isEnabled: true,
+      displayOrder: 0,
+      config: {},
+    } as unknown as ParsedWidget;
+    const { container } = render(
+      <ToolkitRenderer
+        widgets={[w]}
+        openWidgetId="w1"
+        onOpenWidgetChange={() => {}}
+        onWidgetConfigChange={() => {}}
+        labels={LABELS}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-unknown"]')).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith('[ToolkitRenderer] Unknown widget type:', 'BogusType');
+  });
+
+  it('renders empty state when no widgets enabled', () => {
+    const { container } = render(
+      <ToolkitRenderer
+        widgets={[makeWidget('RandomGenerator', 'w1', false)]}
+        openWidgetId={null}
+        onOpenWidgetChange={() => {}}
+        onWidgetConfigChange={() => {}}
+        labels={LABELS}
+      />
+    );
+    expect(container.querySelector('[data-empty="true"]')).not.toBeNull();
+  });
+
+  it('sorts enabled widgets by displayOrder', () => {
+    const { container } = render(
+      <ToolkitRenderer
+        widgets={[
+          makeWidget('RandomGenerator', 'w1', true, 2),
+          makeWidget('TurnManager', 'w2', true, 0),
+          makeWidget('ScoreTracker', 'w3', true, 1),
+        ]}
+        openWidgetId={null}
+        onOpenWidgetChange={() => {}}
+        onWidgetConfigChange={() => {}}
+        labels={LABELS}
+      />
+    );
+    const types = Array.from(container.querySelectorAll('[data-widget-type]'));
+    expect(types[0]?.getAttribute('data-widget-type')).toBe('TurnManager');
+    expect(types[1]?.getAttribute('data-widget-type')).toBe('ScoreTracker');
+    expect(types[2]?.getAttribute('data-widget-type')).toBe('RandomGenerator');
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/internals/Stepper.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/internals/Stepper.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+/**
+ * Stepper — Issue #2376 G5c internal helper.
+ *
+ * Numeric +/- control shared by ScoreTracker and ResourceManager widgets.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §3
+ */
+
+import type { ReactElement } from 'react';
+
+export interface StepperProps {
+  readonly value: number;
+  readonly onChange: (next: number) => void;
+  readonly min?: number;
+  readonly max?: number;
+  readonly step?: number;
+  readonly incrementAriaLabel: string;
+  readonly decrementAriaLabel: string;
+  readonly wide?: boolean;
+  readonly variant?: 'tool' | 'player' | 'session' | 'kb' | 'event';
+}
+
+export function Stepper({
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  incrementAriaLabel,
+  decrementAriaLabel,
+  wide = false,
+  variant = 'session',
+}: StepperProps): ReactElement {
+  const canDecrement = min === undefined || value - step >= min;
+  const canIncrement = max === undefined || value + step <= max;
+
+  const accentMap: Record<string, string> = {
+    tool: 'border-entity-tool/40 bg-entity-tool/10 text-entity-tool hover:bg-entity-tool/20',
+    player:
+      'border-entity-player/40 bg-entity-player/10 text-entity-player hover:bg-entity-player/20',
+    session:
+      'border-entity-session/40 bg-entity-session/10 text-entity-session hover:bg-entity-session/20',
+    kb: 'border-entity-kb/40 bg-entity-kb/10 text-entity-kb hover:bg-entity-kb/20',
+    event: 'border-entity-event/40 bg-entity-event/10 text-entity-event hover:bg-entity-event/20',
+  };
+  const incrementAccent = accentMap[variant] ?? accentMap.session;
+
+  return (
+    <div data-slot="stepper" className="flex items-center gap-1.5">
+      <button
+        type="button"
+        aria-label={decrementAriaLabel}
+        disabled={!canDecrement}
+        onClick={() => onChange(value - step)}
+        className="flex h-6 w-6 items-center justify-center rounded border border-border bg-muted text-sm font-bold text-muted-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        −
+      </button>
+      <span
+        className={`text-center text-sm font-bold tabular-nums text-foreground ${
+          wide ? 'min-w-[2rem]' : 'min-w-[1.5rem]'
+        }`}
+      >
+        {value}
+      </span>
+      <button
+        type="button"
+        aria-label={incrementAriaLabel}
+        disabled={!canIncrement}
+        onClick={() => onChange(value + step)}
+        className={`flex h-6 w-6 items-center justify-center rounded border text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40 ${incrementAccent}`}
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/internals/WidgetShell.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/internals/WidgetShell.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+/**
+ * WidgetShell — Issue #2376 G5c internal helper.
+ *
+ * Accordion-style shell with icon + title + type pill + body.
+ * Body unmounts when collapsed=true (matches ChatAgentPanel §5 contract from #2375 G3).
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §3
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+
+import { ChevronDown } from 'lucide-react';
+
+export interface WidgetShellProps {
+  readonly icon: string;
+  readonly title: string;
+  readonly typeLabel: string;
+  readonly children: ReactNode;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly headerAriaLabel: string;
+  readonly entityAccent?: 'tool' | 'player' | 'session' | 'kb' | 'chat';
+}
+
+export function WidgetShell({
+  icon,
+  title,
+  typeLabel,
+  children,
+  collapsed,
+  onHeaderClick,
+  headerAriaLabel,
+  entityAccent = 'tool',
+}: WidgetShellProps): ReactElement {
+  const accentMap: Record<string, string> = {
+    tool: 'border-entity-tool/30 bg-entity-tool/5 text-entity-tool',
+    player: 'border-entity-player/30 bg-entity-player/5 text-entity-player',
+    session: 'border-entity-session/30 bg-entity-session/5 text-entity-session',
+    kb: 'border-entity-kb/30 bg-entity-kb/5 text-entity-kb',
+    chat: 'border-entity-chat/30 bg-entity-chat/5 text-entity-chat',
+  };
+  const accent = accentMap[entityAccent] ?? accentMap.tool;
+
+  return (
+    <section
+      data-slot="widget-shell"
+      data-collapsed={collapsed ? 'true' : undefined}
+      className={`flex flex-col overflow-hidden rounded-lg border bg-card ${
+        collapsed ? 'border-border' : accent.split(' ')[0]
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onHeaderClick}
+        aria-expanded={!collapsed}
+        aria-label={headerAriaLabel}
+        className={`flex w-full items-center gap-2 border-b px-3 py-2 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          collapsed ? 'border-transparent' : 'border-border/60'
+        }`}
+      >
+        <span
+          aria-hidden="true"
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-sm"
+        >
+          {icon}
+        </span>
+        <span className="flex-1 truncate text-sm font-bold text-foreground">{title}</span>
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold uppercase tracking-wider ${accent}`}
+        >
+          {typeLabel}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-4 w-4 shrink-0 transition-transform ${
+            collapsed ? '-rotate-90' : ''
+          } ${accent.split(' ').pop()}`}
+        />
+      </button>
+      {!collapsed && <div className="p-3">{children}</div>}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/internals/__tests__/Stepper.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/internals/__tests__/Stepper.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Stepper } from '../Stepper';
+
+describe('Stepper', () => {
+  const baseProps = {
+    value: 5,
+    onChange: vi.fn(),
+    incrementAriaLabel: 'Aumenta',
+    decrementAriaLabel: 'Diminuisci',
+  };
+
+  it('renders current value', () => {
+    render(<Stepper {...baseProps} value={42} />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('increment button calls onChange with value+step', () => {
+    const onChange = vi.fn();
+    render(<Stepper {...baseProps} value={5} onChange={onChange} step={2} />);
+    fireEvent.click(screen.getByLabelText('Aumenta'));
+    expect(onChange).toHaveBeenCalledWith(7);
+  });
+
+  it('decrement button calls onChange with value-step', () => {
+    const onChange = vi.fn();
+    render(<Stepper {...baseProps} value={5} onChange={onChange} step={2} />);
+    fireEvent.click(screen.getByLabelText('Diminuisci'));
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('disables decrement at min', () => {
+    render(<Stepper {...baseProps} value={0} min={0} />);
+    expect(screen.getByLabelText('Diminuisci')).toBeDisabled();
+  });
+
+  it('disables increment at max', () => {
+    render(<Stepper {...baseProps} value={10} max={10} />);
+    expect(screen.getByLabelText('Aumenta')).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/internals/__tests__/WidgetShell.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/internals/__tests__/WidgetShell.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WidgetShell } from '../WidgetShell';
+
+describe('WidgetShell', () => {
+  const baseProps = {
+    icon: '🎲',
+    title: 'Test Widget',
+    typeLabel: 'TestType',
+    collapsed: false,
+    onHeaderClick: vi.fn(),
+    headerAriaLabel: 'Espandi o collassa Test Widget',
+  };
+
+  it('renders header with icon + title + type pill', () => {
+    render(
+      <WidgetShell {...baseProps}>
+        <p>body</p>
+      </WidgetShell>
+    );
+    expect(screen.getByText('Test Widget')).toBeInTheDocument();
+    expect(screen.getByText('TestType')).toBeInTheDocument();
+    expect(screen.getByText('🎲')).toBeInTheDocument();
+  });
+
+  it('renders body when collapsed=false', () => {
+    render(
+      <WidgetShell {...baseProps} collapsed={false}>
+        <p data-testid="body">visible</p>
+      </WidgetShell>
+    );
+    expect(screen.getByTestId('body')).toBeInTheDocument();
+  });
+
+  it('unmounts body when collapsed=true', () => {
+    render(
+      <WidgetShell {...baseProps} collapsed={true}>
+        <p data-testid="body">hidden</p>
+      </WidgetShell>
+    );
+    expect(screen.queryByTestId('body')).not.toBeInTheDocument();
+  });
+
+  it('aria-expanded reflects !collapsed', () => {
+    const { rerender, container } = render(
+      <WidgetShell {...baseProps} collapsed={false}>
+        body
+      </WidgetShell>
+    );
+    expect(container.querySelector('button')?.getAttribute('aria-expanded')).toBe('true');
+
+    rerender(
+      <WidgetShell {...baseProps} collapsed={true}>
+        body
+      </WidgetShell>
+    );
+    expect(container.querySelector('button')?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('header click calls onHeaderClick', () => {
+    const onHeaderClick = vi.fn();
+    render(
+      <WidgetShell {...baseProps} onHeaderClick={onHeaderClick}>
+        body
+      </WidgetShell>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onHeaderClick).toHaveBeenCalled();
+  });
+
+  it('data-collapsed attribute reflects collapsed state', () => {
+    const { container, rerender } = render(
+      <WidgetShell {...baseProps} collapsed={false}>
+        body
+      </WidgetShell>
+    );
+    expect(
+      container.querySelector('[data-slot="widget-shell"]')?.getAttribute('data-collapsed')
+    ).toBeNull();
+
+    rerender(
+      <WidgetShell {...baseProps} collapsed={true}>
+        body
+      </WidgetShell>
+    );
+    expect(
+      container.querySelector('[data-slot="widget-shell"]')?.getAttribute('data-collapsed')
+    ).toBe('true');
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/labels.ts
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/labels.ts
@@ -1,0 +1,54 @@
+/**
+ * ToolkitRendererLabels — i18n surface for #2376 G5c ToolkitRenderer.
+ *
+ * Declared here so Task 3 widgets can import it; Task 4 (ToolkitRenderer)
+ * will pass a concrete implementation. Task 5 will wire real i18n keys.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §3
+ */
+
+export interface ToolkitRendererLabels {
+  readonly title: string;
+  readonly emptyTitle: string;
+  readonly emptyBody: string;
+  readonly unknownTitle: string;
+  readonly unknownBody: string;
+  readonly expandAriaTemplate: string; // "Espandi widget {name}"
+  readonly collapseAriaTemplate: string; // "Comprimi widget {name}"
+  readonly randomGenerator: {
+    readonly heading: string;
+    readonly rollLabel: string;
+    readonly lastLabel: string;
+  };
+  readonly turnManager: {
+    readonly heading: string;
+    readonly prevLabel: string;
+    readonly nextLabel: string;
+    readonly turnOfLabel: string;
+    readonly phaseLabel: string;
+  };
+  readonly scoreTracker: {
+    readonly heading: string;
+    readonly incrementAriaTemplate: string; // "Incrementa punteggio {name}"
+    readonly decrementAriaTemplate: string; // "Decrementa punteggio {name}"
+  };
+  readonly resourceManager: {
+    readonly heading: string;
+    readonly sharedHeading: string;
+    readonly incrementAriaTemplate: string; // "Incrementa {label}"
+    readonly decrementAriaTemplate: string; // "Decrementa {label}"
+  };
+  readonly noteManager: {
+    readonly heading: string;
+    readonly inputAriaLabel: string;
+    readonly savingLabel: string;
+    readonly savedLabel: string;
+  };
+  readonly whiteboard: {
+    readonly heading: string;
+    readonly toolPenLabel: string;
+    readonly toolEraserLabel: string;
+    readonly toolCircleLabel: string;
+    readonly placeholderLabel: string;
+  };
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/NoteManagerWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/NoteManagerWidget.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { type ReactElement, useEffect, useRef, useState } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType } from '@/lib/session-live/widget-state';
+
+import { WidgetShell } from '../internals/WidgetShell';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: Extract<ParsedWidget, { type: 'NoteManager' }>;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly onConfigChange: (next: WidgetConfigByType['NoteManager']) => void;
+  readonly labels: ToolkitRendererLabels;
+}
+
+const AUTOSAVE_DEBOUNCE_MS = 800;
+
+export function NoteManagerWidget({
+  widget,
+  collapsed,
+  onHeaderClick,
+  onConfigChange,
+  labels,
+}: Props): ReactElement {
+  const { config } = widget;
+  const [localText, setLocalText] = useState(config.text);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  // External update sync
+  useEffect(() => {
+    setLocalText(config.text);
+  }, [config.text]);
+
+  // Debounced autosave
+  useEffect(() => {
+    if (localText === config.text) return;
+    if (timeoutRef.current != null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = window.setTimeout(() => {
+      onConfigChange({ ...config, text: localText });
+      setSavedAt(Date.now());
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => {
+      if (timeoutRef.current != null) window.clearTimeout(timeoutRef.current);
+    };
+  }, [localText, config, onConfigChange]);
+
+  const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(
+    '{name}',
+    labels.noteManager.heading
+  );
+
+  const isDirty = localText !== config.text;
+
+  return (
+    <WidgetShell
+      icon="📝"
+      title={labels.noteManager.heading}
+      typeLabel="NoteManager"
+      collapsed={collapsed}
+      onHeaderClick={onHeaderClick}
+      headerAriaLabel={headerAria}
+      entityAccent="kb"
+    >
+      <div data-slot="widget-note-manager" className="flex flex-col gap-2">
+        <textarea
+          value={localText}
+          onChange={e => setLocalText(e.target.value)}
+          aria-label={labels.noteManager.inputAriaLabel}
+          rows={3}
+          className="w-full resize-y rounded border border-border bg-card px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+        <p
+          aria-live="polite"
+          className="text-xs text-muted-foreground"
+          data-slot="note-manager-status"
+        >
+          {isDirty
+            ? labels.noteManager.savingLabel
+            : savedAt != null
+              ? labels.noteManager.savedLabel
+              : ''}
+        </p>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/RandomGeneratorWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/RandomGeneratorWidget.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType } from '@/lib/session-live/widget-state';
+
+import { WidgetShell } from '../internals/WidgetShell';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: Extract<ParsedWidget, { type: 'RandomGenerator' }>;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly onConfigChange: (next: WidgetConfigByType['RandomGenerator']) => void;
+  readonly labels: ToolkitRendererLabels;
+}
+
+export function RandomGeneratorWidget({
+  widget,
+  collapsed,
+  onHeaderClick,
+  onConfigChange,
+  labels,
+}: Props): ReactElement {
+  const { config } = widget;
+  const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(
+    '{name}',
+    labels.randomGenerator.heading
+  );
+
+  const handleRoll = (): void => {
+    if (config.faces.length === 0) return;
+    const idx = Math.floor(Math.random() * config.faces.length);
+    onConfigChange({ ...config, last: config.faces[idx]! });
+  };
+
+  return (
+    <WidgetShell
+      icon="🎲"
+      title={config.name || labels.randomGenerator.heading}
+      typeLabel="RandomGenerator"
+      collapsed={collapsed}
+      onHeaderClick={onHeaderClick}
+      headerAriaLabel={headerAria}
+      entityAccent="tool"
+    >
+      <div data-slot="widget-random-generator" className="flex items-center gap-3">
+        <div className="flex-1 rounded-lg border border-dashed border-entity-tool/30 bg-entity-tool/5 p-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-entity-tool">
+            {labels.randomGenerator.lastLabel}
+          </p>
+          <p
+            data-slot="random-generator-last"
+            className="mt-1 text-lg font-bold text-foreground tabular-nums"
+            aria-live="polite"
+          >
+            {config.last ?? '—'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleRoll}
+          className="shrink-0 rounded-lg bg-entity-tool px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {labels.randomGenerator.rollLabel}
+        </button>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/ResourceManagerWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/ResourceManagerWidget.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType } from '@/lib/session-live/widget-state';
+
+import { Stepper } from '../internals/Stepper';
+import { WidgetShell } from '../internals/WidgetShell';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: Extract<ParsedWidget, { type: 'ResourceManager' }>;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly onConfigChange: (next: WidgetConfigByType['ResourceManager']) => void;
+  readonly labels: ToolkitRendererLabels;
+}
+
+export function ResourceManagerWidget({
+  widget,
+  collapsed,
+  onHeaderClick,
+  onConfigChange,
+  labels,
+}: Props): ReactElement {
+  const { config } = widget;
+  const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(
+    '{name}',
+    config.shared ? labels.resourceManager.sharedHeading : labels.resourceManager.heading
+  );
+
+  const handleResourceChange = (idx: number, next: number): void => {
+    const resources = config.resources.map((r, i) => (i === idx ? { ...r, value: next } : r));
+    onConfigChange({ ...config, resources });
+  };
+
+  return (
+    <WidgetShell
+      icon="📦"
+      title={config.shared ? labels.resourceManager.sharedHeading : labels.resourceManager.heading}
+      typeLabel="ResourceManager"
+      collapsed={collapsed}
+      onHeaderClick={onHeaderClick}
+      headerAriaLabel={headerAria}
+      entityAccent="kb"
+    >
+      <div data-slot="widget-resource-manager" className="flex flex-col gap-1.5">
+        {config.resources.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic">Nessuna risorsa</p>
+        ) : (
+          config.resources.map((r, i) => (
+            <div
+              key={r.label}
+              className={`flex items-center gap-2 rounded-md border px-2 py-1.5 ${
+                r.danger ? 'border-entity-event/40 bg-entity-event/5' : 'border-transparent'
+              }`}
+            >
+              <span
+                className={`flex-1 text-sm font-semibold ${
+                  r.danger ? 'text-entity-event' : 'text-foreground'
+                }`}
+              >
+                {r.label}
+              </span>
+              <span className="text-xs font-medium text-muted-foreground">/{r.max}</span>
+              <Stepper
+                value={r.value}
+                onChange={next => handleResourceChange(i, next)}
+                min={0}
+                max={r.max}
+                incrementAriaLabel={labels.resourceManager.incrementAriaTemplate.replace(
+                  '{label}',
+                  r.label
+                )}
+                decrementAriaLabel={labels.resourceManager.decrementAriaTemplate.replace(
+                  '{label}',
+                  r.label
+                )}
+                variant={r.danger ? 'event' : 'kb'}
+              />
+            </div>
+          ))
+        )}
+      </div>
+    </WidgetShell>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/ScoreTrackerWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/ScoreTrackerWidget.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType } from '@/lib/session-live/widget-state';
+
+import { Stepper } from '../internals/Stepper';
+import { WidgetShell } from '../internals/WidgetShell';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: Extract<ParsedWidget, { type: 'ScoreTracker' }>;
+  readonly players?: ReadonlyArray<{ id: string; name: string }>;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly onConfigChange: (next: WidgetConfigByType['ScoreTracker']) => void;
+  readonly labels: ToolkitRendererLabels;
+}
+
+export function ScoreTrackerWidget({
+  widget,
+  players = [],
+  collapsed,
+  onHeaderClick,
+  onConfigChange,
+  labels,
+}: Props): ReactElement {
+  const { config } = widget;
+  const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(
+    '{name}',
+    labels.scoreTracker.heading
+  );
+
+  const handleScoreChange = (playerId: string, next: number): void => {
+    onConfigChange({
+      ...config,
+      scores: { ...config.scores, [playerId]: next },
+    });
+  };
+
+  const visiblePlayers = players.length > 0 ? players : [];
+
+  return (
+    <WidgetShell
+      icon="🧮"
+      title={labels.scoreTracker.heading}
+      typeLabel="ScoreTracker"
+      collapsed={collapsed}
+      onHeaderClick={onHeaderClick}
+      headerAriaLabel={headerAria}
+      entityAccent="session"
+    >
+      <div data-slot="widget-score-tracker" className="flex flex-col gap-2">
+        {visiblePlayers.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic">Nessun giocatore</p>
+        ) : (
+          visiblePlayers.slice(0, 6).map(p => {
+            const score = config.scores[p.id] ?? 0;
+            return (
+              <div key={p.id} className="flex items-center gap-2">
+                <span className="flex-1 truncate text-sm font-semibold text-foreground">
+                  {p.name}
+                </span>
+                <Stepper
+                  value={score}
+                  onChange={next => handleScoreChange(p.id, next)}
+                  incrementAriaLabel={labels.scoreTracker.incrementAriaTemplate.replace(
+                    '{name}',
+                    p.name
+                  )}
+                  decrementAriaLabel={labels.scoreTracker.decrementAriaTemplate.replace(
+                    '{name}',
+                    p.name
+                  )}
+                  wide
+                  variant="session"
+                />
+              </div>
+            );
+          })
+        )}
+      </div>
+    </WidgetShell>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/TurnManagerWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/TurnManagerWidget.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType } from '@/lib/session-live/widget-state';
+
+import { WidgetShell } from '../internals/WidgetShell';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: Extract<ParsedWidget, { type: 'TurnManager' }>;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly onConfigChange: (next: WidgetConfigByType['TurnManager']) => void;
+  readonly labels: ToolkitRendererLabels;
+}
+
+export function TurnManagerWidget({
+  widget,
+  collapsed,
+  onHeaderClick,
+  onConfigChange,
+  labels,
+}: Props): ReactElement {
+  const { config } = widget;
+  const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(
+    '{name}',
+    labels.turnManager.heading
+  );
+
+  const phasesCount = config.phases?.length ?? 0;
+  const canPrev = config.activeIndex > 0;
+  const canNext = phasesCount === 0 || config.activeIndex < phasesCount - 1;
+
+  const handlePrev = (): void => {
+    if (!canPrev) return;
+    onConfigChange({ ...config, activeIndex: config.activeIndex - 1 });
+  };
+  const handleNext = (): void => {
+    if (!canNext) return;
+    onConfigChange({ ...config, activeIndex: config.activeIndex + 1 });
+  };
+
+  const display = config.phaseBased ? (config.phases?.[config.activeIndex] ?? '—') : '—';
+
+  return (
+    <WidgetShell
+      icon="🔄"
+      title={labels.turnManager.heading}
+      typeLabel="TurnManager"
+      collapsed={collapsed}
+      onHeaderClick={onHeaderClick}
+      headerAriaLabel={headerAria}
+      entityAccent="player"
+    >
+      <div data-slot="widget-turn-manager" className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handlePrev}
+          disabled={!canPrev}
+          className="rounded-md border border-border bg-muted px-3 py-2 text-xs font-bold text-muted-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          ‹ {labels.turnManager.prevLabel}
+        </button>
+        <div className="flex-1 text-center" aria-live="polite">
+          <p className="text-xs font-semibold uppercase tracking-wider text-entity-player">
+            {config.phaseBased ? labels.turnManager.phaseLabel : labels.turnManager.turnOfLabel}
+          </p>
+          <p className="text-sm font-bold text-foreground">{display}</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleNext}
+          disabled={!canNext}
+          className="rounded-md border border-entity-player/40 bg-entity-player/10 px-3 py-2 text-xs font-bold text-entity-player transition-colors hover:bg-entity-player/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {labels.turnManager.nextLabel} ›
+        </button>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/UnknownWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/UnknownWidget.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget } from '@/lib/session-live/widget-state';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: ParsedWidget;
+  readonly labels: ToolkitRendererLabels;
+}
+
+export function UnknownWidget({ widget, labels }: Props): ReactElement {
+  return (
+    <section
+      data-slot="widget-unknown"
+      role="status"
+      aria-live="polite"
+      className="flex flex-col gap-2 rounded-lg border border-amber-700/30 bg-amber-900/10 p-3"
+    >
+      <p className="text-sm font-bold text-amber-200">{labels.unknownTitle}</p>
+      <p className="text-xs text-amber-100/70">{labels.unknownBody}</p>
+      <code className="text-xs text-amber-100/50">
+        widget.type: {(widget as { type: string }).type}
+      </code>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/WhiteboardWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/WhiteboardWidget.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { ParsedWidget, WidgetConfigByType } from '@/lib/session-live/widget-state';
+
+import { WidgetShell } from '../internals/WidgetShell';
+
+import type { ToolkitRendererLabels } from '../labels';
+
+interface Props {
+  readonly widget: Extract<ParsedWidget, { type: 'Whiteboard' }>;
+  readonly collapsed: boolean;
+  readonly onHeaderClick: () => void;
+  readonly onConfigChange: (next: WidgetConfigByType['Whiteboard']) => void;
+  readonly labels: ToolkitRendererLabels;
+}
+
+// MVP: tool palette + dashed placeholder canvas. Real drawing deferred per spec §10.
+// onConfigChange wired but currently unused — toolkit save is a no-op in MVP.
+
+export function WhiteboardWidget({
+  widget,
+  collapsed,
+  onHeaderClick,
+  onConfigChange,
+  labels,
+}: Props): ReactElement {
+  const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(
+    '{name}',
+    labels.whiteboard.heading
+  );
+
+  return (
+    <WidgetShell
+      icon="🖊"
+      title={labels.whiteboard.heading}
+      typeLabel="Whiteboard"
+      collapsed={collapsed}
+      onHeaderClick={onHeaderClick}
+      headerAriaLabel={headerAria}
+      entityAccent="chat"
+    >
+      <div data-slot="widget-whiteboard" className="flex flex-col gap-2">
+        <div role="toolbar" aria-label={labels.whiteboard.heading} className="flex gap-1.5">
+          <button
+            type="button"
+            aria-label={labels.whiteboard.toolPenLabel}
+            className="flex h-7 w-7 items-center justify-center rounded border border-entity-chat/40 bg-entity-chat/10 text-sm text-entity-chat focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            ✏️
+          </button>
+          <button
+            type="button"
+            aria-label={labels.whiteboard.toolEraserLabel}
+            className="flex h-7 w-7 items-center justify-center rounded border border-border bg-muted text-sm text-muted-foreground hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            🩹
+          </button>
+          <button
+            type="button"
+            aria-label={labels.whiteboard.toolCircleLabel}
+            className="flex h-7 w-7 items-center justify-center rounded border border-border bg-muted text-sm text-muted-foreground hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            ⭕
+          </button>
+        </div>
+        <div
+          className="flex h-24 items-center justify-center rounded border border-dashed border-entity-chat/30 bg-card text-xs font-medium text-muted-foreground"
+          aria-label={labels.whiteboard.placeholderLabel}
+        >
+          {labels.whiteboard.placeholderLabel}
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/WhiteboardWidget.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/WhiteboardWidget.tsx
@@ -20,10 +20,10 @@ interface Props {
 // onConfigChange wired but currently unused — toolkit save is a no-op in MVP.
 
 export function WhiteboardWidget({
-  widget,
+  widget: _widget,
   collapsed,
   onHeaderClick,
-  onConfigChange,
+  onConfigChange: _onConfigChange,
   labels,
 }: Props): ReactElement {
   const headerAria = (collapsed ? labels.expandAriaTemplate : labels.collapseAriaTemplate).replace(

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/NoteManagerWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/NoteManagerWidget.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NoteManagerWidget } from '../NoteManagerWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+const baseWidget = {
+  id: 'w5',
+  type: 'NoteManager' as const,
+  isEnabled: true,
+  displayOrder: 4,
+  config: {
+    text: 'Regola casa: no alleanze.',
+  },
+};
+
+describe('NoteManagerWidget', () => {
+  const onConfigChange = vi.fn();
+  const onHeaderClick = vi.fn();
+
+  beforeEach(() => {
+    onConfigChange.mockClear();
+    onHeaderClick.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders data-slot and heading from labels', () => {
+    const { container } = render(
+      <NoteManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-note-manager"]')).toBeInTheDocument();
+    expect(screen.getByText('Note')).toBeInTheDocument();
+  });
+
+  it('renders textarea with existing text', () => {
+    render(
+      <NoteManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Scrivi note' });
+    expect(textarea).toHaveValue('Regola casa: no alleanze.');
+  });
+
+  it('typing + advancing fake timers triggers onConfigChange after debounce', async () => {
+    render(
+      <NoteManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Scrivi note' });
+    fireEvent.change(textarea, { target: { value: 'Nuova nota!' } });
+
+    // Before debounce fires: not called yet
+    expect(onConfigChange).not.toHaveBeenCalled();
+
+    // Advance past the 800ms debounce
+    await vi.advanceTimersByTimeAsync(900);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ text: 'Nuova nota!' }));
+  });
+
+  it('shows savingLabel while text is dirty (before debounce)', () => {
+    render(
+      <NoteManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Scrivi note' });
+    fireEvent.change(textarea, { target: { value: 'Edit in progress' } });
+    expect(screen.getByText('Salvataggio...')).toBeInTheDocument();
+  });
+
+  it('does not render body when collapsed', () => {
+    const { container } = render(
+      <NoteManagerWidget
+        widget={baseWidget}
+        collapsed={true}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-note-manager"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/RandomGeneratorWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/RandomGeneratorWidget.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RandomGeneratorWidget } from '../RandomGeneratorWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+const baseWidget = {
+  id: 'w1',
+  type: 'RandomGenerator' as const,
+  isEnabled: true,
+  displayOrder: 0,
+  config: {
+    name: 'Dado D6',
+    faces: [1, 2, 3, 4, 5, 6],
+    quantity: 1,
+    last: null,
+  },
+};
+
+describe('RandomGeneratorWidget', () => {
+  const onConfigChange = vi.fn();
+  const onHeaderClick = vi.fn();
+
+  beforeEach(() => {
+    onConfigChange.mockClear();
+    onHeaderClick.mockClear();
+  });
+
+  it('renders data-slot and heading from labels', () => {
+    const { container } = render(
+      <RandomGeneratorWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-random-generator"]')).toBeInTheDocument();
+    expect(screen.getByText(makeLabels().randomGenerator.lastLabel)).toBeInTheDocument();
+  });
+
+  it('renders roll button with rollLabel', () => {
+    render(
+      <RandomGeneratorWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Genera' })).toBeInTheDocument();
+  });
+
+  it('clicking roll calls onConfigChange with a value from faces (mocked Math.random)', () => {
+    const mathRandom = vi.spyOn(Math, 'random').mockReturnValue(0); // idx = 0 → face = 1
+    render(
+      <RandomGeneratorWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Genera' }));
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ last: 1 }));
+    mathRandom.mockRestore();
+  });
+
+  it('does not call onConfigChange when faces is empty', () => {
+    render(
+      <RandomGeneratorWidget
+        widget={{ ...baseWidget, config: { ...baseWidget.config, faces: [] } }}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Genera' }));
+    expect(onConfigChange).not.toHaveBeenCalled();
+  });
+
+  it('shows last result when config.last is set', () => {
+    render(
+      <RandomGeneratorWidget
+        widget={{ ...baseWidget, config: { ...baseWidget.config, last: 6 } }}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('6')).toBeInTheDocument();
+  });
+
+  it('does not render body when collapsed', () => {
+    const { container } = render(
+      <RandomGeneratorWidget
+        widget={baseWidget}
+        collapsed={true}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(
+      container.querySelector('[data-slot="widget-random-generator"]')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/ResourceManagerWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/ResourceManagerWidget.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ResourceManagerWidget } from '../ResourceManagerWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+const baseWidget = {
+  id: 'w4',
+  type: 'ResourceManager' as const,
+  isEnabled: true,
+  displayOrder: 3,
+  config: {
+    shared: false,
+    resources: [
+      { label: 'Legno', value: 3, max: 10 },
+      { label: 'Ferro', value: 0, max: 5, danger: true },
+    ],
+  },
+};
+
+describe('ResourceManagerWidget', () => {
+  const onConfigChange = vi.fn();
+  const onHeaderClick = vi.fn();
+
+  beforeEach(() => {
+    onConfigChange.mockClear();
+    onHeaderClick.mockClear();
+  });
+
+  it('renders data-slot and heading from labels', () => {
+    const { container } = render(
+      <ResourceManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-resource-manager"]')).toBeInTheDocument();
+    expect(screen.getByText('Risorse')).toBeInTheDocument();
+  });
+
+  it('renders resource labels and max values', () => {
+    render(
+      <ResourceManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Legno')).toBeInTheDocument();
+    expect(screen.getByText('Ferro')).toBeInTheDocument();
+    expect(screen.getByText('/10')).toBeInTheDocument();
+    expect(screen.getByText('/5')).toBeInTheDocument();
+  });
+
+  it('increment button calls onConfigChange with updated resource value', () => {
+    render(
+      <ResourceManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const incrementBtn = screen.getByRole('button', { name: 'Incrementa Legno' });
+    fireEvent.click(incrementBtn);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    const called = onConfigChange.mock.calls[0][0] as {
+      resources: Array<{ label: string; value: number }>;
+    };
+    const legno = called.resources.find(r => r.label === 'Legno');
+    expect(legno?.value).toBe(4);
+  });
+
+  it('decrement button on Legno calls onConfigChange with updated value', () => {
+    render(
+      <ResourceManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const decrementBtn = screen.getByRole('button', { name: 'Decrementa Legno' });
+    fireEvent.click(decrementBtn);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    const called = onConfigChange.mock.calls[0][0] as {
+      resources: Array<{ label: string; value: number }>;
+    };
+    const legno = called.resources.find(r => r.label === 'Legno');
+    expect(legno?.value).toBe(2);
+  });
+
+  it('renders sharedHeading when config.shared is true', () => {
+    render(
+      <ResourceManagerWidget
+        widget={{ ...baseWidget, config: { ...baseWidget.config, shared: true } }}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Risorse condivise')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no resources', () => {
+    render(
+      <ResourceManagerWidget
+        widget={{ ...baseWidget, config: { ...baseWidget.config, resources: [] } }}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Nessuna risorsa')).toBeInTheDocument();
+  });
+
+  it('does not render body when collapsed', () => {
+    const { container } = render(
+      <ResourceManagerWidget
+        widget={baseWidget}
+        collapsed={true}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(
+      container.querySelector('[data-slot="widget-resource-manager"]')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/ScoreTrackerWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/ScoreTrackerWidget.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ScoreTrackerWidget } from '../ScoreTrackerWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+const baseWidget = {
+  id: 'w3',
+  type: 'ScoreTracker' as const,
+  isEnabled: true,
+  displayOrder: 2,
+  config: {
+    scores: { 'player-1': 10, 'player-2': 5 },
+  },
+};
+
+const players = [
+  { id: 'player-1', name: 'Alice' },
+  { id: 'player-2', name: 'Bob' },
+];
+
+describe('ScoreTrackerWidget', () => {
+  const onConfigChange = vi.fn();
+  const onHeaderClick = vi.fn();
+
+  beforeEach(() => {
+    onConfigChange.mockClear();
+    onHeaderClick.mockClear();
+  });
+
+  it('renders data-slot and heading from labels', () => {
+    const { container } = render(
+      <ScoreTrackerWidget
+        widget={baseWidget}
+        players={players}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-score-tracker"]')).toBeInTheDocument();
+    expect(screen.getByText('Punteggi')).toBeInTheDocument();
+  });
+
+  it('renders player names', () => {
+    render(
+      <ScoreTrackerWidget
+        widget={baseWidget}
+        players={players}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('increment button for player calls onConfigChange with updated score', () => {
+    render(
+      <ScoreTrackerWidget
+        widget={baseWidget}
+        players={players}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const incrementBtn = screen.getByRole('button', {
+      name: 'Incrementa punteggio Alice',
+    });
+    fireEvent.click(incrementBtn);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scores: expect.objectContaining({ 'player-1': 11 }),
+      })
+    );
+  });
+
+  it('decrement button for player calls onConfigChange with updated score', () => {
+    render(
+      <ScoreTrackerWidget
+        widget={baseWidget}
+        players={players}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const decrementBtn = screen.getByRole('button', {
+      name: 'Decrementa punteggio Bob',
+    });
+    fireEvent.click(decrementBtn);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scores: expect.objectContaining({ 'player-2': 4 }),
+      })
+    );
+  });
+
+  it('renders empty state when no players provided', () => {
+    render(
+      <ScoreTrackerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Nessun giocatore')).toBeInTheDocument();
+  });
+
+  it('does not render body when collapsed', () => {
+    const { container } = render(
+      <ScoreTrackerWidget
+        widget={baseWidget}
+        players={players}
+        collapsed={true}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-score-tracker"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/TurnManagerWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/TurnManagerWidget.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TurnManagerWidget } from '../TurnManagerWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+const baseWidget = {
+  id: 'w2',
+  type: 'TurnManager' as const,
+  isEnabled: true,
+  displayOrder: 1,
+  config: {
+    phaseBased: true,
+    phases: ['Setup', 'Gioco', 'Fine'],
+    activeIndex: 0,
+  },
+};
+
+describe('TurnManagerWidget', () => {
+  const onConfigChange = vi.fn();
+  const onHeaderClick = vi.fn();
+
+  beforeEach(() => {
+    onConfigChange.mockClear();
+    onHeaderClick.mockClear();
+  });
+
+  it('renders data-slot and heading from labels', () => {
+    const { container } = render(
+      <TurnManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-turn-manager"]')).toBeInTheDocument();
+    expect(screen.getByText('Turni')).toBeInTheDocument();
+  });
+
+  it('shows current phase label', () => {
+    render(
+      <TurnManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Setup')).toBeInTheDocument();
+  });
+
+  it('prev button is disabled at first phase', () => {
+    render(
+      <TurnManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const prevBtn = screen.getByRole('button', { name: /Prec/ });
+    expect(prevBtn).toBeDisabled();
+  });
+
+  it('clicking next calls onConfigChange with incremented activeIndex', () => {
+    render(
+      <TurnManagerWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const nextBtn = screen.getByRole('button', { name: /Succ/ });
+    fireEvent.click(nextBtn);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ activeIndex: 1 }));
+  });
+
+  it('clicking prev calls onConfigChange with decremented activeIndex', () => {
+    render(
+      <TurnManagerWidget
+        widget={{ ...baseWidget, config: { ...baseWidget.config, activeIndex: 1 } }}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const prevBtn = screen.getByRole('button', { name: /Prec/ });
+    fireEvent.click(prevBtn);
+    expect(onConfigChange).toHaveBeenCalledOnce();
+    expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ activeIndex: 0 }));
+  });
+
+  it('next button is disabled at last phase', () => {
+    render(
+      <TurnManagerWidget
+        widget={{ ...baseWidget, config: { ...baseWidget.config, activeIndex: 2 } }}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    const nextBtn = screen.getByRole('button', { name: /Succ/ });
+    expect(nextBtn).toBeDisabled();
+  });
+
+  it('does not render body when collapsed', () => {
+    const { container } = render(
+      <TurnManagerWidget
+        widget={baseWidget}
+        collapsed={true}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-turn-manager"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/UnknownWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/UnknownWidget.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UnknownWidget } from '../UnknownWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+// Cast to ParsedWidget via 'unknown' to simulate an unrecognised future type
+const unknownWidget = {
+  id: 'w99',
+  type: 'SuperNewWidget',
+  isEnabled: true,
+  displayOrder: 99,
+  config: {},
+} as unknown as Parameters<typeof UnknownWidget>[0]['widget'];
+
+describe('UnknownWidget', () => {
+  it('renders data-slot="widget-unknown"', () => {
+    const { container } = render(<UnknownWidget widget={unknownWidget} labels={makeLabels()} />);
+    expect(container.querySelector('[data-slot="widget-unknown"]')).toBeInTheDocument();
+  });
+
+  it('renders unknownTitle from labels', () => {
+    render(<UnknownWidget widget={unknownWidget} labels={makeLabels()} />);
+    expect(screen.getByText('Widget sconosciuto')).toBeInTheDocument();
+  });
+
+  it('renders unknownBody from labels', () => {
+    render(<UnknownWidget widget={unknownWidget} labels={makeLabels()} />);
+    expect(screen.getByText('Tipo non supportato.')).toBeInTheDocument();
+  });
+
+  it('displays the unknown widget type string', () => {
+    render(<UnknownWidget widget={unknownWidget} labels={makeLabels()} />);
+    expect(screen.getByText(/widget\.type: SuperNewWidget/)).toBeInTheDocument();
+  });
+
+  it('has role="status" and aria-live="polite"', () => {
+    render(<UnknownWidget widget={unknownWidget} labels={makeLabels()} />);
+    const section = screen.getByRole('status');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/WhiteboardWidget.test.tsx
+++ b/apps/web/src/components/features/session-live/toolkit-renderer/widgets/__tests__/WhiteboardWidget.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WhiteboardWidget } from '../WhiteboardWidget';
+import type { ToolkitRendererLabels } from '../../labels';
+
+function makeLabels(): ToolkitRendererLabels {
+  return {
+    title: 'Strumenti',
+    emptyTitle: 'Nessuno strumento',
+    emptyBody: 'Aggiungi strumenti dal toolkit.',
+    unknownTitle: 'Widget sconosciuto',
+    unknownBody: 'Tipo non supportato.',
+    expandAriaTemplate: 'Espandi widget {name}',
+    collapseAriaTemplate: 'Comprimi widget {name}',
+    randomGenerator: {
+      heading: 'Generatore',
+      rollLabel: 'Genera',
+      lastLabel: 'Ultimo risultato',
+    },
+    turnManager: {
+      heading: 'Turni',
+      prevLabel: 'Prec',
+      nextLabel: 'Succ',
+      turnOfLabel: 'Turno di',
+      phaseLabel: 'Fase',
+    },
+    scoreTracker: {
+      heading: 'Punteggi',
+      incrementAriaTemplate: 'Incrementa punteggio {name}',
+      decrementAriaTemplate: 'Decrementa punteggio {name}',
+    },
+    resourceManager: {
+      heading: 'Risorse',
+      sharedHeading: 'Risorse condivise',
+      incrementAriaTemplate: 'Incrementa {label}',
+      decrementAriaTemplate: 'Decrementa {label}',
+    },
+    noteManager: {
+      heading: 'Note',
+      inputAriaLabel: 'Scrivi note',
+      savingLabel: 'Salvataggio...',
+      savedLabel: 'Salvato',
+    },
+    whiteboard: {
+      heading: 'Lavagna',
+      toolPenLabel: 'Penna',
+      toolEraserLabel: 'Gomma',
+      toolCircleLabel: 'Cerchio',
+      placeholderLabel: 'Canvas non disponibile in MVP',
+    },
+  };
+}
+
+const baseWidget = {
+  id: 'w6',
+  type: 'Whiteboard' as const,
+  isEnabled: true,
+  displayOrder: 5,
+  config: {
+    strokes: [],
+  },
+};
+
+describe('WhiteboardWidget', () => {
+  const onConfigChange = vi.fn();
+  const onHeaderClick = vi.fn();
+
+  it('renders data-slot and heading from labels', () => {
+    const { container } = render(
+      <WhiteboardWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-whiteboard"]')).toBeInTheDocument();
+    expect(screen.getByText('Lavagna')).toBeInTheDocument();
+  });
+
+  it('renders tool palette buttons', () => {
+    render(
+      <WhiteboardWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Penna' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Gomma' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cerchio' })).toBeInTheDocument();
+  });
+
+  it('renders placeholder canvas area', () => {
+    render(
+      <WhiteboardWidget
+        widget={baseWidget}
+        collapsed={false}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(screen.getByText('Canvas non disponibile in MVP')).toBeInTheDocument();
+  });
+
+  it('does not render body when collapsed', () => {
+    const { container } = render(
+      <WhiteboardWidget
+        widget={baseWidget}
+        collapsed={true}
+        onHeaderClick={onHeaderClick}
+        onConfigChange={onConfigChange}
+        labels={makeLabels()}
+      />
+    );
+    expect(container.querySelector('[data-slot="widget-whiteboard"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/session-live/__tests__/widget-state.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/widget-state.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { defaultConfigFor, parseWidgetConfig } from '../widget-state';
+
+describe('widget-state', () => {
+  describe('defaultConfigFor', () => {
+    it('returns sensible RandomGenerator default', () => {
+      const config = defaultConfigFor('RandomGenerator');
+      expect(config.name).toBe('Generatore');
+      expect(config.faces).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(config.quantity).toBe(1);
+      expect(config.last).toBeNull();
+    });
+
+    it('returns sensible defaults for all 6 types', () => {
+      const types = [
+        'RandomGenerator',
+        'TurnManager',
+        'ScoreTracker',
+        'ResourceManager',
+        'NoteManager',
+        'Whiteboard',
+      ] as const;
+      for (const type of types) {
+        const config = defaultConfigFor(type);
+        expect(config).toBeDefined();
+      }
+    });
+  });
+
+  describe('parseWidgetConfig', () => {
+    it('parses valid JSON into typed config', () => {
+      const config = parseWidgetConfig('NoteManager', JSON.stringify({ text: 'hello' }));
+      expect(config.text).toBe('hello');
+    });
+
+    it('falls back to default + warns on invalid JSON', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const config = parseWidgetConfig('NoteManager', 'not valid json');
+      expect(config.text).toBe('');
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('merges partial JSON with defaults', () => {
+      const config = parseWidgetConfig('RandomGenerator', JSON.stringify({ last: 5 }));
+      expect(config.last).toBe(5);
+      expect(config.name).toBe('Generatore');
+      expect(config.faces).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+  });
+});

--- a/apps/web/src/lib/session-live/widget-state.ts
+++ b/apps/web/src/lib/session-live/widget-state.ts
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * Widget state types for #2376 G5c ToolkitRenderer.
+ *
+ * Discriminated union covering all 6 WidgetType variants. Backend stores
+ * config as JSON string; FE parses into typed union via `parseWidgetConfig`.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §4
+ */
+
+export type WidgetType =
+  | 'RandomGenerator'
+  | 'TurnManager'
+  | 'ScoreTracker'
+  | 'ResourceManager'
+  | 'NoteManager'
+  | 'Whiteboard';
+
+export interface RandomGeneratorConfig {
+  readonly name: string;
+  readonly faces: ReadonlyArray<string | number>;
+  readonly quantity: number;
+  readonly last: string | number | null;
+}
+
+export interface TurnManagerConfig {
+  readonly phaseBased: boolean;
+  readonly phases?: ReadonlyArray<string>;
+  readonly activeIndex: number;
+}
+
+export interface ScoreTrackerConfig {
+  readonly scores: Readonly<Record<string, number>>;
+}
+
+export interface ResourceItem {
+  readonly label: string;
+  readonly value: number;
+  readonly max: number;
+  readonly danger?: boolean;
+}
+
+export interface ResourceManagerConfig {
+  readonly shared: boolean;
+  readonly resources: ReadonlyArray<ResourceItem>;
+}
+
+export interface NoteManagerConfig {
+  readonly text: string;
+}
+
+export interface WhiteboardStroke {
+  readonly tool: string;
+  readonly points: ReadonlyArray<readonly [number, number]>;
+  readonly color: string;
+}
+
+export interface WhiteboardConfig {
+  readonly strokes: ReadonlyArray<WhiteboardStroke>;
+}
+
+export type WidgetConfigByType = {
+  RandomGenerator: RandomGeneratorConfig;
+  TurnManager: TurnManagerConfig;
+  ScoreTracker: ScoreTrackerConfig;
+  ResourceManager: ResourceManagerConfig;
+  NoteManager: NoteManagerConfig;
+  Whiteboard: WhiteboardConfig;
+};
+
+export type ParsedWidget = {
+  [K in WidgetType]: {
+    readonly id: string;
+    readonly type: K;
+    readonly isEnabled: boolean;
+    readonly displayOrder: number;
+    readonly config: WidgetConfigByType[K];
+  };
+}[WidgetType];
+
+export function defaultConfigFor<T extends WidgetType>(type: T): WidgetConfigByType[T] {
+  switch (type) {
+    case 'RandomGenerator':
+      return {
+        name: 'Generatore',
+        faces: [1, 2, 3, 4, 5, 6],
+        quantity: 1,
+        last: null,
+      } as unknown as WidgetConfigByType[T];
+    case 'TurnManager':
+      return { phaseBased: false, activeIndex: 0 } as unknown as WidgetConfigByType[T];
+    case 'ScoreTracker':
+      return { scores: {} } as unknown as WidgetConfigByType[T];
+    case 'ResourceManager':
+      return { shared: false, resources: [] } as unknown as WidgetConfigByType[T];
+    case 'NoteManager':
+      return { text: '' } as unknown as WidgetConfigByType[T];
+    case 'Whiteboard':
+      return { strokes: [] } as unknown as WidgetConfigByType[T];
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+export function parseWidgetConfig<T extends WidgetType>(
+  type: T,
+  json: string
+): WidgetConfigByType[T] {
+  try {
+    const parsed = JSON.parse(json) as Partial<WidgetConfigByType[T]>;
+    return { ...defaultConfigFor(type), ...parsed };
+  } catch (err) {
+    console.warn('[ToolkitRenderer] parseWidgetConfig failed:', type, err);
+    return defaultConfigFor(type);
+  }
+}

--- a/apps/web/src/lib/stores/__tests__/toolkit-renderer-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/toolkit-renderer-store.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useToolkitRendererStore } from '../toolkit-renderer-store';
+
+describe('useToolkitRendererStore', () => {
+  beforeEach(() => {
+    useToolkitRendererStore.getState().reset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('hydrate parses backend widgets into typed config', () => {
+    useToolkitRendererStore.getState().hydrate({
+      widgets: [
+        {
+          id: 'w1',
+          type: 'NoteManager',
+          isEnabled: true,
+          displayOrder: 0,
+          config: JSON.stringify({ text: 'hello' }),
+        },
+      ],
+    });
+    const { widgets } = useToolkitRendererStore.getState();
+    expect(widgets.length).toBe(1);
+    expect(widgets[0]?.type).toBe('NoteManager');
+    if (widgets[0]?.type === 'NoteManager') {
+      expect(widgets[0].config.text).toBe('hello');
+    }
+  });
+
+  it('setOpenWidget updates openWidgetId', () => {
+    useToolkitRendererStore.getState().setOpenWidget('w1');
+    expect(useToolkitRendererStore.getState().openWidgetId).toBe('w1');
+    useToolkitRendererStore.getState().setOpenWidget(null);
+    expect(useToolkitRendererStore.getState().openWidgetId).toBeNull();
+  });
+
+  it('updateWidgetConfig optimistically updates + PATCH success keeps it', async () => {
+    useToolkitRendererStore.getState().hydrate({
+      widgets: [
+        {
+          id: 'w1',
+          type: 'NoteManager',
+          isEnabled: true,
+          displayOrder: 0,
+          config: JSON.stringify({ text: '' }),
+        },
+      ],
+    });
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await useToolkitRendererStore.getState().updateWidgetConfig('w1', { text: 'updated' });
+
+    const { widgets } = useToolkitRendererStore.getState();
+    if (widgets[0]?.type === 'NoteManager') {
+      expect(widgets[0].config.text).toBe('updated');
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/toolkits/widgets/w1',
+      expect.objectContaining({ method: 'PATCH' })
+    );
+
+    fetchMock.mockRestore();
+  });
+
+  it('updateWidgetConfig rolls back on PATCH failure', async () => {
+    useToolkitRendererStore.getState().hydrate({
+      widgets: [
+        {
+          id: 'w1',
+          type: 'NoteManager',
+          isEnabled: true,
+          displayOrder: 0,
+          config: JSON.stringify({ text: 'original' }),
+        },
+      ],
+    });
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    await useToolkitRendererStore.getState().updateWidgetConfig('w1', { text: 'changed' });
+
+    const { widgets } = useToolkitRendererStore.getState();
+    if (widgets[0]?.type === 'NoteManager') {
+      expect(widgets[0].config.text).toBe('original'); // rolled back
+    }
+  });
+
+  it('updateWidgetConfig handles network error with rollback', async () => {
+    useToolkitRendererStore.getState().hydrate({
+      widgets: [
+        {
+          id: 'w1',
+          type: 'NoteManager',
+          isEnabled: true,
+          displayOrder: 0,
+          config: JSON.stringify({ text: 'original' }),
+        },
+      ],
+    });
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network fail'));
+
+    await useToolkitRendererStore.getState().updateWidgetConfig('w1', { text: 'changed' });
+
+    const { widgets } = useToolkitRendererStore.getState();
+    if (widgets[0]?.type === 'NoteManager') {
+      expect(widgets[0].config.text).toBe('original'); // rolled back
+    }
+  });
+});

--- a/apps/web/src/lib/stores/toolkit-renderer-store.ts
+++ b/apps/web/src/lib/stores/toolkit-renderer-store.ts
@@ -1,0 +1,82 @@
+/**
+ * Toolkit Renderer Store — #2376 G5c.
+ *
+ * Zustand store managing parsed widget state + single-expanded accordion FSM
+ * + optimistic config updates with backend PATCH + rollback on failure.
+ *
+ * @see docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md §4.2
+ */
+
+import { create } from 'zustand';
+
+import type { ParsedWidget, WidgetConfigByType, WidgetType } from '@/lib/session-live/widget-state';
+import { parseWidgetConfig } from '@/lib/session-live/widget-state';
+
+interface BackendToolkitWidget {
+  readonly id: string;
+  readonly type: string;
+  readonly isEnabled: boolean;
+  readonly displayOrder: number;
+  readonly config: string;
+}
+
+interface BackendToolkitDashboard {
+  readonly widgets: ReadonlyArray<BackendToolkitWidget>;
+}
+
+interface State {
+  widgets: ReadonlyArray<ParsedWidget>;
+  openWidgetId: string | null;
+  hydrate: (toolkit: BackendToolkitDashboard) => void;
+  setOpenWidget: (id: string | null) => void;
+  updateWidgetConfig: <T extends WidgetType>(
+    widgetId: string,
+    nextConfig: WidgetConfigByType[T]
+  ) => Promise<void>;
+  reset: () => void;
+}
+
+export const useToolkitRendererStore = create<State>()((set, get) => ({
+  widgets: [],
+  openWidgetId: null,
+
+  hydrate: toolkit => {
+    const widgets = toolkit.widgets.map(w => ({
+      id: w.id,
+      type: w.type as WidgetType,
+      isEnabled: w.isEnabled,
+      displayOrder: w.displayOrder,
+      config: parseWidgetConfig(w.type as WidgetType, w.config),
+    })) as ParsedWidget[];
+    set({ widgets });
+  },
+
+  setOpenWidget: id => set({ openWidgetId: id }),
+
+  updateWidgetConfig: async (widgetId, nextConfig) => {
+    const prev = get().widgets;
+    // Optimistic update
+    set({
+      widgets: prev.map(w =>
+        w.id === widgetId ? ({ ...w, config: nextConfig } as ParsedWidget) : w
+      ),
+    });
+
+    try {
+      const res = await fetch(`/api/v1/toolkits/widgets/${widgetId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ configJson: JSON.stringify(nextConfig) }),
+      });
+      if (!res.ok) {
+        throw new Error(`PATCH failed: ${res.status}`);
+      }
+    } catch (err) {
+      console.warn('[useToolkitRendererStore] PATCH failed, rolling back:', err);
+      set({ widgets: prev });
+    }
+  },
+
+  reset: () => set({ widgets: [], openWidgetId: null }),
+}));

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3191,6 +3191,51 @@
         "winnerLabel": "Winner",
         "acknowledgeCta": "Got it",
         "viewSummaryCta": "View summary"
+      },
+      "toolkitRenderer": {
+        "title": "Tools",
+        "emptyTitle": "No active widgets",
+        "emptyBody": "Enable widgets from the toolkit to use them during the session.",
+        "unknownTitle": "Unsupported widget",
+        "unknownBody": "Update the app to support this widget type.",
+        "expandAriaTemplate": "Expand widget {name}",
+        "collapseAriaTemplate": "Collapse widget {name}",
+        "randomGenerator": {
+          "heading": "Generator",
+          "rollLabel": "Roll",
+          "lastLabel": "Last"
+        },
+        "turnManager": {
+          "heading": "Turn manager",
+          "prevLabel": "Prev",
+          "nextLabel": "Next",
+          "turnOfLabel": "Turn of",
+          "phaseLabel": "Phase"
+        },
+        "scoreTracker": {
+          "heading": "Score",
+          "incrementAriaTemplate": "Increment {name} score",
+          "decrementAriaTemplate": "Decrement {name} score"
+        },
+        "resourceManager": {
+          "heading": "Resources",
+          "sharedHeading": "Shared resources",
+          "incrementAriaTemplate": "Increment {label}",
+          "decrementAriaTemplate": "Decrement {label}"
+        },
+        "noteManager": {
+          "heading": "Notes",
+          "inputAriaLabel": "Write a shared note",
+          "savingLabel": "Saving…",
+          "savedLabel": "Saved"
+        },
+        "whiteboard": {
+          "heading": "Whiteboard",
+          "toolPenLabel": "Pen",
+          "toolEraserLabel": "Eraser",
+          "toolCircleLabel": "Circle",
+          "placeholderLabel": "Shared drawing area"
+        }
       }
     },
     "sessionSummary": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3298,6 +3298,51 @@
         "winnerLabel": "Vincitore",
         "acknowledgeCta": "Ho capito",
         "viewSummaryCta": "Vedi riepilogo"
+      },
+      "toolkitRenderer": {
+        "title": "Strumenti",
+        "emptyTitle": "Nessun widget attivo",
+        "emptyBody": "Abilita i widget dal toolkit per usarli durante la sessione.",
+        "unknownTitle": "Widget non supportato",
+        "unknownBody": "Aggiorna l'app per supportare questo tipo di widget.",
+        "expandAriaTemplate": "Espandi widget {name}",
+        "collapseAriaTemplate": "Collassa widget {name}",
+        "randomGenerator": {
+          "heading": "Generatore",
+          "rollLabel": "Genera",
+          "lastLabel": "Ultimo"
+        },
+        "turnManager": {
+          "heading": "Gestore turni",
+          "prevLabel": "Prec",
+          "nextLabel": "Succ",
+          "turnOfLabel": "Turno di",
+          "phaseLabel": "Fase"
+        },
+        "scoreTracker": {
+          "heading": "Punteggio",
+          "incrementAriaTemplate": "Aumenta punteggio {name}",
+          "decrementAriaTemplate": "Diminuisci punteggio {name}"
+        },
+        "resourceManager": {
+          "heading": "Risorse",
+          "sharedHeading": "Risorse condivise",
+          "incrementAriaTemplate": "Aumenta {label}",
+          "decrementAriaTemplate": "Diminuisci {label}"
+        },
+        "noteManager": {
+          "heading": "Note",
+          "inputAriaLabel": "Scrivi una nota condivisa",
+          "savingLabel": "Salvataggio…",
+          "savedLabel": "Salvato"
+        },
+        "whiteboard": {
+          "heading": "Lavagna",
+          "toolPenLabel": "Penna",
+          "toolEraserLabel": "Gomma",
+          "toolCircleLabel": "Cerchio",
+          "placeholderLabel": "Area disegno condivisa"
+        }
       }
     },
     "sessionSummary": {

--- a/claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md
+++ b/claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md
@@ -1,0 +1,177 @@
+# Architectural Audit: `/components/toolkit/` vs `/components/features/session-live/`
+
+**Date**: 2026-06-16
+**Branch**: `main-dev`
+**Scope**: Epic #2354 G5 (ScoringPanelRenderer #2373, TurnIndicatorRenderer #2378, ToolkitRenderer #2376)
+**Auditor**: Claude Code
+
+---
+
+## 1. Executive Summary
+
+- **Two `TurnIndicatorRenderer` components exist simultaneously.** `toolkit/TurnIndicatorRenderer` (issue #1749, shipped PR #1763) serves the **toolkit configuration preview** context (`AiTurnTemplateSuggestion` props, AI-generated template display). `features/session-live/turn-indicator-renderer/TurnIndicatorRenderer` (issue #2378 G5b, PR #2411 in review) serves the **live session** context (`TurnState` discriminated union, SSE-driven real-time display). They share the same name but have different contracts, data sources, and display purposes.
+- **`ScoringPanelRenderer` in `toolkit/` is currently unreferenced from any live-session route.** `SessionLiveView.tsx` uses `LiveScoringPanel` (from `features/session-live/`), not `toolkit/ScoringPanelRenderer`. The toolkit renderer is a configuration-preview component and is not the polymorphic live dispatcher planned for G5a #2373.
+- **`SessionToolsRail` (session-live) and `ToolkitDashboard` (toolkit) are complementary, not duplicates.** `SessionToolsRail` is a role-gated tool action grid for live play (3 hardcoded icons). `ToolkitDashboard` is a full admin/player configuration grid for the B-context widgets (6 domain widgets, persistent state).
+- **The `toolkit/` directory is a standalone island.** It is consumed exclusively by toolkit configuration routes (`/toolkit/[sessionId]`, `/library/.../toolkit/configure`). It has zero consumption from `/sessions/[id]/live`. There is no current cross-dependency — the duplication is about naming, not actual shared code.
+- **Recommended architectural direction**: treat `toolkit/` as the **AI-generation config domain** and `features/session-live/` as the **live play runtime domain**. The two `TurnIndicatorRenderer` instances should remain separate with distinct names. G5a `ScoringPanelRenderer` and G5c `ToolkitRenderer` should be built new inside `features/session-live/` and should NOT wrap or reference `toolkit/` components.
+
+---
+
+## 2. Inventory: `/components/toolkit/`
+
+All 19 files. Git origin: Epic B #5128 (ToolkitDashboard + widgets, commit `369750cf0`) + B19-4a #1749 (polymorphic renderers, commit `3d1f92e96`).
+
+| File | Purpose | Props Contract | Consumers (app routes) | Test Coverage |
+|---|---|---|---|---|
+| `TurnIndicatorRenderer.tsx` | Polymorphic turn-order display for **AI toolkit suggestions**. Switches on `AiTurnTemplateSuggestion.turnOrderType` string. 6 layout variants: RoundRobin, Sequential, Simultaneous, Realtime, None, Custom/Free. | `{ template: AiTurnTemplateSuggestion \| null, currentRound?, currentTurn?, currentPhaseIndex?, activePlayer?, players? }` | **None** (no import found in app pages) | `__tests__/TurnIndicatorRenderer.test.tsx` — 14+ cases |
+| `ScoringPanelRenderer.tsx` | Polymorphic scoring display for **AI toolkit suggestions**. Switches on `AiScoringTemplateSuggestion.scoreType`. 4 layouts: Points, Ranking, BinaryWin, Objectives. | `{ template: AiScoringTemplateSuggestion \| null, scores?, players? }` | **None** (no import found in app pages) | `__tests__/ScoringPanelRenderer.test.tsx` — 15+ cases |
+| `ToolkitDashboard.tsx` | Admin/player widget configuration grid. Renders all 6 B-context widgets in displayOrder. | `{ toolkit: ToolkitDashboardDto \| null, sessionId?, players?, isLoading?, onWidgetToggle?, onWidgetStateChange? }` | `/toolkit/[sessionId]/_content.tsx` (via barrel via session component) | `__tests__/ToolkitDashboard.test.tsx` |
+| `AiToolkitGenerator.tsx` | AI toolkit generation UI (3 states: trigger / loading / review). | `{ gameId, onGenerate, onApply, onDismiss }` | `/library/private/[privateGameId]/toolkit/configure/client.tsx` | `__tests__/AiToolkitGenerator.test.tsx` |
+| `TurnManagerWidget.tsx` | Widget: player turn tracker with cycling. Uses `useWidgetSync`. | `{ isEnabled, players?, sessionId?, toolkitId?, onToggle?, onStateChange? }` | `ToolkitDashboard.tsx` | `__tests__/TurnManagerWidget.test.tsx` |
+| `ScoreTrackerWidget.tsx` | Widget: per-player score accumulator. | `{ isEnabled, players?, sessionId?, toolkitId?, onToggle?, onStateChange? }` | `ToolkitDashboard.tsx` | `__tests__/ScoreTrackerWidget.test.tsx` |
+| `RandomGeneratorWidget.tsx` | Widget: random result generator. | `{ isEnabled, onToggle?, onStateChange? }` | `ToolkitDashboard.tsx` | `__tests__/RandomGeneratorWidget.test.tsx` |
+| `ResourceManagerWidget.tsx` | Widget: resource tracking. | `{ isEnabled, onToggle?, onStateChange? }` | `ToolkitDashboard.tsx` | `__tests__/ResourceManagerWidget.test.tsx` |
+| `NoteManagerWidget.tsx` | Widget: session notes manager. | `{ isEnabled, onToggle?, onStateChange? }` | `ToolkitDashboard.tsx` | `__tests__/NoteManagerWidget.test.tsx` |
+| `WhiteboardWidget.tsx` | Widget: free-form whiteboard. | `{ isEnabled, onToggle?, onStateChange? }` | `ToolkitDashboard.tsx` | (covered by ToolkitDashboard test) |
+| `WidgetCard.tsx` | Card wrapper with enabled/disabled visual state and toggle. | `{ isEnabled, title, icon, onToggle?, children }` | All 6 widget components | `__tests__/WidgetCard.test.tsx` |
+| `CardDeckTool.tsx` | Card deck draw tool. | (self-contained stateful) | `/toolkit/[sessionId]/_content.tsx` (via barrel) | `__tests__/CardDeckTool.test.tsx` |
+| `Counter.tsx` | Numeric counter primitive. | (self-contained) | Internally via `CounterTool.tsx` | (no dedicated test, covered by CounterTool) |
+| `CounterTool.tsx` | Counter tool with min/max/reset. | (self-contained stateful) | `/toolkit/play/page.tsx` | `__tests__/CounterTool.test.tsx` |
+| `DiceRoller.tsx` | Dice roller with history. | (self-contained stateful) | `/toolkit/play/page.tsx`, `/toolkit/[sessionId]/_content.tsx` | `__tests__/DiceRoller.test.tsx` |
+| `Timer.tsx` | Countdown/countup timer. | (self-contained stateful) | `/toolkit/play/page.tsx`, `/toolkit/[sessionId]/_content.tsx` | `__tests__/Timer.test.tsx` |
+| `Randomizer.tsx` | Random picker from list. | (self-contained stateful) | `/toolkit/play/page.tsx` | `__tests__/RandomizerTool.test.tsx` |
+| `Scoreboard.tsx` | Simple scoreboard primitive. | (self-contained stateful) | Internally (not via app pages) | (none found) |
+| `index.ts` | Barrel export: `ToolkitDashboard`, widgets, tools, polymorphic renderers | — | — | — |
+
+**Data contracts used by `toolkit/`**: `AiTurnTemplateSuggestion`, `AiScoringTemplateSuggestion`, `ToolkitDashboardDto`, `WidgetType` — all from `@/lib/api/schemas/toolkit.schemas`.
+
+---
+
+## 3. Inventory: `/components/features/session-live/`
+
+19 components (16 leaf + 3 directory structures). Origin: Wave D.2 (issues #746, #750). G1 additions: ChatAgentPanel (#2374). G5b: turn-indicator-renderer/ (#2378 — PR #2411 in review).
+
+| File/Dir | Purpose | Props Contract | Consumers | Test Coverage |
+|---|---|---|---|---|
+| `TurnIndicatorRenderer.tsx` (dir) | **G5b** polymorphic turn dispatcher for **live session SSE state**. Narrows on `TurnState.type` discriminated union. 7 branches + UnknownBranch fallback. Adds `FirstPlayerToken` variant absent in `toolkit/`. | `{ state: TurnState, players: PlayerInfo[], viewerId: string, compact?, labels }` | `SessionLiveView.tsx` (desktop tab `turn` + mobile sheet `turn`) | `__tests__/TurnIndicatorRenderer.test.tsx` — 8+ cases |
+| `TurnIndicator.tsx` | Simple progress bar + active-player display. Owned by `RoundRobinBranch` (delegation). | `{ current, total, activePlayerName, isMyTurn, compact?, labels }` | `turn-indicator-renderer/branches/RoundRobinBranch.tsx` | (covered by TurnIndicatorRenderer tests) |
+| `LiveScoringPanel.tsx` | Real-time role-aware scoreboard with ±1 delta buttons. NOT polymorphic on `scoreType` — single Points layout. Planned replacement by G5a #2373. | `{ scores: LiveScoringPanelScoreEntry[], viewerRole, viewerId, onScoreUpdate?, compact?, labels }` | `SessionLiveView.tsx` (desktop tab `score` + mobile `score`) | `(no dedicated test found in __tests__/)` |
+| `SessionToolsRail.tsx` | Role-gated tool action grid. Spectator → null. Player/Host → grid of 3 hardcoded icon buttons. | `{ tools: [{id,name,icon}][], viewerRole, onToolExecute, compact?, labels }` | `SessionLiveView.tsx` (desktop tab `widget` + mobile `widget`) | `__tests__/SessionToolsRail.test.tsx` |
+| `ChatAgentPanel.tsx` | **G1 #2374 T3**. Agent header + accordion + `LiveAgentChat` body. Frozen §5 contract for G3. | `{ sessionId?, messages, viewerRole, viewerId, onSendMessage, agentName, agentEmoji?, latencyMs, collapsed?, onHeaderClick?, labels }` | `SessionLiveView.tsx` (desktop LEFT column) | `__tests__/ChatAgentPanel.test.tsx` |
+| `LiveAgentChat.tsx` | Chat message list + compose area with private/shared visibility toggle. | `{ sessionId, messages, viewerRole, viewerId, onSendMessage, compact?, labels }` | `ChatAgentPanel.tsx` | `__tests__/LiveAgentChat.test.tsx` |
+| `DesktopBody.tsx` | 2-col 60/40 CSS grid layout shell (lg+). | `{ leftColumn, rightColumn, className? }` | `SessionLiveView.tsx` | `__tests__/DesktopBody.test.tsx` |
+| `MobileBody.tsx` | Mobile layout: main content + bottom-sheet drawer. | `{ mainContent, sheetContent, ... }` | `SessionLiveView.tsx` | `__tests__/MobileBody.test.tsx` |
+| `MobileBottomSheetDrawer.tsx` | Radix Sheet bottom drawer for mobile tab content. | `{ activeTab, onTabChange, children, labels }` | `MobileBody.tsx` | `__tests__/MobileBottomSheetDrawer.test.tsx` |
+| `RightColumnTabs.tsx` | Tab list + panel for desktop RIGHT col (score/turn/widget/notes). | `{ activeTab, onTabChange, children, labels }` | `SessionLiveView.tsx` | `__tests__/RightColumnTabs.test.tsx` |
+| `ActionLogTimeline.tsx` | Append-only event log. | `{ entries, labels }` | `SessionLiveView.tsx` | (no dedicated test) |
+| `PlayerRosterLive.tsx` | Participant list with online status. | `{ players, viewerId, viewerRole, labels }` | `SessionLiveView.tsx` | (no dedicated test) |
+| `LiveTopBar.tsx` | Session top bar with role-based CTAs + connection state. | (complex labels) | `SessionLiveView.tsx` | `__tests__/LiveTopBar.test.tsx` |
+| `LiveSessionNotes.tsx` | Notes list + add form. | `{ notes, viewerRole, viewerId, onAddNote, labels }` | `SessionLiveView.tsx` | `__tests__/LiveSessionNotes.test.tsx` |
+| `ConnectionLostBanner.tsx` | SSE connection state banner (reconnecting/degraded/failed). | `{ kind, labels }` | `SessionLiveView.tsx` | `__tests__/ConnectionLostBanner.test.tsx` |
+| `PauseOverlay.tsx` / `EndgameDialog.tsx` | Modal overlays with focus traps. | (role + labels) | `SessionLiveView.tsx` (lazy-loaded) | `__tests__/PauseOverlay.test.tsx` / `EndgameDialog.test.tsx` |
+| `SessionStateRenderer.tsx` | 4-state FSM shell (loading/error/not-found/default). | — | `ScoreboardPage.tsx` | `__tests__/SessionStateRenderer.test.tsx` |
+| `index.ts` | Barrel: all session-live + G5b TurnIndicatorRenderer | — | `SessionLiveView.tsx` (2 import statements) | — |
+
+**Data contracts used by `session-live/`**: `TurnState` (from `@/lib/session-live/turn-state`), `ParticipantRole`, `PlayerInfo` — all in `lib/session-live/`. No reference to `toolkit.schemas`.
+
+---
+
+## 4. Duplication Matrix
+
+| `toolkit/` Component | `features/session-live/` Component | Relationship | Notes |
+|---|---|---|---|
+| `TurnIndicatorRenderer` | `turn-indicator-renderer/TurnIndicatorRenderer` | **DUPLICATE names, different contracts** | Same dispatch concept (turn-order type → layout), different data sources. toolkit: `AiTurnTemplateSuggestion` (flat string props, AI config preview). session-live: `TurnState` discriminated union (SSE runtime state, 7 typed variants). `FirstPlayerToken` variant exists only in session-live. |
+| `ScoringPanelRenderer` | `LiveScoringPanel` | **COMPLEMENTARY — different purpose** | toolkit: shows AI-suggested scoring structure (4 ScoreType layouts, static template display). session-live: shows real-time score delta UI (1 layout, role-aware ±1 buttons, live entry data). G5a #2373 will add a third — a polymorphic live scorer. |
+| `ToolkitDashboard` | `SessionToolsRail` | **COMPLEMENTARY — different purpose** | toolkit: full B-context widget configuration grid (6 domain widgets, persistent `WidgetType` state). session-live: simple tool action grid (3 hardcoded icons, role-gated, ephemeral). |
+| `TurnManagerWidget` | `TurnIndicator` (session-live primitive) | **COMPLEMENTARY — different purpose** | toolkit: full add/remove/cycle player UI widget with persistent server state. session-live: thin progress bar + active player display (presentation only). |
+| `ScoreTrackerWidget` | `LiveScoringPanel` | **COMPLEMENTARY — different purpose** | toolkit: full widget with manual add/edit player scores via `useWidgetSync`. session-live: role-aware live scoreboard (read + ±1 delta). |
+| `AiToolkitGenerator` | *(no counterpart)* | **UNIQUE to `toolkit/`** | Configuration-phase AI generation. No live-session equivalent. |
+| `CardDeckTool`, `DiceRoller`, `Timer`, `Counter`, `Randomizer` | *(no counterpart)* | **UNIQUE to `toolkit/`** | Stateful game tool primitives. session-live uses `SessionToolsRail` as a thin triggering surface that eventually executes these tools. |
+
+---
+
+## 5. Migration Path Recommendation
+
+### 5.1 PR #2411 (#2378 G5b) — MERGE AS-IS
+
+**Recommendation: Merge without modification.**
+
+The new `features/session-live/turn-indicator-renderer/TurnIndicatorRenderer` is architecturally correct and not duplicating the `toolkit/TurnIndicatorRenderer` in any harmful way. They serve different domains:
+
+- `toolkit/TurnIndicatorRenderer`: consumes `AiTurnTemplateSuggestion` — an AI suggestion object used during toolkit configuration preview. It is a **config-domain UI** component.
+- `features/session-live/turn-indicator-renderer/TurnIndicatorRenderer`: consumes `TurnState` — a SSE-driven runtime discriminated union. It is a **live-session runtime UI** component. It adds `FirstPlayerToken` (not in the toolkit schema) and is i18n-ready via `labels`.
+
+The two should remain separate. The toolkit one may eventually be deprecated if the AI-config flow is reworked to emit `TurnState`-shaped data, but that is a future refactoring not related to G5.
+
+**One naming action needed**: the `toolkit/index.ts` barrel exports `TurnIndicatorRenderer` without namespace qualification. To prevent future import confusion, consider adding a comment or an alias re-export like `export { TurnIndicatorRenderer as ToolkitTurnIndicatorRenderer }` — but this is a non-blocking cleanup, not a blocker for #2411.
+
+### 5.2 #2376 G5c ToolkitRenderer — BUILD NEW in `features/session-live/`
+
+**Recommendation: Build a new `ToolkitRenderer` inside `features/session-live/` that does NOT wrap or re-export `ToolkitDashboard`.**
+
+The G5c "ToolkitRenderer" for the session-live `widget` tab is architecturally different from `ToolkitDashboard`:
+
+- `ToolkitDashboard` renders the full **6-widget B-context configuration grid** with per-widget toggle and persistent server state. It is a heavy stateful admin/config component.
+- The session-live `widget` tab currently uses `SessionToolsRail` — a **3-tool action trigger surface** (dice, timer, card). G5c should either:
+  - (a) **Keep `SessionToolsRail` as-is** and make it data-driven from the game's toolkit configuration (fetching which tools are enabled), or
+  - (b) **Create a new `ToolkitRenderer`** in `features/session-live/` that bridges the `ToolkitDashboardDto` data to a compact read-only session-play UI — not the full editable `ToolkitDashboard` grid.
+
+Do NOT mount `ToolkitDashboard` inside the session-live `widget` tab — it is a configuration component, not a play component. The widget/toggle UX is wrong for an active session.
+
+### 5.3 #2373 G5a ScoringPanelRenderer — BUILD NEW in `features/session-live/`
+
+**Recommendation: Build a new polymorphic `ScoringPanelRenderer` inside `features/session-live/` that wraps or replaces `LiveScoringPanel`.**
+
+The existing `toolkit/ScoringPanelRenderer` is a **config-preview** component — it displays the AI-suggested scoring structure (`AiScoringTemplateSuggestion`) with no live data. It is NOT what G5a needs.
+
+G5a needs a **live polymorphic scorer** that:
+- Accepts `scoreType` (`Points | Ranking | BinaryWin | Objectives`) from the session's toolkit
+- Renders the appropriate live score UI with the existing `LiveScoringPanel` role-aware delta buttons
+- Replaces the current `LiveScoringPanel` mount in `SessionLiveView.tsx` at the `score` tab
+
+The `toolkit/ScoringPanelRenderer` visual layouts (Points/Ranking/BinaryWin/Objectives) can serve as **reference implementation** for the G5a component, but should not be imported directly. The live version needs `LiveScoringPanelScoreEntry[]` data and `onScoreUpdate` callbacks — props that `toolkit/ScoringPanelRenderer` does not have.
+
+### 5.4 Long-term Architecture
+
+**Canonical direction: `toolkit/` = config domain, `features/session-live/` = runtime domain. No cross-imports.**
+
+| Domain | Location | Data Contract | Purpose |
+|---|---|---|---|
+| AI toolkit config preview | `components/toolkit/` | `AiToolkitSuggestion`, `ToolkitDashboardDto` | Display AI suggestions, configure widget settings |
+| Live session runtime | `components/features/session-live/` | `TurnState`, `LiveScoringPanelScoreEntry`, `ParticipantRole` | Real-time play UI, SSE-driven |
+
+**The `toolkit/TurnIndicatorRenderer` and `toolkit/ScoringPanelRenderer` should be renamed to prevent future confusion:**
+- `toolkit/TurnIndicatorRenderer` → `toolkit/AiTurnPreviewRenderer` (clarifies config-only purpose)
+- `toolkit/ScoringPanelRenderer` → `toolkit/AiScoringPreviewRenderer`
+
+This rename should be tracked as a separate cleanup issue (e.g., `refactor(toolkit): rename preview renderers for clarity`) distinct from G5 work.
+
+---
+
+## 6. Suggested ADR
+
+**Title**: ADR-078 — Toolkit Config Domain vs Session-Live Runtime Domain: Separation of UI Concerns
+
+**Summary** (3 lines):
+
+The `components/toolkit/` directory owns UI components for the AI-config and widget-configuration bounded context, consuming `AiToolkitSuggestion`/`ToolkitDashboardDto` contracts. The `components/features/session-live/` directory owns UI components for the live play runtime, consuming SSE-driven `TurnState`/`LiveScoringPanelScoreEntry` contracts. Cross-imports between the two directories are forbidden; G5 polymorphic renderers (#2373, #2376, #2378) are built exclusively in `session-live/` and may use `toolkit/` schemas as read references but not toolkit UI components.
+
+**File**: `docs/for-claude/architecture/adr/adr-078-toolkit-vs-session-live-ui-separation.md`
+
+---
+
+## Appendix: File Reference Map
+
+| File | Absolute Path |
+|---|---|
+| toolkit/TurnIndicatorRenderer | `apps/web/src/components/toolkit/TurnIndicatorRenderer.tsx` |
+| toolkit/ScoringPanelRenderer | `apps/web/src/components/toolkit/ScoringPanelRenderer.tsx` |
+| toolkit/ToolkitDashboard | `apps/web/src/components/toolkit/ToolkitDashboard.tsx` |
+| session-live TurnIndicatorRenderer | `apps/web/src/components/features/session-live/turn-indicator-renderer/TurnIndicatorRenderer.tsx` |
+| session-live TurnState | `apps/web/src/lib/session-live/turn-state.ts` |
+| session-live LiveScoringPanel | `apps/web/src/components/features/session-live/LiveScoringPanel.tsx` |
+| session-live SessionToolsRail | `apps/web/src/components/features/session-live/SessionToolsRail.tsx` |
+| toolkit.schemas | `apps/web/src/lib/api/schemas/toolkit.schemas.ts` |
+| SessionLiveView orchestrator | `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` |
+| toolkit route content | `apps/web/src/app/(authenticated)/toolkit/[sessionId]/_content.tsx` |
+| toolkit configure client | `apps/web/src/app/(authenticated)/library/private/[privateGameId]/toolkit/configure/client.tsx` |

--- a/docs/superpowers/plans/2026-06-16-issue-2376-g5c-toolkit-renderer.md
+++ b/docs/superpowers/plans/2026-06-16-issue-2376-g5c-toolkit-renderer.md
@@ -1,0 +1,263 @@
+# #2376 G5c ToolkitRenderer — Implementation Plan
+
+> Spec: `docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md`
+> Branch: `feature/issue-2376-g5c-toolkit-renderer` (parent `main-dev`)
+> 6 DEC: full impl · Zustand+PATCH · replace SessionToolsRail · discriminated union · single-expanded accordion · Unknown warning
+
+## Task 1: widget-state.ts types
+
+Create `apps/web/src/lib/session-live/widget-state.ts`:
+
+```ts
+'use client';
+
+export type WidgetType =
+  | 'RandomGenerator' | 'TurnManager' | 'ScoreTracker'
+  | 'ResourceManager' | 'NoteManager' | 'Whiteboard';
+
+export interface RandomGeneratorConfig {
+  readonly name: string;
+  readonly faces: ReadonlyArray<string | number>;
+  readonly quantity: number;
+  readonly last: string | number | null;
+}
+export interface TurnManagerConfig {
+  readonly phaseBased: boolean;
+  readonly phases?: ReadonlyArray<string>;
+  readonly activeIndex: number;
+}
+export interface ScoreTrackerConfig {
+  readonly scores: Readonly<Record<string, number>>;
+}
+export interface ResourceManagerConfig {
+  readonly shared: boolean;
+  readonly resources: ReadonlyArray<{
+    readonly label: string; readonly value: number; readonly max: number; readonly danger?: boolean;
+  }>;
+}
+export interface NoteManagerConfig { readonly text: string; }
+export interface WhiteboardConfig {
+  readonly strokes: ReadonlyArray<{
+    readonly tool: string; readonly points: ReadonlyArray<[number, number]>; readonly color: string;
+  }>;
+}
+
+export type WidgetConfigByType = {
+  RandomGenerator: RandomGeneratorConfig;
+  TurnManager: TurnManagerConfig;
+  ScoreTracker: ScoreTrackerConfig;
+  ResourceManager: ResourceManagerConfig;
+  NoteManager: NoteManagerConfig;
+  Whiteboard: WhiteboardConfig;
+};
+
+export type ParsedWidget = {
+  [K in WidgetType]: {
+    readonly id: string; readonly type: K; readonly isEnabled: boolean;
+    readonly displayOrder: number; readonly config: WidgetConfigByType[K];
+  };
+}[WidgetType];
+
+export function defaultConfigFor<T extends WidgetType>(type: T): WidgetConfigByType[T] {
+  switch (type) {
+    case 'RandomGenerator':
+      return { name: 'Generatore', faces: [1,2,3,4,5,6], quantity: 1, last: null } as WidgetConfigByType[T];
+    case 'TurnManager':
+      return { phaseBased: false, activeIndex: 0 } as WidgetConfigByType[T];
+    case 'ScoreTracker':
+      return { scores: {} } as WidgetConfigByType[T];
+    case 'ResourceManager':
+      return { shared: false, resources: [] } as WidgetConfigByType[T];
+    case 'NoteManager':
+      return { text: '' } as WidgetConfigByType[T];
+    case 'Whiteboard':
+      return { strokes: [] } as WidgetConfigByType[T];
+    default: { const _exhaustive: never = type; return _exhaustive; }
+  }
+}
+
+export function parseWidgetConfig<T extends WidgetType>(type: T, json: string): WidgetConfigByType[T] {
+  try {
+    const parsed = JSON.parse(json) as Partial<WidgetConfigByType[T]>;
+    return { ...defaultConfigFor(type), ...parsed };
+  } catch (err) {
+    console.warn('[ToolkitRenderer] parseWidgetConfig failed:', type, err);
+    return defaultConfigFor(type);
+  }
+}
+```
+
+Commit: `feat(session-live): #2376 widget-state types + parser`
+
+## Task 2: internals — WidgetShell + Stepper
+
+Create `apps/web/src/components/features/session-live/toolkit-renderer/internals/WidgetShell.tsx`:
+
+Accordion-style shell with header button, icon, title, type pill, body unmounts when collapsed (mirrors ChatAgentPanel §5 contract pattern from #2375).
+
+Create `Stepper.tsx`: +/- buttons with aria-labels, controlled by `value` + `onChange`.
+
+Commit: `feat(session-live): #2376 internals WidgetShell + Stepper`
+
+## Task 3: 6 widget components
+
+Each widget under `widgets/` consumes parsed config + emits config changes via `onChange`. Each has unit test in `__tests__/<Widget>.test.tsx`. Use mockup `sp4-session-skeleton-renderers.jsx` lines 501-562 as visual reference but use semantic Tailwind tokens (no raw HSL).
+
+Per widget:
+- RandomGeneratorWidget: "Last" display + "Genera" button (random pick from faces).
+- TurnManagerWidget: ‹ Prev / [phase or '—'] / Next › buttons.
+- ScoreTrackerWidget: Player rows with Stepper.
+- ResourceManagerWidget: Resource rows with Stepper + max + danger flag.
+- NoteManagerWidget: Textarea with 30s autosave via debounce.
+- WhiteboardWidget: Tool palette + dashed placeholder canvas (MVP).
+- UnknownWidget: Warning banner.
+
+Commit per widget: `feat(session-live): #2376 <WidgetName>`.
+
+## Task 4: ToolkitRenderer dispatcher
+
+Create `ToolkitRenderer.tsx`:
+
+```tsx
+'use client';
+
+import { useToolkitRendererStore } from '@/lib/stores/toolkit-renderer-store';
+
+export function ToolkitRenderer({ labels, players }: ToolkitRendererProps): ReactElement {
+  const { widgets, openWidgetId, setOpenWidget, updateWidgetConfig } = useToolkitRendererStore();
+  const enabled = widgets.filter(w => w.isEnabled).sort((a, b) => a.displayOrder - b.displayOrder);
+  if (enabled.length === 0) return <EmptyState labels={labels} />;
+  return (
+    <section data-slot="toolkit-renderer" role="region" aria-label={labels.title}>
+      {enabled.map(w => {
+        const collapsed = w.id !== openWidgetId;
+        const onHeaderClick = () => setOpenWidget(collapsed ? w.id : null);
+        switch (w.type) {
+          case 'RandomGenerator':
+            return <RandomGeneratorWidget key={w.id} widget={w} collapsed={collapsed}
+              onHeaderClick={onHeaderClick} onConfigChange={c => updateWidgetConfig(w.id, c)}
+              labels={labels} />;
+          // ... (5 other branches)
+          default:
+            console.warn('[ToolkitRenderer] Unknown widget type:', w.type);
+            return <UnknownWidget key={w.id} widget={w} labels={labels} />;
+        }
+      })}
+    </section>
+  );
+}
+```
+
+10 unit tests covering each dispatch path + empty state + Unknown.
+
+Commit: `feat(session-live): #2376 ToolkitRenderer dispatcher + 10 tests`
+
+## Task 5: Zustand store with backend PATCH
+
+Create `apps/web/src/lib/stores/toolkit-renderer-store.ts`:
+
+```ts
+import { create } from 'zustand';
+import type { ParsedWidget, WidgetType, WidgetConfigByType } from '@/lib/session-live/widget-state';
+import { parseWidgetConfig } from '@/lib/session-live/widget-state';
+
+interface State {
+  widgets: ReadonlyArray<ParsedWidget>;
+  openWidgetId: string | null;
+  setOpenWidget: (id: string | null) => void;
+  hydrate: (toolkit: ToolkitDashboardDto) => void;
+  updateWidgetConfig: <T extends WidgetType>(id: string, nextConfig: WidgetConfigByType[T]) => Promise<void>;
+}
+
+export const useToolkitRendererStore = create<State>()((set, get) => ({
+  widgets: [],
+  openWidgetId: null,
+  setOpenWidget: id => set({ openWidgetId: id }),
+  hydrate: toolkit => {
+    const widgets = toolkit.widgets.map(w => ({
+      id: w.id, type: w.type as WidgetType, isEnabled: w.isEnabled,
+      displayOrder: w.displayOrder, config: parseWidgetConfig(w.type as WidgetType, w.config),
+    })) as ParsedWidget[];
+    set({ widgets });
+  },
+  updateWidgetConfig: async (id, nextConfig) => {
+    const prev = get().widgets;
+    set({ widgets: prev.map(w => w.id === id ? { ...w, config: nextConfig } as ParsedWidget : w) });
+    try {
+      const res = await fetch(`/api/v1/toolkits/widgets/${id}`, {
+        method: 'PATCH', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ configJson: JSON.stringify(nextConfig) }),
+      });
+      if (!res.ok) throw new Error(`PATCH failed: ${res.status}`);
+    } catch (err) {
+      console.warn('[useToolkitRendererStore] PATCH failed, rolling back:', err);
+      set({ widgets: prev });
+    }
+  },
+}));
+```
+
+5 store unit tests: hydrate, setOpenWidget, updateWidgetConfig optimistic, rollback on failure, parseWidgetConfig fallback.
+
+Commit: `feat(session-live): #2376 useToolkitRendererStore + 5 tests`
+
+## Task 6: i18n keys (~30 keys)
+
+Add to `it.json` and `en.json` under `pages.sessionLive.toolkitRenderer`:
+
+```json
+{
+  "title": "Strumenti",
+  "emptyTitle": "Nessun widget attivo",
+  "emptyBody": "Abilita i widget dal toolkit.",
+  "unknownTitle": "Widget non supportato",
+  "unknownBody": "Aggiorna l'app.",
+  "expandAriaTemplate": "Espandi widget {name}",
+  "collapseAriaTemplate": "Collassa widget {name}",
+  "randomGenerator": { "heading": "Generatore", "rollLabel": "Genera", "lastLabel": "Ultimo" },
+  "turnManager": { "heading": "Gestore turni", "prevLabel": "Precedente", "nextLabel": "Successivo", "turnOfLabel": "Turno di", "phaseLabel": "Fase" },
+  "scoreTracker": { "heading": "Punteggio", "incrementAriaTemplate": "Aumenta punteggio {name}", "decrementAriaTemplate": "Diminuisci punteggio {name}" },
+  "resourceManager": { "heading": "Risorse", "sharedHeading": "Risorse condivise", "incrementAriaTemplate": "Aumenta {label}", "decrementAriaTemplate": "Diminuisci {label}" },
+  "noteManager": { "heading": "Note", "inputAriaLabel": "Scrivi una nota", "savingLabel": "Salvataggio…", "savedLabel": "Salvato" },
+  "whiteboard": { "heading": "Lavagna", "toolPenLabel": "Penna", "toolEraserLabel": "Gomma", "toolCircleLabel": "Cerchio", "placeholderLabel": "Area disegno condivisa" }
+}
+```
+
+Mirror en.json with English translations.
+
+Commit: `feat(i18n): #2376 toolkitRenderer ~30 new keys`
+
+## Task 7: SessionLiveView swap SessionToolsRail → ToolkitRenderer
+
+Wire `<ToolkitRenderer>` in `desktopRightColumn` 'widget' tab + `mobileSheetContent` 'widget' case. Remove `<SessionToolsRail>` from those slots (keep import only if other consumers).
+
+Add hook to load `ToolkitDashboardDto` (use existing `useToolkit` query if available, else `useQuery({ queryKey: ['toolkit', sessionId], queryFn: …, enabled: !!sessionId })`).
+
+Call `hydrate(toolkit)` once loaded.
+
+For mobile use compact prop.
+
+Commit: `feat(session-live): #2376 wire SessionLiveView to ToolkitRenderer`
+
+## Task 8: axe AA test
+
+Create `apps/web/__tests__/session-live-toolkit-renderer-axe.test.tsx` covering 8 states (6 widget types isolated + Unknown + empty).
+
+Commit: `test(a11y): #2376 ToolkitRenderer axe AA 8 tests`
+
+## Task 9: Final verify + PR
+
+```bash
+cd apps/web && pnpm typecheck && pnpm test session-live --run && pnpm lint
+git push -u origin feature/issue-2376-g5c-toolkit-renderer
+gh pr create --base main-dev --title "feat(session-live): #2376 G5c ToolkitRenderer polymorphic dispatch (6 widget)" --body "..."
+```
+
+Commit: none (PR creation only).
+
+---
+
+## Execution
+
+Subagent-driven; dispatch tasks sequentially. Skip per-task code review (rely on TDD self-test + final review). Final comprehensive review before merge.

--- a/docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md
+++ b/docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md
@@ -1,0 +1,185 @@
+# Issue #2376 G5c — ToolkitRenderer polymorphic dispatch (design)
+
+**Date**: 2026-06-16
+**Parent epic**: [#2354 Session live shell](https://github.com/meepleAi-app/meepleai-monorepo/issues/2354)
+**Sub-issue**: [#2376](https://github.com/meepleAi-app/meepleai-monorepo/issues/2376)
+**Effort estimate**: ~3-5gg
+
+## 1. Context
+
+G5c adds a polymorphic `ToolkitRenderer` switching on `WidgetType` over **6 variants**:
+
+1. `RandomGenerator` — dice/coin/card draw.
+2. `TurnManager` — turn order, phase progression.
+3. `ScoreTracker` — multi-player score increments.
+4. `ResourceManager` — resource counters (meeple, tokens).
+5. `NoteManager` — per-player notes.
+6. `Whiteboard` — collaborative canvas.
+
+Backend `WidgetType` enum (`apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/WidgetType.cs`) has all 6 variants. `ToolkitWidgetDto` carries `Type`, `IsEnabled`, `DisplayOrder`, `Config` (JSON string).
+
+### Architectural boundary (ADR-079 candidate)
+
+Per audit `claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md`:
+
+- `apps/web/src/components/toolkit/` is the **AI-config domain** (admin UI consumers, `AiToolkitSuggestion` / `ToolkitDashboardDto` contracts, used by `app/(authenticated)/toolkit/[sessionId]/_content.tsx` and `/library/private/[id]/toolkit/configure/`).
+- `apps/web/src/components/features/session-live/` is the **live-play runtime domain** (SSE-driven, used by `SessionLiveView`).
+
+This spec builds **NEW** components under `features/session-live/toolkit-renderer/`, **NOT** in `toolkit/`. Existing `toolkit/ToolkitDashboard.tsx` stays untouched and serves the admin config UI.
+
+## 2. Decisions locked
+
+| ID | Decision | Rationale |
+|---|---|---|
+| DEC-1 | **Full implementation** — 6 widget components with state + interaction | User-locked. Aligns with mockup expectations. |
+| DEC-2 | **Zustand store + backend PATCH** for widget state persistence | User-locked. Optimistic updates with `PATCH /api/v1/toolkits/widgets/{id}`. |
+| DEC-3 | **Replace SessionToolsRail** in `SessionLiveView` RIGHT 'widget' tab | User-locked. Mockup canonical (`sp4-session-skeleton-renderers.jsx`) uses ToolkitRenderer in this slot. |
+| DEC-4 | **Discriminated union** for widget config TS-side | Mirror #2378 G5b pattern. Backend Config is JSON string; FE parses into typed union via `parseWidgetConfig(type, json)`. |
+| DEC-5 | **Single-expanded accordion** (mockup default) | Match mockup `sp4-session-skeleton-renderers.jsx` line 599-601 (`openId` state, click toggles single open widget). |
+| DEC-6 | **Unknown widget type → warning banner + `console.warn`** | Mirror #2378 G5b Nygard pattern. |
+
+## 3. Component architecture
+
+```
+features/session-live/toolkit-renderer/
+  ├─ ToolkitRenderer.tsx                ← parent dispatcher (accordion FSM + widget list)
+  ├─ labels.ts                          ← TS interface for i18n keys
+  ├─ widgets/
+  │   ├─ RandomGeneratorWidget.tsx      ← dice/coin/card draw
+  │   ├─ TurnManagerWidget.tsx          ← turn cycle controls
+  │   ├─ ScoreTrackerWidget.tsx         ← per-player +/- score
+  │   ├─ ResourceManagerWidget.tsx      ← resource counters
+  │   ├─ NoteManagerWidget.tsx          ← textarea per-player
+  │   ├─ WhiteboardWidget.tsx           ← coloured stroke palette + dashed canvas (MVP)
+  │   └─ UnknownWidget.tsx              ← warning banner
+  ├─ internals/
+  │   ├─ WidgetShell.tsx                ← header + icon + title + type pill + accordion button
+  │   └─ Stepper.tsx                    ← +/- numeric input shared by Score/Resource
+  └─ __tests__/
+      └─ ToolkitRenderer.test.tsx       ← dispatcher tests
+```
+
+Each widget gets its own `__tests__/<Widget>.test.tsx` next to itself.
+
+`data-slot="toolkit-renderer"` on `<ToolkitRenderer>` root. Each widget gets `data-slot="widget-{kebabCase(type)}"`.
+
+## 4. State + persistence
+
+### 4.1 Backend wire
+
+Existing endpoints (verify in `apps/api/src/Api/BoundedContexts/GameToolkit/Routing/`):
+- `GET /api/v1/toolkits/{toolkitId}/widgets` — load full `ToolkitDashboardDto`.
+- `PATCH /api/v1/toolkits/widgets/{widgetId}` — update `IsEnabled` and/or `ConfigJson`.
+
+### 4.2 Zustand store
+
+```ts
+// apps/web/src/lib/stores/toolkit-renderer-store.ts (new)
+
+interface ToolkitRendererState {
+  widgets: ReadonlyArray<ParsedWidget>;            // typed config union per type
+  openWidgetId: string | null;                     // single-expanded accordion
+  setOpenWidget: (id: string | null) => void;
+  updateWidgetConfig: <T extends WidgetType>(
+    id: string,
+    nextConfig: WidgetConfigByType[T]
+  ) => Promise<void>;                              // optimistic + PATCH
+  hydrate: (toolkit: ToolkitDashboardDto) => void; // initial load from backend
+}
+```
+
+The store keeps the parsed `WidgetConfigByType` union locally. On `updateWidgetConfig`:
+1. Update local widget config in-place (optimistic).
+2. POST `PATCH /api/v1/toolkits/widgets/{id}` with `ConfigJson = JSON.stringify(nextConfig)`.
+3. On error: rollback to previous value + toast notification.
+
+### 4.3 Config typing (DEC-4)
+
+```ts
+// apps/web/src/lib/session-live/widget-state.ts (new)
+
+export type WidgetConfigByType = {
+  RandomGenerator: { name: string; faces: ReadonlyArray<string | number>; quantity: number; last: string | number | null };
+  TurnManager: { phaseBased: boolean; phases?: ReadonlyArray<string>; activeIndex: number };
+  ScoreTracker: { scores: Record<string /* playerId */, number> };
+  ResourceManager: { shared: boolean; resources: ReadonlyArray<{ label: string; value: number; max: number; danger?: boolean }> };
+  NoteManager: { text: string };
+  Whiteboard: { strokes: ReadonlyArray<{ tool: string; points: ReadonlyArray<[number, number]>; color: string }> };
+};
+
+export type ParsedWidget = {
+  [K in WidgetType]: { id: string; type: K; isEnabled: boolean; displayOrder: number; config: WidgetConfigByType[K] };
+}[WidgetType];
+
+export function parseWidgetConfig<T extends WidgetType>(
+  type: T,
+  json: string
+): WidgetConfigByType[T] {
+  try {
+    const parsed = JSON.parse(json) as Partial<WidgetConfigByType[T]>;
+    return mergeWithDefaults(type, parsed);
+  } catch {
+    console.warn('[ToolkitRenderer] Failed to parse widget config:', type, json);
+    return defaultConfigFor(type);
+  }
+}
+```
+
+`defaultConfigFor(type)` returns a safe empty config per variant.
+
+## 5. Failure handling
+
+- Unknown `widget.type` → `UnknownWidget` renders warning + `console.warn`. Dispatcher does not throw.
+- Empty widgets list → empty-state component "Nessun widget abilitato".
+- Failed JSON parse → fall back to `defaultConfigFor(type)`, log warning.
+- Backend PATCH error → rollback optimistic update + toast notification (forward via `useToast`).
+- SSR safety: store hydrates from `ToolkitDashboardDto` server-side; `'use client'` directive on every component.
+
+## 6. A11y (axe AA)
+
+- Accordion header is `<button aria-expanded>`.
+- Widget body unmounts when collapsed (no hidden focus traps).
+- Score steppers labeled with `aria-label="{playerName} score increment/decrement"`.
+- Whiteboard tool palette labeled per tool.
+- `aria-live="polite"` on widget body changes (SSE arrivals).
+
+## 7. Testing strategy
+
+- **Unit (Vitest)**: 1 test per widget × 6 + dispatch tests + Unknown fallback + JSON-parse failure + PATCH-error rollback = **~15 tests**.
+- **Integration**: extend `SessionLiveView.test.tsx` to verify `tab='widget'` now mounts `<ToolkitRenderer>` (replaces `SessionToolsRail`).
+- **Axe AA**: 8 tests (6 widgets + Unknown + empty state).
+- **Zustand store**: 5 store unit tests (hydrate, setOpenWidget, updateWidgetConfig optimistic + rollback, JSON parse fallback).
+
+## 8. i18n
+
+~30 new keys under `pages.sessionLive.toolkitRenderer.*`:
+
+- 6 widget headings + 6 widget type labels
+- accordion expand/collapse aria-labels
+- Unknown title/body
+- empty state title/body
+- per-widget action labels (rollDice, +/-, addStroke, etc.)
+
+## 9. Acceptance criteria
+
+- [x] Dispatch corretto per ogni `WidgetType` (6 variant) — Task 3 dispatcher.
+- [x] Stato widget persistente per sessione (Zustand store + backend PATCH) — Task 5 store.
+- [ ] axe AA 0 violations — Task 6.
+- [ ] Unit test 1-per-widget — Tasks 2.x.
+
+## 10. Out of scope
+
+- Backend `WidgetType` enum changes (already complete).
+- `toolkit/` directory refactor — separate cleanup issue per audit.
+- Whiteboard interactive drawing (canvas event handlers, persistence) — MVP renders tool palette + dashed placeholder area; real drawing deferred to follow-up.
+- ADR-079 boundary doc — optional follow-up (current audit doc sufficient for #2376).
+
+## 11. Refs
+
+- Epic: [#2354](https://github.com/meepleAi-app/meepleai-monorepo/issues/2354).
+- Audit: `claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md`.
+- Mockup: `admin-mockups/design_files/sp4-session-skeleton-renderers.jsx` lines 480-616.
+- Backend enum: `apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/WidgetType.cs`.
+- Backend DTO: `apps/api/src/Api/BoundedContexts/GameToolkit/Application/DTOs/ToolkitDashboardDtos.cs`.
+
+🤖 Brainstormed via main-thread Q/A — 6 DEC user-locked.


### PR DESCRIPTION
## Summary
- New `ToolkitRenderer` dispatcher switches on 6 `WidgetType` variants: RandomGenerator · TurnManager · ScoreTracker · ResourceManager · NoteManager · Whiteboard.
- `UnknownWidget` fallback: warning banner + `console.warn` for unregistered types (Nygard pattern from #2378 G5b).
- Zustand `useToolkitRendererStore` with optimistic updates + backend `PATCH /api/v1/toolkits/widgets/{id}` + rollback on failure.
- `WidgetShell` accordion (single-expanded FSM, body unmounts when collapsed — mirrors ChatAgentPanel §5 contract from #2375 G3).
- Shared `Stepper` primitive used by ScoreTracker + ResourceManager.
- `NoteManagerWidget` autosave with 800ms debounce + status indicator (Saving/Saved).
- ~30 new i18n keys under `pages.sessionLive.toolkitRenderer.*`.
- `SessionLiveView` consumes the renderer in BOTH desktop right-column 'widget' tab and mobile bottom-sheet — replaces `SessionToolsRail`.
- ~70 unit tests + 8 axe AA tests + duplication audit committed under `claudedocs/`.

## Refs
- Issue: #2376 (epic #2354 Session live shell)
- Spec: `docs/superpowers/specs/2026-06-16-issue-2376-g5c-toolkit-renderer-design.md`
- Plan: `docs/superpowers/plans/2026-06-16-issue-2376-g5c-toolkit-renderer.md`
- Audit (toolkit/ vs features/session-live/): `claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md`
- Sibling G5a (#2373), G5b shipped in PR #2411.

## 6 DEC user-locked
- DEC-1 Full implementation (6 widgets with state + interaction)
- DEC-2 Zustand local store + backend PATCH (optimistic + rollback)
- DEC-3 Replace SessionToolsRail in SessionLiveView 'widget' tab
- DEC-4 Discriminated union TypeScript pattern for widget config
- DEC-5 Single-expanded accordion (mockup default)
- DEC-6 Unknown widget → warning banner + console.warn

## Out of scope (follow-up issues)
- Backend GET endpoint hydration in SessionLiveView — store starts empty until follow-up wires `useQuery({ queryKey: ['toolkit', sessionId], ... })` + `hydrate(toolkit)`.
- Whiteboard interactive drawing — MVP renders tool palette + dashed placeholder area.
- `toolkit/` directory rename per audit (separate cleanup issue suggested).

## Test plan
- [x] Unit: 70+ tests across widgets + dispatcher + store + internals
- [x] Axe AA: 8 tests (6 widgets + Unknown + empty)
- [x] SessionLiveView integration: all 67 tests pass
- [x] Typecheck + lint (0 errors) + BGG ban pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)