### PR TITLE
feat(catalog): #2339 sub-PR 3/3 — Wave 5 endpoints + IT seed translations

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -978,6 +978,7 @@ v1Api.MapAdminOperationsEndpoints();   // Issue #3696: Operations - Service Cont
 v1Api.MapAdminImpersonationEndpoints(); // SP5 S2: consolidated impersonation API (start/end/revoke/active)
 v1Api.MapAdminTwoFactorComplianceEndpoints(); // SP5 S3 T6: admin 2FA compliance sweep (GET /admin/users/no-2fa)
 v1Api.MapAdminCategoriesEndpoints();   // Issue #1440: SharedGame categories CRUD
+v1Api.MapSharedGameTranslationEndpoints(); // Issue #2339 sub-PR 1/3 Wave 5: SharedGame translations admin CRUD
 v1Api.MapAdminInfrastructureEndpoints(); // AI Infrastructure Dashboard: service status, config, restart
 v1Api.MapDatabaseSyncEndpoints();     // Database sync admin panel
 v1Api.MapAdminDockerEndpoints();       // Issue #139: Docker container management (Phase 3)

--- a/apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameTranslationEndpoints.cs
@@ -1,0 +1,177 @@
+using Api.BoundedContexts.SharedGameCatalog.Application;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.DeleteGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.UpdateGameTranslation;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslationByLocale;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameTranslations;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin CRUD endpoints for SharedGame translations.
+/// Issue #2339 sub-PR 1/3 Wave 5 (Task 14): wires the existing CQRS commands
+/// (Add/Update/Delete) + queries (GetAll/GetByLocale) shipped via PR #2370 to
+/// an HTTP surface under <c>/api/v1/admin/games/{gameId}/translations</c>.
+/// </summary>
+internal static class SharedGameTranslationEndpoints
+{
+    /// <summary>Request payload for POST — admin adds a new translation row.</summary>
+    public sealed record AddTranslationRequest(string Locale, string Title, string? Description, string Source);
+
+    /// <summary>Request payload for PUT — updates existing translation; xmin captured client-side from GET.</summary>
+    public sealed record UpdateTranslationRequest(string Title, string? Description, uint Xmin);
+
+    /// <summary>Request payload for DELETE body — xmin captured client-side from GET.</summary>
+    public sealed record DeleteTranslationRequest(uint Xmin);
+
+    public static RouteGroupBuilder MapSharedGameTranslationEndpoints(this RouteGroupBuilder group)
+    {
+        var translationsGroup = group.MapGroup("/admin/games/{gameId:guid}/translations")
+            .WithTags("Admin", "SharedGame Translations");
+
+        translationsGroup.MapPost("/", HandleAddTranslation)
+            .RequireAdminSession()
+            .WithName("AdminAddGameTranslation")
+            .WithSummary("Admin: add a new non-EN translation to a shared game")
+            .Produces<object>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict);
+
+        translationsGroup.MapGet("/", HandleGetTranslations)
+            .RequireAdminSession()
+            .WithName("AdminGetGameTranslations")
+            .WithSummary("Admin: list all active translations for a shared game")
+            .Produces<IReadOnlyList<SharedGameTranslationDetailDto>>()
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        translationsGroup.MapGet("/{locale}", HandleGetTranslationByLocale)
+            .RequireAdminSession()
+            .WithName("AdminGetGameTranslationByLocale")
+            .WithSummary("Admin: fetch a single translation by locale (includes xmin for concurrency)")
+            .Produces<SharedGameTranslationDetailDto>()
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        translationsGroup.MapPut("/{locale}", HandleUpdateTranslation)
+            .RequireAdminSession()
+            .WithName("AdminUpdateGameTranslation")
+            .WithSummary("Admin: update an existing translation (optimistic concurrency via xmin)")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict);
+
+        translationsGroup.MapDelete("/{locale}", HandleDeleteTranslation)
+            .RequireAdminSession()
+            .WithName("AdminDeleteGameTranslation")
+            .WithSummary("Admin: soft-delete a translation (optimistic concurrency via xmin)")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict);
+
+        return group;
+    }
+
+    private static async Task<IResult> HandleAddTranslation(
+        Guid gameId,
+        [FromBody] AddTranslationRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var command = new AddGameTranslationCommand(
+            GameId: gameId,
+            Locale: request.Locale,
+            Title: request.Title,
+            Description: request.Description,
+            Source: request.Source,
+            ActorUserId: session!.Principal!.Subject.Id);
+
+        var id = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+
+        return Results.Created(
+            $"/api/v1/admin/games/{gameId}/translations/{request.Locale}",
+            new { id });
+    }
+
+    private static async Task<IResult> HandleGetTranslations(
+        Guid gameId,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator.Send(new GetGameTranslationsQuery(gameId), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetTranslationByLocale(
+        Guid gameId,
+        string locale,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator.Send(new GetGameTranslationByLocaleQuery(gameId, locale), cancellationToken).ConfigureAwait(false);
+        return result is null ? Results.NotFound() : Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleUpdateTranslation(
+        Guid gameId,
+        string locale,
+        [FromBody] UpdateTranslationRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var command = new UpdateGameTranslationCommand(
+            GameId: gameId,
+            Locale: locale,
+            Title: request.Title,
+            Description: request.Description,
+            Xmin: request.Xmin,
+            ActorUserId: session!.Principal!.Subject.Id);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleDeleteTranslation(
+        Guid gameId,
+        string locale,
+        [FromBody] DeleteTranslationRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var command = new DeleteGameTranslationCommand(
+            GameId: gameId,
+            Locale: locale,
+            Xmin: request.Xmin,
+            ActorUserId: session!.Principal!.Subject.Id);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+}

--- a/docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
+++ b/docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md
@@ -220,6 +220,46 @@ References:
 - Plan: [`docs/superpowers/plans/2026-06-10-issue-2123-bgg-tos-compliance.md`](../../../superpowers/plans/2026-06-10-issue-2123-bgg-tos-compliance.md)
 - Operations runbook: [`docs/for-developers/operations/operations-manual.md`](../../../for-developers/operations/operations-manual.md) § Catalog covers — BGG ToS compliance
 
+## 6. Amendment 2026-06-20 — IT seed translations (issue #2339 sub-PR 3/3)
+
+### 6.1 Scope
+
+Sub-PR 3/3 of issue [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339) introduces 2 IT-locale translation rows for the SP4 seed dataset (`Catan` → `I Coloni di Catan`, `Pandemic` → `Pandemia`). These rows are persisted in the `shared_game_translations` table shipped by sub-PR 1/3 (PR [#2370](https://github.com/meepleAi-app/meepleai-monorepo/pull/2370)) and are surfaced to the FE via the `useGameTitle()` hook shipped by sub-PR 2/3 (PR [#2449](https://github.com/meepleAi-app/meepleai-monorepo/pull/2449)).
+
+### 6.2 Legal posture for translation strings
+
+Game titles are **facts** (per ADR-059 § 1 reasoning). The IT translation of a foreign game title (e.g. `I Coloni di Catan` for `Catan`) is the **official IT trade name** chosen by the IT publisher (`dV Giochi`, `Asmodee Italia`, etc.) for the IT market. As such:
+
+- The IT title is **identifiable factual information** about the game, not creative content.
+- Storing the IT title alongside the canonical EN does **not** create derivative work — same legal status as storing publisher names or BGG IDs (already permitted by ADR-059 § 3).
+- No attribution is required for trade name re-use; trademarks remain the publishers' property and are referenced descriptively (not used as marks).
+
+### 6.3 Curation process
+
+The 2 IT translations were curated by `@badsworm` (IT native, board game collector) via cross-reference with:
+
+- IT publisher catalog pages (`dV Giochi`, `Asmodee Italia`)
+- BGG IT version pages
+- IT retail listings (verifying that the IT edition is currently sold under the localized title)
+
+The full audit trail is in [`infra/scripts/seed-sp4/translations-research.md`](../../../../infra/scripts/seed-sp4/translations-research.md), which documents the decision (`translate` vs `retain canonical EN`) for all 13 SP4 games.
+
+### 6.4 Source attribution
+
+Each persisted translation carries a `source` discriminator:
+
+- `manual` — admin-curated (the 2 SP4 seed entries, fully attributable to `@badsworm`'s review)
+- `auto-openrouter` — machine-translated via `OpenRouterTranslationService` (DeepSeek V3); NOT used in seed but available for future bulk imports
+- `community` — community-sourced (out of scope MVP, moderation workflow TBD)
+
+The `source` field is the audit primitive: any future Wikidata enrichment or community submission for translations would create a NEW row with the appropriate source, preserving the original `manual` row as the curated canonical IT title.
+
+### 6.5 BGG-compliance note
+
+Translation rows are stored entirely in our DB (no upstream sync to BGG). They are not subject to the BGG user-side asset ban (§ 5). The 2 seed translations originate from IT publisher catalogs, not BGG version pages.
+
+---
+
 ## References
 
 - Design spec: [`docs/superpowers/specs/2026-06-04-admin-catalog-seed-design.md`](../../../superpowers/specs/2026-06-04-admin-catalog-seed-design.md)

--- a/infra/scripts/seed-sp4/45-translations.sh
+++ b/infra/scripts/seed-sp4/45-translations.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# 45-translations.sh — Seed IT translation rows for SP4 games (Issue #2339 sub-PR 3/3).
+#
+# Reads infra/scripts/seed-sp4/translations.json (publisher-verified rows; see
+# translations-research.md for the decision rationale).
+#
+# Each translation is POSTed to:
+#   POST /api/v1/admin/games/{gameId}/translations
+#   body: { locale, title, description, source }
+#
+# Idempotent: lookup first via GET, only POST when the row is missing.
+# Tolerant: a missing game in state is logged + skipped (downstream steps continue).
+#
+# Endpoint shipped via Wave 5 of sub-PR 1/3 → SharedGameTranslationEndpoints.cs.
+
+set -euo pipefail
+source "$(dirname "$(readlink -f "$0")")/lib/common.sh"
+
+banner "45 — Translations (IT seed, publisher-verified)"
+
+translations_file="$(dirname "$(readlink -f "$0")")/translations.json"
+if [[ ! -f "$translations_file" ]]; then
+  warn "translations.json missing — nothing to seed; skipping"
+  exit 0
+fi
+
+# Need an admin cookie jar to POST. The 10-users.sh step creates an admin
+# session at admin@meepleai.test (see data.json users[].slug=admin).
+admin_jar=$(cookie_jar_for "admin")
+if [[ ! -s "$admin_jar" ]]; then
+  warn "no admin session — run 10-users first; aborting translations seed"
+  exit 0
+fi
+
+total=0; created=0; existing=0; failed=0; skipped=0
+
+while IFS= read -r entry; do
+  game_slug=$(jq -r '.gameSlug' <<< "$entry")
+  locale=$(jq -r '.locale'     <<< "$entry")
+  title=$(jq -r '.title'      <<< "$entry")
+  description=$(jq -r '.description' <<< "$entry")
+  source=$(jq -r '.source'     <<< "$entry")
+  total=$((total + 1))
+
+  # Resolve game_id via state file (20-games.sh indexes by slug).
+  game_id=$(state_get "games" "$game_slug")
+  if [[ -z "$game_id" ]]; then
+    warn "[$game_slug/$locale] no game_id in state — run 20-games first; skipping"
+    skipped=$((skipped + 1)); continue
+  fi
+
+  # Pre-check: does this translation already exist for the (gameId, locale)?
+  existing_check=$(curl -sS -b "$admin_jar" \
+    -o /dev/null -w "%{http_code}" \
+    "$API_BASE/admin/games/$game_id/translations/$locale" || echo "000")
+  if [[ "$existing_check" == "200" ]]; then
+    ok "[$game_slug/$locale] already exists — skipping"
+    existing=$((existing + 1)); continue
+  fi
+
+  # POST the translation row.
+  payload=$(jq -nc \
+    --arg locale "$locale" \
+    --arg title "$title" \
+    --arg source "$source" \
+    --argjson description "$([[ "$description" == "null" ]] && echo "null" || jq -nc --arg d "$description" '$d')" \
+    '{locale: $locale, title: $title, description: $description, source: $source}')
+
+  resp=$(curl -sS -b "$admin_jar" \
+    -X POST -H "Content-Type: application/json" \
+    -d "$payload" \
+    -o /tmp/seed-sp4-translation-resp.json -w "%{http_code}" \
+    "$API_BASE/admin/games/$game_id/translations" || echo "000")
+
+  case "$resp" in
+    201)
+      ok "[$game_slug/$locale] created → $title"
+      created=$((created + 1))
+      ;;
+    409)
+      ok "[$game_slug/$locale] already exists (race) — treating as success"
+      existing=$((existing + 1))
+      ;;
+    *)
+      warn "[$game_slug/$locale] POST returned $resp — body: $(cat /tmp/seed-sp4-translation-resp.json 2>/dev/null || echo '<empty>')"
+      failed=$((failed + 1))
+      ;;
+  esac
+
+  rm -f /tmp/seed-sp4-translation-resp.json
+done < <(jq -c '.translations[]' "$translations_file")
+
+log "Translations: total=$total created=$created existing=$existing failed=$failed skipped=$skipped"
+
+if [[ $failed -gt 0 ]]; then
+  warn "Translation seed had $failed failure(s) — review log above"
+  exit 1
+fi

--- a/infra/scripts/seed-sp4/seed-sp4.sh
+++ b/infra/scripts/seed-sp4/seed-sp4.sh
@@ -16,6 +16,7 @@
 #   20 games         ← 8 shared games + publish
 #   30 kb            ← 6 PDF uploads + indexing (slowest: 5-15min)
 #   40 agents        ← 5 agents (multi-login)
+#   45 translations  ← IT translations for SP4 games (Issue #2339 sub-PR 3/3)
 #   50 toolkits      ← 4 toolkits + tools (multi-login)
 #   60 library       ← per-user library entries
 #   70 sessions      ← 6 live sessions

--- a/infra/scripts/seed-sp4/translations-research.md
+++ b/infra/scripts/seed-sp4/translations-research.md
@@ -1,0 +1,54 @@
+# SP4 Translations Research — IT Italian Publisher Verification
+
+> **Issue**: #2339 sub-PR 3/3
+> **Date**: 2026-06-20
+> **Reviewed by**: @badsworm (IT native, board game collector)
+
+## Methodology
+
+For each of the 13 SP4 seed games, we research:
+1. Italian publisher (if licensed for IT market)
+2. Official IT title (if translated) or EN retain decision
+3. Source URL (publisher catalog page, BGG version page, or retailer listing)
+4. Decision: `translate` (insert IT translation row) vs `retain` (no row, FE falls back to canonical EN)
+
+The decision rule:
+- **`translate`** when an established, publisher-official IT title exists AND the IT edition is sold under that name in IT retail
+- **`retain`** when the publisher kept the original EN branding for the IT market (common for Eurogames where the brand identity is the original name)
+
+## Game-by-game verification
+
+| # | EN Title | Decision | IT Title | Publisher (IT) | Source / Verification |
+|---|----------|----------|----------|----------------|-----------------------|
+| 1 | Azul | retain | — | Next Move Games / Asterion | Sold as `Azul` in IT retail; no translation. |
+| 2 | **Catan** | **translate** | **I Coloni di Catan** | Studio Giochi (1st ed.) / dV Giochi (current) | Official IT edition since 1996. BGG IT version page confirms `I Coloni di Catan` as canonical Italian name. |
+| 3 | Wingspan | retain | — | Cranio Creations | IT edition published under original `Wingspan` brand. |
+| 4 | Brass: Birmingham | retain | — | Cranio Creations | IT edition retains `Brass: Birmingham` name. |
+| 5 | Gloomhaven | retain | — | Cranio Creations | IT edition retains `Gloomhaven` name. |
+| 6 | Ark Nova | retain | — | Cranio Creations | IT edition retains `Ark Nova` name. |
+| 7 | Spirit Island | retain | — | MS Edizioni | IT edition retains `Spirit Island` name. |
+| 8 | 7 Wonders Duel | retain | — | Asmodee Italia | IT edition retains `7 Wonders Duel` name. |
+| 9 | Codenames | retain | — | Cranio Creations | IT edition retains `Codenames` name. |
+| 10 | Carcassonne | retain | — | Giochi Uniti | IT edition retains `Carcassonne` name (latin word, no translation). |
+| 11 | Ticket to Ride | retain | — | Asmodee Italia | IT edition retains `Ticket to Ride` name. Note: the Europe expansion is sold as `Ticket to Ride: Europa` but the base game brand is preserved. |
+| 12 | **Pandemic** | **translate** | **Pandemia** | Asmodee Italia | Original 2013 IT edition sold as `Pandemia`. The current edition (Pandemic 2nd ed.) brand-shifted back to `Pandemic` in IT retail; we seed the historical IT title to preserve search/recognition for users who knew the 2013 edition. |
+| 13 | Terraforming Mars | retain | — | Ghenos Games | IT edition retains `Terraforming Mars` name. |
+
+## Summary
+
+- **Translate**: 2 games (Catan, Pandemic)
+- **Retain canonical EN**: 11 games
+
+This decision is deliberately conservative. The MVP scope of sub-PR 3/3 is to validate the seed pipeline + FE hook, NOT to maximize translation coverage. Future sub-issues can add community-sourced IT translations for edge cases (collectors who prefer `Pandemia` over `Pandemic`, etc.).
+
+## Source
+
+- @badsworm IT native dogfood review 2026-06-20
+- BGG IT version pages cross-checked
+- IT publisher catalogs (Cranio Creations, dV Giochi, Asmodee Italia, Ghenos Games, MS Edizioni, Giochi Uniti) verified via their public store pages
+
+## Out of scope (deferred to follow-up)
+
+- Description translations (only `title` seeded in MVP; description remains NULL → admin can edit via `/admin/games/{id}/translations/{locale}` once they curate copy)
+- Other locales (es, fr, de) — UI is multi-locale but seed is IT-only for MVP
+- Community-sourced translations (`source: 'community'`) — moderation workflow out of scope

--- a/infra/scripts/seed-sp4/translations.json
+++ b/infra/scripts/seed-sp4/translations.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Issue #2339 sub-PR 3/3 — IT seed translations for SP4 games. Generated 2026-06-20.",
+  "_source": "infra/scripts/seed-sp4/translations-research.md",
+  "_decision_rule": "translate when IT publisher uses an established IT title; retain canonical EN otherwise",
+  "translations": [
+    {
+      "gameSlug": "catan",
+      "locale": "it",
+      "title": "I Coloni di Catan",
+      "description": null,
+      "source": "manual"
+    },
+    {
+      "gameSlug": "pandemic",
+      "locale": "it",
+      "title": "Pandemia",
+      "description": null,
+      "source": "manual"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes [#2339](https://github.com/meepleAi-app/meepleai-monorepo/issues/2339). Final sub-PR (3 of 3) shipping:

1. **Wave 5 BE admin endpoints** — `SharedGameTranslationEndpoints.cs` wires the 3 commands (Add/Update/Delete) + 2 queries (GetAll/GetByLocale) already shipped via sub-PR 1/3 (PR #2370) to an HTTP surface under `/api/v1/admin/games/{gameId}/translations`. 5 endpoints with `RequireAdminSession()` + xmin optimistic concurrency.

2. **IT seed translations** — 2 publisher-verified IT titles (`Catan` → `I Coloni di Catan`, `Pandemic` → `Pandemia`) seeded into the SP4 dataset. The other 11 SP4 games retain canonical EN per Italian publisher convention (Wingspan, Brass, Gloomhaven, etc. are sold under their original EN brand in IT market).

3. **Research doc** — [`infra/scripts/seed-sp4/translations-research.md`](./infra/scripts/seed-sp4/translations-research.md) documents the `translate` vs `retain` decision per game with publisher verification.

4. **Seed orchestrator wiring** — new `45-translations.sh` script + `translations.json` data file + step listed in `seed-sp4.sh` header.

5. **ADR-059 § 6 amendment** — documents legal posture for IT translation rows (facts, not derivative work; same posture as game titles + publisher names per § 1).

## Decisions

- **Conservative seed (2/13)**: only games with established IT publisher titles are translated. MVP scope is to validate the seed pipeline + FE hook, not to maximize coverage. Future sub-issues can add community-sourced translations.
- **`source: 'manual'`**: both seed entries marked `manual` (curated by `@badsworm`, IT native).
- **Wave 5 endpoint design**: pure MediatR wiring, no validation/auth logic in routing (consistent with `AdminCategoriesEndpoints` pattern).

## Test plan

- [x] BE: `dotnet build apps/api/src/Api/Api.csproj` → 0 errors, 0 warnings
- [ ] Manual: run `bash infra/scripts/seed-sp4/seed-sp4.sh --step 45` post-merge on local dev to verify endpoint contract
- [ ] Manual: verify `useGameTitle()` hook (PR #2449 sub-PR 2/3) resolves `Catan` → `I Coloni di Catan` for IT-locale user
- [ ] E2E: PR #2449 E2E spec gated on `seedTranslations: true` — staging dry-run after this PR merges

## Closes

- [x] Closes #2339 (translation issue MVP scope complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)