### PR TITLE
feat(play-records): #2437-2 share-token + public read-only view

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/GeneratePlayRecordShareTokenCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/GeneratePlayRecordShareTokenCommand.cs
@@ -1,0 +1,9 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+/// <summary>
+/// Command to generate a public share token for a play record. Creator-only (#2437-2).
+/// </summary>
+internal record GeneratePlayRecordShareTokenCommand(Guid PlayRecordId, Guid UserId) : ICommand<ShareLinkResponse>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/GeneratePlayRecordShareTokenCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/GeneratePlayRecordShareTokenCommandHandler.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+/// <summary>
+/// Handles generating a public share token for a play record. Creator-only (#2437-2).
+/// </summary>
+internal class GeneratePlayRecordShareTokenCommandHandler : ICommandHandler<GeneratePlayRecordShareTokenCommand, ShareLinkResponse>
+{
+    private readonly IPlayRecordRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public GeneratePlayRecordShareTokenCommandHandler(
+        IPlayRecordRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<ShareLinkResponse> Handle(GeneratePlayRecordShareTokenCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var record = await _repository.GetByIdAsync(command.PlayRecordId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("PlayRecord", command.PlayRecordId.ToString());
+
+        if (record.CreatedByUserId != command.UserId)
+            throw new ForbiddenException("Only the record creator can generate a share link.");
+
+        var token = record.GenerateShareToken();
+
+        await _repository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new ShareLinkResponse(
+            ShareToken: token,
+            ShareUrl: $"/play-records/shared/{token}");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/RevokePlayRecordShareTokenCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/RevokePlayRecordShareTokenCommand.cs
@@ -1,0 +1,8 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+/// <summary>
+/// Command to revoke the public share token of a play record. Creator-only (#2437-2).
+/// </summary>
+internal record RevokePlayRecordShareTokenCommand(Guid PlayRecordId, Guid UserId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/RevokePlayRecordShareTokenCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/RevokePlayRecordShareTokenCommandHandler.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+
+/// <summary>
+/// Handles revoking the public share token of a play record. Creator-only (#2437-2).
+/// </summary>
+internal class RevokePlayRecordShareTokenCommandHandler : ICommandHandler<RevokePlayRecordShareTokenCommand>
+{
+    private readonly IPlayRecordRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RevokePlayRecordShareTokenCommandHandler(
+        IPlayRecordRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(RevokePlayRecordShareTokenCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var record = await _repository.GetByIdAsync(command.PlayRecordId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("PlayRecord", command.PlayRecordId.ToString());
+
+        if (record.CreatedByUserId != command.UserId)
+            throw new ForbiddenException("Only the record creator can revoke the share link.");
+
+        record.RevokeShareToken();
+
+        await _repository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
@@ -8,6 +8,7 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// Issue #1663: Phase 1 – WinnerPlayerIds and OutcomeType computed on read.
 /// Issue #2436 PR-C: Photos (presigned read-path) added as last parameter.
 /// Issue #2437-1: Xmin concurrency token exposed so clients can round-trip it on update.
+/// Issue #2437-2: ShareToken exposed so the authenticated detail view can show/revoke the link.
 /// </summary>
 public record PlayRecordDto(
     Guid Id,
@@ -29,7 +30,8 @@ public record PlayRecordDto(
     IReadOnlyList<Guid> WinnerPlayerIds,
     string OutcomeType,
     IReadOnlyList<PlayRecordPhotoDto> Photos,
-    uint Xmin
+    uint Xmin,
+    string? ShareToken
 );
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/ShareLinkResponse.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/ShareLinkResponse.cs
@@ -1,0 +1,4 @@
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+
+/// <summary>Share-link response for a play record (#2437-2).</summary>
+public record ShareLinkResponse(string ShareToken, string ShareUrl);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordByShareTokenQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordByShareTokenQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+
+/// <summary>
+/// Anonymous query to retrieve a play record by its public share token.
+/// No user authentication required — possessing the token IS the authorization.
+/// Issue #2437-2.
+/// </summary>
+internal record GetPlayRecordByShareTokenQuery(string ShareToken) : IQuery<PlayRecordDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordByShareTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordByShareTokenQueryHandler.cs
@@ -1,5 +1,4 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
-using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
@@ -10,23 +9,24 @@ using Microsoft.EntityFrameworkCore;
 namespace Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
 
 /// <summary>
-/// Handles retrieving a single play record with full details (authenticated, owner/player access).
-/// Issue #3890: CQRS queries for play records.
-/// Issue #2436 PR-C: Photos presigned read-path.
-/// Issue #2437-2: Delegates DTO mapping to <see cref="PlayRecordDtoMapper"/> (shared with anonymous share-token query).
+/// Handles public (anonymous) retrieval of a play record by its share token.
+/// No user identity check — possessing the token IS the authorization.
+/// Delegates DTO mapping (photo presigning, outcome computation, scoring-config deserialization)
+/// to <see cref="PlayRecordDtoMapper"/>, shared with <see cref="GetPlayRecordQueryHandler"/>.
+/// Issue #2437-2.
 /// </summary>
-internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, PlayRecordDto>
+internal class GetPlayRecordByShareTokenQueryHandler : IQueryHandler<GetPlayRecordByShareTokenQuery, PlayRecordDto>
 {
     private readonly MeepleAiDbContext _context;
     private readonly IBlobStorageService _blobStorage;
 
-    public GetPlayRecordQueryHandler(MeepleAiDbContext context, IBlobStorageService blobStorage)
+    public GetPlayRecordByShareTokenQueryHandler(MeepleAiDbContext context, IBlobStorageService blobStorage)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
     }
 
-    public async Task<PlayRecordDto> Handle(GetPlayRecordQuery query, CancellationToken cancellationToken)
+    public async Task<PlayRecordDto> Handle(GetPlayRecordByShareTokenQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -35,17 +35,11 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
             .Include(r => r.Players)
                 .ThenInclude(p => p.Scores)
             .Include(r => r.Photos)
-            .FirstOrDefaultAsync(r => r.Id == query.RecordId, cancellationToken)
+            .FirstOrDefaultAsync(r => r.ShareToken == query.ShareToken && r.IsShared, cancellationToken)
             .ConfigureAwait(false);
 
         if (entity == null)
-            throw new NotFoundException("PlayRecord", query.RecordId.ToString());
-
-        if (entity.CreatedByUserId != query.UserId
-            && !entity.Players.Any(p => p.UserId == query.UserId))
-        {
-            throw new ForbiddenException("You do not have permission to view this play record.");
-        }
+            throw new NotFoundException("PlayRecord", query.ShareToken);
 
         return await PlayRecordDtoMapper.MapAsync(
             entity, _blobStorage, PlayRecordPhotoUrlResolver.DefaultExpirySeconds, cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordDtoMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordDtoMapper.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Shared mapper that converts a <see cref="PlayRecordEntity"/> (with loaded navigations) into
+/// a fully-populated <see cref="PlayRecordDto"/>, including:
+/// <list type="bullet">
+///   <item>ScoringConfig JSON deserialization</item>
+///   <item>Winner/outcome computation via <see cref="PlayRecordOutcomeCalculator"/></item>
+///   <item>Photo presigned-URL resolution via <see cref="PlayRecordPhotoUrlResolver"/></item>
+///   <item>SessionPlayerDto projection</item>
+///   <item>ShareToken passthrough (null when not shared)</item>
+/// </list>
+/// Extracted from <c>GetPlayRecordQueryHandler</c> so the anonymous
+/// <c>GetPlayRecordByShareTokenQueryHandler</c> can reuse it without duplicating logic.
+/// Issue #2437-2.
+/// </summary>
+internal static class PlayRecordDtoMapper
+{
+    public static async Task<PlayRecordDto> MapAsync(
+        PlayRecordEntity entity,
+        IBlobStorageService blobStorage,
+        int presignExpirySeconds,
+        CancellationToken cancellationToken = default)
+    {
+        // Deserialize outside expression tree to avoid optional parameter issues
+        var scoringConfig = System.Text.Json.JsonSerializer.Deserialize<SessionScoringConfigDto>(entity.ScoringConfigJson)
+            ?? new SessionScoringConfigDto(new List<string>(), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        // Compute outcome fields from player scores (no storage change — computed on read)
+        var winnerPlayerIds = PlayRecordOutcomeCalculator.WinnerPlayerIds(entity.Players);
+        var outcomeType = PlayRecordOutcomeCalculator.OutcomeType(entity.Players);
+
+        // Map photos with presigned URLs (read path, #2436 PR-C). Ordered oldest→newest.
+        var photos = new List<PlayRecordPhotoDto>(entity.Photos.Count);
+        foreach (var p in entity.Photos.OrderBy(p => p.UploadedAt))
+        {
+            var url = await PlayRecordPhotoUrlResolver.ResolveAsync(blobStorage, p.BlobUrl, presignExpirySeconds).ConfigureAwait(false);
+            var thumb = p.ThumbnailUrl is null
+                ? null
+                : await PlayRecordPhotoUrlResolver.ResolveAsync(blobStorage, p.ThumbnailUrl, presignExpirySeconds).ConfigureAwait(false);
+            photos.Add(new PlayRecordPhotoDto(p.Id, url, thumb, p.OcrText, p.Caption, p.UploadedByUserId, p.UploadedAt));
+        }
+
+        return new PlayRecordDto(
+            entity.Id,
+            entity.GameId,
+            entity.GameName,
+            entity.SessionDate,
+            entity.Duration,
+            (Domain.Enums.PlayRecordStatus)entity.Status,
+            entity.Players.Select(p => new SessionPlayerDto(
+                p.Id,
+                p.UserId,
+                p.DisplayName,
+                p.Scores.Select(s => new SessionScoreDto(
+                    s.Dimension,
+                    s.Value,
+                    s.Unit
+                )).ToList(),
+                PlayRecordOutcomeCalculator.TotalScore(p)
+            )).ToList(),
+            scoringConfig,
+            entity.CreatedByUserId,
+            (Domain.Enums.PlayRecordVisibility)entity.Visibility,
+            entity.StartTime,
+            entity.EndTime,
+            entity.Notes,
+            entity.Location,
+            entity.CreatedAt,
+            entity.UpdatedAt,
+            winnerPlayerIds,
+            outcomeType,
+            photos,
+            entity.Xmin,
+            entity.IsShared ? entity.ShareToken : null   // #2437-2: only expose token when currently shared
+        );
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/GeneratePlayRecordShareTokenCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/GeneratePlayRecordShareTokenCommandValidator.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.PlayRecords;
+
+/// <summary>
+/// Validates <see cref="GeneratePlayRecordShareTokenCommand"/> (#2437-2).
+/// </summary>
+internal sealed class GeneratePlayRecordShareTokenCommandValidator : AbstractValidator<GeneratePlayRecordShareTokenCommand>
+{
+    public GeneratePlayRecordShareTokenCommandValidator()
+    {
+        RuleFor(x => x.PlayRecordId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/RevokePlayRecordShareTokenCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/PlayRecords/RevokePlayRecordShareTokenCommandValidator.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.PlayRecords;
+
+/// <summary>
+/// Validates <see cref="RevokePlayRecordShareTokenCommand"/> (#2437-2).
+/// </summary>
+internal sealed class RevokePlayRecordShareTokenCommandValidator : AbstractValidator<RevokePlayRecordShareTokenCommand>
+{
+    public RevokePlayRecordShareTokenCommandValidator()
+    {
+        RuleFor(x => x.PlayRecordId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PlayRecord.cs
@@ -31,6 +31,10 @@ internal sealed class PlayRecord : AggregateRoot<Guid>
     public string? Notes { get; private set; }
     public string? Location { get; private set; }
 
+    // Share token (#2437-2, GameNightPlaylist pattern)
+    public string? ShareToken { get; private set; }
+    public bool IsShared { get; private set; }
+
     // Players & Scoring
     private readonly List<RecordPlayer> _players = new();
     public IReadOnlyList<RecordPlayer> Players => _players.AsReadOnly();
@@ -52,6 +56,31 @@ internal sealed class PlayRecord : AggregateRoot<Guid>
 
     /// <summary>Repository-only: restore the xmin token after loading from persistence.</summary>
     internal void SetXmin(uint xmin) => Xmin = xmin;
+
+    /// <summary>Generates a URL-safe share token for public read access (#2437-2, GameNightPlaylist pattern).</summary>
+    public string GenerateShareToken()
+    {
+        ShareToken = Convert.ToBase64String(Guid.NewGuid().ToByteArray())
+            .Replace("/", "_").Replace("+", "-").TrimEnd('=');
+        IsShared = true;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+        return ShareToken;
+    }
+
+    /// <summary>Revokes the share token, disabling public access.</summary>
+    public void RevokeShareToken()
+    {
+        ShareToken = null;
+        IsShared = false;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>Repository-only: restore share state after loading from persistence.</summary>
+    internal void SetShareState(string? shareToken, bool isShared)
+    {
+        ShareToken = shareToken;
+        IsShared = isShared;
+    }
 
     // Soft Delete (issue #2439 — mirrors GameBook.SoftDelete pattern)
     public bool IsDeleted { get; private set; }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPlayRecordRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPlayRecordRepository.cs
@@ -33,4 +33,10 @@ internal interface IPlayRecordRepository : IRepository<PlayRecord, Guid>
     /// Checks if a user has permission to edit a play record.
     /// </summary>
     Task<bool> CanUserEditAsync(Guid userId, Guid recordId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a publicly shared play record by its share token.
+    /// Returns null if the token does not exist or the record is not shared (#2437-2).
+    /// </summary>
+    Task<PlayRecord?> GetByShareTokenAsync(string shareToken, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordRepository.cs
@@ -203,6 +203,18 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
         return Task.CompletedTask;
     }
 
+    public async Task<PlayRecord?> GetByShareTokenAsync(string shareToken, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(shareToken);
+        var entity = await DbContext.PlayRecords
+            .AsNoTracking()
+            .Include(r => r.Players).ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
+            .FirstOrDefaultAsync(r => r.ShareToken == shareToken && r.IsShared, cancellationToken)
+            .ConfigureAwait(false);
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
     public async Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default)
     {
         return await DbContext.PlayRecords
@@ -292,6 +304,9 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
         // Restore the xmin optimistic-concurrency token (ADR-060). #2436 PR-B / #2437-1.
         record.SetXmin(entity.Xmin);
 
+        // Restore share state (#2437-2, GameNightPlaylist pattern).
+        record.SetShareState(entity.ShareToken, entity.IsShared);
+
         return record;
     }
 
@@ -320,7 +335,9 @@ internal class PlayRecordRepository : RepositoryBase, IPlayRecordRepository
             SourceEventId = record.SourceEventId,
             IsDeleted = record.IsDeleted,
             DeletedAt = record.DeletedAt,
-            Xmin = record.Xmin  // round-trip for detached Update (ADR-060). #2436 PR-B / #2437-1.
+            Xmin = record.Xmin,  // round-trip for detached Update (ADR-060). #2436 PR-B / #2437-1.
+            ShareToken = record.ShareToken,  // #2437-2
+            IsShared = record.IsShared       // #2437-2
         };
 
         // Serialize scoring config

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/PlayRecordEntity.cs
@@ -31,6 +31,10 @@ public class PlayRecordEntity
     public string? Notes { get; set; }
     public string? Location { get; set; }
 
+    // Share token (#2437-2, GameNightPlaylist pattern)
+    public string? ShareToken { get; set; }
+    public bool IsShared { get; set; }
+
     // Scoring Configuration (stored as JSON)
     public string ScoringConfigJson { get; set; } = default!;
 

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/PlayRecordEntityConfiguration.cs
@@ -41,6 +41,10 @@ internal class PlayRecordEntityConfiguration : IEntityTypeConfiguration<PlayReco
         builder.Property(e => e.Notes).HasMaxLength(2000);
         builder.Property(e => e.Location).HasMaxLength(255);
 
+        // Share token (#2437-2, GameNightPlaylist pattern)
+        builder.Property(e => e.ShareToken).HasMaxLength(50);
+        builder.Property(e => e.IsShared).HasDefaultValue(false).IsRequired();
+
         // Scoring Configuration (JSON)
         builder.Property(e => e.ScoringConfigJson)
             .IsRequired()
@@ -81,6 +85,13 @@ internal class PlayRecordEntityConfiguration : IEntityTypeConfiguration<PlayReco
             .IsUnique()
             .HasDatabaseName("UX_play_records_source_event_id")
             .HasFilter("source_event_id IS NOT NULL");
+
+        // Issue #2437-2: ShareToken UNIQUE (partial — only when not null).
+        // Allows multiple non-shared records (all NULL) while enforcing token uniqueness.
+        builder.HasIndex(e => e.ShareToken)
+            .HasDatabaseName("IX_play_records_share_token")
+            .IsUnique()
+            .HasFilter("\"ShareToken\" IS NOT NULL");
 
         // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
         // xmin is a Postgres system column — EF maps it but does NOT create the column.

--- a/apps/api/src/Api/Infrastructure/Migrations/20260621082834_AddPlayRecordShareToken.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260621082834_AddPlayRecordShareToken.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260621082834_AddPlayRecordShareToken")]
+    partial class AddPlayRecordShareToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260621082834_AddPlayRecordShareToken.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260621082834_AddPlayRecordShareToken.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayRecordShareToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsShared",
+                table: "play_records",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShareToken",
+                table: "play_records",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_play_records_share_token",
+                table: "play_records",
+                column: "ShareToken",
+                unique: true,
+                filter: "\"ShareToken\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_play_records_share_token",
+                table: "play_records");
+
+            migrationBuilder.DropColumn(
+                name: "IsShared",
+                table: "play_records");
+
+            migrationBuilder.DropColumn(
+                name: "ShareToken",
+                table: "play_records");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
+++ b/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
@@ -112,6 +112,14 @@ internal static class PlayRecordEndpoints
             .WithTags("PlayRecords")
             .WithSummary("Revoke the share link (creator-only)");
 
+        // Public (anonymous) query — must be registered BEFORE the authenticated /{recordId} route
+        // to avoid the router matching "shared" as a Guid and routing to HandleGetPlayRecord.
+        group.MapGet("/play-records/shared/{token}", HandleGetSharedPlayRecord)
+            .AllowAnonymous()
+            .Produces<PlayRecordDto>(200).Produces(404)
+            .WithTags("PlayRecords")
+            .WithSummary("Get a shared play record by token (public, no auth)");
+
         // Queries
         group.MapGet("/play-records/{recordId}", HandleGetPlayRecord)
             .RequireAuthenticatedUser()
@@ -289,6 +297,15 @@ internal static class PlayRecordEndpoints
     #endregion
 
     #region Query Handlers
+
+    private static async Task<IResult> HandleGetSharedPlayRecord(
+        string token,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetPlayRecordByShareTokenQuery(token), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
 
     private static async Task<IResult> HandleGetPlayRecord(
         Guid recordId,

--- a/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
+++ b/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using ShareLinkResponse = Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords.ShareLinkResponse;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Extensions;
 using MediatR;
@@ -96,6 +97,20 @@ internal static class PlayRecordEndpoints
             .WithTags("PlayRecords")
             .WithSummary("Upload a photo to a play record (creator-only, ≤5MB, opt-in OCR)")
             .WithOpenApi();
+
+        group.MapPost("/play-records/{recordId:guid}/share", HandleGenerateShareLink)
+            .RequireAuthenticatedUser()
+            .Produces<ShareLinkResponse>(200)
+            .Produces(401).Produces(StatusCodes.Status403Forbidden).Produces(404)
+            .WithTags("PlayRecords")
+            .WithSummary("Generate a public share link (creator-only)");
+
+        group.MapDelete("/play-records/{recordId:guid}/share", HandleRevokeShareLink)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(401).Produces(StatusCodes.Status403Forbidden).Produces(404)
+            .WithTags("PlayRecords")
+            .WithSummary("Revoke the share link (creator-only)");
 
         // Queries
         group.MapGet("/play-records/{recordId}", HandleGetPlayRecord)
@@ -245,6 +260,30 @@ internal static class PlayRecordEndpoints
         // ValidationException→400) — matching every other handler in this file.
         var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         return Results.Created($"/api/v1/play-records/{recordId}/photos/{result.PhotoId}", result);
+    }
+
+    private static async Task<IResult> HandleGenerateShareLink(
+        Guid recordId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GeneratePlayRecordShareTokenCommand(recordId, httpContext.User.GetUserId()),
+            cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleRevokeShareLink(
+        Guid recordId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        await mediator.Send(
+            new RevokePlayRecordShareTokenCommand(recordId, httpContext.User.GetUserId()),
+            cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
@@ -262,6 +262,46 @@ public class GetPlayRecordQueryHandlerTests : IDisposable
     }
 
     [Fact]
+    [Trait("Issue", "2437")]
+    public async Task Handle_WhenIsSharedAndTokenSet_ExposesShareToken()
+    {
+        // Arrange
+        var recordId = Guid.NewGuid();
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity> { MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)) };
+        entity.ShareToken = "tok-abc123";
+        entity.IsShared = true;
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayRecordQuery(recordId, entity.CreatedByUserId), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShareToken.Should().Be("tok-abc123");
+    }
+
+    [Fact]
+    [Trait("Issue", "2437")]
+    public async Task Handle_WhenNotShared_ShareTokenIsNull()
+    {
+        // Arrange — token present on entity but IsShared is false (revoked)
+        var recordId = Guid.NewGuid();
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity> { MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)) };
+        entity.ShareToken = "tok-stale";
+        entity.IsShared = false;
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayRecordQuery(recordId, entity.CreatedByUserId), TestContext.Current.CancellationToken);
+
+        // Assert — mapper must not expose the stale token when IsShared=false
+        result.ShareToken.Should().BeNull();
+    }
+
+    [Fact]
     [Trait("Issue", "2436")]
     public async Task Handle_RecordWithPhotos_ReturnsPhotosOrderedByUploadedAt()
     {

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/PlayRecordShareTokenCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/PlayRecordShareTokenCommandHandlerTests.cs
@@ -1,0 +1,145 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+/// <summary>
+/// Unit tests for <see cref="GeneratePlayRecordShareTokenCommandHandler"/>
+/// and <see cref="RevokePlayRecordShareTokenCommandHandler"/> (issue #2437-2).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2437")]
+public class PlayRecordShareTokenCommandHandlerTests
+{
+    private static PlayRecord MakeRecord(Guid creatorId) =>
+        PlayRecord.CreateFreeForm(
+            Guid.NewGuid(), "Catan", creatorId,
+            DateTime.UtcNow.AddDays(-1), PlayRecordVisibility.Private,
+            SessionScoringConfig.CreateDefault());
+
+    // ─── Generate ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Generate_ReturnsNonEmptyToken_AndSaves()
+    {
+        var creatorId = Guid.NewGuid();
+        var record = MakeRecord(creatorId);
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new GeneratePlayRecordShareTokenCommandHandler(repo.Object, uow.Object);
+        var result = await handler.Handle(
+            new GeneratePlayRecordShareTokenCommand(record.Id, creatorId), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.ShareToken.Should().NotBeNullOrEmpty();
+        result.ShareUrl.Should().Contain(result.ShareToken);
+
+        repo.Verify(r => r.UpdateAsync(record, It.IsAny<CancellationToken>()), Times.Once);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Generate_NotCreator_ThrowsForbiddenException()
+    {
+        var creatorId = Guid.NewGuid();
+        var otherUser = Guid.NewGuid();
+        var record = MakeRecord(creatorId);
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new GeneratePlayRecordShareTokenCommandHandler(repo.Object, uow.Object);
+        var act = () => handler.Handle(
+            new GeneratePlayRecordShareTokenCommand(record.Id, otherUser), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Generate_RecordNotFound_ThrowsNotFoundException()
+    {
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlayRecord?)null);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new GeneratePlayRecordShareTokenCommandHandler(repo.Object, uow.Object);
+        var act = () => handler.Handle(
+            new GeneratePlayRecordShareTokenCommand(Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ─── Revoke ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Revoke_ClearsToken_AndSaves()
+    {
+        var creatorId = Guid.NewGuid();
+        var record = MakeRecord(creatorId);
+        // Pre-generate so there is a token to revoke.
+        record.GenerateShareToken();
+        record.ShareToken.Should().NotBeNull("pre-condition: token must exist before revoke");
+
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new RevokePlayRecordShareTokenCommandHandler(repo.Object, uow.Object);
+        await handler.Handle(
+            new RevokePlayRecordShareTokenCommand(record.Id, creatorId), CancellationToken.None);
+
+        record.ShareToken.Should().BeNull();
+        repo.Verify(r => r.UpdateAsync(record, It.IsAny<CancellationToken>()), Times.Once);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Revoke_NotCreator_ThrowsForbiddenException()
+    {
+        var creatorId = Guid.NewGuid();
+        var otherUser = Guid.NewGuid();
+        var record = MakeRecord(creatorId);
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new RevokePlayRecordShareTokenCommandHandler(repo.Object, uow.Object);
+        var act = () => handler.Handle(
+            new RevokePlayRecordShareTokenCommand(record.Id, otherUser), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Revoke_RecordNotFound_ThrowsNotFoundException()
+    {
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlayRecord?)null);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new RevokePlayRecordShareTokenCommandHandler(repo.Object, uow.Object);
+        var act = () => handler.Handle(
+            new RevokePlayRecordShareTokenCommand(Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordShareTokenTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordShareTokenTests.cs
@@ -1,0 +1,204 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the public get-by-share-token query path.
+/// Covers generate → read via token, revoke → token no longer found, bogus token.
+/// Issue #2437-2.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2437")]
+public sealed class PlayRecordShareTokenTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+    private IServiceProvider? _serviceProvider;
+    private readonly TestTimeProvider _timeProvider = new();
+
+    public PlayRecordShareTokenTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IServiceProvider ServiceProvider => _serviceProvider ?? throw new InvalidOperationException("Service provider not initialized.");
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"playrecord_sharetoken_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_connectionString);
+        services.AddScoped<IPlayRecordRepository, PlayRecordRepository>();
+        services.AddScoped<PlayRecordPermissionChecker>();
+        services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+        services.AddScoped<IGameCoreDataProvider, GameCoreDataProvider>();
+        services.AddSingleton<TimeProvider>(_timeProvider);
+        // IBlobStorageService stub — local storage returns null (raw path pass-through)
+        var blobMock = new Mock<Api.Services.Pdf.IBlobStorageService>();
+        blobMock.Setup(b => b.GetPresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<Api.Services.Pdf.BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync((string?)null);
+        services.AddScoped(_ => blobMock.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    /// <summary>
+    /// Generate a share token → GetPlayRecordByShareTokenQuery returns a DTO with the matching Id.
+    /// </summary>
+    [Fact(DisplayName = "GetByShareToken_AfterGenerate_ReturnsDto")]
+    public async Task GetByShareToken_AfterGenerate_ReturnsDto()
+    {
+        // Arrange
+        var userId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(userId);
+
+        var generateResult = await SendInScopeAsync(
+            new GeneratePlayRecordShareTokenCommand(recordId, userId));
+
+        generateResult.ShareToken.Should().NotBeNullOrEmpty();
+
+        // Act
+        var dto = await SendInScopeAsync(
+            new GetPlayRecordByShareTokenQuery(generateResult.ShareToken));
+
+        // Assert
+        dto.Id.Should().Be(recordId);
+        dto.ShareToken.Should().Be(generateResult.ShareToken,
+            "the mapper should expose the token when IsShared=true");
+    }
+
+    /// <summary>
+    /// After revoking, the same token must not be findable — query throws NotFoundException.
+    /// </summary>
+    [Fact(DisplayName = "GetByShareToken_AfterRevoke_ThrowsNotFoundException")]
+    public async Task GetByShareToken_AfterRevoke_ThrowsNotFoundException()
+    {
+        // Arrange
+        var userId = await SeedTestUserAsync();
+        var recordId = await CreateTestRecordAsync(userId);
+
+        var generateResult = await SendInScopeAsync(
+            new GeneratePlayRecordShareTokenCommand(recordId, userId));
+
+        await SendInScopeAsync(
+            new RevokePlayRecordShareTokenCommand(recordId, userId));
+
+        // Act
+        Func<Task> act = async () =>
+            await SendInScopeAsync(new GetPlayRecordByShareTokenQuery(generateResult.ShareToken));
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>(
+            "IsShared=false after revoke — token must not be accessible");
+    }
+
+    /// <summary>
+    /// A token that was never issued throws NotFoundException.
+    /// </summary>
+    [Fact(DisplayName = "GetByShareToken_BogusToken_ThrowsNotFoundException")]
+    public async Task GetByShareToken_BogusToken_ThrowsNotFoundException()
+    {
+        // Act
+        Func<Task> act = async () =>
+            await SendInScopeAsync(new GetPlayRecordByShareTokenQuery("this-token-does-not-exist"));
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedTestUserAsync()
+    {
+        var id = Guid.NewGuid();
+        await using var db = _fixture.CreateDbContext(_connectionString);
+        db.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"sharetoken-{id:N}@meepleai.test",
+            DisplayName = "ShareToken Test User",
+            Role = "user",
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    private async Task<Guid> CreateTestRecordAsync(Guid creatorUserId)
+    {
+        var gameId = Guid.NewGuid();
+        await using var db = _fixture.CreateDbContext(_connectionString);
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "ShareToken Test Game",
+            YearPublished = 2024,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+
+        var command = new CreatePlayRecordCommand(
+            creatorUserId,
+            gameId,
+            "ShareToken Test Game",
+            _timeProvider.UtcNow.AddHours(-1),
+            PlayRecordVisibility.Private);
+
+        return await SendInScopeAsync(command);
+    }
+
+    private async Task<TResult> SendInScopeAsync<TResult>(IRequest<TResult> request)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(request, TestCancellationToken);
+    }
+
+    private async Task SendInScopeAsync(IRequest request)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        await mediator.Send(request, TestCancellationToken);
+    }
+}

--- a/apps/web/src/app/(public)/play-records/shared/[token]/page.tsx
+++ b/apps/web/src/app/(public)/play-records/shared/[token]/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * Public Shared Play Record Page (#2437-2)
+ *
+ * Public route for viewing a shared play record via share-link token.
+ * No authentication required — access controlled by the share token in the URL.
+ *
+ * Route: /play-records/shared/{token}
+ *
+ * Rendering is delegated to PlayRecordPublicView, which fetches the record
+ * and renders it in read-only (spectator) mode via PlayRecordDetailBody.
+ */
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { PlayRecordPublicView } from '@/components/play-records/PlayRecordPublicView';
+
+export default function SharedPlayRecordPage() {
+  const params = useParams();
+  const token = typeof params?.token === 'string' ? params.token : '';
+
+  return <PlayRecordPublicView token={token} />;
+}

--- a/apps/web/src/components/play-records/PlayRecordDetailBody.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailBody.tsx
@@ -34,6 +34,7 @@ import {
   type RankedScore,
   type PlayRecordHeroPodiumLabels,
 } from './primitives/PlayRecordHeroPodium';
+import { SharePlayRecordDialog } from './SharePlayRecordDialog';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -161,6 +162,7 @@ export function PlayRecordDetailBody({
   const { t } = useTranslation();
   const router = useRouter();
   const [photoDialogOpen, setPhotoDialogOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   // ── Derive perspective ──────────────────────────────────────────────────────
   const isCreator = currentUserId !== null && currentUserId === record.createdByUserId;
@@ -268,7 +270,14 @@ export function PlayRecordDetailBody({
             to avoid a double screen-reader announcement of the same title. */}
         <section className="flex flex-col gap-2">
           {isCreator && (
-            <div className="flex">
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShareOpen(true)}
+                className="rounded-md border border-border px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+              >
+                🔗 {t('playRecords.share.button')}
+              </button>
               <button
                 type="button"
                 onClick={() => setPhotoDialogOpen(true)}
@@ -297,6 +306,15 @@ export function PlayRecordDetailBody({
             recordId={record.id}
             open={photoDialogOpen}
             onClose={() => setPhotoDialogOpen(false)}
+          />
+        )}
+
+        {isCreator && (
+          <SharePlayRecordDialog
+            recordId={record.id}
+            currentShareToken={record.shareToken ?? null}
+            open={shareOpen}
+            onClose={() => setShareOpen(false)}
           />
         )}
 

--- a/apps/web/src/components/play-records/PlayRecordDetailBody.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailBody.tsx
@@ -1,0 +1,364 @@
+/**
+ * PlayRecordDetailBody — pure, prop-driven body for a single play record.
+ *
+ * Extracted from PlayRecordDetailView as part of #2437-2 to enable reuse
+ * by a public (share-token) view. Receives an already-loaded `record` and
+ * `currentUserId` (null for anonymous/spectator contexts); all derivations
+ * and the full composition are performed here.
+ *
+ * @see PlayRecordDetailView — thin wrapper that handles hooks + loading/error guards
+ */
+/* eslint-disable local/no-hardcoded-color-utility -- text-white / gradient covers intentionally use colored bg following .e-bg mockup pattern */
+'use client';
+
+import { useState, type ReactElement } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { entityHsl } from '@/components/ui/data-display/meeple-card';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { PlayRecordDto } from '@/lib/api/schemas/play-records.schemas';
+import type { SessionPlayer } from '@/lib/api/schemas/play-records.schemas';
+import { derivePerspective } from '@/lib/play-records/derivePerspective';
+import { formatRelativeDate } from '@/lib/play-records/formatRelativeDate';
+
+import { Classifica, type ClassificaRow } from './detail/Classifica';
+import { ConnectionBar } from './detail/ConnectionBar';
+import { KpiGrid } from './detail/KpiGrid';
+import { ScoreBreakdown, type ScoreBreakdownRow } from './detail/ScoreBreakdown';
+import { PlayRecordPhotoGallery } from './photos/PlayRecordPhotoGallery';
+import { PlayRecordPhotoUploadDialog } from './photos/PlayRecordPhotoUploadDialog';
+import {
+  PlayRecordHeroPodium,
+  type RankedScore,
+  type PlayRecordHeroPodiumLabels,
+} from './primitives/PlayRecordHeroPodium';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Map perspective.kind to the hero variant accepted by PlayRecordHeroPodium.
+ * spectator → use "won" or "tied" visual variant, current-user just isn't highlighted.
+ */
+function perspectiveToHeroVariant(
+  kind: string,
+  winnerCount: number
+): 'won' | 'tied' | 'cooperative' | 'inprogress' | 'planned' {
+  switch (kind) {
+    case 'won':
+      return 'won';
+    case 'tie':
+    case 'tied':
+      return 'tied';
+    case 'cooperative':
+      return 'cooperative';
+    case 'pending':
+      return 'inprogress'; // will be overridden to 'planned' based on status below
+    case 'spectator':
+    case 'lost':
+      // For spectator/lost, still show the competitive podium (won/tied based on winner count)
+      return winnerCount > 1 ? 'tied' : 'won';
+    default:
+      return 'won';
+  }
+}
+
+/** Format .NET TimeSpan or ISO 8601 duration string to human-readable. */
+function formatDuration(raw: string | null): string | null {
+  if (!raw) return null;
+  // .NET TimeSpan: "02:15:00" or "1.02:15:00"
+  // eslint-disable-next-line security/detect-unsafe-regex
+  const match = raw.match(/^(?:(\d+)\.)?(\d+):(\d+):(\d+)$/);
+  if (match) {
+    const days = match[1] ? parseInt(match[1]) : 0;
+    const hours = parseInt(match[2]) + days * 24;
+    const minutes = parseInt(match[3]);
+    const h = hours > 0 ? `${hours}h` : '';
+    const m = minutes > 0 ? `${minutes}min` : '';
+    const result = [h, m].filter(Boolean).join(' ');
+    return result || null;
+  }
+  return raw;
+}
+
+/** Build RankedScore[] sorted descending by totalScore from PlayRecordDto players. */
+function buildRankedScores(players: SessionPlayer[], winnerPlayerIds: string[]): RankedScore[] {
+  return [...players]
+    .sort((a, b) => {
+      const sa = a.totalScore ?? null;
+      const sb = b.totalScore ?? null;
+      if (sa === null && sb === null) return 0;
+      if (sa === null) return 1;
+      if (sb === null) return -1;
+      return sb - sa;
+    })
+    .map(p => ({
+      playerId: p.id,
+      name: p.displayName,
+      score: p.totalScore ?? null,
+      isWinner: winnerPlayerIds.includes(p.id),
+    }));
+}
+
+/** Build ClassificaRow[] from players. */
+function buildClassificaRows(players: SessionPlayer[], winnerPlayerIds: string[]): ClassificaRow[] {
+  return players.map(p => ({
+    playerId: p.id,
+    userId: p.userId,
+    name: p.displayName,
+    totalScore: p.totalScore ?? null,
+    isWinner: winnerPlayerIds.includes(p.id),
+  }));
+}
+
+/** Build ScoreBreakdownRow[] from players. */
+function buildBreakdownRows(players: SessionPlayer[]): ScoreBreakdownRow[] {
+  return players.map(p => ({
+    playerId: p.id,
+    name: p.displayName,
+    scores: p.scores.map(s => ({ dimension: s.dimension, value: s.value })),
+    totalScore: p.totalScore ?? null,
+  }));
+}
+
+/** Compute KPI values from players. */
+function computeKpis(players: SessionPlayer[]): {
+  topScore: number | null;
+  avgScore: number | null;
+  spread: number | null;
+} {
+  const scores = players
+    .map(p => p.totalScore)
+    .filter((s): s is number => s !== null && s !== undefined);
+
+  if (scores.length === 0) {
+    return { topScore: null, avgScore: null, spread: null };
+  }
+
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  const avg = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+
+  return {
+    topScore: max,
+    avgScore: avg,
+    spread: max - min,
+  };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export interface PlayRecordDetailBodyProps {
+  record: PlayRecordDto;
+  currentUserId: string | null;
+}
+
+export function PlayRecordDetailBody({
+  record,
+  currentUserId,
+}: PlayRecordDetailBodyProps): ReactElement {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [photoDialogOpen, setPhotoDialogOpen] = useState(false);
+
+  // ── Derive perspective ──────────────────────────────────────────────────────
+  const isCreator = currentUserId !== null && currentUserId === record.createdByUserId;
+  const perspective = derivePerspective({
+    currentUserId,
+    players: record.players,
+    winnerPlayerIds: record.winnerPlayerIds ?? [],
+    outcomeType: record.outcomeType,
+    status: record.status,
+  });
+
+  // ── Build variant for hero ──────────────────────────────────────────────────
+  let heroVariant = perspectiveToHeroVariant(perspective.kind, record.winnerPlayerIds?.length ?? 0);
+  // Override pending → planned/inprogress based on actual status
+  if (perspective.kind === 'pending') {
+    heroVariant = record.status === 'Planned' ? 'planned' : 'inprogress';
+  }
+
+  const isCooperative = perspective.kind === 'cooperative';
+  const isCompleted = record.status === 'Completed';
+
+  // ── Hero labels ─────────────────────────────────────────────────────────────
+  const heroLabels: PlayRecordHeroPodiumLabels = {
+    variantWon: t('playRecords.detail.hero.won'),
+    variantTied: t('playRecords.detail.hero.tied'),
+    variantCooperative: t('playRecords.detail.hero.cooperative'),
+    variantInProgress: t('playRecords.detail.hero.inprogress'),
+    variantPlanned: t('playRecords.detail.hero.planned'),
+    bannerWon: (winnerName, gameName) =>
+      t('playRecords.detail.hero.bannerWon', { winnerName, gameName }),
+    bannerTied: score => t('playRecords.detail.hero.bannerTied', { score }),
+    bannerCooperative: gameName => t('playRecords.detail.hero.bannerCooperative', { gameName }),
+    bannerInProgress: (gameName, turn) =>
+      turn !== undefined
+        ? `${gameName} in corso · turno ${turn}`
+        : t('playRecords.detail.hero.bannerInProgress', { gameName }),
+    bannerPlanned: gameName => t('playRecords.detail.hero.bannerPlanned', { gameName }),
+    metaPlayers: n => t('playRecords.detail.hero.metaPlayers', { count: n }),
+    ctaStart: t('playRecords.detail.hero.ctaStart'),
+  };
+
+  // ── Data derivatives ────────────────────────────────────────────────────────
+  const rankedScores = buildRankedScores(record.players, record.winnerPlayerIds ?? []);
+  const clasificaRows = buildClassificaRows(record.players, record.winnerPlayerIds ?? []);
+  const breakdownRows = buildBreakdownRows(record.players);
+  const { topScore, avgScore, spread } = computeKpis(record.players);
+
+  const formattedDuration = formatDuration(record.duration);
+  const formattedDate = formatRelativeDate(record.sessionDate);
+
+  // #2437-1 MVP chip: derive from winnerPlayerIds — only when exactly 1 winner.
+  const winnerIds = record.winnerPlayerIds ?? [];
+  const mvpName =
+    winnerIds.length === 1
+      ? (record.players.find(p => p.id === winnerIds[0])?.displayName ?? null)
+      : null;
+
+  const dimensions = record.scoringConfig.enabledDimensions;
+
+  // Game info for hero (EC-2: freeform emoji fallback)
+  const gameForHero = {
+    id: record.gameId,
+    name: record.gameName,
+    coverEmoji: '🎲', // fallback; real cover from useSharedGames in future
+  };
+
+  return (
+    <div data-testid="play-record-detail" className="flex flex-col">
+      {/* Hero Podium — AC-2.2 */}
+      <PlayRecordHeroPodium
+        variant={heroVariant}
+        game={gameForHero}
+        rankedScores={rankedScores}
+        metadata={{
+          date: formattedDate,
+          duration: formattedDuration,
+          playerCount: record.players.length,
+        }}
+        perspective={perspective}
+        labels={heroLabels}
+        onStart={() => router.push(`/play-records/${record.id}/edit`)}
+      />
+
+      {/* Connection Bar — AC-2.3, #2437-1 MVP chip */}
+      <ConnectionBar
+        gameId={record.gameId}
+        gameName={record.gameName}
+        playerCount={record.players.length}
+        dateLabel={formattedDate}
+        chatCount={0}
+        mvpName={mvpName}
+      />
+
+      {/* Body sections */}
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-4 py-6 pb-16 sm:px-8 sm:py-8">
+        {/* KPI Grid — AC-2.4 */}
+        <KpiGrid
+          duration={formattedDuration}
+          topScore={topScore}
+          avgScore={avgScore}
+          spread={spread}
+        />
+
+        {/* Photos — #2436 PR-C. The gallery renders its own <h2>; no section aria-label
+            to avoid a double screen-reader announcement of the same title. */}
+        <section className="flex flex-col gap-2">
+          {isCreator && (
+            <div className="flex">
+              <button
+                type="button"
+                onClick={() => setPhotoDialogOpen(true)}
+                className="ml-auto rounded-md border border-border px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+              >
+                📷 {t('playRecords.photos.addButton')}
+              </button>
+            </div>
+          )}
+          <PlayRecordPhotoGallery
+            photos={record.photos ?? []}
+            labels={{
+              title: t('playRecords.photos.sectionTitle'),
+              emptyTitle: t('playRecords.photos.emptyTitle'),
+              emptyDescription: t('playRecords.photos.emptyDescription'),
+              photoAltFallback: t('playRecords.photos.photoAltFallback'),
+              ocrResultTitle: t('playRecords.photos.ocrResultTitle'),
+              prev: t('playRecords.photos.lightboxPrev'),
+              next: t('playRecords.photos.lightboxNext'),
+            }}
+          />
+        </section>
+
+        {isCreator && (
+          <PlayRecordPhotoUploadDialog
+            recordId={record.id}
+            open={photoDialogOpen}
+            onClose={() => setPhotoDialogOpen(false)}
+          />
+        )}
+
+        {/* Classifica — AC-2.5 */}
+        {clasificaRows.length > 0 && (
+          <Classifica
+            rows={clasificaRows}
+            isCooperative={isCooperative}
+            currentUserPlayerId={perspective.currentUserPlayerId}
+          />
+        )}
+
+        {/* ScoreBreakdown accordion — AC-2.6, EC-10 */}
+        {dimensions.length > 1 && <ScoreBreakdown rows={breakdownRows} dimensions={dimensions} />}
+
+        {/* Notes section */}
+        {record.notes && (
+          <section role="region" aria-label="Note">
+            <h2 className="mb-2 flex items-center gap-1.5 font-display text-sm font-extrabold text-foreground">
+              <span aria-hidden="true">📝</span>
+              Note
+            </h2>
+            <div
+              className="rounded-xl border border-border bg-card px-4 py-3"
+              style={{ borderLeft: `3px solid ${entityHsl('session')}` }}
+            >
+              <p className="text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
+                {record.notes}
+              </p>
+            </div>
+          </section>
+        )}
+
+        {/* Rematch CTA — only for completed non-pending records */}
+        {isCompleted && !isCooperative && (
+          <section
+            className="flex items-center justify-between gap-4 rounded-xl border px-5 py-4"
+            style={{
+              background: `linear-gradient(135deg, ${entityHsl('game', 0.1)}, ${entityHsl('session', 0.1)})`,
+              borderColor: entityHsl('game', 0.3),
+            }}
+            aria-label="Registra rivincita"
+          >
+            <div className="min-w-0 flex-1">
+              <h3 className="font-display text-base font-extrabold text-foreground">
+                🎲 Pronti per la rivincita?
+              </h3>
+              <p className="text-xs text-muted-foreground">Stessi giocatori e gioco.</p>
+            </div>
+            <Link
+              href="/play-records/new"
+              className="shrink-0 rounded-md px-4 py-2 text-sm font-extrabold text-white shadow-md"
+              style={{
+                background: entityHsl('session'),
+                boxShadow: `0 4px 14px ${entityHsl('session', 0.4)}`,
+              }}
+            >
+              ▶ Registra rivincita
+            </Link>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/play-records/PlayRecordDetailView.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailView.tsx
@@ -1,171 +1,27 @@
 /**
  * PlayRecordDetailView — Task 2 (Issue #1488 / Epic #1475 Phase D).
  *
- * Full detail view for a single play record. Composes:
- *   - PlayRecordHeroPodium (variant driven by derivePerspective)
- *   - ConnectionBar (entity-tinted chips: game / players / chat / date)
- *   - KpiGrid (duration, top score, average, spread)
- *   - Classifica (ranked player list with progress bars)
- *   - ScoreBreakdown (accordion for multi-dim scoring, EC-10)
- *   - Notes section (if present)
- *   - Rematch CTA (for completed records)
+ * Thin wrapper: resolves hooks, renders loading/error guards, then delegates
+ * the full composition to PlayRecordDetailBody.
  *
- * Perspective: derived from PlayRecordDto × currentUserId via derivePerspective.
- *
- * AC-2.1: consumes usePlayRecord(id) + derivePerspective
- * AC-2.2: HeroPodium variant matrix (won/tied/cooperative/inprogress/planned/spectator)
- * AC-2.3: ConnectionBar entity-tinted chips
- * AC-2.4: KpiGrid 4 KPI
- * AC-2.5: Classifica ranked + progress bar
- * AC-2.6: ScoreBreakdown accordion for multi-dim (EC-10)
- * AC-2.7: EC-1 cooperative — no OutcomeBadge, classifica neutrale
- * AC-2.8: EC-2 freeform (gameId=null) — emoji fallback, no game link
- * AC-2.9: EC-4/5 spectator — no current-user highlight
- * AC-2.10: EC-6/7 InProgress/Planned — omit duration, relative future date
  * AC-2.12: 404 → redirect to /play-records
  *
+ * @see PlayRecordDetailBody — pure prop-driven body (extracted #2437-2)
  * @see plan `docs/superpowers/plans/2026-05-29-play-records-reskin.md` Task 2
  * @see mockup `admin-mockups/design_files/sp4-play-records-detail.jsx`
  */
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / gradient covers intentionally use colored bg following .e-bg mockup pattern */
+/* eslint-disable local/no-hardcoded-color-utility -- text-white on ErrorState link uses colored bg via style prop, following .e-bg mockup pattern */
 'use client';
 
-import { useState, type ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-import { entityHsl } from '@/components/ui/data-display/meeple-card';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
-import { useTranslation } from '@/hooks/useTranslation';
-import type { SessionPlayer } from '@/lib/api/schemas/play-records.schemas';
 import { usePlayRecord } from '@/lib/domain-hooks/usePlayRecords';
-import { derivePerspective } from '@/lib/play-records/derivePerspective';
-import { formatRelativeDate } from '@/lib/play-records/formatRelativeDate';
 
-import { Classifica, type ClassificaRow } from './detail/Classifica';
-import { ConnectionBar } from './detail/ConnectionBar';
-import { KpiGrid } from './detail/KpiGrid';
-import { ScoreBreakdown, type ScoreBreakdownRow } from './detail/ScoreBreakdown';
-import { PlayRecordPhotoGallery } from './photos/PlayRecordPhotoGallery';
-import { PlayRecordPhotoUploadDialog } from './photos/PlayRecordPhotoUploadDialog';
-import {
-  PlayRecordHeroPodium,
-  type RankedScore,
-  type PlayRecordHeroPodiumLabels,
-} from './primitives/PlayRecordHeroPodium';
-
-// ── helpers ───────────────────────────────────────────────────────────────────
-
-/**
- * Map perspective.kind to the hero variant accepted by PlayRecordHeroPodium.
- * spectator → use "won" or "tied" visual variant, current-user just isn't highlighted.
- */
-function perspectiveToHeroVariant(
-  kind: string,
-  winnerCount: number
-): 'won' | 'tied' | 'cooperative' | 'inprogress' | 'planned' {
-  switch (kind) {
-    case 'won':
-      return 'won';
-    case 'tie':
-    case 'tied':
-      return 'tied';
-    case 'cooperative':
-      return 'cooperative';
-    case 'pending':
-      return 'inprogress'; // will be overridden to 'planned' based on status below
-    case 'spectator':
-    case 'lost':
-      // For spectator/lost, still show the competitive podium (won/tied based on winner count)
-      return winnerCount > 1 ? 'tied' : 'won';
-    default:
-      return 'won';
-  }
-}
-
-/** Format .NET TimeSpan or ISO 8601 duration string to human-readable. */
-function formatDuration(raw: string | null): string | null {
-  if (!raw) return null;
-  // .NET TimeSpan: "02:15:00" or "1.02:15:00"
-  // eslint-disable-next-line security/detect-unsafe-regex
-  const match = raw.match(/^(?:(\d+)\.)?(\d+):(\d+):(\d+)$/);
-  if (match) {
-    const days = match[1] ? parseInt(match[1]) : 0;
-    const hours = parseInt(match[2]) + days * 24;
-    const minutes = parseInt(match[3]);
-    const h = hours > 0 ? `${hours}h` : '';
-    const m = minutes > 0 ? `${minutes}min` : '';
-    const result = [h, m].filter(Boolean).join(' ');
-    return result || null;
-  }
-  return raw;
-}
-
-/** Build RankedScore[] sorted descending by totalScore from PlayRecordDto players. */
-function buildRankedScores(players: SessionPlayer[], winnerPlayerIds: string[]): RankedScore[] {
-  return [...players]
-    .sort((a, b) => {
-      const sa = a.totalScore ?? null;
-      const sb = b.totalScore ?? null;
-      if (sa === null && sb === null) return 0;
-      if (sa === null) return 1;
-      if (sb === null) return -1;
-      return sb - sa;
-    })
-    .map(p => ({
-      playerId: p.id,
-      name: p.displayName,
-      score: p.totalScore ?? null,
-      isWinner: winnerPlayerIds.includes(p.id),
-    }));
-}
-
-/** Build ClassificaRow[] from players. */
-function buildClassificaRows(players: SessionPlayer[], winnerPlayerIds: string[]): ClassificaRow[] {
-  return players.map(p => ({
-    playerId: p.id,
-    userId: p.userId,
-    name: p.displayName,
-    totalScore: p.totalScore ?? null,
-    isWinner: winnerPlayerIds.includes(p.id),
-  }));
-}
-
-/** Build ScoreBreakdownRow[] from players. */
-function buildBreakdownRows(players: SessionPlayer[]): ScoreBreakdownRow[] {
-  return players.map(p => ({
-    playerId: p.id,
-    name: p.displayName,
-    scores: p.scores.map(s => ({ dimension: s.dimension, value: s.value })),
-    totalScore: p.totalScore ?? null,
-  }));
-}
-
-/** Compute KPI values from players. */
-function computeKpis(players: SessionPlayer[]): {
-  topScore: number | null;
-  avgScore: number | null;
-  spread: number | null;
-} {
-  const scores = players
-    .map(p => p.totalScore)
-    .filter((s): s is number => s !== null && s !== undefined);
-
-  if (scores.length === 0) {
-    return { topScore: null, avgScore: null, spread: null };
-  }
-
-  const max = Math.max(...scores);
-  const min = Math.min(...scores);
-  const avg = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
-
-  return {
-    topScore: max,
-    avgScore: avg,
-    spread: max - min,
-  };
-}
+import { PlayRecordDetailBody } from './PlayRecordDetailBody';
 
 // ── Loading skeleton ──────────────────────────────────────────────────────────
 
@@ -221,11 +77,9 @@ export interface PlayRecordDetailViewProps {
 }
 
 export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): ReactElement {
-  const { t } = useTranslation();
   const router = useRouter();
   const { data: currentUser } = useCurrentUser();
   const { data: record, isLoading, error } = usePlayRecord(recordId);
-  const [photoDialogOpen, setPhotoDialogOpen] = useState(false);
 
   if (isLoading) {
     return <LoadingSkeleton />;
@@ -251,204 +105,5 @@ export function PlayRecordDetailView({ recordId }: PlayRecordDetailViewProps): R
     );
   }
 
-  // ── Derive perspective ──────────────────────────────────────────────────────
-  const currentUserId = currentUser?.id ?? null;
-  const isCreator = currentUserId !== null && currentUserId === record.createdByUserId;
-  const perspective = derivePerspective({
-    currentUserId,
-    players: record.players,
-    winnerPlayerIds: record.winnerPlayerIds ?? [],
-    outcomeType: record.outcomeType,
-    status: record.status,
-  });
-
-  // ── Build variant for hero ──────────────────────────────────────────────────
-  let heroVariant = perspectiveToHeroVariant(perspective.kind, record.winnerPlayerIds?.length ?? 0);
-  // Override pending → planned/inprogress based on actual status
-  if (perspective.kind === 'pending') {
-    heroVariant = record.status === 'Planned' ? 'planned' : 'inprogress';
-  }
-
-  const isCooperative = perspective.kind === 'cooperative';
-  const isCompleted = record.status === 'Completed';
-
-  // ── Hero labels ─────────────────────────────────────────────────────────────
-  const heroLabels: PlayRecordHeroPodiumLabels = {
-    variantWon: t('playRecords.detail.hero.won'),
-    variantTied: t('playRecords.detail.hero.tied'),
-    variantCooperative: t('playRecords.detail.hero.cooperative'),
-    variantInProgress: t('playRecords.detail.hero.inprogress'),
-    variantPlanned: t('playRecords.detail.hero.planned'),
-    bannerWon: (winnerName, gameName) =>
-      t('playRecords.detail.hero.bannerWon', { winnerName, gameName }),
-    bannerTied: score => t('playRecords.detail.hero.bannerTied', { score }),
-    bannerCooperative: gameName => t('playRecords.detail.hero.bannerCooperative', { gameName }),
-    bannerInProgress: (gameName, turn) =>
-      turn !== undefined
-        ? `${gameName} in corso · turno ${turn}`
-        : t('playRecords.detail.hero.bannerInProgress', { gameName }),
-    bannerPlanned: gameName => t('playRecords.detail.hero.bannerPlanned', { gameName }),
-    metaPlayers: n => t('playRecords.detail.hero.metaPlayers', { count: n }),
-    ctaStart: t('playRecords.detail.hero.ctaStart'),
-  };
-
-  // ── Data derivatives ────────────────────────────────────────────────────────
-  const rankedScores = buildRankedScores(record.players, record.winnerPlayerIds ?? []);
-  const clasificaRows = buildClassificaRows(record.players, record.winnerPlayerIds ?? []);
-  const breakdownRows = buildBreakdownRows(record.players);
-  const { topScore, avgScore, spread } = computeKpis(record.players);
-
-  const formattedDuration = formatDuration(record.duration);
-  const formattedDate = formatRelativeDate(record.sessionDate);
-
-  // #2437-1 MVP chip: derive from winnerPlayerIds — only when exactly 1 winner.
-  const winnerIds = record.winnerPlayerIds ?? [];
-  const mvpName =
-    winnerIds.length === 1
-      ? (record.players.find(p => p.id === winnerIds[0])?.displayName ?? null)
-      : null;
-
-  const dimensions = record.scoringConfig.enabledDimensions;
-
-  // Game info for hero (EC-2: freeform emoji fallback)
-  const gameForHero = {
-    id: record.gameId,
-    name: record.gameName,
-    coverEmoji: '🎲', // fallback; real cover from useSharedGames in future
-  };
-
-  return (
-    <div data-testid="play-record-detail" className="flex flex-col">
-      {/* Hero Podium — AC-2.2 */}
-      <PlayRecordHeroPodium
-        variant={heroVariant}
-        game={gameForHero}
-        rankedScores={rankedScores}
-        metadata={{
-          date: formattedDate,
-          duration: formattedDuration,
-          playerCount: record.players.length,
-        }}
-        perspective={perspective}
-        labels={heroLabels}
-        onStart={() => router.push(`/play-records/${recordId}/edit`)}
-      />
-
-      {/* Connection Bar — AC-2.3, #2437-1 MVP chip */}
-      <ConnectionBar
-        gameId={record.gameId}
-        gameName={record.gameName}
-        playerCount={record.players.length}
-        dateLabel={formattedDate}
-        chatCount={0}
-        mvpName={mvpName}
-      />
-
-      {/* Body sections */}
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-4 py-6 pb-16 sm:px-8 sm:py-8">
-        {/* KPI Grid — AC-2.4 */}
-        <KpiGrid
-          duration={formattedDuration}
-          topScore={topScore}
-          avgScore={avgScore}
-          spread={spread}
-        />
-
-        {/* Photos — #2436 PR-C. The gallery renders its own <h2>; no section aria-label
-            to avoid a double screen-reader announcement of the same title. */}
-        <section className="flex flex-col gap-2">
-          {isCreator && (
-            <div className="flex">
-              <button
-                type="button"
-                onClick={() => setPhotoDialogOpen(true)}
-                className="ml-auto rounded-md border border-border px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
-              >
-                📷 {t('playRecords.photos.addButton')}
-              </button>
-            </div>
-          )}
-          <PlayRecordPhotoGallery
-            photos={record.photos ?? []}
-            labels={{
-              title: t('playRecords.photos.sectionTitle'),
-              emptyTitle: t('playRecords.photos.emptyTitle'),
-              emptyDescription: t('playRecords.photos.emptyDescription'),
-              photoAltFallback: t('playRecords.photos.photoAltFallback'),
-              ocrResultTitle: t('playRecords.photos.ocrResultTitle'),
-              prev: t('playRecords.photos.lightboxPrev'),
-              next: t('playRecords.photos.lightboxNext'),
-            }}
-          />
-        </section>
-
-        {isCreator && (
-          <PlayRecordPhotoUploadDialog
-            recordId={recordId}
-            open={photoDialogOpen}
-            onClose={() => setPhotoDialogOpen(false)}
-          />
-        )}
-
-        {/* Classifica — AC-2.5 */}
-        {clasificaRows.length > 0 && (
-          <Classifica
-            rows={clasificaRows}
-            isCooperative={isCooperative}
-            currentUserPlayerId={perspective.currentUserPlayerId}
-          />
-        )}
-
-        {/* ScoreBreakdown accordion — AC-2.6, EC-10 */}
-        {dimensions.length > 1 && <ScoreBreakdown rows={breakdownRows} dimensions={dimensions} />}
-
-        {/* Notes section */}
-        {record.notes && (
-          <section role="region" aria-label="Note">
-            <h2 className="mb-2 flex items-center gap-1.5 font-display text-sm font-extrabold text-foreground">
-              <span aria-hidden="true">📝</span>
-              Note
-            </h2>
-            <div
-              className="rounded-xl border border-border bg-card px-4 py-3"
-              style={{ borderLeft: `3px solid ${entityHsl('session')}` }}
-            >
-              <p className="text-sm leading-relaxed text-muted-foreground whitespace-pre-wrap">
-                {record.notes}
-              </p>
-            </div>
-          </section>
-        )}
-
-        {/* Rematch CTA — only for completed non-pending records */}
-        {isCompleted && !isCooperative && (
-          <section
-            className="flex items-center justify-between gap-4 rounded-xl border px-5 py-4"
-            style={{
-              background: `linear-gradient(135deg, ${entityHsl('game', 0.1)}, ${entityHsl('session', 0.1)})`,
-              borderColor: entityHsl('game', 0.3),
-            }}
-            aria-label="Registra rivincita"
-          >
-            <div className="min-w-0 flex-1">
-              <h3 className="font-display text-base font-extrabold text-foreground">
-                🎲 Pronti per la rivincita?
-              </h3>
-              <p className="text-xs text-muted-foreground">Stessi giocatori e gioco.</p>
-            </div>
-            <Link
-              href="/play-records/new"
-              className="shrink-0 rounded-md px-4 py-2 text-sm font-extrabold text-white shadow-md"
-              style={{
-                background: entityHsl('session'),
-                boxShadow: `0 4px 14px ${entityHsl('session', 0.4)}`,
-              }}
-            >
-              ▶ Registra rivincita
-            </Link>
-          </section>
-        )}
-      </div>
-    </div>
-  );
+  return <PlayRecordDetailBody record={record} currentUserId={currentUser?.id ?? null} />;
 }

--- a/apps/web/src/components/play-records/PlayRecordPublicView.tsx
+++ b/apps/web/src/components/play-records/PlayRecordPublicView.tsx
@@ -1,0 +1,85 @@
+/**
+ * PlayRecordPublicView — public (unauthenticated) view for a shared play record.
+ *
+ * Fetches the record by share token via `useSharedPlayRecord` and delegates
+ * rendering to `PlayRecordDetailBody` with `currentUserId={null}` (spectator
+ * mode — no creator actions exposed).
+ *
+ * Issue #2437-2: Public shared play-record route.
+ */
+'use client';
+
+import type { ReactElement } from 'react';
+
+import { AlertTriangle } from 'lucide-react';
+import Link from 'next/link';
+
+import { Card, CardContent } from '@/components/ui/data-display/card';
+import { Button } from '@/components/ui/primitives/button';
+import { useSharedPlayRecord } from '@/lib/domain-hooks/usePlayRecords';
+
+import { PlayRecordDetailBody } from './PlayRecordDetailBody';
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+function LoadingSkeleton(): ReactElement {
+  return (
+    <div data-testid="play-record-public-loading" className="flex flex-col gap-4 p-4 sm:p-8">
+      <div className="h-52 animate-pulse rounded-2xl bg-muted sm:h-64" />
+      <div className="h-12 animate-pulse rounded-xl bg-muted" />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+      <div className="h-48 animate-pulse rounded-xl bg-muted" />
+    </div>
+  );
+}
+
+// ── Not found / error state ───────────────────────────────────────────────────
+
+function NotFoundState(): ReactElement {
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-16">
+        <Card className="max-w-md mx-auto">
+          <CardContent className="flex flex-col items-center py-12 text-center">
+            <AlertTriangle className="h-16 w-16 text-muted-foreground mb-4" />
+            <h2 className="text-xl font-semibold mb-2">Partita Non Trovata</h2>
+            <p className="text-muted-foreground mb-6">
+              Questo link di condivisione potrebbe essere scaduto, revocato o non valido.
+            </p>
+            <Button asChild>
+              <Link href="/">Torna alla Home</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}
+
+// ── Public view ───────────────────────────────────────────────────────────────
+
+export interface PlayRecordPublicViewProps {
+  token: string;
+}
+
+/**
+ * Renders a shared play record identified by `token`.
+ * `currentUserId={null}` ensures the body is fully read-only:
+ * no "Condividi" / "Aggiungi foto" creator buttons are shown.
+ */
+export function PlayRecordPublicView({ token }: PlayRecordPublicViewProps): ReactElement {
+  const { data: record, isLoading, error } = useSharedPlayRecord(token);
+
+  if (isLoading) return <LoadingSkeleton />;
+  if (error || !record) return <NotFoundState />;
+
+  return (
+    <main className="min-h-screen bg-background">
+      <PlayRecordDetailBody record={record} currentUserId={null} />
+    </main>
+  );
+}

--- a/apps/web/src/components/play-records/SharePlayRecordDialog.tsx
+++ b/apps/web/src/components/play-records/SharePlayRecordDialog.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+
+import { toast } from 'sonner';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+import {
+  useGeneratePlayRecordShareToken,
+  useRevokePlayRecordShareToken,
+} from '@/lib/domain-hooks/usePlayRecords';
+
+export interface SharePlayRecordDialogProps {
+  recordId: string;
+  currentShareToken: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SharePlayRecordDialog({
+  recordId,
+  currentShareToken,
+  open,
+  onClose,
+}: SharePlayRecordDialogProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const [token, setToken] = useState<string | null>(currentShareToken);
+  const generate = useGeneratePlayRecordShareToken(recordId);
+  const revoke = useRevokePlayRecordShareToken(recordId);
+
+  const shareUrl = token
+    ? `${typeof window !== 'undefined' ? window.location.origin : ''}/play-records/shared/${token}`
+    : '';
+
+  const handleGenerate = async () => {
+    try {
+      const res = await generate.mutateAsync();
+      setToken(res.shareToken);
+    } catch {
+      toast.error(t('playRecords.share.errorGenerate'));
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    toast.success(t('playRecords.share.copied'));
+  };
+
+  const handleRevoke = async () => {
+    try {
+      await revoke.mutateAsync();
+      setToken(null);
+    } catch {
+      toast.error(t('playRecords.share.errorRevoke'));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogTitle>🔗 {t('playRecords.share.dialogTitle')}</DialogTitle>
+        <DialogDescription>{t('playRecords.share.dialogDescription')}</DialogDescription>
+        {!token ? (
+          <Button onClick={handleGenerate} disabled={generate.isPending}>
+            {generate.isPending
+              ? t('playRecords.share.generating')
+              : t('playRecords.share.generate')}
+          </Button>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <label className="text-sm font-medium">{t('playRecords.share.urlLabel')}</label>
+            <input
+              readOnly
+              value={shareUrl}
+              className="w-full rounded-md border border-border bg-muted px-3 py-1.5 text-sm"
+            />
+            <div className="flex justify-between gap-2">
+              <Button variant="outline" onClick={handleCopy}>
+                {t('playRecords.share.copy')}
+              </Button>
+              <Button variant="destructive" onClick={handleRevoke} disabled={revoke.isPending}>
+                {revoke.isPending ? t('playRecords.share.revoking') : t('playRecords.share.revoke')}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/play-records/__tests__/PlayRecordPublicView.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/PlayRecordPublicView.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * PlayRecordPublicView — TDD tests (#2437-2).
+ *
+ * Verifies the three rendering surfaces:
+ *   1. Loading skeleton — while the query is in-flight
+ *   2. Not-found state — when the query returns an error or null data
+ *   3. Body rendered   — when data arrives, PlayRecordDetailBody receives
+ *                        record + currentUserId={null}
+ *
+ * Creator buttons ("Condividi" / "Aggiungi foto") must NOT appear in the
+ * public view because currentUserId={null} disables the isCreator branch.
+ *
+ * Strategy:
+ *   - Mock `useSharedPlayRecord` directly (vi.mock on the domain-hooks module).
+ *   - Mock `PlayRecordDetailBody` as a lightweight sentinel so we can assert
+ *     props without rendering the full complex body tree (avoids cascading
+ *     vi.mock requirements for router / i18n / derivePerspective etc.).
+ *   - Wrap in QueryClientProvider (required by the hook even when mocked).
+ */
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { PlayRecordDto } from '@/lib/api/schemas/play-records.schemas';
+
+import { PlayRecordPublicView } from '../PlayRecordPublicView';
+
+// ─── Mock: useSharedPlayRecord ────────────────────────────────────────────────
+
+vi.mock('@/lib/domain-hooks/usePlayRecords', () => ({
+  useSharedPlayRecord: vi.fn(),
+  playRecordsKeys: {
+    all: ['play-records'],
+    shared: (token: string) => ['play-records', 'shared', token],
+  },
+}));
+
+// ─── Mock: PlayRecordDetailBody ───────────────────────────────────────────────
+// Lightweight sentinel — renders a div exposing props as data attributes so we
+// can assert them without pulling in the full component tree.
+vi.mock('../PlayRecordDetailBody', () => ({
+  PlayRecordDetailBody: vi.fn(({ record, currentUserId }) => (
+    <div
+      data-testid="mock-detail-body"
+      data-game-name={record?.gameName}
+      data-current-user-id={currentUserId === null ? 'null' : currentUserId}
+    />
+  )),
+}));
+
+// ─── Mock: next/navigation (useParams) ────────────────────────────────────────
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useParams: () => ({ token: 'test-tok-abc' }),
+}));
+
+// ─── import after mock ────────────────────────────────────────────────────────
+import { useSharedPlayRecord } from '@/lib/domain-hooks/usePlayRecords';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeWrapper(): ({ children }: { children: ReactNode }) => JSX.Element {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/** Minimal PlayRecordDto sufficient for the test assertions. */
+const FIXTURE_RECORD: PlayRecordDto = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameName: 'Catan',
+  gameId: 'game-catan',
+  sessionDate: '2026-06-20T10:00:00Z',
+  status: 'Completed',
+  players: [
+    {
+      id: 'plr-1',
+      userId: 'u-other',
+      displayName: 'Alice',
+      scores: [{ dimension: 'points', value: 10, unit: null }],
+      totalScore: 10,
+    },
+  ],
+  winnerPlayerIds: ['plr-1'],
+  outcomeType: 'competitive',
+  visibility: 'Private',
+  createdByUserId: 'u-creator',
+  duration: '01:30:00',
+  scoringConfig: { enabledDimensions: ['points'], dimensionUnits: {} },
+  startTime: null,
+  endTime: null,
+  notes: null,
+  location: null,
+  createdAt: '2026-06-20T10:00:00Z',
+  updatedAt: '2026-06-20T10:00:00Z',
+  shareToken: 'test-tok-abc',
+  photos: [],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PlayRecordPublicView (#2437-2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Surface 1: loading ──────────────────────────────────────────────────────
+  describe('loading state', () => {
+    it('renders the loading skeleton while the query is in-flight', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="test-tok-abc" />, { wrapper: makeWrapper() });
+
+      expect(screen.getByTestId('play-record-public-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('mock-detail-body')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Surface 2: not found / error ────────────────────────────────────────────
+  describe('not-found / error state', () => {
+    it('renders the not-found card when the query returns an error', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Shared play record not found'),
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="bad-token" />, { wrapper: makeWrapper() });
+
+      expect(screen.getByText(/Partita Non Trovata/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /torna alla home/i })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('mock-detail-body')).not.toBeInTheDocument();
+    });
+
+    it('renders the not-found card when data is undefined (no error)', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="missing-token" />, { wrapper: makeWrapper() });
+
+      expect(screen.getByText(/Partita Non Trovata/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Surface 3: content ──────────────────────────────────────────────────────
+  describe('content state (record loaded)', () => {
+    it('renders PlayRecordDetailBody with the fetched record', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: FIXTURE_RECORD,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="test-tok-abc" />, { wrapper: makeWrapper() });
+
+      const body = screen.getByTestId('mock-detail-body');
+      expect(body).toBeInTheDocument();
+      expect(body).toHaveAttribute('data-game-name', 'Catan');
+    });
+
+    it('passes currentUserId={null} to PlayRecordDetailBody (read-only / spectator mode)', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: FIXTURE_RECORD,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="test-tok-abc" />, { wrapper: makeWrapper() });
+
+      const body = screen.getByTestId('mock-detail-body');
+      // Sentinel renders data-current-user-id="null" when prop is null
+      expect(body).toHaveAttribute('data-current-user-id', 'null');
+    });
+
+    it('does NOT render creator buttons (Condividi / Aggiungi foto) in public mode', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: FIXTURE_RECORD,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="test-tok-abc" />, { wrapper: makeWrapper() });
+
+      // These buttons are only rendered by PlayRecordDetailBody when isCreator=true
+      // (i.e. currentUserId === record.createdByUserId). With currentUserId=null,
+      // isCreator is always false. The mock body doesn't render them either.
+      expect(screen.queryByRole('button', { name: /condividi/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /aggiungi foto/i })).not.toBeInTheDocument();
+    });
+
+    it('passes the token from props to useSharedPlayRecord', () => {
+      vi.mocked(useSharedPlayRecord).mockReturnValue({
+        data: FIXTURE_RECORD,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useSharedPlayRecord>);
+
+      render(<PlayRecordPublicView token="my-custom-token" />, { wrapper: makeWrapper() });
+
+      expect(useSharedPlayRecord).toHaveBeenCalledWith('my-custom-token');
+    });
+  });
+});

--- a/apps/web/src/components/play-records/__tests__/SharePlayRecordDialog.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/SharePlayRecordDialog.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * SharePlayRecordDialog — TDD tests (#2437-2).
+ *
+ * Pattern: vi.spyOn on playRecordsApi (same as PlayRecordPhotoUploadDialog.test.tsx).
+ * useTranslation: MESSAGES fixture (key → translated string).
+ * sonner: mocked (toast.success / toast.error spies).
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { toast } from 'sonner';
+
+import { playRecordsApi } from '@/lib/api/play-records.api';
+
+import { SharePlayRecordDialog } from '../SharePlayRecordDialog';
+
+// ─── i18n mock ────────────────────────────────────────────────────────────────
+
+const MESSAGES: Record<string, string> = {
+  'playRecords.share.button': 'Condividi',
+  'playRecords.share.dialogTitle': 'Condividi partita',
+  'playRecords.share.dialogDescription':
+    'Genera un link pubblico per condividere questa partita con chiunque.',
+  'playRecords.share.generate': 'Genera link',
+  'playRecords.share.generating': 'Generazione…',
+  'playRecords.share.urlLabel': 'Link di condivisione',
+  'playRecords.share.copy': 'Copia',
+  'playRecords.share.copied': 'Link copiato',
+  'playRecords.share.revoke': 'Revoca',
+  'playRecords.share.revoking': 'Revoca…',
+  'playRecords.share.notShared': 'Non ancora condivisa',
+  'playRecords.share.errorGenerate': 'Impossibile generare il link. Riprova.',
+  'playRecords.share.errorRevoke': 'Impossibile revocare il link. Riprova.',
+};
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => MESSAGES[key] ?? key,
+  }),
+}));
+
+// ─── sonner mock ─────────────────────────────────────────────────────────────
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// ─── clipboard mock ───────────────────────────────────────────────────────────
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  writable: true,
+  configurable: true,
+});
+
+// ─── wrapper ──────────────────────────────────────────────────────────────────
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('SharePlayRecordDialog', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('when currentShareToken is null (not yet shared)', () => {
+    it('renders the "Genera link" button', () => {
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken={null}
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+      expect(screen.getByRole('button', { name: /genera link/i })).toBeInTheDocument();
+    });
+
+    it('calls generateShareToken and shows the URL input on success', async () => {
+      const spy = vi.spyOn(playRecordsApi, 'generateShareToken').mockResolvedValue({
+        shareToken: 'tok-abc123',
+        shareUrl: 'https://example.com/play-records/shared/tok-abc123',
+      });
+
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken={null}
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /genera link/i }));
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith('rec-1');
+      });
+
+      // After success the URL input should appear
+      await waitFor(() => {
+        const urlInput = screen.getByRole('textbox') as HTMLInputElement;
+        expect(urlInput.value).toContain('tok-abc123');
+        expect(urlInput.value).toContain('/play-records/shared/');
+      });
+    });
+
+    it('shows an error toast when generateShareToken fails', async () => {
+      vi.spyOn(playRecordsApi, 'generateShareToken').mockRejectedValue(new Error('server error'));
+
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken={null}
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /genera link/i }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Impossibile generare il link. Riprova.');
+      });
+    });
+  });
+
+  describe('when currentShareToken is provided (already shared)', () => {
+    it('shows the URL input with the share link', () => {
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken="existing-tok"
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+      const urlInput = screen.getByRole('textbox') as HTMLInputElement;
+      expect(urlInput.value).toContain('existing-tok');
+      expect(urlInput.value).toContain('/play-records/shared/');
+    });
+
+    it('copies the URL to clipboard and shows success toast on "Copia"', async () => {
+      const clipSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken="existing-tok"
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /copia/i }));
+
+      await waitFor(() => {
+        expect(clipSpy).toHaveBeenCalledWith(expect.stringContaining('existing-tok'));
+        expect(toast.success).toHaveBeenCalledWith('Link copiato');
+      });
+    });
+
+    it('calls revokeShareToken and hides the URL input on success', async () => {
+      const spy = vi.spyOn(playRecordsApi, 'revokeShareToken').mockResolvedValue(undefined);
+
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken="existing-tok"
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /revoca/i }));
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith('rec-1');
+      });
+
+      // After revoke, the token is cleared → "Genera link" should reappear
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /genera link/i })).toBeInTheDocument();
+      });
+    });
+
+    it('shows an error toast when revokeShareToken fails', async () => {
+      vi.spyOn(playRecordsApi, 'revokeShareToken').mockRejectedValue(new Error('server error'));
+
+      render(
+        wrap(
+          <SharePlayRecordDialog
+            recordId="rec-1"
+            currentShareToken="existing-tok"
+            open
+            onClose={() => {}}
+          />
+        )
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /revoca/i }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Impossibile revocare il link. Riprova.');
+      });
+    });
+  });
+
+  describe('dialog close behaviour', () => {
+    it('calls onClose when dialog is closed via Radix onOpenChange(false)', () => {
+      // We test this indirectly: the Dialog is open=true; pressing Escape triggers onOpenChange(false).
+      // We mock onClose and verify it is called.
+      const onClose = vi.fn();
+      render(
+        wrap(
+          <SharePlayRecordDialog recordId="rec-1" currentShareToken={null} open onClose={onClose} />
+        )
+      );
+      // The dialog is mounted in a portal — the close button from Radix DialogContent has X
+      // We just verify the component renders without error (onClose wire tested via onOpenChange prop)
+      expect(screen.getByText(/condividi partita/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/play-records/__tests__/play-records-axe.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/play-records-axe.test.tsx
@@ -113,6 +113,8 @@ vi.mock('@/lib/domain-hooks/usePlayRecords', () => ({
     error: null,
   })),
   usePlayRecords: vi.fn(() => ({ data: undefined, isLoading: false, error: null })),
+  useGeneratePlayRecordShareToken: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useRevokePlayRecordShareToken: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
 vi.mock('@/lib/play-records/useSharedGames', () => ({

--- a/apps/web/src/lib/api/__tests__/play-records-share.test.ts
+++ b/apps/web/src/lib/api/__tests__/play-records-share.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { playRecordsApi } from '../play-records.api';
+
+describe('playRecordsApi — share token methods (#2437-2)', () => {
+  beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  // ---- generateShareToken ----
+
+  describe('generateShareToken', () => {
+    it('POSTs to /{id}/share with credentials:include and returns the parsed response', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      const payload = { shareToken: 'tok123', shareUrl: 'https://app.meeple.ai/shared/tok123' };
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => payload,
+      });
+
+      const result = await playRecordsApi.generateShareToken('rec-id-1');
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toMatch(/\/rec-id-1\/share$/);
+      expect(init.method).toBe('POST');
+      expect(init.credentials).toBe('include');
+      expect(result).toEqual(payload);
+    });
+
+    it('throws when the response is not ok', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ message: 'Forbidden' }),
+      });
+
+      await expect(playRecordsApi.generateShareToken('rec-id-1')).rejects.toThrow('Forbidden');
+    });
+
+    it('falls back to generic message when error body has no message', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+
+      await expect(playRecordsApi.generateShareToken('rec-id-1')).rejects.toThrow(
+        'Failed to generate share link'
+      );
+    });
+  });
+
+  // ---- revokeShareToken ----
+
+  describe('revokeShareToken', () => {
+    it('DELETEs /{id}/share with credentials:include and resolves void on 204', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 204,
+        json: async () => null,
+      });
+
+      await expect(playRecordsApi.revokeShareToken('rec-id-2')).resolves.toBeUndefined();
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toMatch(/\/rec-id-2\/share$/);
+      expect(init.method).toBe('DELETE');
+      expect(init.credentials).toBe('include');
+    });
+
+    it('throws when the response is not ok', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'Not allowed' }),
+      });
+
+      await expect(playRecordsApi.revokeShareToken('rec-id-2')).rejects.toThrow('Not allowed');
+    });
+  });
+
+  // ---- getSharedRecord ----
+
+  describe('getSharedRecord', () => {
+    it('GETs /shared/{token} with credentials:include and returns the parsed DTO', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      const dto = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        gameName: 'Terraforming Mars',
+        sessionDate: '2026-06-21',
+        status: 'Completed',
+        players: [],
+        visibility: 'Private',
+        createdByUserId: '550e8400-e29b-41d4-a716-446655440001',
+        gameId: null,
+        duration: null,
+        scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+        startTime: null,
+        endTime: null,
+        notes: null,
+        location: null,
+        createdAt: '2026-06-21T10:00:00Z',
+        updatedAt: '2026-06-21T10:00:00Z',
+      };
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => dto,
+      });
+
+      const result = await playRecordsApi.getSharedRecord('mytoken');
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toMatch(/\/shared\/mytoken$/);
+      expect(init.credentials).toBe('include');
+      expect(result).toEqual(dto);
+    });
+
+    it('throws "Shared play record not found" on 404', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ message: 'Not found' }),
+      });
+
+      await expect(playRecordsApi.getSharedRecord('badtoken')).rejects.toThrow(
+        'Shared play record not found'
+      );
+    });
+
+    it('throws error message from body on non-404 failure', async () => {
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: 'Server exploded' }),
+      });
+
+      await expect(playRecordsApi.getSharedRecord('tok')).rejects.toThrow('Server exploded');
+    });
+  });
+});

--- a/apps/web/src/lib/api/__tests__/play-records-share.test.ts
+++ b/apps/web/src/lib/api/__tests__/play-records-share.test.ts
@@ -87,7 +87,7 @@ describe('playRecordsApi — share token methods (#2437-2)', () => {
   // ---- getSharedRecord ----
 
   describe('getSharedRecord', () => {
-    it('GETs /shared/{token} with credentials:include and returns the parsed DTO', async () => {
+    it('GETs /shared/{token} WITHOUT credentials (public endpoint) and returns the parsed DTO', async () => {
       const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
       const dto = {
         id: '550e8400-e29b-41d4-a716-446655440000',
@@ -118,7 +118,7 @@ describe('playRecordsApi — share token methods (#2437-2)', () => {
       expect(fetchMock).toHaveBeenCalledOnce();
       const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
       expect(url).toMatch(/\/shared\/mytoken$/);
-      expect(init.credentials).toBe('include');
+      expect(init?.credentials).toBeUndefined();
       expect(result).toEqual(dto);
     });
 

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -313,7 +313,10 @@ export const playRecordsApi = {
    * Returns 404 when the token is invalid or the record is unshared.
    */
   async getSharedRecord(token: string): Promise<PlayRecordDto> {
-    const res = await fetch(`${BASE_URL}/shared/${token}`, { credentials: 'include' });
+    // Public endpoint (AllowAnonymous): NO credentials — sending them forces a credentialed
+    // CORS preflight that anonymous cross-origin visitors (the core share-link use-case)
+    // can't satisfy. #2437-2.
+    const res = await fetch(`${BASE_URL}/shared/${token}`);
     if (!res.ok) {
       if (res.status === 404) throw new Error('Shared play record not found');
       const e = await res.json().catch(() => ({ message: 'Failed to load shared record' }));

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -16,6 +16,7 @@ import type {
   AddPlayerRequest,
   RecordScoreRequest,
   UpdatePlayRecordRequest,
+  ShareLinkResponse,
 } from '@/lib/api/schemas/play-records.schemas';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
@@ -272,5 +273,52 @@ export const playRecordsApi = {
       const error = await res.json().catch(() => ({ message: 'Failed to delete record' }));
       throw new Error(error.message || 'Failed to delete record');
     }
+  },
+
+  // ========== Share Token (#2437-2) ==========
+
+  /**
+   * Generate (or rotate) a share token for a play record.
+   * Creator-only. Returns { shareToken, shareUrl }.
+   */
+  async generateShareToken(recordId: string): Promise<ShareLinkResponse> {
+    const res = await fetch(`${BASE_URL}/${recordId}/share`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const e = await res.json().catch(() => ({ message: 'Failed to generate share link' }));
+      throw new Error(e.message || e.error || 'Failed to generate share link');
+    }
+    return res.json();
+  },
+
+  /**
+   * Revoke the share token for a play record (DELETE).
+   * Creator-only. Returns 204 No Content on success.
+   */
+  async revokeShareToken(recordId: string): Promise<void> {
+    const res = await fetch(`${BASE_URL}/${recordId}/share`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const e = await res.json().catch(() => ({ message: 'Failed to revoke share link' }));
+      throw new Error(e.message || e.error || 'Failed to revoke share link');
+    }
+  },
+
+  /**
+   * Fetch a publicly shared play record by its share token (no auth required).
+   * Returns 404 when the token is invalid or the record is unshared.
+   */
+  async getSharedRecord(token: string): Promise<PlayRecordDto> {
+    const res = await fetch(`${BASE_URL}/shared/${token}`, { credentials: 'include' });
+    if (!res.ok) {
+      if (res.status === 404) throw new Error('Shared play record not found');
+      const e = await res.json().catch(() => ({ message: 'Failed to load shared record' }));
+      throw new Error(e.message || 'Failed to load shared record');
+    }
+    return res.json();
   },
 };

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-share.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-share.schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+
+import { ShareLinkResponseSchema, PlayRecordDtoSchema } from '../play-records.schemas';
+
+// Minimal valid PlayRecordDto base (no optional fields)
+const basePr = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameId: null,
+  gameName: 'Wingspan',
+  sessionDate: '2026-06-21',
+  duration: null,
+  status: 'Completed' as const,
+  players: [],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+  createdByUserId: '550e8400-e29b-41d4-a716-446655440001',
+  visibility: 'Private' as const,
+  startTime: null,
+  endTime: null,
+  notes: null,
+  location: null,
+  createdAt: '2026-06-21T10:00:00Z',
+  updatedAt: '2026-06-21T10:00:00Z',
+};
+
+describe('ShareLinkResponseSchema (#2437-2)', () => {
+  it('parses a valid share link response', () => {
+    const result = ShareLinkResponseSchema.parse({
+      shareToken: 'abc123token',
+      shareUrl: 'https://app.meeple.ai/shared/abc123token',
+    });
+    expect(result.shareToken).toBe('abc123token');
+    expect(result.shareUrl).toBe('https://app.meeple.ai/shared/abc123token');
+  });
+
+  it('rejects when shareToken is missing', () => {
+    expect(() =>
+      ShareLinkResponseSchema.parse({ shareUrl: 'https://app.meeple.ai/shared/tok' })
+    ).toThrow();
+  });
+
+  it('rejects when shareUrl is missing', () => {
+    expect(() => ShareLinkResponseSchema.parse({ shareToken: 'tok' })).toThrow();
+  });
+});
+
+describe('PlayRecordDtoSchema.shareToken (#2437-2)', () => {
+  it('accepts a DTO without shareToken (field is optional)', () => {
+    const result = PlayRecordDtoSchema.parse(basePr);
+    expect(result.shareToken).toBeUndefined();
+  });
+
+  it('accepts shareToken as a non-null string', () => {
+    const result = PlayRecordDtoSchema.parse({ ...basePr, shareToken: 'mytoken' });
+    expect(result.shareToken).toBe('mytoken');
+  });
+
+  it('accepts shareToken as null (not shared)', () => {
+    const result = PlayRecordDtoSchema.parse({ ...basePr, shareToken: null });
+    expect(result.shareToken).toBeNull();
+  });
+});

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -61,6 +61,15 @@ export const PlayRecordPhotoSchema = z.object({
 });
 export type PlayRecordPhoto = z.infer<typeof PlayRecordPhotoSchema>;
 
+// ========== Share Link ==========
+
+// #2437-2: response from POST /play-records/{id}/share
+export const ShareLinkResponseSchema = z.object({
+  shareToken: z.string(),
+  shareUrl: z.string(),
+});
+export type ShareLinkResponse = z.infer<typeof ShareLinkResponseSchema>;
+
 // ========== DTOs ==========
 
 export const PlayRecordDtoSchema = z.object({
@@ -88,6 +97,8 @@ export const PlayRecordDtoSchema = z.object({
   photos: z.array(PlayRecordPhotoSchema).optional(),
   // #2437-1: Postgres xmin optimistic-concurrency token (uint). Optional during rollout.
   xmin: z.number().int().nonnegative().optional(),
+  // #2437-2: current share token (null when not shared). Creator-only meaningful.
+  shareToken: z.string().nullable().optional(),
 });
 export type PlayRecordDto = z.infer<typeof PlayRecordDtoSchema>;
 

--- a/apps/web/src/lib/domain-hooks/__tests__/usePlayRecordsShare.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/usePlayRecordsShare.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+import {
+  useGeneratePlayRecordShareToken,
+  useRevokePlayRecordShareToken,
+  useSharedPlayRecord,
+  playRecordsKeys,
+} from '../usePlayRecords';
+
+// Mock the API client so tests don't hit the network
+vi.mock('@/lib/api/play-records.api', () => ({
+  playRecordsApi: {
+    generateShareToken: vi.fn(),
+    revokeShareToken: vi.fn(),
+    getSharedRecord: vi.fn(),
+  },
+}));
+
+import { playRecordsApi } from '@/lib/api/play-records.api';
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function createClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+// Minimal DTO enough to satisfy test assertions
+const minimalDto = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameName: 'Codenames',
+  sessionDate: '2026-06-21',
+  status: 'Completed',
+  players: [],
+  visibility: 'Private',
+  createdByUserId: '550e8400-e29b-41d4-a716-446655440001',
+  gameId: null,
+  duration: null,
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+  startTime: null,
+  endTime: null,
+  notes: null,
+  location: null,
+  createdAt: '2026-06-21T10:00:00Z',
+  updatedAt: '2026-06-21T10:00:00Z',
+};
+
+describe('useGeneratePlayRecordShareToken (#2437-2)', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createClient();
+    vi.clearAllMocks();
+  });
+
+  it('calls playRecordsApi.generateShareToken with the recordId and returns data', async () => {
+    const payload = { shareToken: 'tok1', shareUrl: 'https://app.meeple.ai/shared/tok1' };
+    vi.mocked(playRecordsApi.generateShareToken).mockResolvedValue(payload);
+
+    const { result } = renderHook(() => useGeneratePlayRecordShareToken('rec-1'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(playRecordsApi.generateShareToken).toHaveBeenCalledWith('rec-1');
+    expect(result.current.data).toEqual(payload);
+  });
+
+  it('invalidates the detail query key on success', async () => {
+    vi.mocked(playRecordsApi.generateShareToken).mockResolvedValue({
+      shareToken: 'tok2',
+      shareUrl: 'https://app.meeple.ai/shared/tok2',
+    });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useGeneratePlayRecordShareToken('rec-42'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: playRecordsKeys.detail('rec-42') })
+    );
+  });
+
+  it('surfaces error when the API call fails', async () => {
+    vi.mocked(playRecordsApi.generateShareToken).mockRejectedValue(
+      new Error('Failed to generate share link')
+    );
+
+    const { result } = renderHook(() => useGeneratePlayRecordShareToken('rec-1'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Failed to generate share link');
+  });
+});
+
+describe('useRevokePlayRecordShareToken (#2437-2)', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createClient();
+    vi.clearAllMocks();
+  });
+
+  it('calls playRecordsApi.revokeShareToken with the recordId', async () => {
+    vi.mocked(playRecordsApi.revokeShareToken).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRevokePlayRecordShareToken('rec-2'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(playRecordsApi.revokeShareToken).toHaveBeenCalledWith('rec-2');
+  });
+
+  it('invalidates the detail query key on success', async () => {
+    vi.mocked(playRecordsApi.revokeShareToken).mockResolvedValue(undefined);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRevokePlayRecordShareToken('rec-99'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: playRecordsKeys.detail('rec-99') })
+    );
+  });
+});
+
+describe('useSharedPlayRecord (#2437-2)', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createClient();
+    vi.clearAllMocks();
+  });
+
+  it('fetches the shared record by token', async () => {
+    vi.mocked(playRecordsApi.getSharedRecord).mockResolvedValue(minimalDto as never);
+
+    const { result } = renderHook(() => useSharedPlayRecord('abc123'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(playRecordsApi.getSharedRecord).toHaveBeenCalledWith('abc123');
+    expect(result.current.data).toEqual(minimalDto);
+  });
+
+  it('uses playRecordsKeys.shared as the query key', async () => {
+    vi.mocked(playRecordsApi.getSharedRecord).mockResolvedValue(minimalDto as never);
+
+    const { result } = renderHook(() => useSharedPlayRecord('mytoken'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient
+      .getQueryCache()
+      .find({ queryKey: playRecordsKeys.shared('mytoken') });
+    expect(cached).toBeDefined();
+  });
+
+  it('is disabled when token is empty string', () => {
+    const { result } = renderHook(() => useSharedPlayRecord(''), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(playRecordsApi.getSharedRecord).not.toHaveBeenCalled();
+  });
+
+  it('surfaces error when the API call fails', async () => {
+    vi.mocked(playRecordsApi.getSharedRecord).mockRejectedValue(
+      new Error('Shared play record not found')
+    );
+
+    const { result } = renderHook(() => useSharedPlayRecord('badtoken'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Shared play record not found');
+  });
+});

--- a/apps/web/src/lib/domain-hooks/usePlayRecords.ts
+++ b/apps/web/src/lib/domain-hooks/usePlayRecords.ts
@@ -15,6 +15,7 @@ import type {
   AddPlayerRequest,
   RecordScoreRequest,
   UpdatePlayRecordRequest,
+  ShareLinkResponse,
 } from '@/lib/api/schemas/play-records.schemas';
 
 // ========== Types ==========
@@ -38,6 +39,8 @@ export const playRecordsKeys = {
   statisticsAll: () => [...playRecordsKeys.all, 'statistics'] as const,
   statistics: (range?: StatsRange) =>
     [...playRecordsKeys.statisticsAll(), range?.startDate ?? null, range?.endDate ?? null] as const,
+  // #2437-2: public shared-record query (no auth required)
+  shared: (token: string) => [...playRecordsKeys.all, 'shared', token] as const,
 };
 
 // ========== Queries ==========
@@ -255,5 +258,50 @@ export function useDeleteRecord(recordId: string) {
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.lists() });
       queryClient.invalidateQueries({ queryKey: playRecordsKeys.statisticsAll() });
     },
+  });
+}
+
+// ========== Share Token Hooks (#2437-2) ==========
+
+/**
+ * Generate (or rotate) a share token for a play record.
+ * Creator-only. Invalidates the detail cache so shareToken is refreshed.
+ */
+export function useGeneratePlayRecordShareToken(recordId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<ShareLinkResponse, Error>({
+    mutationFn: () => playRecordsApi.generateShareToken(recordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.detail(recordId) });
+    },
+  });
+}
+
+/**
+ * Revoke the share token for a play record.
+ * Creator-only. Invalidates the detail cache so shareToken clears.
+ */
+export function useRevokePlayRecordShareToken(recordId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error>({
+    mutationFn: () => playRecordsApi.revokeShareToken(recordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: playRecordsKeys.detail(recordId) });
+    },
+  });
+}
+
+/**
+ * Fetch a publicly shared play record by its share token (no auth required).
+ * Disabled when token is empty. retry: false — 404 is a terminal state.
+ */
+export function useSharedPlayRecord(token: string) {
+  return useQuery<PlayRecordDto, Error>({
+    queryKey: playRecordsKeys.shared(token),
+    queryFn: () => playRecordsApi.getSharedRecord(token),
+    enabled: !!token,
+    retry: false,
   });
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -4244,6 +4244,21 @@
         "back": "← Back"
       }
     },
+    "share": {
+      "button": "Share",
+      "dialogTitle": "Share play record",
+      "dialogDescription": "Generate a public link to share this play record with anyone.",
+      "generate": "Generate link",
+      "generating": "Generating…",
+      "urlLabel": "Share link",
+      "copy": "Copy",
+      "copied": "Link copied",
+      "revoke": "Revoke",
+      "revoking": "Revoking…",
+      "notShared": "Not shared yet",
+      "errorGenerate": "Could not generate the link. Please try again.",
+      "errorRevoke": "Could not revoke the link. Please try again."
+    },
     "photos": {
       "sectionTitle": "Game photos",
       "addButton": "Add photo",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -4297,6 +4297,21 @@
         "back": "← Indietro"
       }
     },
+    "share": {
+      "button": "Condividi",
+      "dialogTitle": "Condividi partita",
+      "dialogDescription": "Genera un link pubblico per condividere questa partita con chiunque.",
+      "generate": "Genera link",
+      "generating": "Generazione…",
+      "urlLabel": "Link di condivisione",
+      "copy": "Copia",
+      "copied": "Link copiato",
+      "revoke": "Revoca",
+      "revoking": "Revoca…",
+      "notShared": "Non ancora condivisa",
+      "errorGenerate": "Impossibile generare il link. Riprova.",
+      "errorRevoke": "Impossibile revocare il link. Riprova."
+    },
     "photos": {
       "sectionTitle": "Foto della partita",
       "addButton": "Aggiungi foto",

--- a/docs/superpowers/plans/2026-06-21-issue-2437-pr2-share-token.md
+++ b/docs/superpowers/plans/2026-06-21-issue-2437-pr2-share-token.md
@@ -1,0 +1,278 @@
+# #2437-2 — Play Records share-token + public view — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Condividere un PlayRecord via link pubblico con token rotabile (decisione **M1**): il creator genera/revoca un token; chiunque con il link vede il record read-only senza autenticazione. Replica 1:1 il pattern share-token di **GameNightPlaylist**.
+
+**Architecture:** BE greenfield che clona il pattern `GameNightPlaylist` share-token (entity `ShareToken`/`IsShared` + `GenerateShareToken()`/`RevokeShareToken()` + 2 command + 1 query anonima + 3 endpoint + migration + index unique nullable). FE: refactor `PlayRecordDetailView` → estrae `PlayRecordDetailBody` puro (prop-driven, decisione utente), riusato da detail autenticato e da una nuova `PlayRecordPublicView` (route `(public)/play-records/shared/[token]`); share dialog semplice (genera/copia/revoca, decisione utente).
+
+**Tech Stack:** .NET 9 (MediatR, EF Core, migration, Moq/xUnit/Testcontainers) · Next.js/React 19 (TanStack Query, Zod, Vitest).
+
+**Spec:** `docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md` (#2437 sub-PR 2). **Decisioni utente 2026-06-21**: public view = **refactor estrai DetailBody condiviso**; share UI = **semplice token-style**.
+
+## Reuse map (verificata, file:line)
+- **BE template GameNightPlaylist**: domain `GameNightPlaylist.cs:21-22,194-213` (ShareToken/IsShared + Generate/Revoke); handlers `GenerateShareLinkCommandHandler.cs:27-46` + `RevokeShareLinkCommandHandler.cs:26-40` (creator-only); query `GetPlaylistByShareTokenQueryHandler.cs:23-32`; endpoints `PlaylistEndpoints.cs:176-222`; EF config `GameNightPlaylistEntityConfiguration.cs:35-42,79-82` (index unique nullable filter); repo `GameNightPlaylistRepository.cs:72-84` (GetByShareToken con `&& p.IsShared`); response `ShareLinkResponse(ShareToken, ShareUrl)`.
+- **BE PlayRecord innesto**: `PlayRecord.cs` (domain), `PlayRecordEntity.cs`, `PlayRecordEntityConfiguration.cs`, `PlayRecordRepository.cs:217-385` (MapToDomain/MapToPersistence + `SetXmin` pattern @293), `IPlayRecordRepository.cs`, `PlayRecordEndpoints.cs` (auth **per-endpoint**, non group → GET pubblico usa `.AllowAnonymous()`), `GetPlayRecordQueryHandler.cs` (mapping+presigning da estrarre).
+- **FE**: `PlayRecordDetailView.tsx` (da refactorare), `play-records.api.ts`, `usePlayRecords.ts` (`playRecordsKeys`), `ShareSuccessToast` `share-success-toast.tsx`, route pubblica esempio `app/(public)/library/shared/[token]/page.tsx`, primitive `@/components/ui/overlays/dialog` + `@/components/ui/primitives/button`.
+
+---
+
+## Task 1: BE — persistence foundation (domain + entity + repo + migration)
+
+**Files:** `PlayRecord.cs`, `PlayRecordEntity.cs`, `PlayRecordEntityConfiguration.cs`, `PlayRecordRepository.cs`, `IPlayRecordRepository.cs` (modify); migration (generate).
+
+- [ ] **Step 1: Domain** — in `PlayRecord.cs`, after `Location` add props; add the two methods (clone of GameNightPlaylist) + an internal restore:
+```csharp
+    public string? ShareToken { get; private set; }
+    public bool IsShared { get; private set; }
+```
+```csharp
+    /// <summary>Generates a URL-safe share token for public read access (#2437-2, GameNightPlaylist pattern).</summary>
+    public string GenerateShareToken()
+    {
+        ShareToken = Convert.ToBase64String(Guid.NewGuid().ToByteArray())
+            .Replace("/", "_").Replace("+", "-").TrimEnd('=');
+        IsShared = true;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+        return ShareToken;
+    }
+
+    /// <summary>Revokes the share token, disabling public access.</summary>
+    public void RevokeShareToken()
+    {
+        ShareToken = null;
+        IsShared = false;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>Repository-only: restore share state after loading from persistence.</summary>
+    internal void SetShareState(string? shareToken, bool isShared)
+    {
+        ShareToken = shareToken;
+        IsShared = isShared;
+    }
+```
+
+- [ ] **Step 2: Infra entity + config** — in `PlayRecordEntity.cs` after `Location`:
+```csharp
+    public string? ShareToken { get; set; }
+    public bool IsShared { get; set; }
+```
+In `PlayRecordEntityConfiguration.cs` (after the Location/other property config, before the photo relationship):
+```csharp
+        builder.Property(e => e.ShareToken).HasMaxLength(50);
+        builder.Property(e => e.IsShared).HasDefaultValue(false).IsRequired();
+        builder.HasIndex(e => e.ShareToken)
+            .HasDatabaseName("IX_play_records_share_token")
+            .IsUnique()
+            .HasFilter("\"ShareToken\" IS NOT NULL");
+```
+(Match the column-naming convention of the table — the photo config used PascalCase EF defaults; verify whether play_records uses snake_case or PascalCase columns and align the `HasFilter` quote accordingly. Read the existing `PlayRecordEntityConfiguration` to confirm.)
+
+- [ ] **Step 3: Repository round-trip + GetByShareToken** — in `PlayRecordRepository.cs`:
+  - `MapToDomain` (after the `SetXmin(entity.Xmin)` at ~line 293): `record.SetShareState(entity.ShareToken, entity.IsShared);`
+  - `MapToPersistence` (in the entity initializer after `Location`): `ShareToken = record.ShareToken, IsShared = record.IsShared,`
+  - Add the method:
+```csharp
+    public async Task<PlayRecord?> GetByShareTokenAsync(string shareToken, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(shareToken);
+        var entity = await DbContext.PlayRecords
+            .AsNoTracking()
+            .Include(r => r.Players).ThenInclude(p => p.Scores)
+            .Include(r => r.Photos)
+            .FirstOrDefaultAsync(r => r.ShareToken == shareToken && r.IsShared, cancellationToken)
+            .ConfigureAwait(false);
+        return entity != null ? MapToDomain(entity) : null;
+    }
+```
+  In `IPlayRecordRepository.cs` add: `Task<PlayRecord?> GetByShareTokenAsync(string shareToken, CancellationToken cancellationToken = default);`
+
+- [ ] **Step 4: Migration** — run (from `apps/api/src/Api`):
+```bash
+dotnet ef migrations add AddPlayRecordShareToken
+```
+Review the generated migration: it must `AddColumn` `ShareToken` (nullable, maxLength 50) + `IsShared` (bool, default false) on `play_records`, and `CreateIndex` unique with the `IS NOT NULL` filter. Do NOT edit old migrations.
+
+- [ ] **Step 5: Build** — `dotnet build D:/Repositories/meepleai-monorepo-frontend/apps/api/src/Api/Api.csproj 2>&1 | grep -E "error" || echo BUILD_OK` → BUILD_OK
+
+- [ ] **Step 6: Commit**
+```bash
+git add -A
+git commit -m "feat(play-records): #2437-2 BE share-token persistence + migration"
+```
+
+---
+
+## Task 2: BE — generate/revoke commands + endpoints
+
+**Files (create):** `Application/Commands/PlayRecords/GeneratePlayRecordShareTokenCommand.cs` + `Handler` + `Validator`; `RevokePlayRecordShareTokenCommand.cs` + `Handler` + `Validator`; `Application/DTOs/PlayRecords/ShareLinkResponse.cs`. **Modify:** `PlayRecordEndpoints.cs`. **Test:** handler unit tests.
+
+- [ ] **Step 1: ShareLinkResponse DTO** (PlayRecord-specific, avoid cross-context coupling):
+```csharp
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+/// <summary>Share-link response for a play record (#2437-2).</summary>
+public record ShareLinkResponse(string ShareToken, string ShareUrl);
+```
+
+- [ ] **Step 2: Commands + handlers + validators** (clone GameNightPlaylist generate/revoke, creator-only via `record.CreatedByUserId != command.UserId → UnauthorizedAccessException`). `GeneratePlayRecordShareTokenCommand(Guid PlayRecordId, Guid UserId) : ICommand<ShareLinkResponse>`; handler loads via `_repository.GetByIdAsync`, checks creator, `record.GenerateShareToken()`, `UpdateAsync` + `SaveChangesAsync`, returns `new ShareLinkResponse(token, $"/play-records/shared/{token}")`. `RevokePlayRecordShareTokenCommand(Guid PlayRecordId, Guid UserId) : ICommand`; handler checks creator, `record.RevokeShareToken()`, save. Validators: `NotEmpty` on PlayRecordId + UserId. (Full code mirrors `GenerateShareLinkCommandHandler.cs:27-46` / `RevokeShareLinkCommandHandler.cs:26-40` — read them and adapt names PlayRecord. Note: `UnauthorizedAccessException` maps to 403 via the existing exception middleware — verify it does; if not, use `ForbiddenException` like `UpdatePlayRecordCommandHandler` does.)
+
+> **Authz note:** `UpdatePlayRecordCommandHandler` uses `ForbiddenException` (not `UnauthorizedAccessException`) for the not-creator case (via `PlayRecordPermissionChecker.CanEditAsync`). For consistency, the share handlers should throw `ForbiddenException("Only the record creator can ...")` → 403. Prefer this over GameNightPlaylist's `UnauthorizedAccessException`.
+
+- [ ] **Step 3: Endpoints** — in `PlayRecordEndpoints.cs`, add after the photos endpoint (~line 98), in the Commands region:
+```csharp
+        group.MapPost("/play-records/{recordId:guid}/share", HandleGenerateShareLink)
+            .RequireAuthenticatedUser()
+            .Produces<ShareLinkResponse>(200).Produces(401).Produces(StatusCodes.Status403Forbidden).Produces(404)
+            .WithTags("PlayRecords").WithSummary("Generate a public share link (creator-only)");
+
+        group.MapDelete("/play-records/{recordId:guid}/share", HandleRevokeShareLink)
+            .RequireAuthenticatedUser()
+            .Produces(204).Produces(401).Produces(StatusCodes.Status403Forbidden).Produces(404)
+            .WithTags("PlayRecords").WithSummary("Revoke the share link (creator-only)");
+```
+Add the handler methods in the Command Handlers region:
+```csharp
+    private static async Task<IResult> HandleGenerateShareLink(Guid recordId, [FromServices] IMediator mediator, HttpContext httpContext, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GeneratePlayRecordShareTokenCommand(recordId, httpContext.User.GetUserId()), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+    private static async Task<IResult> HandleRevokeShareLink(Guid recordId, [FromServices] IMediator mediator, HttpContext httpContext, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new RevokePlayRecordShareTokenCommand(recordId, httpContext.User.GetUserId()), cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+```
+
+- [ ] **Step 4: Unit tests** — create handler unit tests (mirror existing GameManagement handler tests with Moq `IPlayRecordRepository` + `IUnitOfWork`): generate sets a token + saves; generate by non-creator throws `ForbiddenException`; revoke clears the token. Run the GameManagement filter → PASS.
+
+- [ ] **Step 5: Build + commit**
+```bash
+dotnet build D:/Repositories/meepleai-monorepo-frontend/apps/api/src/Api/Api.csproj 2>&1 | grep -E "error" || echo BUILD_OK
+git add -A && git commit -m "feat(play-records): #2437-2 BE generate/revoke share-link commands + endpoints"
+```
+
+---
+
+## Task 3: BE — public query (GetByShareToken) + shared DTO mapper + endpoint
+
+**Files:** create `PlayRecordDtoMapper.cs` (extract from `GetPlayRecordQueryHandler`), `GetPlayRecordByShareTokenQuery.cs` + `Handler`; modify `GetPlayRecordQueryHandler.cs`, `PlayRecordEndpoints.cs`; integration test.
+
+- [ ] **Step 1: Extract `PlayRecordDtoMapper`** — create `Application/Services/PlayRecordDtoMapper.cs` with a static `MapAsync(PlayRecordEntity entity, IBlobStorageService blobStorage, int presignExpirySeconds)` that produces a `PlayRecordDto` (the photo-presigning + winner/outcome + scoring-config deserialization currently inline in `GetPlayRecordQueryHandler.Handle`). Then refactor `GetPlayRecordQueryHandler` to call it (keeps its authz check + load). Run `GetPlayRecordQueryHandlerTests` → still PASS (no behaviour change).
+
+- [ ] **Step 2: Query + handler (anonymous)** — `GetPlayRecordByShareTokenQuery(string ShareToken) : IQuery<PlayRecordDto>`. Handler injects `MeepleAiDbContext` + `IBlobStorageService`, loads the entity by token (`_context.PlayRecords.AsNoTracking().Include(Players).ThenInclude(Scores).Include(Photos).FirstOrDefaultAsync(r => r.ShareToken == query.ShareToken && r.IsShared)`), throws `NotFoundException("PlayRecord", query.ShareToken)` if null, returns `await PlayRecordDtoMapper.MapAsync(entity, _blobStorage, 3600)`. (No authz — access IS the token.)
+
+- [ ] **Step 3: Endpoint (AllowAnonymous)** — in `PlayRecordEndpoints.cs` Queries region:
+```csharp
+        group.MapGet("/play-records/shared/{token}", HandleGetSharedPlayRecord)
+            .AllowAnonymous()
+            .Produces<PlayRecordDto>(200).Produces(404)
+            .WithTags("PlayRecords").WithSummary("Get a shared play record by token (public, no auth)");
+```
+```csharp
+    private static async Task<IResult> HandleGetSharedPlayRecord(string token, [FromServices] IMediator mediator, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetPlayRecordByShareTokenQuery(token), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+```
+
+- [ ] **Step 4: Integration test** (Testcontainers) — create `PlayRecordShareTokenTests.cs`: create a record, generate a share token, fetch by token (returns the DTO), revoke, fetch by token again → `NotFoundException`. Also: fetch by a bogus token → NotFound. Run → PASS (Docker; if unavailable, ensure compile + report).
+
+- [ ] **Step 5: Build + commit**
+```bash
+git add -A && git commit -m "feat(play-records): #2437-2 BE public get-by-share-token + DTO mapper"
+```
+
+---
+
+## Task 4: FE — refactor: extract `PlayRecordDetailBody`
+
+**Files:** create `apps/web/src/components/play-records/PlayRecordDetailBody.tsx`; modify `PlayRecordDetailView.tsx`; tests stay green.
+
+- [ ] **Step 1** — Read `PlayRecordDetailView.tsx`. Extract everything AFTER the loading/error guards (the derivation helpers usage + the full JSX composition: HeroPodium, ConnectionBar, KpiGrid, Photos section, Classifica, ScoreBreakdown, Notes, Rematch + the creator-only photo upload) into a new pure component:
+```tsx
+export interface PlayRecordDetailBodyProps {
+  record: PlayRecordDto;
+  currentUserId: string | null;
+}
+export function PlayRecordDetailBody({ record, currentUserId }: PlayRecordDetailBodyProps): ReactElement { /* moved body */ }
+```
+`isCreator` is computed inside from `currentUserId === record.createdByUserId`. The derivation helpers (`buildRankedScores`, `derivePerspective`, etc.) move with it (or stay module-level and are imported). `PlayRecordDetailView` becomes a thin wrapper: `usePlayRecord` + `useCurrentUser` + loading/error guards + `<PlayRecordDetailBody record={record} currentUserId={currentUser?.id ?? null} />`.
+
+- [ ] **Step 2** — Run the existing `PlayRecordDetailView.test.tsx` + `play-records-axe.test.tsx` → MUST stay green (pure refactor, same DOM). Fix any import/mock fallout. Typecheck clean.
+
+- [ ] **Step 3: Commit**
+```bash
+git add -A && git commit -m "refactor(play-records): #2437-2 extract PlayRecordDetailBody (prop-driven)"
+```
+
+---
+
+## Task 5: FE — share API client + hooks
+
+**Files:** modify `play-records.api.ts`, `play-records.schemas.ts` (DTO already has needed fields; add `ShareLinkResponse` schema), `usePlayRecords.ts` (hooks + query keys); tests.
+
+- [ ] **Step 1: schema + api** — add Zod `ShareLinkResponseSchema = z.object({ shareToken: z.string(), shareUrl: z.string() })`. In `play-records.api.ts` add (all with `credentials: 'include'`):
+  - `generateShareToken(recordId): Promise<ShareLinkResponse>` → `POST /play-records/{id}/share`
+  - `revokeShareToken(recordId): Promise<void>` → `DELETE /play-records/{id}/share`
+  - `getSharedRecord(token): Promise<PlayRecordDto>` → `GET /play-records/shared/{token}` (no credentials needed — public, but harmless to include)
+  TDD: a test asserting `generateShareToken` POSTs to the right URL and parses the response; `getSharedRecord` GETs `/shared/{token}`.
+
+- [ ] **Step 2: hooks** — in `usePlayRecords.ts` (or a sibling), add `useGeneratePlayRecordShareToken(recordId)` + `useRevokePlayRecordShareToken(recordId)` (mutations, invalidate `playRecordsKeys.detail(recordId)`) and `useSharedPlayRecord(token)` (query, key `['play-records','shared',token]`, `retry:false`, enabled when token truthy). TDD per hook.
+
+- [ ] **Step 3: Commit**
+```bash
+git add -A && git commit -m "feat(play-records): #2437-2 share API client + hooks"
+```
+
+---
+
+## Task 6: FE — SharePlayRecordDialog + wire button (creator-only) + i18n
+
+**Files:** create `apps/web/src/components/play-records/SharePlayRecordDialog.tsx`; modify `PlayRecordDetailBody.tsx`; i18n it/en; tests.
+
+- [ ] **Step 1: Dialog** — `SharePlayRecordDialog({ recordId, currentShareToken, open, onClose })`. If no token: a "Genera link" button → `useGeneratePlayRecordShareToken`. Once a token exists: show the **FE** share URL `${window.location.origin}/play-records/shared/${token}` (NOT the API path), a Copy button (`navigator.clipboard.writeText(...)` → success toast via `toast`/`ShareSuccessToast`), and a "Revoca" button → `useRevokePlayRecordShareToken`. Pure-ish, labels via `useTranslation`. TDD: generate flow calls the hook; copy writes to clipboard (mock `navigator.clipboard`); revoke calls the hook.
+
+- [ ] **Step 2: Wire in DetailBody** — in `PlayRecordDetailBody`, add a creator-only "🔗 Condividi" button (next to the photo section header or in a header action area) that opens `SharePlayRecordDialog` with `currentShareToken={record.shareToken}`. (Requires `shareToken` on the FE DTO — add `shareToken: z.string().nullable().optional()` to `PlayRecordDtoSchema`. Verify the BE GET DTO exposes shareToken: the `PlayRecordDto` does NOT currently include it; **either** add `ShareToken` to the BE DTO + mapper (so the detail view knows the current token) **or** the dialog fetches it on open. Simplest: add `string? ShareToken` to `PlayRecordDto` + mapper in Task 3, and `shareToken` to the FE schema here. Note this cross-task dependency.)
+
+> **Cross-task note:** add `string? ShareToken` to `PlayRecordDto` (BE, Task 3 mapper) so the authenticated detail view can show the current share state. The PUBLIC `getSharedRecord` response also carries it but that's harmless (the viewer already has the token). Update `PlayRecordDtoSchema` accordingly.
+
+- [ ] **Step 3: i18n** — `playRecords.share.*` (it/en): button, dialogTitle, generate, generating, copy, copied, revoke, revoking, urlLabel, revoked.
+
+- [ ] **Step 4: Commit**
+```bash
+git add -A && git commit -m "feat(play-records): #2437-2 share dialog + creator-only button + i18n"
+```
+
+---
+
+## Task 7: FE — public route + PlayRecordPublicView
+
+**Files:** create `apps/web/src/app/(public)/play-records/shared/[token]/page.tsx` + `apps/web/src/components/play-records/PlayRecordPublicView.tsx`; tests.
+
+- [ ] **Step 1: PublicView** — `PlayRecordPublicView({ token })`: `const { data, isLoading, error } = useSharedPlayRecord(token);` → loading skeleton / not-found state (mirror the library shared page) / `<PlayRecordDetailBody record={data} currentUserId={null} />`. `currentUserId={null}` → no creator actions (no edit/upload/share), spectator perspective. TDD: renders the body for a found record; shows not-found for an error.
+
+- [ ] **Step 2: Public route** — `app/(public)/play-records/shared/[token]/page.tsx`: `'use client'`, `const { token } = useParams()`, render `<PlayRecordPublicView token={...} />`. (Mirror `app/(public)/library/shared/[token]/page.tsx` structure — it's in the `(public)` group, no auth.)
+
+- [ ] **Step 3: Verify** — `pnpm test src/components/play-records "src/app/(public)/play-records" --run` → PASS. Typecheck + lint clean.
+
+- [ ] **Step 4: Commit**
+```bash
+git add -A && git commit -m "feat(play-records): #2437-2 public shared play-record route + view"
+```
+
+---
+
+## Final verification
+- `pnpm test src/components/play-records src/lib/api "src/app/(public)/play-records" --run` → no regressions
+- `pnpm typecheck && pnpm lint` → clean
+- `dotnet build apps/api/src/Api/Api.csproj` → BUILD_OK; BE tests pass (integration needs Docker)
+
+## Self-review notes
+- **Token is URL-safe Base64** (no `/`, `+`, `=`) → safe in a path segment. The FE builds the shareable URL as `origin + /play-records/shared/ + token`; the BE `ShareUrl` (API path) is informational only.
+- **`IsShared` gate**: `GetByShareTokenAsync` requires `IsShared == true`, so a revoked token (nulled) 404s. Unique index is filtered (`IS NOT NULL`) so multiple revoked rows (null token) don't collide.
+- **Public DTO leakage**: the shared DTO exposes the same fields as the authenticated detail (players, scores, photos, notes). That's intended — sharing means making it public. `CreatedByUserId` is exposed (already is in the auth DTO); acceptable.
+- **`ShareToken` on the DTO**: exposing it on the authenticated GET lets the creator's detail view show/revoke the current link. On the public GET it's redundant but harmless.
+- **Closes nothing**: #2437 still needs sub-PR 3 (audit + restore-version).


### PR DESCRIPTION
## Summary

Secondo dei 3 sub-PR di **#2437**. Implementa la condivisione di un PlayRecord via link pubblico con token rotabile (decisione spec-panel **M1**), clonando 1:1 il pattern share-token di `GameNightPlaylist`.

### BE — share-token (greenfield, pattern GameNightPlaylist)
- `PlayRecord.ShareToken`/`IsShared` + `GenerateShareToken()`/`RevokeShareToken()` (token URL-safe Base64, ~128 bit); migration (index unique nullable-filtered); repo round-trip + `GetByShareTokenAsync` con gate `&& IsShared`.
- Command `Generate`/`Revoke` (creator-only → `ForbiddenException` 403); query pubblica `GetPlayRecordByShareToken` (anonima, no authz — il token È l'autorizzazione).
- `PlayRecordDtoMapper` estratto (single DTO call-site, condiviso auth-GET + public-GET); `ShareToken` esposto sul DTO (`null` quando `IsShared=false`).
- 3 endpoint: `POST`/`DELETE /play-records/{id}/share` (auth) + `GET /play-records/shared/{token}` (`AllowAnonymous`, registrato prima di `/{recordId:guid}` per evitare parse ambiguity).
- Integration test (Docker): generate→read, revoke→404, bogus→404.

### FE
- **Refactor** `PlayRecordDetailView` → estratto `PlayRecordDetailBody` puro (prop-driven `{record, currentUserId}`) — riusato da detail autenticato e public view; test esistenti invariati.
- Share api + hooks (`useGenerate`/`useRevoke`/`useSharedPlayRecord`); `SharePlayRecordDialog` (genera/copia URL-FE/revoca, creator-only); button "🔗 Condividi" nel body.
- **Route pubblica** `(public)/play-records/shared/[token]` → `PlayRecordPublicView` (read-only, `currentUserId={null}` → nessuna azione creator). `getSharedRecord` **senza** `credentials` (endpoint pubblico → no CORS preflight credentialed).

## Spec & Plan
- Spec-panel: `docs/superpowers/specs/2026-06-20-issue-2436-prc-2437-spec-panel.md`
- Plan (7 task TDD): `docs/superpowers/plans/2026-06-21-issue-2437-pr2-share-token.md`
- Decisioni utente: public view = refactor DetailBody condiviso; share UI = semplice token-style.

## Test Plan
- [x] BE: handler unit (6) + integration Docker (3) + query handler (11) + build green
- [x] FE: schema/api/hooks/dialog/public-view TDD; refactor DetailBody (test invariati)
- [x] FE full suite — 1745/1745 (no regressioni); `typecheck` + `lint` clean

## Review
- Per-task validation + final holistic review (`feature-dev:code-reviewer`): **APPROVED_FOR_MERGE** dopo 1 Important fixato in-PR (drop `credentials` sul GET pubblico → evita CORS preflight per visitatori anonimi). Authz/revoke/token-nulling/routing/refactor tutti confermati corretti.

> **Non chiude #2437** — resta sub-PR 3 (audit `[Auditable]` + restore-version greenfield).

🤖 Generated with [Claude Code](https://claude.com/claude-code)