### PR TITLE
chore(fe): #2366 rename game-night-create -> game-night-new

### DIFF
--- a/admin-mockups/design_files/sp7-game-night-new.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-new.fidelity.json
@@ -24,8 +24,8 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "apps/web/src/app/(authenticated)/game-nights/new/game-night-create.stories.tsx",
-    "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-create.ts",
+    "story_path": "apps/web/src/app/(authenticated)/game-nights/new/game-night-new.stories.tsx",
+    "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-new.ts",
     "design_intent": "current",
     "viewports": [
       "desktop"

--- a/apps/web/e2e/storybook/diagnostic.snapshot.spec.ts
+++ b/apps/web/e2e/storybook/diagnostic.snapshot.spec.ts
@@ -42,8 +42,8 @@ const STORIES = [
   },
   // DS-17 Phase C-1 sp6-7-nano cluster sample (#2166)
   {
-    name: 'Game Night Create Frame01 Step1 Quando (Phase C-1)',
-    slug: 'pages-sp7-game-night-create--frame-01-step-1-quando',
+    name: 'Game Night New Frame01 Step1 Quando (Phase C-1)',
+    slug: 'pages-sp7-game-night-new--frame-01-step-1-quando',
   },
 ];
 

--- a/apps/web/e2e/storybook/sp6-7-nano.snapshot.spec.ts
+++ b/apps/web/e2e/storybook/sp6-7-nano.snapshot.spec.ts
@@ -13,49 +13,49 @@
 import { test, expect } from '@playwright/test';
 
 const FRAMES = [
-  // sp7-game-night-create (10 Frame + 2 State = 12 stories)
+  // sp7-game-night-new (10 Frame + 2 State = 12 stories)
   {
-    slug: 'pages-sp7-game-night-create--frame-01-step-1-quando',
-    file: 'game-night-create-01-step-1-quando.png',
+    slug: 'pages-sp7-game-night-new--frame-01-step-1-quando',
+    file: 'game-night-new-01-step-1-quando.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-02-step-1-warning',
-    file: 'game-night-create-02-step-1-warning.png',
+    slug: 'pages-sp7-game-night-new--frame-02-step-1-warning',
+    file: 'game-night-new-02-step-1-warning.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-03-step-2-location',
-    file: 'game-night-create-03-step-2-location.png',
+    slug: 'pages-sp7-game-night-new--frame-03-step-2-location',
+    file: 'game-night-new-03-step-2-location.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-04-step-3-empty',
-    file: 'game-night-create-04-step-3-empty.png',
+    slug: 'pages-sp7-game-night-new--frame-04-step-3-empty',
+    file: 'game-night-new-04-step-3-empty.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-05-step-3-typing',
-    file: 'game-night-create-05-step-3-typing.png',
+    slug: 'pages-sp7-game-night-new--frame-05-step-3-typing',
+    file: 'game-night-new-05-step-3-typing.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-06-step-3-filled',
-    file: 'game-night-create-06-step-3-filled.png',
+    slug: 'pages-sp7-game-night-new--frame-06-step-3-filled',
+    file: 'game-night-new-06-step-3-filled.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-07-step-4-games',
-    file: 'game-night-create-07-step-4-games.png',
+    slug: 'pages-sp7-game-night-new--frame-07-step-4-games',
+    file: 'game-night-new-07-step-4-games.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-08-step-4-decide-group',
-    file: 'game-night-create-08-step-4-decide-group.png',
+    slug: 'pages-sp7-game-night-new--frame-08-step-4-decide-group',
+    file: 'game-night-new-08-step-4-decide-group.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-09-mobile-step-flow',
-    file: 'game-night-create-09-mobile-step-flow.png',
+    slug: 'pages-sp7-game-night-new--frame-09-mobile-step-flow',
+    file: 'game-night-new-09-mobile-step-flow.png',
   },
   {
-    slug: 'pages-sp7-game-night-create--frame-10-desktop-split',
-    file: 'game-night-create-10-desktop-split.png',
+    slug: 'pages-sp7-game-night-new--frame-10-desktop-split',
+    file: 'game-night-new-10-desktop-split.png',
   },
-  { slug: 'pages-sp7-game-night-create--loading', file: 'game-night-create-loading.png' },
-  { slug: 'pages-sp7-game-night-create--error-state', file: 'game-night-create-error-state.png' },
+  { slug: 'pages-sp7-game-night-new--loading', file: 'game-night-new-loading.png' },
+  { slug: 'pages-sp7-game-night-new--error-state', file: 'game-night-new-error-state.png' },
 
   // sp7-game-night-detail-rsvp (12 Frame + 2 State = 14 stories)
   {

--- a/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-new.ts
+++ b/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-new.ts
@@ -1,19 +1,19 @@
 /**
- * Game Night Create page-mock fixtures (DS-17 Phase C-1 — argTypes matrix pattern).
+ * Game Night New page-mock fixtures (DS-17 Phase C-1 — argTypes matrix pattern).
  *
- * Consumed by `sp7-game-night-create` cluster Storybook story con axis matrix:
+ * Consumed by `sp7-game-night-new` cluster Storybook story con axis matrix:
  *   step:    1 | 2 | 3 | 4
  *   variant: 'default' | 'conflict' | 'submitting' | 'error'
  *
- * Stage axis discovery: grep `STATES = [` in sp7-game-night-create.jsx
+ * Stage axis discovery: grep `STATES = [` in sp7-game-night-new.jsx
  * (config array lines 1475-1484: 8 mobile state + 1 mobile overview + 1 desktop).
  *
  * Refs: spec docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md,
- *       umbrella #2063, sub-issue #2166.
+ *       umbrella #2063, sub-issue #2166, follow-up #2366 (FE rename).
  *
- * NOTE: this is a SCAFFOLD draft. Move to
- *   apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-create.ts
- * when wiring into the Storybook tree.
+ * NOTE: this is a SCAFFOLD draft. Co-located with the story under
+ *   apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-new.ts
+ * for the Storybook tree.
  */
 
 import { http, HttpResponse } from 'msw';

--- a/apps/web/src/app/(authenticated)/game-nights/new/game-night-new.stories.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/game-night-new.stories.tsx
@@ -13,7 +13,7 @@
  *     get individual dedicated stories alongside their files (see scaffold
  *     decision §6 of parent spec, mirrors auth-flow pattern).
  *
- * Stage axis (sp7-game-night-create.jsx STATES array lines 1475-1484 — 10
+ * Stage axis (sp7-game-night-new.jsx STATES array lines 1475-1484 — 10
  * frames including 8 Mobile + 1 Mobile step-flow overview + 1 Desktop split):
  *   step: 1 | 2 | 3 | 4
  *   variant: null | 'warning' | 'empty' | 'typing' | 'filled' | 'decide-group'
@@ -40,20 +40,20 @@ import {
   MOCK_SP7_CREATE_LIBRARY_GAMES,
   MOCK_SP7_CREATE_REGULARS,
   MOCK_SP7_CREATE_PLAYER_SEARCH_TYPING,
-} from '@/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-create';
+} from '@/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-new';
 import { GameNightCreateWizard } from '@/components/features/game-night-create';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof GameNightCreateWizard> = {
-  title: 'Pages/SP7/Game Night Create',
+  title: 'Pages/SP7/Game Night New',
   component: GameNightCreateWizard,
   parameters: {
     layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'Pixel-faithful matrix di sp7-game-night-create.jsx Mobile frames 01-08 + Mobile step-flow overview 09 + Desktop split-form 10. Hero usa `GameNightCreateWizard` (4-step orchestrator). 6 sub-componenti (DateTimePicker, LocationToggle, PlayerInviteAutocomplete, GameCandidatesPicker, RSVPCardLivePreview) hanno dedicated stories accanto ai loro file.',
+          'Pixel-faithful matrix di sp7-game-night-new.jsx Mobile frames 01-08 + Mobile step-flow overview 09 + Desktop split-form 10. Hero usa `GameNightCreateWizard` (4-step orchestrator). 6 sub-componenti (DateTimePicker, LocationToggle, PlayerInviteAutocomplete, GameCandidatesPicker, RSVPCardLivePreview) hanno dedicated stories accanto ai loro file.',
       },
     },
   },


### PR DESCRIPTION
## Summary

Follow-up to PR #2364 (Tier 1 #2342 cleanup mockup-side). SP7 brief rename (PR #2351) updated the canonical mockup filename to `sp7-game-night-new`; this PR renames the coordinated FE files (story + fixture + e2e slugs) left out-of-scope previously.

## Changes

**Renames (2)**:
- `apps/web/src/app/(authenticated)/game-nights/new/game-night-create.stories.tsx` -> `game-night-new.stories.tsx`
- `apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-create.ts` -> `sp7-game-night-new.ts`

**Refs updated**:
- Story title `Pages/SP7/Game Night Create` -> `Pages/SP7/Game Night New` (regenerates Storybook slugs `pages-sp7-game-night-new--*`)
- Fixture import in renamed story file
- `admin-mockups/design_files/sp7-game-night-new.fidelity.json` (`story_path` + `fixtures_path` lines 27-28)
- `apps/web/e2e/storybook/sp6-7-nano.snapshot.spec.ts` (12 slug refs + 12 PNG filename refs + section comment)
- `apps/web/e2e/storybook/diagnostic.snapshot.spec.ts` (1 slug ref + display name)
- Docstrings inside renamed files (mockup source `.jsx` name + stale path refs)

## Out-of-scope (pre-existing tech debt, left untouched per issue scope)

- `src/components/features/game-night-create/**` — the component name `GameNightCreateWizard` and its `data-slot="game-night-create-*"` attributes are NOT in the rename scope per the issue. Only page/fixture/story files were renamed. The component name is a separate refactor (would cascade to ~30 e2e selectors + a11y + component tests).
- 5 docstring refs to spec doc `docs/superpowers/specs/2026-05-18-sp7-game-night-create.md` in `src/lib/game-nights/wizard-*.ts` + `src/app/(authenticated)/game-nights/new/page.tsx`. The spec doc filename is unchanged (file still exists) and refs are outside the allowed-edit scope.
- `src/lib/game-nights/wizard-fixture.ts` ref to deleted `apps/web/e2e/visual-migrated/sp7-game-night-create.spec.ts` (visual gate removed per CLAUDE.md, stale doc-only ref).

## Test plan

- [x] `pnpm typecheck`: green
- [x] `pnpm lint`: 0 errors (106 pre-existing warnings unrelated to rename)
- [x] `pnpm test --run game-night`: 67 files / 695 tests passed, 0 failed
- [ ] `pnpm test:e2e`: **NOT executed locally** (Playwright suite >10 min budget). Storybook slug regeneration validated via CI `Frontend - E2E` and `Storybook visual` (no PNG baselines exist for these stories since the visual gate was removed; the spec just navigates to iframe by slug).
- [x] grep `sp7-game-night-create` on `apps/web/`: 5 remaining matches are docstring refs to the historical spec doc filename + 1 ref to deleted `visual-migrated/` (all OUT-OF-SCOPE per issue boundary list)

Closes #2366