### PR TITLE
feat(kb): #2324 DEC-D2 distinct-thread upgrade — junction table chat_message_chunk_citations

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -490,10 +490,14 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             var locators = BuildChunkUsageLocators(finalCitations);
             if (locators.Count > 0)
             {
-                // Resolve the assistant message we just persisted. AddAssistantMessageWithMetadata
-                // appends with sequenceNumber = current message count, so the highest sequence
-                // is the row we want. Falling back to Guid.Empty would skip the increment — log
-                // and bail without raising.
+                // Resolve the assistant message we just persisted.
+                // AddAssistantMessageWithMetadata appends with sequenceNumber =
+                // _messages.Count BEFORE the new message is added, which makes the
+                // freshly-appended assistant message the unique row with the highest
+                // SequenceNumber in the aggregate. This handler is the only writer
+                // for the thread within the current request scope (no concurrent
+                // mutation), and no path can append a higher-sequence message AFTER
+                // this point. The OrderByDescending picks that row safely.
                 var assistantMessageId = thread.Messages
                     .OrderByDescending(m => m.SequenceNumber)
                     .Select(m => (Guid?)m.Id)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -479,22 +479,47 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             "Persisted session chat to thread {ThreadId}: user msg + assistant msg ({Tokens} tokens, {Chunks} RAG chunks)",
             thread.Id, totalTokens, assembled.Citations.Count);
 
-        // #2311 BE-1 — Increment text_chunks.usage_count for each cited chunk that we can
-        // resolve to a (PdfDocumentId, ChunkIndex) locator. This is a forward-looking
-        // telemetry metric (DEC-D2 start-from-0) and MUST NOT roll back the message
-        // persistence above — any exception is swallowed and logged.
+        // #2311 BE-1 + #2324 DEC-D2 — Increment text_chunks.usage_count for each cited
+        // chunk with distinct-thread semantics. The handler records each citation in the
+        // chat_message_chunk_citations junction so subsequent messages in the same thread
+        // citing the same chunk do not double-count. This is a forward-looking telemetry
+        // metric and MUST NOT roll back the message persistence above — any exception is
+        // swallowed and logged.
         try
         {
             var locators = BuildChunkUsageLocators(finalCitations);
             if (locators.Count > 0)
             {
-                using var incrementScope = _scopeFactory.CreateScope();
-                var incrementHandler = incrementScope.ServiceProvider
-                    .GetRequiredService<
-                        ICommandHandler<IncrementChunkUsageCountsCommand, int>>();
-                _ = await incrementHandler
-                    .Handle(new IncrementChunkUsageCountsCommand(locators), cancellationToken)
-                    .ConfigureAwait(false);
+                // Resolve the assistant message we just persisted. AddAssistantMessageWithMetadata
+                // appends with sequenceNumber = current message count, so the highest sequence
+                // is the row we want. Falling back to Guid.Empty would skip the increment — log
+                // and bail without raising.
+                var assistantMessageId = thread.Messages
+                    .OrderByDescending(m => m.SequenceNumber)
+                    .Select(m => (Guid?)m.Id)
+                    .FirstOrDefault();
+
+                if (assistantMessageId is null || assistantMessageId == Guid.Empty)
+                {
+                    _logger.LogDebug(
+                        "Skipping chunk-usage increment for thread {ThreadId}: could not resolve the assistant message id",
+                        thread.Id);
+                }
+                else
+                {
+                    using var incrementScope = _scopeFactory.CreateScope();
+                    var incrementHandler = incrementScope.ServiceProvider
+                        .GetRequiredService<
+                            ICommandHandler<IncrementChunkUsageCountsCommand, int>>();
+                    _ = await incrementHandler
+                        .Handle(
+                            new IncrementChunkUsageCountsCommand(
+                                thread.Id,
+                                assistantMessageId.Value,
+                                locators),
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
         }
         catch (Exception ex)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommand.cs
@@ -3,19 +3,30 @@ using Api.SharedKernel.Application.Interfaces;
 namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 
 /// <summary>
-/// #2311 BE-1 — fire-and-forget increment of <c>text_chunks.usage_count</c> for the chunks
-/// cited by a freshly persisted assistant message. Invoked from
-/// <see cref="ChatWithSessionAgentCommandHandler"/> after <c>SaveChangesAsync</c> so the
-/// counter mirrors what survives to durable storage (transient retrieval-only chunks are
-/// never counted).
+/// #2311 BE-1 + #2324 DEC-D2 — fire-and-forget increment of
+/// <c>text_chunks.usage_count</c> for the chunks cited by a freshly persisted
+/// assistant message. Invoked from <see cref="ChatWithSessionAgentCommandHandler"/>
+/// after <c>SaveChangesAsync</c> so the counter mirrors what survives to durable
+/// storage (transient retrieval-only chunks are never counted).
 ///
-/// Each (PdfDocumentId, ChunkIndex) locator is incremented at most once per command
-/// invocation — duplicate citations within the same assistant message are deduplicated by
-/// the handler. Cross-message duplication within the same thread is intentionally NOT
-/// deduplicated in BE-1 (DEC-D2 downgraded from distinct-thread to distinct-message scope;
-/// upgrading to true distinct-thread requires a junction table — tracked separately).
+/// <para><b>Distinct-thread semantics (#2324)</b>: every (PdfDocumentId, ChunkIndex)
+/// locator is incremented at most once <i>per distinct thread</i>. The handler
+/// records each (ThreadId, MessageId, ChunkId) tuple in the
+/// <c>chat_message_chunk_citations</c> junction table; when a subsequent message
+/// in the same thread cites the same chunk, the EXISTS check on the junction
+/// suppresses the increment. Two different threads citing the same chunk still
+/// produce two increments. Intra-message duplicates (the same chunk cited
+/// multiple times in a single assistant response) are deduplicated up-front in
+/// the handler.</para>
+///
+/// <para><b>Idempotency</b>: replaying the same command (same
+/// ThreadId+MessageId+chunks) is a no-op — the junction's composite PK rejects
+/// the duplicate insert and the EXISTS check confirms the increment was already
+/// taken in a prior run.</para>
 /// </summary>
 internal sealed record IncrementChunkUsageCountsCommand(
+    Guid ThreadId,
+    Guid MessageId,
     IReadOnlyList<ChunkUsageLocator> Locators
 ) : ICommand<int>;
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 
@@ -137,12 +138,35 @@ internal sealed class IncrementChunkUsageCountsCommandHandler
             }
         }
 
-        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Parallel-replay race: a sibling command holding a stale "snapshot empty"
+            // view raced us to the junction insert. EF rolls back the whole change
+            // set, so the counter is NOT double-ticked. Treat as a no-op — the
+            // sibling's increment is the canonical one. Log at debug only.
+            _logger.LogDebug(ex,
+                "IncrementChunkUsageCountsCommand: junction insert raced (thread {ThreadId} message {MessageId}); rolled back without ticking",
+                command.ThreadId, command.MessageId);
+            return 0;
+        }
 
         _logger.LogDebug(
             "IncrementChunkUsageCountsCommand: thread {ThreadId} message {MessageId} → {Incremented}/{Matched} chunks ticked (distinct-thread)",
             command.ThreadId, command.MessageId, incremented, matched.Count);
 
         return incremented;
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        // Postgres SQLSTATE 23505 = unique_violation. Surfaces via Npgsql when
+        // the composite PK on chat_message_chunk_citations rejects a duplicate
+        // (ThreadId, MessageId, ChunkId) tuple.
+        return ex.InnerException is PostgresException pg
+            && string.Equals(pg.SqlState, "23505", StringComparison.Ordinal);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandler.cs
@@ -1,25 +1,38 @@
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 
 /// <summary>
-/// Handles <see cref="IncrementChunkUsageCountsCommand"/> by issuing a single bulk
-/// <c>UPDATE</c> through EF Core's <c>ExecuteUpdate</c> against <c>text_chunks</c>.
+/// Handles <see cref="IncrementChunkUsageCountsCommand"/> with distinct-thread
+/// semantics (#2324 DEC-D2 upgrade of the BE-1 distinct-message scope).
 ///
-/// Behaviour notes:
-///  - Empty / null locator list → no-op, returns 0.
-///  - Duplicate locators within the input are deduplicated before the UPDATE so a
-///    chunk cited twice in the same assistant message contributes a single
-///    increment (DEC-D2 downgraded distinct-message scope).
-///  - Unknown (PdfDocumentId, ChunkIndex) tuples (e.g. legacy citations whose
-///    underlying chunk was deleted) silently match zero rows — the caller does
-///    not need to validate locators ahead of time.
-///  - The command is invoked OUTSIDE the chat thread's transaction by design:
-///    the counter is a forward-looking telemetry metric, never a correctness
-///    invariant, so a transient DB failure here MUST NOT roll back message
-///    persistence. The caller catches and logs.
+/// <para><b>Algorithm</b> (per-locator, after intra-command dedup):
+/// <list type="number">
+///   <item><description>Resolve <see cref="ChunkUsageLocator"/> → chunk row(s).</description></item>
+///   <item><description>If the (ThreadId, MessageId, ChunkId) junction row already
+///     exists → no-op (replay protection).</description></item>
+///   <item><description>If any OTHER message in the same thread already cited
+///     this chunk (junction EXISTS check on <c>ix_chat_msg_chunk_thread_chunk</c>) →
+///     record the junction row but DO NOT increment (distinct-thread rule).</description></item>
+///   <item><description>Otherwise → first thread-touch: increment
+///     <c>text_chunks.usage_count</c> and record the junction row.</description></item>
+/// </list>
+/// </para>
+///
+/// <para><b>Race condition</b> (documented, accepted): two parallel commands
+/// targeting the same (ThreadId, ChunkId) from different messages may both
+/// observe "no other message cited" and both increment, yielding a double
+/// count. The counter is forward-looking telemetry (DEC-D2 start-from-0), not
+/// a correctness invariant, and chat threads are essentially sequential — the
+/// window is narrow. A serializable-isolation transaction or an advisory lock
+/// would close the window but is out of scope for #2324 (P3).</para>
+///
+/// <para><b>Caller contract</b>: invoked OUTSIDE the chat thread's transaction
+/// by design — a transient DB failure here MUST NOT roll back message
+/// persistence. The caller catches and logs.</para>
 /// </summary>
 internal sealed class IncrementChunkUsageCountsCommandHandler
     : ICommandHandler<IncrementChunkUsageCountsCommand, int>
@@ -46,7 +59,9 @@ internal sealed class IncrementChunkUsageCountsCommandHandler
             return 0;
         }
 
-        // Deduplicate locators (DEC-D2 distinct-message scope).
+        // Intra-message dedup: a chunk cited 3 times in the same assistant
+        // response contributes a single junction row and (at most) a single
+        // increment, regardless of distinct-thread state.
         var distinctLocators = command.Locators
             .Distinct()
             .ToList();
@@ -60,14 +75,9 @@ internal sealed class IncrementChunkUsageCountsCommandHandler
             .Distinct()
             .ToList();
 
-        // Two-axis prefilter pulls the candidate window, then narrow client-side. The
-        // composite (PdfDocumentId, ChunkIndex) IN cannot be expressed directly in EF —
-        // a server-side AND/OR chain across N pairs blows up for large N. The candidate
-        // window is bounded by the citation budget per chat turn (~10-20 chunks), so the
-        // tracked-update overhead is negligible. We avoid ExecuteUpdate because the
-        // EF InMemory provider used by unit tests does not support it; production
-        // performance is dominated by the SaveChanges single-roundtrip, not the
-        // per-row materialization.
+        // Two-axis prefilter — composite (PdfDocumentId, ChunkIndex) IN is not
+        // expressible directly in EF, but the candidate window is small
+        // (citation budget per chat turn ≈ 10-20 chunks).
         var locatorSet = distinctLocators.ToHashSet();
 
         var candidates = await _dbContext.TextChunks
@@ -82,22 +92,57 @@ internal sealed class IncrementChunkUsageCountsCommandHandler
         if (matched.Count == 0)
         {
             _logger.LogDebug(
-                "IncrementChunkUsageCountsCommand: no matching chunks for {LocatorCount} locator(s)",
-                distinctLocators.Count);
+                "IncrementChunkUsageCountsCommand: no matching chunks for {LocatorCount} locator(s) in thread {ThreadId}",
+                distinctLocators.Count, command.ThreadId);
             return 0;
         }
 
+        // Pre-load the junction slice for this (thread, chunks) cell so the
+        // per-chunk decisions below stay in-memory. Mirrors the candidate
+        // prefilter shape — bounded by the same citation budget.
+        var matchedChunkIds = matched.Select(c => c.Id).ToList();
+        var existingJunctionRows = await _dbContext.ChatMessageChunkCitations
+            .Where(j => j.ThreadId == command.ThreadId && matchedChunkIds.Contains(j.ChunkId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        int incremented = 0;
         foreach (var chunk in matched)
         {
-            chunk.UsageCount += 1;
+            var chunkRows = existingJunctionRows.Where(j => j.ChunkId == chunk.Id).ToList();
+
+            // Replay protection: (Thread, Message, Chunk) already recorded → no-op.
+            var alreadyRecorded = chunkRows.Any(j => j.MessageId == command.MessageId);
+            if (alreadyRecorded)
+            {
+                continue;
+            }
+
+            // Distinct-thread rule: any OTHER message in this thread already cited
+            // the chunk → skip the increment but still record the junction row.
+            var otherMessageCitedInThread = chunkRows.Any(j => j.MessageId != command.MessageId);
+
+            _dbContext.ChatMessageChunkCitations.Add(new ChatMessageChunkCitationEntity
+            {
+                ThreadId = command.ThreadId,
+                MessageId = command.MessageId,
+                ChunkId = chunk.Id,
+                CitedAt = DateTime.UtcNow,
+            });
+
+            if (!otherMessageCitedInThread)
+            {
+                chunk.UsageCount += 1;
+                incremented++;
+            }
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogDebug(
-            "IncrementChunkUsageCountsCommand: incremented {Updated}/{Requested} chunks",
-            matched.Count, distinctLocators.Count);
+            "IncrementChunkUsageCountsCommand: thread {ThreadId} message {MessageId} → {Incremented}/{Matched} chunks ticked (distinct-thread)",
+            command.ThreadId, command.MessageId, incremented, matched.Count);
 
-        return matched.Count;
+        return incremented;
     }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChatMessageChunkCitationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChatMessageChunkCitationEntity.cs
@@ -1,0 +1,31 @@
+namespace Api.Infrastructure.Entities;
+
+/// <summary>
+/// Junction row recording that an assistant <c>ChatMessage</c> (identified by
+/// <see cref="MessageId"/>) cited a <c>TextChunk</c> inside a particular
+/// <see cref="ThreadId"/>. The composite PK <c>(ThreadId, MessageId, ChunkId)</c>
+/// guarantees idempotency on retries, and the secondary index
+/// <c>(ThreadId, ChunkId)</c> backs the EXISTS check the handler uses to
+/// decide whether the current message is the first one in the thread to cite
+/// this chunk.
+///
+/// <para>Issue #2324 — DEC-D2 distinct-thread upgrade. The
+/// <c>text_chunks.usage_count</c> column ticks once per distinct thread that
+/// cites a chunk; the junction makes the EXISTS check efficient.</para>
+///
+/// <para><b>No <c>ChatMessage</c> FK</b>: messages are persisted as a JSON blob
+/// inside <c>ChatThreadEntity.MessagesJson</c>, so MessageId here is a
+/// referenceless value — application-level integrity only. ON DELETE CASCADE on
+/// <see cref="ThreadId"/> cleans up the whole junction when a thread is dropped.</para>
+/// </summary>
+public class ChatMessageChunkCitationEntity
+{
+    public Guid ThreadId { get; set; }
+    public Guid MessageId { get; set; }
+    public Guid ChunkId { get; set; }
+    public DateTime CitedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation
+    public ChatThreadEntity Thread { get; set; } = default!;
+    public Api.Infrastructure.Entities.TextChunkEntity Chunk { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChatMessageChunkCitationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ChatMessageChunkCitationEntity.cs
@@ -23,7 +23,10 @@ public class ChatMessageChunkCitationEntity
     public Guid ThreadId { get; set; }
     public Guid MessageId { get; set; }
     public Guid ChunkId { get; set; }
-    public DateTime CitedAt { get; set; } = DateTime.UtcNow;
+    // CitedAt is assigned by the handler at insert time; no property-level default
+    // because EF would not project it as a column default (the handler is the
+    // single source of truth for this value).
+    public DateTime CitedAt { get; set; }
 
     // Navigation
     public ChatThreadEntity Thread { get; set; } = default!;

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/ChatMessageChunkCitationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/ChatMessageChunkCitationEntityConfiguration.cs
@@ -1,0 +1,47 @@
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations;
+
+/// <summary>
+/// EF Core configuration for <see cref="ChatMessageChunkCitationEntity"/>
+/// (Issue #2324 — DEC-D2 distinct-thread upgrade of <c>text_chunks.usage_count</c>).
+/// </summary>
+internal class ChatMessageChunkCitationEntityConfiguration
+    : IEntityTypeConfiguration<ChatMessageChunkCitationEntity>
+{
+    public void Configure(EntityTypeBuilder<ChatMessageChunkCitationEntity> builder)
+    {
+        builder.ToTable("chat_message_chunk_citations");
+
+        // Composite PK — also the natural idempotency key. A retry of the same
+        // (threadId, messageId, chunkId) tuple is a no-op (unique-violation on
+        // SaveChanges, swallowed by the handler).
+        builder.HasKey(e => new { e.ThreadId, e.MessageId, e.ChunkId });
+
+        builder.Property(e => e.ThreadId).IsRequired();
+        builder.Property(e => e.MessageId).IsRequired();
+        builder.Property(e => e.ChunkId).IsRequired();
+        builder.Property(e => e.CitedAt).IsRequired();
+
+        // Thread FK with CASCADE delete: drop the thread → drop all its citations.
+        builder.HasOne(e => e.Thread)
+            .WithMany()
+            .HasForeignKey(e => e.ThreadId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Chunk FK with CASCADE delete: drop the underlying chunk → drop its
+        // junction rows (mirrors the issue body schema).
+        builder.HasOne(e => e.Chunk)
+            .WithMany()
+            .HasForeignKey(e => e.ChunkId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Secondary index for the "is this the first thread-touch?" EXISTS query.
+        // Order matters: (ThreadId, ChunkId) lets Postgres index-only scan the
+        // per-thread, per-chunk slice without bringing the message_id into play.
+        builder.HasIndex(e => new { e.ThreadId, e.ChunkId })
+            .HasDatabaseName("ix_chat_msg_chunk_thread_chunk");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/ChatMessageChunkCitationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/ChatMessageChunkCitationEntityConfiguration.cs
@@ -43,5 +43,14 @@ internal class ChatMessageChunkCitationEntityConfiguration
         // per-thread, per-chunk slice without bringing the message_id into play.
         builder.HasIndex(e => new { e.ThreadId, e.ChunkId })
             .HasDatabaseName("ix_chat_msg_chunk_thread_chunk");
+
+        // Explicit FK-support index on ChunkId alone — backs the CASCADE scan
+        // when a TextChunk is deleted. EF Core would auto-generate this for the
+        // ChunkId FK, but declaring it explicitly preserves it across any future
+        // migration squash / regeneration. The default name
+        // (IX_chat_message_chunk_citations_ChunkId) matches the existing
+        // migration so this is purely a configuration-side hardening — no
+        // schema diff.
+        builder.HasIndex(e => e.ChunkId);
     }
 }

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -179,6 +179,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<ReportExecutionEntity> ReportExecutions => Set<ReportExecutionEntity>(); // ISSUE-916: Report execution history
     public DbSet<DocumentCollectionEntity> DocumentCollections => Set<DocumentCollectionEntity>(); // ISSUE-2051: Multi-document collections
     public DbSet<ChatThreadCollectionEntity> ChatThreadCollections => Set<ChatThreadCollectionEntity>(); // ISSUE-2051: Chat-collection junction
+    public DbSet<ChatMessageChunkCitationEntity> ChatMessageChunkCitations => Set<ChatMessageChunkCitationEntity>(); // ISSUE-2324: DEC-D2 distinct-thread citation junction
     public DbSet<ShareLinkEntity> ShareLinks => Set<ShareLinkEntity>(); // ISSUE-2052: Shareable chat links
     public DbSet<InvitationTokenEntity> InvitationTokens => Set<InvitationTokenEntity>(); // ISSUE-124: Admin invitation tokens
     public DbSet<InvitationGameSuggestionEntity> InvitationGameSuggestions => Set<InvitationGameSuggestionEntity>(); // Admin Invitation Flow: game suggestions on invitations

--- a/apps/api/src/Api/Infrastructure/Migrations/20260621074658_AddChatMessageChunkCitationsJunction.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260621074658_AddChatMessageChunkCitationsJunction.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260621074658_AddChatMessageChunkCitationsJunction")]
+    partial class AddChatMessageChunkCitationsJunction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260621074658_AddChatMessageChunkCitationsJunction.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260621074658_AddChatMessageChunkCitationsJunction.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChatMessageChunkCitationsJunction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "chat_message_chunk_citations",
+                columns: table => new
+                {
+                    ThreadId = table.Column<Guid>(type: "uuid", nullable: false),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ChunkId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CitedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_chat_message_chunk_citations", x => new { x.ThreadId, x.MessageId, x.ChunkId });
+                    table.ForeignKey(
+                        name: "FK_chat_message_chunk_citations_ChatThreads_ThreadId",
+                        column: x => x.ThreadId,
+                        principalTable: "ChatThreads",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_chat_message_chunk_citations_text_chunks_ChunkId",
+                        column: x => x.ChunkId,
+                        principalTable: "text_chunks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_chat_message_chunk_citations_ChunkId",
+                table: "chat_message_chunk_citations",
+                column: "ChunkId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_chat_msg_chunk_thread_chunk",
+                table: "chat_message_chunk_citations",
+                columns: new[] { "ThreadId", "ChunkId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "chat_message_chunk_citations");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandlerTests.cs
@@ -45,6 +45,21 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         };
     }
 
+    // #2324 (DEC-D2 distinct-thread upgrade): every command now carries the
+    // (ThreadId, MessageId) pair that the citation belongs to. Tests use fresh
+    // Guids per scenario unless they need to share a thread to validate the
+    // junction logic.
+    private static IncrementChunkUsageCountsCommand NewCommand(
+        IReadOnlyList<ChunkUsageLocator>? locators = null,
+        Guid? threadId = null,
+        Guid? messageId = null)
+    {
+        return new IncrementChunkUsageCountsCommand(
+            threadId ?? Guid.NewGuid(),
+            messageId ?? Guid.NewGuid(),
+            locators!);
+    }
+
     [Fact]
     public async Task Handle_EmptyLocators_NoOp_ReturnsZero()
     {
@@ -52,7 +67,7 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         var result = await sut.Handle(
-            new IncrementChunkUsageCountsCommand(Array.Empty<ChunkUsageLocator>()),
+            NewCommand(Array.Empty<ChunkUsageLocator>()),
             CancellationToken.None);
 
         result.Should().Be(0);
@@ -65,7 +80,7 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         var result = await sut.Handle(
-            new IncrementChunkUsageCountsCommand(null!),
+            NewCommand(locators: null),
             CancellationToken.None);
 
         result.Should().Be(0);
@@ -83,7 +98,7 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         var result = await sut.Handle(
-            new IncrementChunkUsageCountsCommand(new[] { new ChunkUsageLocator(pdfId, 5) }),
+            NewCommand(new[] { new ChunkUsageLocator(pdfId, 5) }),
             CancellationToken.None);
 
         result.Should().Be(1);
@@ -102,9 +117,11 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
 
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
-        // Same locator passed thrice — DEC-D2 distinct-message scope must dedupe to +1.
+        // Same locator passed thrice — intra-message dedup must still hold under
+        // the distinct-thread upgrade (one assistant message that cites the same
+        // chunk three times contributes a single increment).
         await sut.Handle(
-            new IncrementChunkUsageCountsCommand(new[]
+            NewCommand(new[]
             {
                 new ChunkUsageLocator(pdfId, 3),
                 new ChunkUsageLocator(pdfId, 3),
@@ -123,7 +140,7 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         var result = await sut.Handle(
-            new IncrementChunkUsageCountsCommand(new[] { new ChunkUsageLocator(Guid.NewGuid(), 99) }),
+            NewCommand(new[] { new ChunkUsageLocator(Guid.NewGuid(), 99) }),
             CancellationToken.None);
 
         result.Should().Be(0);
@@ -143,7 +160,7 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         await sut.Handle(
-            new IncrementChunkUsageCountsCommand(new[]
+            NewCommand(new[]
             {
                 new ChunkUsageLocator(pdfA, 1),       // matches chunkA
                 new ChunkUsageLocator(pdfA, 99),      // no row (same pdf, missing chunkIndex)
@@ -174,7 +191,7 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         await sut.Handle(
-            new IncrementChunkUsageCountsCommand(new[] { new ChunkUsageLocator(pdfA, 7) }),
+            NewCommand(new[] { new ChunkUsageLocator(pdfA, 7) }),
             CancellationToken.None);
 
         var rows = await db.TextChunks.AsNoTracking().ToListAsync();
@@ -194,10 +211,98 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
         var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
 
         await sut.Handle(
-            new IncrementChunkUsageCountsCommand(new[] { new ChunkUsageLocator(pdfId, 0) }),
+            NewCommand(new[] { new ChunkUsageLocator(pdfId, 0) }),
             CancellationToken.None);
 
         var reloaded = await db.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id);
         reloaded.UsageCount.Should().Be(43);
+    }
+
+    // ─── #2324 DEC-D2 distinct-thread invariants ──────────────────────────────
+
+    [Fact]
+    [Trait("Issue", "2324")]
+    public async Task Handle_ChunkCitedInTwoMessagesSameThread_IncrementsOnce()
+    {
+        // The crux of DEC-D2: the second message in a thread that cites the
+        // same chunk MUST NOT inflate the counter — distinct-thread is the
+        // contract. Junction row records both citations; counter ticks once.
+        await using var db = NewDb();
+        var pdfId = Guid.NewGuid();
+        var chunk = NewChunk(pdfId, chunkIndex: 9);
+        db.TextChunks.Add(chunk);
+        await db.SaveChangesAsync();
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+
+        var threadId = Guid.NewGuid();
+        var locator = new ChunkUsageLocator(pdfId, 9);
+
+        // First assistant message cites the chunk → +1.
+        var first = await sut.Handle(
+            NewCommand(new[] { locator }, threadId: threadId),
+            CancellationToken.None);
+        first.Should().Be(1);
+
+        // Second message in the SAME thread cites the same chunk → no increment.
+        var second = await sut.Handle(
+            NewCommand(new[] { locator }, threadId: threadId),
+            CancellationToken.None);
+        second.Should().Be(0);
+
+        var reloaded = await db.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id);
+        reloaded.UsageCount.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Issue", "2324")]
+    public async Task Handle_ChunkCitedInTwoDifferentThreads_IncrementsTwice()
+    {
+        // The same chunk being cited in two different threads represents two
+        // distinct conversations → counter ticks twice.
+        await using var db = NewDb();
+        var pdfId = Guid.NewGuid();
+        var chunk = NewChunk(pdfId, chunkIndex: 11);
+        db.TextChunks.Add(chunk);
+        await db.SaveChangesAsync();
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+        var locator = new ChunkUsageLocator(pdfId, 11);
+
+        await sut.Handle(NewCommand(new[] { locator }, threadId: Guid.NewGuid()), CancellationToken.None);
+        await sut.Handle(NewCommand(new[] { locator }, threadId: Guid.NewGuid()), CancellationToken.None);
+
+        var reloaded = await db.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id);
+        reloaded.UsageCount.Should().Be(2);
+    }
+
+    [Fact]
+    [Trait("Issue", "2324")]
+    public async Task Handle_SameMessageReplayed_IsIdempotent()
+    {
+        // Replay protection: a transient retry of the same (threadId, messageId)
+        // must NOT double-count. The junction row's composite PK guarantees that
+        // the second insert is a no-op.
+        await using var db = NewDb();
+        var pdfId = Guid.NewGuid();
+        var chunk = NewChunk(pdfId, chunkIndex: 13);
+        db.TextChunks.Add(chunk);
+        await db.SaveChangesAsync();
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(db, NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+
+        var threadId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+        var locator = new ChunkUsageLocator(pdfId, 13);
+
+        await sut.Handle(
+            NewCommand(new[] { locator }, threadId: threadId, messageId: messageId),
+            CancellationToken.None);
+        await sut.Handle(
+            NewCommand(new[] { locator }, threadId: threadId, messageId: messageId),
+            CancellationToken.None);
+
+        var reloaded = await db.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id);
+        reloaded.UsageCount.Should().Be(1);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/IncrementChunkUsageCountsCommandHandlerTests.cs
@@ -281,8 +281,12 @@ public sealed class IncrementChunkUsageCountsCommandHandlerTests
     public async Task Handle_SameMessageReplayed_IsIdempotent()
     {
         // Replay protection: a transient retry of the same (threadId, messageId)
-        // must NOT double-count. The junction row's composite PK guarantees that
-        // the second insert is a no-op.
+        // must NOT double-count. Pre-loaded snapshot + alreadyRecorded early-return
+        // delivers idempotency on a shared DbContext (here). The composite PK
+        // also prevents a parallel-replay race in production where each call
+        // has a fresh scope; see IT Handle_ReplayedCommand_IsIdempotent_NoDuplicateJunctionRow
+        // and the 23505 catch in the handler. EF InMemory does NOT enforce the
+        // composite PK, so this test exercises the snapshot-based dedup path only.
         await using var db = NewDb();
         var pdfId = Guid.NewGuid();
         var chunk = NewChunk(pdfId, chunkIndex: 13);

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/IncrementChunkUsageCountsHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/IncrementChunkUsageCountsHandlerIntegrationTests.cs
@@ -1,0 +1,263 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.Authentication;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Postgres-backed integration tests for the #2324 distinct-thread upgrade of
+/// the chunk usage counter. The unit tests cover happy/sad paths with the EF
+/// InMemory provider; this fixture pins the wire behaviour that matters in
+/// production:
+/// <list type="bullet">
+///   <item><description>The migration applies and the junction table is
+///     queryable (composite PK + secondary index materialise).</description></item>
+///   <item><description>The handler increments correctly across distinct
+///     threads but suppresses within the same thread.</description></item>
+///   <item><description>Cascade delete on the thread FK wipes the junction.</description></item>
+///   <item><description>Replaying the same (thread, message, chunks) command
+///     is idempotent (composite PK + handler early-return).</description></item>
+/// </list>
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "2324")]
+[Collection("Integration-GroupA")]
+public class IncrementChunkUsageCountsHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext? _dbContext;
+    private string? _connectionString;
+    private readonly string _databaseName = $"test_chunk_usage_inc_{Guid.NewGuid():N}";
+
+    public IncrementChunkUsageCountsHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(_connectionString);
+        _dbContext = await Api.Tests.Infrastructure.TestHelpers.CreateDbContextAndMigrateAsync(_connectionString);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null) await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact]
+    public async Task Handle_DistinctThreadIncrement_AcrossTwoThreads_TicksTwice()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (pdfId, chunk) = await SeedSharedGameAndChunkAsync(chunkIndex: 5, ct);
+
+        var thread1 = await SeedThreadAsync(ct);
+        var thread2 = await SeedThreadAsync(ct);
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(
+            _dbContext!,
+            NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+
+        await sut.Handle(
+            new IncrementChunkUsageCountsCommand(
+                thread1.Id,
+                Guid.NewGuid(),
+                new[] { new ChunkUsageLocator(pdfId, 5) }),
+            ct);
+        await sut.Handle(
+            new IncrementChunkUsageCountsCommand(
+                thread2.Id,
+                Guid.NewGuid(),
+                new[] { new ChunkUsageLocator(pdfId, 5) }),
+            ct);
+
+        var reloaded = await _dbContext!.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id, ct);
+        reloaded.UsageCount.Should().Be(2);
+
+        var junctionRows = await _dbContext.ChatMessageChunkCitations.AsNoTracking()
+            .Where(j => j.ChunkId == chunk.Id)
+            .CountAsync(ct);
+        junctionRows.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_SameThreadTwoMessages_TicksOnce()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (pdfId, chunk) = await SeedSharedGameAndChunkAsync(chunkIndex: 7, ct);
+        var thread = await SeedThreadAsync(ct);
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(
+            _dbContext!,
+            NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+
+        var msg1 = Guid.NewGuid();
+        var msg2 = Guid.NewGuid();
+
+        await sut.Handle(
+            new IncrementChunkUsageCountsCommand(
+                thread.Id, msg1, new[] { new ChunkUsageLocator(pdfId, 7) }),
+            ct);
+        await sut.Handle(
+            new IncrementChunkUsageCountsCommand(
+                thread.Id, msg2, new[] { new ChunkUsageLocator(pdfId, 7) }),
+            ct);
+
+        var reloaded = await _dbContext!.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id, ct);
+        reloaded.UsageCount.Should().Be(1);
+
+        var junctionRows = await _dbContext.ChatMessageChunkCitations.AsNoTracking()
+            .Where(j => j.ThreadId == thread.Id && j.ChunkId == chunk.Id)
+            .CountAsync(ct);
+        junctionRows.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DeleteThread_CascadesJunctionRows()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (pdfId, chunk) = await SeedSharedGameAndChunkAsync(chunkIndex: 11, ct);
+        var thread = await SeedThreadAsync(ct);
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(
+            _dbContext!,
+            NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+
+        await sut.Handle(
+            new IncrementChunkUsageCountsCommand(
+                thread.Id, Guid.NewGuid(), new[] { new ChunkUsageLocator(pdfId, 11) }),
+            ct);
+
+        // Pre-condition: junction row exists.
+        var pre = await _dbContext!.ChatMessageChunkCitations.AsNoTracking()
+            .Where(j => j.ThreadId == thread.Id)
+            .CountAsync(ct);
+        pre.Should().Be(1);
+
+        // Act — drop the thread → FK cascade on the junction.
+        _dbContext.ChatThreads.Remove(thread);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var post = await _dbContext.ChatMessageChunkCitations.AsNoTracking()
+            .Where(j => j.ThreadId == thread.Id)
+            .CountAsync(ct);
+        post.Should().Be(0);
+
+        // The chunk row survives (it belongs to the pdf, not the thread).
+        var chunkSurvives = await _dbContext.TextChunks.AsNoTracking()
+            .AnyAsync(c => c.Id == chunk.Id, ct);
+        chunkSurvives.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ReplayedCommand_IsIdempotent_NoDuplicateJunctionRow()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (pdfId, chunk) = await SeedSharedGameAndChunkAsync(chunkIndex: 13, ct);
+        var thread = await SeedThreadAsync(ct);
+
+        var sut = new IncrementChunkUsageCountsCommandHandler(
+            _dbContext!,
+            NullLogger<IncrementChunkUsageCountsCommandHandler>.Instance);
+
+        var msgId = Guid.NewGuid();
+        var cmd = new IncrementChunkUsageCountsCommand(
+            thread.Id, msgId, new[] { new ChunkUsageLocator(pdfId, 13) });
+
+        await sut.Handle(cmd, ct);
+        await sut.Handle(cmd, ct); // replay — must not double-tick or violate PK
+
+        var reloaded = await _dbContext!.TextChunks.AsNoTracking().FirstAsync(c => c.Id == chunk.Id, ct);
+        reloaded.UsageCount.Should().Be(1);
+
+        var junctionRows = await _dbContext.ChatMessageChunkCitations.AsNoTracking()
+            .Where(j => j.ThreadId == thread.Id && j.MessageId == msgId && j.ChunkId == chunk.Id)
+            .CountAsync(ct);
+        junctionRows.Should().Be(1);
+    }
+
+    // ─── Seeding helpers ──────────────────────────────────────────────────────
+
+    private async Task<(Guid pdfId, TextChunkEntity chunk)> SeedSharedGameAndChunkAsync(
+        int chunkIndex,
+        CancellationToken ct)
+    {
+        var userId = Guid.NewGuid();
+        var user = new UserEntity
+        {
+            Id = userId,
+            Email = $"u{userId:N}@test",
+            DisplayName = "Tester",
+            Role = "User",
+        };
+        var sharedGame = new SharedGameEntity { Id = Guid.NewGuid(), Title = $"Game {Guid.NewGuid():N}" };
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = userId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow,
+            SharedGameId = sharedGame.Id,
+        };
+        var chunk = new TextChunkEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            ChunkIndex = chunkIndex,
+            Content = $"snippet-{chunkIndex}",
+            CharacterCount = 12,
+            CreatedAt = DateTime.UtcNow,
+            SharedGameId = sharedGame.Id,
+        };
+
+        _dbContext!.Users.Add(user);
+        _dbContext.SharedGames.Add(sharedGame);
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.TextChunks.Add(chunk);
+        await _dbContext.SaveChangesAsync(ct);
+
+        return (pdfId, chunk);
+    }
+
+    private async Task<ChatThreadEntity> SeedThreadAsync(CancellationToken ct)
+    {
+        var userId = Guid.NewGuid();
+        var user = new UserEntity
+        {
+            Id = userId,
+            Email = $"u{userId:N}@test",
+            DisplayName = "Threader",
+            Role = "User",
+        };
+        var thread = new ChatThreadEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            CreatedAt = DateTime.UtcNow,
+            LastMessageAt = DateTime.UtcNow,
+        };
+
+        _dbContext!.Users.Add(user);
+        _dbContext.ChatThreads.Add(thread);
+        await _dbContext.SaveChangesAsync(ct);
+
+        return thread;
+    }
+}


### PR DESCRIPTION
## Summary

Promotes `text_chunks.usage_count` from **distinct-message** (BE-1 #2323) to **distinct-thread** semantics, per the original DEC-D2 spec on #2311. A chunk cited by two assistant messages in the SAME thread now contributes a single increment; cited from two DIFFERENT threads still contributes two.

## Schema (new)

```sql
chat_message_chunk_citations
  thread_id   UUID NOT NULL  REFERENCES "ChatThreads"(Id) ON DELETE CASCADE
  message_id  UUID NOT NULL                       -- ChatMessage.Id (value object, no FK)
  chunk_id    UUID NOT NULL  REFERENCES text_chunks(Id) ON DELETE CASCADE
  cited_at    TIMESTAMPTZ NOT NULL
  PK (thread_id, message_id, chunk_id)
  ix_chat_msg_chunk_thread_chunk (thread_id, chunk_id)
```

Composite PK doubles as the natural idempotency key (replay of the same `(threadId, messageId, chunkId)` is a no-op). The secondary index backs the "is this the first thread-touch?" EXISTS query.

## Handler refactor (algorithm)

Per locator, after intra-command dedup:

1. If the `(ThreadId, MessageId, ChunkId)` junction row already exists → no-op (replay protection).
2. If any OTHER message in the same thread already cited this chunk → record the junction row but DO NOT increment (distinct-thread).
3. Otherwise → first thread-touch: increment `text_chunks.usage_count` and record the junction row.

Intra-message dedup is preserved (a chunk cited 3 times in one assistant response → +1).

## Caller wire

`ChatWithSessionAgentCommandHandler` resolves the freshly-added assistant message via `thread.Messages.OrderByDescending(m => m.SequenceNumber).First()` and passes `(thread.Id, messageId)` to the increment command. Still fire-and-forget — any exception is swallowed and logged.

## Backfill

**DEC-A no-backfill** (coherent with BE-1 start-from-0). Counter keeps incremental change-over semantics; historical inconsistency accepted.

## Race condition (documented, accepted)

Two parallel commands targeting the same `(ThreadId, ChunkId)` from different messages may both observe "no other message cited" and both increment, yielding a double count. Chat threads are essentially sequential, the counter is forward-looking telemetry (not a correctness invariant), and the race window is narrow. Closing the window via serializable-isolation transaction or advisory lock is out of scope for #2324 (P3).

## Test plan

- [x] **11 unit tests** (8 existing + 3 new distinct-thread): `pnpm dotnet test --filter "FullyQualifiedName~IncrementChunkUsageCountsCommandHandlerTests"` → 11/11 pass.
- [x] **4 integration tests** (Testcontainers Postgres) in `IncrementChunkUsageCountsHandlerIntegrationTests`:
  - cross-thread same-chunk → +2
  - same-thread two messages same chunk → +1
  - CASCADE on thread delete → junction rows wiped, chunks survive
  - replay same `(thread, msg, chunks)` → idempotent (no PK violation, no double-tick)
- [x] **Regression**: 2245/2247 `(BoundedContext=KnowledgeBase)&(Category=Unit)` pass (2 unrelated skips pre-existing).
- [ ] CI: full Backend Tests + Integration.

Closes #2324 · Refs #2311 BE-1 (PR #2323)

🤖 Generated with [Claude Code](https://claude.com/claude-code)