### PR TITLE
feat(stories): #2174 Phase D-1 sp7 game-night stems — transition + join-public

### DIFF
--- a/admin-mockups/design_files/sp7-game-night-join-public.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-join-public.fidelity.json
@@ -24,8 +24,8 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
-    "fixtures_path": "",
+    "story_path": "apps/web/src/app/(public)/join/event/[code]/page.stories.tsx",
+    "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-join-public.ts",
     "design_intent": "current",
     "viewports": [
       "desktop"

--- a/admin-mockups/design_files/sp7-game-night-transition.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-transition.fidelity.json
@@ -24,8 +24,8 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
-    "fixtures_path": "",
+    "story_path": "apps/web/src/components/features/game-nights/transition/game-night-transition.stories.tsx",
+    "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-transition.ts",
     "design_intent": "current",
     "viewports": [
       "desktop"

--- a/apps/web/e2e/storybook/sp6-7-nano.snapshot.spec.ts
+++ b/apps/web/e2e/storybook/sp6-7-nano.snapshot.spec.ts
@@ -7,7 +7,7 @@
  *
  * Refs:
  * - Spec: docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md
- * - Skipped stems (6 forward-refactor): Phase D tracking issue raggruppato (Task 20)
+ * - Phase D-1 (game-night stems): #2174 — adds sp7-game-night-transition + sp7-game-night-join-public
  */
 
 import { test, expect } from '@playwright/test';
@@ -183,6 +183,70 @@ const FRAMES = [
   {
     slug: 'pages-sp7-game-night-summary--state-empty-all',
     file: 'game-night-summary-state-empty-all.png',
+  },
+
+  // sp7-game-night-transition (6 Frame + 1 State = 7 stories) — Phase D-1 #2174
+  {
+    slug: 'pages-sp7-game-night-transition--frame-01-default-two-col-split',
+    file: 'game-night-transition-01-default-two-col-split.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-transition--frame-02-rules-loading-skeleton',
+    file: 'game-night-transition-02-rules-loading-skeleton.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-transition--frame-03-rules-load-error',
+    file: 'game-night-transition-03-rules-load-error.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-transition--frame-04-skip-confirm-submodal',
+    file: 'game-night-transition-04-skip-confirm-submodal.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-transition--frame-05-end-night-confirm-submodal',
+    file: 'game-night-transition-05-end-night-confirm-submodal.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-transition--frame-06-mobile-fullscreen',
+    file: 'game-night-transition-06-mobile-fullscreen.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-transition--state-closed',
+    file: 'game-night-transition-state-closed.png',
+  },
+
+  // sp7-game-night-join-public (6 Frame + 2 State = 8 stories) — Phase D-1 #2174
+  {
+    slug: 'pages-sp7-game-night-join-public--frame-01-pending-empty',
+    file: 'game-night-join-public-01-pending-empty.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--frame-02-pending-filled',
+    file: 'game-night-join-public-02-pending-filled.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--frame-03-submitting',
+    file: 'game-night-join-public-03-submitting.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--frame-04-already-responded',
+    file: 'game-night-join-public-04-already-responded.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--frame-05-token-expired',
+    file: 'game-night-join-public-05-token-expired.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--frame-06-rate-limited',
+    file: 'game-night-join-public-06-rate-limited.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--state-token-invalid',
+    file: 'game-night-join-public-state-token-invalid.png',
+  },
+  {
+    slug: 'pages-sp7-game-night-join-public--state-loading',
+    file: 'game-night-join-public-state-loading.png',
   },
 ];
 

--- a/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-join-public.ts
+++ b/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-join-public.ts
@@ -1,0 +1,144 @@
+/**
+ * Public Game Night RSVP (anonymous /join/event/[code]) page-mock fixtures
+ * (DS-17 Phase D-1 — argTypes matrix pattern).
+ *
+ * Consumed by `sp7-game-night-join-public` cluster Storybook story con axis matrix:
+ *   state: 'pending-empty' | 'pending-filled' | 'submitting' | 'already-responded'
+ *        | 'token-expired' | 'rate-limited' | 'token-invalid' | 'loading'
+ *
+ * Stage axis discovery: 6 STATES in sp7-game-night-join-public.jsx
+ * (state-01-pending-empty through state-06-rate-limited, lines 74-82),
+ * extended with `token-invalid` and `loading` for FSM completeness
+ * (the FSM in `PublicJoinEventView` covers loading/invalid in addition).
+ *
+ * Route: `/join/event/[code]` (shipped Issue #1169). The variant is the
+ * `*-public` pendant of `sp7-game-night-detail-rsvp.jsx` (host/invitee
+ * authenticated). NO admin controls, NO Maybe button, NO ConnectionBar,
+ * NO real-time SSE.
+ *
+ * Refs: spec docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md,
+ *       umbrella #2063, sub-issue #2174 (Phase D-1).
+ */
+
+import { http, HttpResponse, delay } from 'msw';
+
+export type Sp7JoinPublicState =
+  | 'pending-empty'
+  | 'pending-filled'
+  | 'submitting'
+  | 'already-responded'
+  | 'token-expired'
+  | 'rate-limited'
+  | 'token-invalid'
+  | 'loading';
+
+const TOKEN = 'tok-public-1169';
+
+// ── Backend DTO shape mirror (PublicGameNightInvitationDto) ──────────────
+const INVITATION_BASE = {
+  token: TOKEN,
+  status: 'Pending',
+  expiresAt: '2026-05-30T20:00:00.000Z',
+  respondedAt: null,
+  hostUserId: '00000000-0000-4000-8000-000000000001',
+  hostDisplayName: 'Marco R.',
+  hostAvatarUrl: null,
+  hostWelcomeMessage: 'Ci vediamo sabato per una serata di Wingspan e snack!',
+  gameNightId: '00000000-0000-4000-8000-000000000002',
+  title: 'Sabato sera con i Padovani',
+  scheduledAt: '2026-05-23T20:00:00.000Z',
+  location: 'Casa Marco · Padova',
+  durationMinutes: 240,
+  expectedPlayers: 6,
+  acceptedSoFar: 3,
+  alreadyRespondedAs: null,
+  respondedByName: null,
+} as const;
+
+// ── MSW handlers ─────────────────────────────────────────────────────────
+
+const INVITATION_URL = `*/api/v1/game-nights/invitations/${TOKEN}`;
+const RESPOND_URL = `*/api/v1/game-nights/invitations/${TOKEN}/respond`;
+
+function jsonInvitation(overrides: Record<string, unknown> = {}) {
+  return HttpResponse.json({ ...INVITATION_BASE, ...overrides });
+}
+
+export function mswForSp7JoinPublicState(state: Sp7JoinPublicState) {
+  // 401 on /auth/me — public surface, anonymous viewer.
+  const authMe = http.get('*/api/v1/auth/me', () =>
+    HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  );
+
+  if (state === 'loading') {
+    return [authMe, http.get(INVITATION_URL, () => new Promise<Response>(() => {}))];
+  }
+
+  if (state === 'token-invalid') {
+    return [
+      authMe,
+      http.get(INVITATION_URL, () => HttpResponse.json({ error: 'Not found' }, { status: 404 })),
+    ];
+  }
+
+  if (state === 'token-expired') {
+    return [
+      authMe,
+      http.get(INVITATION_URL, () =>
+        HttpResponse.json({ error: 'Invitation expired' }, { status: 410 })
+      ),
+    ];
+  }
+
+  if (state === 'rate-limited') {
+    return [
+      authMe,
+      http.get(INVITATION_URL, () =>
+        HttpResponse.json(
+          { error: 'Too many requests' },
+          { status: 429, headers: { 'Retry-After': '12' } }
+        )
+      ),
+    ];
+  }
+
+  if (state === 'already-responded') {
+    return [
+      authMe,
+      http.get(INVITATION_URL, () =>
+        jsonInvitation({
+          status: 'Accepted',
+          respondedAt: '2026-05-20T18:42:00.000Z',
+          alreadyRespondedAs: 'Accepted',
+          respondedByName: 'Marco',
+          acceptedSoFar: 4,
+        })
+      ),
+      http.post(RESPOND_URL, () => HttpResponse.json({ status: 'Accepted' })),
+    ];
+  }
+
+  if (state === 'submitting') {
+    // POST hangs to surface in-flight button + disabled inputs.
+    return [
+      authMe,
+      http.get(INVITATION_URL, () => jsonInvitation()),
+      http.post(RESPOND_URL, async () => {
+        await delay('infinite');
+        return HttpResponse.json({ status: 'Accepted' });
+      }),
+    ];
+  }
+
+  // pending-empty + pending-filled share the same baseline payload — the
+  // "filled" affordance is purely a Story-side initial-display-name seed.
+  return [
+    authMe,
+    http.get(INVITATION_URL, () => jsonInvitation()),
+    http.post(RESPOND_URL, () => HttpResponse.json({ status: 'Accepted' })),
+  ];
+}
+
+// ── Token export ─────────────────────────────────────────────────────────
+// Re-exported so the Story can pass it as the `code` prop to `PublicJoinEventView`.
+export const MOCK_SP7_JOIN_PUBLIC_TOKEN = TOKEN;

--- a/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-transition.ts
+++ b/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-transition.ts
@@ -1,0 +1,81 @@
+/**
+ * Game Night Transition Dialog page-mock fixtures (DS-17 Phase D-1 — argTypes matrix pattern).
+ *
+ * Consumed by `sp7-game-night-transition` cluster Storybook story con axis matrix:
+ *   rulesStatus: 'ok' | 'loading' | 'error'
+ *   submodal:    null | 'skip' | 'end'
+ *   mobile:      boolean
+ *   open:        boolean
+ *
+ * Stage axis discovery: 6 frames in sp7-game-night-transition.jsx
+ * (state-01-transition-default through state-06-mobile-fullscreen, lines 866-927).
+ *
+ * `sp7-game-night-transition.html` is classified `component-mock` in
+ * `admin-mockups/MOCKUPS_INDEX.md` — the dialog is mounted from
+ * `/game-nights/[id]/live` via `NightLiveClientView` rather than its own route.
+ * We export pure-data fixtures (no MSW handlers) because `GameTransitionDialog`
+ * is a presentational primitive — the parent orchestrator owns the network.
+ *
+ * Refs: spec docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md,
+ *       umbrella #2063, sub-issue #2174 (Phase D-1).
+ */
+
+import type {
+  TransitionLastGame,
+  TransitionNextGame,
+} from '@/components/features/game-nights/transition';
+
+// ── LAST GAME — Brass: Birmingham winner Davide 178pt · 2h 45m ───────────
+export const MOCK_SP7_TRANSITION_LAST_GAME: TransitionLastGame = {
+  id: 'gs-brass-1',
+  title: 'Brass: Birmingham',
+  publisher: 'Roxley',
+  emoji: '🏭',
+  cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+  duration: '2h 45m',
+  endedAt: '22:55',
+  winner: {
+    id: 'p-davide',
+    initials: 'DC',
+    name: 'Davide',
+    color: 200,
+    score: 178,
+  },
+  topThree: [
+    {
+      id: 'p-davide',
+      initials: 'DC',
+      name: 'Davide',
+      color: 200,
+      score: 178,
+      delta: '+50 industria',
+    },
+    { id: 'p-marco', initials: 'MR', name: 'Marco', color: 262, score: 142, delta: '+12 network' },
+    { id: 'p-giulia', initials: 'GM', name: 'Giulia', color: 10, score: 128, delta: '+8 carbone' },
+  ],
+};
+
+// ── NEXT GAME — Spirit Island weight 4.08 · 3 rules · setup 2/4 done ─────
+export const MOCK_SP7_TRANSITION_NEXT_GAME: TransitionNextGame = {
+  id: 'gs-spirit-1',
+  title: 'Spirit Island',
+  publisher: 'GMT · co-op',
+  emoji: '🌋',
+  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+  estimated: '90m',
+  weight: 4.08,
+  rules: [
+    { icon: '🔁', text: 'Phase order · Growth → Fast → Slow', src: '§ 4.2' },
+    { icon: '😱', text: 'Fear deck · 9 carte iniziali (level 1/2/3)', src: '§ 5.1' },
+    { icon: '⚡', text: 'Power growth · 1 minor + 1 major per round', src: '§ 6.3' },
+  ],
+  setup: [
+    { icon: '🗺️', text: 'Tabellone · 4 isole', done: true },
+    { icon: '🧝', text: 'Spirit panels (4 spiriti scelti)', done: true },
+    { icon: '🃏', text: 'Invader deck shuffled · stage I', done: false },
+    { icon: '💀', text: 'Fear pool · 9 token', done: false },
+  ],
+};
+
+// ── Night code (matches sp7-game-night-live fixture #GN-042) ─────────────
+export const MOCK_SP7_TRANSITION_NIGHT_CODE = '#GN-042';

--- a/apps/web/src/app/(public)/join/event/[code]/page.stories.tsx
+++ b/apps/web/src/app/(public)/join/event/[code]/page.stories.tsx
@@ -1,0 +1,130 @@
+/**
+ * @mockup admin-mockups/design_files/sp7-game-night-join-public.jsx
+ *
+ * Public Game Night RSVP (anonymous /join/event/[code]) argTypes matrix story —
+ * DS-17 Phase D-1 (sub-issue #2174).
+ *
+ * Multi-state mockup canonical pick (P245):
+ *   The mockup is the public, anonymous variant of `sp7-game-night-detail-rsvp`
+ *   (host/invitee authenticated). 6 states + 2 FSM-derived states are covered
+ *   via MSW handlers on the public invitation endpoints:
+ *     - GET  /api/v1/game-nights/invitations/{token}
+ *     - POST /api/v1/game-nights/invitations/{token}/respond
+ *
+ *   HERO COMPONENT: `PublicJoinEventView` (the page-client at
+ *   apps/web/src/app/(public)/join/event/[code]/_components/PublicJoinEventView.tsx)
+ *   is the canonical render-mode hero. It wires `useGameNightInvitation` +
+ *   `useRespondToInvitation` internally — story drives via MSW handlers
+ *   per state.
+ *
+ *   DO NOT create separate story files per FSM variant; cover via the
+ *   `state` axis (Sp7JoinPublicState union). Mirrors DS-17-9 auth-flow pattern.
+ *
+ * Stage axis (sp7-game-night-join-public.jsx STATES — 6 frames + 2 FSM states):
+ *   pending-empty / pending-filled / submitting / already-responded /
+ *   token-expired / rate-limited / token-invalid / loading
+ *
+ * Variant simplifications vs sp7-game-night-detail-rsvp:
+ *   - NO admin controls (edit, cancel, voting tools)
+ *   - NO "Invite more" / share actions
+ *   - NO Maybe button (backend public POST validator accepts only Accepted/Declined)
+ *   - NO ConnectionBar (public route is not real-time SSE)
+ *
+ * Refs: spec docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md,
+ *       umbrella #2063, sub-issue #2174 (Phase D-1).
+ */
+
+import {
+  mswForSp7JoinPublicState,
+  MOCK_SP7_JOIN_PUBLIC_TOKEN,
+} from '@/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-join-public';
+import { PublicJoinEventView } from '@/app/(public)/join/event/[code]/_components/PublicJoinEventView';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PublicJoinEventView> = {
+  title: 'Pages/SP7/Game Night Join Public',
+  component: PublicJoinEventView,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Pixel-faithful matrix di sp7-game-night-join-public.jsx 6 stati pubblici (no host controls, no SSE) + 2 FSM states (loading, token-invalid). Hero usa `PublicJoinEventView` (page-client `/join/event/[code]`). Tutte le frame coperte via MSW handlers su `/api/v1/game-nights/invitations/{token}` + `/respond`. Variant `*-public` del sp7-game-night-detail-rsvp.',
+      },
+    },
+  },
+  argTypes: {
+    code: {
+      control: 'text',
+      description:
+        'Opaque invitation token (drives the useGameNightInvitation query — MSW handlers per state).',
+    },
+  },
+  args: {
+    code: MOCK_SP7_JOIN_PUBLIC_TOKEN,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PublicJoinEventView>;
+
+// ── Stage frame canonicals (mapped 1:1 ai 6 frame mockup) ──────────────────
+
+export const Frame01_PendingEmpty: Story = {
+  name: '01 · Pending · form pulito, nessun displayName, idle',
+  parameters: { msw: { handlers: mswForSp7JoinPublicState('pending-empty') } },
+};
+
+export const Frame02_PendingFilled: Story = {
+  name: "02 · Pending · user digita displayName 'Marco', idle",
+  parameters: {
+    msw: { handlers: mswForSp7JoinPublicState('pending-filled') },
+    docs: {
+      description: {
+        story:
+          'Documentation-only frame. The "filled" affordance is a user-interaction seed (typing "Marco" in the displayName input). Story renders identical baseline to Frame 01 — the parent `PublicRsvpForm` owns the input state.',
+      },
+    },
+  },
+};
+
+export const Frame03_Submitting: Story = {
+  name: '03 · Submitting · POST in flight, Accept button spinner',
+  parameters: {
+    msw: { handlers: mswForSp7JoinPublicState('submitting') },
+    docs: {
+      description: {
+        story:
+          'In-flight submitting state — POST is mocked as `delay("infinite")` so the spinner pins to the Accept button when the user clicks Confermo.',
+      },
+    },
+  },
+};
+
+export const Frame04_AlreadyResponded: Story = {
+  name: "04 · Already responded · 200 OK con respondedByName='Marco'",
+  parameters: { msw: { handlers: mswForSp7JoinPublicState('already-responded') } },
+};
+
+export const Frame05_TokenExpired: Story = {
+  name: '05 · GET 410 (Expired) — terminal banner',
+  parameters: { msw: { handlers: mswForSp7JoinPublicState('token-expired') } },
+};
+
+export const Frame06_RateLimited: Story = {
+  name: '06 · 429 Rate-limited con Retry-After countdown',
+  parameters: { msw: { handlers: mswForSp7JoinPublicState('rate-limited') } },
+};
+
+// ── State variant frames (FSM completeness — axis = LoadState) ─────────────
+
+export const StateTokenInvalid: Story = {
+  name: 'State · Token invalid (404 not found)',
+  parameters: { msw: { handlers: mswForSp7JoinPublicState('token-invalid') } },
+};
+
+export const StateLoading: Story = {
+  name: 'State · Loading (initial fetch)',
+  parameters: { msw: { handlers: mswForSp7JoinPublicState('loading') } },
+};

--- a/apps/web/src/components/features/game-nights/transition/game-night-transition.stories.tsx
+++ b/apps/web/src/components/features/game-nights/transition/game-night-transition.stories.tsx
@@ -1,0 +1,174 @@
+/**
+ * @mockup admin-mockups/design_files/sp7-game-night-transition.html
+ *
+ * Game Night Transition Dialog argTypes matrix story — DS-17 Phase D-1 (sub-issue #2174).
+ *
+ * Multi-state mockup canonical pick (P245):
+ *   The mockup classified `component-mock` in `admin-mockups/MOCKUPS_INDEX.md`
+ *   covers a single dialog opened from `/game-nights/[id]/live` via
+ *   `NightLiveClientView` (PR #1250). All 6 states are internal variants
+ *   driven by:
+ *     - `rulesStatus`: 'ok' | 'loading' | 'error'  (KB quick-glance status)
+ *     - `submodal`:    null | 'skip' | 'end'       (nested confirm modal)
+ *     - `mobile`:      boolean                     (fullscreen vertical stack)
+ *
+ *   HERO COMPONENT: `GameTransitionDialog` (`apps/web/src/components/features/game-nights/transition/GameTransitionDialog.tsx`)
+ *   is the canonical hero. It is purely presentational — the parent
+ *   orchestrator owns the network round-trips (transition POST, KB fetch).
+ *
+ * Stage axis (sp7-game-night-transition.jsx STATES — 6 frames):
+ *   01 default 2-col split (recap + preview)
+ *   02 KB rules quick-glance loading skeleton
+ *   03 KB fetch failed (fallback banner + 2 micro-CTA)
+ *   04 nested submodal "Saltare Spirit Island?" (warning amber)
+ *   05 nested submodal "Terminare serata qui?" (danger rosso)
+ *   06 mobile fullscreen vertical stack
+ *
+ * Refs: spec docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md,
+ *       umbrella #2063, sub-issue #2174 (Phase D-1).
+ */
+
+import { fn } from 'storybook/test';
+
+import {
+  MOCK_SP7_TRANSITION_LAST_GAME,
+  MOCK_SP7_TRANSITION_NEXT_GAME,
+  MOCK_SP7_TRANSITION_NIGHT_CODE,
+} from '@/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-transition';
+import { GameTransitionDialog } from '@/components/features/game-nights/transition';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof GameTransitionDialog> = {
+  title: 'Pages/SP7/Game Night Transition',
+  component: GameTransitionDialog,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Pixel-faithful matrix di sp7-game-night-transition.jsx 6 frames. Hero usa `GameTransitionDialog` (Screen L) — modal centered 600×500 desktop / fullscreen mobile, 2-col split (recap last | preview next). Mounted da `NightLiveClientView` come overlay del live hub. KB rules quick-glance ha 3 stati (ok/loading/error). 2 submodal nested (skip warning / end danger).',
+      },
+    },
+  },
+  argTypes: {
+    open: { control: 'boolean', description: 'Dialog open/closed.' },
+    rulesStatus: {
+      control: 'select',
+      options: ['ok', 'loading', 'error'],
+      description: 'KB rules quick-glance fetch status.',
+    },
+    submodal: {
+      control: 'select',
+      options: [null, 'skip', 'end'],
+      description:
+        'Nested confirm submodal — null hides, "skip" is warning amber, "end" is danger rosso.',
+    },
+    mobile: {
+      control: 'boolean',
+      description: 'Mobile shell mode (fullscreen vertical stack instead of 2-col grid).',
+    },
+    nightCode: {
+      control: 'text',
+      description: 'Game night code shown in dialog header (e.g. "#GN-042").',
+    },
+  },
+  args: {
+    open: true,
+    lastGame: MOCK_SP7_TRANSITION_LAST_GAME,
+    nextGame: MOCK_SP7_TRANSITION_NEXT_GAME,
+    rulesStatus: 'ok',
+    submodal: null,
+    mobile: false,
+    nightCode: MOCK_SP7_TRANSITION_NIGHT_CODE,
+    onClose: fn(),
+    onPlayNext: fn(),
+    onOpenSubmodal: fn(),
+    onConfirmSubmodal: fn(),
+    onCancelSubmodal: fn(),
+    onRetryRules: fn(),
+    onProceedWithoutRules: fn(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof GameTransitionDialog>;
+
+// ── Stage frame canonicals (mapped 1:1 ai 6 frame mockup) ──────────────────
+
+export const Frame01_DefaultTwoColSplit: Story = {
+  name: '01 · Default 2-col split · recap Brass + preview Spirit popolati',
+  args: {
+    rulesStatus: 'ok',
+    submodal: null,
+    mobile: false,
+  },
+};
+
+export const Frame02_RulesLoadingSkeleton: Story = {
+  name: '02 · KB rules quick-glance in loading · skeleton 3 righe',
+  args: {
+    rulesStatus: 'loading',
+    submodal: null,
+    mobile: false,
+  },
+};
+
+export const Frame03_RulesLoadError: Story = {
+  name: "03 · KB fetch failed · fallback 'Rules non disponibili offline' + retry",
+  args: {
+    rulesStatus: 'error',
+    submodal: null,
+    mobile: false,
+  },
+};
+
+export const Frame04_SkipConfirmSubmodal: Story = {
+  name: "04 · Submodal nested · 'Saltare Spirit Island?' (warning amber)",
+  args: {
+    rulesStatus: 'ok',
+    submodal: 'skip',
+    mobile: false,
+  },
+};
+
+export const Frame05_EndNightConfirmSubmodal: Story = {
+  name: "05 · Submodal nested · 'Terminare serata qui?' (danger rosso)",
+  args: {
+    rulesStatus: 'ok',
+    submodal: 'end',
+    mobile: false,
+  },
+};
+
+export const Frame06_MobileFullscreen: Story = {
+  name: '06 · Mobile fullscreen · vertical stack invece di 2-col',
+  args: {
+    rulesStatus: 'ok',
+    submodal: null,
+    mobile: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Mobile-only frame. Viewport sweep DEFERRED a Phase 4 — story render Desktop layout with `mobile=true` prop for current visual check. Dialog occupa 100% del viewport (no border-radius, no shadow).',
+      },
+    },
+  },
+};
+
+// ── Additional state variant (closed) — useful for FSM completeness ────────
+
+export const StateClosed: Story = {
+  name: 'State · Closed (open=false → returns null)',
+  args: { open: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `open=false` the component returns `null`. Documentation-only frame for completeness.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

DS-17 Phase D-1 (sub-issue #2174) — Storybook stories + MSW fixtures + fidelity wiring for the 2 sp7 game-night stems skipped during Phase C-1 (#2166).

**Discovery-first finding (saved the bulk of estimated work):** both targets in the issue body were already shipped upstream:
- `GameTransitionDialog` primitive lives in `apps/web/src/components/features/game-nights/transition/` and is already mounted from `/game-nights/[id]/live` via `NightLiveClientView` (PR #1250). `sp7-game-night-transition.html` is classified `component-mock` in `admin-mockups/MOCKUPS_INDEX.md` — **NOT a Next.js route**, so creating `/game-nights/[id]/transition/page.tsx` would have been wrong.
- `/join/event/[code]` is the canonical public RSVP page (Issue #1169), with `PublicJoinEventView` + 7 components in `features/game-night-detail/` (including `PublicRsvpForm` mirrored 1:1 from the mockup). Issue body referenced `/game-nights/join/[code]` but the existing route is sibling to `/join/session/[code]`.

Scope therefore reduces to the **DS-17-11 pattern** (#2173): stories + fixtures + fidelity.json wiring + snapshot suite entries — no new routes, no new components.

### Design decisions

- **D1 — Transition state machine**: not applicable. The mockup is a presentational modal driven by 3 axes (`rulesStatus`, `submodal`, `mobile`); the GameNight aggregate state machine (`planned → in-progress → completed`, invariants #1–#20 of the domain spec) is owned by `NightLiveClientView` upstream. The dialog itself emits intent callbacks (`onPlayNext`, `onOpenSubmodal('skip'|'end')`) — no aggregate mutation in the story.
- **D2 — Auth model for public route**: not applicable for this PR. Auth model is already shipped in `PublicJoinEventView` (Option A: opaque single-use token, `dynamic = 'force-dynamic'`, `robots: { index: false }`, optional-auth POST). Story exercises the public surface anonymously via MSW `401` on `/auth/me`.
- **D3 — Route group placement**: not applicable for this PR. Existing routes confirmed (`(authenticated)/game-nights/[id]/live` mounts the dialog; `(public)/join/event/[code]` is the public RSVP).

### Out of scope (Phase D-2 — separate follow-up tracked under issue #2174)

- sp6-libro-game-index
- sp6-libro-game-resume-state
- sp6-libro-game-photo-upload
- sp6-libro-game-quota-credits

## What ships

| File | Content |
|---|---|
| `apps/web/src/components/features/game-nights/transition/game-night-transition.stories.tsx` | 7 stories (6 mockup frames + 1 closed-state FSM), `Pages/SP7/Game Night Transition` |
| `apps/web/src/app/(public)/join/event/[code]/page.stories.tsx` | 8 stories (6 mockup frames + 2 FSM states `loading` + `token-invalid`), `Pages/SP7/Game Night Join Public` |
| `apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-transition.ts` | Shared `TransitionLastGame` / `TransitionNextGame` fixtures (Brass: Birmingham + Spirit Island) |
| `apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-join-public.ts` | `Sp7JoinPublicState` MSW matrix (8 states, hitting `/api/v1/game-nights/invitations/{token}` + `/respond`) |
| `admin-mockups/design_files/sp7-game-night-transition.fidelity.json` | populated `story_path` + `fixtures_path` |
| `admin-mockups/design_files/sp7-game-night-join-public.fidelity.json` | populated `story_path` + `fixtures_path` |
| `apps/web/e2e/storybook/sp6-7-nano.snapshot.spec.ts` | +15 snapshot entries (7 transition + 8 join-public) |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors (106 pre-existing warnings unrelated to this PR)
- [x] `pnpm lint:tokens` 0 violations
- [x] `pnpm lint:fidelity` PASS on both updated fidelity files (PASS sp7-game-night-transition + PASS sp7-game-night-join-public)
- [x] `pnpm mockup-annotations:audit --denominator mappable --threshold 80` → 100% (70/70 mappable)
- [x] `pnpm test --run` on `features/game-nights/transition/` + `fixtures/mockup-pilots/sp6-7-nano/` → 29 / 29 pass
- [ ] CI: Storybook snapshot pickup via `sp6-7-nano.snapshot.spec.ts` (15 new entries; CI generates baseline PNGs)
- [ ] CI: A11y E2E (blocking gate) — covers MSW-driven render of `PublicJoinEventView` in story preview

## Refs

- Umbrella: #2063
- Phase C-1 spec: `docs/superpowers/specs/2026-06-11-ds-17-phase-c-pilot-migration-design.md`
- DS-17-11 spec: `docs/superpowers/specs/2026-06-11-ds-17-11-sp6-7-nano-cluster-design.md`
- DS-17-11 PR (template): #2173
- Closes #2174 partially (Phase D-2 libro-game ecosystem 4 stems remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)