### PR TITLE
feat(play-records): #2436 PR-B photo upload pipeline + OCR (BE)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommand.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+internal record UploadPlayRecordPhotoCommand(
+    Guid RecordId,
+    Guid UserId,
+    Stream FileStream,
+    long FileSizeBytes,
+    string MimeType,
+    bool ExtractScoreFromPhoto,
+    string? Caption
+) : ICommand<PlayRecordPhotoUploadResult>;
+
+internal record PlayRecordPhotoUploadResult(
+    Guid PhotoId,
+    string PhotoUrl,
+    string? ThumbnailUrl,
+    string? OcrText,
+    bool WasDeduplicated);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
@@ -141,9 +141,26 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
             }
         }
 
+        // NOTE (#2436 PR-B): the <=10-photo cap is enforced on the in-memory aggregate. PlayRecord
+        // has no optimistic-concurrency token yet, so two concurrent uploads to the same record can
+        // each pass the cap check and exceed it by 1-2. Proper fix = xmin optimistic concurrency on
+        // PlayRecord (issue #2437-1), which also wires the 409 conflict UI. Acceptable for MVP — the
+        // cap is a soft UX limit; the (PlayRecordId, Sha256Hash) unique index still blocks duplicates.
         record.AddPhoto(photoId, stored.FilePath, thumbUrl, command.FileSizeBytes, sha, ocrText, ocrConfidence, command.Caption, command.UserId, _timeProvider);
-        await _repository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _repository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // I2: surface orphaned blobs so they are reclaimable (store-then-save trade-off,
+            // consistent with SessionAttachmentService). Re-throw to the caller unchanged.
+            _logger.LogError(ex,
+                "Failed to persist play record photo {PhotoId}; orphaned blobs may remain: photo={PhotoPath} thumb={ThumbPath}",
+                photoId, stored.FilePath, thumbUrl);
+            throw;
+        }
 
         var url = await PresignAsync(stored.FilePath, cancellationToken).ConfigureAwait(false);
         return new PlayRecordPhotoUploadResult(photoId, url, thumbUrl, ocrText, WasDeduplicated: false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
@@ -1,0 +1,177 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Helpers;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+/// <summary>
+/// Handles uploading a photo to a PlayRecord. Flow: creator-guard → buffer →
+/// magic-byte validate → SHA256 dedup → StoreAsync → thumbnail (best-effort) →
+/// OCR (opt-in, best-effort) → AddPhoto → UpdateAsync → SaveChanges → presign.
+/// Issue #2436 PR-B (ADR-067).
+/// </summary>
+internal sealed class UploadPlayRecordPhotoCommandHandler
+    : ICommandHandler<UploadPlayRecordPhotoCommand, PlayRecordPhotoUploadResult>
+{
+    private const int PresignExpirySeconds = 3600;
+
+    private readonly IPlayRecordRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly PlayRecordPermissionChecker _permissionChecker;
+    private readonly IPhotoPreprocessor _photoPreprocessor;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<UploadPlayRecordPhotoCommandHandler> _logger;
+
+    public UploadPlayRecordPhotoCommandHandler(
+        IPlayRecordRepository repository,
+        IUnitOfWork unitOfWork,
+        IBlobStorageService blobStorage,
+        PlayRecordPermissionChecker permissionChecker,
+        IPhotoPreprocessor photoPreprocessor,
+        TimeProvider timeProvider,
+        ILogger<UploadPlayRecordPhotoCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _permissionChecker = permissionChecker ?? throw new ArgumentNullException(nameof(permissionChecker));
+        _photoPreprocessor = photoPreprocessor ?? throw new ArgumentNullException(nameof(photoPreprocessor));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PlayRecordPhotoUploadResult> Handle(UploadPlayRecordPhotoCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var record = await _repository.GetByIdAsync(command.RecordId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("PlayRecord", command.RecordId.ToString());
+
+        if (!await _permissionChecker.CanEditAsync(command.UserId, command.RecordId, cancellationToken).ConfigureAwait(false))
+            throw new ForbiddenException("You do not have permission to add photos to this play record.");
+
+        // Buffer the upload (needed for magic-byte, hash, thumbnail, OCR + re-reads).
+        byte[] bytes;
+        using (var buffer = new MemoryStream())
+        {
+            await command.FileStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            bytes = buffer.ToArray();
+        }
+
+        using (var validateStream = new MemoryStream(bytes, writable: false))
+        {
+            var ok = await Api.BoundedContexts.GameManagement.Application.Validators.ImageFileValidator
+                .ValidateMagicBytesAsync(validateStream, command.MimeType).ConfigureAwait(false);
+            if (!ok)
+                throw new ValidationException("File content does not match its declared type.");
+        }
+
+        var sha = CryptographyHelper.ComputeSha256Hash(bytes);
+
+        // Idempotent re-upload: same (record, sha) → return existing.
+        var existing = record.Photos.FirstOrDefault(p => string.Equals(p.Sha256Hash, sha, StringComparison.Ordinal));
+        if (existing != null)
+        {
+            var existingUrl = await PresignAsync(existing.BlobUrl, cancellationToken).ConfigureAwait(false);
+            return new PlayRecordPhotoUploadResult(existing.Id, existingUrl, existing.ThumbnailUrl, existing.OcrText, WasDeduplicated: true);
+        }
+
+        var photoId = Guid.NewGuid();
+        var ext = string.Equals(command.MimeType, "image/png", StringComparison.OrdinalIgnoreCase) ? ".png"
+                : string.Equals(command.MimeType, "image/webp", StringComparison.OrdinalIgnoreCase) ? ".webp" : ".jpg";
+
+        // Use underscore separator so ParseBlobPath can extract fileId (substring before first '_').
+        var resourceKey = $"play-record-{record.Id:N}";
+        var fileName = $"{photoId:N}_{sha[..8]}{ext}";
+
+        BlobStorageResult stored;
+        using (var storeStream = new MemoryStream(bytes, writable: false))
+        {
+            stored = await _blobStorage.StoreAsync(storeStream, fileName, BlobCategory.PlayRecordPhoto, resourceKey, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!stored.Success || stored.FilePath is null)
+            throw new ValidationException(stored.ErrorMessage ?? "Failed to store the photo.");
+
+        // Thumbnail — best-effort.
+        string? thumbUrl = null;
+        try
+        {
+            using var thumbSource = new MemoryStream(bytes, writable: false);
+            using var thumb = await ImageThumbnailHelper.GenerateThumbnailAsync(thumbSource, cancellationToken).ConfigureAwait(false);
+            if (thumb != null)
+            {
+                var thumbFileName = $"{photoId:N}_thumb.jpg";
+                var thumbResult = await _blobStorage.StoreAsync(thumb, thumbFileName, BlobCategory.PlayRecordPhoto, resourceKey, cancellationToken).ConfigureAwait(false);
+                if (thumbResult.Success) thumbUrl = thumbResult.FilePath;
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Thumbnail generation failed for photo {PhotoId}", photoId);
+        }
+
+        // OCR — opt-in, best-effort (DEC-3 smoldocling).
+        string? ocrText = null;
+        double? ocrConfidence = null;
+        if (command.ExtractScoreFromPhoto)
+        {
+            try
+            {
+                var ocr = await _photoPreprocessor.PreprocessAsync(bytes, cancellationToken).ConfigureAwait(false);
+                ocrText = ocr.ExtractedText;
+                ocrConfidence = ocr.ConfidenceScore;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "OCR failed for photo {PhotoId}", photoId);
+            }
+        }
+
+        record.AddPhoto(photoId, stored.FilePath, thumbUrl, command.FileSizeBytes, sha, ocrText, ocrConfidence, command.Caption, command.UserId, _timeProvider);
+        await _repository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var url = await PresignAsync(stored.FilePath, cancellationToken).ConfigureAwait(false);
+        return new PlayRecordPhotoUploadResult(photoId, url, thumbUrl, ocrText, WasDeduplicated: false);
+    }
+
+    private async Task<string> PresignAsync(string blobPath, CancellationToken ct)
+    {
+        // blobPath is the stored FilePath. Mirror SessionAttachmentService.ParseBlobPath:
+        // fileId = substring before the first '_' in the file name.
+        // For local storage, GetPresignedDownloadUrlAsync returns null → fall back to raw path.
+        var fileName = Path.GetFileName(blobPath);
+        if (string.IsNullOrEmpty(fileName))
+            return blobPath;
+
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        if (underscoreIndex <= 0)
+            return blobPath;
+
+        var fileId = fileName[..underscoreIndex];
+        var directory = Path.GetDirectoryName(blobPath);
+        if (string.IsNullOrEmpty(directory))
+            return blobPath;
+
+        var folder = Path.GetFileName(directory);
+        if (string.IsNullOrEmpty(folder))
+            return blobPath;
+
+        var signed = await _blobStorage.GetPresignedDownloadUrlAsync(fileId, BlobCategory.PlayRecordPhoto, folder, PresignExpirySeconds).ConfigureAwait(false);
+        return signed ?? blobPath;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
@@ -141,11 +141,10 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
             }
         }
 
-        // NOTE (#2436 PR-B): the <=10-photo cap is enforced on the in-memory aggregate. PlayRecord
-        // has no optimistic-concurrency token yet, so two concurrent uploads to the same record can
-        // each pass the cap check and exceed it by 1-2. Proper fix = xmin optimistic concurrency on
-        // PlayRecord (issue #2437-1), which also wires the 409 conflict UI. Acceptable for MVP — the
-        // cap is a soft UX limit; the (PlayRecordId, Sha256Hash) unique index still blocks duplicates.
+        // The ≤10-photo cap is enforced on the in-memory aggregate. Concurrent upload races that
+        // both pass the cap check are blocked at SaveChanges via PlayRecord's xmin
+        // optimistic-concurrency token (ADR-060, #2436 PR-B / #2437-1): the losing write sees a
+        // stale xmin → DbUpdateConcurrencyException → global middleware → 409 concurrent-edit.
         record.AddPhoto(photoId, stored.FilePath, thumbUrl, command.FileSizeBytes, sha, ocrText, ocrConfidence, command.Caption, command.UserId, _timeProvider);
         try
         {

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/UploadPlayRecordPhotoCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/UploadPlayRecordPhotoCommandValidator.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.PlayRecords;
+
+internal sealed class UploadPlayRecordPhotoCommandValidator : AbstractValidator<UploadPlayRecordPhotoCommand>
+{
+    internal const long MaxFileSizeBytes = 5 * 1024 * 1024; // 5MB (spec AC)
+    private static readonly HashSet<string> AllowedMimeTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "image/jpeg", "image/png", "image/webp" };
+
+    public UploadPlayRecordPhotoCommandValidator()
+    {
+        RuleFor(c => c.RecordId).NotEmpty();
+        RuleFor(c => c.UserId).NotEmpty();
+        RuleFor(c => c.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File cannot be empty")
+            .LessThanOrEqualTo(MaxFileSizeBytes).WithMessage("File cannot exceed 5MB");
+        RuleFor(c => c.MimeType)
+            .NotEmpty()
+            .Must(m => AllowedMimeTypes.Contains(m))
+            .WithMessage("Only JPEG, PNG, and WebP images are allowed");
+        RuleFor(c => c.Caption).MaximumLength(500).When(c => c.Caption != null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs
@@ -46,6 +46,13 @@ internal sealed class PlayRecord : AggregateRoot<Guid>
     public DateTime CreatedAt { get; private set; }
     public DateTime UpdatedAt { get; private set; }
 
+    /// <summary>Postgres xmin optimistic-concurrency token. Server-owned; the repository
+    /// round-trips it for detached Update (ADR-060). #2436 PR-B / #2437-1.</summary>
+    public uint Xmin { get; private set; }
+
+    /// <summary>Repository-only: restore the xmin token after loading from persistence.</summary>
+    internal void SetXmin(uint xmin) => Xmin = xmin;
+
     // Soft Delete (issue #2439 — mirrors GameBook.SoftDelete pattern)
     public bool IsDeleted { get; private set; }
     public DateTime? DeletedAt { get; private set; }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs
@@ -35,6 +35,10 @@ internal sealed class PlayRecord : AggregateRoot<Guid>
     private readonly List<RecordPlayer> _players = new();
     public IReadOnlyList<RecordPlayer> Players => _players.AsReadOnly();
 
+    // Photos (#2436 PR-B, ADR-067 — max 10 per record)
+    private readonly List<PlayRecordPhoto> _photos = new();
+    public IReadOnlyList<PlayRecordPhoto> Photos => _photos.AsReadOnly();
+
     // Scoring Configuration
     public SessionScoringConfig ScoringConfig { get; private set; }
 
@@ -214,6 +218,37 @@ internal sealed class PlayRecord : AggregateRoot<Guid>
     {
         var player = new RecordPlayer(playerId, Id, userId, displayName);
         _players.Add(player);
+    }
+
+    /// <summary>
+    /// Attaches an uploaded photo. Max 10 per record (#2436 PR-B, ADR-067). Raises a domain event.
+    /// </summary>
+    public void AddPhoto(
+        Guid photoId, string blobUrl, string? thumbnailUrl, long fileSizeBytes,
+        string sha256Hash, string? ocrText, double? ocrConfidence, string? caption,
+        Guid uploadedByUserId, TimeProvider? timeProvider = null)
+    {
+        if (_photos.Count >= 10)
+            throw new DomainException("Cannot attach more than 10 photos to a play record");
+
+        var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+        var photo = new PlayRecordPhoto(photoId, Id, blobUrl, thumbnailUrl, fileSizeBytes,
+            sha256Hash, ocrText, ocrConfidence, caption, uploadedByUserId, now);
+        _photos.Add(photo);
+        UpdatedAt = now;
+        AddDomainEvent(new PlayRecordPhotoUploadedEvent(Id, photo.Id, uploadedByUserId));
+    }
+
+    /// <summary>
+    /// Repository-only reconstitution from persistence (no domain event).
+    /// </summary>
+    internal void RestorePhoto(
+        Guid photoId, string blobUrl, string? thumbnailUrl, long fileSizeBytes,
+        string sha256Hash, string? ocrText, double? ocrConfidence, string? caption,
+        Guid uploadedByUserId, DateTime uploadedAt)
+    {
+        _photos.Add(new PlayRecordPhoto(photoId, Id, blobUrl, thumbnailUrl, fileSizeBytes,
+            sha256Hash, ocrText, ocrConfidence, caption, uploadedByUserId, uploadedAt));
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecordPhoto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecordPhoto.cs
@@ -1,0 +1,61 @@
+using System;
+using Api.SharedKernel.Domain.Entities;
+using Api.SharedKernel.Domain.Exceptions;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// A photo attached to a <see cref="PlayRecord"/> (scoreboard capture, party shot).
+/// Child entity of the PlayRecord aggregate. #2436 PR-B (ADR-067).
+/// </summary>
+internal sealed class PlayRecordPhoto : Entity<Guid>
+{
+    public Guid PlayRecordId { get; private set; }
+    public string BlobUrl { get; private set; }
+    public string? ThumbnailUrl { get; private set; }
+    public long FileSizeBytes { get; private set; }
+    public string Sha256Hash { get; private set; }
+    public string? OcrText { get; private set; }
+    public double? OcrConfidence { get; private set; }
+    public string? Caption { get; private set; }
+    public Guid UploadedByUserId { get; private set; }
+    public DateTime UploadedAt { get; private set; }
+
+#pragma warning disable CS8618
+    private PlayRecordPhoto() : base() { }
+#pragma warning restore CS8618
+
+    internal PlayRecordPhoto(
+        Guid id,
+        Guid playRecordId,
+        string blobUrl,
+        string? thumbnailUrl,
+        long fileSizeBytes,
+        string sha256Hash,
+        string? ocrText,
+        double? ocrConfidence,
+        string? caption,
+        Guid uploadedByUserId,
+        DateTime uploadedAt) : base(id)
+    {
+        if (playRecordId == Guid.Empty)
+            throw new ArgumentException("PlayRecordId cannot be empty", nameof(playRecordId));
+        if (string.IsNullOrWhiteSpace(blobUrl))
+            throw new ValidationException("BlobUrl cannot be empty");
+        if (string.IsNullOrWhiteSpace(sha256Hash))
+            throw new ValidationException("Sha256Hash cannot be empty");
+        if (caption is { Length: > 500 })
+            throw new ValidationException("Caption cannot exceed 500 characters");
+
+        PlayRecordId = playRecordId;
+        BlobUrl = blobUrl;
+        ThumbnailUrl = thumbnailUrl;
+        FileSizeBytes = fileSizeBytes;
+        Sha256Hash = sha256Hash;
+        OcrText = ocrText;
+        OcrConfidence = ocrConfidence;
+        Caption = caption?.Trim();
+        UploadedByUserId = uploadedByUserId;
+        UploadedAt = uploadedAt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/PlayRecordPhotoUploadedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/PlayRecordPhotoUploadedEvent.cs
@@ -1,0 +1,21 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a photo is uploaded to a PlayRecord (scoreboard capture, party shot).
+/// #2436 PR-B (ADR-067).
+/// </summary>
+internal sealed class PlayRecordPhotoUploadedEvent : DomainEventBase
+{
+    public Guid PlayRecordId { get; }
+    public Guid PhotoId { get; }
+    public Guid UploadedByUserId { get; }
+
+    public PlayRecordPhotoUploadedEvent(Guid playRecordId, Guid photoId, Guid uploadedByUserId)
+    {
+        PlayRecordId = playRecordId;
+        PhotoId = photoId;
+        UploadedByUserId = uploadedByUserId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs
@@ -29,6 +29,7 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             .AsNoTracking()
             .Include(r => r.Players)
                 .ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
             .FirstOrDefaultAsync(r => r.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
@@ -46,6 +47,7 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             .AsNoTracking()
             .Include(r => r.Players)
                 .ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
             .OrderByDescending(r => r.SessionDate)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -68,6 +70,7 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             .AsNoTracking()
             .Include(r => r.Players)
                 .ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
             .Where(r => r.CreatedByUserId == userId);
 
         if (gameId.HasValue)
@@ -92,6 +95,7 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
         var record = await DbContext.PlayRecords
             .AsNoTracking()
             .Include(r => r.Players)
+            .Include(r => r.Photos)
             .FirstOrDefaultAsync(r => r.Id == recordId, cancellationToken)
             .ConfigureAwait(false);
 
@@ -154,6 +158,14 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
 
         var existingScoreIdSet = new HashSet<Guid>(existingScoreIds);
 
+        var existingPhotoIds = await DbContext.PlayRecordPhotos
+            .Where(p => p.PlayRecordId == record.Id)
+            .Select(p => p.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var existingPhotoIdSet = new HashSet<Guid>(existingPhotoIds);
+
         // Attach root entity as Modified
         DbContext.PlayRecords.Update(entity);
 
@@ -171,6 +183,14 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
                 {
                     DbContext.Entry(score).State = EntityState.Added;
                 }
+            }
+        }
+
+        foreach (var photo in entity.Photos)
+        {
+            if (!existingPhotoIdSet.Contains(photo.Id))
+            {
+                DbContext.Entry(photo).State = EntityState.Added;
             }
         }
     }
@@ -259,6 +279,16 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             }
         }
 
+        // Restore photos with original IDs (no domain events) — #2436 PR-B
+        foreach (var photoEntity in entity.Photos)
+        {
+            record.RestorePhoto(
+                photoEntity.Id, photoEntity.BlobUrl, photoEntity.ThumbnailUrl,
+                photoEntity.FileSizeBytes, photoEntity.Sha256Hash, photoEntity.OcrText,
+                photoEntity.OcrConfidence, photoEntity.Caption, photoEntity.UploadedByUserId,
+                photoEntity.UploadedAt);
+        }
+
         return record;
     }
 
@@ -326,6 +356,25 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             }
 
             entity.Players.Add(playerEntity);
+        }
+
+        // Map photos — #2436 PR-B
+        foreach (var photo in record.Photos)
+        {
+            entity.Photos.Add(new PlayRecordPhotoEntity
+            {
+                Id = photo.Id,
+                PlayRecordId = record.Id,
+                BlobUrl = photo.BlobUrl,
+                ThumbnailUrl = photo.ThumbnailUrl,
+                FileSizeBytes = photo.FileSizeBytes,
+                Sha256Hash = photo.Sha256Hash,
+                OcrText = photo.OcrText,
+                OcrConfidence = photo.OcrConfidence,
+                Caption = photo.Caption,
+                UploadedByUserId = photo.UploadedByUserId,
+                UploadedAt = photo.UploadedAt,
+            });
         }
 
         return entity;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs
@@ -289,6 +289,9 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
                 photoEntity.UploadedAt);
         }
 
+        // Restore the xmin optimistic-concurrency token (ADR-060). #2436 PR-B / #2437-1.
+        record.SetXmin(entity.Xmin);
+
         return record;
     }
 
@@ -316,7 +319,8 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             UpdatedAt = record.UpdatedAt,
             SourceEventId = record.SourceEventId,
             IsDeleted = record.IsDeleted,
-            DeletedAt = record.DeletedAt
+            DeletedAt = record.DeletedAt,
+            Xmin = record.Xmin  // round-trip for detached Update (ADR-060). #2436 PR-B / #2437-1.
         };
 
         // Serialize scoring config

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentService.cs
@@ -1,9 +1,8 @@
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Application.Validators;
 using Api.BoundedContexts.GameManagement.Domain.Entities.SessionAttachment;
+using Api.Helpers;
 using Api.Services.Pdf;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Processing;
 
 namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
 
@@ -16,8 +15,6 @@ internal sealed class SessionAttachmentService : ISessionAttachmentService
     private readonly IBlobStorageService _blobStorage;
     private readonly ILogger<SessionAttachmentService> _logger;
 
-    private const int ThumbnailMaxDimension = 300;
-    private const int ThumbnailJpegQuality = 80;
     private const int DownloadUrlExpirySeconds = 3600; // 1 hour
 
     public SessionAttachmentService(
@@ -174,44 +171,11 @@ internal sealed class SessionAttachmentService : ISessionAttachmentService
         }
     }
 
-    internal static async Task<MemoryStream?> GenerateThumbnailAsync(Stream sourceStream, CancellationToken ct = default)
-    {
-        using var image = await Image.LoadAsync(sourceStream, ct).ConfigureAwait(false);
-
-        // Calculate new dimensions maintaining aspect ratio
-        var (newWidth, newHeight) = CalculateThumbnailDimensions(image.Width, image.Height);
-
-        image.Mutate(ctx => ctx.Resize(newWidth, newHeight));
-
-        var outputStream = new MemoryStream();
-        var encoder = new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder
-        {
-            Quality = ThumbnailJpegQuality
-        };
-        await image.SaveAsync(outputStream, encoder, ct).ConfigureAwait(false);
-        outputStream.Position = 0;
-        return outputStream;
-    }
+    internal static Task<MemoryStream?> GenerateThumbnailAsync(Stream sourceStream, CancellationToken ct = default)
+        => ImageThumbnailHelper.GenerateThumbnailAsync(sourceStream, ct);
 
     internal static (int width, int height) CalculateThumbnailDimensions(int originalWidth, int originalHeight)
-    {
-        if (originalWidth <= ThumbnailMaxDimension && originalHeight <= ThumbnailMaxDimension)
-        {
-            return (originalWidth, originalHeight);
-        }
-
-        double ratio;
-        if (originalWidth >= originalHeight)
-        {
-            ratio = (double)ThumbnailMaxDimension / originalWidth;
-        }
-        else
-        {
-            ratio = (double)ThumbnailMaxDimension / originalHeight;
-        }
-
-        return (Math.Max(1, (int)(originalWidth * ratio)), Math.Max(1, (int)(originalHeight * ratio)));
-    }
+        => ImageThumbnailHelper.CalculateThumbnailDimensions(originalWidth, originalHeight);
 
     private static bool IsAllowedContentType(string contentType)
     {

--- a/apps/api/src/Api/Helpers/ImageThumbnailHelper.cs
+++ b/apps/api/src/Api/Helpers/ImageThumbnailHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Processing;
+
+namespace Api.Helpers;
+
+/// <summary>Shared image thumbnail generation (300px max, JPEG q80). #2436 PR-B.</summary>
+internal static class ImageThumbnailHelper
+{
+    private const int ThumbnailMaxDimension = 300;
+    private const int ThumbnailJpegQuality = 80;
+
+    public static async Task<MemoryStream?> GenerateThumbnailAsync(Stream sourceStream, CancellationToken ct = default)
+    {
+        using var image = await Image.LoadAsync(sourceStream, ct).ConfigureAwait(false);
+
+        // Calculate new dimensions maintaining aspect ratio
+        var (newWidth, newHeight) = CalculateThumbnailDimensions(image.Width, image.Height);
+
+        image.Mutate(ctx => ctx.Resize(newWidth, newHeight));
+
+        var outputStream = new MemoryStream();
+        var encoder = new JpegEncoder
+        {
+            Quality = ThumbnailJpegQuality
+        };
+        await image.SaveAsync(outputStream, encoder, ct).ConfigureAwait(false);
+        outputStream.Position = 0;
+        return outputStream;
+    }
+
+    public static (int width, int height) CalculateThumbnailDimensions(int originalWidth, int originalHeight)
+    {
+        if (originalWidth <= ThumbnailMaxDimension && originalHeight <= ThumbnailMaxDimension)
+        {
+            return (originalWidth, originalHeight);
+        }
+
+        double ratio;
+        if (originalWidth >= originalHeight)
+        {
+            ratio = (double)ThumbnailMaxDimension / originalWidth;
+        }
+        else
+        {
+            ratio = (double)ThumbnailMaxDimension / originalHeight;
+        }
+
+        return (Math.Max(1, (int)(originalWidth * ratio)), Math.Max(1, (int)(originalHeight * ratio)));
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs
@@ -48,6 +48,12 @@ public class PlayRecordEntity
     /// </summary>
     public Guid? SourceEventId { get; set; }
 
+    // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
+    // Replaces the silently-disabled byte[] RowVersion (no trigger populated it).
+    // Server-owned: Postgres assigns xmin = transaction-id-of-last-write per row.
+    // #2436 PR-B / #2437-1.
+    public uint Xmin { get; set; }
+
     // Navigation Properties
     public ICollection<RecordPlayerEntity> Players { get; set; } = new List<RecordPlayerEntity>();
     public ICollection<PlayRecordPhotoEntity> Photos { get; set; } = new List<PlayRecordPhotoEntity>(); // #2436 PR-B

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs
@@ -50,4 +50,5 @@ public class PlayRecordEntity
 
     // Navigation Properties
     public ICollection<RecordPlayerEntity> Players { get; set; } = new List<RecordPlayerEntity>();
+    public ICollection<PlayRecordPhotoEntity> Photos { get; set; } = new List<PlayRecordPhotoEntity>(); // #2436 PR-B
 }

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordPhotoEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordPhotoEntity.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// Persistence POCO for PlayRecordPhoto.
+/// Maps domain PlayRecordPhoto child entity to the play_record_photos table.
+/// #2436 PR-B (ADR-067).
+/// </summary>
+public class PlayRecordPhotoEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid PlayRecordId { get; set; }
+    public string BlobUrl { get; set; } = string.Empty;
+    public string? ThumbnailUrl { get; set; }
+    public long FileSizeBytes { get; set; }
+    public string Sha256Hash { get; set; } = string.Empty;
+    public string? OcrText { get; set; }
+    public double? OcrConfidence { get; set; }
+    public string? Caption { get; set; }
+    public Guid UploadedByUserId { get; set; }
+    public DateTime UploadedAt { get; set; }
+
+    // Navigation property
+    public PlayRecordEntity? PlayRecord { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordEntityConfiguration.cs
@@ -82,6 +82,17 @@ internal class PlayRecordEntityConfiguration : IEntityTypeConfiguration<PlayReco
             .HasDatabaseName("UX_play_records_source_event_id")
             .HasFilter("source_event_id IS NOT NULL");
 
+        // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
+        // xmin is a Postgres system column — EF maps it but does NOT create the column.
+        // ValueGeneratedOnAddOrUpdate tells EF the DB owns the value on every write.
+        // IsConcurrencyToken() makes EF include it in UPDATE … WHERE xmin = @p0.
+        // #2436 PR-B / #2437-1.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
         // Relationships
         builder.HasMany(e => e.Players)
             .WithOne(p => p.PlayRecord)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordPhotoEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordPhotoEntityConfiguration.cs
@@ -1,0 +1,45 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for PlayRecordPhotoEntity.
+/// #2436 PR-B (ADR-067): photos attached to a PlayRecord.
+/// </summary>
+internal class PlayRecordPhotoEntityConfiguration : IEntityTypeConfiguration<PlayRecordPhotoEntity>
+{
+    public void Configure(EntityTypeBuilder<PlayRecordPhotoEntity> builder)
+    {
+        builder.ToTable("play_record_photos");
+        builder.HasKey(e => e.Id);
+
+        // Properties — use EF default column names (PascalCase) to match record_players convention
+        builder.Property(e => e.PlayRecordId).IsRequired();
+        builder.Property(e => e.BlobUrl).IsRequired().HasMaxLength(1024);
+        builder.Property(e => e.ThumbnailUrl).HasMaxLength(1024);
+        builder.Property(e => e.FileSizeBytes).IsRequired();
+        builder.Property(e => e.Sha256Hash).IsRequired().HasMaxLength(64);
+        builder.Property(e => e.OcrText);
+        builder.Property(e => e.OcrConfidence);
+        builder.Property(e => e.Caption).HasMaxLength(500);
+        builder.Property(e => e.UploadedByUserId).IsRequired();
+        builder.Property(e => e.UploadedAt).IsRequired();
+
+        // FK to play_records (cascade-delete: photo orphans removed when record is deleted)
+        builder.HasOne(e => e.PlayRecord)
+            .WithMany(r => r.Photos)
+            .HasForeignKey(e => e.PlayRecordId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Unique index: same photo cannot be attached twice to the same record
+        builder.HasIndex(e => new { e.PlayRecordId, e.Sha256Hash })
+            .IsUnique()
+            .HasDatabaseName("UX_play_record_photos_playrecord_sha256");
+
+        // Non-unique index for FK traversal
+        builder.HasIndex(e => e.PlayRecordId)
+            .HasDatabaseName("IX_play_record_photos_PlayRecordId");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -90,6 +90,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<GameSessionEntity> GameSessions => Set<GameSessionEntity>(); // DDD-PHASE2: GameSession aggregate
     public DbSet<PlayRecordEntity> PlayRecords => Set<PlayRecordEntity>(); // ISSUE-3888: Play history tracking
     public DbSet<RecordPlayerEntity> RecordPlayers => Set<RecordPlayerEntity>(); // ISSUE-3888: Play record players
+    public DbSet<PlayRecordPhotoEntity> PlayRecordPhotos => Set<PlayRecordPhotoEntity>(); // #2436 PR-B: Photos attached to PlayRecords
     public DbSet<RuleConflictFAQEntity> RuleConflictFAQs => Set<RuleConflictFAQEntity>(); // ISSUE-3761: Conflict resolution FAQ
     public DbSet<GameReviewEntity> GameReviews => Set<GameReviewEntity>(); // ISSUE-4904: Game reviews API
     public DbSet<GameStrategyEntity> GameStrategies => Set<GameStrategyEntity>(); // ISSUE-4903: Game strategies API
@@ -418,6 +419,7 @@ public class MeepleAiDbContext : DbContext
         // NOTE: Game domain aggregate removed by #1320 (P2c) - modelBuilder.Ignore<Game>() no longer needed
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.PlayRecord>(); // ISSUE-3888
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.RecordPlayer>(); // ISSUE-3888
+        modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.PlayRecordPhoto>(); // #2436 PR-B
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.LiveGameSession>(); // ISSUE-4747
         modelBuilder.Ignore<BoundedContexts.GameToolkit.Domain.Entities.GameToolkit>(); // ISSUE-4753
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.ToolState.ToolState>(); // ISSUE-4754

--- a/apps/api/src/Api/Infrastructure/Migrations/20260620145331_AddPlayRecordPhotos.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260620145331_AddPlayRecordPhotos.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620145331_AddPlayRecordPhotos")]
+    partial class AddPlayRecordPhotos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260620145331_AddPlayRecordPhotos.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260620145331_AddPlayRecordPhotos.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayRecordPhotos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "play_record_photos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlayRecordId = table.Column<Guid>(type: "uuid", nullable: false),
+                    BlobUrl = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    ThumbnailUrl = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    Sha256Hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    OcrText = table.Column<string>(type: "text", nullable: true),
+                    OcrConfidence = table.Column<double>(type: "double precision", nullable: true),
+                    Caption = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    UploadedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UploadedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_play_record_photos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_play_record_photos_play_records_PlayRecordId",
+                        column: x => x.PlayRecordId,
+                        principalTable: "play_records",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_play_record_photos_PlayRecordId",
+                table: "play_record_photos",
+                column: "PlayRecordId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_play_record_photos_playrecord_sha256",
+                table: "play_record_photos",
+                columns: new[] { "PlayRecordId", "Sha256Hash" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "play_record_photos");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260620160221_AddPlayRecordXmin.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260620160221_AddPlayRecordXmin.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620160221_AddPlayRecordXmin")]
+    partial class AddPlayRecordXmin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260620160221_AddPlayRecordXmin.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260620160221_AddPlayRecordXmin.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayRecordXmin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // xmin is a PostgreSQL system column (transaction ID of the last update).
+            // It exists on every Postgres table by default and does NOT need to be created.
+            // This migration carries only the EF model snapshot update so that EF can round-trip
+            // the value as a concurrency token (ADR-060). #2436 PR-B / #2437-1.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // xmin is a PostgreSQL system column — nothing to drop.
+        }
+    }
+}

--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -106,6 +106,14 @@ internal class ApiExceptionHandlerMiddleware
             return;
         }
 
+        // #2436 PR-B / #2437-1: optimistic-concurrency conflict (xmin mismatch) → 409 with
+        // X-Warning-Code: concurrent-edit so the FE can render a "reload & retry" prompt.
+        if (ex is Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException concurrencyEx)
+        {
+            await HandleConcurrencyConflictAsync(context, concurrencyEx).ConfigureAwait(false);
+            return;
+        }
+
         // Determine status code and error type based on exception type
         var (statusCode, errorType, message) = MapExceptionToResponse(ex);
 
@@ -303,6 +311,39 @@ internal class ApiExceptionHandlerMiddleware
         {
             error = "two_factor_unavailable",
             message = exception.Message,
+            correlationId = context.TraceIdentifier,
+            timestamp = DateTime.UtcNow
+        };
+
+        await context.Response.WriteAsJsonAsync(errorResponse).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/> with HTTP 409
+    /// and a body carrying <c>error="concurrent_edit"</c> so the FE can render a
+    /// "reload and retry" prompt. The xmin token mismatch means another request already mutated
+    /// the same row between our read and our write. ADR-060. #2436 PR-B / #2437-1.
+    /// </summary>
+    private async Task HandleConcurrencyConflictAsync(
+        HttpContext context,
+        Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException exception)
+    {
+        var endpoint = GetRoutePattern(context) ?? context.Request.Path.ToString();
+
+        MeepleAiMetrics.RecordApiError(
+            exception: exception,
+            httpStatusCode: StatusCodes.Status409Conflict,
+            endpoint: endpoint,
+            isUnhandled: true);
+
+        context.Response.StatusCode = StatusCodes.Status409Conflict;
+        context.Response.Headers["X-Warning-Code"] = "concurrent-edit";
+        context.Response.ContentType = "application/json";
+
+        var errorResponse = new
+        {
+            error = "concurrent_edit",
+            message = "The resource was modified by another request. Reload and retry.",
             correlationId = context.TraceIdentifier,
             timestamp = DateTime.UtcNow
         };

--- a/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
+++ b/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Extensions;
+using Api.Middleware.Exceptions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -87,6 +88,15 @@ internal static class PlayRecordEndpoints
             .WithTags("PlayRecords")
             .WithSummary("Delete play record")
             .WithDescription("Soft-deletes a play record. Creator-only.");
+
+        group.MapPost("/play-records/{recordId:guid}/photos", HandleUploadPhoto)
+            .RequireAuthenticatedUser()
+            .DisableAntiforgery()
+            .Produces<PlayRecordPhotoUploadResult>(201)
+            .Produces(400).Produces(401).Produces(StatusCodes.Status403Forbidden).Produces(404)
+            .WithTags("PlayRecords")
+            .WithSummary("Upload a photo to a play record (creator-only, ≤5MB, opt-in OCR)")
+            .WithOpenApi();
 
         // Queries
         group.MapGet("/play-records/{recordId}", HandleGetPlayRecord)
@@ -210,6 +220,34 @@ internal static class PlayRecordEndpoints
         var command = new DeletePlayRecordCommand(recordId, httpContext.User.GetUserId());
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleUploadPhoto(
+        Guid recordId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var form = await httpContext.Request.ReadFormAsync(cancellationToken).ConfigureAwait(false);
+        var file = form.Files.GetFile("file");
+        if (file is null || file.Length == 0)
+            return Results.BadRequest(new { error = "File is required" });
+
+        var extractScore = form.TryGetValue("extractScoreFromPhoto", out var raw)
+            && bool.TryParse(raw.ToString(), out var b) && b;
+        var caption = form.TryGetValue("caption", out var cap) ? cap.ToString() : null;
+
+        using var stream = file.OpenReadStream();
+        var command = new UploadPlayRecordPhotoCommand(
+            recordId, httpContext.User.GetUserId(), stream, file.Length, file.ContentType, extractScore, caption);
+
+        try
+        {
+            var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            return Results.Created($"/api/v1/play-records/{recordId}/photos/{result.PhotoId}", result);
+        }
+        catch (ForbiddenException ex) { return Results.Json(new { error = ex.Message }, statusCode: 403); }
+        catch (NotFoundException ex) { return Results.NotFound(new { error = ex.Message }); }
     }
 
     #endregion

--- a/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
+++ b/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
@@ -3,7 +3,6 @@ using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Extensions;
-using Api.Middleware.Exceptions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -241,13 +240,11 @@ internal static class PlayRecordEndpoints
         var command = new UploadPlayRecordPhotoCommand(
             recordId, httpContext.User.GetUserId(), stream, file.Length, file.ContentType, extractScore, caption);
 
-        try
-        {
-            var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
-            return Results.Created($"/api/v1/play-records/{recordId}/photos/{result.PhotoId}", result);
-        }
-        catch (ForbiddenException ex) { return Results.Json(new { error = ex.Message }, statusCode: 403); }
-        catch (NotFoundException ex) { return Results.NotFound(new { error = ex.Message }); }
+        // Let exceptions propagate to ApiExceptionHandlerMiddleware for a consistent
+        // ProblemDetails envelope (ForbiddenException→403, NotFoundException→404,
+        // ValidationException→400) — matching every other handler in this file.
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Created($"/api/v1/play-records/{recordId}/photos/{result.PhotoId}", result);
     }
 
     #endregion

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -39,6 +39,10 @@ public enum BlobCategory
     /// (which is the binary PDF document itself). Target prefix <c>photo-batches/{gameId}/</c>.
     /// </summary>
     PhotoBatch,
+
+    /// <summary>Photos attached to a PlayRecord (scoreboard captures, party shots).
+    /// Target prefix <c>play-record-photos/{playRecordId}/</c>.</summary>
+    PlayRecordPhoto,
 }
 
 internal static class BlobCategoryExtensions
@@ -57,6 +61,7 @@ internal static class BlobCategoryExtensions
         BlobCategory.VisionSnapshot => "vision-snapshots",
         BlobCategory.GamebookPhoto => "gamebook-photos",
         BlobCategory.PhotoBatch => "photo-batches",
+        BlobCategory.PlayRecordPhoto => "play-record-photos",
         _ => throw new ArgumentOutOfRangeException(nameof(category), category, null),
     };
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UploadPlayRecordPhotoCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UploadPlayRecordPhotoCommandHandlerTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class UploadPlayRecordPhotoCommandHandlerTests
+{
+    private readonly Mock<IPlayRecordRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IPhotoPreprocessor> _ocr = new();
+
+    private UploadPlayRecordPhotoCommandHandler CreateSut() =>
+        new(_repo.Object, _uow.Object, _blob.Object,
+            new PlayRecordPermissionChecker(_repo.Object), _ocr.Object,
+            TimeProvider.System,
+            NullLogger<UploadPlayRecordPhotoCommandHandler>.Instance);
+
+    private static PlayRecord NewRecord(Guid creator) =>
+        PlayRecord.CreateFreeForm(Guid.NewGuid(), "Catan", creator, DateTime.UtcNow.AddDays(-1),
+            PlayRecordVisibility.Private, SessionScoringConfig.CreateDefault());
+
+    /// <summary>
+    /// Creates a minimal 10x10 blank PNG byte array.
+    /// Using a shared byte[] ensures deterministic SHA256 for dedup tests.
+    /// </summary>
+    private static byte[] MakePngBytes()
+    {
+        var ms = new MemoryStream();
+        using var img = new Image<Rgba32>(10, 10);
+        img.Save(ms, new PngEncoder());
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public async Task Handle_NonCreator_ThrowsForbidden()
+    {
+        var record = NewRecord(Guid.NewGuid());
+        var stranger = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(stranger, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var pngBytes = MakePngBytes();
+        var act = () => CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(record.Id, stranger, new MemoryStream(pngBytes), pngBytes.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MissingRecord_ThrowsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((PlayRecord?)null);
+        var pngBytes = MakePngBytes();
+        var act = () => CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(id, Guid.NewGuid(), new MemoryStream(pngBytes), pngBytes.Length, "image/png", false, null),
+            CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_Creator_StoresPhotoAndSaves()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(creator, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.PlayRecordPhoto, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "play-record-photos/abc/fid_12345678.png", 100));
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        var pngBytes = MakePngBytes();
+        var result = await CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(record.Id, creator, new MemoryStream(pngBytes), pngBytes.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        result.PhotoId.Should().NotBeEmpty();
+        record.Photos.Should().HaveCount(1);
+        _repo.Verify(r => r.UpdateAsync(record, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _ocr.Verify(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never); // flag false
+    }
+
+    [Fact]
+    public async Task Handle_ExtractScore_RunsOcrAndStoresText()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(creator, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "play-record-photos/abc/fid_12345678.png", 100));
+        _ocr.Setup(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoPreprocessResult(Array.Empty<byte>(), "Alice 10 Bob 8", 0.93, PageOrientation.Portrait, false, Array.Empty<string>()));
+
+        var pngBytes = MakePngBytes();
+        var result = await CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(record.Id, creator, new MemoryStream(pngBytes), pngBytes.Length, "image/png", true, null),
+            CancellationToken.None);
+
+        result.OcrText.Should().Be("Alice 10 Bob 8");
+        record.Photos[0].OcrText.Should().Be("Alice 10 Bob 8");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateSha_ReturnsExistingWithoutSecondStore()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(creator, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "play-record-photos/abc/fid_12345678.png", 100));
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        // Use the same byte array for both commands → identical SHA256 → dedup triggers on cmd2.
+        var pngBytes = MakePngBytes();
+
+        var cmd1 = new UploadPlayRecordPhotoCommand(record.Id, creator, new MemoryStream(pngBytes), pngBytes.Length, "image/png", false, null);
+        await CreateSut().Handle(cmd1, CancellationToken.None);
+
+        // Second upload with same bytes: record already has the photo with the same SHA256.
+        var cmd2 = new UploadPlayRecordPhotoCommand(record.Id, creator, new MemoryStream(pngBytes), pngBytes.Length, "image/png", false, null);
+        var result2 = await CreateSut().Handle(cmd2, CancellationToken.None);
+
+        record.Photos.Should().HaveCount(1);              // same bytes → deduped
+        result2.WasDeduplicated.Should().BeTrue();
+        // cmd1 triggers 2 StoreAsync calls (original + thumbnail); cmd2 short-circuits at dedup → 0 extra calls.
+        // Total = 2, NOT 3 or 4.
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UploadPlayRecordPhotoCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UploadPlayRecordPhotoCommandValidatorTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Validators.PlayRecords;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class UploadPlayRecordPhotoCommandValidatorTests
+{
+    private readonly UploadPlayRecordPhotoCommandValidator _validator = new();
+
+    private static UploadPlayRecordPhotoCommand Cmd(long size = 1000, string mime = "image/jpeg") =>
+        new(Guid.NewGuid(), Guid.NewGuid(), new MemoryStream(), size, mime, false, null);
+
+    [Fact]
+    public void Valid_Passes() => _validator.Validate(Cmd()).IsValid.Should().BeTrue();
+
+    [Fact]
+    public void TooLarge_Fails() =>
+        _validator.Validate(Cmd(size: 5 * 1024 * 1024 + 1)).IsValid.Should().BeFalse();
+
+    [Fact]
+    public void EmptyFile_Fails() => _validator.Validate(Cmd(size: 0)).IsValid.Should().BeFalse();
+
+    [Fact]
+    public void BadMime_Fails() =>
+        _validator.Validate(Cmd(mime: "application/pdf")).IsValid.Should().BeFalse();
+
+    [Fact]
+    public void EmptyRecordId_Fails() =>
+        _validator.Validate(new UploadPlayRecordPhotoCommand(Guid.Empty, Guid.NewGuid(),
+            new MemoryStream(), 100, "image/png", false, null)).IsValid.Should().BeFalse();
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PlayRecordAddPhotoTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PlayRecordAddPhotoTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class PlayRecordAddPhotoTests
+{
+    private static PlayRecord NewRecord(Guid creator) =>
+        PlayRecord.CreateFreeForm(Guid.NewGuid(), "Catan", creator, DateTime.UtcNow.AddDays(-1),
+            PlayRecordVisibility.Private, SessionScoringConfig.CreateDefault());
+
+    [Fact]
+    public void AddPhoto_AppendsPhotoAndRaisesEvent()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        record.ClearDomainEvents();
+        var photoId = Guid.NewGuid();
+
+        record.AddPhoto(photoId, "blob/u.jpg", "blob/t.jpg", 100, "sha", "ocr", 0.9, "cap", creator);
+
+        record.Photos.Should().HaveCount(1);
+        record.Photos[0].Id.Should().Be(photoId);
+        record.DomainEvents.OfType<PlayRecordPhotoUploadedEvent>().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddPhoto_Eleventh_Throws()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        for (var i = 0; i < 10; i++)
+            record.AddPhoto(Guid.NewGuid(), $"u{i}", null, 1, $"sha{i}", null, null, null, creator);
+
+        var act = () => record.AddPhoto(Guid.NewGuid(), "u", null, 1, "shaX", null, null, null, creator);
+        act.Should().Throw<DomainException>();
+    }
+
+    [Fact]
+    public void RestorePhoto_AppendsWithoutEvent()
+    {
+        var record = NewRecord(Guid.NewGuid());
+        record.ClearDomainEvents();
+
+        record.RestorePhoto(Guid.NewGuid(), "u", null, 1, "sha", null, null, null, Guid.NewGuid(),
+            DateTime.UtcNow);
+
+        record.Photos.Should().HaveCount(1);
+        record.DomainEvents.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PlayRecordPhotoTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PlayRecordPhotoTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.SharedKernel.Domain.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class PlayRecordPhotoTests
+{
+    private static readonly Guid RecordId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ValidArgs_SetsProperties()
+    {
+        var id = Guid.NewGuid();
+        var uploader = Guid.NewGuid();
+        var at = new DateTime(2026, 6, 20, 18, 0, 0, DateTimeKind.Utc);
+
+        var photo = new PlayRecordPhoto(id, RecordId, "blob/url.jpg", "blob/thumb.jpg",
+            12345, "abc123", "10 - 8", 0.91, "caption", uploader, at);
+
+        photo.Id.Should().Be(id);
+        photo.PlayRecordId.Should().Be(RecordId);
+        photo.BlobUrl.Should().Be("blob/url.jpg");
+        photo.ThumbnailUrl.Should().Be("blob/thumb.jpg");
+        photo.FileSizeBytes.Should().Be(12345);
+        photo.Sha256Hash.Should().Be("abc123");
+        photo.OcrText.Should().Be("10 - 8");
+        photo.OcrConfidence.Should().Be(0.91);
+        photo.Caption.Should().Be("caption");
+        photo.UploadedByUserId.Should().Be(uploader);
+        photo.UploadedAt.Should().Be(at);
+    }
+
+    [Fact]
+    public void Constructor_EmptyPlayRecordId_Throws()
+    {
+        var act = () => new PlayRecordPhoto(Guid.NewGuid(), Guid.Empty, "u", null, 1, "h", null, null, null, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_BlankBlobUrl_Throws()
+    {
+        var act = () => new PlayRecordPhoto(Guid.NewGuid(), RecordId, "  ", null, 1, "h", null, null, null, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void Constructor_BlankSha_Throws()
+    {
+        var act = () => new PlayRecordPhoto(Guid.NewGuid(), RecordId, "u", null, 1, "  ", null, null, null, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<ValidationException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
@@ -1,0 +1,340 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for <see cref="UploadPlayRecordPhotoCommandHandler"/>:
+/// Testcontainers Postgres round-trip covering creator upload, forbidden guard,
+/// and SHA256 dedup (aggregate + DB unique index). Issue #2436 PR-B.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public sealed class PlayRecordPhotoUploadTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private readonly TestTimeProvider _timeProvider = new();
+
+    public PlayRecordPhotoUploadTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IServiceProvider ServiceProvider => _serviceProvider
+        ?? throw new InvalidOperationException("Service provider not initialized.");
+    private MeepleAiDbContext DbContext => _dbContext
+        ?? throw new InvalidOperationException("DbContext not initialized.");
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    // ---------------------------------------------------------------------------
+    // Fake IBlobStorageService — returns a deterministic in-memory result so the
+    // integration test does not need a real filesystem or S3 bucket.
+    // ---------------------------------------------------------------------------
+    private sealed class FakeBlobStorageService : IBlobStorageService
+    {
+        public Task<BlobStorageResult> StoreAsync(
+            Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
+        {
+            var fileId = Guid.NewGuid().ToString("N");
+            // Compose a path that mirrors the local BlobStorageService pattern:
+            // {category.ToS3Folder()}/{resourceKey}/{fileId}_{fileName}
+            var filePath = $"{category.ToS3Folder()}/{resourceKey}/{fileId}_{fileName}";
+            return Task.FromResult(new BlobStorageResult(true, fileId, filePath, 100));
+        }
+
+        public Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
+            => Task.FromResult<Stream?>(null);
+
+        public Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
+            => Task.FromResult(true);
+
+        public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
+            => $"{category.ToS3Folder()}/{resourceKey}/{fileId}_{fileName}";
+
+        public Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        // Local storage returns null (handler falls back to raw path).
+        public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
+            => Task.FromResult<string?>(null);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Lifecycle
+    // ---------------------------------------------------------------------------
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_playrecordphoto_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+
+        // PlayRecord stack
+        services.AddScoped<IPlayRecordRepository, PlayRecordRepository>();
+        services.AddScoped<PlayRecordPermissionChecker>();
+
+        // SharedGameCatalog repos needed by CreatePlayRecordCommandHandler
+        services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+        services.AddScoped<IGameCoreDataProvider, GameCoreDataProvider>();
+
+        // Blob storage: register the fake so the handler can resolve IBlobStorageService
+        services.AddScoped<IBlobStorageService, FakeBlobStorageService>();
+
+        // OCR preprocessor: Moq returning empty text (OCR off by default in tests)
+        var ocrMock = new Mock<IPhotoPreprocessor>();
+        ocrMock.Setup(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoPreprocessResult(
+                Array.Empty<byte>(), "Alice 10 Bob 8", 0.93,
+                PageOrientation.Portrait, false, Array.Empty<string>()));
+        services.AddScoped<IPhotoPreprocessor>(_ => ocrMock.Object);
+
+        // Override the singleton TimeProvider registered by CreateBase with our fake
+        services.AddSingleton<TimeProvider>(_timeProvider);
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await DbContext.Database.MigrateAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+
+        // Fixture handles container lifecycle — we only drop our isolated DB
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// <summary>Generates a minimal but valid PNG byte array using ImageSharp.</summary>
+    private static byte[] MakePngBytes(int width = 10, int height = 10)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        using var ms = new MemoryStream();
+        image.Save(ms, new PngEncoder());
+        return ms.ToArray();
+    }
+
+    private async Task<Guid> SeedTestUserAsync(Guid? userId = null)
+    {
+        var id = userId ?? Guid.NewGuid();
+        using var scope = ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        db.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"photo-test-{id:N}@meepleai.dev",
+            DisplayName = "Photo Test User",
+            Role = "user",
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    private async Task<Guid> CreateTestRecordAsync(Guid creatorUserId)
+    {
+        // We need a shared game for the FK
+        var gameId = Guid.NewGuid();
+        using (var scope = ServiceProvider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            db.SharedGames.Add(new SharedGameEntity
+            {
+                Id = gameId,
+                Title = "Photo Test Game",
+                MinPlayers = 1,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync(TestCancellationToken);
+        }
+
+        var command = new CreatePlayRecordCommand(
+            creatorUserId, gameId, "Photo Test Game",
+            _timeProvider.UtcNow.AddHours(-1), PlayRecordVisibility.Private);
+
+        return await SendInScopeAsync(command);
+    }
+
+    private async Task<TResult> SendInScopeAsync<TResult>(IRequest<TResult> command)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(command, TestCancellationToken);
+    }
+
+    private async Task SendInScopeAsync(IRequest command)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        await mediator.Send(command, TestCancellationToken);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Creator uploads a PNG → command succeeds, one row is written to play_record_photos,
+    /// and the PlayRecord.Photos collection contains the persisted photo.
+    /// </summary>
+    [Fact]
+    public async Task UploadPhoto_AsCreator_PersistsPhotoRow()
+    {
+        // Arrange
+        var creatorId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(creatorId);
+        var pngBytes = MakePngBytes();
+
+        var command = new UploadPlayRecordPhotoCommand(
+            recordId, creatorId,
+            new MemoryStream(pngBytes), pngBytes.Length,
+            "image/png", false, "test caption");
+
+        // Act
+        var result = await SendInScopeAsync(command);
+
+        // Assert — result contract
+        result.Should().NotBeNull();
+        result.PhotoId.Should().NotBeEmpty();
+        result.WasDeduplicated.Should().BeFalse();
+        result.PhotoUrl.Should().NotBeNullOrWhiteSpace();
+
+        // Assert — DB row via a fresh scope
+        using var scope = ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var photos = await db.PlayRecordPhotos
+            .Where(p => p.PlayRecordId == recordId)
+            .ToListAsync(TestCancellationToken);
+
+        photos.Should().HaveCount(1);
+        photos[0].Id.Should().Be(result.PhotoId);
+        photos[0].BlobUrl.Should().NotBeNullOrWhiteSpace();
+        photos[0].Sha256Hash.Should().NotBeNullOrWhiteSpace();
+        photos[0].FileSizeBytes.Should().Be(pngBytes.Length);
+        photos[0].Caption.Should().Be("test caption");
+        photos[0].UploadedByUserId.Should().Be(creatorId);
+    }
+
+    /// <summary>
+    /// A user who is NOT the record creator receives <see cref="ForbiddenException"/>.
+    /// The blob store must NOT be called.
+    /// </summary>
+    [Fact]
+    public async Task UploadPhoto_AsNonCreator_ThrowsForbiddenException()
+    {
+        // Arrange
+        var creatorId = await SeedTestUserAsync();
+        var strangerId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(creatorId);
+        var pngBytes = MakePngBytes();
+
+        var command = new UploadPlayRecordPhotoCommand(
+            recordId, strangerId,
+            new MemoryStream(pngBytes), pngBytes.Length,
+            "image/png", false, null);
+
+        // Act & Assert
+        var act = () => SendInScopeAsync(command);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        // Verify no photo was written
+        using var scope = ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var count = await db.PlayRecordPhotos
+            .CountAsync(p => p.PlayRecordId == recordId, TestCancellationToken);
+        count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Uploading the identical PNG bytes twice returns WasDeduplicated=true on the second
+    /// call and leaves only one row in play_record_photos (aggregate-level SHA256 dedup).
+    /// </summary>
+    [Fact]
+    public async Task UploadPhoto_SameBytes_SecondCallReturnsDeduplicated()
+    {
+        // Arrange — both uploads use byte-identical PNGs (same 10×10 blank image)
+        var creatorId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(creatorId);
+        var pngBytes = MakePngBytes();
+
+        var cmd1 = new UploadPlayRecordPhotoCommand(
+            recordId, creatorId,
+            new MemoryStream(pngBytes), pngBytes.Length,
+            "image/png", false, null);
+
+        var result1 = await SendInScopeAsync(cmd1);
+        result1.WasDeduplicated.Should().BeFalse();
+
+        // Note: The second upload must create a FRESH MemoryStream from the same bytes
+        // (the first command consumed the stream).
+        var cmd2 = new UploadPlayRecordPhotoCommand(
+            recordId, creatorId,
+            new MemoryStream(pngBytes), pngBytes.Length,
+            "image/png", false, null);
+
+        // Act
+        var result2 = await SendInScopeAsync(cmd2);
+
+        // Assert
+        result2.WasDeduplicated.Should().BeTrue();
+        result2.PhotoId.Should().Be(result1.PhotoId);
+
+        // Only ONE row in the DB
+        using var scope = ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var count = await db.PlayRecordPhotos
+            .CountAsync(p => p.PlayRecordId == recordId, TestCancellationToken);
+        count.Should().Be(1);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
@@ -337,4 +337,63 @@ public sealed class PlayRecordPhotoUploadTests : IAsyncLifetime
             .CountAsync(p => p.PlayRecordId == recordId, TestCancellationToken);
         count.Should().Be(1);
     }
+
+    /// <summary>
+    /// Verifies that the xmin optimistic-concurrency token prevents a stale write from
+    /// succeeding. Load the same row into two separate domain aggregates, mutate+save the
+    /// first (advancing the row's xmin in Postgres), then attempt to save the second —
+    /// EF must throw <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>
+    /// because the second aggregate carries the old xmin value.
+    /// ADR-060 / #2436 PR-B / #2437-1.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_ConcurrentWrite_ThrowsDbUpdateConcurrencyException()
+    {
+        // Arrange — seed a record so we have a row with a known xmin.
+        var creatorId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(creatorId);
+
+        // Load scope 1 — aggregateA holds the initial xmin.
+        Api.BoundedContexts.GameManagement.Domain.Entities.PlayRecord aggregateA;
+        using (var scope = ServiceProvider.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IPlayRecordRepository>();
+            aggregateA = (await repo.GetByIdAsync(recordId, TestCancellationToken))!;
+        }
+
+        // Load scope 2 — aggregateB also holds the same initial xmin.
+        Api.BoundedContexts.GameManagement.Domain.Entities.PlayRecord aggregateB;
+        using (var scope = ServiceProvider.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IPlayRecordRepository>();
+            aggregateB = (await repo.GetByIdAsync(recordId, TestCancellationToken))!;
+        }
+
+        // Mutate + save aggregateA in its own scope → Postgres advances xmin for this row.
+        using (var scope = ServiceProvider.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IPlayRecordRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<Api.SharedKernel.Infrastructure.Persistence.IUnitOfWork>();
+            aggregateA.UpdateDetails(notes: "first writer wins", timeProvider: _timeProvider);
+            await repo.UpdateAsync(aggregateA, TestCancellationToken);
+            await uow.SaveChangesAsync(TestCancellationToken);
+        }
+
+        // Act — attempt to save aggregateB (stale xmin) in a new scope.
+        // EF should throw DbUpdateConcurrencyException because the xmin it sends
+        // no longer matches the row's current xmin in Postgres.
+        var act = async () =>
+        {
+            using var scope = ServiceProvider.CreateScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IPlayRecordRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<Api.SharedKernel.Infrastructure.Persistence.IUnitOfWork>();
+            aggregateB.UpdateDetails(notes: "second writer should lose", timeProvider: _timeProvider);
+            await repo.UpdateAsync(aggregateB, TestCancellationToken);
+            await uow.SaveChangesAsync(TestCancellationToken);
+        };
+
+        // Assert — the losing write must surface as a concurrency conflict (→ 409 via middleware).
+        await act.Should().ThrowAsync<Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException>(
+            "xmin mismatch means the row was already updated; EF must reject the stale write");
+    }
 }

--- a/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
@@ -727,6 +727,44 @@ public class ApiExceptionHandlerMiddlewareTests
         errorResponse.RootElement.GetProperty("error").GetString().Should().Be("two_factor_unavailable");
     }
 
+    [Fact]
+    public async Task InvokeAsync_DbUpdateConcurrencyException_Returns409WithConcurrentEditBody()
+    {
+        // #2436 PR-B / #2437-1: concurrent write on the same row (xmin mismatch) → 409 Conflict
+        // with X-Warning-Code: concurrent-edit so the FE can render a "reload & retry" prompt.
+        // DbUpdateConcurrencyException has a constructor that takes just a message;
+        // the entries overload needs EF internals not exposed to test assemblies.
+        var exception = new Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException("Concurrency conflict");
+
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw exception,
+            _loggerMock.Object,
+            _environmentMock.Object);
+
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(409,
+            "a stale xmin token indicates the row was updated by a concurrent request");
+        _httpContext.Response.Headers["X-Warning-Code"].ToString().Should().Be("concurrent-edit",
+            "the FE uses this header to distinguish from other 409s and show a reload prompt");
+
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var responseBody = await reader.ReadToEndAsync(TestCancellationToken);
+        using var errorResponse = ParseErrorResponse(responseBody);
+
+        errorResponse.RootElement.GetProperty("error").GetString()
+            .Should().Be("concurrent_edit");
+        errorResponse.RootElement.GetProperty("message").GetString()
+            .Should().Contain("Reload and retry",
+                "the message should tell the client exactly what to do");
+        errorResponse.RootElement.GetProperty("correlationId").ValueKind
+            .Should().NotBe(System.Text.Json.JsonValueKind.Null,
+                "correlationId must be present so the client can report the incident");
+    }
+
     private static JsonDocument ParseErrorResponse(string responseBody)
     {
         return JsonDocument.Parse(responseBody);

--- a/docs/for-claude/architecture/adr/adr-067-playrecord-photo-upload-pipeline.md
+++ b/docs/for-claude/architecture/adr/adr-067-playrecord-photo-upload-pipeline.md
@@ -1,6 +1,6 @@
 # ADR-067 — PlayRecord Photo Upload Pipeline
 
-**Status**: Proposed
+**Status**: Accepted (amended 2026-06-20)
 **Date**: 2026-06-15
 **Deciders**: @badsworm (pending ratification at PR review)
 **Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 1 — sub-issue [#2359](https://github.com/meepleAi-app/meepleai-monorepo/issues/2359)
@@ -22,7 +22,7 @@ The `BlobCategory` enum already has `SessionPhoto` for session-linked photos. Pl
 
 The `unstructured-service` (`apps/unstructured-service/`) is a FastAPI PDF extraction microservice. Its domain model (`domain/models.py`), main entry point, and API schemas are exclusively PDF-centric — there is no image endpoint, no vision inference path, and no OCR for photos. Re-using it for scoresheet OCR would require adding a new `/extract-image` endpoint that the service was not designed for.
 
-The `smoldocling-service` (`apps/smoldocling-service/`) similarly targets structured document parsing (DocLayNet-trained).
+The `smoldocling-service` (`apps/smoldocling-service/`) targets structured document parsing (DocLayNet-trained). **Amendment 2026-06-20**: the smoldocling service already exposes a `/api/v1/preprocess` endpoint that accepts image bytes and returns extracted text (`ExtractedText`) + confidence (`ConfidenceScore`). The .NET side already models this via `IPhotoPreprocessor` / `SmoldoclingPhotoPreprocessor`. The original context premise "no image endpoint exists" was incorrect at implementation time. See O-D below.
 
 The spec (US-INT-2, Cockburn step 5) describes photo upload with "OCR opzionale per scoresheet card; preview inline" and maps this to a "photo max 5MB; OCR opzionale" acceptance criterion. The spec explicitly calls out OCR as opt-in, not default.
 
@@ -86,15 +86,23 @@ A new `ocr-service` container running Tesseract (open source) or calling a cloud
 
 **Risks**: medium (infra cost, Tesseract quality variance).
 
-#### Option O-C — Opt-in OCR via Unstructured, deferred to Phase 2
+#### Option O-C — Opt-in OCR via Unstructured, deferred to Phase 2 *(superseded by O-D)*
 
 Accept the `extractScoreFromPhoto: bool` flag on the upload command, store the photo, but defer the actual OCR call to a future work item. Phase 1 always returns `ocrText: null` regardless of the flag. The `BlobCategory.PlayRecordPhoto` column on the entity reserves space for `OcrText`.
 
-**Pros**: unblocks US-INT-2b immediately (the flag is wired, the pipeline is ready, the inference is deferred). No new service needed for Phase 1. The spec says OCR is opt-in — defaulting to deferred satisfies the acceptance criterion for Phase 1.
+**Status**: superseded. At implementation time (2026-06-20), `IPhotoPreprocessor` / `SmoldoclingPhotoPreprocessor` was already present in the codebase and capable of image OCR. Deferral was unnecessary. O-D was selected instead.
 
-**Cons**: the OCR flag has no effect in Phase 1. Users who tick "extract score from photo" get no result. Must be clearly communicated in the UX.
+---
 
-**Risks**: low for Phase 1. The deferred implementation decision (Tesseract vs cloud) does not block the storage pipeline.
+#### Option O-D — Reuse smoldocling `/api/v1/preprocess` via `IPhotoPreprocessor` *(selected 2026-06-20)*
+
+Wire the existing `IPhotoPreprocessor` (implemented by `SmoldoclingPhotoPreprocessor`) inside `UploadPlayRecordPhotoCommandHandler`. When `ExtractScoreFromPhoto == true`, the handler calls `PreprocessAsync(bytes, ct)` after the blob upload and stores the returned `ExtractedText` → `OcrText` and `ConfidenceScore` → `OcrConfidence` on the `PlayRecordPhoto` entity. The call is **best-effort**: any exception is caught and logged as a warning, so a smoldocling failure does not fail the upload.
+
+**Pros**: zero new infrastructure — smoldocling was already deployed and already does image OCR via its VLM pipeline. `IPhotoPreprocessor` is the established abstraction (DI-registered, Moq-friendly in tests). OCR result is persisted synchronously during the upload, so the score extraction UX is immediate (no async job needed for the MVP path).
+
+**Cons**: latency of the upload endpoint increases by the smoldocling round-trip time when `ExtractScoreFromPhoto == true`. Acceptable because OCR is opt-in and infrequent.
+
+**Risks**: low. Best-effort wrapper means smoldocling downtime does not block uploads.
 
 ---
 
@@ -126,13 +134,21 @@ Rejected for Phase 1. Can be added later as `PhotoPerceptualHash` column alongsi
 
 ## Decision
 
-**Storage: Option P-A** — new `BlobCategory.PlayRecordPhoto` with key `play-record-photos/{playRecordId}/{photoId}-{sha256[:8]}.{ext}`.
+**Storage: Option P-A** — new `BlobCategory.PlayRecordPhoto` with key `play-record-photos/{playRecordId}/{photoId}_{sha256[:8]}.{ext}`.
 
-**OCR: Option O-C** — opt-in flag accepted, OCR execution deferred to Phase 2.
+**OCR: Option O-D** *(amended 2026-06-20; supersedes O-C)* — reuse `IPhotoPreprocessor` / smoldocling `/api/v1/preprocess`. When `ExtractScoreFromPhoto == true`, the handler calls `PreprocessAsync(bytes, ct)` after the blob store, populating `OcrText` and `OcrConfidence` on `PlayRecordPhoto`. The call is best-effort (exception caught + logged, upload never fails on OCR error).
 
-**Dedup: Option D-A** — SHA256 cryptographic hash, consistent with existing `PdfSeeder.ContentHash` pattern.
+**Dedup: Option D-A** — SHA256 cryptographic hash, consistent with existing `PdfSeeder.ContentHash` pattern. Additionally enforced at the database level via the `UX_play_record_photos_playrecord_sha256` unique index on `(PlayRecordId, Sha256Hash)`.
 
-Rationale: The `SessionAttachmentService` provides a complete prior art for the upload + thumbnail + pre-signed-URL pipeline; the PlayRecord photo pipeline reuses it nearly verbatim, substituting `BlobCategory.PlayRecordPhoto` and `play-record-{playRecordId:N}` as resource key. SHA256 dedup matches the existing pattern and is sufficient for MVP — the "same photo uploaded twice" scenario is the dominant real-world case. OCR deferred: Unstructured is PDF-only, a new Tesseract service is out of scope for US-INT-2, and the spec explicitly marks OCR as opt-in/optional. Deferring OCR execution to Phase 2 unblocks US-INT-2b without introducing new infra.
+Rationale: The `SessionAttachmentService` provides a complete prior art for the upload + thumbnail + pre-signed-URL pipeline; the PlayRecord photo pipeline reuses it nearly verbatim, substituting `BlobCategory.PlayRecordPhoto` and `play-record-{playRecordId:N}` as resource key. SHA256 dedup matches the existing pattern and is sufficient for MVP — the "same photo uploaded twice" scenario is the dominant real-world case. OCR via smoldocling was wired immediately (DEC-3): `IPhotoPreprocessor` was already registered in DI and the smoldocling service already exposed the required endpoint — deferral was unnecessary.
+
+**Implementation shipped (PR-B, 2026-06-20):**
+- `BlobCategory.PlayRecordPhoto` added to enum + `ToS3Folder()` case.
+- `PlayRecordPhoto` child entity on `PlayRecord` aggregate; `AddPhoto` (max 10 per record) + `RestorePhoto`; `PlayRecordPhotoUploadedEvent`.
+- Persistence: `play_record_photos` table (PascalCase EF columns, snake_case mapped), `UX_play_record_photos_playrecord_sha256` unique index, migration `20260620145331_AddPlayRecordPhotos`.
+- `UploadPlayRecordPhotoCommandHandler`: creator-guard → buffer → magic-byte validate → SHA256 dedup → `StoreAsync` → thumbnail (ImageSharp 300px/q80, best-effort) → OCR via `IPhotoPreprocessor` when `ExtractScoreFromPhoto=true` (best-effort) → `AddPhoto` → `UpdateAsync` → `SaveChangesAsync` → presign.
+- 5 MB server-side size limit enforced in `UploadPlayRecordPhotoCommandValidator`.
+- Endpoint: `POST /api/v1/play-records/{recordId}/photos` (multipart form, `file` + `extractScoreFromPhoto` + `caption`).
 
 ## Consequences
 
@@ -145,9 +161,9 @@ Rationale: The `SessionAttachmentService` provides a complete prior art for the 
 
 ### Negative
 
-- OCR opt-in flag in Phase 1 is a no-op — requires clear UX feedback ("Score extraction coming soon").
+- OCR when `ExtractScoreFromPhoto=true` adds latency to the upload response (smoldocling round-trip). Best-effort wrapper prevents upload failure but the result is unavailable if smoldocling is down.
 - SHA256 dedup misses near-duplicate photos (same scoresheet, slightly different crop). Acceptable for MVP.
-- A new `BlobCategory` enum value must be added to the `BlobCategoryExtensions.ToS3Folder()` switch — trivial but must not be forgotten (adding a `BlobCategory` without updating `ToS3Folder()` throws `ArgumentOutOfRangeException` at runtime).
+- A new `BlobCategory` enum value must be added to the `BlobCategoryExtensions.ToS3Folder()` switch — trivial but must not be forgotten (adding a `BlobCategory` without updating `ToS3Folder()` throws `ArgumentOutOfRangeException` at runtime). This has been done in PR-B.
 
 ### Trade-offs Accepted
 

--- a/docs/superpowers/plans/2026-06-20-issue-2436-pr-b-photo-ocr.md
+++ b/docs/superpowers/plans/2026-06-20-issue-2436-pr-b-photo-ocr.md
@@ -1,0 +1,1103 @@
+# #2436 PR-B — PlayRecord Photo Upload + OCR (Backend) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Backend = .NET 9, CQRS (MediatR, endpoints use ONLY `IMediator.Send`), DDD context GameManagement.
+
+**Goal:** Let a PlayRecord creator upload photos (scoreboard captures) — stored via `IBlobStorageService` with SHA256 dedup + thumbnail + opt-in OCR — exposed at `POST /api/v1/play-records/{recordId}/photos`.
+
+**Architecture:** New `PlayRecordPhoto` child entity on the `PlayRecord` aggregate (mirrors `RecordPlayer`), persisted to a new `play_record_photos` table. A `UploadPlayRecordPhotoCommand` handler: creator-guard (ADR-066) → magic-byte validate → SHA256 dedup → `StoreAsync` (`BlobCategory.PlayRecordPhoto`) → thumbnail (ImageSharp 300px/q80) → opt-in OCR via existing `IPhotoPreprocessor` (smoldocling) → persist. Reuses `SessionAttachmentService` prior-art + `ImageFileValidator` + `CryptographyHelper`.
+
+**Tech Stack:** EF Core (Postgres, snake_case), MediatR, FluentValidation, SixLabors.ImageSharp, xUnit + Moq + Testcontainers. Decisions: DEC-3 (wire OCR now via smoldocling); ADR-067 (storage P-A + SHA256 D-A) — **amend §OCR O-C→smoldocling**. Spec: `docs/superpowers/specs/2026-06-20-issue-2436-create-deferred-spec-panel.md`.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecordPhoto.cs` — child entity (`Entity<Guid>`).
+- `apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordPhotoEntity.cs` — persistence POCO.
+- `apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordPhotoEntityConfiguration.cs` — EF mapping.
+- `apps/api/src/Api/Helpers/ImageThumbnailHelper.cs` — extracted shared thumbnail (ImageSharp 300/q80).
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommand.cs` — command + result record.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs`
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/UploadPlayRecordPhotoCommandValidator.cs`
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/PlayRecordPhotoUploadedEvent.cs`
+- Tests under `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/...` + `Integration/GameManagement/`.
+
+**Modify:**
+- `apps/api/src/Api/Services/Pdf/IBlobStorageService.cs` — add `BlobCategory.PlayRecordPhoto` + `ToS3Folder()` case.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs` — `_photos` collection + `AddPhoto` + `RestorePhoto` + `Photos`.
+- `apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs` — `Photos` nav.
+- `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs` — `DbSet<PlayRecordPhotoEntity> PlayRecordPhotos`.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs` — Include + Added-fix + Map loops.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentService.cs` — delegate its 2 static thumbnail methods to `ImageThumbnailHelper` (keeps its tests green).
+- `apps/api/src/Api/Routing/PlayRecordEndpoints.cs` — `POST /play-records/{recordId}/photos`.
+- `docs/for-claude/architecture/adr/adr-067-playrecord-photo-upload-pipeline.md` — amend OCR decision.
+
+All `dotnet` commands run from `apps/api/src/Api`. Tests: `dotnet test apps/api/tests/Api.Tests --filter "<expr>"` from repo root. **Run `tasklist | grep testhost` and kill stragglers before test runs (pitfall #2593).**
+
+---
+
+### Task 1: Add `BlobCategory.PlayRecordPhoto`
+
+**Files:** Modify `apps/api/src/Api/Services/Pdf/IBlobStorageService.cs`
+
+- [ ] **Step 1: Add the enum value.** In the `BlobCategory` enum, after `PhotoBatch,` add:
+
+```csharp
+    /// <summary>Photos attached to a PlayRecord (scoreboard captures, party shots).
+    /// Target prefix <c>play-record-photos/{playRecordId}/</c>.</summary>
+    PlayRecordPhoto,
+```
+
+- [ ] **Step 2: Add the `ToS3Folder()` case.** In `BlobCategoryExtensions.ToS3Folder()`, before the `_ => throw` default, add:
+
+```csharp
+        BlobCategory.PlayRecordPhoto => "play-record-photos",
+```
+
+- [ ] **Step 3: Build to verify.** Run: `dotnet build apps/api/src/Api` → Expected: succeeds (omitting the switch case would throw `ArgumentOutOfRangeException` at runtime; adding it keeps the exhaustive switch valid).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+git commit -m "feat(play-records): #2436 PR-B add PlayRecordPhoto blob category"
+```
+
+---
+
+### Task 2: `PlayRecordPhoto` domain child entity
+
+**Files:** Create `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecordPhoto.cs` + test `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PlayRecordPhotoTests.cs`
+
+Mirrors `RecordPlayer` (`Entity<Guid>`, internal ctor `(Guid id, Guid playRecordId, ...) : base(id)`, private setters, inline validation).
+
+- [ ] **Step 1: Write the failing test.**
+
+```csharp
+using System;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class PlayRecordPhotoTests
+{
+    private static readonly Guid RecordId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ValidArgs_SetsProperties()
+    {
+        var id = Guid.NewGuid();
+        var uploader = Guid.NewGuid();
+        var at = new DateTime(2026, 6, 20, 18, 0, 0, DateTimeKind.Utc);
+
+        var photo = new PlayRecordPhoto(id, RecordId, "blob/url.jpg", "blob/thumb.jpg",
+            12345, "abc123", "10 - 8", 0.91, "caption", uploader, at);
+
+        photo.Id.Should().Be(id);
+        photo.PlayRecordId.Should().Be(RecordId);
+        photo.BlobUrl.Should().Be("blob/url.jpg");
+        photo.ThumbnailUrl.Should().Be("blob/thumb.jpg");
+        photo.FileSizeBytes.Should().Be(12345);
+        photo.Sha256Hash.Should().Be("abc123");
+        photo.OcrText.Should().Be("10 - 8");
+        photo.OcrConfidence.Should().Be(0.91);
+        photo.Caption.Should().Be("caption");
+        photo.UploadedByUserId.Should().Be(uploader);
+        photo.UploadedAt.Should().Be(at);
+    }
+
+    [Fact]
+    public void Constructor_EmptyPlayRecordId_Throws()
+    {
+        var act = () => new PlayRecordPhoto(Guid.NewGuid(), Guid.Empty, "u", null, 1, "h", null, null, null, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_BlankBlobUrl_Throws()
+    {
+        var act = () => new PlayRecordPhoto(Guid.NewGuid(), RecordId, "  ", null, 1, "h", null, null, null, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<System.ComponentModel.DataAnnotations.ValidationException>();
+    }
+
+    [Fact]
+    public void Constructor_BlankSha_Throws()
+    {
+        var act = () => new PlayRecordPhoto(Guid.NewGuid(), RecordId, "u", null, 1, "  ", null, null, null, Guid.NewGuid(), DateTime.UtcNow);
+        act.Should().Throw<System.ComponentModel.DataAnnotations.ValidationException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL.** `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~PlayRecordPhotoTests"` → FAIL (type missing).
+
+- [ ] **Step 3: Implement.**
+
+```csharp
+using System;
+using System.ComponentModel.DataAnnotations;
+using Api.SharedKernel.Domain;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// A photo attached to a <see cref="PlayRecord"/> (scoreboard capture, party shot).
+/// Child entity of the PlayRecord aggregate. #2436 PR-B (ADR-067).
+/// </summary>
+internal sealed class PlayRecordPhoto : Entity<Guid>
+{
+    public Guid PlayRecordId { get; private set; }
+    public string BlobUrl { get; private set; }
+    public string? ThumbnailUrl { get; private set; }
+    public long FileSizeBytes { get; private set; }
+    public string Sha256Hash { get; private set; }
+    public string? OcrText { get; private set; }
+    public double? OcrConfidence { get; private set; }
+    public string? Caption { get; private set; }
+    public Guid UploadedByUserId { get; private set; }
+    public DateTime UploadedAt { get; private set; }
+
+#pragma warning disable CS8618
+    private PlayRecordPhoto() : base() { }
+#pragma warning restore CS8618
+
+    internal PlayRecordPhoto(
+        Guid id,
+        Guid playRecordId,
+        string blobUrl,
+        string? thumbnailUrl,
+        long fileSizeBytes,
+        string sha256Hash,
+        string? ocrText,
+        double? ocrConfidence,
+        string? caption,
+        Guid uploadedByUserId,
+        DateTime uploadedAt) : base(id)
+    {
+        if (playRecordId == Guid.Empty)
+            throw new ArgumentException("PlayRecordId cannot be empty", nameof(playRecordId));
+        if (string.IsNullOrWhiteSpace(blobUrl))
+            throw new ValidationException("BlobUrl cannot be empty");
+        if (string.IsNullOrWhiteSpace(sha256Hash))
+            throw new ValidationException("Sha256Hash cannot be empty");
+        if (caption is { Length: > 500 })
+            throw new ValidationException("Caption cannot exceed 500 characters");
+
+        PlayRecordId = playRecordId;
+        BlobUrl = blobUrl;
+        ThumbnailUrl = thumbnailUrl;
+        FileSizeBytes = fileSizeBytes;
+        Sha256Hash = sha256Hash;
+        OcrText = ocrText;
+        OcrConfidence = ocrConfidence;
+        Caption = caption?.Trim();
+        UploadedByUserId = uploadedByUserId;
+        UploadedAt = uploadedAt;
+    }
+}
+```
+
+> Verify `Entity<Guid>` namespace matches `RecordPlayer.cs` (`using Api.SharedKernel.Domain;`). If `RecordPlayer` uses a different base namespace, mirror it exactly.
+
+- [ ] **Step 4: Run, verify PASS.** Same filter → PASS (4 tests).
+
+- [ ] **Step 5: Commit.** `git commit -m "feat(play-records): #2436 PR-B PlayRecordPhoto domain entity"`
+
+---
+
+### Task 3: Aggregate — `_photos` collection + `AddPhoto` + `RestorePhoto`
+
+**Files:** Modify `PlayRecord.cs` + test `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PlayRecordAddPhotoTests.cs`
+
+- [ ] **Step 1: Write failing test.**
+
+```csharp
+using System;
+using System.Linq;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class PlayRecordAddPhotoTests
+{
+    private static PlayRecord NewRecord(Guid creator) =>
+        PlayRecord.CreateFreeForm(Guid.NewGuid(), "Catan", creator, DateTime.UtcNow.AddDays(-1),
+            PlayRecordVisibility.Private, SessionScoringConfig.CreateDefault());
+
+    [Fact]
+    public void AddPhoto_AppendsPhotoAndRaisesEvent()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        record.ClearDomainEvents();
+        var photoId = Guid.NewGuid();
+
+        record.AddPhoto(photoId, "blob/u.jpg", "blob/t.jpg", 100, "sha", "ocr", 0.9, "cap", creator);
+
+        record.Photos.Should().HaveCount(1);
+        record.Photos[0].Id.Should().Be(photoId);
+        record.DomainEvents.OfType<PlayRecordPhotoUploadedEvent>().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddPhoto_Eleventh_Throws()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        for (var i = 0; i < 10; i++)
+            record.AddPhoto(Guid.NewGuid(), $"u{i}", null, 1, $"sha{i}", null, null, null, creator);
+
+        var act = () => record.AddPhoto(Guid.NewGuid(), "u", null, 1, "shaX", null, null, null, creator);
+        act.Should().Throw<Api.SharedKernel.Domain.Exceptions.DomainException>();
+    }
+
+    [Fact]
+    public void RestorePhoto_AppendsWithoutEvent()
+    {
+        var record = NewRecord(Guid.NewGuid());
+        record.ClearDomainEvents();
+
+        record.RestorePhoto(Guid.NewGuid(), "u", null, 1, "sha", null, null, null, Guid.NewGuid(),
+            DateTime.UtcNow);
+
+        record.Photos.Should().HaveCount(1);
+        record.DomainEvents.Should().BeEmpty();
+    }
+}
+```
+
+> Confirm `ClearDomainEvents()`/`DomainEvents` exist on the aggregate base (used by `RecordPlayer` tests). If named differently, mirror the existing test idiom. Confirm `DomainException` namespace from `PlayRecord.cs` (`AddPlayer` throws it for the 100-cap).
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Implement in `PlayRecord.cs`.** Add beside `_players`:
+
+```csharp
+    private readonly List<PlayRecordPhoto> _photos = new();
+    public IReadOnlyList<PlayRecordPhoto> Photos => _photos.AsReadOnly();
+```
+
+Add the mutator (mirrors `AddPlayer`, max 10 per ADR-067):
+
+```csharp
+    /// <summary>Attach an uploaded photo. Max 10 per record (#2436 PR-B). Raises a domain event.</summary>
+    public void AddPhoto(
+        Guid photoId, string blobUrl, string? thumbnailUrl, long fileSizeBytes,
+        string sha256Hash, string? ocrText, double? ocrConfidence, string? caption,
+        Guid uploadedByUserId, TimeProvider? timeProvider = null)
+    {
+        if (_photos.Count >= 10)
+            throw new DomainException("Cannot attach more than 10 photos to a play record");
+
+        var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+        var photo = new PlayRecordPhoto(photoId, Id, blobUrl, thumbnailUrl, fileSizeBytes,
+            sha256Hash, ocrText, ocrConfidence, caption, uploadedByUserId, now);
+        _photos.Add(photo);
+        UpdatedAt = now;
+        AddDomainEvent(new PlayRecordPhotoUploadedEvent(Id, photo.Id, uploadedByUserId));
+    }
+
+    /// <summary>Repository-only reconstitution from persistence (no event).</summary>
+    internal void RestorePhoto(
+        Guid photoId, string blobUrl, string? thumbnailUrl, long fileSizeBytes,
+        string sha256Hash, string? ocrText, double? ocrConfidence, string? caption,
+        Guid uploadedByUserId, DateTime uploadedAt)
+    {
+        _photos.Add(new PlayRecordPhoto(photoId, Id, blobUrl, thumbnailUrl, fileSizeBytes,
+            sha256Hash, ocrText, ocrConfidence, caption, uploadedByUserId, uploadedAt));
+    }
+```
+
+- [ ] **Step 4: Run, verify PASS.**
+
+- [ ] **Step 5: Commit.** `git commit -m "feat(play-records): #2436 PR-B aggregate AddPhoto/RestorePhoto (max 10)"`
+
+---
+
+### Task 4: `PlayRecordPhotoUploadedEvent`
+
+**Files:** Create `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/PlayRecordPhotoUploadedEvent.cs`
+
+- [ ] **Step 1: Implement** (mirror `PlayerAddedToRecordEvent` shape — find it in the Events folder and match its base interface, e.g. `IDomainEvent`):
+
+```csharp
+using System;
+using Api.SharedKernel.Domain;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+internal sealed record PlayRecordPhotoUploadedEvent(
+    Guid PlayRecordId,
+    Guid PhotoId,
+    Guid UploadedByUserId) : IDomainEvent;
+```
+
+> Match the EXACT base type/interface of the existing `PlayerAddedToRecordEvent` (could be `DomainEvent` base record or `IDomainEvent`). Read it first and mirror. This task is folded into Task 3's first build — if Task 3's test references the event, create this file in Task 3. (Commit together with Task 3 if so.)
+
+- [ ] **Step 2: Build.** `dotnet build apps/api/src/Api` → succeeds.
+
+---
+
+### Task 5: Persistence entity + DbContext + EF config
+
+**Files:** Create `PlayRecordPhotoEntity.cs` + `PlayRecordPhotoEntityConfiguration.cs`; modify `PlayRecordEntity.cs` + `MeepleAiDbContext.cs`
+
+- [ ] **Step 1: `PlayRecordPhotoEntity.cs`** (POCO, mirror `RecordPlayerEntity`):
+
+```csharp
+using System;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+public class PlayRecordPhotoEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid PlayRecordId { get; set; }
+    public string BlobUrl { get; set; } = string.Empty;
+    public string? ThumbnailUrl { get; set; }
+    public long FileSizeBytes { get; set; }
+    public string Sha256Hash { get; set; } = string.Empty;
+    public string? OcrText { get; set; }
+    public double? OcrConfidence { get; set; }
+    public string? Caption { get; set; }
+    public Guid UploadedByUserId { get; set; }
+    public DateTime UploadedAt { get; set; }
+
+    public PlayRecordEntity? PlayRecord { get; set; }
+}
+```
+
+- [ ] **Step 2: Add nav to `PlayRecordEntity.cs`** beside `Players`:
+
+```csharp
+    public ICollection<PlayRecordPhotoEntity> Photos { get; set; } = new List<PlayRecordPhotoEntity>();
+```
+
+- [ ] **Step 3: `PlayRecordPhotoEntityConfiguration.cs`** (mirror `RecordPlayerEntityConfiguration`; snake_case table + UNIQUE index on `(PlayRecordId, Sha256Hash)`):
+
+```csharp
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+internal class PlayRecordPhotoEntityConfiguration : IEntityTypeConfiguration<PlayRecordPhotoEntity>
+{
+    public void Configure(EntityTypeBuilder<PlayRecordPhotoEntity> builder)
+    {
+        builder.ToTable("play_record_photos");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.PlayRecordId).HasColumnName("play_record_id").IsRequired();
+        builder.Property(e => e.BlobUrl).HasColumnName("blob_url").HasMaxLength(1024).IsRequired();
+        builder.Property(e => e.ThumbnailUrl).HasColumnName("thumbnail_url").HasMaxLength(1024);
+        builder.Property(e => e.FileSizeBytes).HasColumnName("file_size_bytes").IsRequired();
+        builder.Property(e => e.Sha256Hash).HasColumnName("sha256_hash").HasMaxLength(64).IsRequired();
+        builder.Property(e => e.OcrText).HasColumnName("ocr_text");
+        builder.Property(e => e.OcrConfidence).HasColumnName("ocr_confidence");
+        builder.Property(e => e.Caption).HasColumnName("caption").HasMaxLength(500);
+        builder.Property(e => e.UploadedByUserId).HasColumnName("uploaded_by_user_id").IsRequired();
+        builder.Property(e => e.UploadedAt).HasColumnName("uploaded_at").IsRequired();
+
+        builder.HasOne(e => e.PlayRecord)
+            .WithMany(r => r.Photos)
+            .HasForeignKey(e => e.PlayRecordId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => new { e.PlayRecordId, e.Sha256Hash })
+            .IsUnique()
+            .HasDatabaseName("UX_play_record_photos_playrecord_sha256");
+    }
+}
+```
+
+- [ ] **Step 4: DbSet in `MeepleAiDbContext.cs`** beside `RecordPlayers`:
+
+```csharp
+    public DbSet<PlayRecordPhotoEntity> PlayRecordPhotos => Set<PlayRecordPhotoEntity>();
+```
+
+- [ ] **Step 5: Build.** `dotnet build apps/api/src/Api` → succeeds.
+
+- [ ] **Step 6: Commit.** `git commit -m "feat(play-records): #2436 PR-B play_record_photos persistence + config"`
+
+---
+
+### Task 6: Repository wiring (Include + Added-fix + Map loops)
+
+**Files:** Modify `PlayRecordRepository.cs`
+
+- [ ] **Step 1: Add `.Include(r => r.Photos)`** to EVERY load query (the 4 sites that have `.Include(r => r.Players)`), e.g.:
+
+```csharp
+        .Include(r => r.Players)
+            .ThenInclude(p => p.Scores)
+        .Include(r => r.Photos)
+```
+
+- [ ] **Step 2: Extend the detached-graph Added-fix in `UpdateAsync`.** After the existing player/score `existing*IdSet` blocks, add photos:
+
+```csharp
+        var existingPhotoIds = await DbContext.PlayRecordPhotos
+            .Where(p => p.PlayRecordId == record.Id).Select(p => p.Id)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var existingPhotoIdSet = new HashSet<Guid>(existingPhotoIds);
+```
+
+And inside the post-`Update(entity)` loop region:
+
+```csharp
+        foreach (var photo in entity.Photos)
+            if (!existingPhotoIdSet.Contains(photo.Id))
+                DbContext.Entry(photo).State = EntityState.Added;
+```
+
+- [ ] **Step 3: MapToDomain restore loop.** After the players restore loop, add:
+
+```csharp
+        foreach (var photoEntity in entity.Photos)
+        {
+            record.RestorePhoto(
+                photoEntity.Id, photoEntity.BlobUrl, photoEntity.ThumbnailUrl,
+                photoEntity.FileSizeBytes, photoEntity.Sha256Hash, photoEntity.OcrText,
+                photoEntity.OcrConfidence, photoEntity.Caption, photoEntity.UploadedByUserId,
+                photoEntity.UploadedAt);
+        }
+```
+
+- [ ] **Step 4: MapToPersistence loop.** After the players persistence loop, add:
+
+```csharp
+        foreach (var photo in record.Photos)
+        {
+            entity.Photos.Add(new PlayRecordPhotoEntity
+            {
+                Id = photo.Id,
+                PlayRecordId = record.Id,
+                BlobUrl = photo.BlobUrl,
+                ThumbnailUrl = photo.ThumbnailUrl,
+                FileSizeBytes = photo.FileSizeBytes,
+                Sha256Hash = photo.Sha256Hash,
+                OcrText = photo.OcrText,
+                OcrConfidence = photo.OcrConfidence,
+                Caption = photo.Caption,
+                UploadedByUserId = photo.UploadedByUserId,
+                UploadedAt = photo.UploadedAt,
+            });
+        }
+```
+
+- [ ] **Step 5: Build.** `dotnet build apps/api/src/Api` → succeeds. (Round-trip is verified by the Task 12 integration test.)
+
+- [ ] **Step 6: Commit.** `git commit -m "feat(play-records): #2436 PR-B repository photo include + graph mapping"`
+
+---
+
+### Task 7: EF migration
+
+**Files:** Generates `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddPlayRecordPhotos.cs`
+
+- [ ] **Step 1: Generate.** From `apps/api/src/Api`: `dotnet ef migrations add AddPlayRecordPhotos`
+- [ ] **Step 2: Review the generated migration.** Confirm: `CreateTable("play_record_photos")` with snake_case columns; FK to `play_records` PK (whatever its actual column name is — EF resolves it); `CreateIndex("UX_play_record_photos_playrecord_sha256", unique: true)`. No unintended changes to other tables (if the diff includes unrelated changes, STOP and report — the model may have drifted).
+- [ ] **Step 3: Apply to a scratch DB to verify it runs** (optional if Docker available): `dotnet ef database update` against a dev DB, or rely on the Task 12 integration test's `MigrateAsync`.
+- [ ] **Step 4: Commit.** `git commit -m "feat(play-records): #2436 PR-B migration play_record_photos table"`
+
+---
+
+### Task 8: Extract `ImageThumbnailHelper` (shared, keeps SessionAttachmentService tests green)
+
+**Files:** Create `apps/api/src/Api/Helpers/ImageThumbnailHelper.cs`; modify `SessionAttachmentService.cs`
+
+- [ ] **Step 1: Create the helper** (copy the two `internal static` methods verbatim from `SessionAttachmentService`):
+
+```csharp
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Processing;
+
+namespace Api.Helpers;
+
+/// <summary>Shared image thumbnail generation (300px max, JPEG q80). #2436 PR-B.</summary>
+internal static class ImageThumbnailHelper
+{
+    private const int ThumbnailMaxDimension = 300;
+    private const int ThumbnailJpegQuality = 80;
+
+    public static async Task<MemoryStream?> GenerateThumbnailAsync(Stream sourceStream, CancellationToken ct = default)
+    {
+        using var image = await Image.LoadAsync(sourceStream, ct).ConfigureAwait(false);
+        var (newWidth, newHeight) = CalculateThumbnailDimensions(image.Width, image.Height);
+        image.Mutate(ctx => ctx.Resize(newWidth, newHeight));
+        var outputStream = new MemoryStream();
+        await image.SaveAsync(outputStream, new JpegEncoder { Quality = ThumbnailJpegQuality }, ct).ConfigureAwait(false);
+        outputStream.Position = 0;
+        return outputStream;
+    }
+
+    public static (int width, int height) CalculateThumbnailDimensions(int originalWidth, int originalHeight)
+    {
+        if (originalWidth <= ThumbnailMaxDimension && originalHeight <= ThumbnailMaxDimension)
+            return (originalWidth, originalHeight);
+        var ratio = originalWidth >= originalHeight
+            ? (double)ThumbnailMaxDimension / originalWidth
+            : (double)ThumbnailMaxDimension / originalHeight;
+        return (Math.Max(1, (int)(originalWidth * ratio)), Math.Max(1, (int)(originalHeight * ratio)));
+    }
+}
+```
+
+- [ ] **Step 2: Delegate in `SessionAttachmentService.cs`.** Replace the BODIES of its `GenerateThumbnailAsync` and `CalculateThumbnailDimensions` static methods with delegations (keep the same signatures so its existing tests still compile + pass):
+
+```csharp
+    internal static Task<MemoryStream?> GenerateThumbnailAsync(Stream sourceStream, CancellationToken ct = default)
+        => ImageThumbnailHelper.GenerateThumbnailAsync(sourceStream, ct);
+
+    internal static (int width, int height) CalculateThumbnailDimensions(int originalWidth, int originalHeight)
+        => ImageThumbnailHelper.CalculateThumbnailDimensions(originalWidth, originalHeight);
+```
+
+Remove the now-unused `ThumbnailMaxDimension`/`ThumbnailJpegQuality` consts from `SessionAttachmentService` ONLY if nothing else references them (keep `DownloadUrlExpirySeconds`).
+
+- [ ] **Step 3: Run the SessionAttachmentService suite** (regression gate): `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~SessionAttachmentServiceTests"` → PASS (unchanged).
+
+- [ ] **Step 4: Commit.** `git commit -m "refactor(api): #2436 PR-B extract ImageThumbnailHelper (shared)"`
+
+---
+
+### Task 9: `UploadPlayRecordPhotoCommand` + validator
+
+**Files:** Create the command/result + validator + test `UploadPlayRecordPhotoCommandValidatorTests.cs`
+
+- [ ] **Step 1: Command + result.**
+
+```csharp
+using System;
+using System.IO;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+internal record UploadPlayRecordPhotoCommand(
+    Guid RecordId,
+    Guid UserId,
+    Stream FileStream,
+    long FileSizeBytes,
+    string MimeType,
+    bool ExtractScoreFromPhoto,
+    string? Caption
+) : ICommand<PlayRecordPhotoUploadResult>;
+
+internal record PlayRecordPhotoUploadResult(
+    Guid PhotoId,
+    string PhotoUrl,
+    string? ThumbnailUrl,
+    string? OcrText,
+    bool WasDeduplicated);
+```
+
+- [ ] **Step 2: Validator test** (mirror `UploadCustomCoverCommandValidator` rules; 5MB cap per spec):
+
+```csharp
+using System;
+using System.IO;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Validators.PlayRecords;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class UploadPlayRecordPhotoCommandValidatorTests
+{
+    private readonly UploadPlayRecordPhotoCommandValidator _validator = new();
+
+    private static UploadPlayRecordPhotoCommand Cmd(long size = 1000, string mime = "image/jpeg") =>
+        new(Guid.NewGuid(), Guid.NewGuid(), new MemoryStream(), size, mime, false, null);
+
+    [Fact]
+    public void Valid_Passes() => _validator.Validate(Cmd()).IsValid.Should().BeTrue();
+
+    [Fact]
+    public void TooLarge_Fails() =>
+        _validator.Validate(Cmd(size: 5 * 1024 * 1024 + 1)).IsValid.Should().BeFalse();
+
+    [Fact]
+    public void EmptyFile_Fails() => _validator.Validate(Cmd(size: 0)).IsValid.Should().BeFalse();
+
+    [Fact]
+    public void BadMime_Fails() =>
+        _validator.Validate(Cmd(mime: "application/pdf")).IsValid.Should().BeFalse();
+
+    [Fact]
+    public void EmptyRecordId_Fails() =>
+        _validator.Validate(new UploadPlayRecordPhotoCommand(Guid.Empty, Guid.NewGuid(),
+            new MemoryStream(), 100, "image/png", false, null)).IsValid.Should().BeFalse();
+}
+```
+
+- [ ] **Step 3: Run, verify FAIL.**
+
+- [ ] **Step 4: Validator.**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using FluentValidation;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.PlayRecords;
+
+internal sealed class UploadPlayRecordPhotoCommandValidator : AbstractValidator<UploadPlayRecordPhotoCommand>
+{
+    internal const long MaxFileSizeBytes = 5 * 1024 * 1024; // 5MB (spec AC)
+    private static readonly HashSet<string> AllowedMimeTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "image/jpeg", "image/png", "image/webp" };
+
+    public UploadPlayRecordPhotoCommandValidator()
+    {
+        RuleFor(c => c.RecordId).NotEmpty();
+        RuleFor(c => c.UserId).NotEmpty();
+        RuleFor(c => c.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File cannot be empty")
+            .LessThanOrEqualTo(MaxFileSizeBytes).WithMessage("File cannot exceed 5MB");
+        RuleFor(c => c.MimeType)
+            .NotEmpty()
+            .Must(m => AllowedMimeTypes.Contains(m))
+            .WithMessage("Only JPEG, PNG, and WebP images are allowed");
+        RuleFor(c => c.Caption).MaximumLength(500).When(c => c.Caption != null);
+    }
+}
+```
+
+- [ ] **Step 5: Run, verify PASS (5 tests). Commit.** `git commit -m "feat(play-records): #2436 PR-B upload command + validator (5MB)"`
+
+---
+
+### Task 10: `UploadPlayRecordPhotoCommandHandler` (blob + SHA256 dedup + thumbnail + OCR)
+
+**Files:** Create handler + test `UploadPlayRecordPhotoCommandHandlerTests.cs`
+
+- [ ] **Step 1: Write failing test** (Moq `IPlayRecordRepository` + `IUnitOfWork` + `IBlobStorageService` + `IPhotoPreprocessor`; real `PlayRecordPermissionChecker`):
+
+```csharp
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Moq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2436")]
+public class UploadPlayRecordPhotoCommandHandlerTests
+{
+    private readonly Mock<IPlayRecordRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IPhotoPreprocessor> _ocr = new();
+
+    private UploadPlayRecordPhotoCommandHandler CreateSut() =>
+        new(_repo.Object, _uow.Object, _blob.Object,
+            new PlayRecordPermissionChecker(_repo.Object), _ocr.Object,
+            new UploadPlayRecordPhotoCommandValidatorWrapperOrTimeProvider());
+
+    private static PlayRecord NewRecord(Guid creator) =>
+        PlayRecord.CreateFreeForm(Guid.NewGuid(), "Catan", creator, DateTime.UtcNow.AddDays(-1),
+            PlayRecordVisibility.Private, SessionScoringConfig.CreateDefault());
+
+    private static MemoryStream PngStream()
+    {
+        var ms = new MemoryStream();
+        using var img = new Image<Rgba32>(10, 10);
+        img.Save(ms, new PngEncoder());
+        ms.Position = 0;
+        return ms;
+    }
+
+    [Fact]
+    public async Task Handle_NonCreator_ThrowsForbidden()
+    {
+        var record = NewRecord(Guid.NewGuid());
+        var stranger = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(stranger, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var act = () => CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(record.Id, stranger, PngStream(), 100, "image/png", false, null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MissingRecord_ThrowsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((PlayRecord?)null);
+        var act = () => CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(id, Guid.NewGuid(), PngStream(), 100, "image/png", false, null),
+            CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_Creator_StoresPhotoAndSaves()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(creator, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.PlayRecordPhoto, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "play-record-photos/x/fid.png", 100));
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        var result = await CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(record.Id, creator, PngStream(), 100, "image/png", false, null),
+            CancellationToken.None);
+
+        result.PhotoId.Should().NotBeEmpty();
+        record.Photos.Should().HaveCount(1);
+        _repo.Verify(r => r.UpdateAsync(record, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _ocr.Verify(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never); // flag false
+    }
+
+    [Fact]
+    public async Task Handle_ExtractScore_RunsOcrAndStoresText()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(creator, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "path/fid.png", 100));
+        _ocr.Setup(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoPreprocessResult(Array.Empty<byte>(), "Alice 10 Bob 8", 0.93, PageOrientation.Portrait, false, Array.Empty<string>()));
+
+        var result = await CreateSut().Handle(
+            new UploadPlayRecordPhotoCommand(record.Id, creator, PngStream(), 100, "image/png", true, null),
+            CancellationToken.None);
+
+        result.OcrText.Should().Be("Alice 10 Bob 8");
+        record.Photos[0].OcrText.Should().Be("Alice 10 Bob 8");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateSha_ReturnsExistingWithoutSecondStore()
+    {
+        var creator = Guid.NewGuid();
+        var record = NewRecord(creator);
+        _repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _repo.Setup(r => r.CanUserEditAsync(creator, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "path/fid.png", 100));
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        var cmd1 = new UploadPlayRecordPhotoCommand(record.Id, creator, PngStream(), 100, "image/png", false, null);
+        await CreateSut().Handle(cmd1, CancellationToken.None);
+        var cmd2 = new UploadPlayRecordPhotoCommand(record.Id, creator, PngStream(), 100, "image/png", false, null);
+        var result2 = await CreateSut().Handle(cmd2, CancellationToken.None);
+
+        record.Photos.Should().HaveCount(1);              // same bytes → deduped
+        result2.WasDeduplicated.Should().BeTrue();
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+> NOTE for implementer: the `CreateSut()` ctor arg list above is illustrative — match it to the ACTUAL handler ctor you write in Step 3 (drop the placeholder wrapper; inject `TimeProvider` if used). The two `PngStream()` calls in the dedup test produce byte-identical PNGs (same 10×10 blank image) → identical SHA256. Adjust if ImageSharp PNG output is nondeterministic — if so, feed identical `byte[]` directly instead of re-encoding.
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Handler.**
+
+```csharp
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Validators;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Helpers;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+internal sealed class UploadPlayRecordPhotoCommandHandler
+    : ICommandHandler<UploadPlayRecordPhotoCommand, PlayRecordPhotoUploadResult>
+{
+    private const int PresignExpirySeconds = 3600;
+    private readonly IPlayRecordRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly PlayRecordPermissionChecker _permissionChecker;
+    private readonly IPhotoPreprocessor _photoPreprocessor;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<UploadPlayRecordPhotoCommandHandler> _logger;
+
+    public UploadPlayRecordPhotoCommandHandler(
+        IPlayRecordRepository repository,
+        IUnitOfWork unitOfWork,
+        IBlobStorageService blobStorage,
+        PlayRecordPermissionChecker permissionChecker,
+        IPhotoPreprocessor photoPreprocessor,
+        TimeProvider timeProvider,
+        ILogger<UploadPlayRecordPhotoCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _permissionChecker = permissionChecker ?? throw new ArgumentNullException(nameof(permissionChecker));
+        _photoPreprocessor = photoPreprocessor ?? throw new ArgumentNullException(nameof(photoPreprocessor));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PlayRecordPhotoUploadResult> Handle(UploadPlayRecordPhotoCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var record = await _repository.GetByIdAsync(command.RecordId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("PlayRecord", command.RecordId.ToString());
+
+        if (!await _permissionChecker.CanEditAsync(command.UserId, command.RecordId, cancellationToken).ConfigureAwait(false))
+            throw new ForbiddenException("You do not have permission to add photos to this play record.");
+
+        // Buffer the upload (needed for magic-byte, hash, thumbnail, OCR + re-reads).
+        byte[] bytes;
+        using (var buffer = new MemoryStream())
+        {
+            await command.FileStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            bytes = buffer.ToArray();
+        }
+
+        using (var validateStream = new MemoryStream(bytes, writable: false))
+        {
+            var ok = await ImageFileValidator.ValidateMagicBytesAsync(validateStream, command.MimeType).ConfigureAwait(false);
+            if (!ok)
+                throw new ValidationException("File content does not match its declared type.");
+        }
+
+        var sha = Api.Helpers.CryptographyHelper.ComputeSha256Hash(bytes);
+
+        // Idempotent re-upload: same (record, sha) → return existing.
+        var existing = record.Photos.FirstOrDefault(p => p.Sha256Hash == sha);
+        if (existing != null)
+        {
+            var existingUrl = await PresignAsync(existing.BlobUrl, cancellationToken).ConfigureAwait(false);
+            return new PlayRecordPhotoUploadResult(existing.Id, existingUrl, existing.ThumbnailUrl, existing.OcrText, WasDeduplicated: true);
+        }
+
+        var photoId = Guid.NewGuid();
+        var ext = command.MimeType.Equals("image/png", StringComparison.OrdinalIgnoreCase) ? ".png"
+                : command.MimeType.Equals("image/webp", StringComparison.OrdinalIgnoreCase) ? ".webp" : ".jpg";
+        var resourceKey = $"play-record-{record.Id:N}";
+        var fileName = $"{photoId:N}-{sha[..8]}{ext}";
+
+        using (var storeStream = new MemoryStream(bytes, writable: false))
+        {
+            var stored = await _blobStorage.StoreAsync(storeStream, fileName, BlobCategory.PlayRecordPhoto, resourceKey, cancellationToken).ConfigureAwait(false);
+            if (!stored.Success || stored.FilePath is null)
+                throw new ValidationException(stored.ErrorMessage ?? "Failed to store the photo.");
+
+            // Thumbnail — best-effort.
+            string? thumbUrl = null;
+            try
+            {
+                using var thumbSource = new MemoryStream(bytes, writable: false);
+                using var thumb = await ImageThumbnailHelper.GenerateThumbnailAsync(thumbSource, cancellationToken).ConfigureAwait(false);
+                if (thumb != null)
+                {
+                    var thumbResult = await _blobStorage.StoreAsync(thumb, $"{photoId:N}-thumb.jpg", BlobCategory.PlayRecordPhoto, resourceKey, cancellationToken).ConfigureAwait(false);
+                    if (thumbResult.Success) thumbUrl = thumbResult.FilePath;
+                }
+            }
+            catch (Exception ex) { _logger.LogWarning(ex, "Thumbnail generation failed for photo {PhotoId}", photoId); }
+
+            // OCR — opt-in, best-effort (DEC-3 smoldocling).
+            string? ocrText = null;
+            double? ocrConfidence = null;
+            if (command.ExtractScoreFromPhoto)
+            {
+                try
+                {
+                    var ocr = await _photoPreprocessor.PreprocessAsync(bytes, cancellationToken).ConfigureAwait(false);
+                    ocrText = ocr.ExtractedText;
+                    ocrConfidence = ocr.ConfidenceScore;
+                }
+                catch (Exception ex) { _logger.LogWarning(ex, "OCR failed for photo {PhotoId}", photoId); }
+            }
+
+            record.AddPhoto(photoId, stored.FilePath, thumbUrl, command.FileSizeBytes, sha, ocrText, ocrConfidence, command.Caption, command.UserId, _timeProvider);
+            await _repository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var url = await PresignAsync(stored.FilePath, cancellationToken).ConfigureAwait(false);
+            return new PlayRecordPhotoUploadResult(photoId, url, thumbUrl, ocrText, WasDeduplicated: false);
+        }
+    }
+
+    private async Task<string> PresignAsync(string blobPath, CancellationToken ct)
+    {
+        // blobPath is the stored FilePath; presign by fileId+folder. For local storage the
+        // presign returns null → fall back to the raw path.
+        var fileName = Path.GetFileName(blobPath);
+        var folder = Path.GetFileName(Path.GetDirectoryName(blobPath) ?? string.Empty);
+        var fileId = fileName.Contains('_') ? fileName[..fileName.IndexOf('_')] : fileName;
+        var signed = await _blobStorage.GetPresignedDownloadUrlAsync(fileId, BlobCategory.PlayRecordPhoto, folder, PresignExpirySeconds).ConfigureAwait(false);
+        return signed ?? blobPath;
+    }
+}
+```
+
+> IMPLEMENTER: verify exact namespaces by reading `UploadCustomCoverCommandHandler` + `SessionAttachmentService.ParseBlobPath` — the `PresignAsync` fileId/folder parse must match how `StoreAsync` composes `FilePath` (the cover/session services derive `fileId` as the substring before the first `_`). If `ImageFileValidator` rejects `image/webp` thumbnails or the stored path shape differs, adjust the parse accordingly. `CryptographyHelper` namespace is `Api.Helpers`.
+
+- [ ] **Step 4: Run, verify PASS (5 tests).**
+
+- [ ] **Step 5: Commit.** `git commit -m "feat(play-records): #2436 PR-B upload handler (dedup+thumb+OCR)"`
+
+---
+
+### Task 11: Endpoint `POST /play-records/{recordId}/photos`
+
+**Files:** Modify `PlayRecordEndpoints.cs`
+
+- [ ] **Step 1: Register the route** in `MapPlayRecordEndpoints` (beside the others):
+
+```csharp
+        group.MapPost("/play-records/{recordId:guid}/photos", HandleUploadPhoto)
+            .RequireAuthenticatedUser()
+            .DisableAntiforgery()
+            .Produces<PlayRecordPhotoUploadResult>(201)
+            .Produces(400).Produces(401).Produces(StatusCodes.Status403Forbidden).Produces(404)
+            .WithTags("PlayRecords")
+            .WithSummary("Upload a photo to a play record (creator-only, ≤5MB, opt-in OCR)")
+            .WithOpenApi();
+```
+
+- [ ] **Step 2: Handler** (multipart; mirror `SessionAttachmentEndpoints` form-read + `httpContext.User.GetUserId()`):
+
+```csharp
+    private static async Task<IResult> HandleUploadPhoto(
+        Guid recordId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var form = await httpContext.Request.ReadFormAsync(cancellationToken).ConfigureAwait(false);
+        var file = form.Files.GetFile("file");
+        if (file is null || file.Length == 0)
+            return Results.BadRequest(new { error = "File is required" });
+
+        var extractScore = form.TryGetValue("extractScoreFromPhoto", out var raw)
+            && bool.TryParse(raw.ToString(), out var b) && b;
+        var caption = form.TryGetValue("caption", out var cap) ? cap.ToString() : null;
+
+        using var stream = file.OpenReadStream();
+        var command = new UploadPlayRecordPhotoCommand(
+            recordId, httpContext.User.GetUserId(), stream, file.Length, file.ContentType, extractScore, caption);
+
+        try
+        {
+            var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            return Results.Created($"/api/v1/play-records/{recordId}/photos/{result.PhotoId}", result);
+        }
+        catch (ForbiddenException ex) { return Results.Json(new { error = ex.Message }, statusCode: 403); }
+        catch (NotFoundException ex) { return Results.NotFound(new { error = ex.Message }); }
+    }
+```
+
+> Add `using` for `UploadPlayRecordPhotoCommand`/`PlayRecordPhotoUploadResult`, `Api.Middleware.Exceptions`, `Microsoft.AspNetCore.Http`. `ValidationException` from the FluentValidation pipeline behavior already maps to 400 (don't catch it). Verify the project's validation behavior maps `ValidationException`→400 by checking an existing endpoint; if not, add a catch.
+
+- [ ] **Step 3: Build + smoke.** `dotnet build apps/api/src/Api` → succeeds. No Program.cs change (route is inside `MapPlayRecordEndpoints`).
+
+- [ ] **Step 4: Commit.** `git commit -m "feat(play-records): #2436 PR-B POST photos endpoint"`
+
+---
+
+### Task 12: Integration test (Testcontainers round-trip)
+
+**Files:** Create `apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs` (mirror `PlayRecordCommandTests` setup; register a `LocalStorageService`/`IBlobStorageService` double + `IPhotoPreprocessor` mock)
+
+- [ ] **Step 1: Write the test** — seed a user + record, dispatch `UploadPlayRecordPhotoCommand`, then read back via a fresh `MeepleAiDbContext` scope and assert `play_record_photos` has 1 row with the sha + blob url; assert a non-creator gets `ForbiddenException`; assert the unique index blocks a duplicate `(recordId, sha)` at the DB level. Use the `IBlobStorageService` registered as a fake returning `BlobStorageResult(true, "fid", "play-record-photos/x/fid.png", 100)`, and an `IPhotoPreprocessor` Moq.
+
+> Follow `PlayRecordCommandTests.cs` for: isolated DB (`CreateIsolatedDatabaseAsync`), `MigrateAsync` (runs the Task 7 migration), `SeedTestUserAsync`, `CreateTestRecordAsync(creatorId)`, `SendInScopeAsync`, fresh-scope read-back. Register `IBlobStorageService` + `IPhotoPreprocessor` + `UploadPlayRecordPhotoCommandHandler` deps in the service collection (the base builder does NOT include blob storage).
+
+- [ ] **Step 2: Run.** `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~PlayRecordPhotoUploadTests"` → PASS. (Requires Docker.)
+
+- [ ] **Step 3: Commit.** `git commit -m "test(play-records): #2436 PR-B photo upload integration round-trip"`
+
+---
+
+### Task 13: Amend ADR-067 (OCR decision)
+
+**Files:** Modify `docs/for-claude/architecture/adr/adr-067-playrecord-photo-upload-pipeline.md`
+
+- [ ] **Step 1: Update Status + add an amendment** documenting that OCR was wired (DEC-3), superseding O-C:
+  - Change `**Status**: Proposed` → `**Status**: Accepted (amended 2026-06-20)`.
+  - In the OCR section, mark O-C superseded and add **O-D — Reuse smoldocling `/api/v1/preprocess`**: the `IPhotoPreprocessor` (`SmoldoclingPhotoPreprocessor`) already does image OCR; the §Context premise "no image endpoint exists" is corrected. The upload handler calls `PreprocessAsync` when `ExtractScoreFromPhoto=true` (best-effort), populating `OcrText`/`OcrConfidence`.
+  - Note `BlobCategory.PlayRecordPhoto`, max-10-photos invariant, and 5MB server-side enforcement now exist.
+
+- [ ] **Step 2: Commit.** `git commit -m "docs(adr-067): #2436 PR-B amend OCR decision to smoldocling (O-D)"`
+
+---
+
+## Final gates (before PR)
+
+- [ ] `dotnet build apps/api/src/Api` clean.
+- [ ] `dotnet test apps/api/tests/Api.Tests --filter "BoundedContext=GameManagement&Category=Unit"` green (incl. all new unit tests + the unchanged SessionAttachmentService + existing PlayRecord suites — **no fail-count growth above baseline**).
+- [ ] Integration test green (Docker).
+- [ ] Open PR to `main-dev`, `Refs #2436` (PR-C remains — do NOT close).
+
+## Self-Review notes
+- **Cross-BC injection**: handler injects `IPhotoPreprocessor` (DocumentProcessing, internal, DI-wide). Acceptable per single-assembly convention; if a reviewer objects, wrap in a thin GameManagement-local interface (follow-up).
+- **Presign parse** (`PresignAsync`) is the riskiest detail — it must mirror how `StoreAsync` composes `FilePath`. The implementer must verify against `SessionAttachmentService.ParseBlobPath` + the local/S3 storage path shape; the integration test (local storage → presign returns null → raw-path fallback) covers the happy path.
+- **Dedup**: in-aggregate (`record.Photos.Any(sha)`) AND DB unique index (defense in depth). Concurrent identical uploads race to the unique index → `DbUpdateException`; acceptable for MVP (rare; user retries).


### PR DESCRIPTION
## Summary

PR-B of #2436 — backend **PlayRecord photo upload pipeline** per ADR-067 (amended) + DEC-3 (OCR wired now via smoldocling).

`POST /api/v1/play-records/{recordId}/photos` — creator-only, ≤5MB, ≤10 photos/record, opt-in OCR.

- **Domain**: `PlayRecordPhoto` child entity on the `PlayRecord` aggregate (`AddPhoto`/`RestorePhoto`, max-10 invariant) + `PlayRecordPhotoUploadedEvent`.
- **Persistence**: `play_record_photos` table, repository graph round-trip, SHA256 dedup via `UNIQUE (PlayRecordId, Sha256Hash)`.
- **Application**: `UploadPlayRecordPhotoCommand` + validator + handler — creator-guard (ADR-066) → magic-byte validate → SHA256 dedup → `StoreAsync(BlobCategory.PlayRecordPhoto)` → thumbnail (ImageSharp 300px/q80, best-effort) → **opt-in OCR via `IPhotoPreprocessor`/smoldocling** (best-effort) → persist → presigned URL.
- **Reuse**: extracted `ImageThumbnailHelper`; `BlobCategory.PlayRecordPhoto`.
- **ADR-067 amended**: OCR O-C (deferred) → **O-D (reuse smoldocling)**; Status → Accepted.

## C1 resolved in-PR (per directive — option B)

The final review flagged **C1**: the ≤10 cap is enforced in-memory, and `PlayRecord` had no concurrency token, so concurrent uploads could exceed it. **Fixed here** by pulling #2437-1's BE foundation forward:
- **xmin optimistic concurrency** on `PlayRecord` (domain token + EF `xid` mapping + repository round-trip; migration is empty — xmin is a Postgres system column) — ADR-060 pattern, mirroring `GameNightPlaylist`.
- **Global `DbUpdateConcurrencyException → 409`** + `X-Warning-Code: concurrent-edit` in `ApiExceptionHandlerMiddleware`. The codebase already *assumed* this mapping existed (see comments in `Update`/`DeleteGameTranslationCommandHandler`) but it was missing — so this also **closes a latent 500-on-conflict gap** in the SharedGameCatalog translation handlers.

Result: the losing concurrent upload's `SaveChanges` sees a stale xmin → `DbUpdateConcurrencyException` → 409, so the cap holds. **Only the FE conflict-UI remains for #2437** (the 409 contract is now in place BE-side).

## Test Plan

- [x] `dotnet test --filter "BoundedContext=GameManagement&Category=Unit"` → **1350 pass / 0 fail** (+17 photo + xmin tests; SessionAttachmentService 25/25 unchanged)
- [x] `ApiExceptionHandlerMiddlewareTests` → **40 pass** (+1: DbUpdateConcurrencyException → 409 + `X-Warning-Code: concurrent-edit`)
- [x] Integration (Testcontainers, Docker) → **4 pass**: creator persists, non-creator 403, duplicate deduped, **concurrent write → DbUpdateConcurrencyException**
- [x] `dotnet build apps/api/src/Api` → 0 warnings / 0 errors
- [x] Independent final review (I1 envelope + I2 orphan-log applied; **C1 fixed**)
- [ ] Manual: upload via UI (PR-C wires the FE)

Refs #2436 (does **NOT** close — PR-C photo UI remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)