### PR TITLE
fix(api): IT FinalizeSession fixture sets OutboxOptions.Mode=Hybrid

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/FinalizeSessionSingleDispatchIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Integration/FinalizeSessionSingleDispatchIntegrationTests.cs
@@ -7,6 +7,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Services;
 using Api.Infrastructure;
+using Api.Infrastructure.DomainEventOutbox;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SessionTracking;
 using Api.Infrastructure.Entities.SharedGameCatalog;
@@ -17,6 +18,7 @@ using FluentAssertions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Moq;
 using Npgsql;
 using Xunit;
@@ -198,6 +200,16 @@ public sealed class FinalizeSessionSingleDispatchIntegrationTests : IAsyncLifeti
             .Setup(r => r.GetActiveByGameSessionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Api.BoundedContexts.KnowledgeBase.Domain.Entities.AgentSession>());
         services.AddScoped(_ => agentSessionRepoMock.Object);
+
+        // Force Hybrid dispatch mode so MediatR.Publish fires inline after SaveChangesAsync.
+        // The default IOptions<DomainEventOutboxOptions> binds Mode=OutboxOnly (steady-state
+        // post-T9 cutover), which queues events for the background DomainEventOutboxProcessor.
+        // The processor is NOT registered in this minimal integration setup; without an
+        // explicit override events would persist to domain_event_outbox without ever firing
+        // their MediatR handlers in the test. See SessionScoresUpdatedSignalRBroadcastIntegrationTests
+        // for the canonical pattern.
+        services.AddSingleton<IOptions<DomainEventOutboxOptions>>(
+            Options.Create(new DomainEventOutboxOptions { Mode = DomainEventDispatchMode.Hybrid }));
 
         if (interceptor is not null)
         {

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationServiceCollectionBuilder.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationServiceCollectionBuilder.cs
@@ -22,6 +22,26 @@ namespace Api.Tests.Infrastructure;
 ///   var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
 ///   services.AddScoped&lt;IMyRepository, MyRepository&gt;(); // test-specific
 ///   _serviceProvider = services.BuildServiceProvider();
+///
+/// <para><b>⚠ Domain event dispatch trap (#2389 audit follow-up):</b></para>
+/// <para>The default <c>IOptions&lt;DomainEventOutboxOptions&gt;</c> binds
+/// <c>Mode = DomainEventDispatchMode.OutboxOnly</c> (steady-state post-T9 cutover, see
+/// <c>docs/superpowers/specs/2026-06-06-issue-1535-event-outbox-design.md</c>). In that
+/// mode <c>MeepleAiDbContext.SaveChangesAsync</c> persists raised domain events to
+/// <c>domain_event_outbox</c> and the <c>DomainEventOutboxProcessor</c> BackgroundService
+/// drains them asynchronously — but that processor is NOT registered in this minimal
+/// integration setup.</para>
+/// <para>ITs that depend on <see cref="MediatR.INotificationHandler{T}"/> handlers firing
+/// inline on SaveChangesAsync (spy handlers, broadcast handlers, side-effect handlers) MUST
+/// override the options to <see cref="DomainEventDispatchMode.Hybrid"/> after calling
+/// <c>CreateBase</c>:
+/// <code>
+/// services.AddSingleton&lt;IOptions&lt;DomainEventOutboxOptions&gt;&gt;(
+///     Options.Create(new DomainEventOutboxOptions { Mode = DomainEventDispatchMode.Hybrid }));
+/// </code>
+/// Without this override the spy handler silently never fires and assertions read 0.
+/// See <c>SessionScoresUpdatedSignalRBroadcastIntegrationTests</c> and
+/// <c>FinalizeSessionSingleDispatchIntegrationTests</c> for the canonical pattern.</para>
 /// </summary>
 internal static class IntegrationServiceCollectionBuilder
 {


### PR DESCRIPTION
## Summary

Follow-up audit of #2389 Block A discovery: `FinalizeSessionSingleDispatchIntegrationTests` (2 tests) failed because the default `DomainEventOutboxOptions.Mode = OutboxOnly` queues domain events to `domain_event_outbox` without dispatching them inline via MediatR. The `DomainEventOutboxProcessor` BackgroundService is NOT registered in minimal IT setups built via `IntegrationServiceCollectionBuilder.CreateBase(...)`, so spy `INotificationHandler<T>` registrations silently never fire and `handlerCallCount == 0`.

## Fix (scope-minimal)

- `FinalizeSessionSingleDispatchIntegrationTests.BuildServices`: add `IOptions<DomainEventOutboxOptions>` singleton override with `Mode = DomainEventDispatchMode.Hybrid` (mirrors canonical pattern in `SessionScoresUpdatedSignalRBroadcastIntegrationTests:217-224`).
- `IntegrationServiceCollectionBuilder` summary: document the trap for future IT authors.

## Audit results

| Pattern grep | Matches | Action |
|---|---|---|
| `IntegrationServiceCollectionBuilder.CreateBase` | 121 files | enumerated, no individual audit needed |
| `AddScoped<INotificationHandler<` / `AddTransient<INotificationHandler<` | **2 files** (T6 canonical + this fix target) | both have Hybrid override post-PR |
| `DomainEventOutboxOptions` / `DomainEventDispatchMode` | 8 files (3 of which correctly require OutboxOnly to test outbox behaviour: `DomainEventOutboxProcessor/Retention`, `Issue1535EventOutboxAcceptance`) | no additional fix needed |

No additional ITs need the fix.

## Verification

- **Before**: 0/2 passed (`handlerCallCount=0`, `captured=null`)
- **After**: **2/2 passed** in 15s
- **Build**: clean

```
Superato!     - Non superati:     0. Superati:     2. Ignorati:     0. Totale:     2. Durata: 15 s
```

## Out of scope

- Centralized fix at `CreateBase` level (would change default for all 121 ITs; preferred surgical fix to avoid blast radius).
- Audit of 119 other ITs that use `CreateBase` but do NOT register spy MediatR handlers — they have no symptom because they assert via other means (DB state, repo calls, command return values).

## CLAUDE.md Known Flaky Tests

Already `_(none — baseline currently clean)_` per 2026-06-13 trajectory. No entry to remove; this PR prevents these tests from regressing into a new baseline entry.

## Related

- #2389 Block A (PR #2428) — where the T6 canonical Hybrid override was first applied, exposing this gotcha.
- #2389 Block C (PR #2442) — predecessor of this audit.
- #1535 event-outbox design — `docs/superpowers/specs/2026-06-06-issue-1535-event-outbox-design.md`

## Test plan

- [x] Target tests pass (2/2)
- [x] Build clean
- [x] No new files; no production code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)