### PR TITLE
chore(toolkit): #2418 rename Toolkit AI preview renderers (audit cleanup)

### DIFF
--- a/apps/web/src/components/toolkit/ToolkitAiScoringPreviewRenderer.tsx
+++ b/apps/web/src/components/toolkit/ToolkitAiScoringPreviewRenderer.tsx
@@ -11,7 +11,7 @@ import type {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-export interface ScoringPanelRendererProps {
+export interface ToolkitAiScoringPreviewRendererProps {
   /** ScoringTemplate from the toolkit. Null if no scoring is configured. */
   template: AiScoringTemplateSuggestion | null;
   /** Optional per-player score values (id → score). When provided, renders read-only mini-scoreboard inline. */
@@ -264,12 +264,12 @@ function InlineScoreboard({
  *
  * Unknown ScoreType falls back to Points layout for graceful degradation.
  */
-export function ScoringPanelRenderer({
+export function ToolkitAiScoringPreviewRenderer({
   template,
   scores,
   players,
   'data-testid': testId,
-}: ScoringPanelRendererProps) {
+}: ToolkitAiScoringPreviewRendererProps) {
   if (!template) {
     return <ScoringEmpty testId={testId} />;
   }

--- a/apps/web/src/components/toolkit/ToolkitAiTurnPreviewRenderer.tsx
+++ b/apps/web/src/components/toolkit/ToolkitAiTurnPreviewRenderer.tsx
@@ -8,7 +8,7 @@ import type { AiTurnTemplateSuggestion } from '@/lib/api/schemas/toolkit.schemas
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-export interface TurnIndicatorRendererProps {
+export interface ToolkitAiTurnPreviewRendererProps {
   /** TurnTemplate from the toolkit. Null if no turn structure is configured. */
   template: AiTurnTemplateSuggestion | null;
   /** Current round (1-indexed). Optional. */
@@ -312,7 +312,7 @@ const LAYOUT_REGISTRY: Readonly<Record<string, LayoutFn>> = Object.freeze({
  *
  * Unknown TurnOrderType falls back to Custom layout.
  */
-export function TurnIndicatorRenderer({
+export function ToolkitAiTurnPreviewRenderer({
   template,
   currentRound,
   currentTurn,
@@ -320,7 +320,7 @@ export function TurnIndicatorRenderer({
   activePlayer,
   players,
   'data-testid': testId,
-}: TurnIndicatorRendererProps) {
+}: ToolkitAiTurnPreviewRendererProps) {
   if (!template) {
     return <TurnEmpty testId={testId} />;
   }

--- a/apps/web/src/components/toolkit/__tests__/ToolkitAiScoringPreviewRenderer.test.tsx
+++ b/apps/web/src/components/toolkit/__tests__/ToolkitAiScoringPreviewRenderer.test.tsx
@@ -1,5 +1,9 @@
 /**
- * ScoringPanelRenderer tests (issue #1749 B19-4a).
+ * ToolkitAiScoringPreviewRenderer tests (issue #1749 B19-4a).
+ *
+ * Renamed in #2418 from `ScoringPanelRenderer` to disambiguate from
+ * the (future) live-runtime polymorphic renderer under `features/session-live/`
+ * (G5a #2373).
  *
  * Covers all 4 ScoreType variants + null template + Categories[] vs legacy
  * Dimensions[] back-compat + inline scoreboard rendering.
@@ -10,7 +14,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-import { ScoringPanelRenderer } from '../ScoringPanelRenderer';
+import { ToolkitAiScoringPreviewRenderer } from '../ToolkitAiScoringPreviewRenderer';
 import type {
   AiScoringTemplateSuggestion,
   AiScoringCategorySuggestion,
@@ -67,23 +71,23 @@ const CODENAMES_OBJECTIVES: AiScoringTemplateSuggestion = {
   scoreType: 'Objectives',
 };
 
-describe('ScoringPanelRenderer', () => {
+describe('ToolkitAiScoringPreviewRenderer', () => {
   describe('empty / null template', () => {
     it('renders empty state when template is null', () => {
-      render(<ScoringPanelRenderer template={null} />);
+      render(<ToolkitAiScoringPreviewRenderer template={null} />);
       expect(screen.getByTestId('scoring-panel-empty')).toBeInTheDocument();
       expect(screen.getByText(/no scoring template/i)).toBeInTheDocument();
     });
 
     it('respects custom data-testid in empty state', () => {
-      render(<ScoringPanelRenderer template={null} data-testid="custom-id" />);
+      render(<ToolkitAiScoringPreviewRenderer template={null} data-testid="custom-id" />);
       expect(screen.getByTestId('custom-id')).toBeInTheDocument();
     });
   });
 
   describe('Points layout (Wingspan v3 categories)', () => {
     it('renders all 4 categories with their computation icons', () => {
-      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} />);
+      render(<ToolkitAiScoringPreviewRenderer template={WINGSPAN_TEMPLATE} />);
       expect(screen.getByTestId('scoring-categories')).toBeInTheDocument();
       WINGSPAN_CATEGORIES.forEach(c => {
         expect(screen.getByTestId(`scoring-category-${c.id}`)).toBeInTheDocument();
@@ -92,7 +96,7 @@ describe('ScoringPanelRenderer', () => {
     });
 
     it('exposes computation type via data attribute for testability', () => {
-      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} />);
+      render(<ToolkitAiScoringPreviewRenderer template={WINGSPAN_TEMPLATE} />);
       expect(screen.getByTestId('scoring-category-birds')).toHaveAttribute(
         'data-computation',
         'Sum'
@@ -108,7 +112,7 @@ describe('ScoringPanelRenderer', () => {
     });
 
     it('shows description when category has one', () => {
-      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} />);
+      render(<ToolkitAiScoringPreviewRenderer template={WINGSPAN_TEMPLATE} />);
       expect(screen.getByText('5/2/1')).toBeInTheDocument();
     });
 
@@ -120,7 +124,7 @@ describe('ScoringPanelRenderer', () => {
           { id: 'normal', label: 'Normal cat', computation: 'Sum', weight: 1 },
         ],
       };
-      render(<ScoringPanelRenderer template={customWeight} />);
+      render(<ToolkitAiScoringPreviewRenderer template={customWeight} />);
       expect(screen.getByText('×2')).toBeInTheDocument();
       expect(screen.queryByText('×1')).not.toBeInTheDocument();
     });
@@ -128,7 +132,7 @@ describe('ScoringPanelRenderer', () => {
 
   describe('Points layout (legacy dimensions only)', () => {
     it('falls back to legacy dimensions chip list when no categories', () => {
-      render(<ScoringPanelRenderer template={LEGACY_TEMPLATE} />);
+      render(<ToolkitAiScoringPreviewRenderer template={LEGACY_TEMPLATE} />);
       expect(screen.getByTestId('scoring-dimensions-legacy')).toBeInTheDocument();
       expect(screen.queryByTestId('scoring-categories')).not.toBeInTheDocument();
       LEGACY_TEMPLATE.dimensions.forEach(d => {
@@ -141,7 +145,11 @@ describe('ScoringPanelRenderer', () => {
     it('renders ranked list with rank pills when scores provided', () => {
       const scores = { p1: 12, p2: 8, p3: 15 };
       render(
-        <ScoringPanelRenderer template={CATAN_RANKING} scores={scores} players={PLAYERS as never} />
+        <ToolkitAiScoringPreviewRenderer
+          template={CATAN_RANKING}
+          scores={scores}
+          players={PLAYERS as never}
+        />
       );
       const ranking = screen.getByTestId('scoring-ranking');
       expect(ranking).toBeInTheDocument();
@@ -154,14 +162,20 @@ describe('ScoringPanelRenderer', () => {
     });
 
     it('shows placeholder when no scores recorded yet', () => {
-      render(<ScoringPanelRenderer template={CATAN_RANKING} players={PLAYERS as never} />);
+      render(
+        <ToolkitAiScoringPreviewRenderer template={CATAN_RANKING} players={PLAYERS as never} />
+      );
       expect(screen.getByTestId('scoring-ranking-empty')).toBeInTheDocument();
     });
 
     it('handles missing player scores as 0', () => {
       const scores = { p1: 10 };
       render(
-        <ScoringPanelRenderer template={CATAN_RANKING} scores={scores} players={PLAYERS as never} />
+        <ToolkitAiScoringPreviewRenderer
+          template={CATAN_RANKING}
+          scores={scores}
+          players={PLAYERS as never}
+        />
       );
       const ranking = screen.getByTestId('scoring-ranking');
       // p2 and p3 missing → both 0, p1 wins
@@ -171,20 +185,20 @@ describe('ScoringPanelRenderer', () => {
 
   describe('BinaryWin layout', () => {
     it('renders collective outcome indicator', () => {
-      render(<ScoringPanelRenderer template={PALEO_BINARY} />);
+      render(<ToolkitAiScoringPreviewRenderer template={PALEO_BINARY} />);
       expect(screen.getByTestId('scoring-binary-win')).toBeInTheDocument();
       expect(screen.getByText(/win\/lose tracked at game end/i)).toBeInTheDocument();
     });
 
     it('changes message when scores present', () => {
-      render(<ScoringPanelRenderer template={PALEO_BINARY} scores={{ result: 1 }} />);
+      render(<ToolkitAiScoringPreviewRenderer template={PALEO_BINARY} scores={{ result: 1 }} />);
       expect(screen.getByText(/outcome recorded/i)).toBeInTheDocument();
     });
   });
 
   describe('Objectives layout', () => {
     it('renders each dimension as a checkable row', () => {
-      render(<ScoringPanelRenderer template={CODENAMES_OBJECTIVES} />);
+      render(<ToolkitAiScoringPreviewRenderer template={CODENAMES_OBJECTIVES} />);
       expect(screen.getByTestId('scoring-objectives')).toBeInTheDocument();
       CODENAMES_OBJECTIVES.dimensions.forEach(d => {
         expect(screen.getByText(d)).toBeInTheDocument();
@@ -196,7 +210,7 @@ describe('ScoringPanelRenderer', () => {
     it('renders inline scoreboard when scores+players provided', () => {
       const scores = { p1: 25, p2: 18, p3: 22 };
       render(
-        <ScoringPanelRenderer
+        <ToolkitAiScoringPreviewRenderer
           template={WINGSPAN_TEMPLATE}
           scores={scores}
           players={PLAYERS as never}
@@ -212,7 +226,9 @@ describe('ScoringPanelRenderer', () => {
     });
 
     it('skips inline scoreboard when only players provided without scores', () => {
-      render(<ScoringPanelRenderer template={WINGSPAN_TEMPLATE} players={PLAYERS as never} />);
+      render(
+        <ToolkitAiScoringPreviewRenderer template={WINGSPAN_TEMPLATE} players={PLAYERS as never} />
+      );
       expect(screen.queryByTestId('scoring-inline-scoreboard')).not.toBeInTheDocument();
     });
   });
@@ -223,7 +239,7 @@ describe('ScoringPanelRenderer', () => {
         ...LEGACY_TEMPLATE,
         scoreType: 'TotallyMadeUp',
       };
-      const { container } = render(<ScoringPanelRenderer template={unknown} />);
+      const { container } = render(<ToolkitAiScoringPreviewRenderer template={unknown} />);
       // Should not crash, should render legacy dimensions
       expect(screen.getByTestId('scoring-dimensions-legacy')).toBeInTheDocument();
       // Section data attribute reflects the (unknown) score type for debugging

--- a/apps/web/src/components/toolkit/__tests__/ToolkitAiTurnPreviewRenderer.test.tsx
+++ b/apps/web/src/components/toolkit/__tests__/ToolkitAiTurnPreviewRenderer.test.tsx
@@ -1,5 +1,8 @@
 /**
- * TurnIndicatorRenderer tests (issue #1749 B19-4a).
+ * ToolkitAiTurnPreviewRenderer tests (issue #1749 B19-4a).
+ *
+ * Renamed in #2418 from `TurnIndicatorRenderer` to disambiguate from
+ * the live-runtime polymorphic renderer under `features/session-live/`.
  *
  * Covers all 7 TurnOrderType variants + null template + Rounds/TurnsPerRound +
  * phase stepper + active player + simultaneous players.
@@ -10,7 +13,7 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-import { TurnIndicatorRenderer } from '../TurnIndicatorRenderer';
+import { ToolkitAiTurnPreviewRenderer } from '../ToolkitAiTurnPreviewRenderer';
 import type { AiTurnTemplateSuggestion } from '@/lib/api/schemas/toolkit.schemas';
 
 const PLAYERS = [
@@ -52,15 +55,15 @@ const CUSTOM_TURN: AiTurnTemplateSuggestion = {
   phases: ['Setup', 'Play', 'Cleanup'],
 };
 
-describe('TurnIndicatorRenderer', () => {
+describe('ToolkitAiTurnPreviewRenderer', () => {
   describe('empty / null template', () => {
     it('renders empty state when template is null', () => {
-      render(<TurnIndicatorRenderer template={null} />);
+      render(<ToolkitAiTurnPreviewRenderer template={null} />);
       expect(screen.getByTestId('turn-indicator-empty')).toBeInTheDocument();
     });
 
     it('respects custom data-testid in empty state', () => {
-      render(<TurnIndicatorRenderer template={null} data-testid="custom-turn-id" />);
+      render(<ToolkitAiTurnPreviewRenderer template={null} data-testid="custom-turn-id" />);
       expect(screen.getByTestId('custom-turn-id')).toBeInTheDocument();
     });
   });
@@ -68,7 +71,7 @@ describe('TurnIndicatorRenderer', () => {
   describe('RoundRobin (Wingspan-like)', () => {
     it('renders round progress with TurnsPerRound', () => {
       render(
-        <TurnIndicatorRenderer
+        <ToolkitAiTurnPreviewRenderer
           template={WINGSPAN_TURN}
           currentRound={2}
           currentTurn={3}
@@ -81,7 +84,7 @@ describe('TurnIndicatorRenderer', () => {
     });
 
     it('shows active player with direction', () => {
-      render(<TurnIndicatorRenderer template={WINGSPAN_TURN} activePlayer={PLAYERS[1]} />);
+      render(<ToolkitAiTurnPreviewRenderer template={WINGSPAN_TURN} activePlayer={PLAYERS[1]} />);
       const badge = screen.getByTestId('turn-active-player');
       expect(badge).toHaveTextContent('Bob');
       expect(badge).toHaveTextContent('clockwise');
@@ -89,7 +92,7 @@ describe('TurnIndicatorRenderer', () => {
 
     it('renders phase stepper with currentPhaseIndex highlight', () => {
       render(
-        <TurnIndicatorRenderer
+        <ToolkitAiTurnPreviewRenderer
           template={WINGSPAN_TURN}
           currentPhaseIndex={1}
           activePlayer={PLAYERS[0]}
@@ -103,13 +106,13 @@ describe('TurnIndicatorRenderer', () => {
     });
 
     it('shows waiting state when no active player', () => {
-      render(<TurnIndicatorRenderer template={WINGSPAN_TURN} />);
+      render(<ToolkitAiTurnPreviewRenderer template={WINGSPAN_TURN} />);
       expect(screen.getByTestId('turn-active-player-empty')).toBeInTheDocument();
     });
 
     it('exposes turn order type via data attribute', () => {
       const { container } = render(
-        <TurnIndicatorRenderer template={WINGSPAN_TURN} activePlayer={PLAYERS[0]} />
+        <ToolkitAiTurnPreviewRenderer template={WINGSPAN_TURN} activePlayer={PLAYERS[0]} />
       );
       expect(container.querySelector('[data-turn-order-type]')).toHaveAttribute(
         'data-turn-order-type',
@@ -120,7 +123,7 @@ describe('TurnIndicatorRenderer', () => {
 
   describe('Sequential (Codenames-like team)', () => {
     it('renders phase stepper as primary indicator', () => {
-      render(<TurnIndicatorRenderer template={CODENAMES_TURN} currentPhaseIndex={0} />);
+      render(<ToolkitAiTurnPreviewRenderer template={CODENAMES_TURN} currentPhaseIndex={0} />);
       const stepper = screen.getByTestId('turn-phase-stepper');
       expect(stepper).toBeInTheDocument();
       const currentStep = stepper.querySelector('[aria-current="step"]');
@@ -128,7 +131,7 @@ describe('TurnIndicatorRenderer', () => {
     });
 
     it('omits active player badge when not provided', () => {
-      render(<TurnIndicatorRenderer template={CODENAMES_TURN} />);
+      render(<ToolkitAiTurnPreviewRenderer template={CODENAMES_TURN} />);
       expect(screen.queryByTestId('turn-active-player')).not.toBeInTheDocument();
       expect(screen.queryByTestId('turn-active-player-empty')).not.toBeInTheDocument();
     });
@@ -136,7 +139,7 @@ describe('TurnIndicatorRenderer', () => {
 
   describe('Simultaneous (Paleo-like co-op)', () => {
     it('renders all-players badge', () => {
-      render(<TurnIndicatorRenderer template={PALEO_TURN} players={PLAYERS as never} />);
+      render(<ToolkitAiTurnPreviewRenderer template={PALEO_TURN} players={PLAYERS as never} />);
       const badge = screen.getByTestId('turn-simultaneous-players');
       expect(badge).toHaveTextContent('Alice');
       expect(badge).toHaveTextContent('Bob');
@@ -145,7 +148,7 @@ describe('TurnIndicatorRenderer', () => {
 
     it('renders phase stepper alongside simultaneous indicator', () => {
       render(
-        <TurnIndicatorRenderer
+        <ToolkitAiTurnPreviewRenderer
           template={PALEO_TURN}
           players={PLAYERS as never}
           currentPhaseIndex={1}
@@ -158,7 +161,7 @@ describe('TurnIndicatorRenderer', () => {
     });
 
     it('handles no players gracefully', () => {
-      render(<TurnIndicatorRenderer template={PALEO_TURN} />);
+      render(<ToolkitAiTurnPreviewRenderer template={PALEO_TURN} />);
       expect(screen.queryByTestId('turn-simultaneous-players')).not.toBeInTheDocument();
       // But the section still renders
       expect(screen.getByTestId('turn-indicator')).toBeInTheDocument();
@@ -167,7 +170,7 @@ describe('TurnIndicatorRenderer', () => {
 
   describe('Realtime (Captain Sonar-like)', () => {
     it('renders warning banner', () => {
-      render(<TurnIndicatorRenderer template={CAPTAIN_SONAR_TURN} />);
+      render(<ToolkitAiTurnPreviewRenderer template={CAPTAIN_SONAR_TURN} />);
       const banner = screen.getByTestId('turn-realtime-banner');
       expect(banner).toBeInTheDocument();
       expect(banner).toHaveTextContent(/real-time play/i);
@@ -176,7 +179,7 @@ describe('TurnIndicatorRenderer', () => {
 
   describe('None (no turn structure)', () => {
     it('renders open-play banner', () => {
-      render(<TurnIndicatorRenderer template={NONE_TURN} />);
+      render(<ToolkitAiTurnPreviewRenderer template={NONE_TURN} />);
       expect(screen.getByTestId('turn-none-banner')).toBeInTheDocument();
       expect(screen.getByText(/no turn order/i)).toBeInTheDocument();
     });
@@ -184,7 +187,7 @@ describe('TurnIndicatorRenderer', () => {
 
   describe('Custom / Free', () => {
     it('renders Custom indicator', () => {
-      render(<TurnIndicatorRenderer template={CUSTOM_TURN} currentPhaseIndex={1} />);
+      render(<ToolkitAiTurnPreviewRenderer template={CUSTOM_TURN} currentPhaseIndex={1} />);
       expect(screen.getByTestId('turn-custom-indicator')).toBeInTheDocument();
       const stepper = screen.getByTestId('turn-phase-stepper');
       expect(stepper.querySelector('[aria-current="step"]')).toHaveTextContent('Play');
@@ -192,7 +195,7 @@ describe('TurnIndicatorRenderer', () => {
 
     it('Free aliases to Custom layout', () => {
       const free: AiTurnTemplateSuggestion = { ...CUSTOM_TURN, turnOrderType: 'Free' };
-      render(<TurnIndicatorRenderer template={free} />);
+      render(<ToolkitAiTurnPreviewRenderer template={free} />);
       expect(screen.getByTestId('turn-custom-indicator')).toBeInTheDocument();
     });
   });
@@ -203,7 +206,7 @@ describe('TurnIndicatorRenderer', () => {
         turnOrderType: 'TotallyInvented',
         phases: ['Phase A'],
       };
-      render(<TurnIndicatorRenderer template={unknown} />);
+      render(<ToolkitAiTurnPreviewRenderer template={unknown} />);
       // Custom layout renders custom indicator
       expect(screen.getByTestId('turn-custom-indicator')).toBeInTheDocument();
     });
@@ -217,12 +220,12 @@ describe('TurnIndicatorRenderer', () => {
         rounds: 4,
         turnsPerRound: [8, 7, 6, 5],
       };
-      render(<TurnIndicatorRenderer template={noPhases} activePlayer={PLAYERS[0]} />);
+      render(<ToolkitAiTurnPreviewRenderer template={noPhases} activePlayer={PLAYERS[0]} />);
       expect(screen.queryByTestId('turn-phase-stepper')).not.toBeInTheDocument();
     });
 
     it('handles currentPhaseIndex past end gracefully (no aria-current set)', () => {
-      render(<TurnIndicatorRenderer template={CUSTOM_TURN} currentPhaseIndex={99} />);
+      render(<ToolkitAiTurnPreviewRenderer template={CUSTOM_TURN} currentPhaseIndex={99} />);
       const stepper = screen.getByTestId('turn-phase-stepper');
       // No phase is at index 99 → no aria-current
       expect(stepper.querySelector('[aria-current="step"]')).toBeNull();

--- a/apps/web/src/components/toolkit/index.ts
+++ b/apps/web/src/components/toolkit/index.ts
@@ -15,8 +15,11 @@ export { NoteManagerWidget } from './NoteManagerWidget';
 export { WhiteboardWidget } from './WhiteboardWidget';
 export { CardDeckTool } from './CardDeckTool';
 export { CounterTool } from './CounterTool';
-// Polymorphic renderers (B19-4a, issue #1749)
-export { ScoringPanelRenderer } from './ScoringPanelRenderer';
-export type { ScoringPanelRendererProps } from './ScoringPanelRenderer';
-export { TurnIndicatorRenderer } from './TurnIndicatorRenderer';
-export type { TurnIndicatorRendererProps } from './TurnIndicatorRenderer';
+// AI-config preview renderers (B19-4a, issue #1749). Renamed in #2418 to
+// disambiguate from the live-runtime polymorphic renderers under
+// `features/session-live/` (PR #2411 G5b, PR #2416 G5c). See audit
+// `claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md`.
+export { ToolkitAiScoringPreviewRenderer } from './ToolkitAiScoringPreviewRenderer';
+export type { ToolkitAiScoringPreviewRendererProps } from './ToolkitAiScoringPreviewRenderer';
+export { ToolkitAiTurnPreviewRenderer } from './ToolkitAiTurnPreviewRenderer';
+export type { ToolkitAiTurnPreviewRendererProps } from './ToolkitAiTurnPreviewRenderer';


### PR DESCRIPTION
## Summary

Rename legacy `toolkit/{TurnIndicator,ScoringPanel}Renderer` to `toolkit/ToolkitAi{Turn,Scoring}PreviewRenderer` per the duplication audit (claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md) shipped with #2376 G5c.

Avoids naming collision with new live-runtime polymorphic renderers under `features/session-live/turn-indicator-renderer/` (PR #2411 G5b shipped) and the future `features/session-live/scoring-panel-renderer/` (G5a #2373).

## Boundary

| Path | Domain | DTO |
|---|---|---|
| `toolkit/ToolkitAi*PreviewRenderer.tsx` | AI-config preview | `AiTurnTemplateSuggestion` / `AiScoringTemplateSuggestion` |
| `features/session-live/*-renderer/` | Live-runtime SSE-driven | `TurnState` discriminated union (G5b) / future polymorphic ScoreState (G5a) |

## Changes

- `git mv` preserves history (98% match on file rename detection).
- 4 file renamed (2 components + 2 test files).
- Component identifiers + Props interfaces + JSX usages + barrel exports + test imports updated.
- Barrel comment in `toolkit/index.ts` documents the rename rationale + link to audit.

## ZERO production consumers

Grep confirmed no app routes or other components import these renderers directly. They were already orphan from the routing surface — only their barrel + test files reference them.

## Refs

- Issue: #2418
- Sibling PRs: #2411 (#2378 G5b shipped), #2416 (#2376 G5c shipped)
- Audit: `claudedocs/2026-06-16-toolkit-vs-session-live-duplication-audit.md`

## Test plan
- [x] 157 toolkit unit tests pass
- [x] Typecheck clean
- [x] Pre-commit hook + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)