### PR TITLE
feat(play-records): #2438 PR-B player-stats Redis cache + invalidation (BE)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandler.cs
@@ -1,0 +1,82 @@
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// #2438 (PR-B): evicts the per-user player-statistics cache tag when a record is Completed.
+/// <para>
+/// <c>GetPlayerStatisticsQueryHandler</c> caches its projection under tag
+/// <c>player-stats:{userId}</c> and filters <c>Status == Completed</c>, so a record
+/// transitioning to Completed is exactly what can change a cached value. Created/Started/Updated
+/// are NOT triggers (a Planned/InProgress record is not counted); deletion is out of scope
+/// (PlayRecord has no delete capability today). See ADR-081 for the full per-event rationale.
+/// </para>
+/// <para>
+/// Invalidation is best-effort: a cache failure is logged and swallowed so it never rolls back
+/// the <c>CompletePlayRecordCommand</c> that raised the event. A missed eviction self-heals at
+/// the 5-min TTL. Mirrors <c>UserActivityCacheInvalidationEventHandler</c>.
+/// </para>
+/// </summary>
+internal sealed class PlayRecordStatsCacheInvalidationHandler
+    : INotificationHandler<PlayRecordCompletedEvent>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<PlayRecordStatsCacheInvalidationHandler> _logger;
+
+    public PlayRecordStatsCacheInvalidationHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<PlayRecordStatsCacheInvalidationHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(PlayRecordCompletedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        // PlayRecordCompletedEvent carries only RecordId + Duration; resolve the owner via a
+        // single indexed lookup. The record exists (it was just completed); Guid.Empty only
+        // occurs on a re-dispatch race against a missing row, in which case there is nothing
+        // to invalidate.
+        var userId = await _context.PlayRecords
+            .Where(r => r.Id == notification.RecordId)
+            .Select(r => r.CreatedByUserId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (userId == Guid.Empty)
+        {
+            _logger.LogWarning(
+                "PlayRecordCompletedEvent for record {RecordId} resolved no owner — skipping stats cache eviction",
+                notification.RecordId);
+            return;
+        }
+
+        try
+        {
+            var removed = await _cache
+                .RemoveByTagAsync($"player-stats:{userId}", cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Player-stats cache invalidated for user {UserId}: {RemovedCount} entries removed (record {RecordId} completed)",
+                userId, removed, notification.RecordId);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types — best-effort invalidation must not break the completing command.
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to invalidate player-stats cache for user {UserId} after record {RecordId} completed",
+                userId, notification.RecordId);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Infrastructure;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,11 +18,19 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 /// </summary>
 internal class GetPlayerStatisticsQueryHandler : IQueryHandler<GetPlayerStatisticsQuery, PlayerStatisticsDto>
 {
-    private readonly MeepleAiDbContext _context;
+    /// <summary>
+    /// #2438 (PR-B): server-side cache TTL for player statistics. Matches the FE React Query
+    /// staleTime and the GetGameLeaderboard precedent. See ADR-081.
+    /// </summary>
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
 
-    public GetPlayerStatisticsQueryHandler(MeepleAiDbContext context)
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+
+    public GetPlayerStatisticsQueryHandler(MeepleAiDbContext context, IHybridCacheService cache)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
     }
 
     public async Task<PlayerStatisticsDto> Handle(
@@ -30,6 +39,22 @@ internal class GetPlayerStatisticsQueryHandler : IQueryHandler<GetPlayerStatisti
     {
         ArgumentNullException.ThrowIfNull(query);
 
+        // #2438 (PR-B): cache per user + per date-range (Ticks → timezone-stable, serialization-safe),
+        // tagged per user so a single RemoveByTagAsync evicts every ranged entry at once (ADR-081).
+        var cacheKey = $"player-stats:{query.UserId}:{query.StartDate?.Ticks ?? 0}:{query.EndDate?.Ticks ?? 0}";
+
+        return await _cache.GetOrCreateAsync(
+            cacheKey,
+            ct => ComputeAsync(query, ct),
+            tags: [$"player-stats:{query.UserId}"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<PlayerStatisticsDto> ComputeAsync(
+        GetPlayerStatisticsQuery query,
+        CancellationToken cancellationToken)
+    {
         var recordsQuery = _context.PlayRecords
             .AsNoTracking()
             .Include(r => r.Players)

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandlerTests.cs
@@ -1,0 +1,128 @@
+using Api.BoundedContexts.GameManagement.Application.EventHandlers;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for <see cref="PlayRecordStatsCacheInvalidationHandler"/> (#2438, PR-B).
+/// The handler evicts the per-user player-statistics cache tag when a record is Completed
+/// (the event that changes which Completed records exist for the user — see ADR-081).
+/// The Completed event carries no userId, so the handler resolves it from the record.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2438")]
+public sealed class PlayRecordStatsCacheInvalidationHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly Mock<IHybridCacheService> _cache;
+    private readonly Mock<ILogger<PlayRecordStatsCacheInvalidationHandler>> _logger;
+    private readonly PlayRecordStatsCacheInvalidationHandler _handler;
+
+    public PlayRecordStatsCacheInvalidationHandlerTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryDbContext();
+        _cache = new Mock<IHybridCacheService>();
+        _logger = new Mock<ILogger<PlayRecordStatsCacheInvalidationHandler>>();
+        _handler = new PlayRecordStatsCacheInvalidationHandler(_context, _cache.Object, _logger.Object);
+
+        _cache
+            .Setup(c => c.RemoveByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task Handle_Completed_ResolvesOwnerAndEvictsUserStatsTag()
+    {
+        // Arrange — seed the completed record so the userId lookup resolves.
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+        _context.PlayRecords.Add(MakeRecord(recordId, userId));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        await _handler.Handle(
+            new PlayRecordCompletedEvent(recordId, TimeSpan.FromHours(1)),
+            TestContext.Current.CancellationToken);
+
+        // Assert — evicts the owning user's tag.
+        _cache.Verify(
+            c => c.RemoveByTagAsync($"player-stats:{userId}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Completed_RecordNotFound_DoesNotEvict()
+    {
+        // Arrange — no record seeded → lookup returns Guid.Empty.
+        // Act
+        await _handler.Handle(
+            new PlayRecordCompletedEvent(Guid.NewGuid(), TimeSpan.FromHours(1)),
+            TestContext.Current.CancellationToken);
+
+        // Assert — never evicts on an unresolved owner (guards re-dispatch races).
+        _cache.Verify(
+            c => c.RemoveByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Completed_NullNotification_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => _handler.Handle(
+            (PlayRecordCompletedEvent)null!,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Handle_Completed_CacheThrows_IsSwallowed_BestEffort()
+    {
+        // Arrange — eviction is best-effort: a cache hiccup must NOT propagate into the
+        // CompletePlayRecordCommand that raised the event (mirrors UserActivityCacheInvalidationEventHandler).
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+        _context.PlayRecords.Add(MakeRecord(recordId, userId));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _cache
+            .Setup(c => c.RemoveByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        // Act
+        var act = () => _handler.Handle(
+            new PlayRecordCompletedEvent(recordId, TimeSpan.FromHours(1)),
+            TestContext.Current.CancellationToken);
+
+        // Assert — does not throw.
+        await act.Should().NotThrowAsync();
+    }
+
+    private static PlayRecordEntity MakeRecord(Guid id, Guid userId) => new()
+    {
+        Id = id,
+        GameId = Guid.NewGuid(),
+        GameName = "Test Game",
+        CreatedByUserId = userId,
+        Visibility = 0,
+        SessionDate = DateTime.UtcNow.AddHours(-1),
+        Status = 2, // Completed
+        ScoringConfigJson = """{"Dimensions":["points","wins"],"Units":{"points":"pts","wins":"W"}}""",
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+    };
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerCacheTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerCacheTests.cs
@@ -1,0 +1,109 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.Infrastructure;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+/// <summary>
+/// Unit tests for the HybridCache wrapping added to <see cref="GetPlayerStatisticsQueryHandler"/>
+/// in #2438 (PR-B). Verifies the handler delegates to <see cref="IHybridCacheService.GetOrCreateAsync"/>
+/// with the per-user/per-range key, the per-user tag, and the 5-minute TTL (ADR-081).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2438")]
+public sealed class GetPlayerStatisticsQueryHandlerCacheTests : IDisposable
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly Mock<IHybridCacheService> _cache;
+
+    public GetPlayerStatisticsQueryHandlerCacheTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryDbContext();
+        _cache = new Mock<IHybridCacheService>();
+
+        // Pass-through: invoke the factory and return its value so the wrapped compute runs.
+        _cache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+                It.IsAny<string[]>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, Func<CancellationToken, Task<PlayerStatisticsDto>>, string[], TimeSpan?, CancellationToken>(
+                (key, factory, tags, exp, ct) => factory(ct));
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task Handle_NoDateRange_UsesPerUserKeyTagAndFiveMinuteTtl()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var handler = new GetPlayerStatisticsQueryHandler(_context, _cache.Object);
+
+        // Act
+        await handler.Handle(
+            new GetPlayerStatisticsQuery(userId),
+            TestContext.Current.CancellationToken);
+
+        // Assert — key is player-stats:{userId}:0:0 (null start/end → Ticks 0),
+        // tag is player-stats:{userId}, TTL is 5 minutes.
+        _cache.Verify(c => c.GetOrCreateAsync(
+            It.Is<string>(k => k == $"player-stats:{userId}:0:0"),
+            It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+            It.Is<string[]>(t => t.Contains($"player-stats:{userId}")),
+            It.Is<TimeSpan?>(e => e == TimeSpan.FromMinutes(5)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithDateRange_EncodesTicksInKeyAndKeepsSamePerUserTag()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var start = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new GetPlayerStatisticsQueryHandler(_context, _cache.Object);
+
+        // Act
+        await handler.Handle(
+            new GetPlayerStatisticsQuery(userId, start, end),
+            TestContext.Current.CancellationToken);
+
+        // Assert — the range Ticks are part of the key; the tag stays per-user (range-agnostic)
+        // so a single eviction clears every ranged entry for the user.
+        _cache.Verify(c => c.GetOrCreateAsync(
+            It.Is<string>(k => k == $"player-stats:{userId}:{start.Ticks}:{end.Ticks}"),
+            It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+            It.Is<string[]>(t => t.Contains($"player-stats:{userId}")),
+            It.Is<TimeSpan?>(e => e == TimeSpan.FromMinutes(5)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullQuery_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handler = new GetPlayerStatisticsQueryHandler(_context, _cache.Object);
+
+        // Act
+        var act = () => handler.Handle(null!, TestContext.Current.CancellationToken);
+
+        // Assert — null-guard runs before any cache interaction.
+        await act.Should().ThrowAsync<ArgumentNullException>();
+        _cache.Verify(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+            It.IsAny<string[]>(),
+            It.IsAny<TimeSpan?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
@@ -5,9 +6,11 @@ using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.GameManagement;
+using Api.Services;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
@@ -31,7 +34,23 @@ public class GetPlayerStatisticsQueryHandlerTests : IDisposable
     public GetPlayerStatisticsQueryHandlerTests()
     {
         _context = TestDbContextFactory.CreateInMemoryDbContext();
-        _handler = new GetPlayerStatisticsQueryHandler(_context);
+
+        // #2438: the handler now wraps its compute in IHybridCacheService.GetOrCreateAsync.
+        // Use a pass-through cache double that always invokes the factory so these tests keep
+        // asserting on the freshly-computed projection (cache behaviour is covered separately
+        // by GetPlayerStatisticsQueryHandlerCacheTests).
+        var cache = new Mock<IHybridCacheService>();
+        cache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+                It.IsAny<string[]>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, Func<CancellationToken, Task<PlayerStatisticsDto>>, string[], TimeSpan?, CancellationToken>(
+                (key, factory, tags, exp, ct) => factory(ct));
+
+        _handler = new GetPlayerStatisticsQueryHandler(_context, cache.Object);
     }
 
     public void Dispose() => _context.Dispose();

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayerStatisticsCacheTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayerStatisticsCacheTests.cs
@@ -1,0 +1,290 @@
+using System.Collections.Concurrent;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.DomainEventOutbox;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.SharedKernel.Application;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// End-to-end integration tests for the player-statistics cache (#2438, PR-B):
+/// proves both that <see cref="GetPlayerStatisticsQuery"/> is cached AND that
+/// <c>PlayRecordStatsCacheInvalidationHandler</c> evicts the per-user tag when a record
+/// completes (raising <see cref="Api.BoundedContexts.GameManagement.Domain.Events.PlayRecordCompletedEvent"/>).
+///
+/// Uses a stateful in-process <see cref="IHybridCacheService"/> double (<see cref="StatefulHybridCache"/>)
+/// that caches by key and evicts by tag — neither the default Moq mock nor
+/// <c>PassthroughHybridCache</c> can prove invalidation (one never caches, the other never evicts).
+///
+/// Forces <see cref="DomainEventDispatchMode.Hybrid"/> so the completion event fires inline through
+/// MediatR after SaveChangesAsync (the default OutboxOnly queues for a background processor that is
+/// not registered in this minimal test DI — see FinalizeSessionSingleDispatchIntegrationTests).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2438")]
+public sealed class PlayerStatisticsCacheTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private readonly TestTimeProvider _timeProvider = new();
+    private readonly StatefulHybridCache _cache = new();
+
+    public PlayerStatisticsCacheTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IServiceProvider ServiceProvider => _serviceProvider ?? throw new InvalidOperationException("Service provider not initialized.");
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_playstats_cache_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+
+        services.AddScoped<IPlayRecordRepository, PlayRecordRepository>();
+        services.AddScoped<PlayRecordPermissionChecker>();
+        services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+        services.AddScoped<IGameCoreDataProvider, GameCoreDataProvider>();
+        services.AddSingleton<TimeProvider>(_timeProvider);
+
+        // Stateful cache double (last registration wins) so the read path actually caches and the
+        // invalidation handler's RemoveByTagAsync actually evicts — required to prove invalidation.
+        services.AddSingleton<IHybridCacheService>(_cache);
+
+        // Force inline MediatR dispatch so PlayRecordCompletedEvent reaches the invalidation handler.
+        services.AddSingleton<IOptions<DomainEventOutboxOptions>>(
+            Options.Create(new DomainEventOutboxOptions { Mode = DomainEventDispatchMode.Hybrid }));
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Stats_AreServedFromCache_OnRepeatQueryWithoutChange()
+    {
+        // Arrange — one completed record for the user.
+        var userId = await SeedTestUserAsync();
+        await CreateCompletedRecordAsync(userId);
+
+        // Act — first query computes + caches; second query (no change) should hit the cache.
+        var first = await SendInScopeAsync(new GetPlayerStatisticsQuery(userId, null, null));
+        var computesAfterFirst = _cache.FactoryInvocations;
+        var second = await SendInScopeAsync(new GetPlayerStatisticsQuery(userId, null, null));
+
+        // Assert — same value, and the factory ran only once across both reads (cache hit on 2nd).
+        first.TotalSessions.Should().Be(1);
+        second.TotalSessions.Should().Be(1);
+        _cache.FactoryInvocations.Should().Be(computesAfterFirst,
+            "the second query with no intervening change should be served from cache");
+    }
+
+    [Fact]
+    public async Task Stats_AreInvalidated_WhenANewRecordCompletes()
+    {
+        // Arrange — one completed record, query once to populate the cache.
+        var userId = await SeedTestUserAsync();
+        await CreateCompletedRecordAsync(userId);
+        var first = await SendInScopeAsync(new GetPlayerStatisticsQuery(userId, null, null));
+        first.TotalSessions.Should().Be(1);
+
+        // Act — completing a second record raises PlayRecordCompletedEvent → invalidation handler
+        // evicts player-stats:{userId}; the next query must recompute (NOT serve the stale "1").
+        await CreateCompletedRecordAsync(userId);
+        var second = await SendInScopeAsync(new GetPlayerStatisticsQuery(userId, null, null));
+
+        // Assert — fresh value reflects both records → cache was evicted, not stale.
+        second.TotalSessions.Should().Be(2);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private async Task<TResult> SendInScopeAsync<TResult>(IRequest<TResult> request)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(request, TestCancellationToken);
+    }
+
+    private async Task SendInScopeAsync(IRequest request)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        await mediator.Send(request, TestCancellationToken);
+    }
+
+    private async Task<(Guid Id, string Title)> CreateTestGameAsync()
+    {
+        var id = Guid.NewGuid();
+        var title = $"Test Game {id:N}";
+
+        using var scope = ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+
+        return (id, title);
+    }
+
+    private async Task<Guid> SeedTestUserAsync()
+    {
+        var id = Guid.NewGuid();
+        using var scope = ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        db.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"stats-cache-{id:N}@meepleai.dev",
+            DisplayName = "Stats Cache User",
+            Role = "user",
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    /// <summary>
+    /// Creates a play record owned by <paramref name="userId"/> and completes it, raising
+    /// PlayRecordCompletedEvent. Build from the canonical Create + Complete command flow.
+    /// </summary>
+    private async Task CreateCompletedRecordAsync(Guid userId)
+    {
+        var (gameId, gameTitle) = await CreateTestGameAsync();
+
+        var recordId = await SendInScopeAsync(new CreatePlayRecordCommand(
+            userId,
+            gameId,
+            gameTitle,
+            _timeProvider.UtcNow.AddHours(-1),
+            PlayRecordVisibility.Private));
+
+        await SendInScopeAsync(new CompletePlayRecordCommand(recordId, userId, TimeSpan.FromHours(1)));
+    }
+
+    /// <summary>
+    /// In-process <see cref="IHybridCacheService"/> double that actually caches by key and evicts by
+    /// tag, so an end-to-end test can distinguish a cache hit (stale) from an eviction (recompute).
+    /// </summary>
+    private sealed class StatefulHybridCache : IHybridCacheService
+    {
+        private readonly ConcurrentDictionary<string, object> _store = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, HashSet<string>> _tagToKeys = new(StringComparer.Ordinal);
+        private readonly object _gate = new();
+
+        /// <summary>Count of factory executions (cache misses) — lets a test assert hit vs miss.</summary>
+        public int FactoryInvocations { get; private set; }
+
+        public async Task<T> GetOrCreateAsync<T>(
+            string cacheKey,
+            Func<CancellationToken, Task<T>> factory,
+            string[]? tags = null,
+            TimeSpan? expiration = null,
+            CancellationToken ct = default) where T : class
+        {
+            if (_store.TryGetValue(cacheKey, out var cached))
+            {
+                return (T)cached;
+            }
+
+            var value = await factory(ct).ConfigureAwait(false);
+
+            lock (_gate)
+            {
+                FactoryInvocations++;
+                _store[cacheKey] = value;
+                foreach (var tag in tags ?? Array.Empty<string>())
+                {
+                    var keys = _tagToKeys.GetOrAdd(tag, _ => new HashSet<string>(StringComparer.Ordinal));
+                    keys.Add(cacheKey);
+                }
+            }
+
+            return value;
+        }
+
+        public Task RemoveAsync(string cacheKey, CancellationToken ct = default)
+        {
+            _store.TryRemove(cacheKey, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<int> RemoveByTagAsync(string tag, CancellationToken ct = default)
+        {
+            var removed = 0;
+            lock (_gate)
+            {
+                if (_tagToKeys.TryRemove(tag, out var keys))
+                {
+                    foreach (var key in keys)
+                    {
+                        if (_store.TryRemove(key, out _))
+                        {
+                            removed++;
+                        }
+                    }
+                }
+            }
+
+            return Task.FromResult(removed);
+        }
+
+        public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default)
+            => Task.FromResult(0);
+
+        public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default)
+            => RemoveByTagAsync(tag, ct);
+
+        public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
+            => Task.FromResult(new HybridCacheStats());
+    }
+}

--- a/docs/for-claude/architecture/adr/adr-081-player-stats-cache.md
+++ b/docs/for-claude/architecture/adr/adr-081-player-stats-cache.md
@@ -1,0 +1,85 @@
+# ADR-081 — Player Statistics Server-Side Cache (HybridCache) + Per-User Invalidation
+
+**Status**: Proposed
+**Date**: 2026-06-20
+**Deciders**: @badsworm (pending ratification at PR review)
+**Tracking**: [#2438](https://github.com/meepleAi-app/meepleai-monorepo/issues/2438) — `[#2350 follow-up] Play Records stats — deferred Path B features (trend, leaderboard, CSV, Redis)` (PR-B = Redis cache slice)
+**Related**: [#2346](https://github.com/meepleAi-app/meepleai-monorepo/issues/2346) (Tier 2 umbrella) · ADR-062 (KB-flag cache propagation) · `GetGameLeaderboardQueryHandler` (#1467 — reference cache pattern)
+
+## Context
+
+`GetPlayerStatistics` (`/play-records/statistics`) is the read model behind the `/players/[id]` v2 surface. Each call runs several EF aggregations over a user's `Completed` play records (totals, win-by-game, most-played, a cross-user leaderboard-rank scan, a favorite-agent lookup, and a 6-month win-rate trend). Today the only caching is the FE React Query `staleTime` (client-side, per-browser). Concurrent or repeat requests recompute the whole projection server-side every time.
+
+Issue #2438 (PR-B) asks for a **server-side cache (5-min TTL) + invalidation on new play record activity** to match the FE `staleTime` and remove redundant recomputation across replicas.
+
+The codebase already has the canonical pattern: `GetGameLeaderboardQueryHandler` wraps its compute in `IHybridCacheService.GetOrCreateAsync` (L1 in-memory + L2 Redis, cache-stampede protection, tag-based invalidation). We reuse it verbatim.
+
+## Decision
+
+Wrap `GetPlayerStatisticsQueryHandler.Handle` in `IHybridCacheService.GetOrCreateAsync` and evict per-user via a MediatR `INotificationHandler` on the events that change which `Completed` records exist for a user.
+
+### Cache key
+
+```
+player-stats:{userId}:{startDate.Ticks ?? 0}:{endDate.Ticks ?? 0}
+```
+
+- **Per-user** (`userId`) — stats are scoped to one player.
+- **Per-range** (`Ticks` of the optional `StartDate`/`EndDate`) — the query accepts an optional date window; different windows are different results. `Ticks` (not a formatted date string) is timezone-stable and serialization-safe, mirroring `GetGameLeaderboard`'s `since:{Ticks}` key segment. `null` → `0`.
+
+### Cache tag
+
+```
+player-stats:{userId}
+```
+
+One tag per user. A single `RemoveByTagAsync("player-stats:{userId}")` evicts **all** of that user's ranged entries at once, so invalidation never has to enumerate date-window combinations.
+
+### TTL
+
+5 minutes (`TimeSpan.FromMinutes(5)`) — matches the FE React Query `staleTime` and the `GetGameLeaderboard` precedent.
+
+### Invalidation triggers
+
+| Event | Trigger? | Rationale |
+|---|---|---|
+| `PlayRecordCompletedEvent` | **Yes** | A record transitioning to `Completed` is exactly what `GetPlayerStatistics` counts (it filters `Status == Completed`). This is the "new play record" activity #2438 refers to. |
+| `PlayRecordCreatedEvent` | **No** | A freshly created record is `Planned`. `GetPlayerStatistics` ignores non-`Completed` records, so a Created event cannot change any cached value. Evicting on Created would be a pure waste (cold cache + re-scan) for a no-op delta. |
+| `PlayRecordStartedEvent` / `PlayRecordUpdatedEvent` | **No** | `Started` moves `Planned → InProgress` (still not counted). `Updated` edits notes/location/session-date on an existing record; it does not change the `Completed`-set membership that drives the cached aggregates. (If a future change lets `UpdateDetails` move a record's `SessionDate` across a cached date-window boundary for an already-`Completed` record, revisit — see Consequences.) |
+| Deletion | **N/A (no capability)** | PlayRecord has **no** delete command, no `PlayRecordDeletedEvent`, and no soft-delete (`IsDeleted`/`DeletedAt`) as of this ADR. The endpoint surface is Create/Start/Complete/AddPlayer/RecordScore/Update + two GETs — no DELETE verb. When deletion is introduced, add a `PlayRecordDeletedEvent` trigger to the same handler (it carries the owning userId directly, so no lookup is needed). |
+
+> The plan that seeded this work assumed a `PlayRecordDeletedEvent(RecordId, DeletedByUserId)`. That event does not exist in the codebase and deletion is out of scope for #2438 ("invalidation subscriber on **new** play record"). The Deleted branch is intentionally **not** implemented here; this row documents the future hook.
+
+### Completed-event userId resolution
+
+`PlayRecordCompletedEvent` carries only `RecordId` + `Duration` (no userId). The invalidation handler resolves the owner with a single indexed lookup:
+
+```csharp
+var userId = await _context.PlayRecords
+    .Where(r => r.Id == notification.RecordId)
+    .Select(r => r.CreatedByUserId)
+    .FirstOrDefaultAsync(ct);
+```
+
+If the lookup returns `Guid.Empty` (record not found — should not happen for a just-completed record, but guards re-dispatch races), the handler no-ops.
+
+### Failure mode (best-effort invalidation)
+
+Invalidation is **best-effort**, mirroring `UserActivityCacheInvalidationEventHandler`: the `RemoveByTagAsync` call is wrapped in try/catch + structured logging so a cache/Redis hiccup never propagates into — and never rolls back — the `CompletePlayRecordCommand` that raised the event. A missed eviction self-heals at the 5-min TTL. On the read path, HybridCache L2 (Redis) failures fall back to L1 per the service contract, so stats stay available.
+
+## Consequences
+
+**Positive**
+- Repeat / concurrent `/play-records/statistics` calls within the TTL serve from L1/L2 instead of re-running the aggregation + the cross-user leaderboard scan.
+- Cross-replica correctness: L2 (Redis) is shared; a completion on replica A invalidates the shared L2 entry so replica B recomputes on its next miss.
+- Cache-stampede protection: the first miss after an eviction runs the factory once; concurrent callers wait and share the result.
+
+**Negative / trade-offs**
+- One extra indexed `SELECT CreatedByUserId` per record completion (the userId lookup). Negligible relative to a completion write.
+- Up to 5 minutes of staleness for changes that are **not** completion events but could in principle affect a cached value — specifically a future `UpdateDetails` that moves an already-`Completed` record's `SessionDate` across a cached date-window boundary. Today the only callers query the default (unbounded) window where this is a non-issue; flagged here so the trigger set is revisited if ranged queries + post-completion date edits both become common.
+
+## Alternatives considered
+
+- **Per-(user,range) tag** — would require the invalidation handler to know every cached window. Rejected; the single per-user tag evicts all windows in one call.
+- **Evict on every PlayRecord event** — simplest to reason about but wastes the cache on `Created`/`Started`/`Updated` deltas that cannot change a `Completed`-filtered projection. Rejected for the documented per-event analysis above.
+- **No server cache (status quo)** — leaves the cross-user leaderboard scan running on every call. Rejected; that scan is the most expensive part of the projection.

--- a/docs/superpowers/plans/2026-06-20-issue-2438-pr-b-redis-cache.md
+++ b/docs/superpowers/plans/2026-06-20-issue-2438-pr-b-redis-cache.md
@@ -1,0 +1,306 @@
+# #2438 PR-B — Player Statistics Redis Cache + Invalidation (BE) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cache `GetPlayerStatistics` server-side (HybridCache L1+L2 Redis, 5-min TTL) with per-user tag invalidation on the events that change a user's stats.
+
+**Architecture:** Wrap `GetPlayerStatisticsQueryHandler.Handle` with `IHybridCacheService.GetOrCreateAsync` (the exact pattern used by `GetGameLeaderboardQueryHandler`), keyed per user + date range, tagged `player-stats:{userId}`. A new MediatR `INotificationHandler` evicts that tag on `PlayRecordCompletedEvent` and `PlayRecordDeletedEvent` (the events that change which Completed records exist for a user). `PlayRecordCreatedEvent` is intentionally NOT a trigger — a freshly created record is `Planned`, and stats only count `Completed` records (documented in the ADR).
+
+**Tech Stack:** .NET 9 · MediatR · IHybridCacheService (HybridCache L1+L2 Redis) · EF Core · xUnit + Moq + Testcontainers
+
+**Reference patterns (read before implementing):**
+- cache wrapping: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryHandler.cs:19,47-55` (TTL const, key string, `GetOrCreateAsync(key, factory, tags, expiration, ct)`)
+- cache service contract: `apps/api/src/Api/Services/IHybridCacheService.cs` (`GetOrCreateAsync<T> where T:class`; `RemoveByTagAsync(tag)`)
+- invalidation handler pattern: `apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/UserActivityCacheInvalidationEventHandler.cs`
+- the handler to wrap: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs`
+- events: `PlayRecordCompletedEvent(RecordId, Duration)` (no userId), `PlayRecordDeletedEvent(RecordId, DeletedByUserId)`, both `: DomainEventBase`
+
+**Notes:** `PlayerStatisticsDto` is a `record` (reference type) → satisfies `GetOrCreateAsync<T> where T : class`. `IHybridCacheService` is registered Singleton (`InfrastructureServiceExtensions.cs:351`). MediatR auto-discovers `INotificationHandler` — no manual DI registration needed (confirm against the reference handler).
+
+**Test command:** `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PlayerStatistics|FullyQualifiedName~PlayRecordStatsCache"`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `docs/for-claude/architecture/adr/adr-NNN-player-stats-cache.md` | ADR: key schema, tag, triggers, TTL | Create |
+| `.../Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs` | inject cache, wrap Handle, extract `ComputeAsync` | Modify |
+| `.../Application/EventHandlers/PlayRecordStatsCacheInvalidationHandler.cs` | evict `player-stats:{userId}` on Completed/Deleted | Create |
+| `tests/.../PlayRecords/GetPlayerStatisticsQueryHandlerCacheTests.cs` | cache hit/miss unit | Create |
+| `tests/.../EventHandlers/PlayRecordStatsCacheInvalidationHandlerTests.cs` | invalidation unit | Create |
+| `tests/.../Integration/GameManagement/PlayerStatisticsCacheTests.cs` | end-to-end cache+invalidation (Testcontainers) | Create |
+
+---
+
+### Task 1: ADR
+
+**Files:**
+- Create: `docs/for-claude/architecture/adr/adr-NNN-player-stats-cache.md` (run `ls docs/for-claude/architecture/adr/ | tail -3` to pick the next ADR number)
+
+- [ ] **Step 1: Write the ADR** (short — context, decision, consequences):
+
+Key points to capture:
+- **Key**: `player-stats:{userId}:{startDate.Ticks ?? 0}:{endDate.Ticks ?? 0}` — per-user, per-range (mirrors `GetGameLeaderboard`'s Ticks-based key for timezone-stable, serialization-safe keys).
+- **Tag**: `player-stats:{userId}` — one tag per user, so a single `RemoveByTagAsync` evicts ALL the user's ranged entries at once (avoids enumerating date combinations).
+- **TTL**: 5 min (matches the FE React Query `staleTime` and `GetGameLeaderboard`).
+- **Triggers**: `PlayRecordCompletedEvent` + `PlayRecordDeletedEvent`. NOT `PlayRecordCreatedEvent` — a new record is `Planned`, and `GetPlayerStatistics` filters `Status == Completed`, so a Created event cannot change any cached stat. Documenting this avoids a useless eviction + a `Completed`-event userId lookup being mistaken for incompleteness.
+- **Completed userId lookup**: `PlayRecordCompletedEvent` carries no userId, so the handler resolves it via `_context.PlayRecords.IgnoreQueryFilters().Where(r => r.Id == recordId).Select(r => r.CreatedByUserId).FirstOrDefaultAsync()`. `PlayRecordDeletedEvent` carries `DeletedByUserId` directly (no lookup).
+- **Failure mode**: HybridCache L2 (Redis) failures fall back to L1 (per the service contract) — stats stay available.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/for-claude/architecture/adr/
+git commit -m "docs(adr): #2438 player-stats cache key + invalidation strategy"
+```
+
+---
+
+### Task 2: Wrap the query handler with HybridCache
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs`
+
+- [ ] **Step 1: Write the failing cache test**
+
+Create `tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerCacheTests.cs`. Mock `IHybridCacheService`; assert the handler delegates to `GetOrCreateAsync` with the expected key + tag. Mirror the mocking flavor of `DeletePlayRecordCommandHandlerTests.cs` (Moq). Because the current handler takes `MeepleAiDbContext` (not easily mockable), the cache test asserts on the cache interaction: set up the mock `GetOrCreateAsync` to invoke its factory and return its value, construct the handler with an in-memory `MeepleAiDbContext` (via `TestDbContextFactory.CreateInMemoryDbContext()`, see `GetPlayRecordQueryHandlerTests.cs`), and `Verify` the key/tag.
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public async Task Handle_UsesCacheKeyAndTagPerUserAndRange()
+{
+    var userId = Guid.NewGuid();
+    var ctx = TestDbContextFactory.CreateInMemoryDbContext();
+    var cache = new Mock<IHybridCacheService>();
+    cache.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+            It.IsAny<string[]>(),
+            It.IsAny<TimeSpan?>(),
+            It.IsAny<CancellationToken>()))
+        .Returns<string, Func<CancellationToken, Task<PlayerStatisticsDto>>, string[], TimeSpan?, CancellationToken>(
+            (key, factory, tags, exp, ct) => factory(ct));
+
+    var handler = new GetPlayerStatisticsQueryHandler(ctx, cache.Object);
+    await handler.Handle(new GetPlayerStatisticsQuery(userId, null, null), CancellationToken.None);
+
+    cache.Verify(c => c.GetOrCreateAsync(
+        It.Is<string>(k => k == $"player-stats:{userId}:0:0"),
+        It.IsAny<Func<CancellationToken, Task<PlayerStatisticsDto>>>(),
+        It.Is<string[]>(t => t.Contains($"player-stats:{userId}")),
+        It.Is<TimeSpan?>(e => e == TimeSpan.FromMinutes(5)),
+        It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run it — FAIL** (ctor has no cache param yet)
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetPlayerStatisticsQueryHandlerCacheTests"`
+Expected: FAIL (compile — `GetPlayerStatisticsQueryHandler` has no 2-arg ctor).
+
+- [ ] **Step 3: Refactor the handler — inject cache, wrap, extract compute**
+
+- Add `using Api.Services;`.
+- Add `private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);` and an `IHybridCacheService _cache` field + ctor param (mirror `GetGameLeaderboardQueryHandler`).
+- Rename the current `Handle` body to `private async Task<PlayerStatisticsDto> ComputeAsync(GetPlayerStatisticsQuery query, CancellationToken cancellationToken)` (keep its logic verbatim).
+- New `Handle`:
+
+```csharp
+public async Task<PlayerStatisticsDto> Handle(GetPlayerStatisticsQuery query, CancellationToken cancellationToken)
+{
+    ArgumentNullException.ThrowIfNull(query);
+
+    var key = $"player-stats:{query.UserId}:{query.StartDate?.Ticks ?? 0}:{query.EndDate?.Ticks ?? 0}";
+
+    return await _cache.GetOrCreateAsync(
+        key,
+        ct => ComputeAsync(query, ct),
+        tags: [$"player-stats:{query.UserId}"],
+        expiration: CacheTtl,
+        ct: cancellationToken).ConfigureAwait(false);
+}
+```
+
+> Move the `ArgumentNullException.ThrowIfNull(query)` out of `ComputeAsync` into `Handle` (above) to avoid double-null-check; keep the rest of `ComputeAsync` exactly as the current body.
+
+- [ ] **Step 4: Run it — PASS**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetPlayerStatisticsQueryHandlerCacheTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing statistics tests — no regression**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetPlayerStatistics"`
+Expected: PASS. If any existing test constructs `GetPlayerStatisticsQueryHandler(ctx)` with one arg, update it to pass a cache mock (or a pass-through `IHybridCacheService` test double). Search: `grep -rn "new GetPlayerStatisticsQueryHandler" tests/`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerCacheTests.cs
+git commit -m "feat(play-records): #2438 cache player statistics (HybridCache 5min)"
+```
+
+---
+
+### Task 3: Invalidation handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandler.cs`
+- Test: `tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandlerTests.cs`
+
+Read `UserActivityCacheInvalidationEventHandler.cs` first for the exact `INotificationHandler` + `IHybridCacheService` injection shape and namespaces.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// Deleted event → evicts player-stats:{DeletedByUserId} (no lookup)
+[Fact]
+[Trait("Category", "Unit")]
+public async Task Handle_Deleted_EvictsUserStatsTag()
+{
+    var userId = Guid.NewGuid();
+    var ctx = TestDbContextFactory.CreateInMemoryDbContext();
+    var cache = new Mock<IHybridCacheService>();
+    var handler = new PlayRecordStatsCacheInvalidationHandler(ctx, cache.Object);
+
+    await handler.Handle(new PlayRecordDeletedEvent(Guid.NewGuid(), userId), CancellationToken.None);
+
+    cache.Verify(c => c.RemoveByTagAsync($"player-stats:{userId}", It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+(Completed-event test requires seeding a record in the in-memory ctx so the userId lookup resolves; add it mirroring the integration seed pattern.)
+
+- [ ] **Step 2: Run — FAIL** (handler missing). Run the filter `~PlayRecordStatsCacheInvalidationHandlerTests`. Expected: FAIL (compile).
+
+- [ ] **Step 3: Implement the handler**
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Evicts the per-user player-statistics cache tag when a record's Completed/Deleted
+/// state changes which Completed records exist for the user (#2438). Created is not a
+/// trigger — a Planned record is not counted by GetPlayerStatistics (see ADR).
+/// </summary>
+internal sealed class PlayRecordStatsCacheInvalidationHandler
+    : INotificationHandler<PlayRecordCompletedEvent>,
+      INotificationHandler<PlayRecordDeletedEvent>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+
+    public PlayRecordStatsCacheInvalidationHandler(MeepleAiDbContext context, IHybridCacheService cache)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public async Task Handle(PlayRecordCompletedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        // Completed event carries no userId — resolve it (record is not deleted here).
+        var userId = await _context.PlayRecords
+            .IgnoreQueryFilters()
+            .Where(r => r.Id == notification.RecordId)
+            .Select(r => r.CreatedByUserId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (userId != Guid.Empty)
+        {
+            await _cache.RemoveByTagAsync($"player-stats:{userId}", cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task Handle(PlayRecordDeletedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        await _cache.RemoveByTagAsync($"player-stats:{notification.DeletedByUserId}", cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+> Verify the event property names against the actual files (`PlayRecordCompletedEvent.RecordId`, `PlayRecordDeletedEvent.RecordId`/`DeletedByUserId`). Verify MediatR auto-discovery covers this handler (the reference `UserActivityCacheInvalidationEventHandler` has no manual registration → none needed here either; if the reference IS registered manually, mirror that).
+
+- [ ] **Step 4: Run — PASS.** Then `grep`-verify no manual registration gap.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandler.cs tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/PlayRecordStatsCacheInvalidationHandlerTests.cs
+git commit -m "feat(play-records): #2438 evict stats cache on Completed/Deleted"
+```
+
+---
+
+### Task 4: Integration test (cache + invalidation end-to-end)
+
+**Files:**
+- Create: `tests/Api.Tests/Integration/GameManagement/PlayerStatisticsCacheTests.cs`
+
+Mirror `PlayRecordCommandTests.cs` for the Testcontainers fixture + `SendInScopeAsync` + seed helpers. Register a REAL `IHybridCacheService` (or the test container's) in the integration service collection if not already present.
+
+- [ ] **Step 1: Write the test**
+
+Scenario: seed a completed record for a user → query stats (miss, computes) → complete a second record (raises `PlayRecordCompletedEvent` → invalidation) → query stats again → the new record is reflected (cache was evicted, not stale).
+
+```csharp
+[Fact]
+[Trait("Category", "Integration")]
+public async Task Stats_AreInvalidated_WhenANewRecordCompletes()
+{
+    var userId = await SeedTestUserAsync();
+    var r1 = await CreateCompletedRecordAsync(userId);     // helper: create+start+complete
+    var first = await SendInScopeAsync(new GetPlayerStatisticsQuery(userId, null, null));
+    first.TotalSessions.Should().Be(1);
+
+    await CreateCompletedRecordAsync(userId);              // raises Completed → invalidation
+    var second = await SendInScopeAsync(new GetPlayerStatisticsQuery(userId, null, null));
+    second.TotalSessions.Should().Be(2);                  // NOT stale → cache was evicted
+}
+```
+
+> Build `CreateCompletedRecordAsync` from the existing `CreateTestRecordAsync` + `StartPlayRecordCommand` + `CompletePlayRecordCommand` helpers in `PlayRecordCommandTests.cs`. If the integration DI lacks `IHybridCacheService`, add it from `InfrastructureServiceExtensions` or register `HybridCacheService` in the test service collection.
+
+- [ ] **Step 2: Run — PASS** (Docker required)
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PlayerStatisticsCacheTests"`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full PlayRecord + statistics suite — no regression**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PlayRecord|FullyQualifiedName~PlayerStatistics"`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Api.Tests/Integration/GameManagement/PlayerStatisticsCacheTests.cs
+git commit -m "test(play-records): #2438 stats cache invalidation integration"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (PR-B = Redis cache + invalidation + ADR):**
+- HybridCache 5-min on GetPlayerStatistics → Task 2. ✅
+- Per-user tag invalidation on the stats-changing events → Task 3 (Completed + Deleted). ✅
+- ADR (key schema + triggers) → Task 1. ✅
+- Created-event correctly excluded (Planned ≠ counted) — documented, not a gap. ✅
+
+**2. Placeholder scan:** Event property names + MediatR auto-discovery + integration DI presence are explicit read-then-verify steps against named reference files, with fallbacks — not vague TODOs. The Completed-event unit test seed is flagged as "mirror the integration seed".
+
+**3. Type consistency:** `IHybridCacheService.GetOrCreateAsync<PlayerStatisticsDto>` (record = class ✅). Key `player-stats:{userId}:{ticks}:{ticks}` and tag `player-stats:{userId}` consistent across Tasks 1, 2, 3. `ComputeAsync` signature matches the wrapped `Handle`. `RemoveByTagAsync(string, ct)` matches the interface.
+
+**Risk:** the Completed-event userId lookup adds one indexed `SELECT` per completion — negligible. If `GetPlayerStatisticsQuery` constructor arity differs from `(userId, startDate, endDate)`, align the test calls to the real record (read `GetPlayerStatisticsQuery.cs`).


### PR DESCRIPTION
## Summary

**Part of #2438** (BE half; companion of PR #2445 FE). Caches `GetPlayerStatistics` server-side (HybridCache L1 + L2 Redis, 5-min TTL) with per-user tag invalidation.

- **Cache**: `GetPlayerStatisticsQueryHandler` wrapped with `IHybridCacheService.GetOrCreateAsync` (pattern from `GetGameLeaderboardQueryHandler`). Key `player-stats:{userId}:{startTicks}:{endTicks}`, tag `player-stats:{userId}`, TTL 5 min.
- **Invalidation**: new `PlayRecordStatsCacheInvalidationHandler` evicts the user's tag on `PlayRecordCompletedEvent` (best-effort + logged; resolves userId from recordId — the event carries none).
- **ADR-081** documents the key schema, per-user tag strategy, and per-event trigger rationale.

### Scope notes
- Created/Started/Updated are **not** triggers — Planned/InProgress records aren't counted by stats (which filter `Completed`).
- **Deleted trigger deferred to #2446**: `PlayRecordDeletedEvent` comes from #2439 (PR #2441), not yet in `main-dev` (PR-B branches from `main-dev`). ADR-081 documents this; ≤5 min staleness on delete until then.
- CSV export + leaderboard board remain out of #2438 scope (YAGNI, not selected).

## Test Plan
- [x] Cache unit (key/tag/TTL): 3/3
- [x] Invalidation unit (Completed evicts; cache errors swallowed best-effort): 4/4
- [x] Integration (Testcontainers, Postgres): cache serves + invalidation on completion: 2/2 — required forcing `DomainEventDispatchMode.Hybrid` in-test (`OutboxOnly` default would otherwise false-green)
- [x] Regression `~PlayRecord | ~PlayerStatistics`: **119/119**
- [x] Build 0 errors

## Refs
- ADR: `docs/for-claude/architecture/adr/adr-081-player-stats-cache.md`
- Plan: `docs/superpowers/plans/2026-06-20-issue-2438-pr-b-redis-cache.md`
- Companion FE: PR #2445 · Deleted-trigger follow-up: #2446

🤖 Generated with [Claude Code](https://claude.com/claude-code)