### PR TITLE
feat(play-records): #2436 PR-C photo UI + gallery + OCR (FE) + DTO read-path (BE)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
@@ -25,8 +25,6 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 internal sealed class UploadPlayRecordPhotoCommandHandler
     : ICommandHandler<UploadPlayRecordPhotoCommand, PlayRecordPhotoUploadResult>
 {
-    private const int PresignExpirySeconds = 3600;
-
     private readonly IPlayRecordRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IBlobStorageService _blobStorage;
@@ -85,8 +83,11 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
         var existing = record.Photos.FirstOrDefault(p => string.Equals(p.Sha256Hash, sha, StringComparison.Ordinal));
         if (existing != null)
         {
-            var existingUrl = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, existing.BlobUrl, PresignExpirySeconds).ConfigureAwait(false);
-            return new PlayRecordPhotoUploadResult(existing.Id, existingUrl, existing.ThumbnailUrl, existing.OcrText, WasDeduplicated: true);
+            var existingUrl = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, existing.BlobUrl, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+            var existingThumb = existing.ThumbnailUrl is null
+                ? null
+                : await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, existing.ThumbnailUrl, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+            return new PlayRecordPhotoUploadResult(existing.Id, existingUrl, existingThumb, existing.OcrText, WasDeduplicated: true);
         }
 
         var photoId = Guid.NewGuid();
@@ -161,7 +162,7 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
             throw;
         }
 
-        var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, stored.FilePath, PresignExpirySeconds).ConfigureAwait(false);
+        var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, stored.FilePath, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
         return new PlayRecordPhotoUploadResult(photoId, url, thumbUrl, ocrText, WasDeduplicated: false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
@@ -85,7 +85,7 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
         var existing = record.Photos.FirstOrDefault(p => string.Equals(p.Sha256Hash, sha, StringComparison.Ordinal));
         if (existing != null)
         {
-            var existingUrl = await PresignAsync(existing.BlobUrl, cancellationToken).ConfigureAwait(false);
+            var existingUrl = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, existing.BlobUrl, PresignExpirySeconds).ConfigureAwait(false);
             return new PlayRecordPhotoUploadResult(existing.Id, existingUrl, existing.ThumbnailUrl, existing.OcrText, WasDeduplicated: true);
         }
 
@@ -161,33 +161,7 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
             throw;
         }
 
-        var url = await PresignAsync(stored.FilePath, cancellationToken).ConfigureAwait(false);
+        var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, stored.FilePath, PresignExpirySeconds).ConfigureAwait(false);
         return new PlayRecordPhotoUploadResult(photoId, url, thumbUrl, ocrText, WasDeduplicated: false);
-    }
-
-    private async Task<string> PresignAsync(string blobPath, CancellationToken ct)
-    {
-        // blobPath is the stored FilePath. Mirror SessionAttachmentService.ParseBlobPath:
-        // fileId = substring before the first '_' in the file name.
-        // For local storage, GetPresignedDownloadUrlAsync returns null → fall back to raw path.
-        var fileName = Path.GetFileName(blobPath);
-        if (string.IsNullOrEmpty(fileName))
-            return blobPath;
-
-        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
-        if (underscoreIndex <= 0)
-            return blobPath;
-
-        var fileId = fileName[..underscoreIndex];
-        var directory = Path.GetDirectoryName(blobPath);
-        if (string.IsNullOrEmpty(directory))
-            return blobPath;
-
-        var folder = Path.GetFileName(directory);
-        if (string.IsNullOrEmpty(folder))
-            return blobPath;
-
-        var signed = await _blobStorage.GetPresignedDownloadUrlAsync(fileId, BlobCategory.PlayRecordPhoto, folder, PresignExpirySeconds).ConfigureAwait(false);
-        return signed ?? blobPath;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs
@@ -163,6 +163,10 @@ internal sealed class UploadPlayRecordPhotoCommandHandler
         }
 
         var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, stored.FilePath, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
-        return new PlayRecordPhotoUploadResult(photoId, url, thumbUrl, ocrText, WasDeduplicated: false);
+        // Presign the thumbnail for the response too (the entity keeps the raw FilePath above).
+        var thumbPresigned = thumbUrl is null
+            ? null
+            : await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, thumbUrl, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+        return new PlayRecordPhotoUploadResult(photoId, url, thumbPresigned, ocrText, WasDeduplicated: false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
@@ -6,6 +6,7 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// DTO for full play record details including players and scores.
 /// Issue #3890: CQRS queries for play records.
 /// Issue #1663: Phase 1 – WinnerPlayerIds and OutcomeType computed on read.
+/// Issue #2436 PR-C: Photos (presigned read-path) added as last parameter.
 /// </summary>
 public record PlayRecordDto(
     Guid Id,
@@ -25,5 +26,20 @@ public record PlayRecordDto(
     DateTime CreatedAt,
     DateTime UpdatedAt,
     IReadOnlyList<Guid> WinnerPlayerIds,
-    string OutcomeType
+    string OutcomeType,
+    IReadOnlyList<PlayRecordPhotoDto> Photos
+);
+
+/// <summary>
+/// A photo attached to a play record, exposed for read (#2436 PR-C).
+/// <c>Url</c>/<c>ThumbnailUrl</c> are presigned download URLs (or raw paths on local storage).
+/// </summary>
+public record PlayRecordPhotoDto(
+    Guid Id,
+    string Url,
+    string? ThumbnailUrl,
+    string? OcrText,
+    string? Caption,
+    Guid UploadedByUserId,
+    DateTime UploadedAt
 );

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
@@ -17,8 +17,6 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 /// </summary>
 internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, PlayRecordDto>
 {
-    private const int PresignExpirySeconds = 3600;
-
     private readonly MeepleAiDbContext _context;
     private readonly IBlobStorageService _blobStorage;
 
@@ -61,10 +59,10 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
         var photos = new List<PlayRecordPhotoDto>(entity.Photos.Count);
         foreach (var p in entity.Photos.OrderBy(p => p.UploadedAt))
         {
-            var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.BlobUrl, PresignExpirySeconds).ConfigureAwait(false);
+            var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.BlobUrl, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
             var thumb = p.ThumbnailUrl is null
                 ? null
-                : await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.ThumbnailUrl, PresignExpirySeconds).ConfigureAwait(false);
+                : await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.ThumbnailUrl, PlayRecordPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
             photos.Add(new PlayRecordPhotoDto(p.Id, url, thumb, p.OcrText, p.Caption, p.UploadedByUserId, p.UploadedAt));
         }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
@@ -1,8 +1,10 @@
+using System.Linq;
 using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,14 +13,19 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 /// <summary>
 /// Handles retrieving a single play record with full details.
 /// Issue #3890: CQRS queries for play records.
+/// Issue #2436 PR-C: Photos presigned read-path.
 /// </summary>
 internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, PlayRecordDto>
 {
-    private readonly MeepleAiDbContext _context;
+    private const int PresignExpirySeconds = 3600;
 
-    public GetPlayRecordQueryHandler(MeepleAiDbContext context)
+    private readonly MeepleAiDbContext _context;
+    private readonly IBlobStorageService _blobStorage;
+
+    public GetPlayRecordQueryHandler(MeepleAiDbContext context, IBlobStorageService blobStorage)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
     }
 
     public async Task<PlayRecordDto> Handle(GetPlayRecordQuery query, CancellationToken cancellationToken)
@@ -29,6 +36,7 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
             .AsNoTracking()
             .Include(r => r.Players)
                 .ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
             .FirstOrDefaultAsync(r => r.Id == query.RecordId, cancellationToken)
             .ConfigureAwait(false);
 
@@ -48,6 +56,17 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
         // Compute outcome fields from player scores (no storage change — computed on read)
         var winnerPlayerIds = PlayRecordOutcomeCalculator.WinnerPlayerIds(entity.Players);
         var outcomeType = PlayRecordOutcomeCalculator.OutcomeType(entity.Players);
+
+        // Map photos with presigned URLs (read path, #2436 PR-C). Ordered oldest→newest.
+        var photos = new List<PlayRecordPhotoDto>(entity.Photos.Count);
+        foreach (var p in entity.Photos.OrderBy(p => p.UploadedAt))
+        {
+            var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.BlobUrl, PresignExpirySeconds).ConfigureAwait(false);
+            var thumb = p.ThumbnailUrl is null
+                ? null
+                : await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.ThumbnailUrl, PresignExpirySeconds).ConfigureAwait(false);
+            photos.Add(new PlayRecordPhotoDto(p.Id, url, thumb, p.OcrText, p.Caption, p.UploadedByUserId, p.UploadedAt));
+        }
 
         return new PlayRecordDto(
             entity.Id,
@@ -77,7 +96,8 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
             entity.CreatedAt,
             entity.UpdatedAt,
             winnerPlayerIds,
-            outcomeType
+            outcomeType,
+            photos
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Resolves a stored PlayRecord photo blob path to a presigned download URL.
+/// Shared by the upload command handler (write path) and the get-record query
+/// handler (read path) so the FilePath→fileId/folder parsing lives in one place.
+/// #2436 PR-C. On local storage GetPresignedDownloadUrlAsync returns null → raw path.
+/// </summary>
+internal static class PlayRecordPhotoUrlResolver
+{
+    public static async Task<string> ResolveAsync(
+        IBlobStorageService blobStorage,
+        string blobPath,
+        int expirySeconds)
+    {
+        var fileName = Path.GetFileName(blobPath);
+        if (string.IsNullOrEmpty(fileName))
+            return blobPath;
+
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        if (underscoreIndex <= 0)
+            return blobPath;
+
+        var fileId = fileName[..underscoreIndex];
+        var directory = Path.GetDirectoryName(blobPath);
+        if (string.IsNullOrEmpty(directory))
+            return blobPath;
+
+        var folder = Path.GetFileName(directory);
+        if (string.IsNullOrEmpty(folder))
+            return blobPath;
+
+        var signed = await blobStorage
+            .GetPresignedDownloadUrlAsync(fileId, BlobCategory.PlayRecordPhoto, folder, expirySeconds)
+            .ConfigureAwait(false);
+        return signed ?? blobPath;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs
@@ -13,6 +13,9 @@ namespace Api.BoundedContexts.GameManagement.Application.Services;
 /// </summary>
 internal static class PlayRecordPhotoUrlResolver
 {
+    /// <summary>Default presigned URL TTL (1 hour), shared by all call-sites.</summary>
+    internal const int DefaultExpirySeconds = 3600;
+
     public static async Task<string> ResolveAsync(
         IBlobStorageService blobStorage,
         string blobPath,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
@@ -3,9 +3,11 @@ using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.GameManagement;
 using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
@@ -22,12 +24,17 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
 public class GetPlayRecordQueryHandlerTests : IDisposable
 {
     private readonly MeepleAiDbContext _context;
+    private readonly Mock<IBlobStorageService> _blob;
     private readonly GetPlayRecordQueryHandler _handler;
 
     public GetPlayRecordQueryHandlerTests()
     {
         _context = TestDbContextFactory.CreateInMemoryDbContext();
-        _handler = new GetPlayRecordQueryHandler(_context);
+        _blob = new Mock<IBlobStorageService>();
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync((string?)null);
+        _handler = new GetPlayRecordQueryHandler(_context, _blob.Object);
     }
 
     public void Dispose() => _context.Dispose();
@@ -236,6 +243,44 @@ public class GetPlayRecordQueryHandlerTests : IDisposable
         // Assert
         result.Should().NotBeNull();
         result.Id.Should().Be(record.Id);
+    }
+
+    [Fact]
+    public async Task Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt()
+    {
+        var recordId = Guid.NewGuid();
+        var uploaderId = Guid.NewGuid();
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity> { MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)) };
+        entity.Photos = new List<PlayRecordPhotoEntity>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(), PlayRecordId = recordId,
+                BlobUrl = "play-record-photos/abc/photo1.webp", ThumbnailUrl = "play-record-photos/abc/thumb1.webp",
+                FileSizeBytes = 1234, Sha256Hash = "h1", OcrText = "42", Caption = "scoreboard",
+                UploadedByUserId = uploaderId, UploadedAt = new DateTime(2026, 6, 20, 10, 0, 0, DateTimeKind.Utc),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(), PlayRecordId = recordId,
+                BlobUrl = "play-record-photos/abc/photo2.webp", ThumbnailUrl = null,
+                FileSizeBytes = 5678, Sha256Hash = "h2", OcrText = null, Caption = null,
+                UploadedByUserId = uploaderId, UploadedAt = new DateTime(2026, 6, 20, 9, 0, 0, DateTimeKind.Utc),
+            },
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId, entity.CreatedByUserId);
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        result.Photos.Should().HaveCount(2);
+        result.Photos[0].Caption.Should().BeNull();
+        result.Photos[0].Url.Should().Be("play-record-photos/abc/photo2.webp");
+        result.Photos[1].Caption.Should().Be("scoreboard");
+        result.Photos[1].OcrText.Should().Be("42");
+        result.Photos[1].ThumbnailUrl.Should().Be("play-record-photos/abc/thumb1.webp");
     }
 
     #region Test Helpers

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
@@ -246,6 +246,7 @@ public class GetPlayRecordQueryHandlerTests : IDisposable
     }
 
     [Fact]
+    [Trait("Issue", "2436")]
     public async Task Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt()
     {
         var recordId = Guid.NewGuid();

--- a/apps/web/src/components/play-records/PlayRecordDetailView.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailView.tsx
@@ -30,7 +30,7 @@
 /* eslint-disable local/no-hardcoded-color-utility -- text-white / gradient covers intentionally use colored bg following .e-bg mockup pattern */
 'use client';
 
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -47,6 +47,8 @@ import { Classifica, type ClassificaRow } from './detail/Classifica';
 import { ConnectionBar } from './detail/ConnectionBar';
 import { KpiGrid } from './detail/KpiGrid';
 import { ScoreBreakdown, type ScoreBreakdownRow } from './detail/ScoreBreakdown';
+import { PlayRecordPhotoGallery } from './photos/PlayRecordPhotoGallery';
+import { PlayRecordPhotoUploadDialog } from './photos/PlayRecordPhotoUploadDialog';
 import {
   PlayRecordHeroPodium,
   type RankedScore,
@@ -223,6 +225,7 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
   const router = useRouter();
   const { data: currentUser } = useCurrentUser();
   const { data: record, isLoading, error } = usePlayRecord(recordId);
+  const [photoDialogOpen, setPhotoDialogOpen] = useState(false);
 
   if (isLoading) {
     return <LoadingSkeleton />;
@@ -250,6 +253,7 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
 
   // ── Derive perspective ──────────────────────────────────────────────────────
   const currentUserId = currentUser?.id ?? null;
+  const isCreator = currentUserId !== null && currentUserId === record.createdByUserId;
   const perspective = derivePerspective({
     currentUserId,
     players: record.players,
@@ -341,6 +345,41 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
           avgScore={avgScore}
           spread={spread}
         />
+
+        {/* Photos — #2436 PR-C */}
+        <section aria-label={t('playRecords.photos.sectionTitle')} className="flex flex-col gap-2">
+          {isCreator && (
+            <div className="flex">
+              <button
+                type="button"
+                onClick={() => setPhotoDialogOpen(true)}
+                className="ml-auto rounded-md border border-border px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+              >
+                📷 {t('playRecords.photos.addButton')}
+              </button>
+            </div>
+          )}
+          <PlayRecordPhotoGallery
+            photos={record.photos ?? []}
+            labels={{
+              title: t('playRecords.photos.sectionTitle'),
+              emptyTitle: t('playRecords.photos.emptyTitle'),
+              emptyDescription: t('playRecords.photos.emptyDescription'),
+              photoAltFallback: t('playRecords.photos.photoAltFallback'),
+              ocrResultTitle: t('playRecords.photos.ocrResultTitle'),
+              prev: t('playRecords.photos.lightboxPrev'),
+              next: t('playRecords.photos.lightboxNext'),
+            }}
+          />
+        </section>
+
+        {isCreator && (
+          <PlayRecordPhotoUploadDialog
+            recordId={recordId}
+            open={photoDialogOpen}
+            onClose={() => setPhotoDialogOpen(false)}
+          />
+        )}
 
         {/* Classifica — AC-2.5 */}
         {clasificaRows.length > 0 && (

--- a/apps/web/src/components/play-records/PlayRecordDetailView.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailView.tsx
@@ -346,8 +346,9 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
           spread={spread}
         />
 
-        {/* Photos — #2436 PR-C */}
-        <section aria-label={t('playRecords.photos.sectionTitle')} className="flex flex-col gap-2">
+        {/* Photos — #2436 PR-C. The gallery renders its own <h2>; no section aria-label
+            to avoid a double screen-reader announcement of the same title. */}
+        <section className="flex flex-col gap-2">
           {isCreator && (
             <div className="flex">
               <button

--- a/apps/web/src/components/play-records/__tests__/PlayRecordDetailView.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/PlayRecordDetailView.test.tsx
@@ -105,6 +105,15 @@ const MESSAGES: Record<string, string> = {
   'playRecords.detail.notFound': 'Partita non trovata',
   'playRecords.detail.retry': 'Riprova',
   'playRecords.detail.backToList': 'Torna alle partite',
+  // #2436 PR-C photos
+  'playRecords.photos.sectionTitle': 'Foto della partita',
+  'playRecords.photos.addButton': 'Aggiungi foto',
+  'playRecords.photos.emptyTitle': 'Nessuna foto',
+  'playRecords.photos.emptyDescription': 'Carica una foto',
+  'playRecords.photos.photoAltFallback': 'Foto',
+  'playRecords.photos.ocrResultTitle': 'Testo',
+  'playRecords.photos.lightboxPrev': 'Prec',
+  'playRecords.photos.lightboxNext': 'Succ',
 };
 
 // ─── render helper ─────────────────────────────────────────────────────────────
@@ -355,6 +364,26 @@ describe('PlayRecordDetailView — variant matrix', () => {
         },
         { timeout: 5000 }
       );
+    });
+  });
+
+  // ── Photos (#2436 PR-C) ──────────────────────────────────────────────────────
+  describe('Photos — #2436 PR-C creator-only upload', () => {
+    it('shows the add-photo button for the record creator', async () => {
+      // FIXTURE_WON.createdByUserId === 'user-me' (the mocked current user)
+      renderView(FIXTURE_WON.id);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /aggiungi foto/i })).toBeInTheDocument();
+      });
+    });
+
+    it('hides the add-photo button for non-creators (spectator)', async () => {
+      // FIXTURE_SPECTATOR.createdByUserId === 'u-other1' (not the current user)
+      renderView(FIXTURE_SPECTATOR.id);
+      await waitFor(() => {
+        expect(document.querySelector('[data-slot="play-record-hero-podium"]')).not.toBeNull();
+      });
+      expect(screen.queryByRole('button', { name: /aggiungi foto/i })).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/play-records/__tests__/play-records-axe.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/play-records-axe.test.tsx
@@ -28,6 +28,7 @@ import {
 import { SessionCreateForm } from '../SessionCreateForm';
 import { StatisticsView } from '../StatisticsView';
 import { PlayRecordDetailView } from '../PlayRecordDetailView';
+import { PlayRecordPhotoGallery } from '../photos/PlayRecordPhotoGallery';
 import { mockPlayerStatisticsEmpty } from '../../play-records/stats/__tests__/fixtures';
 
 expect.extend(toHaveNoViolations);
@@ -217,6 +218,49 @@ describe('play-records — axe AA gate', () => {
     const { container } = withQueryClientAndIntl(
       <PlayRecordDetailView recordId={FIXTURE_WON.id} />
     );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('PlayRecordPhotoGallery (with photo) — no violations', async () => {
+    const labels = {
+      title: 'Foto',
+      emptyTitle: 'Nessuna foto',
+      emptyDescription: 'Carica una foto',
+      photoAltFallback: 'Foto',
+      ocrResultTitle: 'Testo',
+      prev: 'Prec',
+      next: 'Succ',
+    };
+    const { container } = render(
+      <PlayRecordPhotoGallery
+        photos={[
+          {
+            id: 'a',
+            url: 'http://x/a.webp',
+            thumbnailUrl: null,
+            ocrText: '42',
+            caption: 'board',
+            uploadedByUserId: 'u',
+            uploadedAt: '2026-06-20T10:00:00Z',
+          },
+        ]}
+        labels={labels}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('PlayRecordPhotoGallery (empty) — no violations', async () => {
+    const labels = {
+      title: 'Foto',
+      emptyTitle: 'Nessuna foto',
+      emptyDescription: 'Carica una foto',
+      photoAltFallback: 'Foto',
+      ocrResultTitle: 'Testo',
+      prev: 'Prec',
+      next: 'Succ',
+    };
+    const { container } = render(<PlayRecordPhotoGallery photos={[]} labels={labels} />);
     expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx
+++ b/apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx
@@ -13,7 +13,6 @@ export interface PlayRecordPhotoGalleryLabels {
   emptyDescription: string;
   photoAltFallback: string;
   ocrResultTitle: string;
-  close: string;
   prev: string;
   next: string;
 }
@@ -55,7 +54,7 @@ export function PlayRecordPhotoGallery({
         <span aria-hidden="true" className="text-3xl">
           📷
         </span>
-        <h3 className="font-display text-sm font-extrabold text-foreground">{labels.emptyTitle}</h3>
+        <h2 className="font-display text-sm font-extrabold text-foreground">{labels.emptyTitle}</h2>
         <p className="text-xs text-muted-foreground">{labels.emptyDescription}</p>
       </section>
     );
@@ -65,12 +64,12 @@ export function PlayRecordPhotoGallery({
 
   return (
     <section data-slot="play-record-photos" className={clsx('flex flex-col gap-2', className)}>
-      <h3 className="font-display text-base font-extrabold text-foreground">
+      <h2 className="font-display text-base font-extrabold text-foreground">
         <span aria-hidden="true" className="mr-1.5">
           📷
         </span>
         {labels.title}
-      </h3>
+      </h2>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {photos.map((p, i) => {
           const alt = p.caption ?? labels.photoAltFallback;

--- a/apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx
+++ b/apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import clsx from 'clsx';
+
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/overlays/dialog';
+import type { PlayRecordPhoto } from '@/lib/api/schemas/play-records.schemas';
+
+export interface PlayRecordPhotoGalleryLabels {
+  title: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  photoAltFallback: string;
+  ocrResultTitle: string;
+  close: string;
+  prev: string;
+  next: string;
+}
+
+export interface PlayRecordPhotoGalleryProps {
+  photos: readonly PlayRecordPhoto[];
+  labels: PlayRecordPhotoGalleryLabels;
+  className?: string;
+}
+
+export function PlayRecordPhotoGallery({
+  photos,
+  labels,
+  className,
+}: PlayRecordPhotoGalleryProps): React.JSX.Element {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const close = useCallback(() => setOpenIndex(null), []);
+  const prev = useCallback(
+    () => setOpenIndex(i => (i === null ? null : (i - 1 + photos.length) % photos.length)),
+    [photos.length]
+  );
+  const next = useCallback(
+    () => setOpenIndex(i => (i === null ? null : (i + 1) % photos.length)),
+    [photos.length]
+  );
+
+  if (photos.length === 0) {
+    return (
+      <section
+        data-slot="play-record-photos"
+        data-empty="true"
+        role="status"
+        className={clsx(
+          'flex flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-card px-4 py-8 text-center',
+          className
+        )}
+      >
+        <span aria-hidden="true" className="text-3xl">
+          📷
+        </span>
+        <h3 className="font-display text-sm font-extrabold text-foreground">{labels.emptyTitle}</h3>
+        <p className="text-xs text-muted-foreground">{labels.emptyDescription}</p>
+      </section>
+    );
+  }
+
+  const active = openIndex !== null ? photos[openIndex] : null;
+
+  return (
+    <section data-slot="play-record-photos" className={clsx('flex flex-col gap-2', className)}>
+      <h3 className="font-display text-base font-extrabold text-foreground">
+        <span aria-hidden="true" className="mr-1.5">
+          📷
+        </span>
+        {labels.title}
+      </h3>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {photos.map((p, i) => {
+          const alt = p.caption ?? labels.photoAltFallback;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setOpenIndex(i)}
+              aria-label={alt}
+              className="group relative aspect-square overflow-hidden rounded-md border border-border bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- thumbnail tile */}
+              <img
+                src={p.thumbnailUrl ?? p.url}
+                alt=""
+                aria-hidden="true"
+                loading="lazy"
+                className="h-full w-full object-cover transition-transform group-hover:scale-105"
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <Dialog open={active !== null} onOpenChange={o => !o && close()}>
+        <DialogContent className="max-w-3xl">
+          <DialogTitle className="sr-only">
+            {active?.caption ?? labels.photoAltFallback}
+          </DialogTitle>
+          {active && (
+            <div className="flex flex-col gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element -- full-res lightbox */}
+              <img
+                src={active.url}
+                alt={active.caption ?? labels.photoAltFallback}
+                className="max-h-[70vh] w-full rounded-md object-contain"
+              />
+              {active.caption && (
+                <p className="text-sm font-medium text-foreground">{active.caption}</p>
+              )}
+              {active.ocrText && (
+                <p className="rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+                  <span className="font-semibold">{labels.ocrResultTitle}:</span> {active.ocrText}
+                </p>
+              )}
+              {photos.length > 1 && (
+                <div className="flex justify-between">
+                  <button
+                    type="button"
+                    onClick={prev}
+                    aria-label={labels.prev}
+                    className="rounded-md px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+                  >
+                    ← {labels.prev}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={next}
+                    aria-label={labels.next}
+                    className="rounded-md px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+                  >
+                    {labels.next} →
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx
+++ b/apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import { toast } from 'sonner';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { usePlayRecordPhotoUpload } from '@/hooks/mutations/usePlayRecordPhotoUpload';
+import { useTranslation } from '@/hooks/useTranslation';
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5MB — matches BE validator
+const MAX_FILES = 10;
+const ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic'];
+
+export interface PlayRecordPhotoUploadDialogProps {
+  recordId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function PlayRecordPhotoUploadDialog({
+  recordId,
+  open,
+  onClose,
+}: PlayRecordPhotoUploadDialogProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const [files, setFiles] = useState<File[]>([]);
+  const [caption, setCaption] = useState('');
+  const [extractScore, setExtractScore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const upload = usePlayRecordPhotoUpload(recordId);
+
+  const handleSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      setError(null);
+      const selected = Array.from(e.target.files ?? []);
+      if (selected.length === 0) return;
+      if (selected.length > MAX_FILES) {
+        setError(t('playRecords.photos.tooMany'));
+        return;
+      }
+
+      const out: File[] = [];
+      for (const file of selected) {
+        if (!ACCEPTED_MIME.includes(file.type)) {
+          setError(t('playRecords.photos.badFormat'));
+          return;
+        }
+        let candidate = file;
+        if (file.type === 'image/heic') {
+          try {
+            const heic2any = (await import('heic2any')).default;
+            const result = await heic2any({ blob: file, toType: 'image/jpeg', quality: 0.9 });
+            const jpegBlob = Array.isArray(result) ? result[0] : result;
+            candidate = new File([jpegBlob], file.name.replace(/\.heic$/i, '.jpg'), {
+              type: 'image/jpeg',
+            });
+          } catch {
+            setError(t('playRecords.photos.heicFailed'));
+            return;
+          }
+        }
+        if (candidate.size > MAX_BYTES) {
+          setError(t('playRecords.photos.tooLarge'));
+          return;
+        }
+        out.push(candidate);
+      }
+      setFiles(out);
+    },
+    [t]
+  );
+
+  const handleUpload = useCallback(async () => {
+    setError(null);
+    try {
+      for (const file of files) {
+        const res = await upload.mutateAsync({
+          file,
+          caption: caption || undefined,
+          extractScoreFromPhoto: extractScore || undefined,
+        });
+        if (res.wasDeduplicated) {
+          toast.info(t('playRecords.photos.dedupToast'));
+        } else if (res.ocrText) {
+          toast.success(`${t('playRecords.photos.ocrResultTitle')}: ${res.ocrText}`);
+        }
+      }
+      setFiles([]);
+      setCaption('');
+      setExtractScore(false);
+      onClose();
+    } catch {
+      setError(t('playRecords.photos.uploadError'));
+    }
+  }, [files, caption, extractScore, upload, t, onClose]);
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogTitle>{t('playRecords.photos.dialogTitle')}</DialogTitle>
+        <DialogDescription>{t('playRecords.photos.dialogDescription')}</DialogDescription>
+
+        <label className="block">
+          <span className="text-sm font-medium">{t('playRecords.photos.selectLabel')}</span>
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/heic"
+            multiple
+            capture="environment"
+            onChange={handleSelect}
+            aria-label={t('playRecords.photos.selectLabel')}
+            className="mt-1 block w-full"
+          />
+        </label>
+
+        {files.length > 0 && (
+          <p className="text-sm text-muted-foreground">{files.map(f => f.name).join(', ')}</p>
+        )}
+
+        <label className="block">
+          <span className="text-sm font-medium">{t('playRecords.photos.captionLabel')}</span>
+          <input
+            type="text"
+            value={caption}
+            maxLength={500}
+            onChange={e => setCaption(e.target.value)}
+            placeholder={t('playRecords.photos.captionPlaceholder')}
+            aria-label={t('playRecords.photos.captionLabel')}
+            className="mt-1 block w-full rounded-md border border-border bg-card px-3 py-1.5 text-sm"
+          />
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={extractScore}
+            onChange={e => setExtractScore(e.target.checked)}
+            aria-label={t('playRecords.photos.extractScoreLabel')}
+          />
+          {t('playRecords.photos.extractScoreLabel')}
+        </label>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button onClick={handleUpload} disabled={files.length === 0 || upload.isPending}>
+            {upload.isPending
+              ? t('playRecords.photos.uploading')
+              : t('playRecords.photos.uploadCta')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx
+++ b/apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx
@@ -113,7 +113,6 @@ export function PlayRecordPhotoUploadDialog({
             type="file"
             accept="image/jpeg,image/png,image/webp,image/heic"
             multiple
-            capture="environment"
             onChange={handleSelect}
             aria-label={t('playRecords.photos.selectLabel')}
             className="mt-1 block w-full"

--- a/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx
+++ b/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { PlayRecordPhoto } from '@/lib/api/schemas/play-records.schemas';
+
+import { PlayRecordPhotoGallery } from '../PlayRecordPhotoGallery';
+
+const labels = {
+  title: 'Foto',
+  emptyTitle: 'Nessuna foto',
+  emptyDescription: 'Carica una foto',
+  photoAltFallback: 'Foto',
+  ocrResultTitle: 'Testo',
+  close: 'Chiudi',
+  prev: 'Prec',
+  next: 'Succ',
+};
+
+const photos: PlayRecordPhoto[] = [
+  {
+    id: 'a',
+    url: 'http://x/a.webp',
+    thumbnailUrl: null,
+    ocrText: '42',
+    caption: 'board',
+    uploadedByUserId: 'u',
+    uploadedAt: '2026-06-20T09:00:00Z',
+  },
+  {
+    id: 'b',
+    url: 'http://x/b.webp',
+    thumbnailUrl: null,
+    ocrText: null,
+    caption: null,
+    uploadedByUserId: 'u',
+    uploadedAt: '2026-06-20T10:00:00Z',
+  },
+];
+
+describe('PlayRecordPhotoGallery', () => {
+  it('renders empty state', () => {
+    render(<PlayRecordPhotoGallery photos={[]} labels={labels} />);
+    expect(screen.getByText('Nessuna foto')).toBeInTheDocument();
+  });
+
+  it('opens lightbox on tile click and navigates', () => {
+    render(<PlayRecordPhotoGallery photos={photos} labels={labels} />);
+    fireEvent.click(screen.getByRole('button', { name: 'board' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Succ' }));
+    expect(screen.getByAltText('Foto')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx
+++ b/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx
@@ -11,7 +11,6 @@ const labels = {
   emptyDescription: 'Carica una foto',
   photoAltFallback: 'Foto',
   ocrResultTitle: 'Testo',
-  close: 'Chiudi',
   prev: 'Prec',
   next: 'Succ',
 };

--- a/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx
+++ b/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { toast } from 'sonner';
+
 import { playRecordsApi } from '@/lib/api/play-records.api';
 
 import { PlayRecordPhotoUploadDialog } from '../PlayRecordPhotoUploadDialog';
@@ -34,6 +36,15 @@ vi.mock('@/hooks/useTranslation', () => ({
   }),
 }));
 
+// ─── sonner mock ─────────────────────────────────────────────────────────────
+vi.mock('sonner', () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 // ─── wrapper ──────────────────────────────────────────────────────────────────
 
 function wrap(node: ReactNode) {
@@ -42,7 +53,10 @@ function wrap(node: ReactNode) {
 }
 
 describe('PlayRecordPhotoUploadDialog', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
 
   it('rejects files over 5MB', async () => {
     render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
@@ -76,5 +90,34 @@ describe('PlayRecordPhotoUploadDialog', () => {
         expect.objectContaining({ extractScoreFromPhoto: true })
       )
     );
+  });
+
+  it('>10 files triggers the tooMany error', async () => {
+    render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
+    const files = Array.from(
+      { length: 11 },
+      (_, i) => new File(['x'], `p${i}.jpg`, { type: 'image/jpeg' })
+    );
+    const input = screen.getByLabelText(/seleziona foto|select photo/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files } });
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/massimo 10|max 10/i);
+  });
+
+  it('wasDeduplicated shows an info toast', async () => {
+    vi.spyOn(playRecordsApi, 'uploadPhoto').mockResolvedValue({
+      photoId: 'p1',
+      photoUrl: 'u',
+      thumbnailUrl: null,
+      ocrText: null,
+      wasDeduplicated: true,
+    });
+    render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
+    const file = new File(['x'], 'dup.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByLabelText(/seleziona foto|select photo/i), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /carica|upload/i }));
+    await waitFor(() => expect(toast.info).toHaveBeenCalled());
   });
 });

--- a/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx
+++ b/apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { playRecordsApi } from '@/lib/api/play-records.api';
+
+import { PlayRecordPhotoUploadDialog } from '../PlayRecordPhotoUploadDialog';
+
+// ─── i18n mock ────────────────────────────────────────────────────────────────
+// useTranslation in jsdom returns MESSAGES[key] ?? key.
+// We define the keys the component renders so getByLabelText / findByText resolve.
+const MESSAGES: Record<string, string> = {
+  'playRecords.photos.dialogTitle': 'Carica foto',
+  'playRecords.photos.dialogDescription': 'JPG, PNG, WebP o HEIC · max 5MB · fino a 10 foto.',
+  'playRecords.photos.selectLabel': 'Seleziona foto',
+  'playRecords.photos.captionLabel': 'Didascalia (opzionale)',
+  'playRecords.photos.captionPlaceholder': 'Es. tabellone finale',
+  'playRecords.photos.extractScoreLabel': 'Estrai il punteggio dalla foto (OCR)',
+  'playRecords.photos.uploadCta': 'Carica',
+  'playRecords.photos.uploading': 'Caricamento…',
+  'playRecords.photos.tooLarge': 'File troppo grande, massimo 5MB.',
+  'playRecords.photos.tooMany': 'Massimo 10 foto per partita.',
+  'playRecords.photos.badFormat': 'Formato non supportato. Usa JPG, PNG, WebP o HEIC.',
+  'playRecords.photos.heicFailed': 'Conversione HEIC fallita. Riprova con JPEG o PNG.',
+  'playRecords.photos.uploadError': 'Caricamento foto non riuscito.',
+  'playRecords.photos.dedupToast': 'Questa foto è già presente.',
+  'playRecords.photos.ocrResultTitle': 'Testo rilevato',
+};
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => MESSAGES[key] ?? key,
+  }),
+}));
+
+// ─── wrapper ──────────────────────────────────────────────────────────────────
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+describe('PlayRecordPhotoUploadDialog', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('rejects files over 5MB', async () => {
+    render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
+    const big = new File([new Uint8Array(6 * 1024 * 1024)], 'big.jpg', { type: 'image/jpeg' });
+    const input = screen.getByLabelText(/seleziona foto|select photo/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [big] } });
+    // DialogDescription also contains "max 5MB" — query the role="alert" element specifically
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/massimo 5MB|max 5MB/i);
+  });
+
+  it('uploads a valid jpeg with OCR flag', async () => {
+    const spy = vi.spyOn(playRecordsApi, 'uploadPhoto').mockResolvedValue({
+      photoId: 'p1',
+      photoUrl: 'u',
+      thumbnailUrl: null,
+      ocrText: '42',
+      wasDeduplicated: false,
+    });
+    render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
+    const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByLabelText(/seleziona foto|select photo/i), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByLabelText(/estrai il punteggio|extract score/i));
+    fireEvent.click(screen.getByRole('button', { name: /carica|upload/i }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        'r1',
+        expect.any(File),
+        expect.objectContaining({ extractScoreFromPhoto: true })
+      )
+    );
+  });
+});

--- a/apps/web/src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx
+++ b/apps/web/src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { playRecordsApi } from '@/lib/api/play-records.api';
+
+import { usePlayRecordPhotoUpload } from '../usePlayRecordPhotoUpload';
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('usePlayRecordPhotoUpload', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('uploads and invalidates the record detail query', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    vi.spyOn(playRecordsApi, 'uploadPhoto').mockResolvedValue({
+      photoId: 'p1',
+      photoUrl: 'u',
+      thumbnailUrl: null,
+      ocrText: null,
+      wasDeduplicated: false,
+    });
+
+    const { result } = renderHook(() => usePlayRecordPhotoUpload('rec-1'), {
+      wrapper: wrapper(client),
+    });
+
+    result.current.mutate({ file: new Blob(['x'], { type: 'image/jpeg' }) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(playRecordsApi.uploadPhoto).toHaveBeenCalledWith('rec-1', expect.any(Blob), {
+      caption: undefined,
+      extractScoreFromPhoto: undefined,
+    });
+    expect(invalidate).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/mutations/usePlayRecordPhotoUpload.ts
+++ b/apps/web/src/hooks/mutations/usePlayRecordPhotoUpload.ts
@@ -1,0 +1,27 @@
+/**
+ * usePlayRecordPhotoUpload — mutation hook for POST /play-records/{id}/photos.
+ * Invalidates the record detail query so the gallery refetches with the new photo.
+ * #2436 PR-C.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { playRecordsApi, type UploadPlayRecordPhotoResult } from '@/lib/api/play-records.api';
+import { playRecordsKeys } from '@/lib/domain-hooks/usePlayRecords';
+
+export interface UploadPhotoVars {
+  file: Blob;
+  caption?: string;
+  extractScoreFromPhoto?: boolean;
+}
+
+export function usePlayRecordPhotoUpload(recordId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<UploadPlayRecordPhotoResult, Error, UploadPhotoVars>({
+    mutationFn: ({ file, caption, extractScoreFromPhoto }) =>
+      playRecordsApi.uploadPhoto(recordId, file, { caption, extractScoreFromPhoto }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.detail(recordId) });
+    },
+  });
+}

--- a/apps/web/src/lib/api/__tests__/play-records-upload-photo.test.ts
+++ b/apps/web/src/lib/api/__tests__/play-records-upload-photo.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { playRecordsApi } from '../play-records.api';
+
+describe('playRecordsApi.uploadPhoto', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs multipart with file + flags and returns the result', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        photoId: 'p1',
+        photoUrl: 'https://cdn/p.webp',
+        thumbnailUrl: null,
+        ocrText: '42',
+        wasDeduplicated: false,
+      }),
+    });
+
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    const res = await playRecordsApi.uploadPhoto('rec-1', blob, {
+      caption: 'board',
+      extractScoreFromPhoto: true,
+    });
+
+    expect(res.photoId).toBe('p1');
+    expect(res.ocrText).toBe('42');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/play-records/rec-1/photos');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get('extractScoreFromPhoto')).toBe('true');
+    expect((init.body as FormData).get('caption')).toBe('board');
+  });
+
+  it('throws on non-ok response', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 413,
+      json: async () => ({ error: 'too big' }),
+    });
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    await expect(playRecordsApi.uploadPhoto('rec-1', blob, {})).rejects.toThrow('too big');
+  });
+});

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -21,6 +21,14 @@ import type {
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 const BASE_URL = `${API_BASE}/api/v1/play-records`;
 
+export interface UploadPlayRecordPhotoResult {
+  photoId: string;
+  photoUrl: string;
+  thumbnailUrl: string | null;
+  ocrText: string | null;
+  wasDeduplicated: boolean;
+}
+
 /**
  * Play Records API Client
  */
@@ -112,6 +120,32 @@ export const playRecordsApi = {
       const error = await res.json().catch(() => ({ message: 'Failed to update record' }));
       throw new Error(error.message || 'Failed to update record');
     }
+  },
+
+  /**
+   * Upload a photo to an existing play record (multipart). #2436 PR-C.
+   * Raw fetch — httpClient does not support multipart FormData.
+   */
+  async uploadPhoto(
+    recordId: string,
+    file: Blob,
+    opts: { caption?: string; extractScoreFromPhoto?: boolean } = {}
+  ): Promise<UploadPlayRecordPhotoResult> {
+    const form = new FormData();
+    form.append('file', file, file instanceof File ? file.name : 'photo.jpg');
+    if (opts.extractScoreFromPhoto) form.append('extractScoreFromPhoto', 'true');
+    if (opts.caption) form.append('caption', opts.caption);
+
+    const res = await fetch(`${BASE_URL}/${recordId}/photos`, {
+      method: 'POST',
+      body: form,
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ message: 'Failed to upload photo' }));
+      throw new Error(error.error || error.message || 'Failed to upload photo');
+    }
+    return res.json();
   },
 
   // ========== Queries ==========

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+
+import { PlayRecordDtoSchema, PlayRecordPhotoSchema } from '../play-records.schemas';
+
+describe('PlayRecordPhotoSchema', () => {
+  it('parses a full photo DTO', () => {
+    const parsed = PlayRecordPhotoSchema.parse({
+      id: '550e8400-e29b-41d4-a716-446655440001',
+      url: 'https://cdn.example/p.webp',
+      thumbnailUrl: 'https://cdn.example/t.webp',
+      ocrText: '42',
+      caption: 'scoreboard',
+      uploadedByUserId: '550e8400-e29b-41d4-a716-446655440002',
+      uploadedAt: '2026-06-20T10:00:00Z',
+    });
+    expect(parsed.url).toBe('https://cdn.example/p.webp');
+  });
+
+  it('accepts null thumbnail/ocr/caption', () => {
+    const parsed = PlayRecordPhotoSchema.parse({
+      id: '550e8400-e29b-41d4-a716-446655440001',
+      url: 'https://cdn.example/p.webp',
+      thumbnailUrl: null,
+      ocrText: null,
+      caption: null,
+      uploadedByUserId: '550e8400-e29b-41d4-a716-446655440002',
+      uploadedAt: '2026-06-20T10:00:00Z',
+    });
+    expect(parsed.thumbnailUrl).toBeNull();
+  });
+
+  it('PlayRecordDtoSchema treats photos as optional (BE rollout)', () => {
+    const base = {
+      id: '550e8400-e29b-41d4-a716-446655440003',
+      gameId: null,
+      gameName: 'Catan',
+      sessionDate: '2026-06-20',
+      duration: null,
+      status: 'Completed' as const,
+      players: [],
+      scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+      createdByUserId: '550e8400-e29b-41d4-a716-446655440002',
+      visibility: 'Private' as const,
+      startTime: null,
+      endTime: null,
+      notes: null,
+      location: null,
+      createdAt: '2026-06-20T10:00:00Z',
+      updatedAt: '2026-06-20T10:00:00Z',
+    };
+    expect(PlayRecordDtoSchema.parse(base).photos).toBeUndefined();
+    expect(PlayRecordDtoSchema.parse({ ...base, photos: [] }).photos).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -48,6 +48,19 @@ export type SessionPlayer = z.infer<typeof SessionPlayerSchema>;
 export const PlayRecordOutcomeTypeSchema = z.enum(['competitive', 'none']);
 export type PlayRecordOutcomeType = z.infer<typeof PlayRecordOutcomeTypeSchema>;
 
+// #2436 PR-C: photo attached to a play record (read path). url/thumbnailUrl are
+// presigned download URLs (or raw paths on local storage).
+export const PlayRecordPhotoSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string(),
+  thumbnailUrl: z.string().nullable(),
+  ocrText: z.string().nullable(),
+  caption: z.string().nullable(),
+  uploadedByUserId: z.string().uuid(),
+  uploadedAt: z.string(),
+});
+export type PlayRecordPhoto = z.infer<typeof PlayRecordPhotoSchema>;
+
 // ========== DTOs ==========
 
 export const PlayRecordDtoSchema = z.object({
@@ -71,6 +84,8 @@ export const PlayRecordDtoSchema = z.object({
   // Optional during BE rollout; tighten once the BE ships the fields.
   winnerPlayerIds: z.array(z.string().uuid()).optional(),
   outcomeType: PlayRecordOutcomeTypeSchema.optional(),
+  // #2436 PR-C: photos exposed on read. Optional during BE rollout; tighten later.
+  photos: z.array(PlayRecordPhotoSchema).optional(),
 });
 export type PlayRecordDto = z.infer<typeof PlayRecordDtoSchema>;
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -4200,6 +4200,31 @@
         "back": "← Back"
       }
     },
+    "photos": {
+      "sectionTitle": "Game photos",
+      "addButton": "Add photo",
+      "dialogTitle": "Upload photo",
+      "dialogDescription": "JPG, PNG, WebP or HEIC · max 5MB · up to 10 photos.",
+      "selectLabel": "Select photo",
+      "captionLabel": "Caption (optional)",
+      "captionPlaceholder": "E.g. final board",
+      "extractScoreLabel": "Extract score from photo (OCR)",
+      "ocrResultTitle": "Detected text",
+      "uploadCta": "Upload",
+      "uploading": "Uploading…",
+      "emptyTitle": "No photos",
+      "emptyDescription": "Upload a photo of the board or the table.",
+      "photoAltFallback": "Game photo",
+      "dedupToast": "This photo is already attached.",
+      "uploadError": "Photo upload failed.",
+      "tooLarge": "File too large, max 5MB.",
+      "tooMany": "Max 10 photos per game.",
+      "badFormat": "Unsupported format. Use JPG, PNG, WebP or HEIC.",
+      "heicFailed": "HEIC conversion failed. Try JPEG or PNG.",
+      "lightboxClose": "Close",
+      "lightboxPrev": "Previous",
+      "lightboxNext": "Next"
+    },
     "kbGlobale": {
       "hero": {
         "placeholder": "Search across all games' KB…",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -4253,6 +4253,31 @@
         "back": "← Indietro"
       }
     },
+    "photos": {
+      "sectionTitle": "Foto della partita",
+      "addButton": "Aggiungi foto",
+      "dialogTitle": "Carica foto",
+      "dialogDescription": "JPG, PNG, WebP o HEIC · max 5MB · fino a 10 foto.",
+      "selectLabel": "Seleziona foto",
+      "captionLabel": "Didascalia (opzionale)",
+      "captionPlaceholder": "Es. tabellone finale",
+      "extractScoreLabel": "Estrai il punteggio dalla foto (OCR)",
+      "ocrResultTitle": "Testo rilevato",
+      "uploadCta": "Carica",
+      "uploading": "Caricamento…",
+      "emptyTitle": "Nessuna foto",
+      "emptyDescription": "Carica una foto del tabellone o del tavolo.",
+      "photoAltFallback": "Foto della partita",
+      "dedupToast": "Questa foto è già presente.",
+      "uploadError": "Caricamento foto non riuscito.",
+      "tooLarge": "File troppo grande, massimo 5MB.",
+      "tooMany": "Massimo 10 foto per partita.",
+      "badFormat": "Formato non supportato. Usa JPG, PNG, WebP o HEIC.",
+      "heicFailed": "Conversione HEIC fallita. Riprova con JPEG o PNG.",
+      "lightboxClose": "Chiudi",
+      "lightboxPrev": "Precedente",
+      "lightboxNext": "Successiva"
+    },
     "kbGlobale": {
       "hero": {
         "placeholder": "Cerca nella knowledge base…",

--- a/docs/superpowers/plans/2026-06-20-issue-2436-pr-c-photo-ui.md
+++ b/docs/superpowers/plans/2026-06-20-issue-2436-pr-c-photo-ui.md
@@ -1,0 +1,1423 @@
+# #2436 PR-C — Play Records Photo UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettere all'utente di caricare foto (scoresheet/tavolo) su un PlayRecord esistente — con OCR opt-in — e visualizzarle in una gallery con lightbox nella detail view; più una mini-estensione BE che espone le foto in lettura.
+
+**Architecture:** PR-B ha già la scrittura (`POST /play-records/{id}/photos`) + xmin + dedup. Questo PR aggiunge (a) il **read-path BE**: `PlayRecordDto.Photos[]` popolato dal `GetPlayRecordQueryHandler` con URL presigned (logica estratta in un helper DRY condiviso con l'upload handler); (b) il **FE**: schema Zod, api client multipart, hook mutation, dialog di upload multi-file (HEIC→JPEG client-side via `heic2any`), gallery + lightbox montati nella `PlayRecordDetailView` (pulsante upload creator-only).
+
+**Tech Stack:** .NET 9 (CQRS/MediatR, EF Core, Moq+xUnit) · Next.js/React 19 (TanStack Query, Zod, Vitest, Tailwind) · `heic2any` (già in deps, usato da CustomCoverDialog).
+
+**Spec:** `docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md` (decisione **C1** = estendi DTO con `photos[]`).
+
+**Confine chiave:** l'endpoint upload richiede un `recordId` esistente → le foto si caricano dalla **detail view** (record già creato), NON dal create wizard. Il pulsante "Aggiungi foto" è visibile solo al creator (`currentUserId === record.createdByUserId`, ADR-066). La gallery è visibile a chiunque possa vedere il record.
+
+**Contratto BE verificato (PR-B, già su main-dev):**
+- `POST /api/v1/play-records/{recordId}/photos` — multipart fields: `file` (required), `extractScoreFromPhoto` (bool, opt), `caption` (string, opt). Response `201`: `PlayRecordPhotoUploadResult(Guid PhotoId, string PhotoUrl, string? ThumbnailUrl, string? OcrText, bool WasDeduplicated)`. (`PlayRecordEndpoints.cs:91,224-248`)
+- Validator BE: ≤5MB, MIME `image/jpeg|png|webp` (NO HEIC), caption ≤500 char.
+- Entity `PlayRecordPhotoEntity` con nav `PlayRecordEntity.Photos` già mappata (`PlayRecordEntityConfiguration` / `PlayRecordPhotoEntityConfiguration`).
+- `IBlobStorageService.GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)` → `Task<string?>` (null su local storage → fallback raw path). (`Services/Pdf/IBlobStorageService.cs:139`)
+
+---
+
+## File Structure
+
+**BE (create):**
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs` — helper static presigning (DRY).
+
+**BE (modify):**
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs` — `PlayRecordPhotoDto` + `Photos` field.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs` — usa helper (rimpiazza `PresignAsync` privato).
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs` — inietta `IBlobStorageService`, `Include(Photos)`, map+presign.
+- `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs` — ctor + nuovo test foto.
+
+**FE (create):**
+- `apps/web/src/hooks/mutations/usePlayRecordPhotoUpload.ts`
+- `apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx`
+- `apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx`
+- + relativi `__tests__/`
+
+**FE (modify):**
+- `apps/web/src/lib/api/schemas/play-records.schemas.ts` — `PlayRecordPhotoSchema` + `photos` field.
+- `apps/web/src/lib/api/play-records.api.ts` — `uploadPhoto`.
+- `apps/web/src/components/play-records/PlayRecordDetailView.tsx` — mount gallery + upload button.
+- `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json` — `playRecords.photos`.
+
+---
+
+## Task 1: BE — `PlayRecordPhotoDto` + estendi `PlayRecordDto`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs`
+
+- [ ] **Step 1: Aggiungi il DTO foto e il campo `Photos`**
+
+Apri `PlayRecordDto.cs`. Sotto il `record PlayRecordDto(...)` esistente aggiungi un nuovo record nello stesso file e aggiungi `Photos` come **ultimo** parametro del `PlayRecordDto`:
+
+```csharp
+public record PlayRecordDto(
+    Guid Id,
+    Guid? GameId,
+    string GameName,
+    DateTime SessionDate,
+    TimeSpan? Duration,
+    PlayRecordStatus Status,
+    List<SessionPlayerDto> Players,
+    SessionScoringConfigDto ScoringConfig,
+    Guid CreatedByUserId,
+    PlayRecordVisibility Visibility,
+    DateTime? StartTime,
+    DateTime? EndTime,
+    string? Notes,
+    string? Location,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    IReadOnlyList<Guid> WinnerPlayerIds,
+    string OutcomeType,
+    IReadOnlyList<PlayRecordPhotoDto> Photos
+);
+
+/// <summary>
+/// A photo attached to a play record, exposed for read (#2436 PR-C).
+/// <c>Url</c>/<c>ThumbnailUrl</c> are presigned download URLs (or raw paths on local storage).
+/// </summary>
+public record PlayRecordPhotoDto(
+    Guid Id,
+    string Url,
+    string? ThumbnailUrl,
+    string? OcrText,
+    string? Caption,
+    Guid UploadedByUserId,
+    DateTime UploadedAt
+);
+```
+
+- [ ] **Step 2: Verifica che NON compili ancora**
+
+Run: `cd apps/api/src/Api && dotnet build 2>&1 | grep -E "error|PlayRecordDto"`
+Expected: errore in `GetPlayRecordQueryHandler.cs` — il `new PlayRecordDto(...)` ora manca l'argomento `Photos`. È atteso (lo sistemiamo in Task 3). NON committare ancora.
+
+> Nota: Task 1→3 sono un'unica unità di compilazione BE; il commit avviene a fine Task 3 quando il build torna verde.
+
+---
+
+## Task 2: BE — Helper presigning DRY (`PlayRecordPhotoUrlResolver`)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs`
+
+- [ ] **Step 1: Crea l'helper estraendo la logica oggi privata in `UploadPlayRecordPhotoCommandHandler.PresignAsync`**
+
+Create `PlayRecordPhotoUrlResolver.cs`:
+
+```csharp
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Resolves a stored PlayRecord photo blob path to a presigned download URL.
+/// Shared by the upload command handler (write path) and the get-record query
+/// handler (read path) so the FilePath→fileId/folder parsing lives in one place.
+/// #2436 PR-C. On local storage GetPresignedDownloadUrlAsync returns null → raw path.
+/// </summary>
+internal static class PlayRecordPhotoUrlResolver
+{
+    public static async Task<string> ResolveAsync(
+        IBlobStorageService blobStorage,
+        string blobPath,
+        int expirySeconds)
+    {
+        // blobPath is the stored FilePath. Mirror SessionAttachmentService.ParseBlobPath:
+        // fileId = substring before the first '_' in the file name; folder = parent dir name.
+        var fileName = Path.GetFileName(blobPath);
+        if (string.IsNullOrEmpty(fileName))
+            return blobPath;
+
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        if (underscoreIndex <= 0)
+            return blobPath;
+
+        var fileId = fileName[..underscoreIndex];
+        var directory = Path.GetDirectoryName(blobPath);
+        if (string.IsNullOrEmpty(directory))
+            return blobPath;
+
+        var folder = Path.GetFileName(directory);
+        if (string.IsNullOrEmpty(folder))
+            return blobPath;
+
+        var signed = await blobStorage
+            .GetPresignedDownloadUrlAsync(fileId, BlobCategory.PlayRecordPhoto, folder, expirySeconds)
+            .ConfigureAwait(false);
+        return signed ?? blobPath;
+    }
+}
+```
+
+- [ ] **Step 2: Refactor `UploadPlayRecordPhotoCommandHandler` per usare l'helper**
+
+In `UploadPlayRecordPhotoCommandHandler.cs`: (a) aggiungi `using Api.BoundedContexts.GameManagement.Application.Services;` se assente; (b) sostituisci la chiamata nel `Handle` (riga ~164) da:
+
+```csharp
+        var url = await PresignAsync(stored.FilePath, cancellationToken).ConfigureAwait(false);
+```
+a:
+```csharp
+        var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, stored.FilePath, PresignExpirySeconds).ConfigureAwait(false);
+```
+(c) **elimina** l'intero metodo privato `private async Task<string> PresignAsync(string blobPath, CancellationToken ct) { ... }`.
+
+- [ ] **Step 3: Build verde + test upload invariati**
+
+Run: `cd apps/api/src/Api && dotnet build 2>&1 | grep -E "error" || echo BUILD_OK`
+Expected: `BUILD_OK` (a parte l'errore atteso del query handler dal Task 1 — se presente, prosegui a Task 3 e builda lì).
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~PlayRecordPhotoUploadTests" 2>&1 | tail -5`
+Expected: PASS (il refactor non cambia il comportamento dell'upload).
+
+---
+
+## Task 3: BE — `GetPlayRecordQueryHandler` espone le foto presigned
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs`
+
+- [ ] **Step 1: Aggiorna il test (ctor + nuovo caso foto) — deve FALLIRE**
+
+In `GetPlayRecordQueryHandlerTests.cs`: aggiungi gli `using` e un mock blob storage; aggiorna il costruttore del SUT; aggiungi il test foto. Sostituisci i campi/ctor:
+
+```csharp
+using Api.Services.Pdf;   // IBlobStorageService, BlobCategory
+using Moq;
+// ...existing usings...
+
+public class GetPlayRecordQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly Mock<IBlobStorageService> _blob;
+    private readonly GetPlayRecordQueryHandler _handler;
+
+    public GetPlayRecordQueryHandlerTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryDbContext();
+        _blob = new Mock<IBlobStorageService>();
+        // Local-storage style: no presigned URL → handler falls back to the raw BlobUrl.
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync((string?)null);
+        _handler = new GetPlayRecordQueryHandler(_context, _blob.Object);
+    }
+```
+
+Aggiungi il nuovo test in fondo alla classe (prima di `Dispose`/helpers):
+
+```csharp
+    [Fact]
+    public async Task Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt()
+    {
+        // Arrange
+        var recordId = Guid.NewGuid();
+        var uploaderId = Guid.NewGuid();
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity> { MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)) };
+        entity.Photos = new List<PlayRecordPhotoEntity>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(), PlayRecordId = recordId,
+                BlobUrl = "play-record-photos/abc/photo1.webp", ThumbnailUrl = "play-record-photos/abc/thumb1.webp",
+                FileSizeBytes = 1234, Sha256Hash = "h1", OcrText = "42", Caption = "scoreboard",
+                UploadedByUserId = uploaderId, UploadedAt = new DateTime(2026, 6, 20, 10, 0, 0, DateTimeKind.Utc),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(), PlayRecordId = recordId,
+                BlobUrl = "play-record-photos/abc/photo2.webp", ThumbnailUrl = null,
+                FileSizeBytes = 5678, Sha256Hash = "h2", OcrText = null, Caption = null,
+                UploadedByUserId = uploaderId, UploadedAt = new DateTime(2026, 6, 20, 9, 0, 0, DateTimeKind.Utc),
+            },
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId, entity.CreatedByUserId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert — ordered ascending by UploadedAt, presign falls back to raw BlobUrl on local
+        result.Photos.Should().HaveCount(2);
+        result.Photos[0].Caption.Should().BeNull();                          // 09:00 first
+        result.Photos[0].Url.Should().Be("play-record-photos/abc/photo2.webp");
+        result.Photos[1].Caption.Should().Be("scoreboard");                  // 10:00 second
+        result.Photos[1].OcrText.Should().Be("42");
+        result.Photos[1].ThumbnailUrl.Should().Be("play-record-photos/abc/thumb1.webp");
+    }
+```
+
+- [ ] **Step 2: Esegui il test → FAIL (compile error: ctor a 1 arg + manca `Photos`)**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~GetPlayRecordQueryHandlerTests.Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt" 2>&1 | tail -15`
+Expected: FAIL — build error (`GetPlayRecordQueryHandler` non ha un ctor a 2 argomenti / `PlayRecordDto` manca `Photos`).
+
+- [ ] **Step 3: Implementa il query handler**
+
+In `GetPlayRecordQueryHandler.cs`: (a) aggiungi `using Api.BoundedContexts.GameManagement.Application.Services;` e `using Api.Services.Pdf;`; (b) inietta `IBlobStorageService`; (c) `Include(Photos)`; (d) mappa con presigning; (e) passa `photos` al DTO.
+
+```csharp
+internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, PlayRecordDto>
+{
+    private const int PresignExpirySeconds = 3600;
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IBlobStorageService _blobStorage;
+
+    public GetPlayRecordQueryHandler(MeepleAiDbContext context, IBlobStorageService blobStorage)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+    }
+
+    public async Task<PlayRecordDto> Handle(GetPlayRecordQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var entity = await _context.PlayRecords
+            .AsNoTracking()
+            .Include(r => r.Players)
+                .ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
+            .FirstOrDefaultAsync(r => r.Id == query.RecordId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity == null)
+            throw new NotFoundException("PlayRecord", query.RecordId.ToString());
+
+        if (entity.CreatedByUserId != query.UserId
+            && !entity.Players.Any(p => p.UserId == query.UserId))
+        {
+            throw new ForbiddenException("You do not have permission to view this play record.");
+        }
+
+        var scoringConfig = System.Text.Json.JsonSerializer.Deserialize<SessionScoringConfigDto>(entity.ScoringConfigJson)
+            ?? new SessionScoringConfigDto(new List<string>(), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        var winnerPlayerIds = PlayRecordOutcomeCalculator.WinnerPlayerIds(entity.Players);
+        var outcomeType = PlayRecordOutcomeCalculator.OutcomeType(entity.Players);
+
+        // Map photos with presigned URLs (read path, #2436 PR-C). Ordered oldest→newest.
+        var photos = new List<PlayRecordPhotoDto>(entity.Photos.Count);
+        foreach (var p in entity.Photos.OrderBy(p => p.UploadedAt))
+        {
+            var url = await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.BlobUrl, PresignExpirySeconds).ConfigureAwait(false);
+            var thumb = p.ThumbnailUrl is null
+                ? null
+                : await PlayRecordPhotoUrlResolver.ResolveAsync(_blobStorage, p.ThumbnailUrl, PresignExpirySeconds).ConfigureAwait(false);
+            photos.Add(new PlayRecordPhotoDto(p.Id, url, thumb, p.OcrText, p.Caption, p.UploadedByUserId, p.UploadedAt));
+        }
+
+        return new PlayRecordDto(
+            entity.Id,
+            entity.GameId,
+            entity.GameName,
+            entity.SessionDate,
+            entity.Duration,
+            (Domain.Enums.PlayRecordStatus)entity.Status,
+            entity.Players.Select(p => new SessionPlayerDto(
+                p.Id,
+                p.UserId,
+                p.DisplayName,
+                p.Scores.Select(s => new SessionScoreDto(s.Dimension, s.Value, s.Unit)).ToList(),
+                PlayRecordOutcomeCalculator.TotalScore(p)
+            )).ToList(),
+            scoringConfig,
+            entity.CreatedByUserId,
+            (Domain.Enums.PlayRecordVisibility)entity.Visibility,
+            entity.StartTime,
+            entity.EndTime,
+            entity.Notes,
+            entity.Location,
+            entity.CreatedAt,
+            entity.UpdatedAt,
+            winnerPlayerIds,
+            outcomeType,
+            photos
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Verifica registrazione DI del handler**
+
+Il handler è risolto via MediatR assembly-scan; `IBlobStorageService` è già registrato (lo usa l'upload handler). Nessuna modifica DI necessaria. Conferma con build.
+
+Run: `cd apps/api/src/Api && dotnet build 2>&1 | grep -E "error" || echo BUILD_OK`
+Expected: `BUILD_OK`
+
+- [ ] **Step 5: Test verde (nuovo + esistenti del handler)**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~GetPlayRecordQueryHandlerTests" 2>&1 | tail -6`
+Expected: PASS (tutti, incluso il nuovo `Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt`).
+
+- [ ] **Step 6: Commit (BE read-path completo)**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordPhotoUrlResolver.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UploadPlayRecordPhotoCommandHandler.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
+git commit -m "feat(play-records): #2436 PR-C expose photos in PlayRecordDto (presigned read-path)"
+```
+
+---
+
+## Task 4: FE — Schema Zod `PlayRecordPhotoSchema` + `photos` su DTO
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/play-records.schemas.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts` (create)
+
+- [ ] **Step 1: Scrivi il test che fallisce**
+
+Create `apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+
+import { PlayRecordDtoSchema, PlayRecordPhotoSchema } from '../play-records.schemas';
+
+describe('PlayRecordPhotoSchema', () => {
+  it('parses a full photo DTO', () => {
+    const parsed = PlayRecordPhotoSchema.parse({
+      id: '11111111-1111-1111-1111-111111111111',
+      url: 'https://cdn.example/p.webp',
+      thumbnailUrl: 'https://cdn.example/t.webp',
+      ocrText: '42',
+      caption: 'scoreboard',
+      uploadedByUserId: '22222222-2222-2222-2222-222222222222',
+      uploadedAt: '2026-06-20T10:00:00Z',
+    });
+    expect(parsed.url).toBe('https://cdn.example/p.webp');
+  });
+
+  it('accepts null thumbnail/ocr/caption', () => {
+    const parsed = PlayRecordPhotoSchema.parse({
+      id: '11111111-1111-1111-1111-111111111111',
+      url: 'https://cdn.example/p.webp',
+      thumbnailUrl: null,
+      ocrText: null,
+      caption: null,
+      uploadedByUserId: '22222222-2222-2222-2222-222222222222',
+      uploadedAt: '2026-06-20T10:00:00Z',
+    });
+    expect(parsed.thumbnailUrl).toBeNull();
+  });
+
+  it('PlayRecordDtoSchema treats photos as optional (BE rollout)', () => {
+    const base = {
+      id: '33333333-3333-3333-3333-333333333333',
+      gameId: null,
+      gameName: 'Catan',
+      sessionDate: '2026-06-20',
+      duration: null,
+      status: 'Completed' as const,
+      players: [],
+      scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+      createdByUserId: '22222222-2222-2222-2222-222222222222',
+      visibility: 'Private' as const,
+      startTime: null,
+      endTime: null,
+      notes: null,
+      location: null,
+      createdAt: '2026-06-20T10:00:00Z',
+      updatedAt: '2026-06-20T10:00:00Z',
+    };
+    expect(PlayRecordDtoSchema.parse(base).photos).toBeUndefined();
+    expect(PlayRecordDtoSchema.parse({ ...base, photos: [] }).photos).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Esegui → FAIL**
+
+Run: `cd apps/web && pnpm test src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts --run 2>&1 | tail -15`
+Expected: FAIL — `PlayRecordPhotoSchema` non esportato.
+
+- [ ] **Step 3: Aggiungi gli schemi**
+
+In `play-records.schemas.ts`, dopo `PlayRecordOutcomeTypeSchema` (riga ~49) e prima di `// ========== DTOs ==========`, aggiungi:
+
+```ts
+// #2436 PR-C: photo attached to a play record (read path). url/thumbnailUrl are
+// presigned download URLs (or raw paths on local storage).
+export const PlayRecordPhotoSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string(),
+  thumbnailUrl: z.string().nullable(),
+  ocrText: z.string().nullable(),
+  caption: z.string().nullable(),
+  uploadedByUserId: z.string().uuid(),
+  uploadedAt: z.string(),
+});
+export type PlayRecordPhoto = z.infer<typeof PlayRecordPhotoSchema>;
+```
+
+Poi in `PlayRecordDtoSchema` (riga ~73), dopo `outcomeType: PlayRecordOutcomeTypeSchema.optional(),` aggiungi:
+
+```ts
+  // #2436 PR-C: photos exposed on read. Optional during BE rollout; tighten later.
+  photos: z.array(PlayRecordPhotoSchema).optional(),
+```
+
+- [ ] **Step 4: Test verde**
+
+Run: `cd apps/web && pnpm test src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts --run 2>&1 | tail -6`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/play-records.schemas.ts apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts
+git commit -m "feat(play-records): #2436 PR-C add PlayRecordPhoto schema + photos field"
+```
+
+---
+
+## Task 5: FE — `playRecordsApi.uploadPhoto` (multipart)
+
+**Files:**
+- Modify: `apps/web/src/lib/api/play-records.api.ts`
+- Test: `apps/web/src/lib/api/__tests__/play-records-upload-photo.test.ts` (create)
+
+- [ ] **Step 1: Scrivi il test che fallisce**
+
+Create `apps/web/src/lib/api/__tests__/play-records-upload-photo.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { playRecordsApi } from '../play-records.api';
+
+describe('playRecordsApi.uploadPhoto', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs multipart with file + flags and returns the result', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        photoId: 'p1',
+        photoUrl: 'https://cdn/p.webp',
+        thumbnailUrl: null,
+        ocrText: '42',
+        wasDeduplicated: false,
+      }),
+    });
+
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    const res = await playRecordsApi.uploadPhoto('rec-1', blob, {
+      caption: 'board',
+      extractScoreFromPhoto: true,
+    });
+
+    expect(res.photoId).toBe('p1');
+    expect(res.ocrText).toBe('42');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/play-records/rec-1/photos');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get('extractScoreFromPhoto')).toBe('true');
+    expect((init.body as FormData).get('caption')).toBe('board');
+  });
+
+  it('throws on non-ok response', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({ ok: false, status: 413, json: async () => ({ error: 'too big' }) });
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    await expect(playRecordsApi.uploadPhoto('rec-1', blob, {})).rejects.toThrow('too big');
+  });
+});
+```
+
+- [ ] **Step 2: Esegui → FAIL**
+
+Run: `cd apps/web && pnpm test src/lib/api/__tests__/play-records-upload-photo.test.ts --run 2>&1 | tail -12`
+Expected: FAIL — `uploadPhoto` non esiste.
+
+- [ ] **Step 3: Implementa `uploadPhoto`**
+
+In `play-records.api.ts`: aggiungi il tipo result in cima (sotto gli import) e il metodo nel blocco Commands (dopo `updateRecord`, prima di `// ========== Queries ==========`):
+
+```ts
+export interface UploadPlayRecordPhotoResult {
+  photoId: string;
+  photoUrl: string;
+  thumbnailUrl: string | null;
+  ocrText: string | null;
+  wasDeduplicated: boolean;
+}
+```
+
+```ts
+  /**
+   * Upload a photo to an existing play record (multipart). #2436 PR-C.
+   * Raw fetch — httpClient does not support multipart FormData.
+   */
+  async uploadPhoto(
+    recordId: string,
+    file: Blob,
+    opts: { caption?: string; extractScoreFromPhoto?: boolean } = {}
+  ): Promise<UploadPlayRecordPhotoResult> {
+    const form = new FormData();
+    form.append('file', file, file instanceof File ? file.name : 'photo.jpg');
+    if (opts.extractScoreFromPhoto) form.append('extractScoreFromPhoto', 'true');
+    if (opts.caption) form.append('caption', opts.caption);
+
+    const res = await fetch(`${BASE_URL}/${recordId}/photos`, {
+      method: 'POST',
+      body: form,
+      credentials: 'include',
+      // Do NOT set Content-Type — browser sets the multipart boundary.
+    });
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ message: 'Failed to upload photo' }));
+      throw new Error(error.error || error.message || 'Failed to upload photo');
+    }
+    return res.json();
+  },
+```
+
+- [ ] **Step 4: Test verde**
+
+Run: `cd apps/web && pnpm test src/lib/api/__tests__/play-records-upload-photo.test.ts --run 2>&1 | tail -6`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/play-records.api.ts apps/web/src/lib/api/__tests__/play-records-upload-photo.test.ts
+git commit -m "feat(play-records): #2436 PR-C add uploadPhoto API client (multipart)"
+```
+
+---
+
+## Task 6: FE — Hook `usePlayRecordPhotoUpload`
+
+**Files:**
+- Create: `apps/web/src/hooks/mutations/usePlayRecordPhotoUpload.ts`
+- Test: `apps/web/src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx` (create)
+
+> Verifica prima la query key usata da `usePlayRecord` per invalidare correttamente. Leggi `apps/web/src/lib/domain-hooks/usePlayRecords.ts` e usa la **stessa** key del `useQuery` di `usePlayRecord(recordId)` (sotto chiamata `playRecordDetailKey`). Se la key è inline (es. `['play-record', recordId]`), usa quell'array verbatim in `invalidateQueries`.
+
+- [ ] **Step 1: Scrivi il test che fallisce**
+
+Create `apps/web/src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx`:
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { playRecordsApi } from '@/lib/api/play-records.api';
+
+import { usePlayRecordPhotoUpload } from '../usePlayRecordPhotoUpload';
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('usePlayRecordPhotoUpload', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('uploads and invalidates the record detail query', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    vi.spyOn(playRecordsApi, 'uploadPhoto').mockResolvedValue({
+      photoId: 'p1', photoUrl: 'u', thumbnailUrl: null, ocrText: null, wasDeduplicated: false,
+    });
+
+    const { result } = renderHook(() => usePlayRecordPhotoUpload('rec-1'), {
+      wrapper: wrapper(client),
+    });
+
+    result.current.mutate({ file: new Blob(['x'], { type: 'image/jpeg' }) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(playRecordsApi.uploadPhoto).toHaveBeenCalledWith('rec-1', expect.any(Blob), {
+      caption: undefined,
+      extractScoreFromPhoto: undefined,
+    });
+    expect(invalidate).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Esegui → FAIL**
+
+Run: `cd apps/web && pnpm test src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx --run 2>&1 | tail -12`
+Expected: FAIL — hook inesistente.
+
+- [ ] **Step 3: Implementa il hook**
+
+Create `usePlayRecordPhotoUpload.ts` (sostituisci `playRecordDetailKey(recordId)` con la key reale verificata sopra):
+
+```ts
+/**
+ * usePlayRecordPhotoUpload — mutation hook for POST /play-records/{id}/photos.
+ * Invalidates the record detail query so the gallery refetches with the new photo.
+ * #2436 PR-C.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { playRecordsApi, type UploadPlayRecordPhotoResult } from '@/lib/api/play-records.api';
+
+export interface UploadPhotoVars {
+  file: Blob;
+  caption?: string;
+  extractScoreFromPhoto?: boolean;
+}
+
+export function usePlayRecordPhotoUpload(recordId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<UploadPlayRecordPhotoResult, Error, UploadPhotoVars>({
+    mutationFn: ({ file, caption, extractScoreFromPhoto }) =>
+      playRecordsApi.uploadPhoto(recordId, file, { caption, extractScoreFromPhoto }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['play-record', recordId] });
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Test verde**
+
+Run: `cd apps/web && pnpm test src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx --run 2>&1 | tail -6`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/mutations/usePlayRecordPhotoUpload.ts apps/web/src/hooks/mutations/__tests__/usePlayRecordPhotoUpload.test.tsx
+git commit -m "feat(play-records): #2436 PR-C add usePlayRecordPhotoUpload hook"
+```
+
+---
+
+## Task 7: FE — i18n `playRecords.photos` (it + en)
+
+**Files:**
+- Modify: `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+
+> Localizza la chiave `playRecords` (già presente con `stats`, `new`). Aggiungi un oggetto `photos` come sibling. Mantieni l'ordine alfabetico/coerente con i sibling esistenti e **identica struttura** tra it ed en (un test MESSAGES verifica la parità delle chiavi — vedi memory i18n-runtime-catalog-gap).
+
+- [ ] **Step 1: Aggiungi `photos` in `it.json`** (dentro `"playRecords": { ... }`)
+
+```json
+"photos": {
+  "sectionTitle": "Foto della partita",
+  "addButton": "Aggiungi foto",
+  "dialogTitle": "Carica foto",
+  "dialogDescription": "JPG, PNG, WebP o HEIC · max 5MB · fino a 10 foto.",
+  "selectLabel": "Seleziona foto",
+  "captionLabel": "Didascalia (opzionale)",
+  "captionPlaceholder": "Es. tabellone finale",
+  "extractScoreLabel": "Estrai il punteggio dalla foto (OCR)",
+  "ocrResultTitle": "Testo rilevato",
+  "uploadCta": "Carica",
+  "uploading": "Caricamento…",
+  "emptyTitle": "Nessuna foto",
+  "emptyDescription": "Carica una foto del tabellone o del tavolo.",
+  "photoAltFallback": "Foto della partita",
+  "dedupToast": "Questa foto è già presente.",
+  "uploadError": "Caricamento foto non riuscito.",
+  "tooLarge": "File troppo grande, massimo 5MB.",
+  "tooMany": "Massimo 10 foto per partita.",
+  "badFormat": "Formato non supportato. Usa JPG, PNG, WebP o HEIC.",
+  "heicFailed": "Conversione HEIC fallita. Riprova con JPEG o PNG.",
+  "lightboxClose": "Chiudi",
+  "lightboxPrev": "Precedente",
+  "lightboxNext": "Successiva"
+}
+```
+
+- [ ] **Step 2: Aggiungi `photos` in `en.json`** (stessa struttura)
+
+```json
+"photos": {
+  "sectionTitle": "Game photos",
+  "addButton": "Add photo",
+  "dialogTitle": "Upload photo",
+  "dialogDescription": "JPG, PNG, WebP or HEIC · max 5MB · up to 10 photos.",
+  "selectLabel": "Select photo",
+  "captionLabel": "Caption (optional)",
+  "captionPlaceholder": "E.g. final board",
+  "extractScoreLabel": "Extract score from photo (OCR)",
+  "ocrResultTitle": "Detected text",
+  "uploadCta": "Upload",
+  "uploading": "Uploading…",
+  "emptyTitle": "No photos",
+  "emptyDescription": "Upload a photo of the board or the table.",
+  "photoAltFallback": "Game photo",
+  "dedupToast": "This photo is already attached.",
+  "uploadError": "Photo upload failed.",
+  "tooLarge": "File too large, max 5MB.",
+  "tooMany": "Max 10 photos per game.",
+  "badFormat": "Unsupported format. Use JPG, PNG, WebP or HEIC.",
+  "heicFailed": "HEIC conversion failed. Try JPEG or PNG.",
+  "lightboxClose": "Close",
+  "lightboxPrev": "Previous",
+  "lightboxNext": "Next"
+}
+```
+
+- [ ] **Step 3: Verifica parità chiavi + typecheck**
+
+Run: `cd apps/web && pnpm test --run -t "MESSAGES" 2>&1 | tail -10`
+Expected: PASS (o nessun test MESSAGES → prosegui). Poi `pnpm typecheck 2>&1 | tail -5` → nessun errore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/locales/it.json apps/web/src/locales/en.json
+git commit -m "feat(play-records): #2436 PR-C add playRecords.photos i18n (it/en)"
+```
+
+---
+
+## Task 8: FE — `PlayRecordPhotoUploadDialog` (multi-file, heic2any, OCR toggle)
+
+**Files:**
+- Create: `apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx`
+- Test: `apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx` (create)
+
+**Design:** Dialog con input file (`multiple`), per ogni file: valida MIME (jpeg/png/webp/heic) + size ≤5MB (HEIC convertito a JPEG **prima** del check con `heic2any`), enforce ≤10 totali. Toggle OCR (applica `extractScoreFromPhoto` a tutti). Caption opzionale singola applicata a tutti i file del batch. Upload sequenziale via il hook; `WasDeduplicated` → toast info. No crop.
+
+- [ ] **Step 1: Scrivi il test che fallisce**
+
+Create `__tests__/PlayRecordPhotoUploadDialog.test.tsx`:
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { playRecordsApi } from '@/lib/api/play-records.api';
+
+import { PlayRecordPhotoUploadDialog } from '../PlayRecordPhotoUploadDialog';
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+describe('PlayRecordPhotoUploadDialog', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('rejects files over 5MB', async () => {
+    render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
+    const big = new File([new Uint8Array(6 * 1024 * 1024)], 'big.jpg', { type: 'image/jpeg' });
+    const input = screen.getByLabelText(/seleziona foto|select photo/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [big] } });
+    expect(await screen.findByText(/massimo 5MB|max 5MB/i)).toBeInTheDocument();
+  });
+
+  it('uploads a valid jpeg with OCR flag', async () => {
+    const spy = vi.spyOn(playRecordsApi, 'uploadPhoto').mockResolvedValue({
+      photoId: 'p1', photoUrl: 'u', thumbnailUrl: null, ocrText: '42', wasDeduplicated: false,
+    });
+    render(wrap(<PlayRecordPhotoUploadDialog recordId="r1" open onClose={() => {}} />));
+    const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByLabelText(/seleziona foto|select photo/i), { target: { files: [file] } });
+    fireEvent.click(screen.getByLabelText(/estrai il punteggio|extract score/i));
+    fireEvent.click(screen.getByRole('button', { name: /carica|upload/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('r1', expect.any(File), expect.objectContaining({ extractScoreFromPhoto: true })));
+  });
+});
+```
+
+- [ ] **Step 2: Esegui → FAIL**
+
+Run: `cd apps/web && pnpm test src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx --run 2>&1 | tail -12`
+Expected: FAIL — componente inesistente.
+
+- [ ] **Step 3: Implementa il componente**
+
+Create `PlayRecordPhotoUploadDialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import { toast } from 'sonner';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+import { usePlayRecordPhotoUpload } from '@/hooks/mutations/usePlayRecordPhotoUpload';
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5MB — matches BE validator
+const MAX_FILES = 10;
+const ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic'];
+
+export interface PlayRecordPhotoUploadDialogProps {
+  recordId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function PlayRecordPhotoUploadDialog({
+  recordId,
+  open,
+  onClose,
+}: PlayRecordPhotoUploadDialogProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const [files, setFiles] = useState<File[]>([]);
+  const [caption, setCaption] = useState('');
+  const [extractScore, setExtractScore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const upload = usePlayRecordPhotoUpload(recordId);
+
+  const handleSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      setError(null);
+      const selected = Array.from(e.target.files ?? []);
+      if (selected.length === 0) return;
+      if (selected.length > MAX_FILES) {
+        setError(t('playRecords.photos.tooMany'));
+        return;
+      }
+
+      const out: File[] = [];
+      for (const file of selected) {
+        if (!ACCEPTED_MIME.includes(file.type)) {
+          setError(t('playRecords.photos.badFormat'));
+          return;
+        }
+        let candidate = file;
+        if (file.type === 'image/heic') {
+          try {
+            const heic2any = (await import('heic2any')).default;
+            const result = await heic2any({ blob: file, toType: 'image/jpeg', quality: 0.9 });
+            const jpegBlob = Array.isArray(result) ? result[0] : result;
+            candidate = new File([jpegBlob], file.name.replace(/\.heic$/i, '.jpg'), {
+              type: 'image/jpeg',
+            });
+          } catch {
+            setError(t('playRecords.photos.heicFailed'));
+            return;
+          }
+        }
+        if (candidate.size > MAX_BYTES) {
+          setError(t('playRecords.photos.tooLarge'));
+          return;
+        }
+        out.push(candidate);
+      }
+      setFiles(out);
+    },
+    [t]
+  );
+
+  const handleUpload = useCallback(async () => {
+    setError(null);
+    try {
+      for (const file of files) {
+        const res = await upload.mutateAsync({
+          file,
+          caption: caption || undefined,
+          extractScoreFromPhoto: extractScore || undefined,
+        });
+        if (res.wasDeduplicated) {
+          toast.info(t('playRecords.photos.dedupToast'));
+        } else if (res.ocrText) {
+          toast.success(`${t('playRecords.photos.ocrResultTitle')}: ${res.ocrText}`);
+        }
+      }
+      setFiles([]);
+      setCaption('');
+      setExtractScore(false);
+      onClose();
+    } catch {
+      setError(t('playRecords.photos.uploadError'));
+    }
+  }, [files, caption, extractScore, upload, t, onClose]);
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogTitle>{t('playRecords.photos.dialogTitle')}</DialogTitle>
+        <DialogDescription>{t('playRecords.photos.dialogDescription')}</DialogDescription>
+
+        <label className="block">
+          <span className="text-sm font-medium">{t('playRecords.photos.selectLabel')}</span>
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/heic"
+            multiple
+            capture="environment"
+            onChange={handleSelect}
+            className="mt-1 block w-full"
+          />
+        </label>
+
+        {files.length > 0 && (
+          <p className="text-sm text-muted-foreground">{files.map(f => f.name).join(', ')}</p>
+        )}
+
+        <label className="block">
+          <span className="text-sm font-medium">{t('playRecords.photos.captionLabel')}</span>
+          <input
+            type="text"
+            value={caption}
+            maxLength={500}
+            onChange={e => setCaption(e.target.value)}
+            placeholder={t('playRecords.photos.captionPlaceholder')}
+            className="mt-1 block w-full rounded-md border border-border bg-card px-3 py-1.5 text-sm"
+          />
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={extractScore}
+            onChange={e => setExtractScore(e.target.checked)}
+          />
+          {t('playRecords.photos.extractScoreLabel')}
+        </label>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            onClick={handleUpload}
+            disabled={files.length === 0 || upload.isPending}
+          >
+            {upload.isPending
+              ? t('playRecords.photos.uploading')
+              : t('playRecords.photos.uploadCta')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Test verde**
+
+Run: `cd apps/web && pnpm test src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx --run 2>&1 | tail -8`
+Expected: PASS
+
+> Se `useTranslation` nei test richiede un provider/mock, segui il pattern dei test esistenti in `apps/web/src/components/play-records/__tests__/` (es. `PlayHistory.test.tsx`) — di norma `useTranslation` ritorna la chiave o un mock globale; adatta i matcher di testo di conseguenza.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoUploadDialog.test.tsx
+git commit -m "feat(play-records): #2436 PR-C photo upload dialog (multi-file, heic2any, OCR toggle)"
+```
+
+---
+
+## Task 9: FE — `PlayRecordPhotoGallery` (grid + lightbox)
+
+**Files:**
+- Create: `apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx`
+- Test: `apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx` (create)
+
+**Design:** grid responsive (2-col mobile / 4-col desktop) seguendo il pattern di `PhotosGallery.tsx`. Click su una tile → apre un lightbox (Dialog) con la foto a piena risoluzione + prev/next + caption + (se presente) OCR text. Empty state quando `photos` è vuoto. Pure-ish: riceve `photos: PlayRecordPhoto[]` + labels via i18n risolte dall'orchestrator. A11y: tile sono `<button>`, lightbox con `aria-label` close/prev/next, navigazione con frecce.
+
+- [ ] **Step 1: Scrivi il test che fallisce**
+
+Create `__tests__/PlayRecordPhotoGallery.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { PlayRecordPhoto } from '@/lib/api/schemas/play-records.schemas';
+
+import { PlayRecordPhotoGallery } from '../PlayRecordPhotoGallery';
+
+const labels = {
+  title: 'Foto',
+  emptyTitle: 'Nessuna foto',
+  emptyDescription: 'Carica una foto',
+  photoAltFallback: 'Foto',
+  ocrResultTitle: 'Testo',
+  close: 'Chiudi',
+  prev: 'Prec',
+  next: 'Succ',
+};
+
+const photos: PlayRecordPhoto[] = [
+  { id: 'a', url: 'http://x/a.webp', thumbnailUrl: null, ocrText: '42', caption: 'board', uploadedByUserId: 'u', uploadedAt: '2026-06-20T09:00:00Z' },
+  { id: 'b', url: 'http://x/b.webp', thumbnailUrl: null, ocrText: null, caption: null, uploadedByUserId: 'u', uploadedAt: '2026-06-20T10:00:00Z' },
+];
+
+describe('PlayRecordPhotoGallery', () => {
+  it('renders empty state', () => {
+    render(<PlayRecordPhotoGallery photos={[]} labels={labels} />);
+    expect(screen.getByText('Nessuna foto')).toBeInTheDocument();
+  });
+
+  it('opens lightbox on tile click and navigates', () => {
+    render(<PlayRecordPhotoGallery photos={photos} labels={labels} />);
+    fireEvent.click(screen.getByRole('button', { name: 'board' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // OCR text of first photo visible
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Succ' }));
+    // second photo has no caption → alt fallback
+    expect(screen.getByAltText('Foto')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Esegui → FAIL**
+
+Run: `cd apps/web && pnpm test src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx --run 2>&1 | tail -12`
+Expected: FAIL — componente inesistente.
+
+- [ ] **Step 3: Implementa il componente**
+
+Create `PlayRecordPhotoGallery.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import clsx from 'clsx';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import type { PlayRecordPhoto } from '@/lib/api/schemas/play-records.schemas';
+
+export interface PlayRecordPhotoGalleryLabels {
+  title: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  photoAltFallback: string;
+  ocrResultTitle: string;
+  close: string;
+  prev: string;
+  next: string;
+}
+
+export interface PlayRecordPhotoGalleryProps {
+  photos: readonly PlayRecordPhoto[];
+  labels: PlayRecordPhotoGalleryLabels;
+  className?: string;
+}
+
+export function PlayRecordPhotoGallery({
+  photos,
+  labels,
+  className,
+}: PlayRecordPhotoGalleryProps): React.JSX.Element {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const close = useCallback(() => setOpenIndex(null), []);
+  const prev = useCallback(
+    () => setOpenIndex(i => (i === null ? null : (i - 1 + photos.length) % photos.length)),
+    [photos.length]
+  );
+  const next = useCallback(
+    () => setOpenIndex(i => (i === null ? null : (i + 1) % photos.length)),
+    [photos.length]
+  );
+
+  if (photos.length === 0) {
+    return (
+      <section
+        data-slot="play-record-photos"
+        data-empty="true"
+        role="status"
+        className={clsx(
+          'flex flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-card px-4 py-8 text-center',
+          className
+        )}
+      >
+        <span aria-hidden="true" className="text-3xl">📷</span>
+        <h3 className="font-display text-sm font-extrabold text-foreground">{labels.emptyTitle}</h3>
+        <p className="text-xs text-muted-foreground">{labels.emptyDescription}</p>
+      </section>
+    );
+  }
+
+  const active = openIndex !== null ? photos[openIndex] : null;
+
+  return (
+    <section data-slot="play-record-photos" className={clsx('flex flex-col gap-2', className)}>
+      <h3 className="font-display text-base font-extrabold text-foreground">
+        <span aria-hidden="true" className="mr-1.5">📷</span>
+        {labels.title}
+      </h3>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {photos.map((p, i) => {
+          const alt = p.caption ?? labels.photoAltFallback;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setOpenIndex(i)}
+              aria-label={alt}
+              className="group relative aspect-square overflow-hidden rounded-md border border-border bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- thumbnail tile */}
+              <img
+                src={p.thumbnailUrl ?? p.url}
+                alt={alt}
+                loading="lazy"
+                className="h-full w-full object-cover transition-transform group-hover:scale-105"
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <Dialog open={active !== null} onOpenChange={o => !o && close()}>
+        <DialogContent className="max-w-3xl">
+          <DialogTitle className="sr-only">{active?.caption ?? labels.photoAltFallback}</DialogTitle>
+          {active && (
+            <div className="flex flex-col gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element -- full-res lightbox */}
+              <img
+                src={active.url}
+                alt={active.caption ?? labels.photoAltFallback}
+                className="max-h-[70vh] w-full rounded-md object-contain"
+              />
+              {active.caption && (
+                <p className="text-sm font-medium text-foreground">{active.caption}</p>
+              )}
+              {active.ocrText && (
+                <p className="rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+                  <span className="font-semibold">{labels.ocrResultTitle}:</span> {active.ocrText}
+                </p>
+              )}
+              {photos.length > 1 && (
+                <div className="flex justify-between">
+                  <button type="button" onClick={prev} aria-label={labels.prev} className="rounded-md px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted">
+                    ← {labels.prev}
+                  </button>
+                  <button type="button" onClick={next} aria-label={labels.next} className="rounded-md px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted">
+                    {labels.next} →
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Test verde**
+
+Run: `cd apps/web && pnpm test src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx --run 2>&1 | tail -8`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx apps/web/src/components/play-records/photos/__tests__/PlayRecordPhotoGallery.test.tsx
+git commit -m "feat(play-records): #2436 PR-C photo gallery + lightbox component"
+```
+
+---
+
+## Task 10: FE — Mount gallery + upload button in `PlayRecordDetailView`
+
+**Files:**
+- Modify: `apps/web/src/components/play-records/PlayRecordDetailView.tsx`
+- Modify: `apps/web/src/components/play-records/__tests__/PlayRecordDetailView.test.tsx`
+
+**Design:** sotto la KpiGrid (riga ~343), prima della Classifica, monta una sezione foto: la gallery (sempre, mostra empty state) + il pulsante "Aggiungi foto" **solo se** `currentUserId === record.createdByUserId`. Il pulsante apre `PlayRecordPhotoUploadDialog`.
+
+- [ ] **Step 1: Aggiungi un test che fallisce nel test esistente**
+
+In `PlayRecordDetailView.test.tsx` aggiungi un caso: con un record che ha `createdByUserId` uguale all'utente corrente e una foto, la gallery section è presente e mostra il pulsante upload. (Riusa il mock di `usePlayRecord` già presente nel file; aggiungi `photos: [...]` al record mockato e `createdByUserId` allineato al mock di `useCurrentUser`.)
+
+```tsx
+  it('shows the photo gallery and the creator-only add button', () => {
+    // arrange: mock usePlayRecord to return a record with one photo, createdByUserId === current user
+    // (segui il pattern di mocking già usato in questo file per usePlayRecord/useCurrentUser)
+    renderDetail({
+      createdByUserId: 'user-1',
+      photos: [
+        { id: 'ph1', url: 'http://x/a.webp', thumbnailUrl: null, ocrText: null, caption: 'board', uploadedByUserId: 'user-1', uploadedAt: '2026-06-20T10:00:00Z' },
+      ],
+    });
+    expect(screen.getByRole('button', { name: /aggiungi foto|add photo/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'board' })).toBeInTheDocument();
+  });
+```
+
+> Adatta `renderDetail(...)` / i mock al pattern reale del file (leggi l'header del test per il setup di `usePlayRecord`/`useCurrentUser`). Se il file non ha un helper `renderDetail`, replica il `render(<PlayRecordDetailView recordId=... />)` con i `vi.mock` già definiti.
+
+- [ ] **Step 2: Esegui → FAIL**
+
+Run: `cd apps/web && pnpm test src/components/play-records/__tests__/PlayRecordDetailView.test.tsx --run 2>&1 | tail -12`
+Expected: FAIL — nessun pulsante "Aggiungi foto".
+
+- [ ] **Step 3: Implementa il mount**
+
+In `PlayRecordDetailView.tsx`: aggiungi gli import e uno stato per il dialog; monta la sezione. Import in cima (con gli altri import locali):
+
+```tsx
+import { useState } from 'react';
+// ...
+import { PlayRecordPhotoGallery } from './photos/PlayRecordPhotoGallery';
+import { PlayRecordPhotoUploadDialog } from './photos/PlayRecordPhotoUploadDialog';
+```
+
+Dentro il componente, dopo `const { data: record, isLoading, error } = usePlayRecord(recordId);` aggiungi:
+
+```tsx
+  const [photoDialogOpen, setPhotoDialogOpen] = useState(false);
+```
+
+Dopo aver calcolato `currentUserId` (riga ~252) aggiungi:
+
+```tsx
+  const isCreator = currentUserId !== null && currentUserId === record.createdByUserId;
+```
+
+Nel JSX, subito dopo il blocco `<KpiGrid ... />` (riga ~343, dentro il container `max-w-4xl`) inserisci:
+
+```tsx
+        {/* Photos — #2436 PR-C */}
+        <section aria-label={t('playRecords.photos.sectionTitle')} className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <span className="sr-only">{t('playRecords.photos.sectionTitle')}</span>
+            {isCreator && (
+              <button
+                type="button"
+                onClick={() => setPhotoDialogOpen(true)}
+                className="ml-auto rounded-md border border-border px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+              >
+                📷 {t('playRecords.photos.addButton')}
+              </button>
+            )}
+          </div>
+          <PlayRecordPhotoGallery
+            photos={record.photos ?? []}
+            labels={{
+              title: t('playRecords.photos.sectionTitle'),
+              emptyTitle: t('playRecords.photos.emptyTitle'),
+              emptyDescription: t('playRecords.photos.emptyDescription'),
+              photoAltFallback: t('playRecords.photos.photoAltFallback'),
+              ocrResultTitle: t('playRecords.photos.ocrResultTitle'),
+              close: t('playRecords.photos.lightboxClose'),
+              prev: t('playRecords.photos.lightboxPrev'),
+              next: t('playRecords.photos.lightboxNext'),
+            }}
+          />
+        </section>
+
+        {isCreator && (
+          <PlayRecordPhotoUploadDialog
+            recordId={recordId}
+            open={photoDialogOpen}
+            onClose={() => setPhotoDialogOpen(false)}
+          />
+        )}
+```
+
+- [ ] **Step 4: Test verde + suite detail**
+
+Run: `cd apps/web && pnpm test src/components/play-records/__tests__/PlayRecordDetailView.test.tsx --run 2>&1 | tail -8`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/play-records/PlayRecordDetailView.tsx apps/web/src/components/play-records/__tests__/PlayRecordDetailView.test.tsx
+git commit -m "feat(play-records): #2436 PR-C mount photo gallery + creator-only upload in detail view"
+```
+
+---
+
+## Task 11: FE — A11y + full-suite verification
+
+**Files:**
+- Modify (se serve): `apps/web/src/components/play-records/__tests__/play-records-axe.test.tsx`
+
+- [ ] **Step 1: Aggiungi uno smoke axe per la gallery (stato con foto + empty)**
+
+Nel file axe esistente aggiungi un render della `PlayRecordPhotoGallery` (con 1 foto e con 0 foto) dentro un `axe(container)` assert `toHaveNoViolations()`. Segui il pattern degli altri blocchi del file.
+
+- [ ] **Step 2: Esegui axe**
+
+Run: `cd apps/web && pnpm test src/components/play-records/__tests__/play-records-axe.test.tsx --run 2>&1 | tail -8`
+Expected: PASS — 0 violazioni (in particolare 0 color-contrast, gate AA blocking).
+
+- [ ] **Step 3: Typecheck + lint (incl. token + BGG gates)**
+
+Run: `cd apps/web && pnpm typecheck && pnpm lint 2>&1 | tail -20`
+Expected: nessun errore. In particolare `local/no-hardcoded-color-utility` (i nuovi componenti usano solo token semantici `bg-card`/`text-foreground`/`border-border`/`bg-muted`/`text-destructive`).
+
+- [ ] **Step 4: Suite play-records completa**
+
+Run: `cd apps/web && pnpm test src/components/play-records src/hooks/mutations src/lib/api --run 2>&1 | tail -15`
+Expected: PASS (0 regressioni rispetto alla baseline).
+
+- [ ] **Step 5: Build BE finale (sanity)**
+
+Run: `cd apps/api/src/Api && dotnet build 2>&1 | grep -E "error" || echo BUILD_OK`
+Expected: `BUILD_OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/play-records/__tests__/play-records-axe.test.tsx
+git commit -m "test(play-records): #2436 PR-C axe smoke for photo gallery"
+```
+
+---
+
+## Self-review notes (per l'esecutore)
+
+- **Verifica query key** (Task 6): `['play-record', recordId]` è un'ipotesi — confermala leggendo `usePlayRecord` in `apps/web/src/lib/domain-hooks/usePlayRecords.ts` e allinea l'`invalidateQueries`. Se diversa, aggiorna anche il test del Task 6.
+- **Pattern `useTranslation` nei test**: alcuni test usano un mock che ritorna la chiave; i matcher regex (`/aggiungi foto|add photo/i`) coprono entrambi i casi (label tradotta o chiave). Se il file detail usa già un mock specifico, riusalo.
+- **Local storage**: in dev/test le foto non si presignano (URL = raw path), identico al comportamento dell'upload handler — non è una regressione. In staging/prod (S3/R2) il presigning è attivo.
+- **Confine**: nessun upload nel create wizard (record inesistente); upload solo dalla detail view creator-only. Conflict-UI/share/audit/MVP sono fuori da questo PR (→ #2437).
+- **DEC C1 coperta** da Task 1+3. **OCR (DEC-3)** coperto da toggle Task 8 + display read-only (m3, no auto-apply). **Dedup (m2)** Task 8. **Limiti 5MB/MIME (m1)** Task 8. **i18n (m4)** Task 7. **Gallery una sola volta (m5)** Task 9/10.
+
+## Closing (a fine implementazione)
+- PR verso **main-dev** (parent). Titolo: `feat(play-records): #2436 PR-C photo upload UI + gallery + OCR toggle (FE) + DTO read-path (BE)`.
+- Body: linka #2436, riassumi C1, elenca i task, nota che #2436 è completo dopo questo merge (PR-A+PR-B+PR-C) → chiudi #2436.
+- Code-review prima del merge (superpowers:requesting-code-review o feature-dev:code-reviewer).

--- a/docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md
+++ b/docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md
@@ -1,0 +1,116 @@
+# #2436 PR-C + #2437 — Play Records photo UI + detail/edit deferred — Spec-Panel Consolidated Spec
+
+> **Source**: `/sc:spec-panel --mode critique` 2026-06-20 (Wiegers, Fowler, Nygard, Newman, Adzic, Crispin) + 3-agent codebase discovery + fattuale BE/FE verification. Segue [[2026-06-20-issue-2436-create-deferred-spec-panel]] (PR-A/PR-B già MERGED). Companion plans: da scrivere per ciascun PR.
+
+**Issues**: [#2436](https://github.com/meepleAi-app/meepleai-monorepo/issues/2436) (create deferred — resta PR-C) · [#2437](https://github.com/meepleAi-app/meepleai-monorepo/issues/2437) (detail/edit deferred). Parent: #2346. Mockups: `admin-mockups/design_files/sp4-play-records-{new,detail,edit}.{html,jsx}`.
+
+## Stato pregresso (MERGED su main-dev)
+
+- **#2436 PR-A** (autosave + draft localStorage) → `eaf1e7093` (PR #2448).
+- **#2436 PR-B** (photo upload pipeline + OCR + **xmin** + **middleware globale `DbUpdateConcurrencyException → 409` + header `X-Warning-Code: concurrent-edit`**) → `dd5f14529` (PR #2450).
+- BE foundation shipped copre: scrittura foto (`POST /photos`), xmin optimistic-concurrency token (server-owned), mapping 409 globale.
+
+## Locked decisions (user, 2026-06-20 — questa sessione)
+
+| ID | Decisione | Rationale |
+|----|-----------|-----------|
+| **C1** | **Estendi `PlayRecordDto` con `photos[]`** (mappato nel `GET /{id}` esistente) | Gallery persistente richiede read-path. 1 round-trip vs endpoint dedicato. PR-C diventa FE + mini-BE. |
+| **C2** | **Conflict-UI stale-form completo (BE+FE)** | Espone xmin end-to-end (DTO + UpdateRequest + handler check) per coprire il caso "qualcuno ha salvato mentre editavi" — non solo race concorrenti. |
+| **M1** | **#2437 completo (BE+FE)** | Include share-token (BE greenfield) + audit/restore (BE greenfield) nello stesso ciclo, oltre conflict-UI + gallery-mount + MVP. |
+| **M3** | **MVP = winner derivato** | Riusa `WinnerPlayerIds` (già nel DTO, da dimension `wins>0`). Zero BE. Chip non appare nei cooperativi/senza-winner. |
+
+### Decisioni ereditate (ancora valide)
+- **DEC-1** Sequenziale: **#2436 completo (PR-C), poi #2437**.
+- **DEC-3** OCR = wire ora via smoldocling (già shipped in PR-B).
+- **#2437-5 edit-window 7d immutability + 410 → DROPPATO** (mantieni invariante "edit allowed after completion for corrections").
+
+## Panel findings
+
+### ❌ CRITICAL (risolti dalle decisioni)
+- **C1 — Gallery senza read-path**: `PlayRecordDto.cs:10-29` non ha `photos`; endpoint solo `POST /photos`, nessun `GET`. → **risolto da C1** (estendi DTO).
+- **C2 — Conflict-UI vs xmin server-owned**: `PlayRecord.cs:51` xmin `internal`/repository-only, non nel DTO né nel `UpdatePlayRecordCommand` (solo recordId/userId/sessionDate/notes/location). 409 scatta solo su race DB concorrenti, non su form-stale → last-write-wins silenzioso. → **risolto da C2** (xmin end-to-end).
+
+### ⚠️ MAJOR
+- **M1 — #2437 non è FE-only**: share-token greenfield (entity field + 2 cmd handler + 1 query + 3 endpoint + migration + route pubblica anonima); audit opt-in `[Auditable]` (facile) ma **restore-version greenfield totale** (tabella + endpoint list/restore + UI). → **accettato da M1** (#2437 completo).
+- **M2 — `CustomCoverDialog` non è riuso diretto**: è single-file + crop obbligatorio (cover 200×300 WebP). Si riusa il *pattern* `heic2any` (`CustomCoverDialog.tsx:55-67`) + `useCustomCoverUpload` (multipart raw-fetch, `useCustomCoverUpload.ts:38-44`). **BE accetta solo JPEG/PNG/WebP, NON HEIC** → conversione client-side **obbligatoria**.
+- **M3 — "MVP" ambiguo**: domain ha solo winner derivato. → **risolto da M3** (= winner).
+
+### 🔸 MINOR (registrati per i plan)
+- **m1** FE enforce **5MB** (non 10MB) + MIME JPEG/PNG/WebP; convertire HEIC→JPEG **prima** del check size.
+- **m2** Dedup UX: response ha `WasDeduplicated` → non duplicare la card, segnalare "foto già presente".
+- **m3** OCR UX: response ha `OcrText` → mostra read-only (es. pre-compila Note), **NON** auto-applicare agli score (rischio dati errati). Da confermare nel plan PR-C.
+- **m4** i18n: manca `playRecords.photos` in `it/en.json`.
+- **m5** Overlap gallery: "gallery+lightbox" (PR-C) e "photo gallery" (#2437) = **stessa** gallery. Costruita una volta in PR-C; #2437 ci monta sopra MVP chip.
+
+## Struttura PR proposta (DEC-1 sequenziale)
+
+| Ordine | PR | Stack | Contenuto |
+|--------|----|----|-----------|
+| 1 | **#2436 PR-C** | mini-BE + FE | `PlayRecordDto.photos[]` (C1) + upload multi-file (heic2any client-side) + OCR toggle + gallery + lightbox + dedup UX + i18n |
+| 2 | **#2437-1** | BE + FE | Conflict-UI stale-form (C2: xmin end-to-end) + MVP chip (M3, gallery-mount nel DetailView) |
+| 3 | **#2437-2** | BE + FE | Share-token (pattern `GameNightPlaylist`) + route pubblica read-only |
+| 4 | **#2437-3** | BE + FE | Audit (`[Auditable]` opt-in) + restore-version (greenfield: tabella + list last-5 + restore) |
+
+> **Rischio #2437-3**: restore-version è greenfield totale (zero prior-art). Merita un mini-brainstorm sulla snapshot strategy (quando si crea una versione: ad ogni update? solo su K5 fields? last-5 retention) prima del plan.
+
+## PR-C — spec (prossimo deliverable)
+
+### Goal
+UI per caricare foto di una partita (scoresheet/board/tavolo), con OCR opt-in, e visualizzarle in una gallery con lightbox nella detail view. Mini-estensione BE per esporre le foto in lettura.
+
+### BE (mini)
+- **AC-BE1** `PlayRecordDto` espone `Photos` (`IReadOnlyList<PlayRecordPhotoDto>`): `Id, BlobUrl, ThumbnailUrl?, OcrText?, Caption?, UploadedByUserId, UploadedAt`. (Non esporre `Sha256Hash`/`FileSizeBytes`/`OcrConfidence` al client salvo necessità.)
+- **AC-BE2** `GetPlayRecordQueryHandler` carica le foto del record (Include/projection) e le mappa nel DTO ordinate per `UploadedAt`.
+- **AC-BE3** Authz invariata: il GET record già applica visibilità/ownership; le foto seguono il record.
+
+### FE
+- **AC-C1** Schema Zod `PlayRecordPhotoSchema` + `photos: z.array(...).optional()` su `PlayRecordDtoSchema` (optional durante rollout, tighten dopo).
+- **AC-C2** `playRecordsApi.uploadPhoto(recordId, blob, { caption?, extractScoreFromPhoto? })` — multipart raw-fetch (pattern `useCustomCoverUpload`), header auth.
+- **AC-C3** Hook `usePlayRecordPhotoUpload` (TanStack mutation) → su success invalida `usePlayRecord(recordId)`.
+- **AC-C4** Componente upload **multi-file** (≤10 file, ≤5MB ciascuno post-conversione, JPEG/PNG/WebP): HEIC→JPEG client-side via `heic2any` dynamic import **prima** del size check. **No crop.**
+- **AC-C5** OCR toggle ("📷 Estrai punteggio dalla foto") → passa `extractScoreFromPhoto=true`; alla risposta mostra `OcrText` read-only (m3), no auto-apply agli score.
+- **AC-C6** Dedup: se `WasDeduplicated=true` → toast "foto già presente", non aggiungere card duplicata.
+- **AC-C7** Gallery + lightbox nella `PlayRecordDetailView` (riusa/adatta `SessionPhotoGallery` che ha lightbox built-in, o `PhotosGallery` + dialog lightbox). A11y: keyboard nav, alt text.
+- **AC-C8** i18n `playRecords.photos.*` (it/en): title, uploadButton, dragHint, extractScoreLabel, captionLabel, emptyState, dedupToast, errors.
+- **AC-C9** Limiti FE allineati al BE (5MB, MIME) con errore pre-upload chiaro.
+
+### Non-goals PR-C
+- Conflict-UI 409 (→ #2437-1). Share/audit/restore (→ #2437-2/3). MVP chip (→ #2437-1). Auto-apply OCR agli score.
+
+## Reuse map (verificata, file:line)
+
+**Photo upload/gallery (PR-C)**
+- heic2any pattern: `apps/web/src/components/features/library/custom-cover/CustomCoverDialog.tsx:55-67`
+- multipart raw-fetch: `apps/web/src/hooks/mutations/useCustomCoverUpload.ts:38-44`
+- gallery+lightbox: `apps/web/src/components/session/SessionPhotoGallery.tsx` (built-in) · pure: `apps/web/src/components/features/session-summary/PhotosGallery.tsx`
+- BE upload endpoint: `apps/api/src/Api/Routing/PlayRecordEndpoints.cs:91,224-248` — fields `file`/`extractScoreFromPhoto`/`caption`; response `PlayRecordPhotoUploadResult(PhotoId, PhotoUrl, ThumbnailUrl?, OcrText?, WasDeduplicated)`
+- entity: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecordPhoto.cs:11-61`
+- DTO da estendere: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs:10-29`
+- query handler: `GetPlayRecordQueryHandler` (GameManagement/Application/Queries/PlayRecords)
+- FE schema: `apps/web/src/lib/api/schemas/play-records.schemas.ts:53-75`
+- FE api client: `apps/web/src/lib/api/play-records.api.ts`
+- detail mount: `apps/web/src/components/play-records/PlayRecordDetailView.tsx`
+
+**Conflict-UI (#2437-1)**
+- xmin: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs:49-54`
+- update cmd: `UpdatePlayRecordCommand.cs` + `UpdatePlayRecordCommandHandler.cs`
+- update endpoint: `PlayRecordEndpoints.cs:71,200-207`
+- FE edit page: `apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx:59-86`
+- pattern errori tipizzati (live-session): `apps/web/src/hooks/use-update-session-scores.ts:44-54`, `ScoreTabContent.tsx:40-70`
+- MVP source: `PlayRecordOutcomeCalculator.cs:25-68` (WinnerPlayerIds nel DTO)
+
+**Share-token (#2437-2)**
+- domain: `GameNightPlaylist.cs:194-213` (Generate/Revoke)
+- handlers: `GenerateShareLinkCommandHandler.cs:34`, `RevokeShareLinkCommandHandler.cs`, `GetPlaylistByShareTokenQueryHandler.cs`
+- endpoints: `PlaylistEndpoints.cs:176,193,210-222` (`POST /share`, `DELETE /share`, `GET /shared/{token}` AllowAnonymous)
+- FE toast: `apps/web/src/components/ui/share-success-toast/share-success-toast.tsx`
+
+**Audit/restore (#2437-3)**
+- audit infra: `AuditingSaveChangesInterceptor.cs`, `AuditableAttribute.cs`, `AuditLoggingBehavior.cs`
+- restore-version: **greenfield** (nessun prior-art)
+
+## References
+- ADR-067 (photo pipeline): `docs/for-claude/architecture/adr/adr-067-playrecord-photo-upload-pipeline.md`
+- ADR-066 (ownership/creator-only): `docs/for-claude/architecture/adr/adr-066-playrecord-ownership-model.md`
+- ADR-060 (xmin/live-session persistence): `docs/for-claude/architecture/adr/adr-060-live-session-persistence.md`
+- Spec PR-A/PR-B: `docs/superpowers/specs/2026-06-20-issue-2436-create-deferred-spec-panel.md`


### PR DESCRIPTION
## Summary

Completa **#2436** (ultimo dei 3 PR, dopo PR-A autosave `eaf1e7093` + PR-B BE photo pipeline `dd5f14529`). Aggiunge il photo UI end-to-end per i Play Records.

- **BE read-path** (decisione spec-panel **C1**): `PlayRecordDto.photos[]` con URL **presigned**, esposti da `GetPlayRecordQueryHandler`; logica di presigning estratta in un helper DRY `PlayRecordPhotoUrlResolver` condiviso con l'upload handler (dedup + success path).
- **FE**: schema Zod `PlayRecordPhotoSchema` + `playRecordsApi.uploadPhoto` (multipart) + hook `usePlayRecordPhotoUpload` (invalida `playRecordsKeys.detail`); dialog upload **multi-file** (HEIC→JPEG client-side via `heic2any`, ≤5MB/≤10 file, **OCR toggle**, caption, dedup toast); **gallery + lightbox** (grid, prev/next); montati nella `PlayRecordDetailView` con pulsante upload **creator-only** (ADR-066, defense-in-depth; enforcement reale lato BE) e gallery visibile a ogni viewer del record; i18n it/en.

MVP=winner derivato (M3), conflict-UI stale-form (C2) e share-token/audit-restore (M1) sono pianificati per **#2437** (vedi spec consolidato).

## Spec & Plan
- Spec-panel: `docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md`
- Plan (11 task TDD): `docs/superpowers/plans/2026-06-20-issue-2436-pr-c-photo-ui.md`

## Test Plan
- [x] BE: `GetPlayRecordQueryHandlerTests` + `PlayRecordPhotoUploadTests` — 14/14
- [x] FE unit TDD: schema, api client, hook, upload dialog, gallery
- [x] FE: detail-view creator-only mount + axe AA gallery — 29/29
- [x] FE full play-records suite — 1510/1510 (no regressioni)
- [x] `pnpm typecheck` + `pnpm lint` clean

## Review
- Per-task two-stage review (spec + quality) durante l'esecuzione subagent-driven; 3 fix applicati in-PR (dedup thumbnail presign, camera-capture removal, success-path thumbnail presign + a11y double-announce).
- Final holistic review: **READY_TO_MERGE**.

Closes #2436

🤖 Generated with [Claude Code](https://claude.com/claude-code)