### PR TITLE
feat(session-live): #2421 wire ScoringPanelRenderer in SessionLiveView (G5a closure)

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -77,15 +77,12 @@ import {
   ActionLogTimeline,
   ChatAgentPanel,
   DesktopBody,
-  LiveScoringPanel,
   LiveTopBar,
   MobileBody,
   PlayerRosterLive,
   TurnIndicatorRenderer,
   type ActionLogTimelineLabels,
   type ChatAgentPanelLabels,
-  type LiveScoringPanelLabels,
-  type LiveScoringPanelScoreEntry,
   type LiveTopBarLabels,
   type MobileBodyLabels,
   type PlayerRosterLiveLabels,
@@ -95,11 +92,14 @@ import {
   ConnectionLostBanner,
   LiveSessionNotes,
   RightColumnTabs,
+  ScoringPanelRenderer,
   ToolkitRenderer,
   type ConnectionLostBannerLabels,
   type LiveAgentChatLabels,
   type LiveSessionNotesLabels,
   type RightColumnTabsLabels,
+  type ScoringPanelData,
+  type ScoringPanelRendererLabels,
   type ToolkitRendererLabels,
 } from '@/components/features/session-live';
 import { useSession } from '@/hooks/queries/useActiveSessions';
@@ -728,22 +728,51 @@ export function SessionLiveView(): ReactElement {
     };
   }, [t, intl.messages, activeSession?.players.length]);
 
-  const scoringLabels = useMemo<LiveScoringPanelLabels>(
-    (): LiveScoringPanelLabels => ({
-      title: t('pages.sessionLive.scoring.title'),
-      scoreLabelTemplate:
-        (intl.messages['pages.sessionLive.scoring.scoreLabel'] as string) ?? 'Punteggio: {score}',
-      winnerLabel: t('pages.sessionLive.scoring.winnerLabel'),
-      myScoreLabel: t('pages.sessionLive.scoring.myScoreLabel'),
-      incrementAriaLabelTemplate:
-        (intl.messages['pages.sessionLive.scoring.incrementAriaLabel'] as string) ??
-        'Aumenta punteggio di {playerName}',
-      decrementAriaLabelTemplate:
-        (intl.messages['pages.sessionLive.scoring.decrementAriaLabel'] as string) ??
-        'Diminuisci punteggio di {playerName}',
-      scoreInputAriaLabelTemplate:
-        (intl.messages['pages.sessionLive.scoring.scoreInputAriaLabel'] as string) ??
-        'Inserisci punteggio per {playerName}',
+  // G5a #2375: ScoringPanelRenderer labels (polymorphic Points/Ranking/BinaryWin/Objectives).
+  const scoringPanelLabels = useMemo<ScoringPanelRendererLabels>(
+    (): ScoringPanelRendererLabels => ({
+      points: {
+        heading: t('pages.sessionLive.scoring.title'),
+        scoreAriaTemplate:
+          (intl.messages['pages.sessionLive.scoring.scoreAriaTemplate'] as string) ??
+          'Punteggio di {name}',
+        leaderBadgeLabel:
+          (intl.messages['pages.sessionLive.scoring.leaderBadgeLabel'] as string) ?? 'in testa',
+      },
+      ranking: {
+        heading:
+          (intl.messages['pages.sessionLive.scoring.rankingHeading'] as string) ?? 'Posizioni',
+        rankAriaTemplate:
+          (intl.messages['pages.sessionLive.scoring.rankAriaTemplate'] as string) ??
+          'Posizione di {name}',
+        firstPlaceBadgeLabel:
+          (intl.messages['pages.sessionLive.scoring.firstPlaceBadgeLabel'] as string) ??
+          'primo posto',
+      },
+      binaryWin: {
+        heading: (intl.messages['pages.sessionLive.scoring.binaryWinHeading'] as string) ?? 'Esito',
+        inProgressLabel:
+          (intl.messages['pages.sessionLive.scoring.binaryWinInProgress'] as string) ??
+          'Partita in corso',
+        winLabel: (intl.messages['pages.sessionLive.scoring.winLabel'] as string) ?? 'Vince',
+        loseLabel: (intl.messages['pages.sessionLive.scoring.loseLabel'] as string) ?? 'Perde',
+        outcomeAriaTemplate:
+          (intl.messages['pages.sessionLive.scoring.outcomeAriaTemplate'] as string) ??
+          '{name}: {result}',
+      },
+      objectives: {
+        heading:
+          (intl.messages['pages.sessionLive.scoring.objectivesHeading'] as string) ?? 'Obiettivi',
+        completedAriaTemplate:
+          (intl.messages['pages.sessionLive.scoring.completedAriaTemplate'] as string) ??
+          'Completati da {name}',
+        doneAriaTemplate:
+          (intl.messages['pages.sessionLive.scoring.doneAriaTemplate'] as string) ??
+          '{label} (completato)',
+        pendingAriaTemplate:
+          (intl.messages['pages.sessionLive.scoring.pendingAriaTemplate'] as string) ??
+          '{label} (non completato)',
+      },
     }),
     [t, intl.messages]
   );
@@ -911,14 +940,22 @@ export function SessionLiveView(): ReactElement {
 
   // ── Derived data for components ───────────────────────────────────────────
 
-  const scores = useMemo<ReadonlyArray<LiveScoringPanelScoreEntry>>(() => {
-    if (activeSession == null) return [];
-    return activeSession.players.map(p => ({
-      playerId: p.id,
-      playerName: p.name,
-      score: p.score,
-      isWinner: false,
-    }));
+  // G5a #2375 + #2389 follow-up: Adapter maps LiveSessionDto.players to ScoringPanelData
+  // discriminated union. Currently hardcoded to 'Points' variant (foundation proxy);
+  // when `scoringType` arrives on LiveSessionDto (#2389), the kind will derive from it
+  // and populate the appropriate ScoringPanelData shape.
+  const scoringPanelData = useMemo<ScoringPanelData>(() => {
+    if (activeSession == null) {
+      return { kind: 'Points', players: [] };
+    }
+    return {
+      kind: 'Points',
+      players: activeSession.players.map(p => ({
+        id: p.id,
+        displayName: p.name,
+        score: p.score,
+      })),
+    };
   }, [activeSession]);
 
   // ── G5c #2376: Zustand toolkit renderer store ─────────────────────────────
@@ -1066,19 +1103,18 @@ export function SessionLiveView(): ReactElement {
       case 'score':
       default:
         return (
-          <LiveScoringPanel
-            scores={scores}
-            viewerRole={activeSession.viewerRole}
-            viewerId={activeSession.viewerId}
-            labels={scoringLabels}
+          <ScoringPanelRenderer
+            data={scoringPanelData}
+            labels={scoringPanelLabels}
+            className="p-2"
           />
         );
     }
   }, [
     mobileTab,
     activeSession,
-    scores,
-    scoringLabels,
+    scoringPanelData,
+    scoringPanelLabels,
     turnRendererState,
     turnRendererPlayers,
     turnRendererLabels,
@@ -1200,16 +1236,11 @@ export function SessionLiveView(): ReactElement {
 
   // Desktop right column: RightColumnTabs with tab content.
   // Tab keys: 'score' | 'turn' | 'widget' | 'notes' (G1 §3 D-2).
-  // G5 (#2373) will polymorphic-replace LiveScoringPanel; G1 reuses existing renderers (D-6).
+  // G5a (#2375): ScoringPanelRenderer replaces hardcoded LiveScoringPanel Points-only view.
   const desktopRightColumn = (
     <RightColumnTabs activeTab={tab} onTabChange={handleTabChange} labels={rightColumnTabsLabels}>
       {tab === 'score' && (
-        <LiveScoringPanel
-          scores={scores}
-          viewerRole={activeSession.viewerRole}
-          viewerId={activeSession.viewerId}
-          labels={scoringLabels}
-        />
+        <ScoringPanelRenderer data={scoringPanelData} labels={scoringPanelLabels} className="p-3" />
       )}
       {tab === 'turn' && (
         <div className="flex flex-col gap-4 p-3">
@@ -1330,10 +1361,10 @@ export function SessionLiveView(): ReactElement {
       {dialogState === 'endgame' && (
         <Suspense fallback={null}>
           <EndgameDialog
-            finalScores={scores.map(s => ({
-              playerName: s.playerName,
-              score: s.score,
-              isWinner: s.isWinner,
+            finalScores={activeSession.players.map(p => ({
+              playerName: p.name,
+              score: p.score,
+              isWinner: false,
             }))}
             endedAt={endgameEvent?.endedAt ?? '—'}
             endedBy={endgameEvent?.endedBy ?? '—'}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -783,10 +783,10 @@ describe('SessionLiveView (Wave D.2 Interactions — Task 3)', () => {
     expect(container.querySelector('[data-slot="live-session-notes"]')).toBeInTheDocument();
   });
 
-  it('T4.11: RIGHT tab=score renders LiveScoringPanel', () => {
-    // ?tab default → 'score'
+  it('T4.11: RIGHT tab=score renders ScoringPanelRenderer (G5a #2375)', () => {
+    // ?tab default → 'score'. ScoringPanelRenderer replaces LiveScoringPanel (#2421 wire-up).
     const { container } = renderWithIntl(<SessionLiveView />);
-    expect(container.querySelector('[data-slot="live-scoring-panel"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="scoring-panel-renderer"]')).toBeInTheDocument();
   });
 
   // ─── T3.3: Mobile drawer tab routing — Interactions panels (T9 sess.46r) ─

--- a/apps/web/src/components/features/session-live/index.ts
+++ b/apps/web/src/components/features/session-live/index.ts
@@ -45,6 +45,20 @@ export type {
   LiveScoringPanelScoreEntry,
 } from '@/components/features/session-live/LiveScoringPanel';
 
+// ─── G5a #2375 ScoringPanelRenderer (polymorphic, replaces LiveScoringPanel) ──
+export { ScoringPanelRenderer } from '@/components/features/session-live/scoring/ScoringPanelRenderer';
+export type {
+  BinaryWinScoringData,
+  ObjectiveScoringItem,
+  ObjectivesScoringData,
+  PointsScoringData,
+  RankingScoringData,
+  ScoringPanelData,
+  ScoringPanelRendererLabels,
+  ScoringPanelRendererProps,
+  ScoringPlayerEntry,
+} from '@/components/features/session-live/scoring/ScoringPanelRenderer';
+
 export { LiveTopBar } from '@/components/features/session-live/LiveTopBar';
 export type {
   LiveTopBarConnectionState,


### PR DESCRIPTION
## Summary

Re-lands the wire-up of `ScoringPanelRenderer` (G5a polymorphic primitive shipped PR #2419) into both desktop right column (`?tab=score`) and mobile bottom-sheet (`?mtab=score`). Closes the G5a chain in epic #2354.

## Root cause of previous attempt regression

The earlier wire-up attempt (commit `3a7e0dced`, reverted pre-merge) removed the `scores` memo without realising `EndgameDialog` still referenced it at `SessionLiveView.tsx:1365`. The resulting `ReferenceError: scores is not defined` triggered React 19's error path, which serialised the entire Fiber tree back to `console.error` — producing a string > 536MB and surfacing as `RangeError: Invalid string length` at `vitest.setup.tsx:621`. That's why **all 67 SessionLiveView tests failed**, even those unrelated to the score tab.

This PR derives `EndgameDialog.finalScores` directly from `activeSession.players` (same data shape, no intermediate memo), keeping the change scoped.

## Changes

- **`SessionLiveView.tsx`**:
  - Import `ScoringPanelRenderer` + types from barrel; drop `LiveScoringPanel*` legacy imports
  - Replace `scoringLabels` memo (LiveScoringPanelLabels) with `scoringPanelLabels` (ScoringPanelRendererLabels) — Points keys reuse existing i18n catalog; Ranking/BinaryWin/Objectives fall back to inline Italian until #2389
  - Replace `scores` memo with `scoringPanelData` (discriminated union). Hardcoded `kind: 'Points'` until #2389 wires store-level discriminator
  - Derive `EndgameDialog.finalScores` inline from `activeSession.players` (regression fix)
  - Desktop + mobile both mount `<ScoringPanelRenderer data={scoringPanelData} labels={...} />`
- **`index.ts` barrel**: add `ScoringPanelRenderer` + 8 type exports
- **`SessionLiveView.test.tsx`**: update T4.11 selector `[data-slot="live-scoring-panel"]` → `[data-slot="scoring-panel-renderer"]`

## Test plan

- [x] `SessionLiveView.test.tsx`: 67/67 pass
- [x] Whole session subtree (33 files): 413/413 pass
- [x] Typecheck: clean
- [x] Lint: clean (13 pre-existing warnings unrelated)
- [ ] CI green
- [ ] Manual smoke: `?tab=score` desktop + `?mtab=score` mobile renderer mount

## Follow-ups (out of scope)

- **#2389** store-shape migration (~4d): `useLiveSessionStore.scoringType` + `PlayerInfo.displayName`, SignalR `ScoringConfigured` event, `LiveScoringPanel` barrel deprecation, i18n catalog completion. Tracked separately per its body.

## Closes

- Closes #2421 (regression debug + re-land)
- Closes #2373 (G5a primitive wiring complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)