### PR TITLE
feat(observability): #2470 Wikidata SSE plane observability — Grafana panel + alert + heartbeat endpoint

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcaster.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
+using Api.Observability;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
@@ -35,10 +36,24 @@ internal sealed class InMemoryWikidataEnrichmentEventBroadcaster : IWikidataEnri
     {
         ArgumentNullException.ThrowIfNull(payload);
 
+        // Issue #2470 — count every publish call, even when no subscribers
+        // are present. Operationally useful: an admin watching the dashboard
+        // can confirm M9 ticks are still firing even when nobody is on the
+        // dead-letter page.
+        MeepleAiMetrics.WikidataSseMessagesPublished.Add(1);
+
         if (_subscribers.IsEmpty)
         {
             return;
         }
+
+        // Snapshot the subscriber count BEFORE the write loop so the
+        // `received_total` increment is consistent even if a concurrent
+        // subscribe / unsubscribe mutates the dictionary mid-loop. The
+        // counter is a best-effort approximation of delivery (drop-oldest
+        // makes "delivery" itself best-effort anyway).
+        var deliveredCount = _subscribers.Count;
+        MeepleAiMetrics.WikidataSseMessagesReceived.Add(deliveredCount);
 
         foreach (var (_, channel) in _subscribers)
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/RedisWikidataEnrichmentEventBroadcaster.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/RedisWikidataEnrichmentEventBroadcaster.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Threading.Channels;
+using Api.Observability;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
@@ -82,6 +83,14 @@ internal sealed class RedisWikidataEnrichmentEventBroadcaster
     public void Publish(WikidataEnrichmentEvent payload)
     {
         ArgumentNullException.ThrowIfNull(payload);
+
+        // Issue #2470 — count the publish attempt before we touch Redis. A
+        // failed PUBLISH still counts as a publisher-side attempt; the gap
+        // between this counter and the receive counter (post fan-out) on
+        // the same pod is the local delivery loss rate. Multi-pod
+        // fan-out adds remote-pod receives so the ratio inverts naturally
+        // once HPA scales above 1.
+        MeepleAiMetrics.WikidataSseMessagesPublished.Add(1);
 
         var json = JsonSerializer.Serialize(payload, SerializerOptions);
 
@@ -296,6 +305,13 @@ internal sealed class RedisWikidataEnrichmentEventBroadcaster
         }
 
         if (payload is null) return;
+
+        // Issue #2470 — snapshot the subscriber count BEFORE the fan-out so
+        // the counter increment is consistent against concurrent
+        // subscribe/unsubscribe. Mirror of the in-memory broadcaster
+        // bookkeeping.
+        var deliveredCount = _subscribers.Count;
+        MeepleAiMetrics.WikidataSseMessagesReceived.Add(deliveredCount);
 
         foreach (var (_, channel) in _subscribers)
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTracker.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTracker.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #2470 (DEC-C) — TTL'd counter of admin sessions that have recently
+/// posted a heartbeat to the wikidata-dead-letters page. The alert
+/// <c>WikidataSseSubscriberStarvation</c> consults this gauge to fire only
+/// when an admin is actively waiting for live SSE updates — see
+/// <c>infra/prometheus/alerts/wikidata-sse.yml</c>.
+/// </summary>
+/// <remarks>
+/// <para>Heartbeat contract: the admin page posts every 30s while open.
+/// Entries older than the TTL window (default 90s — 3 missed pings, see
+/// <c>WikidataAdminClientHeartbeatTracker.TtlSeconds</c>) are evicted on the
+/// next read. The eviction is lazy so the tracker has no background timer;
+/// <see cref="GetConnectedCount(DateTime)"/> sweeps the dictionary
+/// opportunistically.</para>
+///
+/// <para>Thread-safety: writes go through
+/// <see cref="ConcurrentDictionary{TKey,TValue}.AddOrUpdate(TKey, TValue, Func{TKey, TValue, TValue})"/>;
+/// reads iterate a snapshot of the keys (see comments in
+/// <see cref="GetConnectedCount(DateTime)"/>) so a concurrent writer can never
+/// crash the read.</para>
+/// </remarks>
+public interface IWikidataAdminClientHeartbeatTracker
+{
+    /// <summary>
+    /// Records (or refreshes) the heartbeat for <paramref name="userId"/>.
+    /// </summary>
+    void RecordHeartbeat(Guid userId, DateTime utcNow);
+
+    /// <summary>
+    /// Returns the count of distinct user ids that have heartbeated within
+    /// the TTL window relative to <paramref name="utcNow"/>. Performs lazy
+    /// GC of expired entries.
+    /// </summary>
+    int GetConnectedCount(DateTime utcNow);
+}
+
+/// <inheritdoc cref="IWikidataAdminClientHeartbeatTracker"/>
+internal sealed class WikidataAdminClientHeartbeatTracker : IWikidataAdminClientHeartbeatTracker
+{
+    /// <summary>
+    /// TTL window in seconds. Three FE 30-second pings — anything older
+    /// than this counts as "admin tab closed".
+    /// </summary>
+    public const int TtlSeconds = 90;
+
+    private readonly ConcurrentDictionary<Guid, DateTime> _heartbeats = new();
+    private readonly ILogger<WikidataAdminClientHeartbeatTracker> _logger;
+
+    public WikidataAdminClientHeartbeatTracker(
+        ILogger<WikidataAdminClientHeartbeatTracker> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void RecordHeartbeat(Guid userId, DateTime utcNow)
+    {
+        if (userId == Guid.Empty)
+        {
+            // Defensive: the admin-only filter should have rejected anonymous
+            // requests upstream, but a malformed test or fuzzer should not
+            // pollute the tracker.
+            _logger.LogDebug("WikidataAdminClientHeartbeatTracker: ignored heartbeat with empty user id");
+            return;
+        }
+
+        _heartbeats.AddOrUpdate(userId, utcNow, (_, _) => utcNow);
+    }
+
+    public int GetConnectedCount(DateTime utcNow)
+    {
+        if (_heartbeats.IsEmpty) return 0;
+
+        var threshold = utcNow.AddSeconds(-TtlSeconds);
+
+        // Snapshot the keys so a concurrent writer cannot mutate the
+        // collection while we iterate. We tolerate the small amount of
+        // staleness this introduces — a write that lands during iteration
+        // will simply be counted on the next call.
+        foreach (var (userId, lastBeat) in _heartbeats.ToArray())
+        {
+            if (lastBeat < threshold)
+            {
+                _heartbeats.TryRemove(new KeyValuePair<Guid, DateTime>(userId, lastBeat));
+            }
+        }
+
+        return _heartbeats.Count;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataSseGaugeBinder.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataSseGaugeBinder.cs
@@ -1,0 +1,55 @@
+using Api.Observability;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #2470 — binds the runtime broadcaster and heartbeat-tracker to the
+/// static <see cref="MeepleAiMetrics"/> SSE gauges. The gauges live on the
+/// static partial class so they can be created at type-init time; this
+/// hosted service supplies their callbacks once the DI graph is available.
+/// </summary>
+/// <remarks>
+/// <para>Binding is idempotent: a second <see cref="StartAsync(CancellationToken)"/>
+/// (which can happen in tests that re-host the application) simply re-points
+/// the callbacks at the latest instances. <see cref="StopAsync(CancellationToken)"/>
+/// is intentionally a no-op — the gauges remain valid throughout the host
+/// lifetime, and clearing the callbacks on stop would race with metric
+/// scrapes during graceful shutdown.</para>
+/// </remarks>
+internal sealed class WikidataSseGaugeBinder : IHostedService
+{
+    private readonly IWikidataEnrichmentEventBroadcaster _broadcaster;
+    private readonly IWikidataAdminClientHeartbeatTracker _heartbeatTracker;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WikidataSseGaugeBinder> _logger;
+
+    public WikidataSseGaugeBinder(
+        IWikidataEnrichmentEventBroadcaster broadcaster,
+        IWikidataAdminClientHeartbeatTracker heartbeatTracker,
+        TimeProvider timeProvider,
+        ILogger<WikidataSseGaugeBinder> logger)
+    {
+        _broadcaster = broadcaster ?? throw new ArgumentNullException(nameof(broadcaster));
+        _heartbeatTracker = heartbeatTracker ?? throw new ArgumentNullException(nameof(heartbeatTracker));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        MeepleAiMetrics.SetWikidataSseSubscribersCallback(() => _broadcaster.SubscriberCount);
+        MeepleAiMetrics.SetWikidataSseAdminClientsConnectedCallback(
+            () => _heartbeatTracker.GetConnectedCount(_timeProvider.GetUtcNow().UtcDateTime));
+
+        _logger.LogDebug("WikidataSseGaugeBinder: callbacks registered for SSE gauges");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Intentional no-op — see class remarks.
+        return Task.CompletedTask;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -238,6 +238,18 @@ internal static class SharedGameCatalogServiceExtensions
         // publisher (M9 scheduler / M12 trigger) are unchanged.
         services.AddWikidataEnrichmentEventBroadcaster(configuration);
 
+        // Issue #2470 (DEC-C): FE↔BE correlation for the SSE starvation
+        // alert. The wikidata-dead-letters page POSTs a heartbeat every 30s
+        // while open; the tracker exposes the count via the
+        // meepleai_wikidata_sse_admin_clients_connected gauge. Singleton so
+        // the TTL'd map survives across requests.
+        services.AddSingleton<IWikidataAdminClientHeartbeatTracker, WikidataAdminClientHeartbeatTracker>();
+
+        // Issue #2470: hosted service that binds the static
+        // MeepleAiMetrics SSE gauges to runtime sources (broadcaster +
+        // tracker) once DI is wired. See class remarks re: idempotent re-bind.
+        services.AddHostedService<WikidataSseGaugeBinder>();
+
         // Issue #1823 Wave 3 M9: Quartz scheduler for batch Wikidata cover
         // enrichment. Runs every 1 minute (HPA=1 per DEC-3e). [DisallowConcurrentExecution]
         // on the job class is the belt-and-braces guarantee that we never have

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs
@@ -198,4 +198,135 @@ internal static partial class MeepleAiMetrics
         name: "meepleai.wikidata.quarterly_reverification.reset.total",
         unit: "games",
         description: "Cumulative count of SharedGames reset to NULL by WikidataQuarterlyReVerificationJob (#2055 Phase G AC-G1)");
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Issue #2470 — SSE plane observability (Phase E F4 + #2256 backplane)
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Callback supplied by the hosted gauge binder that resolves the live
+    /// subscriber count from <c>IWikidataEnrichmentEventBroadcaster</c>.
+    /// Null until <see cref="SetWikidataSseSubscribersCallback(Func{int})"/>
+    /// is invoked at host startup; the gauge reports 0 while unbound so a
+    /// missing binder fails open instead of crashing the metric scrape.
+    /// </summary>
+    private static Func<int>? _wikidataSseSubscribersCallback;
+
+    /// <summary>
+    /// Issue #2470 — current SSE subscriber count on this pod. Sourced from
+    /// the broadcaster's <c>SubscriberCount</c> diagnostic via a lazy
+    /// callback set by the hosted binder. Per the issue DEC-A, the
+    /// <c>WikidataSseSubscriberStarvation</c> alert (see
+    /// <c>infra/prometheus/alerts/wikidata-sse.yml</c>) correlates this
+    /// gauge with <see cref="WikidataSseAdminClientsConnected"/> to fire only
+    /// when an admin is actually waiting for live updates.
+    /// </summary>
+    public static readonly ObservableGauge<int> WikidataSseSubscribers = Meter.CreateObservableGauge(
+        name: "meepleai.wikidata.sse.subscribers",
+        observeValue: () =>
+        {
+            try
+            {
+                return _wikidataSseSubscribersCallback?.Invoke() ?? 0;
+            }
+#pragma warning disable CA1031 // Metric scrapes must never throw — degrade to 0.
+            catch
+#pragma warning restore CA1031
+            {
+                return 0;
+            }
+        },
+        unit: "subscribers",
+        description: "Current SSE subscriber count on this pod (#2470)");
+
+    /// <summary>
+    /// Binds the gauge callback. Intended to be called once by
+    /// <c>WikidataSseGaugeBinder</c> at host startup; subsequent calls
+    /// replace the callback atomically (test helpers rely on this to swap
+    /// in deterministic values).
+    /// </summary>
+    public static void SetWikidataSseSubscribersCallback(Func<int> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        System.Threading.Interlocked.Exchange(ref _wikidataSseSubscribersCallback, callback);
+    }
+
+    /// <summary>
+    /// Test-only reset of the callback. Production code MUST NOT call this —
+    /// the gauge will revert to reporting 0 until a new callback is set.
+    /// </summary>
+    internal static void ResetWikidataSseSubscribersCallback()
+    {
+        System.Threading.Interlocked.Exchange(ref _wikidataSseSubscribersCallback, null);
+    }
+
+    /// <summary>
+    /// Callback supplied by the hosted gauge binder that resolves the live
+    /// admin-clients-connected count from
+    /// <c>WikidataAdminClientHeartbeatTracker</c>. Same lazy-init semantics
+    /// as <see cref="_wikidataSseSubscribersCallback"/>.
+    /// </summary>
+    private static Func<int>? _wikidataSseAdminClientsConnectedCallback;
+
+    /// <summary>
+    /// Issue #2470 (DEC-C) — count of distinct admin sessions that have
+    /// posted a heartbeat in the last 90 seconds, indicating the admin
+    /// dead-letter page is open and expecting live updates. Used by the
+    /// alert correlation: a starvation alert only fires when an admin is
+    /// actively watching.
+    /// </summary>
+    public static readonly ObservableGauge<int> WikidataSseAdminClientsConnected = Meter.CreateObservableGauge(
+        name: "meepleai.wikidata.sse.admin_clients_connected",
+        observeValue: () =>
+        {
+            try
+            {
+                return _wikidataSseAdminClientsConnectedCallback?.Invoke() ?? 0;
+            }
+#pragma warning disable CA1031
+            catch
+#pragma warning restore CA1031
+            {
+                return 0;
+            }
+        },
+        unit: "clients",
+        description: "Distinct admin sessions heartbeating the SSE dead-letter page in the last 90s (#2470 DEC-C)");
+
+    /// <summary>Binds the admin-clients gauge callback. Same semantics as <see cref="SetWikidataSseSubscribersCallback(Func{int})"/>.</summary>
+    public static void SetWikidataSseAdminClientsConnectedCallback(Func<int> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        System.Threading.Interlocked.Exchange(ref _wikidataSseAdminClientsConnectedCallback, callback);
+    }
+
+    /// <summary>Test-only reset; mirror of <see cref="ResetWikidataSseSubscribersCallback"/>.</summary>
+    internal static void ResetWikidataSseAdminClientsConnectedCallback()
+    {
+        System.Threading.Interlocked.Exchange(ref _wikidataSseAdminClientsConnectedCallback, null);
+    }
+
+    /// <summary>
+    /// Issue #2470 — counter incremented once per <c>Publish</c> call on the
+    /// broadcaster (both in-memory and Redis variants). Mirrors the
+    /// publisher-side activity rate so an operator can spot "publishes flowing
+    /// but no subscribers" via Grafana panel 10.
+    /// </summary>
+    public static readonly Counter<long> WikidataSseMessagesPublished = Meter.CreateCounter<long>(
+        name: "meepleai.wikidata.sse.messages.published.total",
+        unit: "messages",
+        description: "Wikidata SSE attempt-recorded messages emitted by the publisher (#2470)");
+
+    /// <summary>
+    /// Issue #2470 — counter incremented once per per-subscriber delivery on
+    /// this pod. For the in-memory broadcaster this is +N (N = local
+    /// subscribers) per <c>Publish</c>; for the Redis broadcaster it is +N
+    /// per incoming Redis pub/sub message. Diverges from
+    /// <see cref="WikidataSseMessagesPublished"/> only when a multi-pod
+    /// deployment fans the same publish out to subscribers on remote pods.
+    /// </summary>
+    public static readonly Counter<long> WikidataSseMessagesReceived = Meter.CreateCounter<long>(
+        name: "meepleai.wikidata.sse.messages.received.total",
+        unit: "messages",
+        description: "Wikidata SSE messages delivered to local subscriber channels (#2470)");
 }

--- a/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs
@@ -63,6 +63,15 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
             .WithName("AdminWikidataCoverEnrichment_EventsStream")
             .WithTags("Admin", "WikidataCoverEnrichment");
 
+        // Issue #2470 (DEC-C) — heartbeat endpoint for the admin
+        // dead-letter page. FE posts every 30s while the page is open; the
+        // BE-side tracker exposes the count as
+        // meepleai_wikidata_sse_admin_clients_connected so the starvation
+        // alert can correlate "no subscribers" with "admin actually waiting".
+        group.MapPost("/sse-clients/heartbeat", HandleSseClientHeartbeat)
+            .WithName("AdminWikidataCoverEnrichment_SseClientHeartbeat")
+            .WithTags("Admin", "WikidataCoverEnrichment");
+
         return group;
     }
 
@@ -208,6 +217,29 @@ internal static class AdminWikidataCoverEnrichmentEndpoints
     /// immediately with <c>:ok\n\n</c> so the client sees headers without
     /// waiting for the first event.
     /// </remarks>
+    /// <summary>
+    /// Issue #2470 (DEC-C) — heartbeat endpoint hit by the admin
+    /// wikidata-dead-letters page every 30s while it is open. The TTL'd
+    /// tracker maintains a per-user lastBeat dictionary whose count is
+    /// surfaced through <c>meepleai_wikidata_sse_admin_clients_connected</c>.
+    /// </summary>
+    /// <remarks>
+    /// Group-level <c>RequireAdminSessionFilter</c> already enforces auth;
+    /// anonymous requests are rejected with 401 before this handler runs.
+    /// The endpoint is intentionally body-less — the user id is taken from
+    /// the authenticated session, which dedups multiple tabs / browser
+    /// windows of the same user automatically.
+    /// </remarks>
+    private static IResult HandleSseClientHeartbeat(
+        HttpContext context,
+        IWikidataAdminClientHeartbeatTracker tracker,
+        TimeProvider timeProvider)
+    {
+        var userId = context.User.GetUserId();
+        tracker.RecordHeartbeat(userId, timeProvider.GetUtcNow().UtcDateTime);
+        return Results.NoContent();
+    }
+
     private static async Task HandleEventsStream(
         HttpContext context,
         IWikidataEnrichmentEventBroadcaster broadcaster,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterTests.cs
@@ -161,4 +161,110 @@ public class InMemoryWikidataEnrichmentEventBroadcasterTests
         sut.SubscriberCount.Should().Be(0,
             "the consumer's finally block MUST remove the subscriber on cancellation");
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Issue #2470 — instrumentation: every Publish ticks the published
+    // counter once; the received counter ticks by the snapshot subscriber
+    // count at the time of publish. Tests use a MeterListener to capture
+    // raw measurements off the shared global Meter (mirror of the
+    // WikidataEnrichmentMetricsTests pattern).
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Publish_AlwaysIncrementsPublishedCounter_ByOne()
+    {
+        var sut = CreateSut();
+
+        var delta = MeasureCounterDelta(
+            "meepleai.wikidata.sse.messages.published.total",
+            () => sut.Publish(SampleEvent()));
+
+        delta.Should().Be(1L);
+    }
+
+    [Fact]
+    public void Publish_ZeroSubscribers_DoesNotIncrementReceivedCounter()
+    {
+        var sut = CreateSut();
+
+        var delta = MeasureCounterDelta(
+            "meepleai.wikidata.sse.messages.received.total",
+            () => sut.Publish(SampleEvent()));
+
+        delta.Should().Be(0L,
+            "with zero subscribers nothing is delivered locally, so the received counter stays put");
+    }
+
+    [Fact]
+    public async Task Publish_WithThreeSubscribers_IncrementsReceivedCounterByThree()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Spin up three subscribers and wait for them to register.
+        var subscriberTasks = Enumerable.Range(0, 3).Select(_ => Task.Run(async () =>
+        {
+            await foreach (var _ in sut.SubscribeAsync(cts.Token))
+            {
+                // Drain — we only care that the subscriber count is 3 when
+                // Publish runs.
+            }
+        })).ToList();
+
+        // Wait until all three subscribers are registered in the broadcaster.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (sut.SubscriberCount < 3 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+
+        sut.SubscriberCount.Should().Be(3, "test prerequisite: all subscribers must be registered");
+
+        var receivedDelta = MeasureCounterDelta(
+            "meepleai.wikidata.sse.messages.received.total",
+            () => sut.Publish(SampleEvent()));
+
+        receivedDelta.Should().Be(3L,
+            "the received counter MUST tick by the snapshot subscriber count at publish time");
+
+        cts.Cancel();
+        try
+        {
+            await Task.WhenAll(subscriberTasks);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected.
+        }
+    }
+
+    /// <summary>
+    /// Captures the delta of a global counter while <paramref name="action"/>
+    /// runs. The shared global <c>Meter</c> may receive concurrent ticks from
+    /// other tests in the same process, so we filter measurements down to the
+    /// instrument we asked for. The listener subscribes BEFORE action and is
+    /// disposed AFTER, so any measurement emitted during the action window
+    /// shows up in <c>captured</c>.
+    /// </summary>
+    private static long MeasureCounterDelta(string instrumentName, Action action)
+    {
+        var captured = new List<long>();
+
+        using var listener = new System.Diagnostics.Metrics.MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => captured.Add(value));
+        listener.Start();
+
+        action();
+
+        return captured.Sum();
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/RedisWikidataEnrichmentEventBroadcasterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/RedisWikidataEnrichmentEventBroadcasterTests.cs
@@ -432,4 +432,52 @@ public class RedisWikidataEnrichmentEventBroadcasterTests : IAsyncLifetime
         // single assertion covers every field including the nullable ones.
         received.Should().Be(fullyPopulated);
     }
+
+    /// <summary>
+    /// Issue #2470 — instrumentation contract: every <c>Publish</c> ticks the
+    /// global <c>meepleai_wikidata_sse_messages_published_total</c> counter
+    /// exactly once, regardless of whether the Redis PUBLISH succeeds or fails.
+    /// This preserves the operator's ability to spot "publishes flowing, but
+    /// nothing arrives on the subscribers" via Grafana panel 10 + 11.
+    /// </summary>
+    [Fact]
+    public void Publish_IncrementsPublishedCounter_ByOne()
+    {
+        var broadcaster = CreateBroadcaster(_connectionA!);
+
+        var delta = MeasureCounterDelta(
+            "meepleai.wikidata.sse.messages.published.total",
+            () => broadcaster.Publish(SampleEvent()));
+
+        delta.Should().Be(1L);
+    }
+
+    /// <summary>
+    /// Captures the delta of a global counter while <paramref name="action"/>
+    /// runs. The shared global <c>Meter</c> may receive concurrent ticks from
+    /// other tests in the same process, so we filter measurements down to the
+    /// instrument we asked for. Mirror of the helper in the in-memory broadcaster
+    /// tests + the metrics scaffolding tests.
+    /// </summary>
+    private static long MeasureCounterDelta(string instrumentName, Action action)
+    {
+        var captured = new List<long>();
+
+        using var listener = new System.Diagnostics.Metrics.MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == instrumentName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => captured.Add(value));
+        listener.Start();
+
+        action();
+
+        return captured.Sum();
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTrackerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTrackerTests.cs
@@ -1,0 +1,136 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #2470 — TDD tests for <see cref="WikidataAdminClientHeartbeatTracker"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2470")]
+public class WikidataAdminClientHeartbeatTrackerTests
+{
+    private static readonly ILogger<WikidataAdminClientHeartbeatTracker> NullLogger =
+        NullLogger<WikidataAdminClientHeartbeatTracker>.Instance;
+
+    private static readonly DateTime BaseUtc = new(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void GetConnectedCount_EmptyTracker_ReturnsZero()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+
+        sut.GetConnectedCount(BaseUtc).Should().Be(0);
+    }
+
+    [Fact]
+    public void RecordHeartbeat_SingleUser_GaugeReports1()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+
+        sut.RecordHeartbeat(Guid.NewGuid(), BaseUtc);
+
+        sut.GetConnectedCount(BaseUtc).Should().Be(1);
+    }
+
+    [Fact]
+    public void RecordHeartbeat_TwoDistinctUsers_GaugeReports2()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+
+        sut.RecordHeartbeat(Guid.NewGuid(), BaseUtc);
+        sut.RecordHeartbeat(Guid.NewGuid(), BaseUtc);
+
+        sut.GetConnectedCount(BaseUtc).Should().Be(2);
+    }
+
+    [Fact]
+    public void RecordHeartbeat_SameUserTwice_StillReports1()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+        var userId = Guid.NewGuid();
+
+        sut.RecordHeartbeat(userId, BaseUtc);
+        sut.RecordHeartbeat(userId, BaseUtc.AddSeconds(30));
+
+        sut.GetConnectedCount(BaseUtc.AddSeconds(30)).Should().Be(1);
+    }
+
+    [Fact]
+    public void RecordHeartbeat_EmptyGuid_IsIgnored()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+
+        sut.RecordHeartbeat(Guid.Empty, BaseUtc);
+
+        sut.GetConnectedCount(BaseUtc)
+            .Should().Be(0, "empty Guid is non-sensical and MUST NOT pollute the tracker");
+    }
+
+    [Fact]
+    public void GetConnectedCount_ExpiredEntries_AreEvicted()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+        var oldUser = Guid.NewGuid();
+        var freshUser = Guid.NewGuid();
+
+        sut.RecordHeartbeat(oldUser, BaseUtc);
+        // 91s later — past the 90s TTL — old user has not heartbeated.
+        sut.RecordHeartbeat(freshUser, BaseUtc.AddSeconds(91));
+
+        sut.GetConnectedCount(BaseUtc.AddSeconds(91))
+            .Should().Be(1, "the 91s-old entry MUST be evicted on the next read");
+    }
+
+    [Fact]
+    public void GetConnectedCount_RefreshedEntry_StaysConnected()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+        var userId = Guid.NewGuid();
+
+        sut.RecordHeartbeat(userId, BaseUtc);
+        // 80s later (within TTL) — refresh.
+        sut.RecordHeartbeat(userId, BaseUtc.AddSeconds(80));
+        // Another 80s later — would expire from original, but refresh
+        // kept it alive.
+        sut.GetConnectedCount(BaseUtc.AddSeconds(160))
+            .Should().Be(1, "an active user that refreshes within TTL stays connected indefinitely");
+    }
+
+    [Fact]
+    public void GetConnectedCount_BoundaryAtTtl_IsTreatedAsConnected()
+    {
+        // The TTL boundary is "strictly less than threshold". An entry at
+        // exactly TTL seconds old is still connected. This keeps a slow
+        // ping that arrives at exactly the boundary from flipping the gauge.
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+        var userId = Guid.NewGuid();
+
+        sut.RecordHeartbeat(userId, BaseUtc);
+
+        sut.GetConnectedCount(BaseUtc.AddSeconds(WikidataAdminClientHeartbeatTracker.TtlSeconds))
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public void RecordHeartbeat_1000ConcurrentCallers_AllRecorded()
+    {
+        var sut = new WikidataAdminClientHeartbeatTracker(NullLogger);
+        var userIds = Enumerable.Range(0, 1000).Select(_ => Guid.NewGuid()).ToArray();
+
+        Parallel.ForEach(userIds, id => sut.RecordHeartbeat(id, BaseUtc));
+
+        sut.GetConnectedCount(BaseUtc).Should().Be(1000);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var act = () => new WikidataAdminClientHeartbeatTracker(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataSseGaugeBinderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataSseGaugeBinderTests.cs
@@ -1,0 +1,219 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Observability;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #2470 — TDD tests for <see cref="WikidataSseGaugeBinder"/>.
+/// </summary>
+[Collection("WikidataMetrics")]
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2470")]
+public class WikidataSseGaugeBinderTests
+{
+    [Fact]
+    public async Task StartAsync_BindsSubscribersCallback_ToBroadcasterCount()
+    {
+        var broadcaster = new FakeBroadcaster { SubscriberCount = 4 };
+        var tracker = new FakeHeartbeatTracker { ConnectedCount = 0 };
+        var binder = CreateBinder(broadcaster, tracker, FakeTimeProvider.AtFixed(new DateTime(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc)));
+
+        try
+        {
+            await binder.StartAsync(CancellationToken.None);
+
+            ReadObservableGauge(MeepleAiMetrics.WikidataSseSubscribers).Should().Be(4);
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+            MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_BindsAdminClientsCallback_ToTrackerCount()
+    {
+        var broadcaster = new FakeBroadcaster { SubscriberCount = 0 };
+        var tracker = new FakeHeartbeatTracker { ConnectedCount = 3 };
+        var binder = CreateBinder(broadcaster, tracker, FakeTimeProvider.AtFixed(new DateTime(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc)));
+
+        try
+        {
+            await binder.StartAsync(CancellationToken.None);
+
+            ReadObservableGauge(MeepleAiMetrics.WikidataSseAdminClientsConnected).Should().Be(3);
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+            MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_TrackerCallback_UsesCurrentUtcFromTimeProvider()
+    {
+        var broadcaster = new FakeBroadcaster { SubscriberCount = 0 };
+        var tracker = new FakeHeartbeatTracker { ConnectedCount = 7 };
+        var capturedUtc = new List<DateTime>();
+        tracker.OnGetConnectedCount = utc => capturedUtc.Add(utc);
+
+        var fixedUtc = new DateTime(2026, 6, 22, 13, 30, 0, DateTimeKind.Utc);
+        var binder = CreateBinder(broadcaster, tracker, FakeTimeProvider.AtFixed(fixedUtc));
+
+        try
+        {
+            await binder.StartAsync(CancellationToken.None);
+
+            ReadObservableGauge(MeepleAiMetrics.WikidataSseAdminClientsConnected);
+
+            capturedUtc.Should().NotBeEmpty();
+            capturedUtc[^1].Should().Be(fixedUtc, "the tracker MUST receive the UTC from TimeProvider, not DateTime.UtcNow");
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+            MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_CalledTwice_LatestBroadcasterWins()
+    {
+        var firstBroadcaster = new FakeBroadcaster { SubscriberCount = 1 };
+        var secondBroadcaster = new FakeBroadcaster { SubscriberCount = 9 };
+        var tracker = new FakeHeartbeatTracker { ConnectedCount = 0 };
+        var time = FakeTimeProvider.AtFixed(new DateTime(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc));
+
+        try
+        {
+            var first = CreateBinder(firstBroadcaster, tracker, time);
+            await first.StartAsync(CancellationToken.None);
+
+            var second = CreateBinder(secondBroadcaster, tracker, time);
+            await second.StartAsync(CancellationToken.None);
+
+            ReadObservableGauge(MeepleAiMetrics.WikidataSseSubscribers)
+                .Should().Be(9, "the latest StartAsync MUST swap the callback atomically");
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+            MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_IsNoOp_GaugesRemainValid()
+    {
+        var broadcaster = new FakeBroadcaster { SubscriberCount = 2 };
+        var tracker = new FakeHeartbeatTracker { ConnectedCount = 1 };
+        var binder = CreateBinder(broadcaster, tracker, FakeTimeProvider.AtFixed(new DateTime(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc)));
+
+        try
+        {
+            await binder.StartAsync(CancellationToken.None);
+            await binder.StopAsync(CancellationToken.None);
+
+            ReadObservableGauge(MeepleAiMetrics.WikidataSseSubscribers).Should().Be(2);
+            ReadObservableGauge(MeepleAiMetrics.WikidataSseAdminClientsConnected).Should().Be(1);
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+            MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Constructor_NullDependency_Throws(int nullDependencyIndex)
+    {
+        var broadcaster = nullDependencyIndex == 0 ? null! : new FakeBroadcaster();
+        var tracker = nullDependencyIndex == 1 ? null! : new FakeHeartbeatTracker();
+        var time = nullDependencyIndex == 2 ? null! : FakeTimeProvider.AtFixed(DateTime.UtcNow);
+        var logger = nullDependencyIndex == 3
+            ? null!
+            : NullLogger<WikidataSseGaugeBinder>.Instance;
+
+        var act = () => new WikidataSseGaugeBinder(broadcaster, tracker, time, logger);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static WikidataSseGaugeBinder CreateBinder(
+        IWikidataEnrichmentEventBroadcaster broadcaster,
+        IWikidataAdminClientHeartbeatTracker tracker,
+        TimeProvider time)
+        => new(broadcaster, tracker, time, NullLogger<WikidataSseGaugeBinder>.Instance);
+
+    private static int ReadObservableGauge(System.Diagnostics.Metrics.ObservableGauge<int> gauge)
+    {
+        var collected = new List<int>();
+
+        using var listener = new System.Diagnostics.Metrics.MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument == gauge)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<int>((_, value, _, _) => collected.Add(value));
+        listener.Start();
+        listener.RecordObservableInstruments();
+
+        collected.Should().HaveCountGreaterThanOrEqualTo(1);
+        return collected[^1];
+    }
+
+    private sealed class FakeBroadcaster : IWikidataEnrichmentEventBroadcaster
+    {
+        public int SubscriberCount { get; set; }
+        public void Publish(WikidataEnrichmentEvent payload) { }
+        public IAsyncEnumerable<WikidataEnrichmentEvent> SubscribeAsync(CancellationToken cancellationToken)
+            => AsyncEnumerable.Empty<WikidataEnrichmentEvent>();
+    }
+
+    private sealed class FakeHeartbeatTracker : IWikidataAdminClientHeartbeatTracker
+    {
+        public int ConnectedCount { get; set; }
+        public Action<DateTime>? OnGetConnectedCount { get; set; }
+        public void RecordHeartbeat(Guid userId, DateTime utcNow) { }
+        public int GetConnectedCount(DateTime utcNow)
+        {
+            OnGetConnectedCount?.Invoke(utcNow);
+            return ConnectedCount;
+        }
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        private FakeTimeProvider(DateTimeOffset now) { _now = now; }
+        public override DateTimeOffset GetUtcNow() => _now;
+        public static FakeTimeProvider AtFixed(DateTime utc) => new(new DateTimeOffset(DateTime.SpecifyKind(utc, DateTimeKind.Utc)));
+    }
+
+    private static class AsyncEnumerable
+    {
+        public static async IAsyncEnumerable<T> Empty<T>()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Routing/AdminWikidataCoverEnrichmentEndpointsTests.cs
@@ -203,6 +203,70 @@ public sealed class AdminWikidataCoverEnrichmentEndpointsTests : IAsyncLifetime
         result.Items[0].Reason.Should().Be("image-processing-error");
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // Issue #2470 (DEC-C) — heartbeat endpoint tests.
+    //
+    // The wikidata-dead-letters page POSTs every 30s while open; the BE
+    // tracker exposes the count as the
+    // meepleai_wikidata_sse_admin_clients_connected gauge, which the
+    // WikidataSseSubscriberStarvation alert correlates against
+    // meepleai_wikidata_sse_subscribers.
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SseClientHeartbeat_AnonymousRequest_Returns401()
+    {
+        var url = $"{EndpointBase}/sse-clients/heartbeat";
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "the heartbeat endpoint MUST be admin-gated like the rest of the group");
+    }
+
+    [Fact]
+    public async Task SseClientHeartbeat_AdminSession_Returns204()
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{EndpointBase}/sse-clients/heartbeat",
+            _adminSessionToken);
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task SseClientHeartbeat_AdminSession_RegistersOnTracker()
+    {
+        // Snapshot count BEFORE the heartbeat (could be 0, could be >0 if a
+        // sibling test in the collection landed a heartbeat already).
+        var tracker = _factory.Services.GetRequiredService<
+            Api.BoundedContexts.SharedGameCatalog.Application.Services.IWikidataAdminClientHeartbeatTracker>();
+        var before = tracker.GetConnectedCount(DateTime.UtcNow);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{EndpointBase}/sse-clients/heartbeat",
+            _adminSessionToken);
+
+        var response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var after = tracker.GetConnectedCount(DateTime.UtcNow);
+
+        // The same admin id can only contribute once (idempotent upsert), so
+        // the gauge MUST satisfy: after ∈ {before, before+1}. before+1 when
+        // the admin was not previously tracked; before when this test or a
+        // sibling already registered the same admin within TTL.
+        after.Should().BeOneOf(before, before + 1);
+        after.Should().BeGreaterThan(0,
+            "after a successful heartbeat the tracker MUST report at least one connected admin");
+    }
+
     private async Task<Guid> SeedDeadLetterAsync(
         string gameTitle = "M16 Test Game",
         string reason = "r2-upload-error")

--- a/apps/api/tests/Api.Tests/Observability/WikidataEnrichmentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/WikidataEnrichmentMetricsTests.cs
@@ -131,6 +131,172 @@ public class WikidataEnrichmentMetricsTests
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Issue #2470 — SSE plane (subscribers + publish/receive + admin clients)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WikidataSseSubscribers_BeforeCallbackSet_GaugeReports0()
+    {
+        MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+
+        ReadObservableGaugeValue(MeepleAiMetrics.WikidataSseSubscribers)
+            .Should().Be(0, "the gauge degrades to 0 when no broadcaster callback is bound");
+    }
+
+    [Fact]
+    public void WikidataSseSubscribers_AfterCallbackSet_GaugeReportsCallbackValue()
+    {
+        try
+        {
+            MeepleAiMetrics.SetWikidataSseSubscribersCallback(() => 7);
+
+            ReadObservableGaugeValue(MeepleAiMetrics.WikidataSseSubscribers).Should().Be(7);
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+        }
+    }
+
+    [Fact]
+    public void WikidataSseSubscribers_CallbackThrows_GaugeDegradesTo0()
+    {
+        try
+        {
+            MeepleAiMetrics.SetWikidataSseSubscribersCallback(() => throw new InvalidOperationException("broadcaster torn down"));
+
+            ReadObservableGaugeValue(MeepleAiMetrics.WikidataSseSubscribers)
+                .Should().Be(0, "scrape MUST NOT throw — a thrown callback is treated as 0");
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseSubscribersCallback();
+        }
+    }
+
+    [Fact]
+    public void SetWikidataSseSubscribersCallback_Null_Throws()
+    {
+        var act = () => MeepleAiMetrics.SetWikidataSseSubscribersCallback(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void WikidataSseAdminClientsConnected_BeforeCallbackSet_GaugeReports0()
+    {
+        MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+
+        ReadObservableGaugeValue(MeepleAiMetrics.WikidataSseAdminClientsConnected).Should().Be(0);
+    }
+
+    [Fact]
+    public void WikidataSseAdminClientsConnected_AfterCallbackSet_GaugeReportsCallbackValue()
+    {
+        try
+        {
+            MeepleAiMetrics.SetWikidataSseAdminClientsConnectedCallback(() => 3);
+
+            ReadObservableGaugeValue(MeepleAiMetrics.WikidataSseAdminClientsConnected).Should().Be(3);
+        }
+        finally
+        {
+            MeepleAiMetrics.ResetWikidataSseAdminClientsConnectedCallback();
+        }
+    }
+
+    [Fact]
+    public void SetWikidataSseAdminClientsConnectedCallback_Null_Throws()
+    {
+        var act = () => MeepleAiMetrics.SetWikidataSseAdminClientsConnectedCallback(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void WikidataSseMessagesPublished_Name_MatchesIssue2470Contract()
+    {
+        // PR review / Grafana panel 10 + alert WikidataSseSubscriberStarvation
+        // depend on this exact metric name; renaming requires updating the
+        // dashboard JSON + the alert YAML in lockstep.
+        MeepleAiMetrics.WikidataSseMessagesPublished.Name
+            .Should().Be("meepleai.wikidata.sse.messages.published.total");
+        MeepleAiMetrics.WikidataSseMessagesPublished.Unit.Should().Be("messages");
+    }
+
+    [Fact]
+    public void WikidataSseMessagesReceived_Name_MatchesIssue2470Contract()
+    {
+        MeepleAiMetrics.WikidataSseMessagesReceived.Name
+            .Should().Be("meepleai.wikidata.sse.messages.received.total");
+        MeepleAiMetrics.WikidataSseMessagesReceived.Unit.Should().Be("messages");
+    }
+
+    [Fact]
+    public void WikidataSseSubscribers_Name_MatchesIssue2470Contract()
+    {
+        MeepleAiMetrics.WikidataSseSubscribers.Name
+            .Should().Be("meepleai.wikidata.sse.subscribers");
+        MeepleAiMetrics.WikidataSseSubscribers.Unit.Should().Be("subscribers");
+    }
+
+    [Fact]
+    public void WikidataSseAdminClientsConnected_Name_MatchesIssue2470Contract()
+    {
+        MeepleAiMetrics.WikidataSseAdminClientsConnected.Name
+            .Should().Be("meepleai.wikidata.sse.admin_clients_connected");
+        MeepleAiMetrics.WikidataSseAdminClientsConnected.Unit.Should().Be("clients");
+    }
+
+    [Fact]
+    public void WikidataSseMessagesPublished_RecordsIncrements_AndIsCollectable()
+    {
+        var measurements = new List<long>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.wikidata.sse.messages.published.total")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => measurements.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.WikidataSseMessagesPublished.Add(1);
+        MeepleAiMetrics.WikidataSseMessagesPublished.Add(5);
+
+        // Tolerant: shared global counter; only assert OUR two increments
+        // arrived through the listener wiring.
+        measurements.Should().Contain(1).And.Contain(5);
+    }
+
+    [Fact]
+    public void WikidataSseMessagesReceived_RecordsIncrements_AndIsCollectable()
+    {
+        var measurements = new List<long>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.wikidata.sse.messages.received.total")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => measurements.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.WikidataSseMessagesReceived.Add(3);
+        MeepleAiMetrics.WikidataSseMessagesReceived.Add(7);
+
+        measurements.Should().Contain(3).And.Contain(7);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────────────
 

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2902,6 +2902,85 @@ Companion script: `infra/runner/monitor.sh` (textfile collector emits the
 
 ---
 
+## 22. Wikidata SSE Subscriber Starvation
+
+### Alert: `WikidataSseSubscriberStarvation`
+
+| Property | Value |
+|---|---|
+| Severity | warning |
+| Subsystem | wikidata-sse |
+| Threshold | `meepleai_wikidata_sse_subscribers == 0 AND meepleai_wikidata_sse_admin_clients_connected > 0` |
+| Sustained for | 15m |
+| Defined in | `infra/prometheus/alerts/wikidata-sse.yml` |
+
+### What it means
+
+An admin has the wikidata dead-letter visibility page open (it is
+heartbeating every 30s, so the `admin_clients_connected` gauge is
+above zero), but the local broadcaster reports **zero SSE subscribers**.
+Live row updates are silently not flowing — the admin sees a stale page
+until they hard-reload.
+
+Background metric contract:
+
+- `meepleai_wikidata_sse_subscribers` — gauge fed by
+  `IWikidataEnrichmentEventBroadcaster.SubscriberCount`.
+- `meepleai_wikidata_sse_admin_clients_connected` — gauge fed by
+  `WikidataAdminClientHeartbeatTracker.GetConnectedCount(now)`. TTL is
+  90 seconds (3 missed FE pings); entries older are GC'd on read.
+
+### Investigation steps
+
+1. **Confirm the alert is real**. In Grafana → dashboard
+   "Wikidata Cover Enrichment — Pipeline Health" → Panels 9 + 12.
+   Panel 9 should read 0; Panel 12 should be ≥ 1 (one or more admins
+   actively watching). If Panel 12 is also 0, the alert is misfiring
+   — file a sub-issue.
+
+2. **Check publisher activity**. Panel 10 (`SSE publish rate`) — if it
+   is also flat at 0, the alert is benign (nothing to deliver). If it
+   is non-zero, every published event is being dropped on this pod.
+
+3. **Search api logs for failure patterns**. SSH to the running pod
+   and grep:
+
+   ```bash
+   docker logs meepleai-api --since 30m 2>&1 | grep -E \
+     "RedisWikidataEnrichmentEventBroadcaster.*(SUBSCRIBE failed|dropped malformed|UNSUBSCRIBE failed)|InMemoryWikidataEnrichmentEventBroadcaster.*dropped event"
+   ```
+
+   - `failed to open SUBSCRIBE` → Redis backplane handshake broken.
+     Verify Redis health (`docker exec meepleai-redis redis-cli PING`).
+   - `dropped malformed message` → schema-version mismatch between pods
+     after a partial deploy.
+   - Nothing in logs → likely a client-side EventSource drop (step 4).
+
+4. **Ask the admin to hard-reload the page**. If the gauge climbs back
+   to ≥ 1 within 30 seconds, the issue was a stale FE EventSource and
+   the alert clears within ~15 min. If the gauge stays at 0, the SSE
+   endpoint is genuinely starving — investigate reverse-proxy /
+   ingress idle-timeout (Traefik, nginx) on `/api/v1/admin/wikidata/enrichment/events`.
+
+### Resolution paths
+
+| Symptom | Fix |
+|---|---|
+| FE EventSource dropped | Admin hard-reload; consider a future client-side auto-reconnect with exponential backoff |
+| Redis SUBSCRIBE failed | `docker restart meepleai-api` (re-runs `EnsureRedisSubscriptionAsync` lazily on next subscriber) |
+| Proxy idle-timeout | Bump the ingress `proxy_read_timeout` / Traefik `transport.respondingTimeouts.readTimeout` above the 30s heartbeat |
+| Malformed-message rate spike | Roll forward to a single deploy version — partial rollout broke the wire schema |
+
+### Refs
+
+- Issue: [#2470](https://github.com/meepleAi-app/meepleai-monorepo/issues/2470)
+- Companion: [#2256](https://github.com/meepleAi-app/meepleai-monorepo/issues/2256) (Redis backplane shipped in PR #2469)
+- Originating SSE endpoint: `apps/api/src/Api/Routing/Admin/AdminWikidataCoverEnrichmentEndpoints.cs` → `HandleEventsStream`
+- Broadcaster: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/*WikidataEnrichmentEventBroadcaster.cs`
+- Heartbeat tracker: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTracker.cs`
+
+---
+
 ## Appendix A: Complete Command Reference
 
 ### Service Management

--- a/docs/superpowers/plans/2026-06-22-issue-2470-wikidata-sse-observability.md
+++ b/docs/superpowers/plans/2026-06-22-issue-2470-wikidata-sse-observability.md
@@ -1,0 +1,176 @@
+# Plan — Issue #2470 Wikidata SSE Observability (TDD)
+
+**Spec**: [`2026-06-22-issue-2470-wikidata-sse-observability-design.md`](../specs/2026-06-22-issue-2470-wikidata-sse-observability-design.md)
+**Branch**: `feature/issue-2470-wikidata-sse-observability` (parent: `main-dev`)
+**Effort estimate**: ~10-14h across 4 phases.
+**Workflow**: TDD red→green→refactor per task.
+
+---
+
+## Phase 1 — BE metric scaffolding (3 metrics + 1 gauge) — ~3h
+
+### T1.1 — Extend `MeepleAiMetrics.WikidataEnrichment.cs` (RED → GREEN)
+**File**: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs`
+- Add `meepleai.wikidata.sse.messages.published.total` (`Counter<long>`).
+- Add `meepleai.wikidata.sse.messages.received.total` (`Counter<long>`).
+- Add backing field `_wikidataSseSubscribers` + `SetWikidataSseSubscribers(int)` + `ObservableGauge<int>` `meepleai.wikidata.sse.subscribers`.
+- Add backing field `_wikidataSseAdminClients` + `SetWikidataSseAdminClientsConnected(int)` + `ObservableGauge<int>` `meepleai.wikidata.sse.admin_clients_connected`.
+
+### T1.2 — Tests on the metric public surface
+**File**: `apps/api/tests/Api.Tests/Observability/WikidataEnrichmentMetricsTests.cs`
+- `SseMetrics_AreRegistered_WithExpectedNames` — extends existing test to assert the 4 new names appear on the `Meter`.
+- `SetWikidataSseSubscribers_ClampsNegatives_ToZero`.
+- `SetWikidataSseAdminClientsConnected_ClampsNegatives_ToZero`.
+- `WikidataSseMessagesPublished_AcceptsLongIncrement`.
+- `WikidataSseMessagesReceived_AcceptsLongIncrement`.
+
+### T1.3 — Verify build + green tests
+`dotnet build apps/api/src/Api` and `dotnet test --filter "FullyQualifiedName~WikidataEnrichmentMetricsTests"`.
+
+---
+
+## Phase 2 — Instrument broadcasters + admin heartbeat — ~5h
+
+### T2.1 — `WikidataAdminClientHeartbeatTracker` singleton (RED → GREEN)
+**Files**: new `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTracker.cs` + DI in `SharedGameCatalogServiceExtensions.cs`.
+- `RecordHeartbeat(Guid userId, DateTime utcNow)` → upsert in `ConcurrentDictionary<Guid, DateTime>`.
+- `GetConnectedCount(DateTime utcNow)` → lazy GC: evict entries where `utcNow - lastBeat > 90s`, return count.
+- Tests in `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/WikidataAdminClientHeartbeatTrackerTests.cs`:
+  - `RecordHeartbeat_NewUser_AddsEntry`.
+  - `RecordHeartbeat_SameUserTwice_RefreshesTimestamp`.
+  - `GetConnectedCount_EvictsExpiredEntries`.
+  - `RecordHeartbeat_ConcurrentCallers_AllRecorded` (1000 parallel).
+
+### T2.2 — Wire tracker → gauge via hosted refresh OR per-call set
+**Decision (T2.2-a)**: prefer **per-callback read** — the existing `MeepleAiMetrics` pattern accepts a backing field updated by callers. Easiest path: gauge callback resolves tracker via DI and calls `GetConnectedCount(DateTime.UtcNow)`.
+**Problem**: `MeepleAiMetrics` is static; cannot inject. **Fix**: register a hosted `WikidataAdminClientGaugeBinder : IHostedService` that on `StartAsync` registers the gauge callback via `MeepleAiMetrics.RegisterAdminClientsCallback(() => tracker.GetConnectedCount(DateTime.UtcNow))`. Add `RegisterAdminClientsCallback` to the metrics class (one-shot set on first call, guarded against re-register).
+**Symmetric pattern for broadcaster**: register a callback `MeepleAiMetrics.RegisterSseSubscribersCallback(() => broadcaster.SubscriberCount)`.
+- Tests: `Binder_StartAsync_RegistersCallback` + `Binder_Idempotent_OnSecondStart` (defensive against test host re-starts).
+
+### T2.3 — Instrument `InMemoryWikidataEnrichmentEventBroadcaster`
+- `Publish(...)`: increment `WikidataSseMessagesPublished` by 1. Increment `WikidataSseMessagesReceived` by `_subscribers.Count` (snapshot before write loop — race-tolerant, conservative count).
+- Add test in `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/InMemoryWikidataEnrichmentEventBroadcasterMetricsTests.cs`:
+  - `Publish_WithThreeSubscribers_IncrementsReceivedBy3`.
+  - `Publish_WithZeroSubscribers_IncrementsPublishedBy1_AndReceivedBy0`.
+
+### T2.4 — Instrument `RedisWikidataEnrichmentEventBroadcaster`
+- `Publish(...)`: increment `WikidataSseMessagesPublished` by 1 (counts PUBLISH attempts; failed PUBLISH still counts — proxy for outbound activity).
+- `FanOutToLocalChannels(...)`: increment `WikidataSseMessagesReceived` by `_subscribers.Count` (snapshot).
+- IT test with Testcontainers Redis in `apps/api/tests/Api.Tests/Integration/SharedGameCatalog/RedisWikidataEnrichmentEventBroadcasterMetricsIntegrationTests.cs`:
+  - `Publish_Then_FanOut_IncrementsBothCounters` — single-pod scenario.
+
+### T2.5 — Heartbeat endpoint
+**File**: extend `AdminWikidataCoverEnrichmentEndpoints.cs`.
+- `POST /sse-clients/heartbeat` → handler `HandleSseClientHeartbeat`:
+  - Resolve `WikidataAdminClientHeartbeatTracker` via DI.
+  - Call `tracker.RecordHeartbeat(context.User.GetUserId(), DateTime.UtcNow)`.
+  - Return `Results.NoContent()`.
+- Group-level `RequireAdminSessionFilter` already enforces auth.
+- Tests in `apps/api/tests/Api.Tests/Integration/Routing/Admin/AdminWikidataCoverEnrichmentEndpointsTests.cs`:
+  - `Heartbeat_Anonymous_Returns401`.
+  - `Heartbeat_NonAdmin_Returns403`.
+  - `Heartbeat_Admin_Returns204_AndIncrementsGauge`.
+
+---
+
+## Phase 3 — Grafana dashboard extension — ~1h
+
+### T3.1 — Add 3 panels to `wikidata-enrichment.json`
+**File**: `infra/monitoring/grafana/dashboards/wikidata-enrichment.json`.
+- **Panel 9** — `SSE subscribers (current)`: stat with thresholds `red < 1 (when admin online)`, `green >= 1`. Expr: `meepleai_wikidata_sse_subscribers`.
+- **Panel 10** — `SSE publish rate (5min rolling)`: timeseries. Expr: `rate(meepleai_wikidata_sse_messages_published_total[5m])`.
+- **Panel 11** — `SSE receive rate (5min rolling)`: timeseries. Expr: `rate(meepleai_wikidata_sse_messages_received_total[5m])`.
+- Bonus stat panel **Panel 12** — `Admin clients connected`: `meepleai_wikidata_sse_admin_clients_connected`.
+- Update dashboard `description` + `tags` (add `issue-2470`).
+- Increment `version` from 1 → 2.
+
+### T3.2 — Verify JSON parses (no Grafana running)
+- `python -m json.tool infra/monitoring/grafana/dashboards/wikidata-enrichment.json > /dev/null` from a docker exec (or `jq . file > /dev/null` if jq present).
+
+---
+
+## Phase 4 — Alert rule + runbook — ~1.5h
+
+### T4.1 — New alert file `infra/prometheus/alerts/wikidata-sse.yml`
+**Group**: `meepleai_wikidata_sse_alerts`.
+**Rule**:
+```yaml
+- alert: WikidataSseSubscriberStarvation
+  expr: |
+    meepleai_wikidata_sse_subscribers == 0
+    and
+    meepleai_wikidata_sse_admin_clients_connected > 0
+  for: 15m
+  labels:
+    severity: warning
+    subsystem: wikidata-sse
+  annotations:
+    summary: "Wikidata SSE: admin online but no live subscribers ({{ $labels.instance }})"
+    description: |
+      An admin is actively watching the wikidata dead-letter page
+      (admin_clients_connected={{ $value }}) but the local broadcaster
+      reports 0 SSE subscribers for 15 minutes. Live row updates are
+      not flowing — admin will see a stale page.
+
+      Likely causes:
+        1. Frontend EventSource connection dropped silently
+        2. RedisWikidataEnrichmentEventBroadcaster SUBSCRIBE not opened
+        3. Reverse proxy / ingress closing long-lived connections
+    runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#22-wikidata-sse-subscriber-starvation"
+```
+
+### T4.2 — Mount the new rule file
+**Files**:
+- `infra/docker-compose.yml` (monitoring profile) — add volume mount `./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro`.
+- `infra/prometheus.yml` `rule_files` — append `- '/etc/prometheus/wikidata-sse.yml'`.
+- `infra/prometheus.staging.yml` — same.
+- `infra/compose.staging.yml` if it overrides the volume list — sanity-check.
+
+### T4.3 — Runbook entry
+**File**: `docs/for-developers/operations/operations-manual.md`.
+- New section `## 22. Wikidata SSE Subscriber Starvation` after § 21 Self-Hosted Runner Recovery.
+- Subsections:
+  - Alert: WikidataSseSubscriberStarvation (definition + threshold)
+  - Investigation steps:
+    1. Confirm the alert: query `meepleai_wikidata_sse_subscribers` + `meepleai_wikidata_sse_admin_clients_connected` in Grafana.
+    2. Check api logs for `RedisWikidataEnrichmentEventBroadcaster.*UNSUBSCRIBE failed` or `dropped malformed message`.
+    3. Verify reverse-proxy/ingress config (Traefik) — `X-Accel-Buffering: no` is set on the SSE endpoint, but check downstream headers.
+    4. Ask the admin to hard-reload the dead-letter page. If the gauge climbs back to 1 → FE EventSource was dropped client-side (browser side); if it stays 0 → BE issue.
+  - Resolution paths (3 short branches: FE drop, Redis backplane issue, ingress).
+
+---
+
+## Phase 5 — PR + review — ~0.5h
+
+### T5.1 — Commit + push + open PR
+- Conventional commits per phase.
+- PR body: closes #2470 + acceptance checklist mirroring the 9 Gherkin scenarios.
+- Base branch: `main-dev` (parent set via `git config branch.<branch>.parent`).
+
+### T5.2 — `/code-review:code-review` against the diff
+- Address any HIGH findings before requesting merge.
+- Document any DEFER to follow-up issue (filed in same PR body).
+
+---
+
+## Verification gates (per spec § 6 AC matrix)
+
+| AC | Verification |
+|---|---|
+| AC-1 metrics exposed | Unit test `WikidataEnrichmentMetricsTests` ✅ + manual `/metrics` curl |
+| AC-2 subscribers gauge tracks count | Test in `InMemoryWikidataEnrichmentEventBroadcasterMetricsTests` |
+| AC-3 publish counter ticks | Same |
+| AC-4 receive counter equals publishes × subscribers | Same |
+| AC-5 heartbeat refreshes gauge | `WikidataAdminClientHeartbeatTrackerTests` + endpoint IT |
+| AC-6 endpoint auth | Endpoint IT 401 / 403 / 204 |
+| AC-7 Grafana panels render | Manual `make dev` + visit dashboard |
+| AC-8 alert fires | Pattern review only — alert evaluation tested in staging soak post-merge |
+| AC-9 runbook reachable | Lint the markdown link from `runbook_url` annotation in IT (`grep`) |
+
+---
+
+## Out-of-scope follow-ups (capture in PR body)
+
+- FE indicator in admin page (visual "live" badge when `EventSource.readyState === 1`).
+- Multi-pod scale test under HPA>1 (DEC-3e revisit).
+- Alert routing to actual on-call (Slack/PagerDuty integration) — alertmanager config not in this PR's scope.

--- a/docs/superpowers/specs/2026-06-22-issue-2470-wikidata-sse-observability-design.md
+++ b/docs/superpowers/specs/2026-06-22-issue-2470-wikidata-sse-observability-design.md
@@ -1,0 +1,178 @@
+# Issue #2470 — Wikidata SSE multi-pod observability (Grafana panel + alert)
+
+**Status**: PROPOSED → ACTIVE on first commit landing
+**Date**: 2026-06-22
+**Author**: badsworm
+**Type**: ops / observability follow-up to #2256 (Redis backplane shipped via PR #2469)
+**Parent**: #1823 umbrella (Phase E F4 SSE stream)
+
+---
+
+## 1. Context
+
+PR [#2469](https://github.com/meepleAi-app/meepleai-monorepo/pull/2469) shipped the Redis pub/sub backplane for the Wikidata cover-enrichment SSE stream (`IWikidataEnrichmentEventBroadcaster` ↔ `wikidata-enrichment:attempt-recorded` channel). The factory selects between `InMemoryWikidataEnrichmentEventBroadcaster` (default) and `RedisWikidataEnrichmentEventBroadcaster` via the env var `WIKIDATA_SSE_BACKPLANE`.
+
+Observability for the SSE plane was explicitly out-of-scope of #2469 and tracked as #2470. Today:
+
+- `IWikidataEnrichmentEventBroadcaster.SubscriberCount` is exposed as a diagnostic on the interface but **not surfaced as a Prometheus metric**.
+- No counter for PUBLISH or message-received events.
+- No alert when admin dead-letter page is open (an active SSE client expected) but local pod reports `subscribers == 0`.
+- No runbook entry covering the investigation path.
+
+Single-pod assumption (ADR DEC-3e) is still in force — `HPA=1`. The new metrics are foundational work that will pay off when DEC-3e is revisited; for now they protect a single admin-facing surface (the dead-letter visibility page) against silent SSE starvation.
+
+## 2. Goals
+
+- **G1**: surface SSE subscriber count, publish rate, and receive rate as Prometheus metrics, scraped via the existing `meepleai-api` job.
+- **G2**: extend `wikidata-enrichment.json` dashboard with a dedicated row of SSE panels.
+- **G3**: ship an alert that fires when subscribers stay at 0 for 15 minutes WHILE the admin dead-letter page is open (BE↔FE correlation).
+- **G4**: document the alert's investigation path in `operations-manual.md`.
+
+## 3. Non-goals
+
+- Multi-pod Redis fan-out validation under HPA>1 — handled by a separate revisit of DEC-3e.
+- Per-event traceability or per-game subscription topology.
+- Adversarial subscriber-churn metrics (Nygard N-1 deferred — gauge + rates sufficient for V1).
+- Per-backplane label split (`backplane=in-memory|redis`) — deployment knows which broadcaster is live via the env var; metric split would amplify cardinality without operational value.
+
+## 4. Locked decisions (post spec-panel critique 2026-06-22)
+
+### DEC-A — Alert threshold: 15min sustained
+**Why**: tolerates SSE reconnect window + admin page reload without raising false positives. 5min was deemed too aggressive (deploy / browser restart), 30min too conservative (incidents masked).
+**How to apply**: Prometheus `for: 15m` clause on the alert rule.
+
+### DEC-B — Dashboard placement: extend `wikidata-enrichment.json`
+**Why**: keep all Wikidata enrichment observability on one board so the on-call engineer doesn't tab-juggle. 8 → ~11 panels still well within Grafana density limits.
+**How to apply**: add a new row "SSE plane" with 3 panels (subscribers, publish rate, receive rate) below the existing M9/M11/F1 panels.
+
+### DEC-C — FE↔BE correlation: BE heartbeat endpoint
+**Why**: the issue body suggests a "sentinel signal from the FE". A push-gateway approach is operationally heavy. Simpler: the admin dead-letter page POSTs a heartbeat every 30s to `POST /api/v1/admin/wikidata/enrichment/sse-clients/heartbeat`. BE keeps an in-memory TTL'd counter and exposes it as `meepleai_wikidata_sse_admin_clients_connected` (gauge). The alert then becomes `subscribers == 0 AND admin_clients_connected > 0 sustained 15m` — only triggers when an actual admin is watching.
+**How to apply**: new endpoint + new gauge + FE hook in the wikidata-dead-letters page. TTL window: 90s (3 missed heartbeats → counted as disconnected).
+**Why not Option C (publish_rate>0 && subscribers=0)**: would fire during background batch runs even when no admin needs the live feed. Operationally noisy.
+
+### DEC-D — Drop `subscription_active` gauge
+**Why**: per Newman S-2 — `subscribers > 0` already implies the Redis SUBSCRIBE is open (per `EnsureRedisSubscriptionAsync` lazy open / `MaybeReleaseRedisSubscriptionAsync` last-leave close). The two metrics carry the same information.
+**How to apply**: stay with 3 SSE metrics (subscribers + 2 counters) + 1 admin-clients gauge.
+
+## 5. Metric contracts
+
+All metrics emitted by `MeepleAiMetrics.WikidataEnrichment.cs` (extension, same `Meter`). Prometheus exporter normalises dots → underscores; the documented Prometheus names appear below.
+
+### `meepleai_wikidata_sse_subscribers` — Gauge
+- **.NET API**: `ObservableGauge<int>` with callback reading `IWikidataEnrichmentEventBroadcaster.SubscriberCount`.
+- **Semantics**: local pod's current SSE subscriber count.
+- **Labels**: none in V1 (Prometheus `instance` label already disambiguates pods via scrape config).
+
+### `meepleai_wikidata_sse_messages_published_total` — Counter
+- **.NET API**: `Counter<long>`.
+- **Increment site**: `IWikidataEnrichmentEventBroadcaster.Publish(...)` — both `InMemory` and `Redis` implementations call this on every event the M9 runner / M12 admin trigger / F2 bulk-retry publishes.
+- **Semantics**: events emitted by the publisher. For the Redis backplane this equals the number of PUBLISH calls; for in-memory it equals the number of local Channel writes.
+
+### `meepleai_wikidata_sse_messages_received_total` — Counter
+- **.NET API**: `Counter<long>`.
+- **Increment site**:
+  - `InMemoryWikidataEnrichmentEventBroadcaster.Publish(...)` → increment by `_subscribers.Count` (the count of local channels that received the write).
+  - `RedisWikidataEnrichmentEventBroadcaster.FanOutToLocalChannels(...)` → increment by `_subscribers.Count` once per Redis-incoming message.
+- **Semantics**: per-pod messages handed off to a subscriber's bounded channel. With 2 pods and 1 admin client each, 1 PUBLISH → 2 `received` counts globally.
+
+### `meepleai_wikidata_sse_admin_clients_connected` — Gauge
+- **.NET API**: `ObservableGauge<int>` reading a TTL'd dictionary maintained by a new singleton `WikidataAdminClientHeartbeatTracker`.
+- **Heartbeat endpoint**: `POST /api/v1/admin/wikidata/enrichment/sse-clients/heartbeat` (admin-only, group-level filter). Body: empty. Returns `204 No Content`.
+- **TTL**: 90 seconds (3 × FE 30s ping). Entries older than TTL are evicted on read of `SubscriberCount` / metric callback (lazy GC, no background timer).
+- **FE hook**: the admin wikidata-dead-letters page calls heartbeat on mount + every 30s thereafter; aborts on unmount.
+
+## 6. Acceptance criteria (Gherkin)
+
+```gherkin
+Feature: Wikidata SSE observability + alert
+  Surface the SSE plane in Prometheus, Grafana, and alerts so an operator
+  catches silent SSE starvation while an admin is actively waiting for live
+  dead-letter rows.
+
+  Scenario: AC-1 Metrics are exposed
+    Given the api is running with the monitoring profile
+    When I curl http://api:8080/metrics
+    Then the response body contains "meepleai_wikidata_sse_subscribers"
+    And contains "meepleai_wikidata_sse_messages_published_total"
+    And contains "meepleai_wikidata_sse_messages_received_total"
+    And contains "meepleai_wikidata_sse_admin_clients_connected"
+
+  Scenario: AC-2 Subscribers gauge tracks SubscriberCount
+    Given the in-memory broadcaster has 0 subscribers
+    When 2 SSE clients connect to /api/v1/admin/wikidata/enrichment/events
+    Then "meepleai_wikidata_sse_subscribers" equals 2
+    When 1 client disconnects
+    Then "meepleai_wikidata_sse_subscribers" equals 1
+
+  Scenario: AC-3 Publish counter ticks per Publish call
+    Given subscribers count is 1
+    When the M9 runner publishes 5 attempt-recorded events
+    Then "meepleai_wikidata_sse_messages_published_total" delta equals 5
+
+  Scenario: AC-4 Receive counter equals publishes × subscribers (in-memory)
+    Given the in-memory broadcaster has 3 subscribers
+    When 2 events are published
+    Then "meepleai_wikidata_sse_messages_received_total" delta equals 6
+
+  Scenario: AC-5 Admin heartbeat endpoint refreshes gauge
+    Given no admin heartbeats in the last 90s
+    Then "meepleai_wikidata_sse_admin_clients_connected" equals 0
+    When admin A posts /sse-clients/heartbeat
+    And admin B posts /sse-clients/heartbeat from a different session
+    Then "meepleai_wikidata_sse_admin_clients_connected" equals 2
+    When 91s pass without further heartbeats
+    Then "meepleai_wikidata_sse_admin_clients_connected" equals 0
+
+  Scenario: AC-6 Heartbeat endpoint enforces admin auth
+    Given an anonymous request
+    When I POST /api/v1/admin/wikidata/enrichment/sse-clients/heartbeat
+    Then the response status is 401
+
+  Scenario: AC-7 Grafana dashboard panels render
+    Given the grafana container has loaded wikidata-enrichment.json
+    When I open the dashboard
+    Then 3 new panels exist with titles:
+      | Panel 9 — SSE subscribers (per pod)        |
+      | Panel 10 — SSE publish rate (5min rolling) |
+      | Panel 11 — SSE receive rate (5min rolling) |
+
+  Scenario: AC-8 Alert fires on starvation
+    Given the alert rule WikidataSseSubscriberStarvation is loaded by prometheus
+    And meepleai_wikidata_sse_subscribers == 0 for the last 15m
+    And meepleai_wikidata_sse_admin_clients_connected > 0 for the last 15m
+    Then the alert is in firing state with severity=warning
+
+  Scenario: AC-9 Runbook is reachable from the alert
+    Given the alert fires
+    Then the annotations.runbook_url points to operations-manual.md section "SSE subscriber starvation"
+    And the section documents 4 investigation steps
+```
+
+## 7. Out of scope
+
+- Multi-pod scale validation under HPA>1 (DEC-3e revisit).
+- Push gateway approach for FE→Prom direct.
+- Per-event tracing / OpenTelemetry spans.
+- `subscription_active` 0/1 sentinel gauge (DEC-D drop).
+- `backplane=in-memory|redis` label split.
+- Frontend visual indicator of "live stream healthy" status (separate UX task).
+
+## 8. Risks + mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| Heartbeat tracker memory leak under attack (1M fake heartbeats) | Low | Medium | TTL+lazy GC bounds dictionary size + admin-only auth filter |
+| Counter overflow on long-running pod (`long.MaxValue`) | Negligible | None | `Counter<long>` — overflow only after >10^18 events |
+| FE heartbeat double-fires (StrictMode dev) | Medium | None | Dedup by sessionId server-side (use existing `HttpContext.User.GetUserId()`) |
+| ObservableGauge callback throws on broadcaster dispose | Low | Low | Wrap callback in try/catch returning 0 |
+
+## 9. References
+
+- Closed parent issue: #2256
+- Shipping PR Redis backplane: #2469
+- F4 in-process broadcaster PR: #2227
+- ADR DEC-3e single-pod assumption: docs/superpowers/specs/2026-06-04-asse-a-semantic-alignment.md § DEC-3e (cross-ref in umbrella #1823)
+- ADR DEC-3g metric scaffolding: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs`
+- Existing dashboard: `infra/monitoring/grafana/dashboards/wikidata-enrichment.json`
+- Existing alert pattern: `infra/prometheus/alerts/provider-quota.yml`
+- Operations manual: `docs/for-developers/operations/operations-manual.md` § 14 Monitoring Stack

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -217,6 +217,8 @@ services:
     volumes:
       - ./prometheus.prod.yml:/etc/prometheus/prometheus.yml:ro  # prod-specific labels
       - ./prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
+      # Issue #2470 — Wikidata SSE plane starvation alert.
+      - ./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -273,6 +273,12 @@ services:
     volumes:
       - ./prometheus.staging.yml:/etc/prometheus/prometheus.yml:ro  # staging-specific labels
       - ./prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
+      # Issue #2019 — runner availability alerts (referenced from staging
+      # config rule_files; mount kept in parity with docker-compose.yml so
+      # Prometheus startup does not log a missing-rule-file warning).
+      - ./prometheus/alerts/runner-availability.yml:/etc/prometheus/runner-availability.yml:ro
+      # Issue #2470 — Wikidata SSE plane starvation alert.
+      - ./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/monitoring/grafana/dashboards/wikidata-enrichment.json
+++ b/infra/monitoring/grafana/dashboards/wikidata-enrichment.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Wikidata cover enrichment pipeline observability — Issue #1823 (Phase B-F shipped) + #2055 Phase G (AC-G4). Tracks enrichment rate, failure breakdown, SPARQL latency, queue depth, batch duration, dead-letter count, and quarterly re-verification activity.",
+  "description": "Wikidata cover enrichment pipeline observability — Issue #1823 (Phase B-F shipped) + #2055 Phase G (AC-G4) + #2470 (SSE plane: subscribers, publish/receive rates, admin clients connected). Tracks enrichment rate, failure breakdown, SPARQL latency, queue depth, batch duration, dead-letter count, quarterly re-verification activity, and SSE pipeline health.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -653,12 +653,298 @@
       ],
       "title": "Panel 8 — Quarterly re-verification reset (1d window)",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Issue #2470 — current SSE subscriber count on this pod. Red < 1 = no admin getting live updates. Correlate with Panel 12 to decide whether the gap is 'admin offline' (benign) or 'admin online but starved' (alert).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "meepleai_wikidata_sse_subscribers",
+          "refId": "A"
+        }
+      ],
+      "title": "Panel 9 — SSE subscribers (current)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Issue #2470 (DEC-C) — distinct admin sessions heartbeating the dead-letter page in the last 90s. Co-display with Panel 9: subscribers=0 AND admin_clients>0 sustained 15m fires WikidataSseSubscriberStarvation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "meepleai_wikidata_sse_admin_clients_connected",
+          "refId": "A"
+        }
+      ],
+      "title": "Panel 12 — Admin clients connected (90s TTL)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Issue #2470 — broadcaster Publish call rate. Background M9 ticks tick this counter even with zero subscribers; alert correlation uses Panels 9 + 12 to gate on 'admin online'.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(meepleai_wikidata_sse_messages_published_total[5m])",
+          "legendFormat": "publish rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Panel 10 — SSE publish rate (5min rolling)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Issue #2470 — local-channel delivery rate. For in-memory backplane, this equals publish_rate × subscribers; for Redis backplane, the same value reflects N pods × local subscribers per pod (single-pod = same behaviour as in-memory).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(meepleai_wikidata_sse_messages_received_total[5m])",
+          "legendFormat": "receive rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Panel 11 — SSE receive rate (5min rolling)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["meepleai", "wikidata", "enrichment", "issue-1823", "issue-2055", "phase-g"],
+  "tags": ["meepleai", "wikidata", "enrichment", "issue-1823", "issue-2055", "issue-2470", "phase-g", "sse-observability"],
   "templating": {
     "list": []
   },
@@ -670,6 +956,6 @@
   "timezone": "browser",
   "title": "Wikidata Cover Enrichment — Pipeline Health",
   "uid": "wikidata-enrichment",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -21,6 +21,8 @@ alerting:
 
 rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
+  # Issue #2470 — Wikidata SSE plane starvation alerts.
+  - '/etc/prometheus/wikidata-sse.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -23,6 +23,8 @@ rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
   # Issue #2019 — self-hosted GitHub Actions runner availability alerts.
   - '/etc/prometheus/runner-availability.yml'
+  # Issue #2470 — Wikidata SSE plane starvation alerts.
+  - '/etc/prometheus/wikidata-sse.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -28,6 +28,8 @@ rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
   # Issue #2019 — self-hosted GitHub Actions runner availability alerts.
   - '/etc/prometheus/runner-availability.yml'
+  # Issue #2470 — Wikidata SSE plane starvation alerts.
+  - '/etc/prometheus/wikidata-sse.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/wikidata-sse.yml
+++ b/infra/prometheus/alerts/wikidata-sse.yml
@@ -1,0 +1,54 @@
+# Issue #2470 — Wikidata SSE plane alerts.
+#
+# Metric sources (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs):
+#   - meepleai_wikidata_sse_subscribers (ObservableGauge)
+#     Live SSE subscriber count for the wikidata-dead-letters admin page,
+#     resolved via the broadcaster SubscriberCount property.
+#   - meepleai_wikidata_sse_admin_clients_connected (ObservableGauge)
+#     Distinct admin sessions that have hit the heartbeat endpoint in the
+#     last 90s. Acts as the "admin is actually watching" sentinel for
+#     starvation alerts (DEC-C).
+#   - meepleai_wikidata_sse_messages_published_total (Counter)
+#     Tick per broadcaster.Publish call — useful for sanity-checking that
+#     the M9 scheduler / M12 admin trigger is still producing events.
+#   - meepleai_wikidata_sse_messages_received_total (Counter)
+#     Tick per per-subscriber local delivery.
+#
+# Backplane assumption: single-pod (ADR DEC-3e, HPA=1). Multi-pod fan-out
+# via the Redis backplane (#2256) is already wired but tagged out-of-scope
+# for these alerts until DEC-3e is revisited; the metrics + dashboard
+# already split per-pod via the Prometheus `instance` label so a future
+# HPA>1 lift does not require alert changes.
+
+groups:
+  - name: meepleai_wikidata_sse_alerts
+    rules:
+      - alert: WikidataSseSubscriberStarvation
+        expr: |
+          meepleai_wikidata_sse_subscribers == 0
+          and
+          meepleai_wikidata_sse_admin_clients_connected > 0
+        for: 15m
+        labels:
+          severity: warning
+          subsystem: wikidata-sse
+        annotations:
+          summary: "Wikidata SSE: admin online but no live subscribers ({{ $labels.instance }})"
+          description: |
+            An admin is actively watching the wikidata dead-letter page
+            (admin_clients_connected={{ $value }}) but the local broadcaster
+            reports 0 SSE subscribers for 15 minutes. Live row updates are
+            not flowing — the admin sees a stale page.
+
+            Likely causes (most → least common):
+              1. Frontend EventSource connection dropped silently — admin
+                 hard-reload usually restores it.
+              2. RedisWikidataEnrichmentEventBroadcaster SUBSCRIBE failed
+                 to open on this pod (multi-pod only; check api logs for
+                 'RedisWikidataEnrichmentEventBroadcaster: failed to open
+                 SUBSCRIBE on channel').
+              3. Reverse-proxy / ingress closing long-lived SSE connections
+                 mid-flight (Traefik / nginx idle-timeout settings).
+
+            Resolution path is in the runbook below.
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#22-wikidata-sse-subscriber-starvation"


### PR DESCRIPTION
## Summary

Closes #2470. Follow-up to #2256 (Redis backplane shipped in PR #2469). Adds Prometheus/Grafana observability + a starvation alert for the Wikidata cover-enrichment SSE plane.

4 phases shipped TDD:

- **Phase 1** — 4 new metrics on `MeepleAiMetrics.WikidataEnrichment.cs`:
  - `meepleai.wikidata.sse.subscribers` (ObservableGauge) bound to broadcaster.SubscriberCount
  - `meepleai.wikidata.sse.admin_clients_connected` (ObservableGauge) bound to heartbeat tracker
  - `meepleai.wikidata.sse.messages.{published,received}.total` (Counter<long>)
  - Both gauges degrade to 0 when unbound or when the callback throws — metric scrapes MUST NOT throw.
- **Phase 2** — runtime wiring:
  - `WikidataAdminClientHeartbeatTracker` (singleton) — TTL'd `ConcurrentDictionary<Guid, DateTime>` with lazy GC.
  - `WikidataSseGaugeBinder` (IHostedService) — binds the static gauges to runtime callbacks once DI is wired.
  - Instrumented `InMemoryWikidataEnrichmentEventBroadcaster.Publish` + `RedisWikidataEnrichmentEventBroadcaster.Publish` / `FanOutToLocalChannels`.
  - New endpoint `POST /api/v1/admin/wikidata/enrichment/sse-clients/heartbeat` — admin-only via existing group filter.
- **Phase 3** — extended `wikidata-enrichment.json` dashboard with 4 panels (subscribers, admin clients, publish rate, receive rate). Dashboard version bumped 1→2.
- **Phase 4** — `WikidataSseSubscriberStarvation` alert in `infra/prometheus/alerts/wikidata-sse.yml`. Mounted + referenced in dev / staging / prod compose + prometheus configs. Runbook section § 22 in `operations-manual.md`.

## Decisions locked (post spec-panel critique 2026-06-22)

- **DEC-A**: alert window 15min sustained (tolerates reconnect + page reload)
- **DEC-B**: extend `wikidata-enrichment.json` rather than new dashboard
- **DEC-C**: BE heartbeat endpoint (FE posts every 30s) instead of push gateway — alert correlates `subscribers=0 AND admin_clients_connected>0`
- **DEC-D**: drop `subscription_active` gauge (redundant with `subscribers>0` per `EnsureRedisSubscriptionAsync` semantics)

Spec + plan: `docs/superpowers/specs/2026-06-22-issue-2470-wikidata-sse-observability-design.md` + `docs/superpowers/plans/2026-06-22-issue-2470-wikidata-sse-observability.md`.

## Acceptance (Gherkin matrix per spec § 6)

- [x] AC-1 metrics exposed (`WikidataEnrichmentMetricsTests` ✅ + manual /metrics curl pending dev)
- [x] AC-2 subscribers gauge tracks broadcaster.SubscriberCount (`WikidataSseGaugeBinderTests`)
- [x] AC-3 publish counter ticks per Publish call (`InMemoryWikidataEnrichmentEventBroadcasterMetricsTests`)
- [x] AC-4 receive counter equals publishes × subscribers (in-memory) (`InMemoryWikidataEnrichmentEventBroadcasterMetricsTests`)
- [x] AC-5 heartbeat endpoint refreshes gauge (`WikidataAdminClientHeartbeatTrackerTests` + endpoint IT)
- [x] AC-6 endpoint auth (`AdminWikidataCoverEnrichmentEndpointsTests.SseClientHeartbeat_*`)
- [ ] AC-7 Grafana panels render (manual `make dev` + visit dashboard — to verify post-merge)
- [ ] AC-8 alert fires (review-only — alert evaluation tested in staging soak post-merge)
- [x] AC-9 runbook reachable (operations-manual § 22)

## Tests

- 50 unit tests pass (23 metrics + 10 tracker + 9 binder + 8 InMemory broadcaster)
- 3 admin endpoint IT (heartbeat 401 anon / 204 admin / tracker delta)
- 1 Redis broadcaster instrumentation test (Testcontainers) + existing 12 Redis IT preserved
- 0 regression

## Out of scope

- Multi-pod scale validation under HPA>1 (DEC-3e revisit).
- Push gateway approach for direct FE → Prometheus.
- Per-event OpenTelemetry tracing.
- FE indicator of "live stream healthy" status (separate UX task).

## Test plan

- [ ] CI pipeline green on this PR (backend unit + integration)
- [ ] Manual: `make dev`, hit `http://localhost:8080/metrics`, grep for `meepleai_wikidata_sse_`
- [ ] Manual: open Grafana, verify 4 new panels render
- [ ] Manual: POST to `/api/v1/admin/wikidata/enrichment/sse-clients/heartbeat` as admin, confirm 204 + gauge tick
- [ ] Post-merge: staging soak 24h, verify alert YAML loads without `promtool` errors

Refs: closes #2470 · companion #2256 #2469 · parent #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)