### PR TITLE
feat(play-records): #2437-1 conflict-UI stale-form (xmin) + MVP chip

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommand.cs
@@ -6,11 +6,15 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 /// Command to update play record details.
 /// Allowed even after completion for corrections.
 /// Issue #3889: CQRS commands for play records.
+/// Issue #2437-1: nullable Xmin for stale-form optimistic concurrency. When provided,
+/// the handler pushes it onto the domain object so EF raises DbUpdateConcurrencyException
+/// on a stale-form write → 409. When absent, fresh-load behaviour (no concurrency check).
 /// </summary>
 internal record UpdatePlayRecordCommand(
     Guid RecordId,
     Guid UserId,
     DateTime? SessionDate = null,
     string? Notes = null,
-    string? Location = null
+    string? Location = null,
+    uint? Xmin = null
 ) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
@@ -49,6 +49,15 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
             command.Location,
             _timeProvider);
 
+        // #2437-1: stale-form optimistic concurrency. When the client sends the xmin it read,
+        // push it so EF's concurrency check compares against the value the client saw — a
+        // concurrent edit then yields DbUpdateConcurrencyException → 409. When absent, skip →
+        // fresh-load behaviour (no check). Mirrors SharedGameTranslation.SetXmin(cmd.Xmin).
+        if (command.Xmin.HasValue)
+        {
+            record.SetXmin(command.Xmin.Value);
+        }
+
         await _recordRepository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
@@ -7,6 +7,7 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// Issue #3890: CQRS queries for play records.
 /// Issue #1663: Phase 1 – WinnerPlayerIds and OutcomeType computed on read.
 /// Issue #2436 PR-C: Photos (presigned read-path) added as last parameter.
+/// Issue #2437-1: Xmin concurrency token exposed so clients can round-trip it on update.
 /// </summary>
 public record PlayRecordDto(
     Guid Id,
@@ -27,7 +28,8 @@ public record PlayRecordDto(
     DateTime UpdatedAt,
     IReadOnlyList<Guid> WinnerPlayerIds,
     string OutcomeType,
-    IReadOnlyList<PlayRecordPhotoDto> Photos
+    IReadOnlyList<PlayRecordPhotoDto> Photos,
+    uint Xmin
 );
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
@@ -95,7 +95,8 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
             entity.UpdatedAt,
             winnerPlayerIds,
             outcomeType,
-            photos
+            photos,
+            entity.Xmin   // #2437-1: expose concurrency token so clients can round-trip it on update
         );
     }
 }

--- a/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
+++ b/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
@@ -205,7 +205,7 @@ internal static class PlayRecordEndpoints
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var command = new UpdatePlayRecordCommand(recordId, httpContext.User.GetUserId(), request.SessionDate, request.Notes, request.Location);
+        var command = new UpdatePlayRecordCommand(recordId, httpContext.User.GetUserId(), request.SessionDate, request.Notes, request.Location, request.Xmin);
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }
@@ -305,7 +305,10 @@ internal static class PlayRecordEndpoints
 
     private sealed record CompleteRecordRequest(TimeSpan? ManualDuration);
 
-    private sealed record UpdateRecordRequest(DateTime? SessionDate, string? Notes, string? Location);
+    // Xmin: optional Postgres xmin token captured by the client on read.
+    // When present, EF raises DbUpdateConcurrencyException on stale-form writes → 409.
+    // Omit to retain legacy fresh-load behaviour (no concurrency check). #2437-1.
+    private sealed record UpdateRecordRequest(DateTime? SessionDate, string? Notes, string? Location, uint? Xmin = null);
 
     private sealed record GetHistoryQueryParams(int Page = 1, int PageSize = 20, Guid? GameId = null);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
@@ -246,6 +246,22 @@ public class GetPlayRecordQueryHandlerTests : IDisposable
     }
 
     [Fact]
+    [Trait("Issue", "2437")]
+    public async Task Handle_ExposesXminConcurrencyToken()
+    {
+        var recordId = Guid.NewGuid();
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity> { MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)) };
+        entity.Xmin = 4242u;
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _handler.Handle(new GetPlayRecordQuery(recordId, entity.CreatedByUserId), TestContext.Current.CancellationToken);
+
+        result.Xmin.Should().Be(4242u);
+    }
+
+    [Fact]
     [Trait("Issue", "2436")]
     public async Task Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt()
     {

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordConcurrencyTests.cs
@@ -1,0 +1,197 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for PlayRecord optimistic concurrency via PostgreSQL xmin.
+/// Issue #2437-1: end-to-end stale-form 409.
+///
+/// Two scenarios:
+/// 1. Stale xmin → DbUpdateConcurrencyException (the middleware maps this to 409).
+/// 2. Null xmin  → fresh-load fallback, no concurrency check, succeeds.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2437")]
+public sealed class PlayRecordConcurrencyTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+    private IServiceProvider? _serviceProvider;
+    private readonly TestTimeProvider _timeProvider = new();
+
+    public PlayRecordConcurrencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IServiceProvider ServiceProvider => _serviceProvider ?? throw new InvalidOperationException("Service provider not initialized.");
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"playrecord_xmin_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+
+        // Also build DI container for handler-level tests
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_connectionString);
+        services.AddScoped<IPlayRecordRepository, PlayRecordRepository>();
+        services.AddScoped<PlayRecordPermissionChecker>();
+        services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+        services.AddScoped<IGameCoreDataProvider, GameCoreDataProvider>();
+        services.AddSingleton<TimeProvider>(_timeProvider);
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    /// <summary>
+    /// When the client holds a stale xmin (another writer committed in between),
+    /// the UPDATE matches 0 rows → EF raises DbUpdateConcurrencyException.
+    /// The global middleware maps this to 409 with X-Warning-Code: concurrent-edit.
+    /// </summary>
+    [Fact(DisplayName = "Update_WithStaleXmin_ThrowsDbUpdateConcurrencyException")]
+    public async Task Update_WithStaleXmin_ThrowsDbUpdateConcurrencyException()
+    {
+        // ── Arrange: seed a play record row ────────────────────────────────────
+        var userId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(userId);
+
+        // Capture the current xmin by reading the row from Postgres
+        await using var dbA = _fixture.CreateDbContext(_connectionString);
+        var rowA = await dbA.PlayRecords.FirstAsync(r => r.Id == recordId, TestCancellationToken);
+        var staleXmin = rowA.Xmin;
+
+        // ── Act (part 1): first writer updates the row (xmin advances in DB) ──
+        var firstUpdate = new UpdatePlayRecordCommand(
+            recordId,
+            userId,
+            Notes: "First writer wins",
+            Xmin: null);  // no xmin check — just mutate to advance xmin
+        await SendInScopeAsync(firstUpdate);
+
+        // ── Act (part 2): second writer uses the stale xmin → must throw ──────
+        var staleUpdate = new UpdatePlayRecordCommand(
+            recordId,
+            userId,
+            Notes: "Stale form submit",
+            Xmin: staleXmin);  // #2437-1: push stale token → EF rejects
+
+        Func<Task> act = async () => await SendInScopeAsync(staleUpdate);
+
+        // ── Assert ─────────────────────────────────────────────────────────────
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "the second writer holds a stale xmin — " +
+            "EF optimistic concurrency must reject the update (0 rows affected)");
+    }
+
+    /// <summary>
+    /// When Xmin is null (omitted / non-versioned caller), the handler skips SetXmin
+    /// → fresh-load behaviour → always succeeds even after a concurrent write.
+    /// </summary>
+    [Fact(DisplayName = "Update_WithoutXmin_SucceedsFreshLoad")]
+    public async Task Update_WithoutXmin_SucceedsFreshLoad()
+    {
+        // ── Arrange ─────────────────────────────────────────────────────────────
+        var userId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(userId);
+
+        // Advance xmin by performing a first update
+        await SendInScopeAsync(new UpdatePlayRecordCommand(recordId, userId, Notes: "First write"));
+
+        // ── Act: second update with Xmin == null (no concurrency check) ────────
+        Func<Task> act = async () => await SendInScopeAsync(
+            new UpdatePlayRecordCommand(recordId, userId, Notes: "Second write, no xmin"));
+
+        // ── Assert ─────────────────────────────────────────────────────────────
+        await act.Should().NotThrowAsync(
+            "null Xmin means fresh-load behaviour — no concurrency check is applied");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedTestUserAsync()
+    {
+        var id = Guid.NewGuid();
+        await using var db = _fixture.CreateDbContext(_connectionString);
+        db.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"xmin-{id:N}@meepleai.test",
+            DisplayName = "Xmin Test User",
+            Role = "user",
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    private async Task<Guid> CreateTestRecordAsync(Guid creatorUserId)
+    {
+        var gameId = Guid.NewGuid();
+        await using var db = _fixture.CreateDbContext(_connectionString);
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Xmin Test Game",
+            YearPublished = 2024,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+
+        var command = new CreatePlayRecordCommand(
+            creatorUserId,
+            gameId,
+            "Xmin Test Game",
+            _timeProvider.UtcNow.AddHours(-1),
+            PlayRecordVisibility.Private);
+
+        return await SendInScopeAsync(command);
+    }
+
+    private async Task<TResult> SendInScopeAsync<TResult>(IRequest<TResult> command)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(command, TestCancellationToken);
+    }
+
+    private async Task SendInScopeAsync(IRequest command)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        await mediator.Send(command, TestCancellationToken);
+    }
+}

--- a/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
+++ b/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
@@ -289,6 +289,13 @@ export const playRecordsEditMessages = {
   'a11y.focusSessionDate': 'Focus iniziale sul campo data',
   'a11y.ariaReadonly': 'Questo campo non è modificabile',
 
+  // Conflict dialog (#2437-1)
+  'conflict.title': 'Modifica concorrente',
+  'conflict.description':
+    'Qualcuno ha modificato questa partita mentre la stavi modificando. Ricarica i dati aggiornati o sovrascrivi con le tue modifiche.',
+  'conflict.reload': 'Ricarica',
+  'conflict.overwrite': 'Sovrascrivi comunque',
+
   // Actions
   'actions.save': 'Salva modifiche',
   'actions.saving': 'Salvataggio…',

--- a/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
+++ b/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
@@ -295,6 +295,8 @@ export const playRecordsEditMessages = {
     'Qualcuno ha modificato questa partita mentre la stavi modificando. Ricarica i dati aggiornati o sovrascrivi con le tue modifiche.',
   'conflict.reload': 'Ricarica',
   'conflict.overwrite': 'Sovrascrivi comunque',
+  'conflict.stillConflict':
+    "Anche il tuo salvataggio è stato battuto da un'altra modifica. Riprova.",
 
   // Actions
   'actions.save': 'Salva modifiche',

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
@@ -162,6 +162,7 @@ vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
+    warning: vi.fn(),
   },
 }));
 

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
@@ -20,6 +20,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import EditPlayRecordPage from './page';
 import { playRecordsEditMessages } from '@/__tests__/fixtures/i18n-test-messages';
+import { UpdatePlayRecordError } from '@/lib/api/play-records.api';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -40,15 +41,10 @@ vi.mock('next/navigation', () => ({
 
 // usePlayRecord — provide fixture data
 const mockUsePlayRecord = vi.fn();
+const mockUseUpdateRecord = vi.fn();
 vi.mock('@/lib/domain-hooks/usePlayRecords', () => ({
   usePlayRecord: (id: string) => mockUsePlayRecord(id),
-  useUpdateRecord: () => ({
-    mutateAsync: vi.fn(async data => {
-      // Mock successful update
-      return { id: 'record-123' };
-    }),
-    isPending: false,
-  }),
+  useUpdateRecord: (id: string) => mockUseUpdateRecord(id),
   useDeleteRecord: () => ({
     mutateAsync: vi.fn(async () => {
       // Mock successful delete
@@ -56,6 +52,26 @@ vi.mock('@/lib/domain-hooks/usePlayRecords', () => ({
     }),
     isPending: false,
   }),
+}));
+
+// PlayRecordConflictDialog — mock to avoid Radix portal issues in jsdom
+vi.mock('@/components/play-records/PlayRecordConflictDialog', () => ({
+  PlayRecordConflictDialog: ({
+    open,
+    labels,
+  }: {
+    open: boolean;
+    labels: { title: string; description: string; reload: string; overwrite: string };
+    isOverwriting: boolean;
+    onReload: () => void;
+    onOverwrite: () => void;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label={labels.title}>
+        <span>{labels.title}</span>
+        <span>{labels.description}</span>
+      </div>
+    ) : null,
 }));
 
 // SessionCreateForm — mock the form component.
@@ -192,6 +208,11 @@ describe('EditPlayRecordPage', () => {
       data: playRecordFixture,
       isLoading: false,
       error: null,
+    });
+    // Default: successful update
+    mockUseUpdateRecord.mockReturnValue({
+      mutateAsync: vi.fn(async () => ({ id: 'record-123' })),
+      isPending: false,
     });
   });
 
@@ -391,6 +412,46 @@ describe('EditPlayRecordPage', () => {
     // to t('error.loadFailed') only when error has no message).
     await waitFor(() => {
       expect(screen.getByText(/Failed to load record/i)).toBeInTheDocument();
+    });
+  });
+
+  it('#2437-1: shows conflict dialog when updateRecord rejects with kind="conflict"', async () => {
+    const user = userEvent.setup();
+
+    // Override useUpdateRecord to reject with a conflict error
+    mockUseUpdateRecord.mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue(
+          new UpdatePlayRecordError(
+            'Modifica concorrente rilevata.',
+            'conflict',
+            409,
+            'concurrent-edit'
+          )
+        ),
+      isPending: false,
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditPlayRecordPage />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-form')).toBeInTheDocument();
+    });
+
+    // Submit the form — triggers handleSubmit → conflict path
+    const form = screen.getByTestId('session-form');
+    await user.click(form.querySelector('button[type="submit"]')!);
+
+    // Conflict dialog should appear
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(playRecordsEditMessages['conflict.title'])).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
@@ -33,10 +33,12 @@ import { toast } from 'sonner';
 
 import { FormPageContainer } from '@/components/layout/PageContainer';
 import { EditGateBanner } from '@/components/play-records/EditGateBanner';
+import { PlayRecordConflictDialog } from '@/components/play-records/PlayRecordConflictDialog';
 import { SessionCreateForm } from '@/components/play-records/SessionCreateForm';
 import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
 import { Button } from '@/components/ui/primitives/button';
 import { useTranslation } from '@/hooks/useTranslation';
+import { UpdatePlayRecordError, playRecordsApi } from '@/lib/api/play-records.api';
 import {
   type SessionCreateForm as SessionCreateFormData,
   UpdatePlayRecordRequestSchema,
@@ -51,37 +53,60 @@ export default function EditPlayRecordPage() {
 
   const recordId = typeof params?.id === 'string' ? params.id : '';
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [conflictForm, setConflictForm] = useState<SessionCreateFormData | null>(null);
 
   const { data: record, isLoading, error } = usePlayRecord(recordId);
   const updateMutation = useUpdateRecord(recordId);
   const deleteMutation = useDeleteRecord(recordId);
 
+  const submitUpdate = async (data: SessionCreateFormData, xmin?: number) => {
+    const validated = UpdatePlayRecordRequestSchema.parse({
+      sessionDate: data.sessionDate,
+      notes: data.notes,
+      location: data.location,
+      xmin,
+    });
+    await updateMutation.mutateAsync(validated);
+    queryClient.invalidateQueries({ queryKey: ['play-records', 'detail', recordId] });
+    queryClient.invalidateQueries({ queryKey: ['play-records', 'history'] });
+    queryClient.invalidateQueries({ queryKey: ['play-records', 'stats'] });
+    toast.success(t('playRecords.edit.success.toast'), {
+      description: t('playRecords.edit.success.toastDescription'),
+    });
+    router.push(`/play-records/${recordId}`);
+  };
+
   const handleSubmit = async (data: SessionCreateFormData) => {
     try {
-      // Extract only the editable fields (K5 gate)
-      const updateData = {
-        sessionDate: data.sessionDate,
-        notes: data.notes,
-        location: data.location,
-      };
-
-      // Validate against schema
-      const validated = UpdatePlayRecordRequestSchema.parse(updateData);
-      await updateMutation.mutateAsync(validated);
-
-      // K11 cache invalidation
-      queryClient.invalidateQueries({ queryKey: ['play-records', 'detail', recordId] });
-      queryClient.invalidateQueries({ queryKey: ['play-records', 'history'] });
-      queryClient.invalidateQueries({ queryKey: ['play-records', 'stats'] });
-
-      toast.success(t('playRecords.edit.success.toast'), {
-        description: t('playRecords.edit.success.toastDescription'),
-      });
-      router.push(`/play-records/${recordId}`);
+      await submitUpdate(data, record?.xmin);
     } catch (error) {
+      if (error instanceof UpdatePlayRecordError && error.kind === 'conflict') {
+        setConflictForm(data);
+        return;
+      }
       toast.error(t('playRecords.edit.error.updateFailed'), {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
+    }
+  };
+
+  const handleConflictReload = () => {
+    setConflictForm(null);
+    queryClient.invalidateQueries({ queryKey: ['play-records', 'detail', recordId] });
+  };
+
+  const handleConflictOverwrite = async () => {
+    if (!conflictForm) return;
+    try {
+      const fresh = await playRecordsApi.getRecord(recordId);
+      await submitUpdate(conflictForm, fresh.xmin);
+      setConflictForm(null);
+    } catch (error) {
+      if (error instanceof UpdatePlayRecordError && error.kind === 'conflict') return;
+      toast.error(t('playRecords.edit.error.updateFailed'), {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+      setConflictForm(null);
     }
   };
 
@@ -227,6 +252,20 @@ export default function EditPlayRecordPage() {
           </div>
         </div>
       )}
+
+      {/* #2437-1: Conflict resolution dialog */}
+      <PlayRecordConflictDialog
+        open={conflictForm !== null}
+        isOverwriting={updateMutation.isPending}
+        labels={{
+          title: t('playRecords.edit.conflict.title'),
+          description: t('playRecords.edit.conflict.description'),
+          reload: t('playRecords.edit.conflict.reload'),
+          overwrite: t('playRecords.edit.conflict.overwrite'),
+        }}
+        onReload={handleConflictReload}
+        onOverwrite={handleConflictOverwrite}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
@@ -102,7 +102,10 @@ export default function EditPlayRecordPage() {
       await submitUpdate(conflictForm, fresh.xmin);
       setConflictForm(null);
     } catch (error) {
-      if (error instanceof UpdatePlayRecordError && error.kind === 'conflict') return;
+      if (error instanceof UpdatePlayRecordError && error.kind === 'conflict') {
+        toast.warning(t('playRecords.edit.conflict.stillConflict'));
+        return;
+      }
       toast.error(t('playRecords.edit.error.updateFailed'), {
         description: error instanceof Error ? error.message : 'Unknown error',
       });

--- a/apps/web/src/components/play-records/PlayRecordConflictDialog.tsx
+++ b/apps/web/src/components/play-records/PlayRecordConflictDialog.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+
+export interface PlayRecordConflictDialogLabels {
+  title: string;
+  description: string;
+  reload: string;
+  overwrite: string;
+}
+
+export interface PlayRecordConflictDialogProps {
+  open: boolean;
+  labels: PlayRecordConflictDialogLabels;
+  isOverwriting: boolean;
+  onReload: () => void;
+  onOverwrite: () => void;
+}
+
+export function PlayRecordConflictDialog({
+  open,
+  labels,
+  isOverwriting,
+  onReload,
+  onOverwrite,
+}: PlayRecordConflictDialogProps): React.JSX.Element {
+  return (
+    <Dialog open={open}>
+      <DialogContent hideCloseButton>
+        <DialogTitle>⚠️ {labels.title}</DialogTitle>
+        <DialogDescription>{labels.description}</DialogDescription>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onReload} disabled={isOverwriting}>
+            {labels.reload}
+          </Button>
+          <Button variant="destructive" onClick={onOverwrite} disabled={isOverwriting}>
+            {labels.overwrite}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/play-records/PlayRecordDetailView.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailView.tsx
@@ -301,6 +301,13 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
   const formattedDuration = formatDuration(record.duration);
   const formattedDate = formatRelativeDate(record.sessionDate);
 
+  // #2437-1 MVP chip: derive from winnerPlayerIds — only when exactly 1 winner.
+  const winnerIds = record.winnerPlayerIds ?? [];
+  const mvpName =
+    winnerIds.length === 1
+      ? (record.players.find(p => p.id === winnerIds[0])?.displayName ?? null)
+      : null;
+
   const dimensions = record.scoringConfig.enabledDimensions;
 
   // Game info for hero (EC-2: freeform emoji fallback)
@@ -327,13 +334,14 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
         onStart={() => router.push(`/play-records/${recordId}/edit`)}
       />
 
-      {/* Connection Bar — AC-2.3 */}
+      {/* Connection Bar — AC-2.3, #2437-1 MVP chip */}
       <ConnectionBar
         gameId={record.gameId}
         gameName={record.gameName}
         playerCount={record.players.length}
         dateLabel={formattedDate}
         chatCount={0}
+        mvpName={mvpName}
       />
 
       {/* Body sections */}

--- a/apps/web/src/components/play-records/__tests__/PlayRecordConflictDialog.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/PlayRecordConflictDialog.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { PlayRecordConflictDialog } from '../PlayRecordConflictDialog';
+
+const labels = {
+  title: 'Modifica concorrente',
+  description: 'Qualcuno ha modificato questa partita.',
+  reload: 'Ricarica',
+  overwrite: 'Sovrascrivi',
+};
+
+describe('PlayRecordConflictDialog', () => {
+  it('fires onReload and onOverwrite', () => {
+    const onReload = vi.fn();
+    const onOverwrite = vi.fn();
+    render(
+      <PlayRecordConflictDialog
+        open
+        labels={labels}
+        isOverwriting={false}
+        onReload={onReload}
+        onOverwrite={onOverwrite}
+      />
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Ricarica' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Sovrascrivi' }));
+    expect(onReload).toHaveBeenCalledOnce();
+    expect(onOverwrite).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/play-records/detail/ConnectionBar.tsx
+++ b/apps/web/src/components/play-records/detail/ConnectionBar.tsx
@@ -26,6 +26,8 @@ export interface ConnectionBarProps {
   readonly playerCount: number;
   readonly dateLabel: string;
   readonly chatCount: number;
+  /** #2437-1 MVP chip: pass the single winner's displayName, or null/undefined for no chip. */
+  readonly mvpName?: string | null;
   readonly className?: string;
 }
 
@@ -54,6 +56,7 @@ export function ConnectionBar({
   playerCount,
   dateLabel,
   chatCount,
+  mvpName,
   className,
 }: ConnectionBarProps): ReactElement {
   const hasChat = chatCount > 0;
@@ -124,6 +127,14 @@ export function ConnectionBar({
         <span aria-hidden="true">📅</span>
         {dateLabel}
       </span>
+
+      {/* MVP chip — #2437-1: only when exactly 1 winner (decision M3) */}
+      {mvpName && (
+        <span className={CHIP_BASE} style={chipStyle('player')} aria-label={`MVP: ${mvpName}`}>
+          <span aria-hidden="true">🎯</span>
+          MVP: {mvpName}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/play-records/detail/__tests__/ConnectionBar.test.tsx
+++ b/apps/web/src/components/play-records/detail/__tests__/ConnectionBar.test.tsx
@@ -62,4 +62,20 @@ describe('ConnectionBar', () => {
     const gameAnchor = container.querySelector('a[href*="/games/g-1"]');
     expect(gameAnchor).not.toBeNull();
   });
+
+  // #2437-1: MVP chip (derived winner, decision M3)
+  it('renders MVP chip when mvpName is provided', () => {
+    render(<ConnectionBar {...defaultProps} mvpName="Alice" />);
+    expect(screen.getByText('MVP: Alice')).toBeTruthy();
+  });
+
+  it('does NOT render MVP chip when mvpName is undefined', () => {
+    render(<ConnectionBar {...defaultProps} />);
+    expect(screen.queryByText(/MVP/i)).toBeNull();
+  });
+
+  it('does NOT render MVP chip when mvpName is null', () => {
+    render(<ConnectionBar {...defaultProps} mvpName={null} />);
+    expect(screen.queryByText(/MVP/i)).toBeNull();
+  });
 });

--- a/apps/web/src/lib/api/__tests__/play-records-update-conflict.test.ts
+++ b/apps/web/src/lib/api/__tests__/play-records-update-conflict.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { playRecordsApi, UpdatePlayRecordError } from '../play-records.api';
+
+describe('playRecordsApi.updateRecord conflict handling (#2437-1)', () => {
+  beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sends xmin in the body when provided', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+      json: async () => ({}),
+    });
+    await playRecordsApi.updateRecord('r1', { notes: 'hi', xmin: 99 });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.xmin).toBe(99);
+  });
+
+  it('throws UpdatePlayRecordError kind=conflict on 409 with X-Warning-Code', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      headers: new Headers({ 'X-Warning-Code': 'concurrent-edit' }),
+      json: async () => ({ error: 'concurrent_edit' }),
+    });
+    await expect(playRecordsApi.updateRecord('r1', { notes: 'hi', xmin: 1 })).rejects.toMatchObject(
+      {
+        kind: 'conflict',
+        status: 409,
+        warningCode: 'concurrent-edit',
+      }
+    );
+  });
+});

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -21,6 +21,19 @@ import type {
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 const BASE_URL = `${API_BASE}/api/v1/play-records`;
 
+// #2437-1: Typed error for updateRecord — consumers can narrow on `kind` for conflict UI.
+export class UpdatePlayRecordError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: 'conflict' | 'forbidden' | 'validation' | 'server',
+    public readonly status: number,
+    public readonly warningCode?: string
+  ) {
+    super(message);
+    this.name = 'UpdatePlayRecordError';
+  }
+}
+
 export interface UploadPlayRecordPhotoResult {
   photoId: string;
   photoUrl: string;
@@ -108,18 +121,45 @@ export const playRecordsApi = {
   },
 
   /**
-   * Update play record details
+   * Update play record details.
+   * #2437-1: Sends optional `xmin` for optimistic-concurrency; throws `UpdatePlayRecordError`
+   * with `kind='conflict'` on 409 + `X-Warning-Code: concurrent-edit`.
    */
   async updateRecord(recordId: string, updates: UpdatePlayRecordRequest): Promise<void> {
     const res = await fetch(`${BASE_URL}/${recordId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(updates),
     });
-    if (!res.ok) {
-      const error = await res.json().catch(() => ({ message: 'Failed to update record' }));
-      throw new Error(error.message || 'Failed to update record');
+    if (res.ok) return;
+    const warningCode = res.headers.get('X-Warning-Code') ?? undefined;
+    if (res.status === 409) {
+      throw new UpdatePlayRecordError(
+        'Modifica concorrente rilevata.',
+        'conflict',
+        409,
+        warningCode
+      );
     }
+    if (res.status === 403) {
+      throw new UpdatePlayRecordError(
+        'Non hai i permessi per modificare.',
+        'forbidden',
+        403,
+        warningCode
+      );
+    }
+    if (res.status === 400) {
+      throw new UpdatePlayRecordError('Dati non validi.', 'validation', 400, warningCode);
+    }
+    const err = await res.json().catch(() => ({ message: 'Failed to update record' }));
+    throw new UpdatePlayRecordError(
+      err.message || 'Failed to update record',
+      'server',
+      res.status,
+      warningCode
+    );
   },
 
   /**

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -55,6 +55,7 @@ export const playRecordsApi = {
     const res = await fetch(BASE_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(data),
     });
     if (!res.ok) {
@@ -71,6 +72,7 @@ export const playRecordsApi = {
     const res = await fetch(`${BASE_URL}/${recordId}/players`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(player),
     });
     if (!res.ok) {
@@ -86,6 +88,7 @@ export const playRecordsApi = {
     const res = await fetch(`${BASE_URL}/${recordId}/scores`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(score),
     });
     if (!res.ok) {
@@ -100,6 +103,7 @@ export const playRecordsApi = {
   async startRecord(recordId: string): Promise<void> {
     const res = await fetch(`${BASE_URL}/${recordId}/start`, {
       method: 'POST',
+      credentials: 'include',
     });
     if (!res.ok) {
       const error = await res.json().catch(() => ({ message: 'Failed to start record' }));
@@ -113,6 +117,7 @@ export const playRecordsApi = {
   async completeRecord(recordId: string): Promise<void> {
     const res = await fetch(`${BASE_URL}/${recordId}/complete`, {
       method: 'POST',
+      credentials: 'include',
     });
     if (!res.ok) {
       const error = await res.json().catch(() => ({ message: 'Failed to complete record' }));
@@ -194,7 +199,7 @@ export const playRecordsApi = {
    * Get full play record details
    */
   async getRecord(id: string): Promise<PlayRecordDto> {
-    const res = await fetch(`${BASE_URL}/${id}`);
+    const res = await fetch(`${BASE_URL}/${id}`, { credentials: 'include' });
     if (!res.ok) {
       if (res.status === 404) throw new Error('Play record not found');
       const error = await res.json().catch(() => ({ message: 'Failed to get record' }));
@@ -224,7 +229,9 @@ export const playRecordsApi = {
     if (params.dateFrom) searchParams.set('dateFrom', params.dateFrom);
     if (params.dateTo) searchParams.set('dateTo', params.dateTo);
 
-    const res = await fetch(`${BASE_URL}/history?${searchParams.toString()}`);
+    const res = await fetch(`${BASE_URL}/history?${searchParams.toString()}`, {
+      credentials: 'include',
+    });
     if (!res.ok) {
       const error = await res.json().catch(() => ({ message: 'Failed to get history' }));
       throw new Error(error.message || 'Failed to get history');
@@ -243,7 +250,9 @@ export const playRecordsApi = {
     if (params.startDate) search.set('startDate', params.startDate);
     if (params.endDate) search.set('endDate', params.endDate);
     const qs = search.toString();
-    const res = await fetch(`${BASE_URL}/statistics${qs ? `?${qs}` : ''}`);
+    const res = await fetch(`${BASE_URL}/statistics${qs ? `?${qs}` : ''}`, {
+      credentials: 'include',
+    });
     if (!res.ok) {
       const error = await res.json().catch(() => ({ message: 'Failed to get statistics' }));
       throw new Error(error.message || 'Failed to get statistics');
@@ -257,6 +266,7 @@ export const playRecordsApi = {
   async deleteRecord(recordId: string): Promise<void> {
     const res = await fetch(`${BASE_URL}/${recordId}`, {
       method: 'DELETE',
+      credentials: 'include',
     });
     if (!res.ok) {
       const error = await res.json().catch(() => ({ message: 'Failed to delete record' }));

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-xmin.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-xmin.schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import { PlayRecordDtoSchema, UpdatePlayRecordRequestSchema } from '../play-records.schemas';
+
+const base = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameId: null,
+  gameName: 'Catan',
+  sessionDate: '2026-06-21',
+  duration: null,
+  status: 'Completed' as const,
+  players: [],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+  createdByUserId: '550e8400-e29b-41d4-a716-446655440001',
+  visibility: 'Private' as const,
+  startTime: null,
+  endTime: null,
+  notes: null,
+  location: null,
+  createdAt: '2026-06-21T10:00:00Z',
+  updatedAt: '2026-06-21T10:00:00Z',
+};
+
+describe('xmin schemas (#2437-1)', () => {
+  it('PlayRecordDtoSchema accepts a numeric xmin and is optional', () => {
+    expect(PlayRecordDtoSchema.parse(base).xmin).toBeUndefined();
+    expect(PlayRecordDtoSchema.parse({ ...base, xmin: 4242 }).xmin).toBe(4242);
+  });
+  it('UpdatePlayRecordRequestSchema accepts optional xmin', () => {
+    expect(UpdatePlayRecordRequestSchema.parse({ notes: 'x' }).xmin).toBeUndefined();
+    expect(UpdatePlayRecordRequestSchema.parse({ notes: 'x', xmin: 7 }).xmin).toBe(7);
+  });
+});

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -86,6 +86,8 @@ export const PlayRecordDtoSchema = z.object({
   outcomeType: PlayRecordOutcomeTypeSchema.optional(),
   // #2436 PR-C: photos exposed on read. Optional during BE rollout; tighten later.
   photos: z.array(PlayRecordPhotoSchema).optional(),
+  // #2437-1: Postgres xmin optimistic-concurrency token (uint). Optional during rollout.
+  xmin: z.number().int().nonnegative().optional(),
 });
 export type PlayRecordDto = z.infer<typeof PlayRecordDtoSchema>;
 
@@ -177,6 +179,8 @@ export const UpdatePlayRecordRequestSchema = z.object({
   sessionDate: z.string().optional(),
   notes: z.string().max(2000).optional(),
   location: z.string().max(255).optional(),
+  // #2437-1: Postgres xmin optimistic-concurrency token (uint). Optional during rollout.
+  xmin: z.number().int().nonnegative().optional(),
 });
 export type UpdatePlayRecordRequest = z.infer<typeof UpdatePlayRecordRequestSchema>;
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -4219,6 +4219,12 @@
         "deleteToast": "Record deleted",
         "deleteToastDescription": "The record was deleted successfully"
       },
+      "conflict": {
+        "title": "Concurrent edit",
+        "description": "Someone modified this game while you were editing. Reload the latest data or overwrite with your changes.",
+        "reload": "Reload",
+        "overwrite": "Overwrite anyway"
+      },
       "error": {
         "loadFailed": "Could not load the record",
         "updateFailed": "Update failed",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -4223,7 +4223,8 @@
         "title": "Concurrent edit",
         "description": "Someone modified this game while you were editing. Reload the latest data or overwrite with your changes.",
         "reload": "Reload",
-        "overwrite": "Overwrite anyway"
+        "overwrite": "Overwrite anyway",
+        "stillConflict": "Your save was also beaten by another edit. Try again."
       },
       "error": {
         "loadFailed": "Could not load the record",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -4272,6 +4272,12 @@
         "deleteToast": "Partita eliminata",
         "deleteToastDescription": "La partita è stata eliminata correttamente"
       },
+      "conflict": {
+        "title": "Modifica concorrente",
+        "description": "Qualcuno ha modificato questa partita mentre la stavi modificando. Ricarica i dati aggiornati o sovrascrivi con le tue modifiche.",
+        "reload": "Ricarica",
+        "overwrite": "Sovrascrivi comunque"
+      },
       "error": {
         "loadFailed": "Impossibile caricare la partita",
         "updateFailed": "Aggiornamento non riuscito",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -4276,7 +4276,8 @@
         "title": "Modifica concorrente",
         "description": "Qualcuno ha modificato questa partita mentre la stavi modificando. Ricarica i dati aggiornati o sovrascrivi con le tue modifiche.",
         "reload": "Ricarica",
-        "overwrite": "Sovrascrivi comunque"
+        "overwrite": "Sovrascrivi comunque",
+        "stillConflict": "Anche il tuo salvataggio è stato battuto da un'altra modifica. Riprova."
       },
       "error": {
         "loadFailed": "Impossibile caricare la partita",

--- a/docs/superpowers/plans/2026-06-21-issue-2437-pr1-conflict-mvp.md
+++ b/docs/superpowers/plans/2026-06-21-issue-2437-pr1-conflict-mvp.md
@@ -1,0 +1,486 @@
+# #2437-1 — Conflict-UI stale-form (xmin end-to-end) + MVP chip — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Coprire il caso "form stale" sull'edit di un PlayRecord (decisione **C2**): il client legge lo `xmin` quando carica il record, lo rimanda al salvataggio, e se un altro utente ha modificato nel frattempo riceve un 409 con un dialog ricarica/sovrascrivi. Più il **MVP chip** (decisione **M3**: MVP = winner derivato) nella detail view.
+
+**Architecture:** L'infra xmin è già in place (PR-B): `PlayRecord.Xmin` (uint, `IsConcurrencyToken`), repository `Update()` detached con xmin round-trip, middleware `DbUpdateConcurrencyException → 409 + X-Warning-Code: concurrent-edit`. Oggi l'update fa fresh-load → il check scatta solo su race concorrenti. Questo PR fa passare lo xmin **end-to-end** (pattern identico a `SharedGameTranslation`): l'handler chiama `record.SetXmin(command.Xmin)` con il valore dal client. **Robustezza**: xmin è **nullable** ovunque — se il client non lo fornisce (fixture/rollout) l'handler NON chiama SetXmin → fresh-load come oggi (retrocompatibile).
+
+**Tech Stack:** .NET 9 (MediatR, EF Core xmin, Moq/xUnit, Testcontainers) · Next.js/React 19 (TanStack Query, Zod, Vitest).
+
+**Spec:** `docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md` (#2437 sub-PR 1).
+
+## Reuse map (verificata, file:line)
+- **BE template xmin end-to-end**: `SharedGameTranslation` — handler `UpdateGameTranslationCommandHandler.cs:85` (`existing.SetXmin(cmd.Xmin)`); command `UpdateGameTranslationCommand.cs:18-24` (`uint Xmin`).
+- **BE PlayRecord**: command `UpdatePlayRecordCommand.cs:10-16`; handler `UpdatePlayRecordCommandHandler.cs:46-53`; endpoint + `UpdateRecordRequest` `PlayRecordEndpoints.cs:201-211,308`; DTO `PlayRecordDto.cs`; query handler `GetPlayRecordQueryHandler.cs`; `PlayRecord.SetXmin` `PlayRecord.cs:54` (internal); repo già detached `PlayRecordRepository.cs:135-196,293,323`; middleware `ApiExceptionHandlerMiddleware.cs:109-115,327-352`.
+- **BE test template**: `GameNightPlaylistRowVersionConcurrencyTests.cs` (scenario stale-form 409).
+- **FE error class template**: `use-update-session-scores.ts:44-54` (`UpdateSessionScoresError` kind/status/details).
+- **FE api client**: `play-records.api.ts:105-115` (`updateRecord`); schemas `play-records.schemas.ts:53-90,161-166`.
+- **FE edit page**: `app/(authenticated)/play-records/[id]/edit/page.tsx:59-86` (`handleSubmit`).
+- **FE mutation hook**: `usePlayRecords.ts:232-243` (`useUpdateRecord`).
+- **FE MVP mount**: `ConnectionBar.tsx:23-30,89-127` (props + chips); `PlayRecordDetailView.tsx:327-333` (ConnectionBar usage), winner resolution `buildClassificaRows`.
+
+---
+
+## Task 1: BE — xmin end-to-end (nullable)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommand.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs`
+- Modify: `apps/api/src/Api/Routing/PlayRecordEndpoints.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordConcurrencyTests.cs` (create)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs` (extend)
+
+- [ ] **Step 1: Expose `Xmin` on `PlayRecordDto`**
+
+In `PlayRecordDto.cs`, add `uint Xmin` as the LAST positional parameter of `PlayRecordDto` (after `Photos`):
+```csharp
+    IReadOnlyList<PlayRecordPhotoDto> Photos,
+    uint Xmin
+);
+```
+
+- [ ] **Step 2: Map `Xmin` in the query handler + extend its unit test (TDD)**
+
+In `GetPlayRecordQueryHandlerTests.cs`, add to the existing photo test (or a new one) an assertion that the DTO carries the entity xmin. Since EF InMemory doesn't populate xmin, set it explicitly on the entity in a new test:
+```csharp
+    [Fact]
+    [Trait("Issue", "2437")]
+    public async Task Handle_ExposesXminConcurrencyToken()
+    {
+        var recordId = Guid.NewGuid();
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity> { MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)) };
+        entity.Xmin = 4242u;
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _handler.Handle(new GetPlayRecordQuery(recordId, entity.CreatedByUserId), TestContext.Current.CancellationToken);
+
+        result.Xmin.Should().Be(4242u);
+    }
+```
+Run → FAIL (DTO has no Xmin / constructor arity). Then in `GetPlayRecordQueryHandler.cs`, pass `entity.Xmin` as the last argument of `new PlayRecordDto(...)`:
+```csharp
+            outcomeType,
+            photos,
+            entity.Xmin
+        );
+```
+Run → PASS.
+
+- [ ] **Step 3: Add nullable `Xmin` to the command + request + endpoint**
+
+`UpdatePlayRecordCommand.cs` — add `uint? Xmin = null` as the last param:
+```csharp
+internal record UpdatePlayRecordCommand(
+    Guid RecordId,
+    Guid UserId,
+    DateTime? SessionDate = null,
+    string? Notes = null,
+    string? Location = null,
+    uint? Xmin = null
+) : ICommand;
+```
+
+`PlayRecordEndpoints.cs:308` — add `uint? Xmin` to `UpdateRecordRequest`:
+```csharp
+private sealed record UpdateRecordRequest(DateTime? SessionDate, string? Notes, string? Location, uint? Xmin);
+```
+
+`PlayRecordEndpoints.cs:201-211` `HandleUpdateRecord` — pass `request.Xmin`:
+```csharp
+        var command = new UpdatePlayRecordCommand(recordId, httpContext.User.GetUserId(),
+            request.SessionDate, request.Notes, request.Location, request.Xmin);
+```
+
+- [ ] **Step 4: Handler applies the client xmin (only when provided)**
+
+`UpdatePlayRecordCommandHandler.cs` — after `record.UpdateDetails(...)` (line ~50) and before `UpdateAsync`, add:
+```csharp
+        // #2437-1: stale-form optimistic concurrency. When the client sends the xmin it read,
+        // push it so EF's concurrency check (IsConcurrencyToken on xmin) compares against the
+        // value the client saw — a concurrent edit then yields DbUpdateConcurrencyException → 409.
+        // When absent (rollout / non-versioned callers), skip → fresh-load behaviour (no check).
+        if (command.Xmin.HasValue)
+        {
+            record.SetXmin(command.Xmin.Value);
+        }
+```
+(`PlayRecord.SetXmin` is `internal`; the handler is in assembly `Api` → accessible. Same as `SharedGameTranslation`.)
+
+- [ ] **Step 5: Build green**
+
+Run: `dotnet build D:/Repositories/meepleai-monorepo-frontend/apps/api/src/Api/Api.csproj 2>&1 | grep -E "error" || echo BUILD_OK`
+Expected: `BUILD_OK`
+
+- [ ] **Step 6: Integration test — stale-form yields 409 (TDD, Testcontainers)**
+
+Read `GameNightPlaylistRowVersionConcurrencyTests.cs` first to mirror its fixture/setup. Create `PlayRecordConcurrencyTests.cs` that: (a) creates a PlayRecord via the API/handler; (b) reads it twice (two stale copies, capturing `xmin = X`); (c) updates once (xmin advances to Y in DB); (d) updates again with the stale `xmin = X` → asserts the second update throws `DbUpdateConcurrencyException` (or, if going through the HTTP pipeline, returns 409 with header `X-Warning-Code: concurrent-edit`). Also add a test that an update WITHOUT xmin (null) succeeds (fresh-load fallback, no conflict).
+
+```csharp
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2437")]
+public class PlayRecordConcurrencyTests : IntegrationTestBase  // mirror the base used by GameNightPlaylistRowVersionConcurrencyTests
+{
+    // ... fixture setup mirroring the GameNightPlaylist concurrency test ...
+
+    [Fact]
+    public async Task Update_WithStaleXmin_ThrowsConcurrency()
+    {
+        // Arrange: create a record, capture its xmin, mutate it once (xmin advances).
+        // Act: second update reusing the stale xmin.
+        // Assert: DbUpdateConcurrencyException (or 409 via the HTTP path).
+    }
+
+    [Fact]
+    public async Task Update_WithoutXmin_SucceedsFreshLoad()
+    {
+        // Arrange: create a record. Act: update with command.Xmin == null. Assert: no throw.
+    }
+}
+```
+Fill the bodies by adapting the GameNightPlaylist test's create/update helpers to PlayRecord (use `UpdatePlayRecordCommand` with/without `Xmin`). Run the two tests → PASS.
+
+Run: `dotnet test D:/Repositories/meepleai-monorepo-frontend/apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~PlayRecordConcurrencyTests|FullyQualifiedName~GetPlayRecordQueryHandlerTests" 2>&1 | tail -8`
+Expected: PASS (note: integration tests need Docker; if unavailable, document that the integration test is written but requires Docker to run, and ensure the unit test in Step 2 passes).
+
+- [ ] **Step 7: Commit**
+```bash
+git add -A
+git commit -m "feat(play-records): #2437-1 BE xmin end-to-end for stale-form 409"
+```
+
+---
+
+## Task 2: FE — `xmin` on DTO + UpdateRequest schemas
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/play-records.schemas.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts` (extend) — or a new test file `play-records-xmin.schema.test.ts`
+
+- [ ] **Step 1: Test (TDD)** — create `apps/web/src/lib/api/schemas/__tests__/play-records-xmin.schema.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+
+import { PlayRecordDtoSchema, UpdatePlayRecordRequestSchema } from '../play-records.schemas';
+
+const base = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameId: null, gameName: 'Catan', sessionDate: '2026-06-21', duration: null,
+  status: 'Completed' as const, players: [], scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+  createdByUserId: '550e8400-e29b-41d4-a716-446655440001', visibility: 'Private' as const,
+  startTime: null, endTime: null, notes: null, location: null,
+  createdAt: '2026-06-21T10:00:00Z', updatedAt: '2026-06-21T10:00:00Z',
+};
+
+describe('xmin schemas (#2437-1)', () => {
+  it('PlayRecordDtoSchema accepts a numeric xmin and is optional', () => {
+    expect(PlayRecordDtoSchema.parse(base).xmin).toBeUndefined();
+    expect(PlayRecordDtoSchema.parse({ ...base, xmin: 4242 }).xmin).toBe(4242);
+  });
+  it('UpdatePlayRecordRequestSchema accepts optional xmin', () => {
+    expect(UpdatePlayRecordRequestSchema.parse({ notes: 'x' }).xmin).toBeUndefined();
+    expect(UpdatePlayRecordRequestSchema.parse({ notes: 'x', xmin: 7 }).xmin).toBe(7);
+  });
+});
+```
+Run → FAIL.
+
+- [ ] **Step 2: Implement** — in `play-records.schemas.ts`, add `xmin: z.number().int().nonnegative().optional()` to BOTH `PlayRecordDtoSchema` (after `photos`) and `UpdatePlayRecordRequestSchema` (after `location`). Comment: `// #2437-1: Postgres xmin optimistic-concurrency token (uint). Optional during rollout.`
+Run → PASS.
+
+- [ ] **Step 3: Commit**
+```bash
+git add apps/web/src/lib/api/schemas/play-records.schemas.ts apps/web/src/lib/api/schemas/__tests__/play-records-xmin.schema.test.ts
+git commit -m "feat(play-records): #2437-1 add xmin to DTO + update-request schemas"
+```
+
+---
+
+## Task 3: FE — `UpdatePlayRecordError` + `updateRecord` sends xmin & detects 409
+
+**Files:**
+- Modify: `apps/web/src/lib/api/play-records.api.ts`
+- Test: `apps/web/src/lib/api/__tests__/play-records-update-conflict.test.ts` (create)
+
+- [ ] **Step 1: Test (TDD)** — create `play-records-update-conflict.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { playRecordsApi, UpdatePlayRecordError } from '../play-records.api';
+
+describe('playRecordsApi.updateRecord conflict handling (#2437-1)', () => {
+  beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sends xmin in the body when provided', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({ ok: true, status: 204, headers: new Headers(), json: async () => ({}) });
+    await playRecordsApi.updateRecord('r1', { notes: 'hi', xmin: 99 });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.xmin).toBe(99);
+  });
+
+  it('throws UpdatePlayRecordError kind=conflict on 409 with X-Warning-Code', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: false, status: 409,
+      headers: new Headers({ 'X-Warning-Code': 'concurrent-edit' }),
+      json: async () => ({ error: 'concurrent_edit' }),
+    });
+    await expect(playRecordsApi.updateRecord('r1', { notes: 'hi', xmin: 1 }))
+      .rejects.toMatchObject({ kind: 'conflict', status: 409, warningCode: 'concurrent-edit' });
+  });
+});
+```
+Run → FAIL.
+
+- [ ] **Step 2: Implement** — in `play-records.api.ts` add the error class (top-level export) and rewrite `updateRecord`:
+```ts
+export class UpdatePlayRecordError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: 'conflict' | 'forbidden' | 'validation' | 'server',
+    public readonly status: number,
+    public readonly warningCode?: string
+  ) {
+    super(message);
+    this.name = 'UpdatePlayRecordError';
+  }
+}
+```
+```ts
+  async updateRecord(recordId: string, updates: UpdatePlayRecordRequest): Promise<void> {
+    const res = await fetch(`${BASE_URL}/${recordId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(updates),
+    });
+    if (res.ok) return;
+    const warningCode = res.headers.get('X-Warning-Code') ?? undefined;
+    if (res.status === 409) {
+      throw new UpdatePlayRecordError('Modifica concorrente rilevata.', 'conflict', 409, warningCode);
+    }
+    if (res.status === 403) {
+      throw new UpdatePlayRecordError('Non hai i permessi per modificare.', 'forbidden', 403, warningCode);
+    }
+    if (res.status === 400) {
+      throw new UpdatePlayRecordError('Dati non validi.', 'validation', 400, warningCode);
+    }
+    const err = await res.json().catch(() => ({ message: 'Failed to update record' }));
+    throw new UpdatePlayRecordError(err.message || 'Failed to update record', 'server', res.status, warningCode);
+  },
+```
+Run → PASS. Verify the existing `play-records.api` callers still typecheck.
+
+- [ ] **Step 3: Commit**
+```bash
+git add apps/web/src/lib/api/play-records.api.ts apps/web/src/lib/api/__tests__/play-records-update-conflict.test.ts
+git commit -m "feat(play-records): #2437-1 updateRecord sends xmin + typed 409 conflict error"
+```
+
+---
+
+## Task 4: FE — `PlayRecordConflictDialog` (greenfield, simple)
+
+**Files:**
+- Create: `apps/web/src/components/play-records/PlayRecordConflictDialog.tsx`
+- Test: `apps/web/src/components/play-records/__tests__/PlayRecordConflictDialog.test.tsx` (create)
+
+> Greenfield, NOT reusing `editor/ConflictResolutionModal` (that one is RuleSpec-specific with local/remote/merge diffs — overkill here). Two actions: reload (discard my edits, show fresh data) / overwrite (force my edits).
+
+- [ ] **Step 1: Test (TDD)** — create the test:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { PlayRecordConflictDialog } from '../PlayRecordConflictDialog';
+
+const labels = {
+  title: 'Modifica concorrente',
+  description: 'Qualcuno ha modificato questa partita.',
+  reload: 'Ricarica',
+  overwrite: 'Sovrascrivi',
+};
+
+describe('PlayRecordConflictDialog', () => {
+  it('fires onReload and onOverwrite', () => {
+    const onReload = vi.fn();
+    const onOverwrite = vi.fn();
+    render(
+      <PlayRecordConflictDialog open labels={labels} isOverwriting={false}
+        onReload={onReload} onOverwrite={onOverwrite} />
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Ricarica' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Sovrascrivi' }));
+    expect(onReload).toHaveBeenCalledOnce();
+    expect(onOverwrite).toHaveBeenCalledOnce();
+  });
+});
+```
+Run → FAIL.
+
+- [ ] **Step 2: Implement** — create `PlayRecordConflictDialog.tsx`:
+```tsx
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+
+export interface PlayRecordConflictDialogLabels {
+  title: string;
+  description: string;
+  reload: string;
+  overwrite: string;
+}
+
+export interface PlayRecordConflictDialogProps {
+  open: boolean;
+  labels: PlayRecordConflictDialogLabels;
+  isOverwriting: boolean;
+  onReload: () => void;
+  onOverwrite: () => void;
+}
+
+export function PlayRecordConflictDialog({
+  open,
+  labels,
+  isOverwriting,
+  onReload,
+  onOverwrite,
+}: PlayRecordConflictDialogProps): React.JSX.Element {
+  return (
+    <Dialog open={open}>
+      <DialogContent hideCloseButton>
+        <DialogTitle>⚠️ {labels.title}</DialogTitle>
+        <DialogDescription>{labels.description}</DialogDescription>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onReload} disabled={isOverwriting}>
+            {labels.reload}
+          </Button>
+          <Button variant="destructive" onClick={onOverwrite} disabled={isOverwriting}>
+            {labels.overwrite}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+(If `DialogContent` has no `hideCloseButton` prop, read the primitive and adapt; the dialog must render `role="dialog"`.)
+Run → PASS.
+
+- [ ] **Step 3: Commit**
+```bash
+git add apps/web/src/components/play-records/PlayRecordConflictDialog.tsx apps/web/src/components/play-records/__tests__/PlayRecordConflictDialog.test.tsx
+git commit -m "feat(play-records): #2437-1 conflict resolution dialog (reload/overwrite)"
+```
+
+---
+
+## Task 5: FE — wire conflict flow in the edit page + i18n
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx`
+- Modify: `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+- Modify: `apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx` (extend)
+
+- [ ] **Step 1: i18n** — add under `playRecords.edit` in both locales:
+```json
+"conflict": {
+  "title": "Modifica concorrente",
+  "description": "Qualcuno ha modificato questa partita mentre la stavi modificando. Ricarica i dati aggiornati o sovrascrivi con le tue modifiche.",
+  "reload": "Ricarica",
+  "overwrite": "Sovrascrivi comunque"
+}
+```
+(en: "Concurrent edit" / "Someone modified this game while you were editing. Reload the latest data or overwrite with your changes." / "Reload" / "Overwrite anyway".)
+
+- [ ] **Step 2: Test (TDD)** — read `page.test.tsx` first to learn its mock setup (usePlayRecord/useUpdateRecord/useTranslation). Add a test: when `updateMutation.mutateAsync` rejects with `new UpdatePlayRecordError('x','conflict',409,'concurrent-edit')`, submitting the form shows the conflict dialog (`getByRole('dialog')` with the conflict title). Mock `useUpdateRecord` so its `mutateAsync` rejects with that error. Run → FAIL.
+
+- [ ] **Step 3: Implement** — modify `edit/page.tsx`:
+  - Import `UpdatePlayRecordError` from `@/lib/api/play-records.api`, `playRecordsApi` (for the overwrite refetch), and `PlayRecordConflictDialog`.
+  - Add state: `const [conflictForm, setConflictForm] = useState<SessionCreateFormData | null>(null);`
+  - Extract a `submitUpdate(data, xmin)` helper that builds `{ sessionDate, notes, location, xmin }`, validates with `UpdatePlayRecordRequestSchema`, `await updateMutation.mutateAsync(validated)`, then invalidates + toast + `router.push`.
+  - `handleSubmit(data)`: `try { await submitUpdate(data, record.xmin); } catch (e) { if (e instanceof UpdatePlayRecordError && e.kind === 'conflict') setConflictForm(data); else toast.error(...); }`
+  - `handleReload()`: `setConflictForm(null); queryClient.invalidateQueries({ queryKey: ['play-records', 'detail', recordId] });` (form re-renders from fresh `initialValues`).
+  - `handleOverwrite()`: `if (!conflictForm) return; const fresh = await playRecordsApi.getRecord(recordId); await submitUpdate(conflictForm, fresh.xmin); setConflictForm(null);` (force last-write-wins with the current xmin).
+  - Render `<PlayRecordConflictDialog open={conflictForm !== null} isOverwriting={updateMutation.isPending} labels={{ title: t('playRecords.edit.conflict.title'), description: t('playRecords.edit.conflict.description'), reload: t('playRecords.edit.conflict.reload'), overwrite: t('playRecords.edit.conflict.overwrite') }} onReload={handleReload} onOverwrite={handleOverwrite} />`
+
+Run the edit page test → PASS. Run typecheck.
+
+- [ ] **Step 4: Commit**
+```bash
+git add apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx apps/web/src/locales/it.json apps/web/src/locales/en.json
+git commit -m "feat(play-records): #2437-1 wire conflict dialog in edit page (reload/overwrite)"
+```
+
+---
+
+## Task 6: FE — MVP chip in the detail view
+
+**Files:**
+- Modify: `apps/web/src/components/play-records/detail/ConnectionBar.tsx`
+- Modify: `apps/web/src/components/play-records/PlayRecordDetailView.tsx`
+- Modify: `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+- Modify: `apps/web/src/components/play-records/detail/__tests__/ConnectionBar.test.tsx` (extend)
+
+> M3: MVP = derived winner. Chip appears ONLY when there is exactly ONE winner (no chip for cooperative/no-winner or multi-winner ties — the Classifica already shows co-winners). The orchestrator (DetailView) resolves the name and passes `mvpName` (keeps ConnectionBar pure).
+
+- [ ] **Step 1: Test (TDD)** — in `ConnectionBar.test.tsx`, add: renders an MVP chip when `mvpName` is set (`getByText(/MVP/i)` contains the name); no MVP chip when `mvpName` is undefined/null. Run → FAIL.
+
+- [ ] **Step 2: ConnectionBar** — add `readonly mvpName?: string | null;` to `ConnectionBarProps` and render a `'player'`-tinted chip after the date chip when `mvpName` is truthy:
+```tsx
+      {mvpName && (
+        <span className={CHIP_BASE} style={chipStyle('player')} aria-label={`MVP: ${mvpName}`}>
+          <span aria-hidden="true">🎯</span>
+          MVP: {mvpName}
+        </span>
+      )}
+```
+(Destructure `mvpName` in the component signature.)
+
+- [ ] **Step 3: DetailView resolves the MVP name** — in `PlayRecordDetailView.tsx`, before the `<ConnectionBar .../>` usage compute:
+```tsx
+  const winnerIds = record.winnerPlayerIds ?? [];
+  const mvpName =
+    winnerIds.length === 1
+      ? (record.players.find(p => p.id === winnerIds[0])?.displayName ?? null)
+      : null;
+```
+Pass `mvpName={mvpName}` to `<ConnectionBar .../>`. (Note: the chip uses a literal "MVP:" prefix in ConnectionBar for simplicity, matching the existing literal-Italian chips like "giocatori"/"Collegamenti" in that component. If i18n is desired later, lift to a label prop — out of scope here. Keep consistent with the component's current literal style.)
+
+- [ ] **Step 4: Verify** — run `pnpm test src/components/play-records/detail/__tests__/ConnectionBar.test.tsx src/components/play-records/__tests__/PlayRecordDetailView.test.tsx --run` → PASS. Run axe test still green.
+
+> i18n note: ConnectionBar currently uses hardcoded Italian literals ("Collegamenti", "giocatori", "Nessuna chat"). To stay consistent and avoid scope-creeping an i18n refactor of the whole component, the MVP chip uses the same literal style ("MVP:"). Skip the `playRecords.detail.mvpChip` i18n key (DO NOT add it) — revisit if ConnectionBar is fully i18n'd later.
+
+- [ ] **Step 5: Commit**
+```bash
+git add apps/web/src/components/play-records/detail/ConnectionBar.tsx apps/web/src/components/play-records/PlayRecordDetailView.tsx apps/web/src/components/play-records/detail/__tests__/ConnectionBar.test.tsx
+git commit -m "feat(play-records): #2437-1 MVP chip in connection bar (derived winner)"
+```
+
+---
+
+## Final verification (after all tasks)
+- `pnpm test src/components/play-records src/lib/api src/app/\(authenticated\)/play-records --run` → no regressions
+- `pnpm typecheck && pnpm lint` → clean
+- `dotnet build apps/api/src/Api/Api.csproj` → BUILD_OK; BE tests pass (integration needs Docker)
+
+## Self-review notes (for the executor)
+- **xmin is nullable everywhere** — verify the BE handler skips `SetXmin` when null (fresh-load fallback) and the FE sends `xmin` only when the DTO carried one. This keeps MSW fixtures (no xmin) working.
+- **Overwrite re-fetches xmin** via `playRecordsApi.getRecord` before re-submitting (last-write-wins with the current token).
+- **uint serialization**: xmin ≤ 4.29e9 < `Number.MAX_SAFE_INTEGER` → `z.number()` is safe.
+- **MVP chip** stays a literal-Italian chip to match ConnectionBar's existing style; no new i18n key (avoid half-i18n'ing the component).
+- **Closes** nothing yet — #2437 needs sub-PR 2 (share) + 3 (audit/restore) before it closes.


### PR DESCRIPTION
## Summary

Primo dei 3 sub-PR di **#2437** (detail/edit deferred). Implementa la **conflict-UI stale-form** (decisione spec-panel **C2**) e il **MVP chip** (decisione **M3**).

### BE — xmin end-to-end (nullable)
- `PlayRecordDto.Xmin` esposto sul GET; `UpdatePlayRecordCommand`/`UpdateRecordRequest`/endpoint propagano un **`uint? Xmin` nullable**; l'handler fa `if (command.Xmin.HasValue) record.SetXmin(command.Xmin.Value)` (pattern identico a `SharedGameTranslation`). Infra xmin (repo detached + round-trip + `IsConcurrencyToken` + middleware 409 `X-Warning-Code: concurrent-edit`) già shipped in PR-B.
- **Robustezza**: xmin nullable ovunque → se il client non lo fornisce (rollout / fixture), l'handler salta SetXmin = fresh-load (nessun check). Nessun path "silent-zero".
- Integration test (Testcontainers, **Docker**): stale xmin → `DbUpdateConcurrencyException` (→409); null xmin → fresh-load success.

### FE — conflict-UI + MVP
- `xmin` opzionale su DTO + update-request Zod schemas; `playRecordsApi.updateRecord` invia xmin + lancia `UpdatePlayRecordError` tipizzato (legge `X-Warning-Code`); `credentials: 'include'` reso coerente su tutto `playRecordsApi`.
- `PlayRecordConflictDialog` (reload/overwrite); edit page wire: conflict → dialog; **reload** = invalida + ricarica; **overwrite** = refetch xmin fresco + resubmit (last-write-wins consapevole) con toast su re-conflict; i18n it/en.
- **MVP chip** (M3 = winner derivato): "🎯 MVP: <nome>" nel ConnectionBar solo con winner unico (no tie/coop), riusa `WinnerPlayerIds`.

## Spec & Plan
- Spec-panel: `docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md`
- Plan (6 task TDD): `docs/superpowers/plans/2026-06-21-issue-2437-pr1-conflict-mvp.md`

## Test Plan
- [x] BE: `PlayRecordConcurrencyTests` (2, Docker) + `GetPlayRecordQueryHandlerTests` (xmin) — 14/14
- [x] FE unit TDD: schemas, conflict error/api, dialog, edit-page wire, MVP chip
- [x] FE full play-records + api + edit suite — 1522/1522 (no regressioni)
- [x] `pnpm typecheck` + `pnpm lint` clean

## Review
- Per-task two-stage review + final holistic review (`feature-dev:code-reviewer`): **APPROVED_FOR_MERGE**; 2 Important fixati in-PR (credentials consistency, overwrite re-conflict feedback).

> **Non chiude #2437** — restano sub-PR 2 (share-token + route pubblica) e sub-PR 3 (audit + restore-version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)