### PR TITLE
fix(play-records): #2461 retry version-number on concurrent update conflict

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/RestorePlayRecordVersionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/RestorePlayRecordVersionCommandHandler.cs
@@ -2,9 +2,11 @@ using System.Globalization;
 using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 
@@ -18,6 +20,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 ///   5. Apply the target version's values via UpdateDetails.
 ///   6. Persist, then prune to the 5-version cap.
 /// Issue #2437-3: version history + restore.
+/// Issue #2461: retry on version-number unique conflict (transparent server-side retry).
 /// </summary>
 internal sealed class RestorePlayRecordVersionCommandHandler : ICommandHandler<RestorePlayRecordVersionCommand>
 {
@@ -26,6 +29,7 @@ internal sealed class RestorePlayRecordVersionCommandHandler : ICommandHandler<R
     private readonly IUnitOfWork _unitOfWork;
     private readonly TimeProvider _timeProvider;
     private readonly PlayRecordPermissionChecker _permissionChecker;
+    private readonly Func<DbUpdateException, bool> _isVersionConflict;
 
     public RestorePlayRecordVersionCommandHandler(
         IPlayRecordRepository recordRepository,
@@ -33,13 +37,37 @@ internal sealed class RestorePlayRecordVersionCommandHandler : ICommandHandler<R
         IUnitOfWork unitOfWork,
         TimeProvider timeProvider,
         PlayRecordPermissionChecker permissionChecker)
+        : this(recordRepository, versionRepository, unitOfWork, timeProvider, permissionChecker,
+               PlayRecordVersionRepository.IsVersionNumberConflict)
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for testing — allows injecting a custom conflict detector so that
+    /// tests can simulate a version-number unique violation without constructing a real
+    /// <see cref="Npgsql.PostgresException"/> (whose properties are not publicly settable).
+    /// </summary>
+    internal RestorePlayRecordVersionCommandHandler(
+        IPlayRecordRepository recordRepository,
+        IPlayRecordVersionRepository versionRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        PlayRecordPermissionChecker permissionChecker,
+        Func<DbUpdateException, bool> isVersionConflict)
     {
         _recordRepository = recordRepository ?? throw new ArgumentNullException(nameof(recordRepository));
         _versionRepository = versionRepository ?? throw new ArgumentNullException(nameof(versionRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _permissionChecker = permissionChecker ?? throw new ArgumentNullException(nameof(permissionChecker));
+        _isVersionConflict = isVersionConflict ?? throw new ArgumentNullException(nameof(isVersionConflict));
     }
+
+    /// <summary>
+    /// Maximum number of times we retry the version+update save when a concurrent request
+    /// races to assign the same version number. Mirrors UpdatePlayRecordCommandHandler.
+    /// </summary>
+    private const int MaxVersionConflictRetries = 5;
 
     public async Task Handle(RestorePlayRecordVersionCommand command, CancellationToken cancellationToken)
     {
@@ -64,16 +92,35 @@ internal sealed class RestorePlayRecordVersionCommandHandler : ICommandHandler<R
             ?? throw new NotFoundException("PlayRecordVersion", command.VersionNumber.ToString(CultureInfo.InvariantCulture));
 
         // 4. Snapshot the CURRENT state BEFORE mutating so the restore is undo-able.
-        await PlayRecordVersionSnapshotter.SnapshotCurrentAsync(
+        // Returns the staged version so we can identify it for the #2461 retry.
+        var stagedVersion = await PlayRecordVersionSnapshotter.SnapshotCurrentAsync(
             _versionRepository, record, command.UserId, _timeProvider, cancellationToken)
             .ConfigureAwait(false);
 
         // 5. Apply the target version's values
         record.UpdateDetails(targetVersion.SessionDate, targetVersion.Notes, targetVersion.Location, _timeProvider);
 
-        // 6. Persist update + snapshot together
+        // 6. Persist update + snapshot together, with #2461 retry on version-number conflict.
         await _recordRepository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var saveAttempt = 0;
+        while (true)
+        {
+            try
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                break; // success
+            }
+            catch (DbUpdateException ex) when (
+                _isVersionConflict(ex)
+                && saveAttempt < MaxVersionConflictRetries)
+            {
+                saveAttempt++;
+                await _versionRepository.ReassignVersionNumberAsync(
+                    command.RecordId, stagedVersion.Id, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
 
         // Prune to the 5-version cap (post-save so the new snapshot is never deleted)
         await _versionRepository

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
@@ -1,9 +1,11 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 
@@ -11,6 +13,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 /// Handles updating play record details.
 /// Issue #3889: CQRS commands for play records.
 /// Issue #2437-3: snapshot pre-edit state as a version before mutating, cap to 5 most-recent.
+/// Issue #2461: retry on version-number unique conflict (transparent server-side retry, no 500).
 /// </summary>
 internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecordCommand>
 {
@@ -19,6 +22,7 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
     private readonly IUnitOfWork _unitOfWork;
     private readonly TimeProvider _timeProvider;
     private readonly PlayRecordPermissionChecker _permissionChecker;
+    private readonly Func<DbUpdateException, bool> _isVersionConflict;
 
     public UpdatePlayRecordCommandHandler(
         IPlayRecordRepository recordRepository,
@@ -26,13 +30,38 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
         IUnitOfWork unitOfWork,
         TimeProvider timeProvider,
         PlayRecordPermissionChecker permissionChecker)
+        : this(recordRepository, versionRepository, unitOfWork, timeProvider, permissionChecker,
+               PlayRecordVersionRepository.IsVersionNumberConflict)
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for testing — allows injecting a custom conflict detector so that
+    /// tests can simulate a version-number unique violation without constructing a real
+    /// <see cref="Npgsql.PostgresException"/> (whose properties are not publicly settable).
+    /// </summary>
+    internal UpdatePlayRecordCommandHandler(
+        IPlayRecordRepository recordRepository,
+        IPlayRecordVersionRepository versionRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        PlayRecordPermissionChecker permissionChecker,
+        Func<DbUpdateException, bool> isVersionConflict)
     {
         _recordRepository = recordRepository ?? throw new ArgumentNullException(nameof(recordRepository));
         _versionRepository = versionRepository ?? throw new ArgumentNullException(nameof(versionRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _permissionChecker = permissionChecker ?? throw new ArgumentNullException(nameof(permissionChecker));
+        _isVersionConflict = isVersionConflict ?? throw new ArgumentNullException(nameof(isVersionConflict));
     }
+
+    /// <summary>
+    /// Maximum number of times we retry the version+update save when a concurrent request
+    /// races to assign the same version number. Each retry re-reads MAX and increments.
+    /// In practice one retry always suffices; 5 guards against pathological concurrency.
+    /// </summary>
+    private const int MaxVersionConflictRetries = 5;
 
     public async Task Handle(UpdatePlayRecordCommand command, CancellationToken cancellationToken)
     {
@@ -50,7 +79,8 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
         // #2437-3: snapshot the pre-edit state so this update is restorable.
         // Captured BEFORE mutating, so each version is a prior state
         // (the first update captures the initial state, making it undo-able).
-        await PlayRecordVersionSnapshotter.SnapshotCurrentAsync(
+        // Returns the staged version so we can identify it for the #2461 retry.
+        var stagedVersion = await PlayRecordVersionSnapshotter.SnapshotCurrentAsync(
             _versionRepository, record, command.UserId, _timeProvider, cancellationToken)
             .ConfigureAwait(false);
 
@@ -70,7 +100,31 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
         }
 
         await _recordRepository.UpdateAsync(record, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // #2461: retry on version-number unique conflict.
+        // Two tabs / double-submit can read the same MAX → same VersionNumber → 23505.
+        // On conflict: re-read MAX, update the tracked version entity's VersionNumber, retry.
+        // This keeps the version + update save atomic. Cap at MaxVersionConflictRetries.
+        var saveAttempt = 0;
+        while (true)
+        {
+            try
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                break; // success
+            }
+            catch (DbUpdateException ex) when (
+                _isVersionConflict(ex)
+                && saveAttempt < MaxVersionConflictRetries)
+            {
+                // Re-read MAX and update the still-tracked (Added) version entity so the
+                // next SaveChangesAsync will use the correct, non-conflicting number.
+                saveAttempt++;
+                await _versionRepository.ReassignVersionNumberAsync(
+                    command.RecordId, stagedVersion.Id, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
 
         // Keep only the 5 most-recent versions per record (pruned AFTER the update save
         // so the new version is never accidentally deleted before it is persisted).

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordVersionSnapshotter.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordVersionSnapshotter.cs
@@ -27,7 +27,13 @@ internal static class PlayRecordVersionSnapshotter
     /// <param name="userId">User triggering the update (stored on the version for audit).</param>
     /// <param name="timeProvider">Clock abstraction for the snapshot's CreatedAt timestamp.</param>
     /// <param name="ct">Cancellation token.</param>
-    public static async Task SnapshotCurrentAsync(
+    /// <returns>
+    /// The staged <see cref="PlayRecordVersion"/> (not yet persisted). The caller may use its
+    /// <c>Id</c> to re-assign the version number via
+    /// <see cref="IPlayRecordVersionRepository.ReassignVersionNumberAsync"/> in the event of a
+    /// concurrent version-number collision on save.
+    /// </returns>
+    public static async Task<PlayRecordVersion> SnapshotCurrentAsync(
         IPlayRecordVersionRepository versionRepository,
         PlayRecord record,
         Guid userId,
@@ -42,17 +48,18 @@ internal static class PlayRecordVersionSnapshotter
             .GetNextVersionNumberAsync(record.Id, ct)
             .ConfigureAwait(false);
 
-        await versionRepository.AddAsync(
-            new PlayRecordVersion(
-                Guid.NewGuid(),
-                record.Id,
-                versionNumber,
-                record.SessionDate,
-                record.Notes,
-                record.Location,
-                timeProvider.GetUtcNow().UtcDateTime,
-                userId),
-            ct)
-            .ConfigureAwait(false);
+        var version = new PlayRecordVersion(
+            Guid.NewGuid(),
+            record.Id,
+            versionNumber,
+            record.SessionDate,
+            record.Notes,
+            record.Location,
+            timeProvider.GetUtcNow().UtcDateTime,
+            userId);
+
+        await versionRepository.AddAsync(version, ct).ConfigureAwait(false);
+
+        return version;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPlayRecordVersionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPlayRecordVersionRepository.cs
@@ -35,4 +35,13 @@ internal interface IPlayRecordVersionRepository
     /// Does not call SaveChanges — the UnitOfWork saves.
     /// </summary>
     Task PruneOldestAsync(Guid playRecordId, int keep, CancellationToken ct = default);
+
+    /// <summary>
+    /// Re-assigns the version number of a tracked (but not yet committed) version entity
+    /// to the next available number. Used by the concurrency-retry loop in command handlers
+    /// when a <c>UX_play_record_versions_record_version</c> unique violation is detected.
+    /// Reads the current MAX and sets the tracked entity's <c>VersionNumber</c> to MAX+1.
+    /// Does not call SaveChanges — the caller retries the save.
+    /// </summary>
+    Task ReassignVersionNumberAsync(Guid playRecordId, Guid versionId, CancellationToken ct = default);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordVersionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PlayRecordVersionRepository.cs
@@ -5,6 +5,7 @@ using Api.Infrastructure.Entities.GameManagement;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 
@@ -80,6 +81,52 @@ internal sealed class PlayRecordVersionRepository : RepositoryBase, IPlayRecordV
             DbContext.PlayRecordVersions.RemoveRange(toDelete);
         }
     }
+
+    /// <inheritdoc />
+    public async Task ReassignVersionNumberAsync(Guid playRecordId, Guid versionId, CancellationToken ct = default)
+    {
+        // Re-read the current MAX to get the next safe version number.
+        var maxVersion = await DbContext.PlayRecordVersions
+            .Where(v => v.PlayRecordId == playRecordId)
+            .MaxAsync(v => (int?)v.VersionNumber, ct)
+            .ConfigureAwait(false);
+
+        var newVersionNumber = (maxVersion ?? 0) + 1;
+
+        // Update the already-tracked (Added) entity in the change tracker so the
+        // next SaveChangesAsync will use the newly computed VersionNumber.
+        var trackedEntry = DbContext.ChangeTracker
+            .Entries<PlayRecordVersionEntity>()
+            .FirstOrDefault(e => e.Entity.Id == versionId);
+
+        if (trackedEntry is not null)
+        {
+            trackedEntry.Entity.VersionNumber = newVersionNumber;
+        }
+    }
+
+    // ========================================================================
+    // Conflict detection
+    // ========================================================================
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="ex"/> wraps a PostgreSQL unique-violation
+    /// on the <c>UX_play_record_versions_record_version</c> index — the signal that two
+    /// concurrent saves computed the same MAX+1 version number for the same record.
+    /// Delegates to the testable overload so tests can probe the predicate without
+    /// constructing a real <see cref="PostgresException"/>.
+    /// </summary>
+    internal static bool IsVersionNumberConflict(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pgEx
+        && IsVersionNumberConflict(pgEx.SqlState, pgEx.ConstraintName);
+
+    /// <summary>
+    /// Testable inner predicate — checks SQLSTATE 23505 + the specific constraint name.
+    /// Mirrors the split used by <c>NotificationDedupePipelineBehavior.IsNotificationDedupViolation</c>.
+    /// </summary>
+    internal static bool IsVersionNumberConflict(string? sqlState, string? constraintName) =>
+        string.Equals(sqlState, "23505", StringComparison.Ordinal)
+        && string.Equals(constraintName, "UX_play_record_versions_record_version", StringComparison.Ordinal);
 
     // ========================================================================
     // Mapping

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UpdatePlayRecordCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UpdatePlayRecordCommandHandlerTests.cs
@@ -4,10 +4,12 @@ using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
@@ -50,6 +52,26 @@ public class UpdatePlayRecordCommandHandlerTests
             uow.Object,
             timeProvider ?? TimeProvider.System,
             new PlayRecordPermissionChecker(repo.Object));
+    }
+
+    /// <summary>
+    /// Overload for the #2461 retry tests — injects a custom conflict detector so tests can
+    /// simulate a version-number unique violation without a real Npgsql.PostgresException.
+    /// </summary>
+    private static UpdatePlayRecordCommandHandler CreateSutWithConflictDetector(
+        Mock<IPlayRecordRepository> repo,
+        Mock<IPlayRecordVersionRepository> versionRepo,
+        Mock<IUnitOfWork> uow,
+        Func<DbUpdateException, bool> isVersionConflict,
+        TimeProvider? timeProvider = null)
+    {
+        return new UpdatePlayRecordCommandHandler(
+            repo.Object,
+            versionRepo.Object,
+            uow.Object,
+            timeProvider ?? TimeProvider.System,
+            new PlayRecordPermissionChecker(repo.Object),
+            isVersionConflict);
     }
 
     // -------------------------------------------------------------------------
@@ -214,5 +236,125 @@ public class UpdatePlayRecordCommandHandlerTests
         record.Notes.Should().Be("My note");
         record.Location.Should().Be("Pub");
         repo.Verify(r => r.UpdateAsync(record, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // #2461: version-number conflict predicate
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("23505", "UX_play_record_versions_record_version", true)]
+    [InlineData("23505", "ux_play_record_versions_record_version", false)] // case-sensitive
+    [InlineData("23505", "UX_some_other_unique_index", false)]             // wrong constraint
+    [InlineData("23503", "UX_play_record_versions_record_version", false)] // FK violation, not unique
+    [InlineData("23505", null, false)]
+    [InlineData(null, "UX_play_record_versions_record_version", false)]
+    [InlineData(null, null, false)]
+    public void IsVersionNumberConflict_PredicateBehavior(
+        string? sqlState, string? constraintName, bool expected)
+    {
+        var result = PlayRecordVersionRepository.IsVersionNumberConflict(sqlState, constraintName);
+
+        result.Should().Be(expected, "predicate must match exactly SqlState 23505 + the right constraint name");
+    }
+
+    // -------------------------------------------------------------------------
+    // #2461: retry on version-number unique conflict
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_VersionNumberConflictOnFirstSave_RetriesAndSucceeds()
+    {
+        // Arrange: happy-path record + permissions
+        var record = MakeRecord();
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        repo.Setup(r => r.CanUserEditAsync(CreatorId, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        // GetNextVersionNumberAsync is called:
+        //  - once by SnapshotCurrentAsync (initial number)
+        //  - once by ReassignVersionNumberAsync (re-read after conflict)
+        // Both return 1 here; in production the second call would return a higher value.
+        var versionRepo = new Mock<IPlayRecordVersionRepository>();
+        versionRepo.Setup(v => v.GetNextVersionNumberAsync(record.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        versionRepo.Setup(v => v.ReassignVersionNumberAsync(
+                record.Id, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // SaveChangesAsync: throw on attempt 1 (version conflict), succeed on attempt 2+.
+        var saveCallCount = 0;
+        var conflictException = new DbUpdateException("version conflict simulation");
+        var uow = new Mock<IUnitOfWork>();
+        uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                saveCallCount++;
+                if (saveCallCount == 1)
+                    throw conflictException; // first save: simulate unique violation
+                return 1; // subsequent saves: succeed
+            });
+
+        // Inject a conflict detector that recognises our synthetic exception.
+        Func<DbUpdateException, bool> detector = ex => ReferenceEquals(ex, conflictException);
+
+        var sut = CreateSutWithConflictDetector(repo, versionRepo, uow, detector);
+
+        // Act — must NOT throw
+        var act = () => sut.Handle(
+            new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "Retry notes"),
+            CancellationToken.None);
+
+        await act.Should().NotThrowAsync("the handler must absorb the version conflict and retry");
+
+        // Assert: ReassignVersionNumberAsync was invoked exactly once (the retry)
+        versionRepo.Verify(
+            v => v.ReassignVersionNumberAsync(record.Id, It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "must re-read the max version number on conflict");
+
+        // Two save cycles: (1) first save = conflict caught → retry; (2) second save = OK.
+        // Plus one more save for the prune step → total 3 SaveChangesAsync calls.
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(3));
+
+        // The record update must still have been applied despite the initial conflict.
+        record.Notes.Should().Be("Retry notes", "the update must persist after the retry");
+    }
+
+    [Fact]
+    public async Task Handle_NonVersionConflictDbUpdateException_Rethrows()
+    {
+        // Arrange: simulate a DbUpdateException that is NOT a version-number conflict.
+        var record = MakeRecord();
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        repo.Setup(r => r.CanUserEditAsync(CreatorId, record.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var versionRepo = new Mock<IPlayRecordVersionRepository>();
+        versionRepo.Setup(v => v.GetNextVersionNumberAsync(record.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var differentException = new DbUpdateException("other db error");
+        var uow = new Mock<IUnitOfWork>();
+        uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(differentException);
+
+        // Detector always returns false (this is not a version conflict)
+        Func<DbUpdateException, bool> detector = _ => false;
+
+        var sut = CreateSutWithConflictDetector(repo, versionRepo, uow, detector);
+
+        var act = () => sut.Handle(
+            new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "x"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .Where(ex => ReferenceEquals(ex, differentException),
+                   "unrelated DbUpdateExceptions must not be swallowed");
+
+        // ReassignVersionNumberAsync must never be called on a non-version conflict
+        versionRepo.Verify(
+            v => v.ReassignVersionNumberAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

Fix per la follow-up **#2461** (sorta dal final review di #2437-3). `PlayRecordVersionRepository.GetNextVersionNumberAsync` faceva `MAX(VersionNumber)+1` senza lock → due update concorrenti dello stesso record (2 tab / double-submit) potevano calcolare lo stesso numero → unique-violation su `UX_play_record_versions_record_version` → **500**.

## Fix (transparent server-side retry, atomico)
- `SnapshotCurrentAsync` ora ritorna la versione staged.
- `UpdatePlayRecordCommandHandler` + `RestorePlayRecordVersionCommandHandler`: il `SaveChangesAsync` che committa versione+update è in un retry-loop. Su `DbUpdateException` con SQLSTATE `23505` + constraint `UX_play_record_versions_record_version` → `ReassignVersionNumberAsync` (ri-legge MAX, aggiorna il VersionNumber dell'entity ancora tracciata Added) → ritenta. **version + update restano atomici**. Cap a 5 retry.
- `PlayRecordVersionRepository.IsVersionNumberConflict(DbUpdateException)` + overload testabile `(sqlState, constraintName)`.
- Internal ctor sui handler per iniettare un conflict-detector → il test simula la collisione senza costruire una `PostgresException` reale.

## Test Plan
- [x] 21/21 BE test pass (build + nuovo retry test che simula la collisione 23505 → verifica re-read MAX + retry, no exception)

Closes #2461

🤖 Generated with [Claude Code](https://claude.com/claude-code)