### PR TITLE
feat(catalog): #2339 sub-PR 2/3 — translations FE hook + consumer migration

### DIFF
--- a/apps/web/e2e/translations-fe-hook.spec.ts
+++ b/apps/web/e2e/translations-fe-hook.spec.ts
@@ -24,7 +24,7 @@ test.describe('useGameTitle E2E', () => {
   });
 
   test.skip(
-    ({}, testInfo) => !testInfo.project.metadata?.seedTranslations,
+    (_fixtures, testInfo) => !testInfo.project.metadata?.seedTranslations,
     'Requires sub-PR 3/3 seed translations to land first'
   );
 

--- a/apps/web/e2e/translations-fe-hook.spec.ts
+++ b/apps/web/e2e/translations-fe-hook.spec.ts
@@ -1,0 +1,68 @@
+// apps/web/e2e/translations-fe-hook.spec.ts
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #2339 sub-PR 2/3 — E2E happy path verifying that an IT user sees
+ * IT-localized titles when seed translations exist. Seed translation data
+ * lands in sub-PR 3/3; this test is guarded by `test.skip()` until then.
+ *
+ * The test asserts behavior, not the absence of UI flicker (which is covered
+ * by unit tests around useMemo identity preservation).
+ *
+ * aria-label assertions match both EN ("localized from English") and IT
+ * ("tradotto da") substrings per DEC-FE-9 i18n chiave (react-intl resolves
+ * the `common.localizedFromEnglish` key based on UI locale).
+ */
+
+test.describe('useGameTitle E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    // Force browser locale via context override
+    await page.context().addInitScript(() => {
+      Object.defineProperty(navigator, 'language', { get: () => 'it-IT' });
+      Object.defineProperty(navigator, 'languages', { get: () => ['it-IT', 'it'] });
+    });
+  });
+
+  test.skip(
+    ({}, testInfo) => !testInfo.project.metadata?.seedTranslations,
+    'Requires sub-PR 3/3 seed translations to land first'
+  );
+
+  test('IT user sees IT-localized title on Library page', async ({ page }) => {
+    await page.goto('/library');
+
+    // After seed sub-PR 3/3 lands, "Catan" → "I Coloni di Catan" in card heading
+    const catanCard = page.getByRole('article').filter({ hasText: /Coloni di Catan|Catan/ });
+    await expect(catanCard).toBeVisible();
+
+    const heading = catanCard.getByRole('heading', { level: 3 });
+    await expect(heading).toHaveText('I Coloni di Catan');
+    // DEC-FE-9: aria-label resolves via react-intl key common.localizedFromEnglish
+    // EN UI → "(localized from English: Catan)"
+    // IT UI → "(tradotto da: Catan)"
+    // Match the originalTitle "Catan" plus either localization phrase.
+    await expect(heading).toHaveAttribute(
+      'aria-label',
+      /(localized from English|tradotto da):\s*Catan/i
+    );
+  });
+
+  test('IT user sees IT-localized title on Discover page', async ({ page }) => {
+    await page.goto('/games?tab=discover');
+    const heading = page.getByRole('heading', { name: /Coloni di Catan/i });
+    await expect(heading).toBeVisible();
+  });
+
+  test('EN-override user sees canonical EN even with browser it-IT', async ({ page }) => {
+    // Set profile override via cookie or login as user with Language='en'
+    await page
+      .context()
+      .addCookies([{ name: 'preferredLocale', value: 'en', url: 'http://localhost:3000' }]);
+    await page.goto('/library');
+
+    const heading = page.getByRole('heading', { name: /^Catan$/ });
+    await expect(heading).toBeVisible();
+    // Canonical → no localization aria-label augmentation
+    await expect(heading).not.toHaveAttribute('aria-label', /localized from English|tradotto da/i);
+  });
+});

--- a/apps/web/eslint-rules/index.js
+++ b/apps/web/eslint-rules/index.js
@@ -16,9 +16,11 @@
 'use strict';
 
 const noStoreScoresDirect = require('./no-store-scores-direct.js');
+const preferUseGameTitle = require('./prefer-use-game-title.js');
 
 module.exports = {
   rules: {
     'no-store-scores-direct': noStoreScoresDirect,
+    'prefer-use-game-title': preferUseGameTitle,
   },
 };

--- a/apps/web/eslint-rules/prefer-use-game-title.js
+++ b/apps/web/eslint-rules/prefer-use-game-title.js
@@ -1,0 +1,79 @@
+/**
+ * ESLint Custom Rule: prefer-use-game-title
+ *
+ * Issue #2339 sub-PR 2/3 — encourages adoption of localization-aware title
+ * rendering. WARN-only in this PR; promote to ERROR in a follow-up PR after
+ * 14gg of trajectory verde on main-dev (per DEC-FE-8).
+ *
+ * **Problem:**
+ * Direct `game.title` JSX rendering bypasses the locale + source priority chain
+ * documented in `docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`.
+ * The canonical EN title is correct fallback, but localized users (IT, etc.)
+ * miss the translation surfaced by the BE pipeline (PR #2370).
+ *
+ * **Solution:**
+ * Use `useGameTitle(game)` from `@/lib/i18n/use-game-title` to resolve the
+ * best-fit title for the viewer locale, then render `value` in JSX.
+ *
+ * **Allow-list:**
+ * - Lines containing `useGameTitle` (heuristic — migration in progress)
+ * - `aria-label` JSX attribute values (DEC-FE-9 references canonical EN intentionally
+ *   inside the i18n placeholder for `common.localizedFromEnglish`)
+ * - Files under `__tests__/`, `.stories.*`, `.test.*` (test fixtures)
+ * - Files under `apps/web/src/lib/i18n/` (the hook itself uses `game.title`)
+ *
+ * **Scope:**
+ * Applied to all source files under apps/web/src (ts, tsx).
+ *
+ * **References:**
+ * - Issue #2339
+ * - docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md
+ * - DEC-FE-8 (warn-mode lock)
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer useGameTitle() hook over raw game.title in JSX',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      preferHook:
+        'Use `useGameTitle(game)` instead of `game.title` directly in JSX. The hook resolves locale + source priority. See docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.',
+    },
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename();
+
+    // Allow-list: skip test files, stories, and the i18n hook itself
+    if (
+      filename.includes('__tests__') ||
+      filename.includes('.stories.') ||
+      filename.includes('.test.') ||
+      filename.includes('/lib/i18n/') ||
+      filename.includes('\\lib\\i18n\\')
+    ) {
+      return {};
+    }
+
+    return {
+      'JSXExpressionContainer MemberExpression[object.name="game"][property.name="title"]'(node) {
+        const sourceCode = context.sourceCode || context.getSourceCode();
+        const lineText = sourceCode.lines[node.loc.start.line - 1];
+        if (lineText && lineText.includes('useGameTitle')) return;
+
+        let parent = node.parent;
+        while (parent && parent.type !== 'JSXAttribute') parent = parent.parent;
+        if (parent && parent.name && parent.name.name === 'aria-label') return;
+
+        context.report({ node, messageId: 'preferHook' });
+      },
+    };
+  },
+};

--- a/apps/web/eslint-rules/prefer-use-game-title.test.js
+++ b/apps/web/eslint-rules/prefer-use-game-title.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for `local/prefer-use-game-title` (issue #2339 sub-PR 2/3).
+ *
+ * Run with:
+ *   node --test apps/web/eslint-rules/prefer-use-game-title.test.js
+ */
+
+'use strict';
+
+const { RuleTester } = require('eslint');
+const test = require('node:test');
+const rule = require('./prefer-use-game-title.js');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+test('prefer-use-game-title', () => {
+  ruleTester.run('prefer-use-game-title', rule, {
+    valid: [
+      // Resolved title from useGameTitle in JSX — happy path
+      {
+        code: `function Card({ game }) {
+  const { value: title } = useGameTitle(game);
+  return <h3>{title}</h3>;
+}`,
+        filename: 'apps/web/src/components/games/GameCard.tsx',
+      },
+      // aria-label is allowed to reference canonical EN (DEC-FE-9)
+      {
+        code: `function Card({ game, title }) {
+  return <h3 aria-label={\`Localized: \${game.title}\`}>{title}</h3>;
+}`,
+        filename: 'apps/web/src/components/games/GameCard.tsx',
+      },
+      // Heuristic: line containing useGameTitle is allowed even with raw access
+      {
+        code: `function Card({ game }) {
+  const { value: title } = useGameTitle(game); /* fallback: game.title */
+  return <h3>{title}</h3>;
+}`,
+        filename: 'apps/web/src/components/games/GameCard.tsx',
+      },
+      // Test files are skipped via allow-list
+      {
+        code: `function Card({ game }) { return <h3>{game.title}</h3>; }`,
+        filename: 'apps/web/src/components/__tests__/GameCard.test.tsx',
+      },
+      // Storybook fixtures skipped
+      {
+        code: `function Card({ game }) { return <h3>{game.title}</h3>; }`,
+        filename: 'apps/web/src/components/games/GameCard.stories.tsx',
+      },
+      // The i18n hook itself uses game.title internally — allowed
+      {
+        code: `function resolveTitle(game) { return game.title; }`,
+        filename: 'apps/web/src/lib/i18n/use-game-title.ts',
+      },
+      // Non-JSX context (e.g. plain TS) — rule does not fire
+      {
+        code: `function logTitle(game) { console.log(game.title); }`,
+        filename: 'apps/web/src/lib/utils/log.ts',
+      },
+      // Different identifier (not `game`) — rule does not fire
+      {
+        code: `function Card({ board }) { return <h3>{board.title}</h3>; }`,
+        filename: 'apps/web/src/components/games/Card.tsx',
+      },
+    ],
+    invalid: [
+      {
+        code: `function Card({ game }) { return <h3>{game.title}</h3>; }`,
+        filename: 'apps/web/src/components/games/GameCard.tsx',
+        errors: [{ messageId: 'preferHook' }],
+      },
+      {
+        code: `function Hero({ game }) {
+  return (
+    <div>
+      <h1>{game.title}</h1>
+      <p>Subtitle</p>
+    </div>
+  );
+}`,
+        filename: 'apps/web/src/components/discover/Hero.tsx',
+        errors: [{ messageId: 'preferHook' }],
+      },
+    ],
+  });
+});

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -30,6 +30,8 @@ import noGameDetailOrphanRoutes from "./eslint-rules/no-game-detail-orphan-route
 // Forbids direct reads of `useLiveSessionStore(s => s.scores)`; consumers
 // must use `useSessionScores()` from @/lib/domain-hooks/useSessionScores.
 import noStoreScoresDirect from "./eslint-rules/no-store-scores-direct.js";
+// Issue #2339 sub-PR 2/3 — encourage useGameTitle() adoption (warn-only).
+import preferUseGameTitle from "./eslint-rules/prefer-use-game-title.js";
 
 export default [
   {
@@ -119,6 +121,8 @@ export default [
           "no-game-detail-orphan-routes": noGameDetailOrphanRoutes,
           // Issue #2389 Block A.7 — useLiveSessionStore.scores is deprecated; use useSessionScores() instead.
           "no-store-scores-direct": noStoreScoresDirect,
+          // Issue #2339 sub-PR 2/3 — encourage useGameTitle() adoption (warn-only per DEC-FE-8).
+          "prefer-use-game-title": preferUseGameTitle,
         },
       },
     },
@@ -289,6 +293,12 @@ export default [
       // call in ScoreBoard.tsx surfaces without breaking CI; Block C will
       // migrate ScoreBoard, promote to `error`, then remove the store field.
       "local/no-store-scores-direct": "warn",
+      // Issue #2339 sub-PR 2/3 — surfaces direct `game.title` JSX access that
+      // bypasses `useGameTitle()` locale + source priority resolution. WARN-only
+      // per DEC-FE-8 until 14gg of trajectory verde on main-dev; follow-up PR
+      // promotes to `error`. Allow-list: aria-label values (DEC-FE-9), test
+      // files, stories, lib/i18n/.
+      "local/prefer-use-game-title": "warn",
     },
     settings: {
       react: {

--- a/apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
@@ -37,6 +37,23 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+// Issue #2339 — SearchResultRow uses useTranslation for aria-label hint.
+// Mock to avoid IntlProvider dependency (test predates i18n wiring).
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (id: string, values?: Record<string, string>) =>
+      values
+        ? Object.entries(values).reduce((s, [k, v]) => s.replace(`{${k}}`, String(v)), id)
+        : id,
+  }),
+}));
+
+// Issue #2339 — useGameTitle calls useUserLocale internally; stub to return
+// a deterministic locale and skip the api.* fetch.
+vi.mock('@/hooks/useUserLocale', () => ({
+  useUserLocale: () => 'it',
+}));
+
 describe('SearchExpander', () => {
   const mockOnViewGame = vi.fn();
   const mockOnAskAboutGame = vi.fn<(game: SharedGameSearchResult) => void>();

--- a/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
@@ -42,6 +42,7 @@ import { useSharedGameDetail } from '@/hooks/useSharedGameDetail';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useUrlHashState } from '@/hooks/useUrlHashState';
 import { type SharedGameDetail, type TopContributor } from '@/lib/api/shared-games';
+import { useGameTitle } from '@/lib/i18n/use-game-title';
 
 const VALID_TAB_KEYS: ReadonlySet<TabKey> = new Set(TAB_KEYS);
 
@@ -125,6 +126,13 @@ export function SharedGameDetailPageClient({
   // SSR seed guarantees `data` is defined on first paint, but TanStack Query
   // can briefly undefine it during refetch. Fall back to the SSR `detail` prop.
   const game: SharedGameDetail = data ?? detail;
+
+  // Issue #2339 — viewer-locale title resolution. The `Hero` primitive does
+  // not currently expose an `aria-label` slot, so the
+  // `common.localizedFromEnglish` hint cannot be wired here; the title text
+  // itself is the resolved viewer-locale value. Track follow-up in the
+  // ESLint warn-rule sweep (Task 7).
+  const { value: resolvedTitle } = useGameTitle(game);
 
   // Override `empty-tab` clears nested arrays so EmptyState renders unobstructed.
   const toolkits = stateOverride === 'empty-tab' ? [] : (game.toolkits ?? []);
@@ -330,7 +338,7 @@ export function SharedGameDetailPageClient({
     >
       <div className="mx-auto flex max-w-[1024px] flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
         <Hero
-          title={game.title}
+          title={resolvedTitle}
           coverUrl={game.imageUrl && game.imageUrl.length > 0 ? game.imageUrl : null}
           year={game.yearPublished > 0 ? game.yearPublished : null}
           minPlayers={game.minPlayers > 0 ? game.minPlayers : null}

--- a/apps/web/src/components/catalog/MeepleGameCatalogCard.tsx
+++ b/apps/web/src/components/catalog/MeepleGameCatalogCard.tsx
@@ -40,6 +40,7 @@ import { useGameInLibraryStatus } from '@/hooks/queries';
 import type { GameStatusSimple } from '@/hooks/queries/useBatchGameStatus';
 import { api } from '@/lib/api';
 import type { SharedGame, SharedGameDetail } from '@/lib/api';
+import { useGameTitle } from '@/lib/i18n/use-game-title';
 
 // Dynamic imports to avoid DOMMatrix SSR error on statically generated pages
 const KbDrawerSheet = dynamic(
@@ -127,6 +128,13 @@ export function MeepleGameCatalogCard({
   className,
   libraryStatus,
 }: MeepleGameCatalogCardProps) {
+  // Issue #2339 — viewer-locale title resolution. MeepleCard primitive does
+  // not currently expose an `aria-label` slot, so the
+  // `common.localizedFromEnglish` hint cannot be wired here; the title text
+  // itself is the resolved viewer-locale value. Track follow-up in the
+  // ESLint warn-rule sweep (Task 7) when MeepleCard gains a slot.
+  const { value: title } = useGameTitle(game);
+
   // Issue #4822: Open wizard instead of direct add
   const { openWizard } = useAddGameWizard();
   const handleAddToCollection = useCallback(() => {
@@ -134,7 +142,7 @@ export function MeepleGameCatalogCard({
       { type: 'fromGameCard', sharedGameId: game.id },
       {
         gameId: game.id,
-        title: game.title,
+        title,
         imageUrl: game.imageUrl || undefined,
         thumbnailUrl: game.thumbnailUrl || undefined,
         minPlayers: game.minPlayers ?? undefined,
@@ -147,7 +155,7 @@ export function MeepleGameCatalogCard({
         source: 'catalog',
       }
     );
-  }, [openWizard, game]);
+  }, [openWizard, game, title]);
 
   // Check if game is already in user's library
   const { data: individualStatus, isLoading: statusLoading } = useGameInLibraryStatus(
@@ -246,7 +254,7 @@ export function MeepleGameCatalogCard({
       <MeepleCard
         entity="game"
         variant={variant}
-        title={game.title}
+        title={title}
         subtitle={subtitle}
         imageUrl={game.imageUrl || undefined}
         rating={game.averageRating ?? 0}

--- a/apps/web/src/components/dashboard/SearchExpander.tsx
+++ b/apps/web/src/components/dashboard/SearchExpander.tsx
@@ -13,8 +13,10 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Search, Loader2 } from 'lucide-react';
 
 import { useLibrary } from '@/hooks/queries/useLibrary';
+import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
 import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
+import { useGameTitle } from '@/lib/i18n/use-game-title';
 
 // ========== Types ==========
 
@@ -33,6 +35,13 @@ export interface SearchExpanderProps {
 
 const DEBOUNCE_MS = 300;
 const PAGE_SIZE = 5;
+
+// ========== Helpers ==========
+
+function formatPlayers(min: number, max: number): string {
+  if (min === max) return `${min} giocatori`;
+  return `${min}-${max} giocatori`;
+}
 
 // ========== Component ==========
 
@@ -139,11 +148,6 @@ export function SearchExpander({
     isInLibrary: libraryGameIds.has(game.id),
   }));
 
-  const formatPlayers = (min: number, max: number) => {
-    if (min === max) return `${min} giocatori`;
-    return `${min}-${max} giocatori`;
-  };
-
   return (
     <div data-testid="search-expander" className="absolute inset-x-4 bottom-20 z-50">
       {/* Search Input */}
@@ -167,62 +171,100 @@ export function SearchExpander({
         {enrichedResults.length > 0 && (
           <div className="mt-2 space-y-1 max-h-[280px] overflow-y-auto">
             {enrichedResults.map(game => (
-              <div
+              <SearchResultRow
                 key={game.id}
-                className="flex items-center gap-3 p-2 rounded-xl hover:bg-card/40 transition-colors"
-              >
-                {/* Thumbnail */}
-                {game.thumbnailUrl && (
-                  <img
-                    src={game.thumbnailUrl}
-                    alt={game.title}
-                    className="h-10 w-10 rounded-lg object-cover flex-shrink-0"
-                  />
-                )}
-
-                {/* Game Info */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-foreground truncate">{game.title}</span>
-                    {game.isInLibrary && (
-                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 whitespace-nowrap">
-                        ✓ In libreria
-                      </span>
-                    )}
-                  </div>
-                  <span className="text-xs text-muted-foreground">
-                    {formatPlayers(game.minPlayers, game.maxPlayers)}
-                  </span>
-                </div>
-
-                {/* Action Buttons */}
-                <div className="flex items-center gap-1.5 flex-shrink-0">
-                  <button
-                    onClick={() => onViewGame(game.id)}
-                    className="px-2.5 py-1 text-xs font-medium rounded-lg bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"
-                  >
-                    Vedi
-                  </button>
-                  <button
-                    onClick={() => onAskAboutGame(game)}
-                    className={`px-2.5 py-1 text-xs font-medium rounded-lg transition-colors ${
-                      game.isInLibrary
-                        ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
-                        : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
-                    }`}
-                  >
-                    Chiedi
-                  </button>
-                </div>
-              </div>
+                game={game}
+                onViewGame={onViewGame}
+                onAskAboutGame={onAskAboutGame}
+              />
             ))}
           </div>
         )}
 
         {/* Empty state when searching with no results */}
         {query.trim() && !isSearching && results.length === 0 && (
-          <div className="mt-2 py-4 text-center text-xs text-muted-foreground">Nessun gioco trovato</div>
+          <div className="mt-2 py-4 text-center text-xs text-muted-foreground">
+            Nessun gioco trovato
+          </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+// ========== Subcomponents ==========
+
+interface SearchResultRowProps {
+  game: SharedGameSearchResult;
+  onViewGame: (gameId: string) => void;
+  onAskAboutGame: (game: SharedGameSearchResult) => void;
+}
+
+/**
+ * Single search result row. Extracted as a subcomponent because
+ * `useGameTitle` is a hook and cannot be called inside `.map()` callbacks
+ * (Rules of Hooks). Each row resolves the viewer-locale title independently.
+ *
+ * Issue #2339 — `game.title` (canonical EN) remains the source of truth for
+ * aria-label fallback per DEC-FE-9.
+ */
+function SearchResultRow({ game, onViewGame, onAskAboutGame }: SearchResultRowProps) {
+  const { value: title, source } = useGameTitle(game);
+  const { t } = useTranslation();
+  const titleAriaLabel =
+    source === 'translation'
+      ? t('common.localizedFromEnglish', { localizedTitle: title, originalTitle: game.title })
+      : undefined;
+
+  return (
+    <div className="flex items-center gap-3 p-2 rounded-xl hover:bg-card/40 transition-colors">
+      {/* Thumbnail */}
+      {game.thumbnailUrl && (
+        <img
+          src={game.thumbnailUrl}
+          alt={title}
+          className="h-10 w-10 rounded-lg object-cover flex-shrink-0"
+        />
+      )}
+
+      {/* Game Info */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span
+            className="text-sm font-medium text-foreground truncate"
+            aria-label={titleAriaLabel}
+          >
+            {title}
+          </span>
+          {game.isInLibrary && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 whitespace-nowrap">
+              ✓ In libreria
+            </span>
+          )}
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {formatPlayers(game.minPlayers, game.maxPlayers)}
+        </span>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        <button
+          onClick={() => onViewGame(game.id)}
+          className="px-2.5 py-1 text-xs font-medium rounded-lg bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"
+        >
+          Vedi
+        </button>
+        <button
+          onClick={() => onAskAboutGame(game)}
+          className={`px-2.5 py-1 text-xs font-medium rounded-lg transition-colors ${
+            game.isInLibrary
+              ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
+              : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+          }`}
+        >
+          Chiedi
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/components/discover/GameDiscoverDetail.tsx
+++ b/apps/web/src/components/discover/GameDiscoverDetail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import type { RulebookAnalysisDto, SharedGameDetail } from '@/lib/api/schemas/shared-games.schemas';
+import { useGameTitle } from '@/lib/i18n/use-game-title';
 
 import { AnalysisResultsPanel } from './AnalysisResultsPanel';
 import { GameDiscoverHero } from './GameDiscoverHero';
@@ -15,6 +16,12 @@ interface GameDiscoverDetailProps {
 export function GameDiscoverDetail({ game }: GameDiscoverDetailProps) {
   const [analyses, setAnalyses] = useState<RulebookAnalysisDto[]>([]);
 
+  // Issue #2339 — viewer-locale title resolution. `GameRulesSection` consumes
+  // the resolved title as plain-text body copy ("Regole non ancora
+  // disponibili per X"); the canonical EN remains accessible via the Hero
+  // aria-label fallback per DEC-FE-9.
+  const { value: title } = useGameTitle(game);
+
   useEffect(() => {
     fetch(`/api/v1/shared-games/${game.id}/analysis`)
       .then(r => (r.ok ? r.json() : []))
@@ -26,7 +33,7 @@ export function GameDiscoverDetail({ game }: GameDiscoverDetailProps) {
     <div className="space-y-8">
       <GameDiscoverHero game={game} />
       {analyses.length > 0 && <AnalysisResultsPanel analyses={analyses} />}
-      <GameRulesSection rules={game.rules} gameTitle={game.title} />
+      <GameRulesSection rules={game.rules} gameTitle={title} />
     </div>
   );
 }

--- a/apps/web/src/components/discover/GameDiscoverHero.tsx
+++ b/apps/web/src/components/discover/GameDiscoverHero.tsx
@@ -8,7 +8,9 @@ import { toast } from '@/components/layout/Toast';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/primitives/button';
 import { useAddGameToLibrary, useGameInLibraryStatus } from '@/hooks/queries';
+import { useTranslation } from '@/hooks/useTranslation';
 import type { SharedGameDetail } from '@/lib/api/schemas/shared-games.schemas';
+import { useGameTitle } from '@/lib/i18n/use-game-title';
 
 interface GameDiscoverHeroProps {
   game: SharedGameDetail;
@@ -21,6 +23,15 @@ export function GameDiscoverHero({ game }: GameDiscoverHeroProps) {
   const { data: status } = useGameInLibraryStatus(game.id);
   const isInLibrary = status?.inLibrary ?? false;
 
+  // Issue #2339 — viewer-locale title resolution. `game.title` (canonical EN)
+  // remains the source of truth for aria-label fallback per DEC-FE-9.
+  const { value: title, source } = useGameTitle(game);
+  const { t } = useTranslation();
+  const titleAriaLabel =
+    source === 'translation'
+      ? t('common.localizedFromEnglish', { localizedTitle: title, originalTitle: game.title })
+      : undefined;
+
   function handleAddToLibrary() {
     if (isInLibrary) {
       router.push(`/library/${game.id}`);
@@ -30,7 +41,7 @@ export function GameDiscoverHero({ game }: GameDiscoverHeroProps) {
       { gameId: game.id },
       {
         onSuccess: () => {
-          toast.success(`${game.title} aggiunto alla tua libreria.`);
+          toast.success(`${title} aggiunto alla tua libreria.`);
           router.push(`/library/${game.id}`);
         },
         onError: error => {
@@ -53,7 +64,7 @@ export function GameDiscoverHero({ game }: GameDiscoverHeroProps) {
           {game.imageUrl ? (
             <Image
               src={game.imageUrl}
-              alt={game.title}
+              alt={title}
               fill
               className="object-cover"
               sizes="(max-width: 640px) 192px, 224px"
@@ -71,8 +82,11 @@ export function GameDiscoverHero({ game }: GameDiscoverHeroProps) {
       <div className="flex flex-1 flex-col gap-4">
         {/* Title + year */}
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            {game.title}
+          <h1
+            className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+            aria-label={titleAriaLabel}
+          >
+            {title}
           </h1>
           {game.yearPublished > 0 && (
             <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">

--- a/apps/web/src/components/features/hub/HubGameCard.tsx
+++ b/apps/web/src/components/features/hub/HubGameCard.tsx
@@ -11,8 +11,10 @@
 
 import Link from 'next/link';
 
+import { useTranslation } from '@/hooks/useTranslation';
 import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
 import { shouldUsePlaceholder } from '@/lib/games/cover-utils';
+import { useGameTitle } from '@/lib/i18n/use-game-title';
 
 export interface HubGameCardProps {
   readonly game: SharedGame;
@@ -30,6 +32,15 @@ export function HubGameCard({ game, onClick }: HubGameCardProps) {
   // routes to the deterministic emoji fallback.
   const coverSrc = game.coverUrl ?? game.thumbnailUrl ?? '';
   const showImage = !shouldUsePlaceholder(coverSrc);
+
+  // Issue #2339 — viewer-locale title resolution. `game.title` (canonical EN)
+  // remains the source of truth for aria-label fallback per DEC-FE-9.
+  const { value: title, source } = useGameTitle(game);
+  const { t } = useTranslation();
+  const titleAriaLabel =
+    source === 'translation'
+      ? t('common.localizedFromEnglish', { localizedTitle: title, originalTitle: game.title })
+      : undefined;
   return (
     <Link
       href={`/games/${game.id}`}
@@ -57,8 +68,11 @@ export function HubGameCard({ game, onClick }: HubGameCardProps) {
         )}
       </div>
       <div className="flex flex-col gap-1 p-3">
-        <h3 className="line-clamp-1 font-bold font-[Quicksand] text-sm text-foreground">
-          {game.title}
+        <h3
+          className="line-clamp-1 font-bold font-[Quicksand] text-sm text-foreground"
+          aria-label={titleAriaLabel}
+        >
+          {title}
         </h3>
         <div className="font-mono text-[10px] text-muted-foreground">
           {formatYear(game.yearPublished)}

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -227,12 +227,12 @@ export const SharedGameSchema = z.object({
   // populated a cover for this game; consumers MUST fall back to a
   // deterministic placeholder via `lib/games/cover-utils.ts`.
   coverUrl: z.string().url().nullable().optional(),
-  // Issue #2339 sub-PR 2/3 — localized titles. Null = legacy admin endpoint
-  // that doesn't surface translations; empty array = explicit "no translations".
-  // FE consumers use `useGameTitle(game)` to resolve the best-fit title; never
-  // read `translations` directly to avoid bypassing the source/locale priority
-  // chain documented in docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
-  translations: z.array(SharedGameTranslationDtoSchema).nullable().default([]),
+  // Issue #2339 — see SharedGameTranslationDtoSchema docstring above.
+  translations: z
+    .array(SharedGameTranslationDtoSchema)
+    .nullable()
+    .default([])
+    .transform(v => v ?? []),
 });
 
 export type SharedGame = z.infer<typeof SharedGameSchema>;
@@ -347,12 +347,12 @@ export const SharedGameDetailSchema = z.object({
   hasKnowledgeBase: z.boolean().default(false),
   isTopRated: z.boolean().default(false),
   isNew: z.boolean().default(false),
-  // Issue #2339 sub-PR 2/3 — localized titles. Null = legacy admin endpoint
-  // that doesn't surface translations; empty array = explicit "no translations".
-  // FE consumers use `useGameTitle(game)` to resolve the best-fit title; never
-  // read `translations` directly to avoid bypassing the source/locale priority
-  // chain documented in docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
-  translations: z.array(SharedGameTranslationDtoSchema).nullable().default([]),
+  // Issue #2339 — see SharedGameTranslationDtoSchema docstring above.
+  translations: z
+    .array(SharedGameTranslationDtoSchema)
+    .nullable()
+    .default([])
+    .transform(v => v ?? []),
 });
 
 export type SharedGameDetail = z.infer<typeof SharedGameDetailSchema>;

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -158,6 +158,37 @@ export const GamePublisherSchema = z.object({
 
 export type GamePublisher = z.infer<typeof GamePublisherSchema>;
 
+// ========== Translations (Issue #2339 sub-PR 2/3) ==========
+
+/**
+ * Translation source provider, mirroring backend `TranslationSource` enum.
+ *
+ * - `manual` — admin-curated translation (highest quality).
+ * - `auto-openrouter` — machine-translated via OpenRouter (DeepSeek V3).
+ * - `community` — community-sourced (future feature, no moderation in MVP).
+ *
+ * See `useGameTitle()` hook (apps/web/src/hooks/useGameTitle.ts) for the
+ * source priority chain (manual > auto-openrouter > community).
+ */
+export const TranslationProviderSchema = z.enum(['manual', 'auto-openrouter', 'community']);
+export type TranslationProvider = z.infer<typeof TranslationProviderSchema>;
+
+/**
+ * Single non-EN game title localization (Issue #2339).
+ *
+ * Returned by 4 SharedGameCatalog query handlers (GetAllSharedGames,
+ * SearchSharedGames, GetFilteredSharedGames, GetPendingApprovalGames) enriched
+ * via `IGameTitleResolver`. Canonical EN remains on `SharedGameDto.title`.
+ */
+export const SharedGameTranslationDtoSchema = z.object({
+  locale: z.string().min(2).max(10), // 'it', 'en-GB', etc. (ISO 639-1 + optional region)
+  title: z.string().min(1).max(500),
+  description: z.string().nullable(),
+  source: TranslationProviderSchema,
+});
+
+export type SharedGameTranslationDto = z.infer<typeof SharedGameTranslationDtoSchema>;
+
 // ========== Shared Game DTOs ==========
 
 /**
@@ -196,6 +227,12 @@ export const SharedGameSchema = z.object({
   // populated a cover for this game; consumers MUST fall back to a
   // deterministic placeholder via `lib/games/cover-utils.ts`.
   coverUrl: z.string().url().nullable().optional(),
+  // Issue #2339 sub-PR 2/3 — localized titles. Null = legacy admin endpoint
+  // that doesn't surface translations; empty array = explicit "no translations".
+  // FE consumers use `useGameTitle(game)` to resolve the best-fit title; never
+  // read `translations` directly to avoid bypassing the source/locale priority
+  // chain documented in docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
+  translations: z.array(SharedGameTranslationDtoSchema).nullable().default([]),
 });
 
 export type SharedGame = z.infer<typeof SharedGameSchema>;
@@ -310,6 +347,12 @@ export const SharedGameDetailSchema = z.object({
   hasKnowledgeBase: z.boolean().default(false),
   isTopRated: z.boolean().default(false),
   isNew: z.boolean().default(false),
+  // Issue #2339 sub-PR 2/3 — localized titles. Null = legacy admin endpoint
+  // that doesn't surface translations; empty array = explicit "no translations".
+  // FE consumers use `useGameTitle(game)` to resolve the best-fit title; never
+  // read `translations` directly to avoid bypassing the source/locale priority
+  // chain documented in docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
+  translations: z.array(SharedGameTranslationDtoSchema).nullable().default([]),
 });
 
 export type SharedGameDetail = z.infer<typeof SharedGameDetailSchema>;

--- a/apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts
+++ b/apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts
@@ -1,0 +1,60 @@
+// apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { pickBestTranslation } from '@/lib/i18n/pick-best-translation';
+import type { SharedGameTranslationDto } from '@/lib/api/schemas/shared-games.schemas';
+
+const TR = (overrides: Partial<SharedGameTranslationDto>): SharedGameTranslationDto => ({
+  locale: 'it',
+  title: 'Titolo',
+  description: null,
+  source: 'manual',
+  ...overrides,
+});
+
+describe('pickBestTranslation', () => {
+  it('returns null when no translation matches locale', () => {
+    expect(pickBestTranslation([TR({ locale: 'it' })], 'fr')).toBeNull();
+  });
+
+  it('prefers manual over auto-openrouter for same locale', () => {
+    const result = pickBestTranslation(
+      [
+        TR({ locale: 'it', title: 'Auto', source: 'auto-openrouter' }),
+        TR({ locale: 'it', title: 'Manual', source: 'manual' }),
+      ],
+      'it'
+    );
+    expect(result?.title).toBe('Manual');
+    expect(result?.source).toBe('manual');
+  });
+
+  it('prefers auto-openrouter over community for same locale', () => {
+    const result = pickBestTranslation(
+      [
+        TR({ locale: 'it', title: 'Community', source: 'community' }),
+        TR({ locale: 'it', title: 'Auto', source: 'auto-openrouter' }),
+      ],
+      'it'
+    );
+    expect(result?.title).toBe('Auto');
+    expect(result?.source).toBe('auto-openrouter');
+  });
+
+  it('returns single match when only one source available', () => {
+    const result = pickBestTranslation(
+      [TR({ locale: 'it', title: 'Only', source: 'community' })],
+      'it'
+    );
+    expect(result?.title).toBe('Only');
+    expect(result?.source).toBe('community');
+  });
+
+  it('returns null for empty translations list', () => {
+    expect(pickBestTranslation([], 'it')).toBeNull();
+  });
+
+  it('matches exact locale only (no BCP-47 fallback here — that is resolveLocale)', () => {
+    expect(pickBestTranslation([TR({ locale: 'it' })], 'it-IT')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts
+++ b/apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts
@@ -1,0 +1,41 @@
+// apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocale } from '@/lib/i18n/resolve-locale';
+
+describe('resolveLocale', () => {
+  it('returns exact match when present', () => {
+    expect(resolveLocale('it-IT', ['it-IT', 'it', 'en'])).toBe('it-IT');
+  });
+
+  it('falls back from region to language', () => {
+    expect(resolveLocale('it-IT', ['it'])).toBe('it');
+  });
+
+  it('returns null when only language requested but region available', () => {
+    // User did NOT request a region; we should not upgrade.
+    expect(resolveLocale('it', ['it-IT'])).toBeNull();
+  });
+
+  it('returns exact when both available', () => {
+    expect(resolveLocale('it-IT', ['it-IT', 'it'])).toBe('it-IT');
+  });
+
+  it('returns null for unmatched locale', () => {
+    expect(resolveLocale('de', ['it', 'fr'])).toBeNull();
+  });
+
+  it('returns null for empty available list', () => {
+    expect(resolveLocale('it', [])).toBeNull();
+  });
+
+  it('is case-insensitive on the language segment', () => {
+    expect(resolveLocale('IT', ['it'])).toBe('it');
+    expect(resolveLocale('it', ['IT'])).toBe('IT');
+  });
+
+  it('preserves region casing in the returned value', () => {
+    // We return the matching available locale string verbatim (don't re-normalize).
+    expect(resolveLocale('it-it', ['it-IT'])).toBe('it-IT');
+  });
+});

--- a/apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
+++ b/apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
@@ -1,0 +1,136 @@
+// apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useGameTitle } from '@/lib/i18n/use-game-title';
+import * as useUserLocaleModule from '@/hooks/useUserLocale';
+import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
+
+const BASE_GAME: Pick<SharedGame, 'id' | 'title' | 'translations'> = {
+  id: '00000000-0000-0000-0000-000000000001' as never,
+  title: 'Catan',
+  translations: [],
+};
+
+function mockUserLocale(locale: 'it' | 'en' | 'es' | 'fr' | 'de') {
+  vi.spyOn(useUserLocaleModule, 'useUserLocale').mockReturnValue(locale);
+}
+
+describe('useGameTitle (matrix T1-T6)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('T1: en user, no translations → canonical EN', () => {
+    mockUserLocale('en');
+    const { result } = renderHook(() => useGameTitle(BASE_GAME));
+    expect(result.current).toEqual({
+      value: 'Catan',
+      source: 'canonical',
+      locale: 'en',
+    });
+  });
+
+  it('T2: it user, [it manual] → IT manual translation', () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        { locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const },
+      ],
+    };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current).toEqual({
+      value: 'I Coloni di Catan',
+      source: 'translation',
+      locale: 'it',
+      provider: 'manual',
+    });
+  });
+
+  it('T3: it-IT user, [it manual] → IT manual (BCP-47 fallback)', () => {
+    // The user-locale hook returns 'it' for it-IT (drops region). To simulate
+    // it-IT we override via the options arg.
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        { locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const },
+      ],
+    };
+    const { result } = renderHook(() => useGameTitle(game, { locale: 'it-IT' }));
+    expect(result.current).toEqual({
+      value: 'I Coloni di Catan',
+      source: 'translation',
+      locale: 'it', // resolved via fallback, not it-IT
+      provider: 'manual',
+    });
+  });
+
+  it('T4: de user, [it manual, fr community] → canonical EN', () => {
+    mockUserLocale('de');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        { locale: 'it', title: 'IT', description: null, source: 'manual' as const },
+        { locale: 'fr', title: 'FR', description: null, source: 'community' as const },
+      ],
+    };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current.value).toBe('Catan');
+    expect(result.current.source).toBe('canonical');
+  });
+
+  it('T5: explicit override en, [it manual] → canonical EN (override wins)', () => {
+    // Even with browser/profile it, an explicit options.locale='en' overrides.
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'IT', description: null, source: 'manual' as const }],
+    };
+    const { result } = renderHook(() => useGameTitle(game, { locale: 'en' }));
+    expect(result.current).toEqual({
+      value: 'Catan',
+      source: 'canonical',
+      locale: 'en',
+    });
+  });
+
+  it('T6: it user, [it manual, it auto-openrouter] → manual wins (source priority)', () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        { locale: 'it', title: 'Auto MT', description: null, source: 'auto-openrouter' as const },
+        { locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const },
+      ],
+    };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current).toEqual({
+      value: 'I Coloni di Catan',
+      source: 'translation',
+      locale: 'it',
+      provider: 'manual',
+    });
+  });
+
+  it('handles null translations payload defensively (backward compat)', () => {
+    mockUserLocale('it');
+    const game = { ...BASE_GAME, translations: null as never };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current.value).toBe('Catan');
+    expect(result.current.source).toBe('canonical');
+  });
+
+  it('memoizes: re-render with same inputs returns same object reference', () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'IT', description: null, source: 'manual' as const }],
+    };
+    const { result, rerender } = renderHook(() => useGameTitle(game));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
+++ b/apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
@@ -1,10 +1,18 @@
 // apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { IntlProvider } from 'react-intl';
 
 import { useGameTitle } from '@/lib/i18n/use-game-title';
 import * as useUserLocaleModule from '@/hooks/useUserLocale';
+import { useTranslation } from '@/hooks/useTranslation';
 import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
+
+import enMessages from '@/locales/en.json';
+import itMessages from '@/locales/it.json';
+
+expect.extend(toHaveNoViolations);
 
 const BASE_GAME: Pick<SharedGame, 'id' | 'title' | 'translations'> = {
   id: '00000000-0000-0000-0000-000000000001' as never,
@@ -132,5 +140,116 @@ describe('useGameTitle (matrix T1-T6)', () => {
     const first = result.current;
     rerender();
     expect(result.current).toBe(first);
+  });
+});
+
+// ─── A11y tests (A1/A2/A3) ──────────────────────────────────────────────────
+// DEC-FE-9: aria-label uses i18n key `common.localizedFromEnglish` via
+// react-intl, NOT a hardcoded EN string. Localized for both UI=en and UI=it.
+
+/**
+ * Flatten nested locale JSON to dot-notation keys for react-intl messages.
+ * `common.localizedFromEnglish` → flat["common.localizedFromEnglish"] = "..."
+ */
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'string') {
+      result[path] = value;
+    } else if (value && typeof value === 'object') {
+      Object.assign(result, flatten(value as Record<string, unknown>, path));
+    }
+  }
+  return result;
+}
+
+const EN_FLAT = flatten(enMessages as Record<string, unknown>);
+const IT_FLAT = flatten(itMessages as Record<string, unknown>);
+
+function renderWithIntl(locale: 'en' | 'it', component: React.ReactElement) {
+  const messages = locale === 'en' ? EN_FLAT : IT_FLAT;
+  return render(
+    <IntlProvider locale={locale} messages={messages}>
+      {component}
+    </IntlProvider>
+  );
+}
+
+describe('useGameTitle a11y (axe AA + DEC-FE-9 i18n)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function CardWithAriaLabel({ game }: { game: typeof BASE_GAME }) {
+    const { value, source } = useGameTitle(game);
+    const { t } = useTranslation();
+    const ariaLabel =
+      source === 'translation'
+        ? t('common.localizedFromEnglish', {
+            localizedTitle: value,
+            originalTitle: game.title,
+          })
+        : undefined;
+    return <h3 aria-label={ariaLabel}>{value}</h3>;
+  }
+
+  it('A1: localized title aria-label uses common.localizedFromEnglish key (UI=en)', async () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        {
+          locale: 'it',
+          title: 'I Coloni di Catan',
+          description: null,
+          source: 'manual' as const,
+        },
+      ],
+    };
+
+    const { container } = renderWithIntl('en', <CardWithAriaLabel game={game} />);
+    const heading = container.querySelector('h3')!;
+    expect(heading.getAttribute('aria-label')).toContain('localized from English');
+    expect(heading.getAttribute('aria-label')).toContain('Catan');
+    expect(heading.getAttribute('aria-label')).toContain('I Coloni di Catan');
+
+    const axeResults = await axe(container);
+    expect(axeResults).toHaveNoViolations();
+  });
+
+  it('A2: canonical title rendered with no aria-label augmentation', async () => {
+    mockUserLocale('en');
+
+    const { container } = renderWithIntl('en', <CardWithAriaLabel game={BASE_GAME} />);
+    const heading = container.querySelector('h3')!;
+    expect(heading.getAttribute('aria-label')).toBeNull();
+
+    const axeResults = await axe(container);
+    expect(axeResults).toHaveNoViolations();
+  });
+
+  it('A3: localized title aria-label uses IT translation when UI locale=it', async () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        {
+          locale: 'it',
+          title: 'I Coloni di Catan',
+          description: null,
+          source: 'manual' as const,
+        },
+      ],
+    };
+
+    const { container } = renderWithIntl('it', <CardWithAriaLabel game={game} />);
+    const heading = container.querySelector('h3')!;
+    expect(heading.getAttribute('aria-label')).toContain('tradotto da');
+    expect(heading.getAttribute('aria-label')).toContain('Catan');
+    expect(heading.getAttribute('aria-label')).toContain('I Coloni di Catan');
+
+    const axeResults = await axe(container);
+    expect(axeResults).toHaveNoViolations();
   });
 });

--- a/apps/web/src/lib/i18n/pick-best-translation.ts
+++ b/apps/web/src/lib/i18n/pick-best-translation.ts
@@ -1,0 +1,45 @@
+// apps/web/src/lib/i18n/pick-best-translation.ts
+import type {
+  SharedGameTranslationDto,
+  TranslationProvider,
+} from '@/lib/api/schemas/shared-games.schemas';
+
+/**
+ * Source priority chain. Lower index = higher priority.
+ *
+ * - `manual`           → admin-curated, highest quality (REQ-FE-4).
+ * - `auto-openrouter`  → machine-translated via DeepSeek V3.
+ * - `community`        → community-sourced, no moderation in MVP.
+ */
+const SOURCE_PRIORITY: ReadonlyArray<TranslationProvider> = [
+  'manual',
+  'auto-openrouter',
+  'community',
+];
+
+/**
+ * Picks the highest-priority translation matching an exact locale string.
+ *
+ * Does NOT apply BCP-47 fallback — that's `resolveLocale`'s job. Call this
+ * AFTER resolving the user's requested locale to an available one.
+ *
+ * @returns The best translation or `null` if no exact match exists.
+ *
+ * Issue #2339 sub-PR 2/3 — see spec
+ * docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md §5.4 REQ-FE-4.
+ */
+export function pickBestTranslation(
+  translations: ReadonlyArray<SharedGameTranslationDto>,
+  locale: string
+): SharedGameTranslationDto | null {
+  const matching = translations.filter(t => t.locale === locale);
+  if (matching.length === 0) return null;
+
+  for (const source of SOURCE_PRIORITY) {
+    const found = matching.find(t => t.source === source);
+    if (found) return found;
+  }
+
+  // Should be unreachable (all enum members covered), but defensive.
+  return matching[0];
+}

--- a/apps/web/src/lib/i18n/resolve-locale.ts
+++ b/apps/web/src/lib/i18n/resolve-locale.ts
@@ -1,0 +1,48 @@
+// apps/web/src/lib/i18n/resolve-locale.ts
+/**
+ * Picks the best-fit available locale for a user-preferred locale, per BCP-47.
+ *
+ * Fallback chain:
+ *   1. Exact match (case-insensitive on language; region case-preserved by the
+ *      caller-supplied available list).
+ *   2. Language-only match: a "xx-YY" user can fall back to "xx" if it exists.
+ *   3. null: caller falls back to canonical EN.
+ *
+ * The hook does NOT upgrade a language-only request to a region-specific
+ * available locale ("it" user → "it-IT" available is treated as no match)
+ * because the user did not request a specific region and we cannot infer one
+ * without surprise.
+ *
+ * @example
+ *   resolveLocale('it-IT', ['it'])         → 'it'    (region drop fallback)
+ *   resolveLocale('it', ['it-IT'])         → null    (cannot upgrade)
+ *   resolveLocale('it-IT', ['it-IT'])      → 'it-IT' (exact wins)
+ *   resolveLocale('it-IT', ['it-IT','it']) → 'it-IT' (exact precedes fallback)
+ *
+ * Issue #2339 sub-PR 2/3 — see spec
+ * docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md §6.
+ */
+export function resolveLocale(
+  userLocale: string,
+  availableLocales: ReadonlyArray<string>
+): string | null {
+  if (availableLocales.length === 0) return null;
+
+  const normalizedUser = userLocale.trim();
+  if (!normalizedUser) return null;
+
+  const userLanguage = normalizedUser.split('-')[0].toLowerCase();
+
+  // 1. Exact case-insensitive match
+  const exact = availableLocales.find(l => l.toLowerCase() === normalizedUser.toLowerCase());
+  if (exact) return exact;
+
+  // 2. Language-only fallback (only when user requested a region)
+  const userHasRegion = normalizedUser.includes('-');
+  if (userHasRegion) {
+    const languageMatch = availableLocales.find(l => l.toLowerCase() === userLanguage);
+    if (languageMatch) return languageMatch;
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/i18n/use-game-title.ts
+++ b/apps/web/src/lib/i18n/use-game-title.ts
@@ -1,0 +1,109 @@
+// apps/web/src/lib/i18n/use-game-title.ts
+import { useMemo } from 'react';
+
+import { useUserLocale, type SupportedLocale } from '@/hooks/useUserLocale';
+import type {
+  SharedGame,
+  SharedGameTranslationDto,
+  TranslationProvider,
+} from '@/lib/api/schemas/shared-games.schemas';
+import { pickBestTranslation } from '@/lib/i18n/pick-best-translation';
+import { resolveLocale } from '@/lib/i18n/resolve-locale';
+
+/**
+ * Result of resolving a game's title for the current viewer locale.
+ *
+ * Discriminated by `source`:
+ * - `'canonical'` → no translation matched; `value` is `game.title` (EN);
+ *                  `provider` is undefined.
+ * - `'translation'` → a translation matched; `value` is the localized title;
+ *                    `provider` is the authoring source (manual / auto-openrouter / community).
+ *
+ * `locale` reflects the resolved tag (e.g. `'it-IT'` if exact match, `'it'` if
+ * BCP-47 fallback, `'en'` if canonical fallback).
+ */
+export interface ResolvedTitle {
+  value: string;
+  source: 'canonical' | 'translation';
+  locale: string;
+  provider?: TranslationProvider;
+}
+
+export interface UseGameTitleOptions {
+  /**
+   * Force a specific locale, bypassing `useUserLocale()` entirely.
+   * Useful for admin previewing other locales without changing profile state.
+   */
+  locale?: string;
+}
+
+interface GameTitleInput {
+  title: string;
+  translations: ReadonlyArray<SharedGameTranslationDto> | null;
+}
+
+/**
+ * Resolve the best-fit title for a SharedGame given the current viewer locale.
+ *
+ * Pure + memoized: safe to call inside `.map()` callbacks. Re-resolves only
+ * when `game.id` (when present), `game.translations`, or the resolved locale
+ * changes.
+ *
+ * Per design spec §5: REQ-FE-1..5 enforce locale exact-match → BCP-47 language
+ * fallback → canonical EN, with source priority manual > auto-openrouter >
+ * community when multiple translations exist for the same locale.
+ *
+ * Issue #2339 sub-PR 2/3 — see
+ * docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
+ */
+export function useGameTitle(
+  game: GameTitleInput & Partial<Pick<SharedGame, 'id'>>,
+  options?: UseGameTitleOptions
+): ResolvedTitle {
+  const profileLocale: SupportedLocale = useUserLocale();
+  const targetLocale: string = options?.locale ?? profileLocale;
+
+  // Destructure primitive/stable props so memoization is keyed by value, not
+  // by `game` object reference (which may churn in parent re-renders).
+  // Note: `game.id` is intentionally excluded — `resolveTitle` is a pure
+  // function of `{title, translations}` so id has no bearing on the output.
+  const { title, translations } = game;
+
+  return useMemo(
+    () => resolveTitle({ title, translations }, targetLocale),
+    [title, translations, targetLocale]
+  );
+}
+
+/**
+ * Pure resolution function — exported for unit testing without React lifecycle.
+ * @internal
+ */
+export function resolveTitle(game: GameTitleInput, locale: string): ResolvedTitle {
+  const translations = game.translations ?? [];
+
+  if (translations.length === 0) {
+    return { value: game.title, source: 'canonical', locale: 'en' };
+  }
+
+  const availableLocales = Array.from(new Set(translations.map(t => t.locale)));
+  const matched = resolveLocale(locale, availableLocales);
+
+  if (matched === null) {
+    return { value: game.title, source: 'canonical', locale: 'en' };
+  }
+
+  const best = pickBestTranslation(translations, matched);
+  if (best === null) {
+    // Defensive: resolveLocale matched but pickBest returned null — shouldn't
+    // happen in practice (same input set). Fallback canonical.
+    return { value: game.title, source: 'canonical', locale: 'en' };
+  }
+
+  return {
+    value: best.title,
+    source: 'translation',
+    locale: matched,
+    provider: best.source,
+  };
+}

--- a/apps/web/src/lib/shared-games/visual-test-fixture.ts
+++ b/apps/web/src/lib/shared-games/visual-test-fixture.ts
@@ -126,6 +126,7 @@ const FIXTURE_DETAIL: SharedGameDetail = {
   hasKnowledgeBase: true,
   isTopRated: true,
   isNew: false,
+  translations: [],
 };
 
 const FIXTURE_CONTRIBUTORS: readonly TopContributor[] = [

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -357,6 +357,7 @@
     "filter": "Filter",
     "import": "Import",
     "loading": "Loading...",
+    "localizedFromEnglish": "{localizedTitle} (localized from English: {originalTitle})",
     "loginRequired": "Login required to continue.",
     "next": "Next",
     "no": "No",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -348,6 +348,7 @@
     "filter": "Filtra",
     "import": "Importa",
     "loading": "Caricamento...",
+    "localizedFromEnglish": "{localizedTitle} (tradotto da: {originalTitle})",
     "loginRequired": "Accesso richiesto per continuare.",
     "next": "Avanti",
     "no": "No",

--- a/docs/superpowers/plans/2026-06-20-translations-fe-hook.md
+++ b/docs/superpowers/plans/2026-06-20-translations-fe-hook.md
@@ -1,0 +1,1241 @@
+# Shared Game Translations — Frontend Hook Implementation Plan (sub-PR 2/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship FE hook `useGameTitle()` + Zod DTO `translations[]` extension + 5 highest-traffic consumer migration + ESLint rule warn-mode + axe AA gate, closing sub-PR 2/3 of issue [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339) per design spec [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](../specs/2026-06-20-translations-fe-hook-design.md).
+
+**Architecture:** Pure helpers `resolveLocale` + `pickBestTranslation` composed inside `useGameTitle()` hook → `ResolvedTitle` discriminated union. Hook consumes existing `useUserLocale` for the override chain. Zod schema extension is additive (optional field). No new dependencies; no React Query; pure `useMemo` cache.
+
+**Tech Stack:** Next.js 16 + React 19 + TypeScript 5 + Zod 3 + Vitest + React Testing Library + `@axe-core/react` + MSW (for Accept-Language mocking) + Playwright (E2E happy-path).
+
+**Spec source**: [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](../specs/2026-06-20-translations-fe-hook-design.md)
+
+---
+
+## Branch & PR conventions
+
+- **Parent branch**: `main-dev` (per CLAUDE.md branch hygiene)
+- **Feature branch**: `feature/issue-2339-translations-fe-hook`
+- **Branch parent config**:
+  ```bash
+  git config branch.feature/issue-2339-translations-fe-hook.parent main-dev
+  ```
+- **PR target**: `main-dev`
+- **PR title**: `feat(catalog): #2339 sub-PR 2/3 — useGameTitle hook + DTO translations[] + consumer migration`
+- **Commit prefix**: `feat(catalog)`, `test(catalog)`, `refactor(catalog)`, `chore(lint)` as appropriate
+- **Co-author footer** on commits:
+  ```
+  Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+  ```
+
+---
+
+## File Structure
+
+### Files to CREATE
+
+```
+apps/web/src/lib/i18n/
+├── resolve-locale.ts             (pure BCP-47 fallback helper)
+├── pick-best-translation.ts      (pure source priority helper)
+├── use-game-title.ts             (hook wrapping the 2 helpers + useMemo)
+└── __tests__/
+    ├── resolve-locale.test.ts
+    ├── pick-best-translation.test.ts
+    └── use-game-title.test.tsx
+```
+
+### Files to MODIFY
+
+```
+apps/web/src/lib/api/schemas/shared-games.schemas.ts
+  → add SharedGameTranslationDtoSchema export
+  → add `translations: z.array(SharedGameTranslationDtoSchema).nullable().default([])`
+    to SharedGameSchema and SharedGameDetailSchema
+```
+
+### Files to MIGRATE (5 highest-traffic, Task 6.2 list)
+
+```
+apps/web/src/components/discover/GameDiscoverDetail.tsx
+apps/web/src/components/features/hub/HubGameCard.tsx
+apps/web/src/components/games/MeepleGameCard.tsx
+apps/web/src/components/library/MeepleUserLibraryCard.tsx
+apps/web/src/app/(public)/shared-games/[id]/page-client.tsx
+```
+
+### Files to CREATE (codemod + lint)
+
+```
+apps/web/scripts/codemod/use-game-title-migration.ts     (jscodeshift script, idempotent)
+apps/web/eslint-rules/prefer-use-game-title.js           (custom rule, warn mode)
+apps/web/.eslintrc.js                                    (modify: register rule)
+```
+
+### Test files
+
+```
+apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx    (6 matrix rows + 2 a11y)
+apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts     (8+ BCP-47 cases)
+apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts (4+ source priority cases)
+apps/web/e2e/translations-fe-hook.spec.ts                  (Playwright Accept-Language flow)
+```
+
+---
+
+## Pre-flight checks
+
+- [ ] **Pre-flight 0.1: Verify HEAD is on main-dev clean**
+
+  ```bash
+  git branch --show-current  # MUST print main-dev
+  git status                 # MUST show clean tree
+  git pull --ff-only         # MUST succeed
+  ```
+
+  If `git branch --show-current` prints `feature/...`, STOP. Run `git checkout main-dev && git pull` first (per CLAUDE.md § Branch Hygiene Rule).
+
+- [ ] **Pre-flight 0.2: Verify BE DTO + repository still on main-dev**
+
+  ```bash
+  grep -n "Translations = null" apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs
+  ```
+
+  Expected: line 64 confirms `IReadOnlyList<SharedGameTranslationDto>? Translations = null`. If missing, sub-PR 1/3 (PR #2370) was reverted — STOP and investigate.
+
+- [ ] **Pre-flight 0.3: Confirm existing `useUserLocale` hook still exposes the expected API**
+
+  ```bash
+  grep -n "^export function useUserLocale" apps/web/src/hooks/useUserLocale.ts
+  ```
+
+  Expected: line 100 confirms `useUserLocale(): SupportedLocale`. If signature changed, adapt Task 2 accordingly.
+
+- [ ] **Pre-flight 0.4: Create feature branch**
+
+  ```bash
+  git checkout -b feature/issue-2339-translations-fe-hook
+  git config branch.feature/issue-2339-translations-fe-hook.parent main-dev
+  ```
+
+---
+
+## Task 1: Zod schema extension — DTO TypeScript update
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/shared-games.schemas.ts`
+
+### Step 1.1: Add `SharedGameTranslationDtoSchema` export
+
+After line 160 (just before `// ========== Shared Game DTOs ==========`), insert:
+
+```ts
+// ========== Translations (Issue #2339 sub-PR 2/3) ==========
+
+/**
+ * Translation source provider, mirroring backend `TranslationSource` enum.
+ *
+ * - `manual` — admin-curated translation (highest quality).
+ * - `auto-openrouter` — machine-translated via OpenRouter (DeepSeek V3).
+ * - `community` — community-sourced (future feature, no moderation in MVP).
+ *
+ * See `useGameTitle()` hook (apps/web/src/lib/i18n/use-game-title.ts) for the
+ * source priority chain (manual > auto-openrouter > community).
+ */
+export const TranslationProviderSchema = z.enum(['manual', 'auto-openrouter', 'community']);
+export type TranslationProvider = z.infer<typeof TranslationProviderSchema>;
+
+/**
+ * Single non-EN game title localization (Issue #2339).
+ *
+ * Returned by 4 SharedGameCatalog query handlers (GetAllSharedGames,
+ * SearchSharedGames, GetFilteredSharedGames, GetPendingApprovalGames) enriched
+ * via `IGameTitleResolver`. Canonical EN remains on `SharedGameDto.title`.
+ */
+export const SharedGameTranslationDtoSchema = z.object({
+  locale: z.string().min(2).max(10), // 'it', 'en-GB', etc. (ISO 639-1 + optional region)
+  title: z.string().min(1).max(500),
+  description: z.string().nullable(),
+  source: TranslationProviderSchema,
+});
+
+export type SharedGameTranslationDto = z.infer<typeof SharedGameTranslationDtoSchema>;
+```
+
+### Step 1.2: Extend `SharedGameSchema` with `translations` field
+
+Modify `SharedGameSchema` (currently at line 166-199). Add the new field just before the closing `})`:
+
+```ts
+  // Issue #2339 sub-PR 2/3 — localized titles. Null = legacy admin endpoint
+  // that doesn't surface translations; empty array = explicit "no translations".
+  // FE consumers use `useGameTitle(game)` to resolve the best-fit title; never
+  // read `translations` directly to avoid bypassing the source/locale priority
+  // chain documented in docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
+  translations: z.array(SharedGameTranslationDtoSchema).nullable().default([]),
+```
+
+### Step 1.3: Extend `SharedGameDetailSchema` identically
+
+In `SharedGameDetailSchema` (line 263-313), add the same `translations` field just before the closing `})`.
+
+### Step 1.4: Run typecheck to verify additive
+
+```bash
+cd apps/web
+pnpm typecheck
+```
+
+Expected: 0 errors. The Zod schema's `.default([])` means existing fetches that don't surface `translations` deserialize as `[]`, so no consumer is forced to handle nullability.
+
+### Step 1.5: Commit
+
+```bash
+git add apps/web/src/lib/api/schemas/shared-games.schemas.ts
+git commit -m "feat(catalog): extend SharedGameSchema with optional translations[] (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 2: Pure helper `resolveLocale` + tests
+
+**Files:**
+- Create: `apps/web/src/lib/i18n/resolve-locale.ts`
+- Create: `apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts`
+
+### Step 2.1: Write failing tests (TDD red)
+
+```ts
+// apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocale } from '@/lib/i18n/resolve-locale';
+
+describe('resolveLocale', () => {
+  it('returns exact match when present', () => {
+    expect(resolveLocale('it-IT', ['it-IT', 'it', 'en'])).toBe('it-IT');
+  });
+
+  it('falls back from region to language', () => {
+    expect(resolveLocale('it-IT', ['it'])).toBe('it');
+  });
+
+  it('returns null when only language requested but region available', () => {
+    // User did NOT request a region; we should not upgrade.
+    expect(resolveLocale('it', ['it-IT'])).toBeNull();
+  });
+
+  it('returns exact when both available', () => {
+    expect(resolveLocale('it-IT', ['it-IT', 'it'])).toBe('it-IT');
+  });
+
+  it('returns null for unmatched locale', () => {
+    expect(resolveLocale('de', ['it', 'fr'])).toBeNull();
+  });
+
+  it('returns null for empty available list', () => {
+    expect(resolveLocale('it', [])).toBeNull();
+  });
+
+  it('is case-insensitive on the language segment', () => {
+    expect(resolveLocale('IT', ['it'])).toBe('it');
+    expect(resolveLocale('it', ['IT'])).toBe('IT');
+  });
+
+  it('preserves region casing in the returned value', () => {
+    // We return the matching available locale string verbatim (don't re-normalize).
+    expect(resolveLocale('it-it', ['it-IT'])).toBe('it-IT');
+  });
+});
+```
+
+Run: `cd apps/web && pnpm vitest run src/lib/i18n/__tests__/resolve-locale.test.ts`. Expected: FAIL (module not found).
+
+### Step 2.2: Implement helper (TDD green)
+
+```ts
+// apps/web/src/lib/i18n/resolve-locale.ts
+/**
+ * Picks the best-fit available locale for a user-preferred locale, per BCP-47.
+ *
+ * Fallback chain:
+ *   1. Exact match (case-insensitive on language; region case-preserved by the
+ *      caller-supplied available list).
+ *   2. Language-only match: a "xx-YY" user can fall back to "xx" if it exists.
+ *   3. null: caller falls back to canonical EN.
+ *
+ * The hook does NOT upgrade a language-only request to a region-specific
+ * available locale ("it" user → "it-IT" available is treated as no match)
+ * because the user did not request a specific region and we cannot infer one
+ * without surprise.
+ *
+ * @example
+ *   resolveLocale('it-IT', ['it'])         → 'it'    (region drop fallback)
+ *   resolveLocale('it', ['it-IT'])         → null    (cannot upgrade)
+ *   resolveLocale('it-IT', ['it-IT'])      → 'it-IT' (exact wins)
+ *   resolveLocale('it-IT', ['it-IT','it']) → 'it-IT' (exact precedes fallback)
+ *
+ * Issue #2339 sub-PR 2/3 — see spec
+ * docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md §6.
+ */
+export function resolveLocale(
+  userLocale: string,
+  availableLocales: ReadonlyArray<string>
+): string | null {
+  if (availableLocales.length === 0) return null;
+
+  const normalizedUser = userLocale.trim();
+  if (!normalizedUser) return null;
+
+  const userLanguage = normalizedUser.split('-')[0].toLowerCase();
+
+  // 1. Exact case-insensitive match
+  const exact = availableLocales.find(l => l.toLowerCase() === normalizedUser.toLowerCase());
+  if (exact) return exact;
+
+  // 2. Language-only fallback (only when user requested a region)
+  const userHasRegion = normalizedUser.includes('-');
+  if (userHasRegion) {
+    const languageMatch = availableLocales.find(l => l.toLowerCase() === userLanguage);
+    if (languageMatch) return languageMatch;
+  }
+
+  return null;
+}
+```
+
+Run: `pnpm vitest run src/lib/i18n/__tests__/resolve-locale.test.ts`. Expected: 8/8 pass.
+
+### Step 2.3: Commit
+
+```bash
+git add apps/web/src/lib/i18n/resolve-locale.ts apps/web/src/lib/i18n/__tests__/resolve-locale.test.ts
+git commit -m "feat(catalog): add resolveLocale BCP-47 fallback helper (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 3: Pure helper `pickBestTranslation` + tests
+
+**Files:**
+- Create: `apps/web/src/lib/i18n/pick-best-translation.ts`
+- Create: `apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts`
+
+### Step 3.1: Write failing tests
+
+```ts
+// apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts
+import { describe, expect, it } from 'vitest';
+
+import { pickBestTranslation } from '@/lib/i18n/pick-best-translation';
+import type { SharedGameTranslationDto } from '@/lib/api/schemas/shared-games.schemas';
+
+const TR = (overrides: Partial<SharedGameTranslationDto>): SharedGameTranslationDto => ({
+  locale: 'it',
+  title: 'Titolo',
+  description: null,
+  source: 'manual',
+  ...overrides,
+});
+
+describe('pickBestTranslation', () => {
+  it('returns null when no translation matches locale', () => {
+    expect(pickBestTranslation([TR({ locale: 'it' })], 'fr')).toBeNull();
+  });
+
+  it('prefers manual over auto-openrouter for same locale', () => {
+    const result = pickBestTranslation(
+      [
+        TR({ locale: 'it', title: 'Auto', source: 'auto-openrouter' }),
+        TR({ locale: 'it', title: 'Manual', source: 'manual' }),
+      ],
+      'it'
+    );
+    expect(result?.title).toBe('Manual');
+    expect(result?.source).toBe('manual');
+  });
+
+  it('prefers auto-openrouter over community for same locale', () => {
+    const result = pickBestTranslation(
+      [
+        TR({ locale: 'it', title: 'Community', source: 'community' }),
+        TR({ locale: 'it', title: 'Auto', source: 'auto-openrouter' }),
+      ],
+      'it'
+    );
+    expect(result?.title).toBe('Auto');
+    expect(result?.source).toBe('auto-openrouter');
+  });
+
+  it('returns single match when only one source available', () => {
+    const result = pickBestTranslation(
+      [TR({ locale: 'it', title: 'Only', source: 'community' })],
+      'it'
+    );
+    expect(result?.title).toBe('Only');
+    expect(result?.source).toBe('community');
+  });
+
+  it('returns null for empty translations list', () => {
+    expect(pickBestTranslation([], 'it')).toBeNull();
+  });
+
+  it('matches exact locale only (no BCP-47 fallback here — that is resolveLocale)', () => {
+    expect(pickBestTranslation([TR({ locale: 'it' })], 'it-IT')).toBeNull();
+  });
+});
+```
+
+Run: expect FAIL.
+
+### Step 3.2: Implement helper
+
+```ts
+// apps/web/src/lib/i18n/pick-best-translation.ts
+import type {
+  SharedGameTranslationDto,
+  TranslationProvider,
+} from '@/lib/api/schemas/shared-games.schemas';
+
+/**
+ * Source priority chain. Lower index = higher priority.
+ *
+ * - `manual`           → admin-curated, highest quality (REQ-FE-4).
+ * - `auto-openrouter`  → machine-translated via DeepSeek V3.
+ * - `community`        → community-sourced, no moderation in MVP.
+ */
+const SOURCE_PRIORITY: ReadonlyArray<TranslationProvider> = [
+  'manual',
+  'auto-openrouter',
+  'community',
+];
+
+/**
+ * Picks the highest-priority translation matching an exact locale string.
+ *
+ * Does NOT apply BCP-47 fallback — that's `resolveLocale`'s job. Call this
+ * AFTER resolving the user's requested locale to an available one.
+ *
+ * @returns The best translation or `null` if no exact match exists.
+ *
+ * Issue #2339 sub-PR 2/3 — see spec
+ * docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md §5.4 REQ-FE-4.
+ */
+export function pickBestTranslation(
+  translations: ReadonlyArray<SharedGameTranslationDto>,
+  locale: string
+): SharedGameTranslationDto | null {
+  const matching = translations.filter(t => t.locale === locale);
+  if (matching.length === 0) return null;
+
+  for (const source of SOURCE_PRIORITY) {
+    const found = matching.find(t => t.source === source);
+    if (found) return found;
+  }
+
+  // Should be unreachable (all enum members covered), but defensive.
+  return matching[0];
+}
+```
+
+### Step 3.3: Run + commit
+
+```bash
+pnpm vitest run src/lib/i18n/__tests__/pick-best-translation.test.ts
+# expect 6/6 pass
+
+git add apps/web/src/lib/i18n/pick-best-translation.ts apps/web/src/lib/i18n/__tests__/pick-best-translation.test.ts
+git commit -m "feat(catalog): add pickBestTranslation source-priority helper (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 4: `useGameTitle` hook composition
+
+**Files:**
+- Create: `apps/web/src/lib/i18n/use-game-title.ts`
+- Create: `apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx` (matrix T1-T6)
+
+### Step 4.1: Write failing tests (matrix T1-T6 from design spec §8)
+
+```tsx
+// apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useGameTitle } from '@/lib/i18n/use-game-title';
+import * as useUserLocaleModule from '@/hooks/useUserLocale';
+import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
+
+const BASE_GAME: Pick<SharedGame, 'id' | 'title' | 'translations'> = {
+  id: '00000000-0000-0000-0000-000000000001' as never,
+  title: 'Catan',
+  translations: [],
+};
+
+function mockUserLocale(locale: 'it' | 'en' | 'es' | 'fr' | 'de') {
+  vi.spyOn(useUserLocaleModule, 'useUserLocale').mockReturnValue(locale);
+}
+
+describe('useGameTitle (matrix T1-T6)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('T1: en user, no translations → canonical EN', () => {
+    mockUserLocale('en');
+    const { result } = renderHook(() => useGameTitle(BASE_GAME));
+    expect(result.current).toEqual({
+      value: 'Catan',
+      source: 'canonical',
+      locale: 'en',
+    });
+  });
+
+  it('T2: it user, [it manual] → IT manual translation', () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const }],
+    };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current).toEqual({
+      value: 'I Coloni di Catan',
+      source: 'translation',
+      locale: 'it',
+      provider: 'manual',
+    });
+  });
+
+  it('T3: it-IT user, [it manual] → IT manual (BCP-47 fallback)', () => {
+    // The user-locale hook returns 'it' for it-IT (drops region). To simulate
+    // it-IT we override via the options arg.
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const }],
+    };
+    const { result } = renderHook(() => useGameTitle(game, { locale: 'it-IT' }));
+    expect(result.current).toEqual({
+      value: 'I Coloni di Catan',
+      source: 'translation',
+      locale: 'it', // resolved via fallback, not it-IT
+      provider: 'manual',
+    });
+  });
+
+  it('T4: de user, [it manual, fr community] → canonical EN', () => {
+    mockUserLocale('de');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        { locale: 'it', title: 'IT', description: null, source: 'manual' as const },
+        { locale: 'fr', title: 'FR', description: null, source: 'community' as const },
+      ],
+    };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current.value).toBe('Catan');
+    expect(result.current.source).toBe('canonical');
+  });
+
+  it('T5: explicit override en, [it manual] → canonical EN (override wins)', () => {
+    // Even with browser/profile it, an explicit options.locale='en' overrides.
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'IT', description: null, source: 'manual' as const }],
+    };
+    const { result } = renderHook(() => useGameTitle(game, { locale: 'en' }));
+    expect(result.current).toEqual({
+      value: 'Catan',
+      source: 'canonical',
+      locale: 'en',
+    });
+  });
+
+  it('T6: it user, [it manual, it auto-openrouter] → manual wins (source priority)', () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [
+        { locale: 'it', title: 'Auto MT', description: null, source: 'auto-openrouter' as const },
+        { locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const },
+      ],
+    };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current).toEqual({
+      value: 'I Coloni di Catan',
+      source: 'translation',
+      locale: 'it',
+      provider: 'manual',
+    });
+  });
+
+  it('handles null translations payload defensively (backward compat)', () => {
+    mockUserLocale('it');
+    const game = { ...BASE_GAME, translations: null as never };
+    const { result } = renderHook(() => useGameTitle(game));
+    expect(result.current.value).toBe('Catan');
+    expect(result.current.source).toBe('canonical');
+  });
+
+  it('memoizes: re-render with same inputs returns same object reference', () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'IT', description: null, source: 'manual' as const }],
+    };
+    const { result, rerender } = renderHook(() => useGameTitle(game));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+```
+
+Run: expect FAIL (module not found).
+
+### Step 4.2: Implement hook
+
+```ts
+// apps/web/src/lib/i18n/use-game-title.ts
+import { useMemo } from 'react';
+
+import { useUserLocale, type SupportedLocale } from '@/hooks/useUserLocale';
+import { pickBestTranslation } from '@/lib/i18n/pick-best-translation';
+import { resolveLocale } from '@/lib/i18n/resolve-locale';
+import type {
+  SharedGame,
+  SharedGameTranslationDto,
+  TranslationProvider,
+} from '@/lib/api/schemas/shared-games.schemas';
+
+/**
+ * Result of resolving a game's title for the current viewer locale.
+ *
+ * Discriminated by `source`:
+ * - `'canonical'` → no translation matched; `value` is `game.title` (EN);
+ *                  `provider` is undefined.
+ * - `'translation'` → a translation matched; `value` is the localized title;
+ *                    `provider` is the authoring source (manual / auto-openrouter / community).
+ *
+ * `locale` reflects the resolved tag (e.g. `'it-IT'` if exact match, `'it'` if
+ * BCP-47 fallback, `'en'` if canonical fallback).
+ */
+export interface ResolvedTitle {
+  value: string;
+  source: 'canonical' | 'translation';
+  locale: string;
+  provider?: TranslationProvider;
+}
+
+export interface UseGameTitleOptions {
+  /**
+   * Force a specific locale, bypassing `useUserLocale()` entirely.
+   * Useful for admin previewing other locales without changing profile state.
+   */
+  locale?: string;
+}
+
+interface GameTitleInput {
+  title: string;
+  translations: ReadonlyArray<SharedGameTranslationDto> | null;
+}
+
+/**
+ * Resolve the best-fit title for a SharedGame given the current viewer locale.
+ *
+ * Pure + memoized: safe to call inside `.map()` callbacks. Re-resolves only
+ * when `game.id` (when present), `game.translations`, or the resolved locale
+ * changes.
+ *
+ * Per design spec §5: REQ-FE-1..5 enforce locale exact-match → BCP-47 language
+ * fallback → canonical EN, with source priority manual > auto-openrouter >
+ * community when multiple translations exist for the same locale.
+ *
+ * Issue #2339 sub-PR 2/3 — see
+ * docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.
+ */
+export function useGameTitle(
+  game: GameTitleInput & Partial<Pick<SharedGame, 'id'>>,
+  options?: UseGameTitleOptions
+): ResolvedTitle {
+  const profileLocale: SupportedLocale = useUserLocale();
+  const targetLocale: string = options?.locale ?? profileLocale;
+
+  return useMemo(
+    () => resolveTitle(game, targetLocale),
+    [game.id, game.translations, targetLocale, game.title]
+  );
+}
+
+/**
+ * Pure resolution function — exported for unit testing without React lifecycle.
+ * @internal
+ */
+export function resolveTitle(game: GameTitleInput, locale: string): ResolvedTitle {
+  const translations = game.translations ?? [];
+
+  if (translations.length === 0) {
+    return { value: game.title, source: 'canonical', locale: 'en' };
+  }
+
+  const availableLocales = Array.from(new Set(translations.map(t => t.locale)));
+  const matched = resolveLocale(locale, availableLocales);
+
+  if (matched === null) {
+    return { value: game.title, source: 'canonical', locale: 'en' };
+  }
+
+  const best = pickBestTranslation(translations, matched);
+  if (best === null) {
+    // Defensive: resolveLocale matched but pickBest returned null — shouldn't
+    // happen in practice (same input set). Fallback canonical.
+    return { value: game.title, source: 'canonical', locale: 'en' };
+  }
+
+  return {
+    value: best.title,
+    source: 'translation',
+    locale: matched,
+    provider: best.source,
+  };
+}
+```
+
+### Step 4.3: Run tests
+
+```bash
+pnpm vitest run src/lib/i18n/__tests__/use-game-title.test.tsx
+```
+
+Expected: 8/8 pass (6 matrix + null defense + memoization).
+
+### Step 4.4: Commit
+
+```bash
+git add apps/web/src/lib/i18n/use-game-title.ts apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
+git commit -m "feat(catalog): add useGameTitle hook with locale + source priority (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 5: Axe a11y tests for localization aria-label
+
+**Files:**
+- Modify: `apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx` (add A1+A2 from design spec §8)
+
+### Step 5.1: Add a11y test rows
+
+Append to the file from Task 4:
+
+```tsx
+import { axe } from 'jest-axe';
+import { render } from '@testing-library/react';
+
+describe('useGameTitle a11y (axe AA)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('A1: localized title rendered with aria-label includes canonical EN', async () => {
+    mockUserLocale('it');
+    const game = {
+      ...BASE_GAME,
+      translations: [{ locale: 'it', title: 'I Coloni di Catan', description: null, source: 'manual' as const }],
+    };
+
+    function Card() {
+      const { value, source } = useGameTitle(game);
+      const ariaLabel = source === 'translation'
+        ? `${value} (localized from English: ${game.title})`
+        : undefined;
+      return <h3 aria-label={ariaLabel}>{value}</h3>;
+    }
+
+    const { container } = render(<Card />);
+    const heading = container.querySelector('h3')!;
+    expect(heading.getAttribute('aria-label')).toBe('I Coloni di Catan (localized from English: Catan)');
+
+    const axeResults = await axe(container);
+    expect(axeResults.violations).toHaveLength(0);
+  });
+
+  it('A2: canonical title rendered with no aria-label augmentation', async () => {
+    mockUserLocale('en');
+    const { container } = render((() => {
+      const { value, source } = useGameTitle(BASE_GAME);
+      const ariaLabel = source === 'translation' ? `${value} (localized)` : undefined;
+      return <h3 aria-label={ariaLabel}>{value}</h3>;
+    })());
+    const heading = container.querySelector('h3')!;
+    expect(heading.getAttribute('aria-label')).toBeNull();
+
+    const axeResults = await axe(container);
+    expect(axeResults.violations).toHaveLength(0);
+  });
+});
+```
+
+### Step 5.2: Run + commit
+
+```bash
+pnpm vitest run src/lib/i18n/__tests__/use-game-title.test.tsx
+# expect 10/10 pass (8 from Task 4 + 2 a11y)
+
+git add apps/web/src/lib/i18n/__tests__/use-game-title.test.tsx
+git commit -m "test(catalog): add axe AA a11y tests for useGameTitle (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 6: Migrate 5 highest-traffic consumers + grep sweep
+
+### Step 6.1: Baseline grep
+
+```bash
+grep -rn "game\.title\|game\?.title" apps/web/src/ --include="*.tsx" --include="*.ts" | wc -l
+```
+
+Expected: ~141 (per design spec §10.1). Save to `audits/2026-06-20-game-title-baseline.txt` for diff verification at end.
+
+### Step 6.2: Migrate `HubGameCard.tsx` (template for the other 4)
+
+Read the file, identify the `<h3>{game.title}</h3>` site, replace with:
+
+```tsx
+'use client';
+
+import { useGameTitle } from '@/lib/i18n/use-game-title';
+
+// ... existing imports ...
+
+export function HubGameCard({ game, ... }: Props) {
+  const { value: title, source } = useGameTitle(game);
+  const titleAriaLabel = source === 'translation'
+    ? `${title} (localized from English: ${game.title})`
+    : undefined;
+
+  return (
+    // ... existing JSX ...
+    <h3
+      aria-label={titleAriaLabel}
+      className="line-clamp-1 font-bold font-[Quicksand] text-sm text-foreground"
+    >
+      {title}
+    </h3>
+    // ...
+  );
+}
+```
+
+### Step 6.3: Migrate the remaining 4 highest-traffic surfaces
+
+Apply the same pattern to:
+- `apps/web/src/components/discover/GameDiscoverDetail.tsx`
+- `apps/web/src/components/games/MeepleGameCard.tsx`
+- `apps/web/src/components/library/MeepleUserLibraryCard.tsx`
+- `apps/web/src/app/(public)/shared-games/[id]/page-client.tsx`
+
+For each:
+1. Add the `useGameTitle` import.
+2. Replace direct `game.title` access with `const { value: title, source } = useGameTitle(game);`.
+3. Wire `aria-label` per source.
+4. Use `title` variable inside JSX.
+5. Update unit tests in `__tests__/<component>.test.tsx` to mock `useGameTitle` or pass `translations: []` fixtures.
+
+Run `pnpm test --changed` after each file to keep regressions surfaced early.
+
+### Step 6.4: Codemod sweep for the remaining ~77 files
+
+Create `apps/web/scripts/codemod/use-game-title-migration.ts` (ts-morph):
+
+```ts
+// apps/web/scripts/codemod/use-game-title-migration.ts
+// Idempotent codemod: replaces `game.title` JSX expressions with `useGameTitle(game).value`.
+//
+// DOES NOT migrate:
+//  - non-component files (.ts files, .stories.tsx, __tests__)
+//  - search/filter logic (filter(g => g.title.includes(...)) — deliberate, search stays canonical)
+//  - storybook fixtures
+//
+// Run: pnpm tsx apps/web/scripts/codemod/use-game-title-migration.ts --dry-run
+//      pnpm tsx apps/web/scripts/codemod/use-game-title-migration.ts --apply
+
+import { Project, SyntaxKind } from 'ts-morph';
+import path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../../src');
+const APPLY = process.argv.includes('--apply');
+
+// Skip these directories — they are not user-facing consumers.
+const SKIP_PATTERNS = [/__tests__/, /\.stories\.tsx$/, /\.test\./, /\/lib\/i18n\//];
+
+const project = new Project({ tsConfigFilePath: path.resolve(__dirname, '../../tsconfig.json') });
+
+let touched = 0;
+let skipped = 0;
+
+for (const file of project.getSourceFiles(`${ROOT}/**/*.{ts,tsx}`)) {
+  const filePath = file.getFilePath();
+  if (SKIP_PATTERNS.some(p => p.test(filePath))) {
+    skipped++;
+    continue;
+  }
+  // ... heuristic: find `game.title` PropertyAccessExpression inside JsxExpression,
+  // determine if `game` is typed as SharedGame, and rewrite.
+  // (Full implementation in actual codemod file.)
+  // ...
+}
+
+console.log(`Codemod: ${touched} files touched, ${skipped} files skipped`);
+if (APPLY) project.saveSync();
+```
+
+Run dry-run, review the diff, then apply:
+
+```bash
+pnpm tsx apps/web/scripts/codemod/use-game-title-migration.ts --dry-run
+# review output
+
+pnpm tsx apps/web/scripts/codemod/use-game-title-migration.ts --apply
+```
+
+### Step 6.5: Verify total migration
+
+```bash
+grep -rn "game\.title" apps/web/src/ --include="*.tsx" --include="*.ts" \
+  | grep -v "__tests__" \
+  | grep -v ".stories.tsx" \
+  | grep -v "useGameTitle" \
+  | grep -v "filter\|sort\|includes" \
+  | wc -l
+```
+
+Expected: 0. If non-zero, inspect each remaining occurrence — they're either:
+- type-only references (`Pick<SharedGame, 'title'>`) — OK, leave them.
+- defensive aria-label callsites referencing canonical EN — OK, that's the design.
+- legitimate other (storybook, mock) — OK.
+
+### Step 6.6: Commit
+
+```bash
+git add -p  # carefully stage migrated component files
+git add apps/web/scripts/codemod/
+git commit -m "refactor(catalog): migrate 5 highest-traffic + codemod sweep to useGameTitle (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 7: ESLint rule `local/prefer-use-game-title` (warn mode)
+
+**Files:**
+- Create: `apps/web/eslint-rules/prefer-use-game-title.js`
+- Modify: `apps/web/.eslintrc.js` (or whichever config registers `local/*` rules)
+
+### Step 7.1: Implement rule
+
+```js
+// apps/web/eslint-rules/prefer-use-game-title.js
+/**
+ * @fileoverview Warn when `game.title` is accessed inside JSX expression
+ * containers without going through the `useGameTitle()` hook.
+ *
+ * Issue #2339 sub-PR 2/3 — encourages adoption of localization-aware title
+ * rendering. WARN-only in this PR; promote to ERROR in a follow-up PR after
+ * 14gg of trajectory verde on main-dev.
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer useGameTitle() hook over raw game.title in JSX',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      preferHook:
+        'Use `useGameTitle(game)` instead of `game.title` directly in JSX. The hook resolves locale + source priority. See docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md.',
+    },
+  },
+
+  create(context) {
+    return {
+      // Match `game.title` inside JsxExpressionContainer
+      'JSXExpressionContainer MemberExpression[object.name="game"][property.name="title"]'(node) {
+        // Allow if the surrounding line includes "useGameTitle" — heuristic, may need refinement
+        const sourceCode = context.getSourceCode();
+        const lineText = sourceCode.lines[node.loc.start.line - 1];
+        if (lineText && lineText.includes('useGameTitle')) return;
+
+        context.report({ node, messageId: 'preferHook' });
+      },
+    };
+  },
+};
+```
+
+### Step 7.2: Register rule in ESLint config
+
+Modify `apps/web/.eslintrc.js` (or `eslint.config.js` for ESLint 9 flat config) to register `local/prefer-use-game-title: 'warn'`. Reference existing `local/no-bgg-host` and `local/no-hardcoded-color-utility` rules as templates.
+
+### Step 7.3: Run lint to verify rule fires (or not) correctly
+
+```bash
+cd apps/web && pnpm lint
+```
+
+Expected: no NEW errors (rule is warn). Any preexisting violations from non-migrated files surface as warnings only — counted but non-blocking.
+
+### Step 7.4: Commit
+
+```bash
+git add apps/web/eslint-rules/prefer-use-game-title.js apps/web/.eslintrc.js
+git commit -m "chore(lint): add local/prefer-use-game-title rule in warn mode (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 8: E2E Playwright happy-path
+
+**Files:**
+- Create: `apps/web/e2e/translations-fe-hook.spec.ts`
+
+### Step 8.1: Write E2E spec
+
+```ts
+// apps/web/e2e/translations-fe-hook.spec.ts
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #2339 sub-PR 2/3 — E2E happy path verifying that an IT user sees
+ * IT-localized titles when seed translations exist. Seed translation data
+ * lands in sub-PR 3/3; this test will be guarded by `test.skip()` until then.
+ *
+ * The test asserts behavior, not the absence of UI flicker (which is covered
+ * by unit tests around useMemo identity preservation).
+ */
+
+test.describe('useGameTitle E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    // Force browser locale via context override
+    await page.context().addInitScript(() => {
+      Object.defineProperty(navigator, 'language', { get: () => 'it-IT' });
+      Object.defineProperty(navigator, 'languages', { get: () => ['it-IT', 'it'] });
+    });
+  });
+
+  test.skip(({ }, testInfo) => !testInfo.project.metadata.seedTranslations,
+    'Requires sub-PR 3/3 seed translations to land first');
+
+  test('IT user sees IT-localized title on Library page', async ({ page }) => {
+    await page.goto('/library');
+
+    // After seed sub-PR 3/3 lands, "Catan" → "I Coloni di Catan" in card heading
+    const catanCard = page.getByRole('article').filter({ hasText: /Coloni di Catan|Catan/ });
+    await expect(catanCard).toBeVisible();
+
+    const heading = catanCard.getByRole('heading', { level: 3 });
+    await expect(heading).toHaveText('I Coloni di Catan');
+    await expect(heading).toHaveAttribute(
+      'aria-label',
+      /Localized from English: Catan/
+    );
+  });
+
+  test('IT user sees IT-localized title on Discover page', async ({ page }) => {
+    await page.goto('/games?tab=discover');
+    const heading = page.getByRole('heading', { name: /Coloni di Catan/i });
+    await expect(heading).toBeVisible();
+  });
+
+  test('EN-override user sees canonical EN even with browser it-IT', async ({ page }) => {
+    // Set profile override via cookie or login as user with Language='en'
+    await page.context().addCookies([{ name: 'preferredLocale', value: 'en', url: 'http://localhost:3000' }]);
+    await page.goto('/library');
+
+    const heading = page.getByRole('heading', { name: /^Catan$/ });
+    await expect(heading).toBeVisible();
+    await expect(heading).not.toHaveAttribute('aria-label', /Localized/);
+  });
+});
+```
+
+### Step 8.2: Run E2E
+
+```bash
+cd apps/web && pnpm test:e2e --grep "translations-fe-hook"
+```
+
+Expected: 3 tests skipped (requires sub-PR 3/3 seed data). After sub-PR 3/3 ships, project metadata flips `seedTranslations: true` and tests run.
+
+### Step 8.3: Commit
+
+```bash
+git add apps/web/e2e/translations-fe-hook.spec.ts
+git commit -m "test(catalog): add E2E translations-fe-hook spec (gated on sub-PR 3/3) (#2339 sub-PR 2/3)"
+```
+
+---
+
+## Task 9: Push, PR, close sub-PR 2/3
+
+### Step 9.1: Final pre-push checks
+
+```bash
+cd apps/web
+pnpm typecheck   # MUST be green
+pnpm lint        # MUST be green (warns allowed for prefer-use-game-title on non-migrated files)
+pnpm test --coverage src/lib/i18n   # ≥85% on new files
+```
+
+If any gate red, FIX before push.
+
+### Step 9.2: Push
+
+```bash
+git push -u origin feature/issue-2339-translations-fe-hook
+```
+
+### Step 9.3: Open PR
+
+```bash
+gh pr create --base main-dev \
+  --title "feat(catalog): #2339 sub-PR 2/3 — useGameTitle hook + DTO translations[] + consumer migration" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Sub-PR 2/3 of #2339. Implements FE hook + DTO TS schema + consumer migration
+per spec [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md).
+
+- `SharedGameSchema` + `SharedGameDetailSchema` extended with optional `translations[]`
+- New schema `SharedGameTranslationDtoSchema` + `TranslationProviderSchema`
+- Hook `useGameTitle(game, options?): ResolvedTitle` with REQ-FE-1..5 enforced
+- Pure helpers `resolveLocale` (BCP-47 fallback) + `pickBestTranslation` (source priority)
+- 5 highest-traffic consumers migrated (Library card, Hub card, Discover detail, MeepleGameCard, Shared game detail page)
+- Codemod sweep for remaining consumers (idempotent, dry-runnable)
+- ESLint rule `local/prefer-use-game-title` in **warn** mode (promote to error follow-up)
+- 6 matrix test rows + 2 axe a11y rows green
+- E2E Playwright happy-path skeleton (gated on sub-PR 3/3 seed)
+
+## Decisions locked (designer review pending)
+
+See `## 2. Decisioni locked` in the spec. Key picks:
+- DEC-FE-1: `ResolvedTitle` discriminated union return (NOT plain string)
+- DEC-FE-2: source priority `manual > auto-openrouter > community`
+- DEC-FE-3: BCP-47 fallback chain region → language → canonical
+- DEC-FE-5: client-side locale resolution (BE sends "Both" shape)
+- DEC-FE-8: consumer migration codemod-assisted, ESLint rule in warn mode
+
+## Out of scope
+
+- Seed translations IT (sub-PR 3/3 — separate PR)
+- Search input localized filter (DEC-FE-DEFER, follow-up issue)
+- Description field UI (deferred)
+- Promoting ESLint rule to error (follow-up post-14gg trajectory)
+
+## Test plan
+
+- [x] Vitest matrix T1-T6 green
+- [x] Axe AA a11y tests A1+A2 green
+- [x] Coverage ≥85% on new files
+- [x] `pnpm typecheck` + `pnpm lint` green
+- [x] 5 highest-traffic consumers visually verified locally
+- [x] Codemod dry-run + apply produces clean diff
+- [ ] E2E Playwright gated; flips to green when sub-PR 3/3 ships seed data
+
+Closes part of #2339 (sub-PR 2/3).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Step 9.4: Update #2339 body
+
+```bash
+gh issue comment 2339 --body "Sub-PR 2/3 opened: #<PR_NUMBER>. FE hook + DTO + consumer migration shipped. Next: sub-PR 3/3 seed translations IT."
+```
+
+Update the progress table at top of #2339:
+
+```bash
+gh issue edit 2339 --body-file <(gh issue view 2339 --json body --jq '.body' | sed 's|⏳ TODO | ⏳ Sub-PR 2/3 IN REVIEW |')
+```
+
+(Or hand-edit the Sub-PR 2 row in the table from `⏳ TODO` → `⏳ IN REVIEW` → `✅ MERGED` post-merge.)
+
+### Step 9.5: Code review subagent (per CLAUDE.md `/implementa` Phase 6 rule)
+
+```bash
+# After pushing:
+# /code-review:code-review <PR_URL>
+```
+
+If reviewer finds blockers, fix in NEW commits (per CLAUDE.md "always create new commits rather than amending"). After review approved, merge — auto-delete branch on merge.
+
+### Step 9.6: Post-merge cleanup
+
+```bash
+git checkout main-dev
+git pull
+git branch -D feature/issue-2339-translations-fe-hook
+git remote prune origin
+```
+
+---
+
+## Effort estimate
+
+| Task | Effort |
+|---|---|
+| Task 1: Zod schema extension | 0.5h |
+| Task 2: `resolveLocale` helper + tests | 1.5h |
+| Task 3: `pickBestTranslation` helper + tests | 1h |
+| Task 4: `useGameTitle` hook + matrix tests | 2h |
+| Task 5: Axe a11y tests | 1h |
+| Task 6: 5 consumers + codemod sweep | 3h |
+| Task 7: ESLint rule | 1h |
+| Task 8: E2E spec (skeleton) | 1h |
+| Task 9: PR + review + cleanup | 1h |
+| **Total** | **~12h** (~1.5gg single FTE) |
+
+---
+
+## Self-review checklist
+
+- [ ] **Spec coverage**: each spec §3-13 maps to a task or is explicitly out-of-scope
+  - §3 Use cases → Task 4 (hook covers all 3 UC paths)
+  - §4 REQ-FE-1..5 → Tasks 2, 3, 4 (helpers + composition)
+  - §5 Contract API → Task 4
+  - §6 Locale algorithm → Task 2
+  - §7 Gherkin → Task 4 (matrix tests)
+  - §8 Test matrix → Tasks 4, 5
+  - §9 Cache strategy → Task 4 (useMemo)
+  - §10 Consumer migration → Task 6
+  - §11 Sub-PR 3/3 scope → separate plan
+  - §12 Out of scope → respected (no search, no preference UI, no description editor)
+- [ ] **No placeholders**: every code block contains real implementation
+- [ ] **Type consistency**: `ResolvedTitle` shape consistent across Tasks 4, 5, 6
+- [ ] **Tests assert behavior, not implementation**: matrix rows test inputs/outputs, NOT useMemo deps
+- [ ] **Test file paths match Files declarations**: `__tests__/use-game-title.test.tsx` location verified
+- [ ] **Branch hygiene preflight 0.1-0.4 executed**: HEAD on main-dev before `git checkout -b`
+- [ ] **PR target main-dev confirmed**: NOT main, NOT main-staging
+- [ ] **Code review subagent invoked**: Step 9.5 not skipped
+
+---
+
+## Cross-references
+
+- **Spec source**: [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](../specs/2026-06-20-translations-fe-hook-design.md)
+- **Companion sub-PR 3/3 plan**: [`docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md`](./2026-06-20-translations-seed-subpr3.md)
+- **Wave 1 spec (BE foundation)**: [`docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`](../specs/2026-06-15-shared-game-translations-design.md)
+- **Wave 1 plan TDD**: [`docs/superpowers/plans/2026-06-15-shared-game-translations.md`](./2026-06-15-shared-game-translations.md)
+- **Tracker**: [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339)
+- **Wave 1 shipped PR**: [#2370](https://github.com/meepleAi-app/meepleai-monorepo/pull/2370) (`cd041ca35`)

--- a/docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md
+++ b/docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md
@@ -1,0 +1,716 @@
+# Shared Game Translations — Seed Translations IT Implementation Plan (sub-PR 3/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 13 IT translations curate per SP4 seed dataset + translations-research provenance doc + seed script `45-translations.sh` + ADR-059 §6 amendment + Q4 doc closure in `docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md`, chiudendo sub-PR 3/3 dell'issue [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339).
+
+**Architecture:** Augment seed dataset (`infra/scripts/seed-sp4/data.json`) with `gameTranslations[]` array, sequential POST to BE admin endpoint shipped in Wave 5 (`POST /api/v1/admin/games/{id}/translations`), idempotent via list+filter pattern (mirror of `40-agents.sh`). Research doc è prerequisite manual work — pubblica IT title verification per gioco.
+
+**Tech Stack:** Bash + `curl` + `jq` + Postgres `meepleai_staging` DB target via existing tunnel pattern + admin login cookie jar (shared with other seed steps).
+
+**Spec source**: [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](../specs/2026-06-20-translations-fe-hook-design.md) §11 (sub-PR 3/3 scope preview)
+
+**Dependency**: BE admin endpoint `POST /api/v1/admin/games/{id}/translations` (Wave 5 di issue #2339). Se non shipped yet, Task 4 fail-fast con messaggio chiaro.
+
+---
+
+## Branch & PR conventions
+
+- **Parent branch**: `main-dev` (per CLAUDE.md branch hygiene)
+- **Feature branch**: `feature/issue-2339-translations-seed`
+- **Branch parent config**:
+  ```bash
+  git config branch.feature/issue-2339-translations-seed.parent main-dev
+  ```
+- **PR target**: `main-dev`
+- **PR title**: `feat(catalog): #2339 sub-PR 3/3 — seed IT translations + ADR-059 amendment`
+- **Commit prefix**: `feat(seed)`, `chore(docs)`, `chore(adr)`
+
+---
+
+## File Structure
+
+### Files to CREATE
+
+```
+infra/scripts/seed-sp4/translations-research.md   (provenance research, manual fill)
+infra/scripts/seed-sp4/45-translations.sh         (seed script, idempotent)
+```
+
+### Files to MODIFY
+
+```
+infra/scripts/seed-sp4/data.json                  (add gameTranslations[] array)
+infra/scripts/seed-sp4/seed-sp4.sh                (update step list comment to include 45)
+docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
+  → add §6 amendment "Translations seed legal posture"
+docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md
+  → §9 Q4 closure note: "RESOLVED via #2339 sub-PR 3/3"
+```
+
+---
+
+## Pre-flight checks
+
+- [ ] **Pre-flight 0.1: Verify HEAD is on main-dev clean**
+
+  ```bash
+  git branch --show-current  # MUST print main-dev
+  git status                 # MUST show clean tree
+  git pull --ff-only
+  ```
+
+- [ ] **Pre-flight 0.2: Verify Wave 5 BE admin endpoint shipped**
+
+  ```bash
+  grep -rn "MapPost.*translations" apps/api/src/Api/Routing/ | head -3
+  ```
+
+  Expected: confirms `POST /api/v1/admin/games/{gameId:guid}/translations` is registered. If absent, **STOP** and complete Wave 5 first (Task 14 of `docs/superpowers/plans/2026-06-15-shared-game-translations.md`).
+
+- [ ] **Pre-flight 0.3: Verify dev DB schema includes translations table**
+
+  ```bash
+  pwsh -c "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c '\d shared_game_translations'"
+  ```
+
+  Expected: confirms 13 columns + 4 indices. If table missing, run `cd apps/api/src/Api && dotnet ef database update` to apply Wave 2 migration.
+
+- [ ] **Pre-flight 0.4: Verify 13 SP4 games seeded**
+
+  ```bash
+  cd infra && make seed-sp4
+  pwsh -c "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c \"SELECT COUNT(*) FROM shared_games WHERE deleted_at IS NULL;\""
+  ```
+
+  Expected: ≥13 rows. If less, run `make seed-sp4` to bootstrap.
+
+- [ ] **Pre-flight 0.5: Create feature branch**
+
+  ```bash
+  git checkout -b feature/issue-2339-translations-seed
+  git config branch.feature/issue-2339-translations-seed.parent main-dev
+  ```
+
+---
+
+## Task 1: Research doc skeleton
+
+**Files:**
+- Create: `infra/scripts/seed-sp4/translations-research.md`
+
+### Step 1.1: Create skeleton with empty research table
+
+```markdown
+# SP4 Translations IT Research
+
+Research provenance per IT translation curate del seed SP4. Compilato manualmente
+prima del shipping di `45-translations.sh` per assicurare verification dei titoli
+e classification corretta del `source` field.
+
+Issue: #2339 sub-PR 3/3
+Date: 2026-06-20
+
+## Classification policy
+
+- `source: "manual"` — IT title è ufficiale (publisher italiano confermato via fonte
+  primaria pubblica) ED revisionato da native speaker (in MVP single-FTE: badsworm@gmail.com,
+  IT-native).
+- `source: "auto-openrouter"` — IT title NON è ufficiale o NON verificato; usato il
+  Wave 1 backend translation service (DeepSeek V3) come fallback. Subject ad admin
+  revision in follow-up.
+- `source: "community"` — riservato per future contributions, NON usato in MVP seed.
+
+## Verified IT Titles
+
+| # | Game (EN) | IT Title proposed | Source verified? | Publisher IT | Publisher URL | Native review by | Decision (manual/auto/skip) |
+|---|---|---|---|---|---|---|---|
+| 1 | Azul | ? | TBD | Asmodee Italia? | ? | badsworm | TBD |
+| 2 | Catan | I Coloni di Catan | YES — historical Asterion edition | Asterion Press (storica) / Giochi Uniti (corrente) | https://giochiuniti.it/games/catan | badsworm | manual |
+| 3 | Wingspan | Wingspan | NO — Ghenos mantiene EN | Ghenos Games | https://www.ghenosgames.com/portfolio/wingspan/ | badsworm | manual (EN retained) |
+| 4 | Brass: Birmingham | Brass: Birmingham | NO — Mancalamaro mantiene EN | Mancalamaro | https://mancalamaro.com/brass-birmingham | badsworm | manual (EN retained) |
+| 5 | Gloomhaven | Gloomhaven | NO — Asmodee Italia mantiene EN | Asmodee Italia | ? | badsworm | manual (EN retained) |
+| 6 | Ark Nova | Ark Nova | NO — Cranio Creations mantiene EN | Cranio Creations | https://www.craniocreations.it/ark-nova | badsworm | manual (EN retained) |
+| 7 | Spirit Island | Spirit Island | NO — Ghenos mantiene EN | Ghenos Games | ? | badsworm | manual (EN retained) |
+| 8 | 7 Wonders Duel | 7 Wonders Duel | NO — Asterion mantiene EN | Asterion Press | ? | badsworm | manual (EN retained) |
+| 9 | Codenames | Nome in codice | YES — Cranio Creations edizione IT | Cranio Creations | https://www.craniocreations.it/nome-in-codice | badsworm | manual |
+| 10 | Carcassonne | Carcassonne | YES — Giochi Uniti mantiene il nome (toponimo) | Giochi Uniti | https://giochiuniti.it/games/carcassonne | badsworm | manual (toponym retained) |
+| 11 | Ticket to Ride | Ticket to Ride | NO — Asmodee Italia mantiene EN | Asmodee Italia | ? | badsworm | manual (EN retained) |
+| 12 | Pandemic | Pandemic | NO — Asmodee Italia mantiene EN (storica "Pandemia" deprecata) | Asmodee Italia | ? | badsworm | manual (EN retained) |
+| 13 | Terraforming Mars | Terraforming Mars | NO — Ghenos mantiene EN | Ghenos Games | https://www.ghenosgames.com/portfolio/terraforming-mars/ | badsworm | manual (EN retained) |
+
+## Decision summary
+
+- 13 giochi × IT translation:
+  - **3** con IT title diverso da EN (Catan, Codenames, ... + eventuali aggiornamenti post-research).
+  - **10** mantengono EN (publisher italiano ha mantenuto il nome originale).
+- Tutti classified `source: "manual"` perché il titolo è confermato dalla fonte
+  publisher anche quando coincide con EN — la decisione di mantenere EN è un atto
+  curatorial.
+- Zero `auto-openrouter` in MVP (research-driven only).
+
+## TODO before sub-PR 3/3 ships
+
+- [ ] Verificare i 4 publisher URL marcati `?` (Azul, Spirit Island, 7 Wonders Duel, Ticket to Ride, Pandemic Asmodee Italia).
+- [ ] Cross-check con BGG IT page per ciascuno (es. https://boardgamegeek.com/boardgame/13/catan → "Italian language editions").
+- [ ] Aggiornare tabella → no più `TBD` o `?` lasciati.
+
+## Description field
+
+Per MVP `45-translations.sh` shippa SOLO `title` field (description=null).
+Description IT curata è deferred — admin compila post-launch via PUT.
+
+## Out of scope
+
+- Translation di altri giochi nel catalogo (160+ rows snapshot — solo 13 SP4 in scope).
+- Translation di campi `description` per i 13 (richiede effort 10-20× il title).
+- Translation `auto-openrouter` di tipo fall-back (deferred a admin discretion).
+- Locale altri (`en-GB`, `de`, `fr`, `es`) — out of scope MVP.
+
+## References
+
+- Issue tracker: #2339 sub-PR 3/3
+- Wave 1 spec: `docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`
+- Sub-PR 2/3 design: `docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`
+- ADR-059 amendment: `docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md` §6 (added in this PR)
+- BGG IT editions: per-game `https://boardgamegeek.com/boardgame/<bgg_id>/<slug>/credits` § Versions
+```
+
+### Step 1.2: Commit skeleton
+
+```bash
+git add infra/scripts/seed-sp4/translations-research.md
+git commit -m "docs(seed): add translations-research.md skeleton (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 2: Manual research — fill in the verified URLs and decisions
+
+**Files:**
+- Modify: `infra/scripts/seed-sp4/translations-research.md`
+
+### Step 2.1: Verify publisher URLs and edition info
+
+Per ciascun gioco marcato `TBD` o `?` nella tabella di Task 1, eseguire:
+
+1. Visita BGG game page → tab Versions → filter by language=Italian.
+2. Click su edition IT → annota nome publisher + ISBN + url eventuale.
+3. Cerca publisher home page → annota url IT del gioco.
+4. Conferma se il publisher IT ha cambiato il titolo o mantenuto EN.
+
+**Esempio cluster lookup (esegui manualmente)**:
+
+- Azul → BGG ID 230802 → versions IT → Lacerta editions ed Asmodee Italia. Cerca "Azul Asmodee Italia" → conferma se "Azul" rimane (toponym/pattern reference).
+- Spirit Island → BGG ID 162886 → versions IT → Ghenos Games. Cerca pubblicazione "Spirit Island Ghenos" → conferma title.
+
+### Step 2.2: Update tabella in `translations-research.md`
+
+Sostituire i `?` con URL verificati + colonna `Source verified?` con `YES`/`NO`/`PARTIAL`.
+
+### Step 2.3: Lock decision summary
+
+Aggiornare § "Decision summary" con count finale (X giochi con IT title diverso da EN, Y con EN retained).
+
+### Step 2.4: Commit research
+
+```bash
+git add infra/scripts/seed-sp4/translations-research.md
+git commit -m "docs(seed): verify IT publisher URLs for all 13 SP4 games (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 3: Add `gameTranslations[]` to `data.json`
+
+**Files:**
+- Modify: `infra/scripts/seed-sp4/data.json`
+
+### Step 3.1: Add `gameTranslations` array
+
+Append before the closing `}` of the JSON root:
+
+```json
+  "gameTranslations": [
+    { "gameSlug": "azul",        "locale": "it", "title": "Azul",              "source": "manual" },
+    { "gameSlug": "catan",       "locale": "it", "title": "I Coloni di Catan", "source": "manual" },
+    { "gameSlug": "wingspan",    "locale": "it", "title": "Wingspan",          "source": "manual" },
+    { "gameSlug": "brass",       "locale": "it", "title": "Brass: Birmingham", "source": "manual" },
+    { "gameSlug": "gloomhaven",  "locale": "it", "title": "Gloomhaven",        "source": "manual" },
+    { "gameSlug": "arknova",     "locale": "it", "title": "Ark Nova",          "source": "manual" },
+    { "gameSlug": "spirit",      "locale": "it", "title": "Spirit Island",     "source": "manual" },
+    { "gameSlug": "7wonders",    "locale": "it", "title": "7 Wonders Duel",    "source": "manual" },
+    { "gameSlug": "codenames",   "locale": "it", "title": "Nome in codice",    "source": "manual" },
+    { "gameSlug": "carcassonne", "locale": "it", "title": "Carcassonne",       "source": "manual" },
+    { "gameSlug": "ticket",      "locale": "it", "title": "Ticket to Ride",    "source": "manual" },
+    { "gameSlug": "pandemic",    "locale": "it", "title": "Pandemic",          "source": "manual" },
+    { "gameSlug": "terraforming","locale": "it", "title": "Terraforming Mars", "source": "manual" }
+  ]
+```
+
+(Verify final values from `translations-research.md` — example above shows the MVP picks but Task 2 manual research may revise specific titles, e.g. Wingspan IT could come back as `"Wingspan: Ali del Mondo"` if publisher revised name.)
+
+### Step 3.2: Validate JSON
+
+```bash
+jq empty infra/scripts/seed-sp4/data.json
+echo "Translations count: $(jq '.gameTranslations | length' infra/scripts/seed-sp4/data.json)"
+```
+
+Expected: no errors, count = 13.
+
+### Step 3.3: Commit
+
+```bash
+git add infra/scripts/seed-sp4/data.json
+git commit -m "feat(seed): add gameTranslations[] array for 13 SP4 IT titles (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 4: Implement `45-translations.sh` script
+
+**Files:**
+- Create: `infra/scripts/seed-sp4/45-translations.sh`
+
+### Step 4.1: Implement idempotent seed script
+
+```bash
+#!/usr/bin/env bash
+# 45-translations.sh — Create IT translations for the 13 SP4 SharedGames.
+#
+# Idempotent: GET /admin/games/{id}/translations to find existing locale entries.
+# Mirrors 40-agents.sh pattern for ownership/login.
+#
+# Requires:
+#   - 20-games.sh executed (state_file has games[slug] → gameId)
+#   - BE admin endpoint POST /api/v1/admin/games/{id}/translations shipped (Wave 5)
+#   - Migration AddSharedGameTranslations applied (Wave 2)
+#
+# Issue: #2339 sub-PR 3/3
+
+set -euo pipefail
+source "$(dirname "$(readlink -f "$0")")/lib/common.sh"
+
+banner "45 — Game Translations (13 SP4 IT)"
+ADMIN_JAR=$(cookie_jar_for "admin")
+[[ -s "$ADMIN_JAR" ]] || { admin_login; }
+
+total=0; created=0; existing=0; failed=0; skipped=0
+
+while IFS= read -r t; do
+  game_slug=$(jq -r '.gameSlug' <<< "$t")
+  locale=$(jq -r '.locale'      <<< "$t")
+  title=$(jq -r '.title'        <<< "$t")
+  source=$(jq -r '.source'      <<< "$t")
+  total=$((total + 1))
+
+  # Resolve game_id
+  game_id=$(state_get "games" "$game_slug")
+  if [[ -z "$game_id" || "$game_id" == "null" ]]; then
+    warn "[$game_slug/$locale] missing game_id — run 20-games first; skipping"
+    skipped=$((skipped + 1)); continue
+  fi
+
+  # Pre-check: does translation for this locale already exist?
+  list_resp=$(curl_get "/admin/games/$game_id/translations" "$ADMIN_JAR")
+  list_body=$(echo "$list_resp" | sed '$d')
+  list_code=$(echo "$list_resp" | tail -n1)
+
+  if [[ "$list_code" == "200" ]]; then
+    existing_id=$(echo "$list_body" | jq -r --arg l "$locale" \
+      '.[]? | select(.locale==$l) | .locale' 2>/dev/null | head -1)
+    if [[ -n "$existing_id" && "$existing_id" != "null" ]]; then
+      skip "$game_slug/$locale already exists — skipping"
+      existing=$((existing + 1)); continue
+    fi
+  elif [[ "$list_code" != "404" ]]; then
+    warn "[$game_slug/$locale] list endpoint HTTP $list_code unexpected"
+  fi
+
+  # Create translation
+  create_payload=$(jq -nc \
+    --arg locale "$locale" \
+    --arg title "$title" \
+    --arg source "$source" \
+    '{locale:$locale, title:$title, description:null, source:$source}')
+
+  cr=$(curl_json POST "/admin/games/$game_id/translations" "$ADMIN_JAR" "$create_payload")
+  cr_body=$(echo "$cr" | sed '$d')
+  cr_code=$(echo "$cr" | tail -n1)
+
+  if http_check "201|200" "$cr_code" "$cr_body" "create $game_slug/$locale"; then
+    ok "Created $game_slug/$locale → '$title' ($source)"
+    created=$((created + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done < <(data_get_compact '.gameTranslations[]')
+
+log "Summary: total=$total  created=$created  existing=$existing  skipped=$skipped  failed=$failed"
+[[ $failed -gt 0 ]] && fail "45-translations completed with $failed failures"
+ok "45-translations complete"
+```
+
+### Step 4.2: Make executable
+
+```bash
+chmod +x infra/scripts/seed-sp4/45-translations.sh
+```
+
+### Step 4.3: Smoke-test locally (dev DB)
+
+```bash
+cd infra
+# Ensure 20-games has run first (state file populated)
+./scripts/seed-sp4/seed-sp4.sh --step 45
+```
+
+Expected output:
+```
+45 — Game Translations (13 SP4 IT)
+Created azul/it → 'Azul' (manual)
+Created catan/it → 'I Coloni di Catan' (manual)
+... 13 lines total ...
+Summary: total=13  created=13  existing=0  skipped=0  failed=0
+45-translations complete
+```
+
+Verify in DB:
+
+```bash
+pwsh -c "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c \"SELECT COUNT(*) FROM shared_game_translations WHERE NOT is_deleted;\""
+```
+
+Expected: 13.
+
+### Step 4.4: Idempotency check — re-run
+
+```bash
+./scripts/seed-sp4/seed-sp4.sh --step 45
+```
+
+Expected output:
+```
+Summary: total=13  created=0  existing=13  skipped=0  failed=0
+```
+
+### Step 4.5: Commit script
+
+```bash
+git add infra/scripts/seed-sp4/45-translations.sh
+git commit -m "feat(seed): add 45-translations.sh seed script (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 5: Update orchestrator + seed-sp4.sh banner
+
+**Files:**
+- Modify: `infra/scripts/seed-sp4/seed-sp4.sh`
+
+### Step 5.1: Update banner comment
+
+In `seed-sp4.sh` at the step list comment block (lines 14-25), add:
+
+```bash
+#   45 translations   ← 13 IT game title translations (#2339)
+```
+
+between `40 agents` and `50 toolkits`.
+
+### Step 5.2: Verify orchestrator picks up new step
+
+```bash
+./infra/scripts/seed-sp4/seed-sp4.sh --help
+# Expected output now lists 45-translations.sh in the step enumeration
+```
+
+Note: The orchestrator uses `ls [0-9][0-9]-*.sh` glob (line 55), so the new script is auto-picked-up — no further code change needed beyond the banner comment.
+
+### Step 5.3: Run full pipeline locally
+
+```bash
+cd infra && make seed-sp4
+```
+
+Expected: all 12 steps complete green (00, 10, 20, 30, 40, 45, 50, 60, 70, 80, 90, 95).
+
+### Step 5.4: Commit
+
+```bash
+git add infra/scripts/seed-sp4/seed-sp4.sh
+git commit -m "chore(seed): register 45-translations in orchestrator banner (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 6: ADR-059 §6 amendment
+
+**Files:**
+- Modify: `docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md`
+
+### Step 6.1: Append §6 amendment after current §5 (User-side BGG asset ban)
+
+Add this section right before the `## References` block:
+
+```markdown
+## 6. Amendment 2026-06-20 — Translations seed legal posture (issue #2339 sub-PR 3/3)
+
+ADR-059 §2 narrowly addressed metadata fields fetched from external providers
+(Wikidata primary / BGG whitelisted fallback). Issue #2339 sub-PR 3/3 introduces
+a new data stream: **IT translations of game titles** for the SP4 seed dataset,
+seeded via `infra/scripts/seed-sp4/45-translations.sh` against the
+`shared_game_translations` table (Wave 2 of #2339).
+
+The legal vectors are different from §2 because translations are:
+1. **Curated by us**, not fetched from a third-party provider's database.
+2. **Fact-based** in Feist v. Rural sense — a title is a factual identifier of
+   a published product, not a creative expression. The IT translation "I Coloni
+   di Catan" is the publicly available product name of the Italian-licensed
+   edition (Asterion Press / Giochi Uniti). Feist 499 U.S. 340 (1991) and the
+   parallel EU jurisprudence both exclude facts from copyright.
+3. **Provenance-tracked** via the per-row `translations-research.md` document
+   that records publisher URL + verification status for each title.
+
+### 6.1 Decision
+
+**Translations seed data is OUT OF SCOPE of §2 BGG whitelist** because:
+- The translation data is NOT fetched from BGG. It is researched against the
+  Italian publisher's public website (Asterion, Cranio Creations, Ghenos,
+  Asmodee Italia, Mancalamaro, Giochi Uniti).
+- The data shape is `{ shared_game_id, locale, title, source }` — title is a
+  fact, source is provenance metadata.
+- The `source` enum values (`manual` / `auto-openrouter` / `community`) record
+  the authoring path so audit trail mirrors §2 provenance approach.
+
+### 6.2 In-scope governance for translation seed
+
+- **Verification mandate** (§6.3 below): every `source: "manual"` row MUST have a
+  recorded publisher URL in `translations-research.md` at the time of seed
+  shipping. PRs touching `gameTranslations[]` in `data.json` MUST update the
+  research doc in the same commit.
+- **`source: "auto-openrouter"` records** (when added): MUST be marked clearly
+  in the research doc as machine-translated and subject to admin review before
+  promotion to `manual`.
+- **`source: "community"` records**: BLOCKED in MVP. No community contribution
+  workflow exists; field is reserved for future feature.
+
+### 6.3 Per-row provenance schema
+
+`infra/scripts/seed-sp4/translations-research.md` carries the table:
+
+| Game (EN) | IT Title | Source verified? | Publisher IT | Publisher URL | Native review by | Decision |
+|---|---|---|---|---|---|---|
+
+The "Decision" column must be one of:
+- `manual` — publisher confirmed, native review done.
+- `manual (EN retained)` — publisher kept the English name; the row exists for
+  consistency but the title equals canonical EN.
+- `auto-openrouter` — fall-back, admin TODO to verify.
+- `skip` — game intentionally excluded from translations seed.
+
+### 6.4 Out of scope for §6
+
+- Translations for non-EN languages other than IT (deferred to per-locale follow-up).
+- Translations of `description` field (BE Wave 1 schema supports it; seed scope is title-only).
+- Community-sourced translations workflow.
+- Auto-translation triggered at fetch time (would be ADR-059 §2 territory because OpenRouter is a third-party provider; but no FE consumer triggers this in MVP).
+
+### 6.5 References
+
+- Issue: [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339) sub-PR 3/3
+- Wave 1 spec (BE foundation): [`docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`](../../../superpowers/specs/2026-06-15-shared-game-translations-design.md)
+- Sub-PR 2/3 design: [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](../../../superpowers/specs/2026-06-20-translations-fe-hook-design.md)
+- Sub-PR 3/3 plan: [`docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md`](../../../superpowers/plans/2026-06-20-translations-seed-subpr3.md)
+- Provenance research: `infra/scripts/seed-sp4/translations-research.md`
+- Feist Publications v. Rural Telephone Service, 499 U.S. 340 (1991)
+```
+
+### Step 6.2: Commit ADR
+
+```bash
+git add docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
+git commit -m "chore(adr): ADR-059 §6 — translations seed legal posture (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 7: Close Q4 mitigation note in seed-kb-coverage-evaluation spec
+
+**Files:**
+- Modify: `docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md`
+
+### Step 7.1: Replace Q4 closure block (§9)
+
+Find the existing block starting `- **Q4 — RESOLVED via canonical EN + translation deferred**:` (around line 323) and replace with:
+
+```markdown
+- **Q4 — RESOLVED via #2339 (all sub-PRs shipped)**: titolo del seed Catan rimane `Catan` canonical EN; il dual-row anomaly su snapshot DB è risolto da Wave 1 (PR #2370). IT translation `I Coloni di Catan` shipped via sub-PR 3/3 (seed script `infra/scripts/seed-sp4/45-translations.sh` + `gameTranslations[]` array in `data.json`). Translation service backend wire-up: `IGameTitleResolver` arricchisce `SharedGameDto.Translations[]` su 4 query handler (sub-PR 1/3); FE hook `useGameTitle()` consume il payload con BCP-47 fallback + source priority (sub-PR 2/3).
+  - **Schema attuale**: `shared_game_translations` table (Wave 2 migration `AddSharedGameTranslations`).
+  - **Frontend i18n entity titles**: hook `useGameTitle()` in `apps/web/src/lib/i18n/use-game-title.ts` — vedi spec `docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`.
+  - **Legal posture**: ADR-059 §6 (amendment 2026-06-20) lock-in translations seed governance separately from §2 BGG whitelist.
+  - **Misurazione**: baseline su snapshot DB §9.1 ora include 13 IT translations attive; M3 ora atteso 12/13 (Gloomhaven excluded by design Q2).
+```
+
+### Step 7.2: Update baseline measurement note in §9.1
+
+Just under the baseline table (around line 352), append a note:
+
+```markdown
+**Post Q4 sub-PR 3/3 closure**: tabella ora include `it` translation in `shared_game_translations` table per ciascuno dei 13 giochi (10 `manual (EN retained)` + 3 `manual` con titolo IT divergente: Catan, Codenames, + eventuali revisioni post-research). Misura M3 invariata (translation NON impatta KB indexing).
+```
+
+### Step 7.3: Commit
+
+```bash
+git add docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md
+git commit -m "chore(docs): close Q4 mitigation note — #2339 all sub-PRs shipped (#2339 sub-PR 3/3)"
+```
+
+---
+
+## Task 8: Push, PR, close #2339
+
+### Step 8.1: Final pre-push checks
+
+```bash
+# 1. Verify seed orchestrator green end-to-end
+cd infra && make seed-sp4
+
+# 2. Verify translations table populated
+pwsh -c "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c \"SELECT game_id, locale, title, source FROM shared_game_translations WHERE NOT is_deleted ORDER BY locale, title;\""
+# Expected: 13 rows, all source='manual'
+
+# 3. Verify FE happy-path (manual smoke)
+cd ../apps/web && pnpm dev
+# Browser → http://localhost:3000/library → see "I Coloni di Catan" + "Nome in codice" titles
+```
+
+If any gate red, FIX before push.
+
+### Step 8.2: Push
+
+```bash
+git push -u origin feature/issue-2339-translations-seed
+```
+
+### Step 8.3: Open PR
+
+```bash
+gh pr create --base main-dev \
+  --title "feat(catalog): #2339 sub-PR 3/3 — seed IT translations + ADR-059 amendment" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Sub-PR 3/3 of #2339. Closes issue #2339 with all 3 waves shipped:
+- Sub-PR 1/3 (BE foundation) — PR #2370 merged 2026-06-15
+- Sub-PR 2/3 (FE hook + DTO + consumer migration) — PR #<TBD>
+- Sub-PR 3/3 (this PR — seed IT translations + ADR-059 amendment + Q4 closure)
+
+## Changes
+
+- `infra/scripts/seed-sp4/data.json` → `gameTranslations[]` array (13 IT titles).
+- `infra/scripts/seed-sp4/45-translations.sh` → idempotent seed script (mirror 40-agents.sh pattern).
+- `infra/scripts/seed-sp4/translations-research.md` → per-row provenance research (publisher URL + native review).
+- `docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md` → §6 amendment: translations seed legal posture (separate from §2 BGG whitelist).
+- `docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md` → §9 Q4 closure note replaced.
+
+## Test plan
+
+- [x] `make seed-sp4` green end-to-end (12 steps incl. new step 45).
+- [x] `45-translations.sh` idempotent: re-run shows `existing=13`.
+- [x] Postgres `shared_game_translations` table populated with 13 active rows.
+- [x] FE happy-path: IT browser locale shows IT translated titles on Library + Discover.
+- [x] Provenance research doc filled, no `?` or `TBD` remaining.
+- [x] ADR-059 §6 documents the translations-vs-BGG distinction.
+- [x] Q4 doc closure note reflects all 3 sub-PRs shipped.
+
+Closes #2339.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Step 8.4: Code review subagent (per CLAUDE.md `/implementa` Phase 6 rule)
+
+```bash
+# /code-review:code-review <PR_URL>
+```
+
+If reviewer finds blockers, fix in NEW commits.
+
+### Step 8.5: Update #2339 body — final closure
+
+```bash
+gh issue edit 2339 --body-file <(gh issue view 2339 --json body --jq '.body' | sed 's|⏳ TODO|✅ MERGED|g')
+```
+
+Or hand-edit the progress table:
+- Sub-PR 3/3 row: `⏳ TODO` → `✅ MERGED` with PR link and merge SHA.
+
+### Step 8.6: Close issue
+
+Once PR merges, GitHub auto-closes issue #2339 via the `Closes #2339` body line. Verify:
+
+```bash
+gh issue view 2339 --json state --jq '.state'
+# Expected: CLOSED
+```
+
+### Step 8.7: Post-merge cleanup
+
+```bash
+git checkout main-dev
+git pull
+git branch -D feature/issue-2339-translations-seed
+git remote prune origin
+```
+
+---
+
+## Effort estimate
+
+| Task | Effort |
+|---|---|
+| Task 1: Research doc skeleton | 0.5h |
+| Task 2: Manual research (13 games × verification) | 2-3h |
+| Task 3: `gameTranslations[]` add to data.json | 0.5h |
+| Task 4: `45-translations.sh` implementation + smoke | 1.5h |
+| Task 5: Orchestrator banner update + full pipeline run | 0.5h |
+| Task 6: ADR-059 §6 amendment | 1h |
+| Task 7: Q4 doc closure | 0.5h |
+| Task 8: PR + review + cleanup | 0.5h |
+| **Total** | **~7h** (~1gg single FTE post-research) |
+
+The Task 2 manual research is the long pole. If publisher URLs are pre-verified in a quick async call, the actual implementation reduces to ~4h.
+
+---
+
+## Self-review checklist
+
+- [ ] **Pre-flight Wave 5 verified**: admin POST endpoint live before Task 4.
+- [ ] **Research doc completed**: no `?` or `TBD` in `translations-research.md` table at merge time.
+- [ ] **Seed script idempotent**: re-run shows `existing=13` not `created=26`.
+- [ ] **ADR-059 §6 differentiates** translation seed vs §2 BGG whitelist clearly.
+- [ ] **Q4 doc closure** references all 3 sub-PRs (1/3 #2370, 2/3 <pr>, 3/3 <pr>).
+- [ ] **PR body has `Closes #2339`** → auto-close on merge.
+- [ ] **Code review subagent invoked** per CLAUDE.md /implementa Phase 6.
+- [ ] **Branch hygiene preflight 0.1-0.5 executed**.
+- [ ] **PR target main-dev** confirmed.
+
+---
+
+## Cross-references
+
+- **Spec source (sub-PR 2/3 + 3/3 scope)**: [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](../specs/2026-06-20-translations-fe-hook-design.md) §11
+- **Companion sub-PR 2/3 plan**: [`docs/superpowers/plans/2026-06-20-translations-fe-hook.md`](./2026-06-20-translations-fe-hook.md)
+- **Wave 1 spec (BE foundation)**: [`docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`](../specs/2026-06-15-shared-game-translations-design.md)
+- **Wave 1 plan TDD**: [`docs/superpowers/plans/2026-06-15-shared-game-translations.md`](./2026-06-15-shared-game-translations.md)
+- **Tracker**: [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339)
+- **Wave 1 shipped PR**: [#2370](https://github.com/meepleAi-app/meepleai-monorepo/pull/2370) (`cd041ca35`)
+- **Q4 closure target**: [`docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md`](../../for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md) §9
+- **ADR-059 (catalog seed legal posture)**: [`docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md`](../../for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md)

--- a/docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md
+++ b/docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md
@@ -1,0 +1,513 @@
+# Shared Game Translations — Frontend Hook Design (sub-PR 2/3)
+
+> **Status**: DESIGN APPROVED — 2026-06-20
+> **Tracker issue**: [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339)
+> **Wave 1 reference**: [`docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`](./2026-06-15-shared-game-translations-design.md) — BE foundation + admin endpoints SHIPPED via PR [#2370](https://github.com/meepleAi-app/meepleai-monorepo/pull/2370) (`cd041ca35`)
+> **Plan**: [`docs/superpowers/plans/2026-06-20-translations-fe-hook.md`](../plans/2026-06-20-translations-fe-hook.md)
+> **Companion (sub-PR 3/3)**: [`docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md`](../plans/2026-06-20-translations-seed-subpr3.md) — seed translations IT curate
+> **Sub-PR position**: 2 di 3 — FE consumption layer. Sub-PR 1/3 = BE foundation (SHIPPED). Sub-PR 3/3 = seed data.
+
+## 1. Contesto
+
+Wave 1 (PR #2370) ha shipped la foundation BE: `shared_game_translations` table, aggregate `SharedGameTranslation`, `IGameTitleResolver` che enricha 4 query handler (`GetAllSharedGames`, `SearchSharedGames`, `GetFilteredSharedGames`, `GetPendingApprovalGames`) con il campo nullable `Translations: IReadOnlyList<SharedGameTranslationDto>?` su `SharedGameDto`. Il DTO C# è già live in `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs:64` come **field opzionale al fondo del positional record** (nullable, default null).
+
+Sub-PR 2/3 chiude il gap consumer-side: il payload arriva sulla FE già arricchito, ma:
+
+1. Le Zod schemas in `apps/web/src/lib/api/schemas/shared-games.schemas.ts` **non hanno ancora** il campo `translations[]` — i 141 callsite di `game.title` su 82 file leggono il titolo canonical EN.
+2. Non esiste un punto centrale che applichi le policy di selezione (locale fallback, source priority, override esplicito utente).
+3. La a11y richiede che il titolo localizzato venga annunciato come tale agli screen reader (l'utente IT che legge "Catan" su un titolo che esiste in IT come "I Coloni di Catan" deve poter risolvere l'ambiguità).
+
+Questo doc lock-in il design del hook `useGameTitle()` + DTO TS update + consumer migration. Output: ResolvedTitle pattern (NON plain string) + 5 REQ-FE + locale resolution chain BCP-47 + 6 GWT scenarios + 6-row test matrix + axe AA gate.
+
+### 1.1 Why sub-PR 2/3 separately from sub-PR 1/3
+
+- **Independent merge gate**: il BE foundation è già pulito in staging snapshot, no rollback risk se la FE ship in PR diversa.
+- **Review scope chiaro**: PR 1/3 = 53 file BE; PR 2/3 = ~30 file FE diff (hook + types + 82 consumer touch); PR 3/3 = seed bash + research doc. Squash isolato facilita revert chirurgico.
+- **Sub-PR 3/3 dipende solo dal BE endpoint** (Wave 5 #2339 admin POST/PUT/DELETE), NON dal FE hook. I 2 stream possono procedere in parallelo se Wave 5 ships prima.
+
+## 2. Decisioni locked
+
+Lockate via spec-panel review (Wiegers/Cockburn/Adzic/Fowler/Crispin/Gregory, 2026-06-20).
+
+> ✅ **DECISION BUNDLE LOCKED 2026-06-20** — 11 DEC accepted-as-default in user review session 2026-06-20:
+> - DEC-FE-1..8 + DEC-FE-10 + DEC-FE-DEFER accepted senza modifiche (bundle "Accept all defaults")
+> - DEC-FE-9 lockato esplicito su i18n chiave react-intl (NOT hardcoded EN string)
+> - Audit trail: spec-panel review session 2026-06-20, sub-agent A output, user AskUserQuestion 2026-06-20
+
+| # | Status | Q | Decisione | Rationale |
+|---|---|---|---|---|
+| DEC-FE-1 | ✅ **LOCKED 2026-06-20** | Hook return type | `ResolvedTitle` struct (NON `string`) | Consumer a11y + admin badge richiedono `source/locale` discriminator; plain string nasconde il context (Fowler hard reject su API design) |
+| DEC-FE-2 | ✅ **LOCKED 2026-06-20** | Source priority | `manual` > `auto-openrouter` > `community` | Gregory: manual è curato umano → quality > automation > unverified community |
+| DEC-FE-3 | ✅ **LOCKED 2026-06-20** | Locale fallback chain | `region-specific` → `language-only` → `canonical` (NO upgrade `it` → `it-IT`) | BCP-47 `it-IT` → `it` → `en` (Crispin matrix row 3). User request `it` NON viene upgradato a `it-IT` per evitare surprise behavior. |
+| DEC-FE-4 | ✅ **LOCKED 2026-06-20** | Explicit override wins | User profile `preferredLocale` precede browser `Accept-Language` | Wiegers REQ-FE-5: respect user agency, no surprise |
+| DEC-FE-5 | ✅ **LOCKED 2026-06-20** | Locale resolution side | Client-side (FE hook) | "Both" DTO shape già lockato in Wave 1 spec §2 → BE non fa resolution, payload include sempre tutte le translation attive |
+| DEC-FE-6 | ✅ **LOCKED 2026-06-20** | DTO TS update path | Manual edit a `apps/web/src/lib/api/schemas/shared-games.schemas.ts` (Zod schemas) | Non c'è OpenAPI-generator wire (confermato via grep su `schemas/` directory). FE types sono scritti a mano, validati a runtime via Zod |
+| DEC-FE-7 | ✅ **LOCKED 2026-06-20** | Cache strategy | `useMemo` deps `[game.id, game.translations, locale]` | Hook chiamato dentro `.map()` su list pages — memoize per evitare re-resolve su ogni render; non React Query (locale è puro client) |
+| DEC-FE-8 | ✅ **LOCKED 2026-06-20** | Consumer migration | Codemod-assisted grep+replace, ESLint **warn** initial → **error** post-migration (14gg trajectory verde) | 82 file × 141 occurrence — graduale, hook adoption non-blocking inizialmente. Promotion `warn` → `error` via follow-up issue dopo trajectory verde verificata |
+| DEC-FE-9 | ✅ **LOCKED 2026-06-20** | a11y pattern | `aria-label = intl.formatMessage({ id: 'common.localizedFromEnglish' }, { localizedTitle, originalTitle })` via `react-intl` | WCAG 2.1 SC 3.1.2 Language of Parts. Solo quando `source === 'translation'`. **i18n chiave** (NON hardcoded EN string) → cresce naturale a 5+ locales, zero string drift. Richiede aggiunta chiave in `apps/web/src/locales/{it,en}.json` (§5.4) |
+| DEC-FE-10 | ✅ **LOCKED 2026-06-20** | "Untranslated" badge | Solo admin pages (`/admin/shared-games/...`); end-user UI no | Gregory: free-tier user non deve essere bombardato di "italiano mancante" notifications. Admin curator vuole signal |
+| DEC-FE-DEFER | ✅ **LOCKED 2026-06-20** | Search filter scope | Canonical-only in sub-PR 2/3 (search input continua a matchare `SharedGame.title` EN) | Apre follow-up issue per decidere se search filter deve anche matchare `Translations[i].title` (es. user IT cerca "Coloni" → trova Catan via translation). NON in scope sub-PR 2/3 per evitare DB index changes + perf risk |
+
+## 3. Use Cases
+
+Tre actor distinti emergono dal panel (Cockburn). Goal/success/failure modes esplicitati.
+
+### 3.1 UC-1: Free-tier user browse catalogo
+
+- **Primary actor**: end-user authenticated, browser `it-IT`, profile language `null` (mai impostato).
+- **Goal**: vedere "I Coloni di Catan" sul Discover hub invece di "Catan" se il translation esiste.
+- **Frequency**: ogni page render (alta) — `useGameTitle()` chiamato dentro `.map()` su 10-50 card.
+- **Success scenario**: hook risolve in <1ms via memoization; UI rendering 0 layout shift; aria-label localizzato attached.
+- **Failure modes**:
+  - Translation array vuoto → fallback canonical EN, no indicator, no console.warn (silent — è il caso più comune per giochi non-popolari).
+  - Translation array `null` (BE non l'ha mandato — admin endpoint legacy) → treat as empty, fallback canonical EN.
+  - Locale non-matchable → fallback canonical EN, no error UI.
+
+### 3.2 UC-2: Admin curator translations
+
+- **Primary actor**: admin user via `/admin/shared-games/{id}` editing translations.
+- **Goal**: vedere subito quali giochi non hanno IT translation per prioritizzare il backlog.
+- **Frequency**: bassa (1-2 sessioni/settimana), accuracy-sensitive.
+- **Success scenario**: hook ritorna `source: 'canonical'` e UI mostra badge "⚠ untranslated" sui list item; admin clicca e arriva al form modale.
+- **Failure modes**:
+  - Translation source `auto-openrouter` confuso con `manual` → admin pensa che sia curato umano. Mitigation: badge differenziato (icona MachineLearning vs Person).
+
+### 3.3 UC-3: Player in live game session
+
+- **Primary actor**: end-user in `/sessions/{id}/live` durante partita attiva.
+- **Goal**: vedere lo stesso titolo del gioco su ogni component (header, breadcrumb, score panel) senza flicker su re-render.
+- **Frequency**: continua per durata partita (10-90 min), consistency-sensitive.
+- **Success scenario**: hook è puro/memoized → re-render del live session non triggera locale re-resolution; titolo stabile.
+- **Failure modes**:
+  - User cambia locale durante la session (raro ma possibile, theme-toggle pattern) → hook re-resolve su nuovo locale; nessun crash, titolo aggiornato graceful.
+  - SSE/WebSocket re-fetch del game DTO con `translations` campo diverso (es. admin appena aggiunto IT translation mid-session) → memoization invalidata, hook ritorna nuovo titolo. Comportamento atteso, non un bug.
+
+## 4. Requirements
+
+Formato SMART (Wiegers): `WHO SHALL WHAT WHEN/WHERE`. Priority `P0` = must-ship sub-PR 2/3.
+
+### REQ-FE-1 — Locale exact-match precedence (P0)
+
+> `useGameTitle(game)` **SHALL** return the localized title when the resolved user locale matches a translation with `source ∈ {'manual', 'auto-openrouter', 'community'}` EXACTLY (case-insensitive on language tag, region preserved per BCP-47).
+
+**Acceptance criterion**: Given `game.translations = [{ locale: 'it', title: 'I Coloni di Catan', source: 'manual' }]` and `useUserLocale() → 'it'`, the hook returns `{ value: 'I Coloni di Catan', source: 'translation', locale: 'it', provider: 'manual' }`.
+
+**Rationale**: zero-config happy path per il 90% degli use case.
+
+### REQ-FE-2 — Canonical EN fallback (P0)
+
+> The hook **SHALL** fallback to `game.title` (canonical EN) when no translation matches the resolved locale chain (REQ-FE-3), without emitting any error or warning.
+
+**Acceptance criterion**: Given `game.translations = [{ locale: 'fr', ... }]` and `useUserLocale() → 'de'`, the hook returns `{ value: game.title, source: 'canonical', locale: 'en' }`. No `console.warn`. No `provider` field.
+
+**Rationale**: free-tier users (UC-1) outnumber localized users; silent fallback is correct UX.
+
+### REQ-FE-3 — BCP-47 locale resolution chain (P0)
+
+> The hook **SHALL** preferire una translation `it` su una translation `it-IT` quando l'utente browser è `it-IT` ma solo `it` translation esiste, e viceversa. La chain è: `region-specific` → `language-only` → `canonical`.
+
+**Acceptance criterion**: matrix 6-row in §8 covers:
+- User `it-IT`, translations `[it]` → match on language fallback (`it` wins).
+- User `it`, translations `[it-IT]` → NO match (region is more specific than user request), fallback canonical EN.
+- User `it-IT`, translations `[it-IT, it]` → match exact (`it-IT` wins).
+
+**Rationale**: BCP-47 standard "Tags for Identifying Languages" (RFC 5646) § Subtag Negotiation. The hook is the single source of truth for matching.
+
+**Note implementativa**: helper puro `resolveLocale(userLocale: string, availableLocales: string[]): string | null` testato in isolamento (Task 3).
+
+### REQ-FE-4 — Source priority `manual > auto-openrouter > community` (P0)
+
+> The hook **SHALL** prefer `manual` source over `auto-openrouter` over `community` when multiple translations exist for the same locale.
+
+**Acceptance criterion**: Given `game.translations = [{ locale: 'it', source: 'auto-openrouter', title: 'Coloni MT' }, { locale: 'it', source: 'manual', title: 'I Coloni di Catan' }]`, the hook returns title `'I Coloni di Catan'` with `provider: 'manual'`.
+
+**Rationale**: Gregory finding — manual è curato umano, quality bar superiore. Auto-OpenRouter è MT (machine translation) non revisionata. Community è user-generated, no moderation in MVP (Wave 1 spec §10).
+
+**Note pratica BE**: il DB unique index `uq_active_translation_per_locale ON (shared_game_id, locale) WHERE NOT is_deleted` impedisce di avere 2 row attive con stesso `(game, locale)` simultaneamente. Quindi REQ-FE-4 si applica solo a translations soft-deleted ri-attivate o a stale snapshot del payload. Il check FE è defensive — costa zero ma blinda casi edge.
+
+### REQ-FE-5 — User explicit override precedence (P0)
+
+> The hook **SHALL** respect the user's explicit locale preference (via `useUserLocale()` reading `UserProfile.Language`) over the browser `Accept-Language` header.
+
+**Acceptance criterion**: Given browser `it-IT` and `useUserLocale() → 'en'` (user has set `Language=en` in profile), the hook returns canonical EN even when `game.translations` includes `[{ locale: 'it', ... }]`. No surprise localization.
+
+**Rationale**: Wiegers — respect user agency. `useUserLocale` hook (existing `apps/web/src/hooks/useUserLocale.ts`) already implements the fallback chain `profile → browser → default`. The translation hook MUST consume this hook (NOT `navigator.language` directly) so the override propagates.
+
+## 5. Contract API
+
+### 5.1 Type definition
+
+```ts
+// apps/web/src/lib/i18n/use-game-title.ts
+
+/**
+ * The provider that authored a translation, mirroring backend `TranslationSource` enum.
+ * Used by the admin badge to differentiate human-curated vs machine-translated content.
+ */
+export type TranslationProvider = 'manual' | 'auto-openrouter' | 'community';
+
+/**
+ * Result of resolving a game's title for the current viewer locale.
+ *
+ * Discriminated union via `source`:
+ * - `source: 'canonical'` → no translation matched; `value` is `game.title` (EN); `provider` is undefined.
+ * - `source: 'translation'` → a translation matched; `value` is the localized title; `provider` is the authoring source.
+ *
+ * `locale` reflects the resolved tag (e.g. `'it-IT'` if exact match, `'it'` if BCP-47 fallback, `'en'` if canonical).
+ */
+export interface ResolvedTitle {
+  value: string;
+  source: 'canonical' | 'translation';
+  locale: string;
+  provider?: TranslationProvider;
+}
+
+/**
+ * Optional override knobs. The default behavior reads locale from `useUserLocale()`.
+ *
+ * - `locale`: force a specific locale (e.g. for admin previewing other locales).
+ *   Bypasses the user/browser chain entirely.
+ */
+export interface UseGameTitleOptions {
+  locale?: string;
+}
+
+/**
+ * Resolve the best-fit title for a SharedGame given the current viewer's locale.
+ *
+ * Pure + memoized: safe to call inside `.map()` callbacks. Re-resolves only when
+ * `game.id`, `game.translations`, or the resolved locale changes.
+ *
+ * @example list of game cards (DEC-FE-9 react-intl pattern)
+ * ```tsx
+ * function GameGrid({ games }: { games: SharedGame[] }) {
+ *   const intl = useIntl();
+ *   return games.map(g => {
+ *     const { value, source, locale } = useGameTitle(g);
+ *     const ariaLabel = source === 'translation'
+ *       ? intl.formatMessage(
+ *           { id: 'common.localizedFromEnglish' },
+ *           { localizedTitle: value, originalTitle: g.title }
+ *         )
+ *       : value;
+ *     return <h3 aria-label={ariaLabel}>{value}</h3>;
+ *   });
+ * }
+ * ```
+ *
+ * @example admin previewing French
+ * ```tsx
+ * const { value } = useGameTitle(game, { locale: 'fr' });
+ * ```
+ */
+export function useGameTitle(
+  game: Pick<SharedGame, 'title' | 'translations'>,
+  options?: UseGameTitleOptions
+): ResolvedTitle;
+```
+
+### 5.2 Type narrowing aside
+
+The `Pick<SharedGame, 'title' | 'translations'>` input bound (not full `SharedGame`) lets unit tests pass minimal fixtures and avoids coupling the hook to fields it doesn't need (the consumer migration step can rely on `SharedGame | SharedGameDetail` since both will satisfy the bound after Task 1).
+
+### 5.3 Why `useMemo` not React Query
+
+- React Query is for async data fetching with cache invalidation. Title resolution is **pure client-side computation** from already-loaded `game.translations[]`.
+- `useMemo([game.id, game.translations, locale])` is sufficient and avoids extra QueryClient cache overhead. Deps stable across re-renders because:
+  - `game.id` is a UUID string (referential equality safe).
+  - `game.translations` is the same array reference unless the parent fetch returns a fresh payload (React Query response semantics).
+  - `locale` is a string from `useUserLocale()` which itself memoizes.
+
+### 5.4 i18n keys da aggiungere (DEC-FE-9 ✅ LOCKED 2026-06-20)
+
+aria-label localization usa `react-intl` con chiave `common.localizedFromEnglish`. Da aggiungere:
+
+**`apps/web/src/locales/it.json`**:
+```json
+{
+  "common.localizedFromEnglish": "{localizedTitle} (tradotto da: {originalTitle})"
+}
+```
+
+**`apps/web/src/locales/en.json`**:
+```json
+{
+  "common.localizedFromEnglish": "{localizedTitle} (localized from English: {originalTitle})"
+}
+```
+
+**Per future locales** (es. `es`, `fr`, `de` — out of scope sub-PR 2/3, ma chiave i18n garantisce zero-touch sviluppo futuro):
+```jsonc
+// es.json: "{localizedTitle} (traducido del inglés: {originalTitle})"
+// fr.json: "{localizedTitle} (traduit de l'anglais: {originalTitle})"
+// de.json: "{localizedTitle} (übersetzt aus dem Englischen: {originalTitle})"
+```
+
+**Reject hardcoded EN string**: `aria-label = \`${value} (localized from English: ${original})\`` rifiutato perché un utente DE che vede un game con solo IT translation avrebbe aria-label in EN — string drift. Con `intl.formatMessage`, l'aria-label segue automatically il locale UI dell'utente.
+
+**Test consideration**: nei Vitest unit test, wrap component con `<IntlProvider locale="en" messages={enMessages}>...` come pattern già usato in altri component test (vedi `apps/web/src/components/.../[component].test.tsx` per reference).
+
+## 6. Locale Resolution Algorithm
+
+Pure helper extracted for unit-testability:
+
+```ts
+// apps/web/src/lib/i18n/resolve-locale.ts
+
+/**
+ * Picks the best-fit available locale for a user-preferred locale.
+ *
+ * Fallback chain per BCP-47:
+ *   1. Exact match (case-insensitive language, case-preserved region).
+ *   2. Language-only match (drop region: 'it-IT' → 'it').
+ *   3. null (caller falls back to canonical EN).
+ *
+ * `null` available locales list returns `null` immediately.
+ *
+ * Examples:
+ *   resolveLocale('it-IT', ['it'])      → 'it'    (region drop fallback)
+ *   resolveLocale('it', ['it-IT'])      → null    (cannot upgrade language to region)
+ *   resolveLocale('it-IT', ['it-IT'])   → 'it-IT' (exact match wins)
+ *   resolveLocale('it-IT', ['it-IT','it']) → 'it-IT' (exact wins over fallback)
+ *   resolveLocale('de', ['it','fr'])    → null
+ */
+export function resolveLocale(
+  userLocale: string,
+  availableLocales: ReadonlyArray<string>
+): string | null;
+```
+
+**Decision tree**:
+
+```
+user="xx-YY" → exact "xx-YY" in available? → yes → return "xx-YY"
+                                            ↓ no
+              language "xx" in available? → yes → return "xx"
+                                            ↓ no
+                                          → return null
+
+user="xx"    → exact "xx" in available?   → yes → return "xx"
+                                            ↓ no
+              (NO upgrade to "xx-YY" — user did not request a region)
+                                          → return null
+```
+
+**Note BCP-47**: case normalization is `language: lowercase`, `region: uppercase`. The BE VO `Locale.Create()` already enforces this on storage (`apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/Locale.cs:432`), so payload-side strings are already in canonical form. The FE helper normalizes input defensively (`userLocale.toLowerCase()` on the language segment) but trusts the payload as-is.
+
+## 7. Gherkin Scenarios (Acceptance-driven)
+
+Adzic — executable spec via Gherkin GWT. These map 1:1 to test cases in Task 2 (Vitest).
+
+```gherkin
+Feature: Localized game titles
+
+  Background:
+    Given a game "Catan" with canonical EN title "Catan"
+
+  Scenario: S1 - User browser locale it-IT, game has only 'it' translation
+    Given the game has translation { locale: "it", title: "I Coloni di Catan", source: "manual" }
+    And the user has no profile locale set
+    And the browser language is "it-IT"
+    When I render the game card
+    Then the displayed title is "I Coloni di Catan"
+    And the source is "translation"
+    And the resolved locale is "it"
+    And the provider is "manual"
+    And the heading aria-label resolves via react-intl key "common.localizedFromEnglish"
+    And with UI locale "it" the aria-label is "I Coloni di Catan (tradotto da: Catan)"
+    And with UI locale "en" the aria-label is "I Coloni di Catan (localized from English: Catan)"
+
+  Scenario: S2 - User explicit override EN, game has IT translation
+    Given the game has translation { locale: "it", title: "I Coloni di Catan", source: "manual" }
+    And the user profile locale is "en"
+    And the browser language is "it-IT"
+    When I render the game card
+    Then the displayed title is "Catan"
+    And the source is "canonical"
+    And the resolved locale is "en"
+    And there is no localization indicator
+    And no aria-label augmentation occurs
+
+  Scenario: S3 - Manual translation wins over auto-openrouter for same locale
+    Given the game has translations:
+      | locale | title              | source           |
+      | it     | Coloni MT          | auto-openrouter  |
+      | it     | I Coloni di Catan  | manual           |
+    And the user resolved locale is "it"
+    When I render the game card
+    Then the displayed title is "I Coloni di Catan"
+    And the provider is "manual"
+
+  Scenario: S4 - No matching translation, silent canonical fallback
+    Given the game has translation { locale: "fr", title: "Les Colons de Catane", source: "manual" }
+    And the user resolved locale is "de"
+    When I render the game card
+    Then the displayed title is "Catan"
+    And the source is "canonical"
+    And no console warning is emitted
+    And no error UI is shown
+
+  Scenario: S5 - Translations array missing (null), backward compat
+    Given the game has translations = null (legacy admin endpoint payload)
+    And the user resolved locale is "it"
+    When I render the game card
+    Then the displayed title is "Catan"
+    And the source is "canonical"
+    And no error is thrown
+
+  Scenario: S6 - BCP-47 fallback it-IT → it
+    Given the game has translation { locale: "it", title: "I Coloni di Catan", source: "manual" }
+    And the user resolved locale is "it-IT"
+    When I render the game card
+    Then the displayed title is "I Coloni di Catan"
+    And the resolved locale is "it" (fallback, not "it-IT")
+    And the provider is "manual"
+
+  Scenario: S7 - Admin preview overrides user locale
+    Given the game has translation { locale: "fr", title: "Les Colons de Catane", source: "manual" }
+    And the user resolved locale is "it"
+    When I call useGameTitle(game, { locale: "fr" })
+    Then the displayed title is "Les Colons de Catane"
+    And the source is "translation"
+    And the resolved locale is "fr"
+```
+
+## 8. Test Matrix (Crispin)
+
+6-row mandatory matrix. Each row = 1 Vitest test in Task 2.
+
+| # | Browser locale | Profile override | Available translations | Expected title | Expected source | Expected locale |
+|---|---|---|---|---|---|---|
+| T1 | `en` | — | `[]` (none) | canonical EN | `canonical` | `en` |
+| T2 | `it` | — | `[{it, manual}]` | IT manual | `translation` | `it` |
+| T3 | `it-IT` | — | `[{it, manual}]` | IT manual (region fallback) | `translation` | `it` |
+| T4 | `de` | — | `[{it, manual}, {fr, community}]` | canonical EN | `canonical` | `en` |
+| T5 | `it` | `en` (explicit) | `[{it, manual}]` | canonical EN (override wins) | `canonical` | `en` |
+| T6 | `it` | — | `[{it, manual}, {it, auto-openrouter}]` | IT manual (source priority) | `translation` | `it` |
+
+**Plus 3 a11y rows** (axe + react-intl, DEC-FE-9 LOCKED):
+
+| # | Scenario | Axe rule | Expected |
+|---|---|---|---|
+| A1 | Localized title rendered with `intl.formatMessage('common.localizedFromEnglish')` aria-label (UI locale=en) | `aria-allowed-attr`, `aria-valid-attr-value` | 0 violations + aria-label contains "localized from English" |
+| A2 | Canonical title rendered with no aria-label augmentation | `aria-required-children` (parent heading) | 0 violations |
+| A3 | Localized title aria-label with UI locale=it via `IntlProvider locale="it"` wrap | `aria-allowed-attr` | aria-label contains "tradotto da" (verifica chiave i18n switching) |
+
+## 9. Cache & Memoization
+
+```tsx
+function useGameTitle(game, options) {
+  const fallbackLocale = useUserLocale();
+  const locale = options?.locale ?? fallbackLocale;
+
+  return useMemo(
+    () => resolveTitle(game, locale),
+    [game.id, game.translations, locale]
+  );
+}
+```
+
+**Why `[game.id, game.translations, locale]`**:
+- `game.id` is the stable identity key. If the parent fetch returns the same id but a different translations array (admin just added IT translation), the second dep triggers re-resolve.
+- `game.translations` reference equality is sufficient — React Query / fetch responses produce a fresh array on each successful refetch.
+- `locale` from `useUserLocale()` is itself memoized (the existing hook uses `useState`, so the reference is stable until the profile fetch updates it).
+
+**Anti-pattern banned**: `useMemo(() => ..., [game])` would invalidate on every re-render because parents often spread `{ ...game }` — too coarse.
+
+**Performance budget**: 100 cards × `useGameTitle()` = 100 `useMemo` calls. React `useMemo` overhead is ~1µs per call; 100µs/frame is well under the 16ms frame budget. No perf concern.
+
+## 10. Consumer Migration Plan
+
+### 10.1 Grep pattern
+
+The reference grep produced 141 occurrences across 82 files (verified 2026-06-20). Cluster:
+
+| Cluster | Files | Pattern | Strategy |
+|---|---|---|---|
+| Render-only display (no logic) | ~60 | `<h3>{game.title}</h3>` | Replace with `const { value } = useGameTitle(game); <h3>{value}</h3>` |
+| Inside `.map()` over list | ~15 | `games.map(g => <Card title={g.title} />)` | Hook MUST be called at the leaf component level, NOT inside `.map()` body of a parent function component (Rules of Hooks) — extract `<GameCardContent game={g} />` if not already |
+| Storybook/test fixtures | ~5 | `mockGame.title === 'X'` | Leave canonical EN; fixtures should not rely on translation resolution |
+| Search input filter / sort | ~10 | `games.filter(g => g.title.includes(...))` | Open question: search by canonical only, or also by translations? **DEC-FE-DEFER**: search remains canonical-only in sub-PR 2/3 (Wiegers parking lot — out of scope, follow-up filed) |
+| Type definitions / generic | ~10 | `type X = Pick<SharedGame, 'title'>` | No change — type stays |
+| Admin pages | ~20 | `game.title` displayed alongside metadata | Use hook + show "untranslated" badge per DEC-FE-10 |
+
+### 10.2 Migration order
+
+1. **Task 6.1**: Run `grep -rn "game\.title" apps/web/src/ --include="*.tsx" --include="*.ts"` → save baseline count (141).
+2. **Task 6.2**: Migrate the 5 highest-traffic surfaces first:
+   - `apps/web/src/components/discover/GameDiscoverDetail.tsx` (UC-1 hot path)
+   - `apps/web/src/components/features/hub/HubGameCard.tsx` (Discover row card)
+   - `apps/web/src/components/games/MeepleGameCard.tsx` (catalog card)
+   - `apps/web/src/components/library/MeepleUserLibraryCard.tsx` (Library card)
+   - `apps/web/src/app/(public)/shared-games/[id]/page-client.tsx` (shared game detail)
+3. **Task 6.3**: Sweep the rest with the codemod (`scripts/codemod/use-game-title-migration.ts`, ts-morph or jscodeshift).
+4. **Task 6.4**: ESLint custom rule `local/prefer-use-game-title` in **warn** mode (NOT error in this PR) — flags raw `game.title` access in JSX expressions. Promote to error in a follow-up PR after 14gg main-dev trajectory verde.
+
+### 10.3 Risk mitigation
+
+- **Tests stale**: 82 files include 9 `__tests__/*.test.tsx`. After each migration sub-batch, run `pnpm test --changed`.
+- **Storybook snapshots drift**: 5 `.stories.tsx` files touched. Re-record via `pnpm storybook:test --update-snapshots` only if visual conformity gate exists (note: visual gate retired 2026-05-20 per CLAUDE.md — so no auto-gate, just sanity check).
+- **Type errors at consumer**: the `translations?: SharedGameTranslationDto[]` Zod field is **optional**; existing consumers that don't pass it through will still typecheck.
+
+### 10.4 Out-of-scope for migration
+
+- Search input filter (UC-DEFER above). Open follow-up issue: "Should search match localized titles?". Stays canonical-only for sub-PR 2/3.
+- Storybook fixtures that hardcode `title: 'Catan'`. They remain English; user-facing pages use the hook.
+- BE-emitted notification text (e.g. game-night invite email) — that's a server-side concern, separate issue.
+
+## 11. Sub-PR 3/3 Scope (preview)
+
+Detail lives in [`docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md`](../plans/2026-06-20-translations-seed-subpr3.md). Summary here for cross-reference:
+
+- **Research doc** `infra/scripts/seed-sp4/translations-research.md`: per-game IT title verification (publisher URL + retailer + native review) + classification `manual` vs `auto-openrouter`.
+- **Seed data** `infra/scripts/seed-sp4/data.json` extension: add `gameTranslations[]` array with `{ gameSlug, locale: "it", title, source }`.
+- **Seed script** `infra/scripts/seed-sp4/45-translations.sh`: POST sequential to `/api/v1/admin/games/{id}/translations` for each game-translation pair.
+- **ADR-059 update** §5.x: clarify translation seeds are not in BGG ToS scope (titles only, fact-based per Feist doctrine).
+- **Q4 doc closure** in `docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md` §9: replace "follow-up dedicato" note with "RESOLVED via #2339 sub-PR 3/3".
+
+Note: sub-PR 3/3 depends on Wave 5 admin endpoints (`POST /api/v1/admin/games/{id}/translations`) being shipped first — those are part of issue #2339 task 14 (still TODO at sub-PR 2/3 time). If Wave 5 ships in parallel, sub-PR 3/3 can land same day as sub-PR 2/3.
+
+## 12. Out of Scope (esplicito non-goals)
+
+- ❌ Server-side locale negotiation via `Accept-Language` middleware (Wave 1 already lockata su "Both" DTO, no `ILocaleProvider`).
+- ❌ Community translations moderation queue (Wave 1 spec §10).
+- ❌ User preference UI panel for setting `preferredLocale` (existing `useUserLocale` hook reads from `UserProfile.Language`, which is managed in `/profile/settings` — already shipped).
+- ❌ Search input localized filter (DEC-FE-DEFER, follow-up issue).
+- ❌ E2E translation of admin endpoint error messages (separate concern).
+- ❌ Description field localization (sub-PR 2/3 wires `translations[].description` into the type but no UI consumer reads it yet; admin form for description ships in sub-PR 3/3 spec or follow-up).
+- ❌ Promoting `local/prefer-use-game-title` ESLint rule to error mode (deferred to follow-up post-14gg trajectory).
+- ❌ Storybook fixtures localization (canonical EN forever; UI tests use English).
+
+## 13. Acceptance Criteria
+
+- [ ] DTO TS Zod schema `SharedGameSchema` and `SharedGameDetailSchema` extended with optional `translations: SharedGameTranslationDtoSchema[]`.
+- [ ] New schema `SharedGameTranslationDtoSchema` exported from `shared-games.schemas.ts`.
+- [ ] Hook `useGameTitle(game, options?): ResolvedTitle` shipped in `apps/web/src/lib/i18n/use-game-title.ts`.
+- [ ] Pure helper `resolveLocale(userLocale, available)` shipped in `apps/web/src/lib/i18n/resolve-locale.ts`.
+- [ ] Pure helper `pickBestTranslation(translations, locale)` shipped in `apps/web/src/lib/i18n/pick-best-translation.ts`.
+- [ ] 6 Vitest unit tests covering test matrix T1-T6 (§8) all green.
+- [ ] 2 axe a11y tests A1+A2 green.
+- [ ] 5 highest-traffic consumers migrated (§10.2 Task 6.2 list).
+- [ ] Remaining consumers swept via codemod or PR comment marker, all 141 occurrences accounted for.
+- [ ] ESLint rule `local/prefer-use-game-title` in **warn** mode, no false positives on type-only references.
+- [ ] E2E Playwright happy-path: `pnpm test:e2e --grep "translations-fe-hook"` green with Accept-Language `it` showing IT title on Library and Discover.
+- [ ] `pnpm typecheck` + `pnpm lint` green project-wide.
+- [ ] `pnpm test --coverage` ≥85% on new files.
+- [ ] Issue #2339 body updated with sub-PR 2/3 closure note.
+
+## 14. References
+
+- Wave 1 design: [`docs/superpowers/specs/2026-06-15-shared-game-translations-design.md`](./2026-06-15-shared-game-translations-design.md)
+- Wave 1 plan TDD: [`docs/superpowers/plans/2026-06-15-shared-game-translations.md`](../plans/2026-06-15-shared-game-translations.md)
+- Wave 1 shipped PR: [#2370](https://github.com/meepleAi-app/meepleai-monorepo/pull/2370) (`cd041ca35`)
+- Sub-PR 2/3 plan TDD: [`docs/superpowers/plans/2026-06-20-translations-fe-hook.md`](../plans/2026-06-20-translations-fe-hook.md)
+- Sub-PR 3/3 plan TDD: [`docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md`](../plans/2026-06-20-translations-seed-subpr3.md)
+- BE DTO: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameDto.cs:29-64`
+- BE Translation DTO: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/SharedGameTranslationDto.cs:13-17`
+- FE Zod schemas: `apps/web/src/lib/api/schemas/shared-games.schemas.ts:166-199`
+- Existing locale hook: `apps/web/src/hooks/useUserLocale.ts:100-141`
+- Existing i18n provider: `apps/web/src/components/providers/IntlProvider.tsx`
+- ADR-059 (catalog seed legal posture, relevant for sub-PR 3/3): [`docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md`](../../for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md)
+- Q4 closure note: [`docs/for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md`](../../for-developers/specs/2026-06-14-seed-kb-coverage-evaluation.md) §9
+- BCP-47 / RFC 5646 — Tags for Identifying Languages
+- WCAG 2.1 SC 3.1.2 Language of Parts


### PR DESCRIPTION
## Summary

Sub-PR 2/3 of [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339) (translations BE foundation shipped via [#2370](https://github.com/meepleAi-app/meepleai-monorepo/pull/2370) `cd041ca35`).

Adds `useGameTitle()` hook + DTO TS update + a11y i18n keys + 5 highest-traffic consumer migration + ESLint warn rule + E2E spec (gated on sub-PR 3/3 seed).

### What ships

- **Zod schema extension** (`shared-games.schemas.ts`): `TranslationProviderSchema` enum + `SharedGameTranslationDtoSchema` + `translations` field on `SharedGameSchema` + `SharedGameDetailSchema` (pattern aligned with `toolkits`/`agents`/`kbs` sibling fields via `.transform(v => v ?? [])`)
- **Pure helpers**: `resolveLocale` (BCP-47 fallback chain — NO upgrade `it` → `it-IT`, DEC-FE-3) + `pickBestTranslation` (source priority `manual > auto-openrouter > community`, DEC-FE-2)
- **Hook**: `useGameTitle(game, options?)` → `ResolvedTitle` struct (discriminated by `source`) with `useMemo` memoization (DEC-FE-7)
- **i18n keys**: `common.localizedFromEnglish` in `en.json` + `it.json` for aria-label react-intl pattern (DEC-FE-9)
- **Test matrix**: 11 Vitest tests (6 matrix T1-T6 + null defense + memoization + 3 axe a11y A1/A2/A3)
- **Consumer migration**: 5 highest-traffic surfaces (`GameDiscoverHero`, `MeepleGameCatalogCard`, `SearchExpander`, `shared-games/[id]/page-client`, `HubGameCard`) — 2 fallback files used where original targets use `Game`/`UserGameDto` types (lacking `translations`)
- **ESLint rule**: `local/prefer-use-game-title` (warn mode per DEC-FE-8); allow-list: `aria-label` values, tests, stories, `lib/i18n/`
- **E2E spec**: 3 scenarios (gated on `seedTranslations` project metadata; activates after sub-PR 3/3)

### Decisions LOCKED 2026-06-20 (full list in spec doc)

11 DEC accepted via spec-panel review (Wiegers/Cockburn/Adzic/Fowler/Crispin/Gregory). Highlights:
- **DEC-FE-1**: `ResolvedTitle` struct return (NOT `string`) — preserves source/locale/provider context
- **DEC-FE-9**: aria-label via `intl.formatMessage('common.localizedFromEnglish', { localizedTitle, originalTitle })` — NOT hardcoded EN string
- **DEC-FE-DEFER**: search filter remains canonical-only (follow-up issue for translation matching)

Full design: [`docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md`](./docs/superpowers/specs/2026-06-20-translations-fe-hook-design.md)
Full plan: [`docs/superpowers/plans/2026-06-20-translations-fe-hook.md`](./docs/superpowers/plans/2026-06-20-translations-fe-hook.md)

### Out of scope (sub-PR 3/3)

- Seed 13 IT translations + research doc → [`docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md`](./docs/superpowers/plans/2026-06-20-translations-seed-subpr3.md)
- ADR-059 §6 amendment + Q4 doc closure
- Codemod sweep for remaining ~131 `game.title` occurrences (deferred; ESLint warn surfaces them)

## Test plan

- [x] Vitest: `pnpm vitest run src/lib/i18n` → 59/59 pass (5 files)
- [x] Typecheck clean (`pnpm typecheck` → 0 errors)
- [x] Lint clean (`pnpm lint` → 0 errors, 107 warnings — 100 are the new warn-rule firing on non-migrated files as designed; baseline `--max-warnings=510`)
- [x] ESLint rule unit test: `node --test eslint-rules/prefer-use-game-title.test.js` → 1/1 pass (10 sub-cases: 8 valid + 2 invalid)
- [ ] E2E: skipped until sub-PR 3/3 lands seed data + flips `project.metadata.seedTranslations`
- [ ] Designer review: manual verify aria-label on 5 migrated components (in EN + IT UI locale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)