### PR TITLE
feat(play-records): #2438 PR-A stats trend chart + date-range filter (FE)

### DIFF
--- a/apps/web/src/components/play-records/StatisticsView.tsx
+++ b/apps/web/src/components/play-records/StatisticsView.tsx
@@ -1,32 +1,52 @@
 'use client';
 
 /**
- * StatisticsView — Play Records statistics (Task 5 reskin)
+ * StatisticsView — Play Records statistics (Task 5 reskin · #2438 trend/range)
  *
  * Reusable stats body rendered both by the standalone `/play-records/stats`
  * route (legacy, redirected) AND inline by `/play-records?tab=stats` (the
  * canonical entry per route-consolidation #5039 — next.config redirects the
  * standalone path to the tab).
  *
+ * - Date-range preset filter (Tutto · 30g · 90g · 12 mesi) → narrows stats (#2438)
  * - StatsHero: 4-col KPI (Partite/Giochi/Win rate/Preferito)
  * - MostPlayedBar: top 5 giochi, barre proporzionali
  * - WinByGameBar: win-rate per gioco, sorted descending
+ * - TrendChart: win-rate trend (recharts area) — full width below grid (#2438)
  * - Loading/Error/Empty states · Responsive 1-col mobile / 2-col desktop
  */
+
+import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
 import { MostPlayedBar } from '@/components/play-records/stats/MostPlayedBar';
 import { StatsHero } from '@/components/play-records/stats/StatsHero';
+import { TrendChart } from '@/components/play-records/stats/TrendChart';
 import { WinByGameBar } from '@/components/play-records/stats/WinByGameBar';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { useTranslation } from '@/hooks/useTranslation';
-import { usePlayerStatistics } from '@/lib/domain-hooks/usePlayRecords';
+import { usePlayerStatistics, type StatsRange } from '@/lib/domain-hooks/usePlayRecords';
+
+type RangePreset = 'all' | '30d' | '90d' | '12m';
+
+const PRESETS: RangePreset[] = ['all', '30d', '90d', '12m'];
+
+function rangeForPreset(preset: RangePreset): StatsRange | undefined {
+  if (preset === 'all') return undefined;
+  const now = new Date();
+  const from = new Date(now);
+  if (preset === '30d') from.setDate(now.getDate() - 30);
+  else if (preset === '90d') from.setDate(now.getDate() - 90);
+  else if (preset === '12m') from.setMonth(now.getMonth() - 12);
+  return { startDate: from.toISOString() };
+}
 
 export function StatisticsView() {
   const router = useRouter();
   const { t } = useTranslation();
-  const { data: stats, isLoading, error } = usePlayerStatistics();
+  const [preset, setPreset] = useState<RangePreset>('all');
+  const { data: stats, isLoading, error } = usePlayerStatistics(rangeForPreset(preset));
 
   return (
     <div className="flex flex-col min-h-full bg-background" data-testid="stats-page">
@@ -34,6 +54,32 @@ export function StatisticsView() {
         title={t('playRecords.stats.headerTitle')}
         onBack={() => router.push('/play-records')}
       />
+
+      {/* Date-range preset filter (#2438) */}
+      <div className="px-4 pt-4" data-testid="stats-range-filter">
+        <div
+          className="inline-flex rounded-lg border border-border bg-card p-1"
+          role="group"
+          aria-label={t('playRecords.stats.range.label')}
+        >
+          {PRESETS.map(p => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPreset(p)}
+              aria-pressed={preset === p}
+              data-testid={`range-${p}`}
+              className={
+                preset === p
+                  ? 'rounded-md bg-entity-game px-3 py-1.5 text-[11px] font-bold text-white'
+                  : 'rounded-md px-3 py-1.5 text-[11px] font-bold text-muted-foreground hover:text-foreground'
+              }
+            >
+              {t(`playRecords.stats.range.${p}`)}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Loading State */}
       {isLoading && (
@@ -80,12 +126,15 @@ export function StatisticsView() {
       {!isLoading && !error && stats && (
         <>
           <StatsHero stats={stats} />
-          <div
-            className="flex-1 px-4 pt-6 pb-12 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6"
-            data-testid="stats-grid"
-          >
-            <MostPlayedBar stats={stats} />
-            <WinByGameBar stats={stats} />
+          <div className="flex-1 px-4 pt-6 pb-12 flex flex-col gap-4 md:gap-6">
+            <div
+              className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6"
+              data-testid="stats-grid"
+            >
+              <MostPlayedBar stats={stats} />
+              <WinByGameBar stats={stats} />
+            </div>
+            <TrendChart stats={stats} />
           </div>
         </>
       )}

--- a/apps/web/src/components/play-records/__tests__/StatisticsView.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/StatisticsView.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * StatisticsView integration tests (#2438)
+ *
+ * Covers the date-range preset filter (aria-pressed state + switch) and the
+ * TrendChart mount. Data hooks are mocked (PlayHistory-style harness) so no
+ * QueryClient/MSW provider is needed and the assertions are deterministic.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { StatisticsView } from '../StatisticsView';
+import type { PlayerStatistics } from '@/lib/api/schemas/play-records.schemas';
+
+// i18n: return the key path (deterministic, no catalog dependency)
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// next/navigation: router.push is a no-op spy
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// Child bars depend on useSharedGames (React Query) — mock it to an empty map
+vi.mock('@/lib/play-records/useSharedGames', () => ({
+  useSharedGames: vi.fn(() => ({ data: new Map(), isLoading: false, error: null })),
+}));
+
+// Controlled stats hook
+const mockUsePlayerStatistics = vi.fn();
+vi.mock('@/lib/domain-hooks/usePlayRecords', () => ({
+  usePlayerStatistics: (...args: unknown[]) => mockUsePlayerStatistics(...args),
+}));
+
+const statsWithTrend: PlayerStatistics = {
+  totalSessions: 5,
+  totalWins: 3,
+  gamePlayCounts: {},
+  averageScoresByGame: {},
+  mostPlayedGames: [],
+  winByGame: [],
+  winRateTrend: [
+    { month: '2026-04', winRate: 0.5 },
+    { month: '2026-05', winRate: 1 },
+  ],
+};
+
+describe('StatisticsView (#2438)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePlayerStatistics.mockReturnValue({
+      data: statsWithTrend,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('renders the range filter and the trend section on success', () => {
+    render(<StatisticsView />);
+    expect(screen.getByTestId('stats-range-filter')).toBeInTheDocument();
+    // "all" preset is selected by default
+    expect(screen.getByTestId('range-all')).toHaveAttribute('aria-pressed', 'true');
+    // TrendChart renders its chart section (fixture has trend data)
+    expect(screen.getByTestId('trend-section')).toBeInTheDocument();
+  });
+
+  it('switching preset updates aria-pressed', async () => {
+    const user = userEvent.setup();
+    render(<StatisticsView />);
+
+    const btn30 = screen.getByTestId('range-30d');
+    expect(btn30).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(btn30);
+
+    expect(btn30).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('range-all')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('passes a date range to the stats hook when a non-all preset is active', async () => {
+    const user = userEvent.setup();
+    render(<StatisticsView />);
+
+    // default render: called with undefined (all)
+    expect(mockUsePlayerStatistics).toHaveBeenCalledWith(undefined);
+
+    await user.click(screen.getByTestId('range-90d'));
+
+    // after switch: called with a { startDate } range
+    const lastCall = mockUsePlayerStatistics.mock.calls.at(-1)?.[0];
+    expect(lastCall).toMatchObject({ startDate: expect.any(String) });
+  });
+});

--- a/apps/web/src/components/play-records/stats/TrendChart.tsx
+++ b/apps/web/src/components/play-records/stats/TrendChart.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * TrendChart — win-rate trend over the last 6 months (#2438).
+ * Consumes stats.winRateTrend ({month: "YYYY-MM", winRate: 0..1}), already
+ * populated by the BE. recharts AreaChart; win rate shown as 0–100%.
+ *
+ * Chart colors use `hsl(var(--c-game))` — the entity-game HSL triplet from
+ * design-tokens-canonical.css (mirrors CostStackedArea's `hsl(var(--c-*))`).
+ * The Tailwind utility `--entity-game` is not a raw CSS var, so recharts'
+ * `stroke`/`fill` props read the underlying `--c-game` triplet directly.
+ */
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { PlayerStatistics } from '@/lib/api/schemas/play-records.schemas';
+
+interface TrendChartProps {
+  stats: PlayerStatistics;
+}
+
+// "YYYY-MM" → localized short month (e.g. "giu").
+function formatMonthShort(month: string): string {
+  const [y, m] = month.split('-').map(Number);
+  if (!y || !m) return month;
+  return new Date(y, m - 1, 1).toLocaleDateString('it-IT', { month: 'short' });
+}
+
+interface TrendTooltipProps {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}
+
+function TrendTooltip({ active, payload, label }: TrendTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const pct = Math.round((payload[0].value ?? 0) * 100);
+  return (
+    <div className="rounded-md border border-border bg-card/95 px-3 py-2 font-mono text-[11px] shadow-lg backdrop-blur-sm">
+      <p className="font-display text-[12px] font-bold text-foreground">
+        {label ? formatMonthShort(label) : ''}
+      </p>
+      <p className="mt-1 text-muted-foreground">
+        win rate <span className="font-bold text-foreground">{pct}%</span>
+      </p>
+    </div>
+  );
+}
+
+export function TrendChart({ stats }: TrendChartProps) {
+  const { t } = useTranslation();
+  const trend = stats.winRateTrend ?? [];
+  const isEmpty = trend.length === 0;
+
+  if (isEmpty) {
+    return (
+      <section
+        className="rounded-lg border border-border bg-card p-4 md:p-5"
+        data-testid="trend-empty"
+        aria-label={t('playRecords.stats.trend.title')}
+      >
+        <header className="mb-4 flex items-center gap-3">
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-entity-game/12 text-entity-game">
+            📈
+          </div>
+          <h2 className="font-display text-base font-black text-foreground md:text-lg">
+            {t('playRecords.stats.trend.title')}
+          </h2>
+        </header>
+        <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-entity-game/30 bg-muted/30 px-4 py-6 text-center">
+          <p className="text-xs text-muted-foreground">{t('playRecords.stats.trend.empty')}</p>
+        </div>
+      </section>
+    );
+  }
+
+  // Screen-reader summary: list each month's win rate as a percentage.
+  const srSummary = trend
+    .map(m => `${formatMonthShort(m.month)} ${Math.round(m.winRate * 100)}%`)
+    .join(', ');
+
+  return (
+    <section
+      className="rounded-lg border border-border bg-card p-4 md:p-5"
+      data-testid="trend-section"
+      aria-label={t('playRecords.stats.trend.title')}
+    >
+      <header className="mb-4 flex items-center gap-3">
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-entity-game/12 text-entity-game">
+          📈
+        </div>
+        <h2 className="font-display text-base font-black text-foreground md:text-lg">
+          {t('playRecords.stats.trend.title')}
+        </h2>
+      </header>
+
+      <div role="img" aria-label={`${t('playRecords.stats.trend.title')}: ${srSummary}`}>
+        <ResponsiveContainer width="100%" height={220}>
+          <AreaChart data={trend} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+            <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="3 3" />
+            <XAxis
+              dataKey="month"
+              tickFormatter={formatMonthShort}
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={10}
+              tickLine={false}
+              axisLine={{ stroke: 'hsl(var(--border))' }}
+            />
+            <YAxis
+              domain={[0, 1]}
+              tickFormatter={v => `${Math.round(v * 100)}%`}
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={10}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+            />
+            <Tooltip content={<TrendTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="winRate"
+              stroke="hsl(var(--c-game))"
+              fill="hsl(var(--c-game))"
+              fillOpacity={0.25}
+              strokeWidth={2}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Visually-hidden data table for screen readers / non-visual axe checks */}
+      <table className="sr-only">
+        <caption>{t('playRecords.stats.trend.title')}</caption>
+        <thead>
+          <tr>
+            <th>{t('playRecords.stats.trend.month')}</th>
+            <th>{t('playRecords.stats.trend.winRate')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trend.map(m => (
+            <tr key={m.month}>
+              <td>{formatMonthShort(m.month)}</td>
+              <td>{Math.round(m.winRate * 100)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/web/src/components/play-records/stats/__tests__/TrendChart.test.tsx
+++ b/apps/web/src/components/play-records/stats/__tests__/TrendChart.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TrendChart } from '../TrendChart';
+import type { PlayerStatistics } from '@/lib/api/schemas/play-records.schemas';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const base: PlayerStatistics = {
+  totalSessions: 3,
+  totalWins: 2,
+  gamePlayCounts: {},
+  averageScoresByGame: {},
+};
+
+describe('TrendChart', () => {
+  it('renders the empty state when winRateTrend is missing/empty', () => {
+    render(<TrendChart stats={base} />);
+    expect(screen.getByTestId('trend-empty')).toBeInTheDocument();
+  });
+
+  it('renders the chart section + sr-only data table when trend has data', () => {
+    const stats: PlayerStatistics = {
+      ...base,
+      winRateTrend: [
+        { month: '2026-04', winRate: 0.5 },
+        { month: '2026-05', winRate: 1 },
+      ],
+    };
+    render(<TrendChart stats={stats} />);
+    expect(screen.getByTestId('trend-section')).toBeInTheDocument();
+    // sr-only table mirrors the data points as percentages
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -159,10 +159,17 @@ export const playRecordsApi = {
   },
 
   /**
-   * Get player statistics across all games
+   * Get player statistics across all games. Optional date range narrows the
+   * window; the BE binds startDate/endDate case-insensitively (#2438).
    */
-  async getPlayerStatistics(): Promise<PlayerStatistics> {
-    const res = await fetch(`${BASE_URL}/statistics`);
+  async getPlayerStatistics(
+    params: { startDate?: string; endDate?: string } = {}
+  ): Promise<PlayerStatistics> {
+    const search = new URLSearchParams();
+    if (params.startDate) search.set('startDate', params.startDate);
+    if (params.endDate) search.set('endDate', params.endDate);
+    const qs = search.toString();
+    const res = await fetch(`${BASE_URL}/statistics${qs ? `?${qs}` : ''}`);
     if (!res.ok) {
       const error = await res.json().catch(() => ({ message: 'Failed to get statistics' }));
       throw new Error(error.message || 'Failed to get statistics');

--- a/apps/web/src/lib/domain-hooks/usePlayRecords.ts
+++ b/apps/web/src/lib/domain-hooks/usePlayRecords.ts
@@ -33,13 +33,11 @@ export const playRecordsKeys = {
   list: (filters: Record<string, unknown>) => [...playRecordsKeys.lists(), filters] as const,
   details: () => [...playRecordsKeys.all, 'detail'] as const,
   detail: (id: string) => [...playRecordsKeys.details(), id] as const,
+  // Prefix for ALL statistics queries (any range). Mutations invalidate this
+  // prefix so every cached range refreshes, not just the no-range entry (#2438).
+  statisticsAll: () => [...playRecordsKeys.all, 'statistics'] as const,
   statistics: (range?: StatsRange) =>
-    [
-      ...playRecordsKeys.all,
-      'statistics',
-      range?.startDate ?? null,
-      range?.endDate ?? null,
-    ] as const,
+    [...playRecordsKeys.statisticsAll(), range?.startDate ?? null, range?.endDate ?? null] as const,
 };
 
 // ========== Queries ==========
@@ -131,7 +129,7 @@ export function useCreatePlayRecord() {
     onSuccess: () => {
       // Invalidate history to show new record
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statistics() });
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statisticsAll() });
     },
   });
 }
@@ -192,7 +190,7 @@ export function useRecordScore(recordId: string) {
     mutationFn: (score: RecordScoreRequest) => playRecordsApi.recordScore(recordId, score),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.detail(recordId) });
-      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statistics() });
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statisticsAll() });
     },
   });
 }
@@ -223,7 +221,7 @@ export function useCompleteRecord(recordId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.detail(recordId) });
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statistics() });
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statisticsAll() });
     },
   });
 }
@@ -255,7 +253,7 @@ export function useDeleteRecord(recordId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.detail(recordId) });
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statistics() });
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.statisticsAll() });
     },
   });
 }

--- a/apps/web/src/lib/domain-hooks/usePlayRecords.ts
+++ b/apps/web/src/lib/domain-hooks/usePlayRecords.ts
@@ -17,6 +17,14 @@ import type {
   UpdatePlayRecordRequest,
 } from '@/lib/api/schemas/play-records.schemas';
 
+// ========== Types ==========
+
+/**
+ * Optional date-range window for player statistics (#2438). Both bounds are
+ * ISO-8601 strings; either may be omitted to leave that side unbounded.
+ */
+export type StatsRange = { startDate?: string; endDate?: string };
+
 // ========== Query Keys ==========
 
 export const playRecordsKeys = {
@@ -25,7 +33,13 @@ export const playRecordsKeys = {
   list: (filters: Record<string, unknown>) => [...playRecordsKeys.lists(), filters] as const,
   details: () => [...playRecordsKeys.all, 'detail'] as const,
   detail: (id: string) => [...playRecordsKeys.details(), id] as const,
-  statistics: () => [...playRecordsKeys.all, 'statistics'] as const,
+  statistics: (range?: StatsRange) =>
+    [
+      ...playRecordsKeys.all,
+      'statistics',
+      range?.startDate ?? null,
+      range?.endDate ?? null,
+    ] as const,
 };
 
 // ========== Queries ==========
@@ -95,10 +109,10 @@ export function useInfinitePlayHistory(params: {
  * AC-5.9: staleTime 5 minutes (300000ms) — stats are relatively stable,
  * allows client-side cache reuse across navigations without refetch.
  */
-export function usePlayerStatistics() {
+export function usePlayerStatistics(range?: StatsRange) {
   return useQuery({
-    queryKey: playRecordsKeys.statistics(),
-    queryFn: () => playRecordsApi.getPlayerStatistics(),
+    queryKey: playRecordsKeys.statistics(range),
+    queryFn: () => playRecordsApi.getPlayerStatistics(range ?? {}),
     staleTime: 5 * 60 * 1000, // 5 minutes
     retry: false,
   });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3967,6 +3967,19 @@
       "error": {
         "title": "Could not load statistics",
         "description": "A network error occurred. Check your connection and try again."
+      },
+      "trend": {
+        "title": "Win rate trend",
+        "empty": "Not enough data for a trend",
+        "month": "Month",
+        "winRate": "Win rate"
+      },
+      "range": {
+        "label": "Filter period",
+        "all": "All",
+        "30d": "30d",
+        "90d": "90d",
+        "12m": "12mo"
       }
     },
     "new": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -4020,6 +4020,19 @@
       "error": {
         "title": "Impossibile caricare le statistiche",
         "description": "Si è verificato un errore di rete. Verifica la connessione e riprova."
+      },
+      "trend": {
+        "title": "Andamento win rate",
+        "empty": "Dati insufficienti per l'andamento",
+        "month": "Mese",
+        "winRate": "Win rate"
+      },
+      "range": {
+        "label": "Filtra periodo",
+        "all": "Tutto",
+        "30d": "30g",
+        "90d": "90g",
+        "12m": "12 mesi"
       }
     },
     "new": {

--- a/docs/superpowers/plans/2026-06-20-issue-2438-pr-a-fe-trend-daterange.md
+++ b/docs/superpowers/plans/2026-06-20-issue-2438-pr-a-fe-trend-daterange.md
@@ -1,0 +1,598 @@
+# #2438 PR-A — Stats Trend Chart + Date-Range Filter (FE) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a recharts win-rate trend chart and a date-range preset filter to the Play Records statistics view, consuming BE data that is already shipped.
+
+**Architecture:** `StatisticsView` gains (1) a preset segmented control (`Tutto · 30g · 90g · 12 mesi`) held in local state that feeds an optional `{startDate?, endDate?}` range into `usePlayerStatistics`, and (2) a full-width `TrendChart` section below the existing 2-col grid that renders `stats.winRateTrend` via a recharts `AreaChart`. The BE query handler already filters `StartDate`/`EndDate` and already populates `winRateTrend`, so this is FE-only.
+
+**Tech Stack:** Next.js 16 · React 19 · recharts ^3.8.1 · React Query · Vitest + Testing Library · Tailwind semantic tokens
+
+**Reference patterns (read before implementing):**
+- recharts area chart + tokens + tooltip + loading/error/empty: `apps/web/src/components/admin/business/CostStackedArea.tsx`
+- stats section style (card/border/header/empty/`data-testid`/`aria-label`/i18n): `apps/web/src/components/play-records/stats/MostPlayedBar.tsx`
+- the schema: `MonthlyWinRate = {month: "YYYY-MM", winRate: 0..1}`, `PlayerStatistics.winRateTrend?: MonthlyWinRate[]` in `apps/web/src/lib/api/schemas/play-records.schemas.ts:108-132`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `apps/web/src/lib/api/play-records.api.ts` | `getPlayerStatistics` accepts optional range → query params | Modify (lines 164-171) |
+| `apps/web/src/lib/domain-hooks/usePlayRecords.ts` | `usePlayerStatistics(range?)` + range in query key | Modify (lines 26-28 keys, 98-105 hook) |
+| `apps/web/src/components/play-records/stats/TrendChart.tsx` | recharts win-rate trend section | Create |
+| `apps/web/src/components/play-records/stats/__tests__/TrendChart.test.tsx` | TrendChart unit + a11y | Create |
+| `apps/web/src/components/play-records/StatisticsView.tsx` | preset filter state + mount TrendChart | Modify |
+| `apps/web/src/components/play-records/__tests__/StatisticsView.test.tsx` | preset re-query + TrendChart mount | Modify/Create (check existing) |
+| `apps/web/src/locales/{it,en}.json` | i18n keys (verify path via existing `playRecords.stats.*`) | Modify |
+
+**Test command:** `pnpm -C apps/web test -- play-records` · **Typecheck:** `pnpm -C apps/web typecheck`
+
+---
+
+### Task 1: Extend API client with optional date range
+
+**Files:**
+- Modify: `apps/web/src/lib/api/play-records.api.ts:164-171`
+
+- [ ] **Step 1: Replace `getPlayerStatistics` with a range-aware version**
+
+```typescript
+  /**
+   * Get player statistics across all games. Optional date range narrows the
+   * window; the BE binds startDate/endDate case-insensitively (#2438).
+   */
+  async getPlayerStatistics(
+    params: { startDate?: string; endDate?: string } = {}
+  ): Promise<PlayerStatistics> {
+    const search = new URLSearchParams();
+    if (params.startDate) search.set('startDate', params.startDate);
+    if (params.endDate) search.set('endDate', params.endDate);
+    const qs = search.toString();
+    const res = await fetch(`${BASE_URL}/statistics${qs ? `?${qs}` : ''}`);
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ message: 'Failed to get statistics' }));
+      throw new Error(error.message || 'Failed to get statistics');
+    }
+    return res.json();
+  },
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm -C apps/web typecheck`
+Expected: PASS (no callers break — the param is optional with a default).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/play-records.api.ts
+git commit -m "feat(play-records): #2438 getPlayerStatistics accepts date range"
+```
+
+---
+
+### Task 2: Range-aware `usePlayerStatistics` hook
+
+**Files:**
+- Modify: `apps/web/src/lib/domain-hooks/usePlayRecords.ts` (keys ~line 28, hook ~lines 98-105)
+
+- [ ] **Step 1: Define the range type + extend the query key**
+
+At the top of the file (near the other type imports) add:
+
+```typescript
+export type StatsRange = { startDate?: string; endDate?: string };
+```
+
+Change the `statistics` key (line 28) from:
+```typescript
+  statistics: () => [...playRecordsKeys.all, 'statistics'] as const,
+```
+to:
+```typescript
+  statistics: (range?: StatsRange) =>
+    [...playRecordsKeys.all, 'statistics', range?.startDate ?? null, range?.endDate ?? null] as const,
+```
+
+- [ ] **Step 2: Extend the hook (lines 98-105)**
+
+```typescript
+export function usePlayerStatistics(range?: StatsRange) {
+  return useQuery({
+    queryKey: playRecordsKeys.statistics(range),
+    queryFn: () => playRecordsApi.getPlayerStatistics(range ?? {}),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: false,
+  });
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm -C apps/web typecheck`
+Expected: PASS — `usePlayerStatistics()` with no arg still valid; `statistics()` key callers unaffected (optional param). If any other call site references `playRecordsKeys.statistics()` for invalidation, it still resolves (range optional).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/domain-hooks/usePlayRecords.ts
+git commit -m "feat(play-records): #2438 usePlayerStatistics accepts date range"
+```
+
+---
+
+### Task 3: `TrendChart` component (recharts area)
+
+**Files:**
+- Create: `apps/web/src/components/play-records/stats/TrendChart.tsx`
+
+Follow `CostStackedArea.tsx` for the recharts wiring and `MostPlayedBar.tsx` for the section shell (card/border/header/empty/`data-testid`/`aria-label`/i18n).
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+'use client';
+
+/**
+ * TrendChart — win-rate trend over the last 6 months (#2438).
+ * Consumes stats.winRateTrend ({month: "YYYY-MM", winRate: 0..1}), already
+ * populated by the BE. recharts AreaChart; win rate shown as 0–100%.
+ */
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { PlayerStatistics } from '@/lib/api/schemas/play-records.schemas';
+
+interface TrendChartProps {
+  stats: PlayerStatistics;
+}
+
+// "YYYY-MM" → localized short month (e.g. "giu").
+function formatMonthShort(month: string): string {
+  const [y, m] = month.split('-').map(Number);
+  if (!y || !m) return month;
+  return new Date(y, m - 1, 1).toLocaleDateString('it-IT', { month: 'short' });
+}
+
+interface TrendTooltipProps {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}
+
+function TrendTooltip({ active, payload, label }: TrendTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const pct = Math.round((payload[0].value ?? 0) * 100);
+  return (
+    <div className="rounded-md border border-border bg-card/95 px-3 py-2 font-mono text-[11px] shadow-lg backdrop-blur-sm">
+      <p className="font-display text-[12px] font-bold text-foreground">
+        {label ? formatMonthShort(label) : ''}
+      </p>
+      <p className="mt-1 text-muted-foreground">
+        win rate <span className="font-bold text-foreground">{pct}%</span>
+      </p>
+    </div>
+  );
+}
+
+export function TrendChart({ stats }: TrendChartProps) {
+  const { t } = useTranslation();
+  const trend = stats.winRateTrend ?? [];
+  const isEmpty = trend.length === 0;
+
+  if (isEmpty) {
+    return (
+      <section
+        className="rounded-lg border border-border bg-card p-4 md:p-5"
+        data-testid="trend-empty"
+        aria-label={t('playRecords.stats.trend.title')}
+      >
+        <header className="mb-4 flex items-center gap-3">
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-entity-game/12 text-entity-game">
+            📈
+          </div>
+          <h2 className="font-display text-base font-black text-foreground md:text-lg">
+            {t('playRecords.stats.trend.title')}
+          </h2>
+        </header>
+        <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-entity-game/30 bg-muted/30 px-4 py-6 text-center">
+          <p className="text-xs text-muted-foreground">{t('playRecords.stats.trend.empty')}</p>
+        </div>
+      </section>
+    );
+  }
+
+  // Screen-reader summary: list each month's win rate as a percentage.
+  const srSummary = trend
+    .map(m => `${formatMonthShort(m.month)} ${Math.round(m.winRate * 100)}%`)
+    .join(', ');
+
+  return (
+    <section
+      className="rounded-lg border border-border bg-card p-4 md:p-5"
+      data-testid="trend-section"
+      aria-label={t('playRecords.stats.trend.title')}
+    >
+      <header className="mb-4 flex items-center gap-3">
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-entity-game/12 text-entity-game">
+          📈
+        </div>
+        <h2 className="font-display text-base font-black text-foreground md:text-lg">
+          {t('playRecords.stats.trend.title')}
+        </h2>
+      </header>
+
+      <div role="img" aria-label={`${t('playRecords.stats.trend.title')}: ${srSummary}`}>
+        <ResponsiveContainer width="100%" height={220}>
+          <AreaChart data={trend} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+            <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="3 3" />
+            <XAxis
+              dataKey="month"
+              tickFormatter={formatMonthShort}
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={10}
+              tickLine={false}
+              axisLine={{ stroke: 'hsl(var(--border))' }}
+            />
+            <YAxis
+              domain={[0, 1]}
+              tickFormatter={v => `${Math.round(v * 100)}%`}
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={10}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+            />
+            <Tooltip content={<TrendTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="winRate"
+              stroke="hsl(var(--entity-game))"
+              fill="hsl(var(--entity-game))"
+              fillOpacity={0.25}
+              strokeWidth={2}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Visually-hidden data table for screen readers / non-visual axe checks */}
+      <table className="sr-only">
+        <caption>{t('playRecords.stats.trend.title')}</caption>
+        <thead>
+          <tr>
+            <th>{t('playRecords.stats.trend.month')}</th>
+            <th>{t('playRecords.stats.trend.winRate')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trend.map(m => (
+            <tr key={m.month}>
+              <td>{formatMonthShort(m.month)}</td>
+              <td>{Math.round(m.winRate * 100)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+```
+
+> **Verify during implementation:** the token `--entity-game` exists as a CSS var consumable via `hsl(var(--entity-game))`. `MostPlayedBar` uses the Tailwind utility `text-entity-game`/`bg-entity-game`. If `hsl(var(--entity-game))` does not resolve (entity tokens may be defined as full colors, not H S L triplets), fall back to `var(--entity-game)` (no `hsl()` wrapper) — check `apps/web/src/styles/design-tokens-canonical.css` for the token's format and match it. This mirrors how `CostStackedArea` uses `hsl(var(--c-*))` for the dedicated chart palette.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm -C apps/web typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit** (with Task 4 tests)
+
+---
+
+### Task 4: `TrendChart` tests
+
+**Files:**
+- Create: `apps/web/src/components/play-records/stats/__tests__/TrendChart.test.tsx`
+
+Mirror `MostPlayedBar.test.tsx` for the render/i18n harness (read it for the exact `render` wrapper + i18n mock pattern used by stats tests). recharts needs a sized container in jsdom — assert on the `sr-only` table + section testid, not on SVG geometry.
+
+- [ ] **Step 1: Write the tests**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { TrendChart } from '@/components/play-records/stats/TrendChart';
+import type { PlayerStatistics } from '@/lib/api/schemas/play-records.schemas';
+
+const base: PlayerStatistics = {
+  totalSessions: 3,
+  totalWins: 2,
+  gamePlayCounts: {},
+  averageScoresByGame: {},
+};
+
+describe('TrendChart', () => {
+  it('renders the empty state when winRateTrend is missing/empty', () => {
+    render(<TrendChart stats={base} />);
+    expect(screen.getByTestId('trend-empty')).toBeInTheDocument();
+  });
+
+  it('renders the chart section + sr-only data table when trend has data', () => {
+    const stats: PlayerStatistics = {
+      ...base,
+      winRateTrend: [
+        { month: '2026-04', winRate: 0.5 },
+        { month: '2026-05', winRate: 1 },
+      ],
+    };
+    render(<TrendChart stats={stats} />);
+    expect(screen.getByTestId('trend-section')).toBeInTheDocument();
+    // sr-only table mirrors the data points as percentages
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pnpm -C apps/web test -- TrendChart`
+Expected: PASS (2 tests). If the i18n mock differs (keys render as raw strings), adjust assertions to match what `MostPlayedBar.test.tsx` does (it may assert testids only).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/play-records/stats/TrendChart.tsx apps/web/src/components/play-records/stats/__tests__/TrendChart.test.tsx
+git commit -m "feat(play-records): #2438 TrendChart win-rate recharts component"
+```
+
+---
+
+### Task 5: Date-range preset filter + mount TrendChart in `StatisticsView`
+
+**Files:**
+- Modify: `apps/web/src/components/play-records/StatisticsView.tsx`
+
+- [ ] **Step 1: Add preset state + range derivation + filter UI + TrendChart**
+
+Replace the component body (currently lines 26-94) so it: holds a `preset` state, derives a `range`, passes it to `usePlayerStatistics`, renders a segmented control in the header area, and mounts `<TrendChart>` below the grid.
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { MostPlayedBar } from '@/components/play-records/stats/MostPlayedBar';
+import { StatsHero } from '@/components/play-records/stats/StatsHero';
+import { TrendChart } from '@/components/play-records/stats/TrendChart';
+import { WinByGameBar } from '@/components/play-records/stats/WinByGameBar';
+import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
+import { useTranslation } from '@/hooks/useTranslation';
+import { usePlayerStatistics, type StatsRange } from '@/lib/domain-hooks/usePlayRecords';
+
+type RangePreset = 'all' | '30d' | '90d' | '12m';
+
+const PRESETS: RangePreset[] = ['all', '30d', '90d', '12m'];
+
+function rangeForPreset(preset: RangePreset): StatsRange | undefined {
+  if (preset === 'all') return undefined;
+  const now = new Date();
+  const from = new Date(now);
+  if (preset === '30d') from.setDate(now.getDate() - 30);
+  else if (preset === '90d') from.setDate(now.getDate() - 90);
+  else if (preset === '12m') from.setMonth(now.getMonth() - 12);
+  return { startDate: from.toISOString() };
+}
+
+export function StatisticsView() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const [preset, setPreset] = useState<RangePreset>('all');
+  const { data: stats, isLoading, error } = usePlayerStatistics(rangeForPreset(preset));
+
+  return (
+    <div className="flex flex-col min-h-full bg-background" data-testid="stats-page">
+      <MobileHeader
+        title={t('playRecords.stats.headerTitle')}
+        onBack={() => router.push('/play-records')}
+      />
+
+      {/* Date-range preset filter */}
+      <div className="px-4 pt-4" data-testid="stats-range-filter">
+        <div
+          className="inline-flex rounded-lg border border-border bg-card p-1"
+          role="group"
+          aria-label={t('playRecords.stats.range.label')}
+        >
+          {PRESETS.map(p => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPreset(p)}
+              aria-pressed={preset === p}
+              data-testid={`range-${p}`}
+              className={
+                preset === p
+                  ? 'rounded-md bg-entity-game px-3 py-1.5 text-[11px] font-bold text-white'
+                  : 'rounded-md px-3 py-1.5 text-[11px] font-bold text-muted-foreground hover:text-foreground'
+              }
+            >
+              {t(`playRecords.stats.range.${p}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="flex-1 px-4 pt-6 pb-12 flex flex-col gap-6" data-testid="stats-loading">
+          <div className="h-40 animate-pulse rounded-lg bg-muted" />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6" data-testid="stats-grid">
+            <div className="h-56 animate-pulse rounded-lg bg-muted" data-testid="section-skeleton" />
+            <div className="h-56 animate-pulse rounded-lg bg-muted" data-testid="section-skeleton" />
+          </div>
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <>
+          {stats && <StatsHero stats={stats} />}
+          <div className="flex-1 px-4 pt-6 pb-12">
+            <div
+              className="rounded-lg border border-danger/30 bg-danger/10 px-6 py-6 text-center"
+              data-testid="stats-error"
+            >
+              <div className="text-4xl mb-3" aria-hidden="true">
+                ⚠️
+              </div>
+              <h3 className="font-bold text-foreground">{t('playRecords.stats.error.title')}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {t('playRecords.stats.error.description')}
+              </p>
+            </div>
+          </div>
+        </>
+      )}
+
+      {!isLoading && !error && stats && (
+        <>
+          <StatsHero stats={stats} />
+          <div className="flex-1 px-4 pt-6 pb-12 flex flex-col gap-4 md:gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6" data-testid="stats-grid">
+              <MostPlayedBar stats={stats} />
+              <WinByGameBar stats={stats} />
+            </div>
+            <TrendChart stats={stats} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm -C apps/web typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/play-records/StatisticsView.tsx
+git commit -m "feat(play-records): #2438 date-range preset filter + mount TrendChart"
+```
+
+---
+
+### Task 6: i18n keys
+
+**Files:**
+- Modify: `apps/web/src/locales/it.json` + `apps/web/src/locales/en.json` (verify path: grep for an existing key like `"headerTitle"` under `playRecords.stats` to find the file and nesting)
+
+- [ ] **Step 1: Locate the stats namespace**
+
+Run: `grep -rln "playRecords" apps/web/src/locales apps/web/src/**/messages* 2>/dev/null | head`
+Then open the file(s) and find the `playRecords.stats` object.
+
+- [ ] **Step 2: Add keys under `playRecords.stats`** (both it + en)
+
+it.json:
+```json
+"trend": { "title": "Andamento win rate", "empty": "Dati insufficienti per l'andamento", "month": "Mese", "winRate": "Win rate" },
+"range": { "label": "Filtra periodo", "all": "Tutto", "30d": "30g", "90d": "90g", "12m": "12 mesi" }
+```
+en.json:
+```json
+"trend": { "title": "Win rate trend", "empty": "Not enough data for a trend", "month": "Month", "winRate": "Win rate" },
+"range": { "label": "Filter period", "all": "All", "30d": "30d", "90d": "90d", "12m": "12mo" }
+```
+
+- [ ] **Step 3: Run the i18n consistency test + the stats tests**
+
+Run: `pnpm -C apps/web test -- play-records`
+Expected: PASS. If the repo has a MESSAGES/locale-parity test, it confirms it+en have identical key sets.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/locales/
+git commit -m "feat(play-records): #2438 i18n keys for trend + range filter"
+```
+
+---
+
+### Task 7: StatisticsView integration test (preset re-query + TrendChart mount)
+
+**Files:**
+- Modify/Create: `apps/web/src/components/play-records/__tests__/StatisticsView.test.tsx` (check if it exists first)
+
+- [ ] **Step 1: Check for an existing test + its harness**
+
+Run: `ls apps/web/src/components/play-records/__tests__/ | grep -i statistics`
+If it exists, read it for the React Query + MSW harness. Add the cases below to it; otherwise create it mirroring that harness.
+
+- [ ] **Step 2: Add the cases**
+
+```tsx
+it('renders the range filter and the trend section on success', async () => {
+  // ... render StatisticsView within the existing RQ+MSW provider wrapper ...
+  expect(await screen.findByTestId('stats-range-filter')).toBeInTheDocument();
+  expect(screen.getByTestId('range-all')).toHaveAttribute('aria-pressed', 'true');
+  // TrendChart renders (section or empty depending on MSW fixture)
+  expect(
+    screen.getByTestId('trend-section') ?? screen.getByTestId('trend-empty')
+  ).toBeInTheDocument();
+});
+
+it('switching preset updates aria-pressed', async () => {
+  // ... render ...
+  const btn30 = await screen.findByTestId('range-30d');
+  await userEvent.click(btn30);
+  expect(btn30).toHaveAttribute('aria-pressed', 'true');
+});
+```
+
+> Fill the render wrapper from the existing stats test harness (Step 1). If the MSW `statistics` handler ignores query params, the preset switch still re-queries the same fixture — the test asserts UI state (`aria-pressed`), not network, so it is deterministic.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `pnpm -C apps/web test -- play-records`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/play-records/__tests__/StatisticsView.test.tsx
+git commit -m "test(play-records): #2438 StatisticsView range filter + trend"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (PR-A scope = trend chart + date-range):**
+- Trend chart (recharts, consumes winRateTrend, default+empty, a11y) → Tasks 3, 4. ✅
+- Date-range preset filter (api+hook+UI) → Tasks 1, 2, 5. ✅
+- i18n → Task 6. ✅
+- Integration → Task 7. ✅
+- Redis cache / CSV / leaderboard → correctly NOT here (PR-B / out of scope). ✅
+
+**2. Placeholder scan:** The "verify during implementation" notes (token format in Task 3; i18n path in Task 6; test harness in Tasks 4/7) are explicit read-then-match instructions with named fallbacks, not vague TODOs. Test render wrappers in Tasks 4/7 reference the real sibling harness (`MostPlayedBar.test.tsx` / existing StatisticsView test) to copy — flagged as a read step.
+
+**3. Type consistency:** `StatsRange` defined in Task 2, consumed in Tasks 1 (shape `{startDate?, endDate?}`), 2, 5. `getPlayerStatistics(params)` signature consistent Task 1 ↔ Task 2 call. `winRateTrend`/`MonthlyWinRate` match the schema. `rangeForPreset`/`RangePreset` defined+used in Task 5 only.
+
+**Risk:** recharts in jsdom renders no real SVG geometry — tests assert on the `sr-only` table + testids (Task 4), not chart pixels. The `--entity-game` token format (`hsl(var())` vs `var()`) is flagged for verification against `design-tokens-canonical.css` in Task 3.

--- a/docs/superpowers/specs/2026-06-20-issue-2438-stats-trend-daterange-redis-design.md
+++ b/docs/superpowers/specs/2026-06-20-issue-2438-stats-trend-daterange-redis-design.md
@@ -1,0 +1,71 @@
+# #2438 — Play Records Stats: trend chart + date-range + Redis cache — Design
+
+**Status**: APPROVED (design lock 2026-06-20)
+**Issue**: #2438 (follow-up of #2350 / epic #2346)
+**Parent**: US-INT-2 Tier 2 Play Records
+
+## Context & rescope
+
+Discovery (2026-06-20) found the issue body over-estimates the work — most BE is already shipped:
+
+- `PlayerStatisticsDto.WinRateTrend` (`IReadOnlyList<MonthlyWinRate>`, `{Month: "YYYY-MM", WinRate: 0..1}`) is **already populated** (6-month sliding window) in `GetPlayerStatisticsQueryHandler` (lines 168-198).
+- The query handler **already filters** `StartDate`/`EndDate` (lines 41-49). The FE just never sends them (`playRecordsApi.getPlayerStatistics()` takes no params).
+- `LeaderboardRank` scalar is already exposed; a leaderboard *board* (list) would be a NEW query — **out of scope** (not selected).
+- The canonical mockup `sp4-play-records-stats` is "4 KPI + 2 bar" and the current FE `StatisticsView` matches it exactly. All features below go **beyond** the mockup → designer self-waiver (P250, user is the designer; fidelity.json already `design_intent: current`, self-approved 2026-06-15).
+
+## Scope (locked via AskUserQuestion 2026-06-20)
+
+**In scope** — 3 pieces, 2 PRs (FE-first split):
+
+| # | Piece | Layer | PR |
+|---|---|---|---|
+| 1 | Trend chart (recharts area, consumes `winRateTrend`) | FE | PR-A |
+| 2 | Date-range filter (preset segmented control) | FE | PR-A |
+| 3 | Redis server cache + invalidation | BE | PR-B |
+
+**Out of scope** (not selected — YAGNI): CSV export, leaderboard board. They remain unchecked in the #2438 body.
+
+## PR-A — Frontend
+
+### Component 1: `TrendChart`
+
+- **File**: `apps/web/src/components/play-records/stats/TrendChart.tsx`
+- **Input**: `stats: PlayerStatistics` (uses `stats.winRateTrend`).
+- **Render**: recharts `AreaChart` — X axis = `month` (formatted `MMM` short), Y axis = win rate scaled to 0–100%, `Tooltip` showing month + `NN%`. Single `Area` series, semantic-token stroke/fill (`var(--primary)` via Tailwind `text-primary`/arbitrary value — no raw HSL).
+- **States**: `default` (≥1 month) · `empty` (`winRateTrend.length === 0` → muted "dati insufficienti" panel, no chart).
+- **a11y**: chart wrapped with `role="img"` + `aria-label` summarizing the trend; a visually-hidden `<table>` mirrors the data points for screen readers (axe AA, 0 violations).
+- **Placement**: rendered in `StatisticsView` as a full-width section **below** the 2-col `MostPlayedBar`/`WinByGameBar` grid.
+
+### Component 2: Date-range filter
+
+- **API**: extend `playRecordsApi.getPlayerStatistics(params?: { dateFrom?: string; dateTo?: string })` → append `dateFrom`/`dateTo` query params when present. (Backend `GetStatisticsQueryParams` already binds `StartDate`/`EndDate`; endpoint maps them — verify query-param names `startDate`/`endDate` vs `dateFrom`/`dateTo` during planning and align.)
+- **Hook**: `usePlayerStatistics(range?: StatsRange)` — `range` participates in the React Query key so each range is cached separately.
+- **UI**: a **preset segmented control** in the `StatisticsView` header: `Tutto · 30g · 90g · 12 mesi`. Selecting a preset computes `dateFrom` client-side (`now - N`) and re-queries; `Tutto` sends no params. Preset chosen over a custom date-picker (YAGNI — covers the real need without a calendar widget).
+- **State**: selected preset held in `StatisticsView` local state (`useState`), default `Tutto`.
+
+## PR-B — Backend
+
+### Component 3: Redis cache on `GetPlayerStatisticsQueryHandler`
+
+- **Cache**: wrap the handler body with `IHybridCacheService` (pattern from `GetGameLeaderboardQueryHandler`), **TTL 5 min**.
+- **Key**: `player-stats:{userId}:{startDate?:o}:{endDate?:o}` (date parts use round-trip `o` format or empty when null).
+- **Invalidation**: a new `INotificationHandler<>` reacting to `PlayRecordCreatedEvent`, `PlayRecordCompletedEvent`, and `PlayRecordDeletedEvent` (introduced in #2439) → evicts the user's stats cache entries. Because keys are date-parametrized, eviction uses a **per-user tag** (`IHybridCacheService` tag-based eviction) rather than enumerating date combinations — verify tag support during planning; fallback = cache a single un-parametrized `player-stats:{userId}` entry and apply date filters post-cache (simpler, still correct) if tags are unavailable.
+- **ADR**: a short ADR documents the key schema + the invalidation trigger set + the tag-vs-single-entry decision.
+
+## Testing
+
+- **PR-A**: `TrendChart` unit (default render asserts data points; empty state) + axe AA test; date-range hook+UI unit (preset change re-queries with correct `dateFrom`); no regression in existing `StatisticsView` tests.
+- **PR-B**: handler cache unit (miss → compute+store; hit → no DB call); invalidation handler unit (each of the 3 events evicts); integration (Testcontainers) end-to-end cache+invalidation.
+
+## Risks
+
+- **R1**: query-param naming mismatch FE↔BE (`dateFrom/dateTo` vs `startDate/endDate`) — resolved in planning by reading the endpoint binding.
+- **R2**: `IHybridCacheService` tag-based eviction may not exist → fallback to single un-parametrized cache entry (documented in ADR).
+- **R3**: recharts SSR/`'use client'` — `TrendChart` is a client component; ensure dynamic import is not needed (recharts works in client components).
+
+## Self-review
+
+- **Placeholders**: none — every piece has a concrete file/approach. The two "verify during planning" notes (R1 param names, R2 tag support) are explicit risk-resolutions with named fallbacks, not vague TODOs.
+- **Consistency**: scope table (3 pieces) matches the per-PR sections. CSV/leaderboard consistently marked out-of-scope.
+- **Scope**: focused; FE-first split keeps PR-A independently shippable (consumes already-shipped BE data). PR-B is independently shippable (pure server-side optimization, no FE change).
+- **Ambiguity**: date-range = preset (not date-picker) — made explicit.


### PR DESCRIPTION
## Summary

**Part of #2438** (PR-A of 2 — FE-first split; does not close the issue). Adds the win-rate trend chart + date-range preset filter to Play Records statistics, consuming BE data that is **already shipped** (`winRateTrend` populated; the query handler already filters `startDate`/`endDate`).

- **TrendChart** (recharts `AreaChart`): consumes `stats.winRateTrend`, Y axis 0–100%, custom tooltip, `default`+`empty` states, a11y (`role="img"` + `aria-label` + `sr-only` data table). Chart color `hsl(var(--c-game))` (entity-game triplet, mirrors `CostStackedArea`).
- **Date-range preset filter** (`Tutto · 30g · 90g · 12 mesi`) in `StatisticsView` → feeds `{startDate}` into `usePlayerStatistics(range)`.
- **Invalidation fix**: mutations now invalidate the `statisticsAll()` prefix so every cached range refreshes (PR-A introduced ranged query keys; the no-range invalidation would otherwise miss them).
- **i18n** keys (it + en) for `trend` + `range`.

**Out of scope** (not selected — YAGNI): CSV export, leaderboard board. **Redis cache → PR-B** (BE).

Designer self-waiver (P250 — user is the designer): all features go beyond the canonical "4 KPI + 2 bar" mockup; `fidelity.json` `design_intent: current`.

## Test Plan

- [x] TrendChart unit (default + empty) + StatisticsView integration (range filter + trend mount + range→hook): **5/5 isolated**
- [x] Full `play-records` scope green (177 subagent) + invalidation fix verified post-edit
- [x] typecheck PASS · ESLint 0 errors
- [ ] **Note**: the full FE suite shows 5 flaky failures in `admin/wikidata-dead-letters` (`waitFor` timing under full-suite contention, 1245s run) — **UNRELATED** to this PR; they pass isolated (8/8). Not a regression (a prior full run on a sibling branch was 0-fail).

## Refs
- Design: `docs/superpowers/specs/2026-06-20-issue-2438-stats-trend-daterange-redis-design.md`
- Plan: `docs/superpowers/plans/2026-06-20-issue-2438-pr-a-fe-trend-daterange.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)