### PR TITLE
feat(session-live): #2431 polymorphic EndgameDialog finalScores adapter

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -115,6 +115,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
 import { hasRequiredRole } from '@/lib/session-live/participant-role';
+import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
 import {
   deriveSessionLiveUiState,
   deriveSessionLiveDialogState,
@@ -953,6 +954,12 @@ export function SessionLiveView(): ReactElement {
 
   const setScoringConfig = useLiveSessionStore(s => s.setScoringConfig);
 
+  // #2431: polymorphic endgame summary — selectors feed mapScoreDataToEndgameSummary
+  // below. Subscribed reactively so the EndgameDialog refreshes as scoreData
+  // changes (final-tick edits before the host acknowledges).
+  const endgameScoringType = useLiveSessionStore(s => s.scoringType);
+  const endgameScoreData = useLiveSessionStore(s => s.scoreData);
+
   // #2389 Block B + #2430 Block B+: REST hydration with race guard +
   // observability. Pre-populate the store from sessionQuery.data on initial
   // mount so the renderer paints in ~300ms instead of waiting for SignalR.
@@ -1388,11 +1395,19 @@ export function SessionLiveView(): ReactElement {
       {dialogState === 'endgame' && (
         <Suspense fallback={null}>
           <EndgameDialog
-            finalScores={activeSession.players.map(p => ({
-              playerName: p.name,
-              score: p.score,
-              isWinner: false,
-            }))}
+            finalScores={
+              endgameScoringType !== null && endgameScoreData !== null
+                ? mapScoreDataToEndgameSummary(
+                    endgameScoringType,
+                    endgameScoreData,
+                    activeSession.players
+                  )
+                : activeSession.players.map(p => ({
+                    playerName: p.name,
+                    score: p.score,
+                    isWinner: false,
+                  }))
+            }
             endedAt={endgameEvent?.endedAt ?? '—'}
             endedBy={endgameEvent?.endedBy ?? '—'}
             onAcknowledge={() => handleDialogChange('none')}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -1395,6 +1395,12 @@ export function SessionLiveView(): ReactElement {
       {dialogState === 'endgame' && (
         <Suspense fallback={null}>
           <EndgameDialog
+            // #2431: polymorphic path when scoringType + scoreData are loaded;
+            // otherwise the legacy `{ score, isWinner: false }` shape keeps the
+            // dialog renderable during cold-start.
+            // TODO(#2389 Block C cleanup): once the legacy `p.score` scalar is
+            // removed by the polymorphic migration, drop this fallback and
+            // either return [] or gate the dialog mount on scoringType !== null.
             finalScores={
               endgameScoringType !== null && endgameScoreData !== null
                 ? mapScoreDataToEndgameSummary(

--- a/apps/web/src/lib/session-live/__tests__/score-data-to-endgame-summary.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/score-data-to-endgame-summary.test.ts
@@ -92,6 +92,18 @@ describe('mapScoreDataToEndgameSummary — Points', () => {
       { playerName: 'Luca', score: 0, isWinner: false },
     ]);
   });
+
+  it('treats all-zero (no one scored) as no winner', () => {
+    const scoreData: ScoreDataByType['Points'] = {
+      scores: [
+        { playerId: 'p1', points: 0 },
+        { playerId: 'p2', points: 0 },
+        { playerId: 'p3', points: 0 },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Points', scoreData, PLAYERS);
+    expect(result.every(r => !r.isWinner)).toBe(true);
+  });
 });
 
 // ─── BinaryWin ────────────────────────────────────────────────────────────────
@@ -161,6 +173,24 @@ describe('mapScoreDataToEndgameSummary — Ranking', () => {
     const result = mapScoreDataToEndgameSummary('Ranking', scoreData, PLAYERS);
     expect(result[0]).toEqual({ playerName: 'Marco', score: 1, isWinner: false });
     expect(result[1]).toEqual({ playerName: 'Anna B.', score: 3, isWinner: true });
+    expect(result[2]).toEqual({ playerName: 'Luca', score: 1, isWinner: false });
+  });
+
+  it('clamps out-of-range positions to [1, N] without crowning (defensive)', () => {
+    // BE bug / store desync: position 0 (off-by-one) and position > N.
+    // The synthetic score must stay in [1, N]; isWinner stays strict on
+    // position === 1, so position 0 is NOT crowned.
+    const scoreData: ScoreDataByType['Ranking'] = {
+      positions: [
+        { playerId: 'p1', position: 0 }, // out-of-range low
+        { playerId: 'p2', position: 1 }, // real winner
+        { playerId: 'p3', position: 99 }, // out-of-range high
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Ranking', scoreData, PLAYERS);
+    expect(result[0]).toEqual({ playerName: 'Marco', score: 3, isWinner: false }); // clamped to pos 1 → score 3, but NOT winner
+    expect(result[1]).toEqual({ playerName: 'Anna B.', score: 3, isWinner: true });
+    expect(result[2]).toEqual({ playerName: 'Luca', score: 1, isWinner: false }); // clamped to pos N
   });
 });
 

--- a/apps/web/src/lib/session-live/__tests__/score-data-to-endgame-summary.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/score-data-to-endgame-summary.test.ts
@@ -1,0 +1,224 @@
+/**
+ * mapScoreDataToEndgameSummary unit tests — Issue #2431.
+ *
+ * Pure adapter that derives EndgameDialog.finalScores (winner badge + sorted
+ * display) from the polymorphic store shape. Replaces the hardcoded
+ * `isWinner: false` mapping at SessionLiveView.tsx (#2389 Block B leftover).
+ *
+ * Winner rules per variant:
+ *   Points     → first player with max points (tie-break by player order).
+ *   BinaryWin  → every player with isWinner: true (co-op / multi-winner OK).
+ *   Ranking    → position === 1 is the winner.
+ *   Objectives → first player with max completedObjectives.length (tie-break).
+ *
+ * Score field semantics (Dialog already sorts winners first, then score DESC):
+ *   Points     → raw points.
+ *   BinaryWin  → 0 (winner status drives visibility; score is unused).
+ *   Ranking    → (players.length - position + 1) so winner is highest, last is 1.
+ *   Objectives → completedObjectives.length.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
+import type { ScoreDataByType } from '@/components/sessions/score-strategies/types';
+
+const PLAYERS = [
+  { id: 'p1', name: 'Marco' },
+  { id: 'p2', name: 'Anna', displayName: 'Anna B.' },
+  { id: 'p3', name: 'Luca' },
+] as const;
+
+// ─── Null gates ───────────────────────────────────────────────────────────────
+
+describe('mapScoreDataToEndgameSummary — null gates', () => {
+  it('returns empty array when scoringType is null', () => {
+    const result = mapScoreDataToEndgameSummary(null, { scores: [] }, PLAYERS);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when scoreData is null', () => {
+    const result = mapScoreDataToEndgameSummary('Points', null, PLAYERS);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when both null', () => {
+    const result = mapScoreDataToEndgameSummary(null, null, PLAYERS);
+    expect(result).toEqual([]);
+  });
+});
+
+// ─── Points ───────────────────────────────────────────────────────────────────
+
+describe('mapScoreDataToEndgameSummary — Points', () => {
+  it('marks the top scorer as winner', () => {
+    const scoreData: ScoreDataByType['Points'] = {
+      scores: [
+        { playerId: 'p1', points: 7 },
+        { playerId: 'p2', points: 12 },
+        { playerId: 'p3', points: 3 },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Points', scoreData, PLAYERS);
+    expect(result).toEqual([
+      { playerName: 'Marco', score: 7, isWinner: false },
+      { playerName: 'Anna B.', score: 12, isWinner: true },
+      { playerName: 'Luca', score: 3, isWinner: false },
+    ]);
+  });
+
+  it('tie-breaks by player order (first with max wins)', () => {
+    const scoreData: ScoreDataByType['Points'] = {
+      scores: [
+        { playerId: 'p1', points: 10 },
+        { playerId: 'p2', points: 10 },
+        { playerId: 'p3', points: 5 },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Points', scoreData, PLAYERS);
+    expect(result.filter(r => r.isWinner)).toEqual([
+      { playerName: 'Marco', score: 10, isWinner: true },
+    ]);
+  });
+
+  it('pads missing player with score 0 (non-winner)', () => {
+    const scoreData: ScoreDataByType['Points'] = {
+      scores: [{ playerId: 'p1', points: 5 }],
+    };
+    const result = mapScoreDataToEndgameSummary('Points', scoreData, PLAYERS);
+    expect(result).toEqual([
+      { playerName: 'Marco', score: 5, isWinner: true },
+      { playerName: 'Anna B.', score: 0, isWinner: false },
+      { playerName: 'Luca', score: 0, isWinner: false },
+    ]);
+  });
+});
+
+// ─── BinaryWin ────────────────────────────────────────────────────────────────
+
+describe('mapScoreDataToEndgameSummary — BinaryWin', () => {
+  it('mirrors isWinner from scoreData (single winner)', () => {
+    const scoreData: ScoreDataByType['BinaryWin'] = {
+      results: [
+        { playerId: 'p1', isWinner: false },
+        { playerId: 'p2', isWinner: true },
+        { playerId: 'p3', isWinner: false },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('BinaryWin', scoreData, PLAYERS);
+    expect(result).toEqual([
+      { playerName: 'Marco', score: 0, isWinner: false },
+      { playerName: 'Anna B.', score: 0, isWinner: true },
+      { playerName: 'Luca', score: 0, isWinner: false },
+    ]);
+  });
+
+  it('supports multi-winner (co-op)', () => {
+    const scoreData: ScoreDataByType['BinaryWin'] = {
+      results: [
+        { playerId: 'p1', isWinner: true },
+        { playerId: 'p2', isWinner: true },
+        { playerId: 'p3', isWinner: true },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('BinaryWin', scoreData, PLAYERS);
+    expect(result.every(r => r.isWinner)).toBe(true);
+  });
+
+  it('defaults missing player to isWinner: false', () => {
+    const scoreData: ScoreDataByType['BinaryWin'] = {
+      results: [{ playerId: 'p1', isWinner: true }],
+    };
+    const result = mapScoreDataToEndgameSummary('BinaryWin', scoreData, PLAYERS);
+    expect(result[1]).toEqual({ playerName: 'Anna B.', score: 0, isWinner: false });
+  });
+});
+
+// ─── Ranking ──────────────────────────────────────────────────────────────────
+
+describe('mapScoreDataToEndgameSummary — Ranking', () => {
+  it('marks position 1 as winner with highest synthetic score', () => {
+    const scoreData: ScoreDataByType['Ranking'] = {
+      positions: [
+        { playerId: 'p1', position: 2 },
+        { playerId: 'p2', position: 1 },
+        { playerId: 'p3', position: 3 },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Ranking', scoreData, PLAYERS);
+    // score = players.length - position + 1 → winner (pos 1) gets N (=3), last (pos N) gets 1
+    expect(result).toEqual([
+      { playerName: 'Marco', score: 2, isWinner: false }, // pos 2 → 3-2+1=2
+      { playerName: 'Anna B.', score: 3, isWinner: true }, // pos 1 → 3-1+1=3
+      { playerName: 'Luca', score: 1, isWinner: false }, // pos 3 → 3-3+1=1
+    ]);
+  });
+
+  it('defaults missing player to last position (score 1, not winner)', () => {
+    const scoreData: ScoreDataByType['Ranking'] = {
+      positions: [{ playerId: 'p2', position: 1 }],
+    };
+    const result = mapScoreDataToEndgameSummary('Ranking', scoreData, PLAYERS);
+    expect(result[0]).toEqual({ playerName: 'Marco', score: 1, isWinner: false });
+    expect(result[1]).toEqual({ playerName: 'Anna B.', score: 3, isWinner: true });
+  });
+});
+
+// ─── Objectives ───────────────────────────────────────────────────────────────
+
+describe('mapScoreDataToEndgameSummary — Objectives', () => {
+  it('marks the player with most completed objectives as winner', () => {
+    const scoreData: ScoreDataByType['Objectives'] = {
+      completedByPlayer: [
+        { playerId: 'p1', objectives: ['A'] },
+        { playerId: 'p2', objectives: ['A', 'B', 'C'] },
+        { playerId: 'p3', objectives: ['A', 'B'] },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Objectives', scoreData, PLAYERS);
+    expect(result).toEqual([
+      { playerName: 'Marco', score: 1, isWinner: false },
+      { playerName: 'Anna B.', score: 3, isWinner: true },
+      { playerName: 'Luca', score: 2, isWinner: false },
+    ]);
+  });
+
+  it('tie-breaks by player order (first with max wins)', () => {
+    const scoreData: ScoreDataByType['Objectives'] = {
+      completedByPlayer: [
+        { playerId: 'p1', objectives: ['A', 'B'] },
+        { playerId: 'p2', objectives: ['A', 'B'] },
+        { playerId: 'p3', objectives: ['A'] },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Objectives', scoreData, PLAYERS);
+    expect(result.filter(r => r.isWinner)).toEqual([
+      { playerName: 'Marco', score: 2, isWinner: true },
+    ]);
+  });
+
+  it('treats all-zero (no completion) as no winner', () => {
+    const scoreData: ScoreDataByType['Objectives'] = {
+      completedByPlayer: [
+        { playerId: 'p1', objectives: [] },
+        { playerId: 'p2', objectives: [] },
+        { playerId: 'p3', objectives: [] },
+      ],
+    };
+    const result = mapScoreDataToEndgameSummary('Objectives', scoreData, PLAYERS);
+    expect(result.every(r => !r.isWinner)).toBe(true);
+  });
+});
+
+// ─── displayName fallback ─────────────────────────────────────────────────────
+
+describe('mapScoreDataToEndgameSummary — display name', () => {
+  it('falls back to player.name when displayName is absent', () => {
+    const scoreData: ScoreDataByType['Points'] = {
+      scores: [{ playerId: 'p1', points: 1 }],
+    };
+    const result = mapScoreDataToEndgameSummary('Points', scoreData, PLAYERS);
+    expect(result[0].playerName).toBe('Marco'); // no displayName on p1
+    expect(result[1].playerName).toBe('Anna B.'); // displayName on p2
+  });
+});

--- a/apps/web/src/lib/session-live/score-data-to-endgame-summary.ts
+++ b/apps/web/src/lib/session-live/score-data-to-endgame-summary.ts
@@ -51,7 +51,10 @@ export function mapScoreDataToEndgameSummary(
         score: scoresByPlayer.get(p.id) ?? 0,
       }));
       const maxScore = enriched.length > 0 ? Math.max(...enriched.map(e => e.score)) : 0;
-      const winnerIndex = enriched.findIndex(e => e.score === maxScore);
+      // No winner when no one has scored (cold-start, mid-game before first
+      // point). Mirrors the Objectives guard — avoids auto-crowning the first
+      // player when the whole table is at zero.
+      const winnerIndex = maxScore > 0 ? enriched.findIndex(e => e.score === maxScore) : -1;
       return enriched.map((e, i) => ({
         ...e,
         isWinner: i === winnerIndex,
@@ -74,9 +77,13 @@ export function mapScoreDataToEndgameSummary(
       const lastPosition = players.length;
       return players.map(p => {
         const position = positionByPlayer.get(p.id) ?? lastPosition;
+        // Clamp the synthetic score to [1, players.length] to defend against
+        // out-of-range positions (BE bug, store desync). isWinner stays strict
+        // on `position === 1` so an off-by-one position 0 is NOT crowned.
+        const clamped = Math.max(1, Math.min(position, lastPosition));
         return {
           playerName: p.displayName ?? p.name,
-          score: players.length - position + 1,
+          score: lastPosition - clamped + 1,
           isWinner: position === 1,
         };
       });

--- a/apps/web/src/lib/session-live/score-data-to-endgame-summary.ts
+++ b/apps/web/src/lib/session-live/score-data-to-endgame-summary.ts
@@ -1,0 +1,110 @@
+/**
+ * mapScoreDataToEndgameSummary — pure adapter from polymorphic scoreData
+ * (editor / store shape) to EndgameDialog.finalScores entries.
+ *
+ * Issue #2431 — replaces the hardcoded `isWinner: false` mapping in
+ * SessionLiveView.tsx (leftover after #2389 Block B polymorphic migration).
+ *
+ * Winner rules per variant:
+ *   Points     → first player with max points (tie-break by player order).
+ *   BinaryWin  → every player whose isWinner flag is true (co-op aware).
+ *   Ranking    → position === 1.
+ *   Objectives → first player with max completedObjectives.length (tie-break
+ *                by player order, no winner if all are zero).
+ *
+ * Score field semantics (EndgameDialog sorts winners first, then DESC by score):
+ *   Points     → raw points.
+ *   BinaryWin  → 0 (isWinner alone drives the winner badge; ties on score are
+ *                rendered in player order, which matches insertion order).
+ *   Ranking    → players.length - position + 1, so the winner has the highest
+ *                synthetic score and the last place has 1. Keeps the dialog's
+ *                DESC sort natural.
+ *   Objectives → completedObjectives.length.
+ *
+ * Returns `[]` for null gates. Caller decides any legacy fallback.
+ *
+ * Pure: no side effects, no implicit imports, deterministic.
+ */
+
+import type { FinalScoreEntry } from '@/components/features/session-live/EndgameDialog';
+import type { ScoreDataByType, ScoreType } from '@/components/sessions/score-strategies/types';
+
+interface AdapterPlayer {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName?: string;
+}
+
+export function mapScoreDataToEndgameSummary(
+  scoringType: ScoreType | null,
+  scoreData: ScoreDataByType[ScoreType] | null,
+  players: ReadonlyArray<AdapterPlayer>
+): ReadonlyArray<FinalScoreEntry> {
+  if (scoringType === null || scoreData === null) return [];
+
+  switch (scoringType) {
+    case 'Points': {
+      const data = scoreData as ScoreDataByType['Points'];
+      const scoresByPlayer = new Map(data.scores.map(s => [s.playerId, s.points]));
+      const enriched = players.map(p => ({
+        playerName: p.displayName ?? p.name,
+        score: scoresByPlayer.get(p.id) ?? 0,
+      }));
+      const maxScore = enriched.length > 0 ? Math.max(...enriched.map(e => e.score)) : 0;
+      const winnerIndex = enriched.findIndex(e => e.score === maxScore);
+      return enriched.map((e, i) => ({
+        ...e,
+        isWinner: i === winnerIndex,
+      }));
+    }
+
+    case 'BinaryWin': {
+      const data = scoreData as ScoreDataByType['BinaryWin'];
+      const winnerByPlayer = new Map(data.results.map(r => [r.playerId, r.isWinner]));
+      return players.map(p => ({
+        playerName: p.displayName ?? p.name,
+        score: 0,
+        isWinner: winnerByPlayer.get(p.id) ?? false,
+      }));
+    }
+
+    case 'Ranking': {
+      const data = scoreData as ScoreDataByType['Ranking'];
+      const positionByPlayer = new Map(data.positions.map(r => [r.playerId, r.position]));
+      const lastPosition = players.length;
+      return players.map(p => {
+        const position = positionByPlayer.get(p.id) ?? lastPosition;
+        return {
+          playerName: p.displayName ?? p.name,
+          score: players.length - position + 1,
+          isWinner: position === 1,
+        };
+      });
+    }
+
+    case 'Objectives': {
+      const data = scoreData as ScoreDataByType['Objectives'];
+      const completedByPlayer = new Map(
+        data.completedByPlayer.map(r => [r.playerId, r.objectives.length])
+      );
+      const enriched = players.map(p => ({
+        playerName: p.displayName ?? p.name,
+        score: completedByPlayer.get(p.id) ?? 0,
+      }));
+      const maxScore = enriched.length > 0 ? Math.max(...enriched.map(e => e.score)) : 0;
+      // No winner if no one has completed anything (avoids "first player wins by default").
+      const winnerIndex = maxScore > 0 ? enriched.findIndex(e => e.score === maxScore) : -1;
+      return enriched.map((e, i) => ({
+        ...e,
+        isWinner: i === winnerIndex,
+      }));
+    }
+
+    default:
+      return assertNever(scoringType);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`mapScoreDataToEndgameSummary: unhandled scoringType "${value as string}"`);
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `isWinner: false` mapping in `SessionLiveView.tsx` (leftover after #2389 Block B polymorphic migration) with a new pure adapter `mapScoreDataToEndgameSummary` that derives the winner per `ScoreType` variant.

## Winner rules

| Variant | Winner | Score field |
|---|---|---|
| Points | first player with max points (tie-break by player order) | raw points |
| BinaryWin | every player with `isWinner: true` (co-op aware) | 0 |
| Ranking | `position === 1` | `players.length - position + 1` |
| Objectives | first with max `completedObjectives.length`, no winner if all zero | `completedObjectives.length` |

Score values were chosen so `EndgameDialog`'s built-in sort (winners-first then DESC) renders naturally — Ranking's synthetic score puts the winner at the highest value, last place at 1.

## Wire

`SessionLiveView` reads `scoringType` + `scoreData` from `useLiveSessionStore` via reactive selectors. Adapter is called inline only when both are non-null; otherwise falls back to the legacy `{ score: p.score, isWinner: false }` shape (cold-start safety — dialog still renders during loading).

## Test plan

- [x] 15 new unit tests (`score-data-to-endgame-summary.test.ts`): null gates ×3 + Points ×3 (winner + tie-break + padding) + BinaryWin ×3 + Ranking ×2 + Objectives ×3 + displayName fallback ×1. RED verified (vite import error), GREEN after.
- [x] `pnpm typecheck` clean.
- [x] Regression: `pnpm test session-live EndgameDialog SessionLiveView` → 658/658 across 45 files.
- [ ] CI: Frontend Tests + typecheck.

Closes #2431 · Refs #2389 Block B

🤖 Generated with [Claude Code](https://claude.com/claude-code)