### PR TITLE
feat(catalog): #2055 Phase 7 — Wikidata cover attribution footer (FE wiring)

### DIFF
--- a/apps/web/src/app/(public)/shared-games/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/page-client.tsx
@@ -234,6 +234,10 @@ export function SharedGamesPageClient({
       agentsCount: g.agentsCount,
       kbsCount: g.kbsCount,
       newThisWeekCount: g.newThisWeekCount,
+      // Issue #2055 Phase 7 — Wikidata cover attribution pass-through.
+      wikidataCoverLicense: g.wikidataCoverLicense ?? null,
+      wikidataCoverAttribution: g.wikidataCoverAttribution ?? null,
+      wikidataCoverSourceUrl: g.wikidataCoverSourceUrl ?? null,
     }));
   }, [data]);
 

--- a/apps/web/src/components/ui/shared-games/meeple-card-game.test.tsx
+++ b/apps/web/src/components/ui/shared-games/meeple-card-game.test.tsx
@@ -127,4 +127,68 @@ describe('MeepleCardGame (v2)', () => {
     );
     expect(container.querySelector('img')).toHaveAttribute('alt', '');
   });
+
+  // Issue #2055 Phase 7 — Wikidata cover attribution footer
+  describe('Wikidata attribution footer', () => {
+    it('renders <footer> with license text when wikidataCoverLicense is provided', () => {
+      const { container } = render(
+        <MeepleCardGame
+          {...baseProps}
+          wikidataCoverLicense="CC BY-SA 4.0"
+          wikidataCoverAttribution="Doe, John"
+          wikidataCoverSourceUrl="https://commons.wikimedia.org/wiki/File:Catan.jpg"
+        />
+      );
+      const footer = container.querySelector('footer');
+      expect(footer).not.toBeNull();
+      expect(footer).toHaveTextContent('CC BY-SA 4.0');
+    });
+
+    it('renders attribution text in footer when provided', () => {
+      render(
+        <MeepleCardGame
+          {...baseProps}
+          wikidataCoverLicense="CC BY 4.0"
+          wikidataCoverAttribution="Jane Smith"
+        />
+      );
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    });
+
+    it('renders a source link when wikidataCoverSourceUrl is provided', () => {
+      const { container } = render(
+        <MeepleCardGame
+          {...baseProps}
+          wikidataCoverLicense="CC BY-SA 4.0"
+          wikidataCoverSourceUrl="https://commons.wikimedia.org/wiki/File:Catan.jpg"
+        />
+      );
+      const link = container.querySelector('footer a');
+      expect(link).not.toBeNull();
+      expect(link).toHaveAttribute('href', 'https://commons.wikimedia.org/wiki/File:Catan.jpg');
+      expect(link).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('renders no <footer> when wikidataCoverLicense is null', () => {
+      const { container } = render(<MeepleCardGame {...baseProps} wikidataCoverLicense={null} />);
+      expect(container.querySelector('footer')).toBeNull();
+    });
+
+    it('renders no <footer> when wikidataCoverLicense is omitted', () => {
+      const { container } = render(<MeepleCardGame {...baseProps} />);
+      expect(container.querySelector('footer')).toBeNull();
+    });
+
+    it('renders license-only footer when attribution and sourceUrl are absent', () => {
+      const { container } = render(
+        <MeepleCardGame {...baseProps} wikidataCoverLicense="Public Domain" />
+      );
+      const footer = container.querySelector('footer');
+      expect(footer).not.toBeNull();
+      expect(footer).toHaveTextContent('Public Domain');
+      // No separator dots or extra content beyond the license.
+      expect(footer?.querySelector('a')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/ui/shared-games/meeple-card-game.tsx
+++ b/apps/web/src/components/ui/shared-games/meeple-card-game.tsx
@@ -18,6 +18,7 @@ import type { JSX } from 'react';
 import clsx from 'clsx';
 import Link from 'next/link';
 
+import { MeepleCardAttributionFooter } from '@/components/ui/data-display/meeple-card/MeepleCardAttributionFooter';
 import { EntityChip } from '@/components/ui/entity-chip/entity-chip';
 
 export interface MeepleCardGameLabels {
@@ -50,6 +51,14 @@ export interface MeepleCardGameProps {
   readonly labels: MeepleCardGameLabels;
   readonly compact?: boolean;
   readonly className?: string;
+  /**
+   * Issue #2055 Phase 7 — Wikidata cover attribution fields.
+   * Forwarded from `SharedGame.wikidataCoverLicense/Attribution/SourceUrl` (Zod schema).
+   * When `wikidataCoverLicense` is null/undefined, `MeepleCardAttributionFooter` returns null.
+   */
+  readonly wikidataCoverLicense?: string | null;
+  readonly wikidataCoverAttribution?: string | null;
+  readonly wikidataCoverSourceUrl?: string | null;
 }
 
 function Stars({
@@ -88,87 +97,100 @@ export function MeepleCardGame({
   labels,
   compact = false,
   className,
+  wikidataCoverLicense = null,
+  wikidataCoverAttribution = null,
+  wikidataCoverSourceUrl = null,
 }: MeepleCardGameProps): JSX.Element {
   const showNewBadge = newThisWeekCount >= 2;
   const coverH = compact ? 'h-24' : 'h-[116px]';
   const ratingFive = Math.round(Math.max(0, Math.min(5, rating)));
 
   return (
-    <Link
-      href={`/shared-games/${id}`}
-      prefetch
-      data-slot="shared-games-card"
-      data-game-id={id}
-      className={clsx(
-        'group relative flex flex-col overflow-hidden rounded-lg border border-border bg-card no-underline',
-        'text-foreground transition-[transform,box-shadow,border-color] duration-150',
-        'hover:-translate-y-0.5 hover:shadow-md hover:border-[hsl(var(--c-game)/0.4)]',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--c-game))] focus-visible:ring-offset-2',
-        className
-      )}
-    >
-      {/* Cover */}
-      <div
+    <>
+      <Link
+        href={`/shared-games/${id}`}
+        prefetch
+        data-slot="shared-games-card"
+        data-game-id={id}
         className={clsx(
-          'relative flex items-center justify-center bg-[hsl(var(--c-game)/0.12)]',
-          coverH
+          'group relative flex flex-col overflow-hidden rounded-lg border border-border bg-card no-underline',
+          'text-foreground transition-[transform,box-shadow,border-color] duration-150',
+          'hover:-translate-y-0.5 hover:shadow-md hover:border-[hsl(var(--c-game)/0.4)]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--c-game))] focus-visible:ring-offset-2',
+          className
         )}
       >
-        {coverUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={coverUrl}
-            alt=""
-            className="absolute inset-0 h-full w-full object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <span aria-hidden="true" className={compact ? 'text-[36px]' : 'text-[44px]'}>
-            🎲
-          </span>
-        )}
-        {showNewBadge ? (
-          <span
-            aria-label={labels.newWeekAriaLabel(newThisWeekCount)}
-            className="absolute right-2 top-2 rounded-full bg-[hsl(var(--c-event))] px-2 py-0.5 font-mono text-[10px] font-bold text-white shadow-sm"
-          >
-            +{newThisWeekCount}
-          </span>
-        ) : null}
-      </div>
-
-      {/* Body */}
-      <div className={clsx('flex flex-col gap-1.5', compact ? 'p-2.5' : 'p-3.5')}>
-        <div className="flex items-start justify-between gap-2">
-          <h3
-            className={clsx(
-              'm-0 line-clamp-2 font-display font-bold leading-tight text-foreground',
-              compact ? 'text-[13px]' : 'text-[14px]'
-            )}
-          >
-            {title}
-          </h3>
-          <Stars rating={rating} ariaLabel={`${labels.ratingAriaLabel} ${ratingFive} ${'di'} 5`} />
+        {/* Cover */}
+        <div
+          className={clsx(
+            'relative flex items-center justify-center bg-[hsl(var(--c-game)/0.12)]',
+            coverH
+          )}
+        >
+          {coverUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={coverUrl}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <span aria-hidden="true" className={compact ? 'text-[36px]' : 'text-[44px]'}>
+              🎲
+            </span>
+          )}
+          {showNewBadge ? (
+            <span
+              aria-label={labels.newWeekAriaLabel(newThisWeekCount)}
+              className="absolute right-2 top-2 rounded-full bg-[hsl(var(--c-event))] px-2 py-0.5 font-mono text-[10px] font-bold text-white shadow-sm"
+            >
+              +{newThisWeekCount}
+            </span>
+          ) : null}
         </div>
 
-        {year != null ? (
-          <p className="m-0 font-mono text-[10px] uppercase tracking-[0.06em] text-[hsl(var(--text-muted))]">
-            {year}
-          </p>
-        ) : null}
-
-        {(toolkitsCount > 0 || agentsCount > 0 || kbsCount > 0) && (
-          <div className="mt-1 flex flex-wrap gap-1.5">
-            {toolkitsCount > 0 ? (
-              <EntityChip entity="toolkit" label={`${toolkitsCount} ${labels.toolkitLabel}`} />
-            ) : null}
-            {agentsCount > 0 ? (
-              <EntityChip entity="agent" label={`${agentsCount} ${labels.agentLabel}`} />
-            ) : null}
-            {kbsCount > 0 ? <EntityChip entity="kb" label={String(kbsCount)} /> : null}
+        {/* Body */}
+        <div className={clsx('flex flex-col gap-1.5', compact ? 'p-2.5' : 'p-3.5')}>
+          <div className="flex items-start justify-between gap-2">
+            <h3
+              className={clsx(
+                'm-0 line-clamp-2 font-display font-bold leading-tight text-foreground',
+                compact ? 'text-[13px]' : 'text-[14px]'
+              )}
+            >
+              {title}
+            </h3>
+            <Stars
+              rating={rating}
+              ariaLabel={`${labels.ratingAriaLabel} ${ratingFive} ${'di'} 5`}
+            />
           </div>
-        )}
-      </div>
-    </Link>
+
+          {year != null ? (
+            <p className="m-0 font-mono text-[10px] uppercase tracking-[0.06em] text-[hsl(var(--text-muted))]">
+              {year}
+            </p>
+          ) : null}
+
+          {(toolkitsCount > 0 || agentsCount > 0 || kbsCount > 0) && (
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {toolkitsCount > 0 ? (
+                <EntityChip entity="toolkit" label={`${toolkitsCount} ${labels.toolkitLabel}`} />
+              ) : null}
+              {agentsCount > 0 ? (
+                <EntityChip entity="agent" label={`${agentsCount} ${labels.agentLabel}`} />
+              ) : null}
+              {kbsCount > 0 ? <EntityChip entity="kb" label={String(kbsCount)} /> : null}
+            </div>
+          )}
+        </div>
+      </Link>
+      <MeepleCardAttributionFooter
+        license={wikidataCoverLicense}
+        attribution={wikidataCoverAttribution}
+        sourceUrl={wikidataCoverSourceUrl}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

**Phase 7** di #2055 (Wikidata L2 cover enrichment). La discovery ha rivelato che il **core BE (M1-M8) è già shipped** (provider+P18, Commons client, LicenseValidator, WebpVariantGenerator Magick.NET, Quartz job, handler, admin endpoint, aggregate, integration tests) — vedi [commento #2055](https://github.com/meepleAi-app/meepleai-monorepo/issues/2055#issuecomment-4763249344). Anche lo schema FE + `MeepleCard` props + `MeepleCardAttributionFooter` esistevano già; mancava solo il **pass-through** nei consumer wrapper.

Questo PR wira l'attribution end-to-end (legal-required: CC-BY/CC-BY-SA richiedono credit visibile):
- `MeepleCardGame` (`ui/shared-games/meeple-card-game.tsx`): 3 props `wikidataCover*` + monta `MeepleCardAttributionFooter` (self-`null` quando license assente).
- shared-games grid (`(public)/shared-games/page-client.tsx`): il mapper DTO→card forwarda i 3 campi (già nel `SharedGameSchema` Zod).
- `HorizontalRow`/`DiscoverHub`: **skippati** (card bespoke senza `MeepleCard` — nessuna superficie attribution; no force-fit).

## Test Plan
- [x] 6 nuovi test `meeple-card-game.test.tsx` (footer render full/license-only/source-link/null-hidden)
- [x] 508/508 test pass (FE shared-games + meeple-card + discover + public); `typecheck` + `lint` clean

## Scope note
**Non chiude #2055** — restano (vedi commento aggiornato): Phase 2 (quarterly-job test harden), Phase 5 (Grafana dashboard), Phase 6 (WireMock contract tests). Phase 3 (Magick.NET) + Phase 4 (Cache-Control) già shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)