### PR TITLE
docs(mockups): #2114 close-out — sp4-dashboard obsolete tracking + divergence note

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -87,7 +87,7 @@
 | `sp4-agent-detail.html` | page-mock | `/agents/[id]`, `/library/[gameId]/agent` |
 | `sp4-agents-index.html` | page-mock | `/agents`, `/editor/agent-proposals/*` (partial), `/chat/agents/create` (partial) |
 | `sp4-citation-pdf-viewer.html` | component-mock | Citation overlay used by `/chat/[threadId]` and game-chat tabs |
-| `sp4-dashboard.html` | page-mock | `/dashboard` (forward-design Pre-Stage-3, closes #491) |
+| `sp4-dashboard.html` | page-mock (obsolete) | `/dashboard` — historical Pre-Stage-3 mockup, superseded by Asse C #1898 priority-driven design (4 priority sections replace 5 entity sections); tracking #2114 |
 | `sp4-discover.html` | page-mock | `/discover` |
 | `sp4-game-chat-tab.html` | component-mock | Chat tab embedded in `/library/[gameId]/agent`, `/games/[id]` |
 | `sp4-game-detail.html` | page-mock | `/games/[id]`, `/library/[gameId]`, `/private-games/[id]` |

--- a/admin-mockups/design_files/sp4-dashboard.fidelity.json
+++ b/admin-mockups/design_files/sp4-dashboard.fidelity.json
@@ -30,6 +30,6 @@
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": "#2144"
+    "obsolete_tracking_issue": "#2114"
   }
 }

--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -20,7 +20,13 @@
  *   empty   → derived (length === 0)
  *   default → otherwise
  *
- * Pixel-faithful to admin-mockups/design_files/sp4-dashboard.jsx.
+ * Note on mockup divergence (#2114): `admin-mockups/design_files/sp4-dashboard.{html,jsx}`
+ * is the legacy Pre-Stage-3 design with 5 entity sections — it is intentionally
+ * NOT the design target for this component. The mockup is classified
+ * `forward-refactor-obsolete` in its fidelity.json companion; the codebase
+ * supersedes it via the Asse C refactor. There is no current pixel-faithful
+ * mockup for the priority-driven layout; the spec lives in the plan archived
+ * under `docs/superpowers/plans/` (2026-06-05 Asse C session).
  */
 
 'use client';


### PR DESCRIPTION
## Summary

Closes #2114. Cleanup of stale references identifying `admin-mockups/design_files/sp4-dashboard.{html,jsx}` as the legacy Pre-Stage-3 design now superseded by the Asse C #1898 priority-driven dashboard refactor (shipped 2026-06-05 sess.34).

The DS-17 Phase B audit (sub-issue #2127) already classified the mockup as `forward-refactor-obsolete`, but three downstream references didn't get the memo:

- **fidelity.json `obsolete_tracking_issue`** pointed at #2144 (the duplicate-of stub closed with the title "Already tracked in #2114"). Repointed at #2114.
- **MOCKUPS_INDEX row** still read "forward-design Pre-Stage-3, closes #491" — that was the original B7 mockup-commission. Rewritten to reflect post-Asse-C status.
- **DashboardClient JSDoc** claimed the component is "pixel-faithful to sp4-dashboard.jsx" — it intentionally diverges (4 priority sections vs 5 entity sections). Replaced with an explicit divergence note.

## Decision

Phase B audit implicitly locked **(c) keep + document divergence** — the mockup stays in `admin-mockups/` as a historical artifact, fidelity.json marks it obsolete, no story migration. This PR makes that decision visible in all three places.

No Storybook stories existed for the surface, so nothing to delete.

## Test plan

- [x] `pnpm lint:fidelity` passes (sp4-dashboard.fidelity.json validates)
- [x] `pnpm typecheck` passes (DashboardClient.tsx comment-only change)

## Refs

- Parent audit: #2127 (DS-17 Phase B sub-issue)
- Refactor that obsoleted the mockup: Asse C #1898 (shipped 2026-06-05)
- Original commission: closed #491 (B7)
- DS-17 umbrella: #2063
- Spurious duplicate (closed): #2144

🤖 Generated with [Claude Code](https://claude.com/claude-code)