### PR TITLE
docs(adr): #2055 Phase 1 — ratify ADR-082 + tighten Wikimedia port visibility

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWebpVariantGenerator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWebpVariantGenerator.cs
@@ -25,7 +25,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 /// <c>SharedGameCatalogServiceExtensions.AddSharedGameCatalogContext</c>.
 /// </para>
 /// </remarks>
-public interface IWebpVariantGenerator
+internal interface IWebpVariantGenerator
 {
     /// <summary>
     /// Generates a WebP variant of the original image, cropped to the requested

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaCommonsClient.cs
@@ -26,8 +26,9 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 /// <b>Architectural boundary</b>: this port lives in <c>SharedGameCatalog/Infrastructure/Services/</c>
 /// (BC-internal). ADR-082 (External Media Enrichment: Ports/Adapters Layout) codifies
 /// the promotion ladder: if a second BC (e.g. PdfDocument cover thumbnails, Player avatars)
-/// needs Wikimedia Commons access, the adapter moves to <c>SharedKernel/ExternalServices/</c>
-/// while the consumer-owned port stays in the consuming BC. Direct cross-BC injection of
+/// needs Wikimedia Commons access, the adapter moves to <c>Api/Infrastructure/ExternalServices/Wikimedia/</c>
+/// (sibling of <c>Api/Infrastructure/ExternalServices/BoardGameGeek/</c>) while the
+/// consumer-owned orchestrator port stays in the consuming BC. Direct cross-BC injection of
 /// this interface is rejected (see ADR-082 § "Anti-promotion rules", Option C rejected).
 /// </para>
 /// </remarks>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaRateLimiter.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/IWikimediaRateLimiter.cs
@@ -24,7 +24,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 /// past 5 RPS combined.
 /// </para>
 /// </remarks>
-public interface IWikimediaRateLimiter
+internal interface IWikimediaRateLimiter
 {
     /// <summary>
     /// Waits asynchronously until a 5 RPS token is available, then consumes it.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ImageProcessingException.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/ImageProcessingException.cs
@@ -3,7 +3,8 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 /// <summary>
 /// Thrown by <see cref="IWebpVariantGenerator"/> when the source image bytes
 /// cannot be decoded — either because they are corrupted, truncated, or encoded
-/// in a format ImageSharp does not recognize.
+/// in a format Magick.NET does not recognize (PNG, JPEG, WebP, GIF, BMP, TIFF
+/// are the bundled decoders).
 /// </summary>
 /// <remarks>
 /// Surfaces as a typed domain exception so callers (the cover enrichment

--- a/docs/for-claude/architecture/adr/adr-082-external-media-enrichment-ports.md
+++ b/docs/for-claude/architecture/adr/adr-082-external-media-enrichment-ports.md
@@ -1,8 +1,8 @@
 # ADR-082 — External Media Enrichment: Ports/Adapters Layout
 
-**Status**: Proposed
-**Date**: 2026-06-20
-**Deciders**: @badsworm (pending ratification at PR review)
+**Status**: Accepted
+**Date**: 2026-06-20 (proposed) · 2026-06-22 (ratified post-verification, #2055 Phase 1)
+**Deciders**: @badsworm
 **Tracking**: [#2055](https://github.com/meepleAi-app/meepleai-monorepo/issues/2055) ("Plan harden") gap closure
 **Related**:
 - [`adr-2026-06-09-wikidata-enrichment-architecture.md`](./adr-2026-06-09-wikidata-enrichment-architecture.md) (Accepted) — DEC-3a..3j Wikidata cover pipeline
@@ -113,7 +113,7 @@ apps/api/src/Api/BoundedContexts/SharedGameCatalog/
     │   ├── InMemoryWikimediaRateLimiter.cs       ← adapter (BC-internal initially)
     │   ├── LicenseValidator.cs                   ← pure domain helper (static, non-port)
     │   ├── IWebpVariantGenerator.cs              ← port (BC-internal)
-    │   ├── WebpVariantGenerator.cs               ← adapter (ImageSharp 2.x per DEC-3d-1)
+    │   ├── WebpVariantGenerator.cs               ← adapter (Magick.NET-Q8-AnyCPU 14.x per DEC-3d-1, superseded ImageSharp 3.x rejected for license)
     │   ├── ICoverR2UploadPipeline.cs             ← port (BC-internal)
     │   └── CoverR2UploadPipeline.cs              ← adapter (wraps IBlobStorageService shared)
     └── Resilience/
@@ -214,13 +214,28 @@ When a second BC needs to enrich via Wikimedia Commons (e.g. `PdfDocumentBC.PdfD
 
 ## Compliance
 
-- [x] No `MediaEnrichment` BC created.
-- [x] `IWikimediaCommonsClient` lives in `Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services` (catalog-internal) ✅ as-shipped.
-- [x] `IWikidataCoverEnrichmentRunner` lives in `Api.BoundedContexts.SharedGameCatalog.Application.Services` (orchestrator port BC-owned) ✅ as-shipped.
-- [x] `WikidataCatalogProvider` is shared between catalog seed + cover P18 — currently in SharedGameCatalog BC-internal namespace; promotion ladder defined in § Decision for when second BC consumer arrives.
-- [x] DEC-3e single-pod rate-limit constraint preserved — `InMemoryWikimediaRateLimiter` is process-singleton.
-- [ ] Future Phase G migration audit: cross-link this ADR in CODEOWNERS for `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/Wikimedia*` (manual setup, post-Accepted).
-- [ ] Future PR template: add "ADR-082 promotion check" checkbox if PR touches Wikimedia adapter visibility.
+### As-shipped verification (2026-06-22 ratification, #2055 Phase 1)
+
+- [x] **No `MediaEnrichment` BC created** — Glob `apps/api/src/Api/BoundedContexts/**/MediaEnrichment*` returns zero matches.
+- [x] **`IWikimediaCommonsClient` lives in `Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services`** (catalog-internal) ✅ — declared `internal interface`.
+- [x] **`IWikidataCoverEnrichmentRunner` lives in `Api.BoundedContexts.SharedGameCatalog.Application.Services`** (orchestrator port BC-owned) ✅ — declared `internal interface`, DI `AddScoped`.
+- [x] **`WikidataCatalogProvider` is shared between catalog seed + cover P18** — in `SharedGameCatalog/Infrastructure/Providers/`, declared `internal sealed class`. Promotion ladder applies when second BC consumer arrives.
+- [x] **DEC-3e single-pod rate-limit constraint preserved** — `InMemoryWikimediaRateLimiter` registered `AddSingleton<IWikimediaRateLimiter, InMemoryWikimediaRateLimiter>()` (line 203 of `SharedGameCatalogServiceExtensions.cs`); class is `internal sealed : IWikimediaRateLimiter, IDisposable`.
+- [x] **All adapter ports `internal` visibility** — verified 2026-06-22:
+  - `IWikidataCoverEnrichmentRunner` → `internal` ✅
+  - `IWikimediaCommonsClient` → `internal` ✅
+  - `IWikimediaRateLimiter` → `internal` ✅ (tightened in #2055 Phase 1 from initial `public` shipping; no cross-BC consumer existed)
+  - `IWebpVariantGenerator` → `internal` ✅ (tightened in #2055 Phase 1 from initial `public` shipping; no cross-BC consumer existed)
+  - `ICoverR2UploadPipeline` → `internal` ✅
+  - `LicenseValidator` → `internal static` ✅
+  - `ImageProcessingException` → `public sealed` ⚠️ (constraint: Sonar S3871 forbids `internal` exception types — catch-across-assembly assumption; documented exception to "no public-leak" rule, surfaces only in tests via `Assert.ThrowsAsync<ImageProcessingException>`)
+- [x] **Adapter ImageSharp → Magick.NET supersession recorded** — DEC-3d-1 LOCKED 2026-06-20 (License: Six Labors Split License conflict on ImageSharp 3.x). § Decision Layout updated to reflect Magick.NET-Q8-AnyCPU 14.x.
+
+### Forward action items (post-Accepted)
+
+- [ ] **Phase G CODEOWNERS cross-link**: add `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/Wikimedia*` and `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Resilience/Wikimedia*` entries pointing to architecture owner. Manual one-off.
+- [ ] **PR template enhancement**: add "ADR-082 promotion check" checkbox triggered when PR touches `Infrastructure/Services/IWikimedia*` or visibility modifiers thereof.
+- [ ] **Promotion PR contract**: when a second consumer BC ships, the promotion PR must (a) move files per § Decision Steps 2-3, (b) upgrade `internal` → `public`, (c) update DI registrations in both BCs, (d) append a `Phase 2 promotion executed YYYY-MM-DD` line to this ADR Status.
 
 ---
 
@@ -250,4 +265,4 @@ This ADR codifies the AS-SHIPPED layout. No migration is required for current `S
 
 ---
 
-**Last updated**: 2026-06-20 | **Status**: Proposed → Accepted at PR review.
+**Last updated**: 2026-06-22 | **Status**: Accepted (ratified at #2055 Phase 1, verified against as-shipped code; 2 minor `public → internal` visibility tightenings applied in the same PR).


### PR DESCRIPTION
## Summary

Ratifies **ADR-082 (External Media Enrichment: Ports/Adapters Layout)** against as-shipped code under issue #1823 Phase B/C/D/E/F + Phase G migration. Status: **Proposed → Accepted**.

## Verification (as-shipped, 2026-06-22)

- ✅ **9/9 file locations match § Decision Layout** (verified via Glob).
- ✅ **No `MediaEnrichment` BC accidentally created** (Glob `BoundedContexts/**/MediaEnrichment*` → zero matches).
- ✅ **`InMemoryWikimediaRateLimiter` registered Singleton** — DEC-3e single-pod rate-limit constraint preserved (`SharedGameCatalogServiceExtensions.cs:203`).
- ✅ **All adapter ports `internal` visibility** post tightening (see below).

## Visibility tightening (`public → internal`)

2 minor over-exposures discovered during compliance verification, tightened in this PR:

| Port | Before | After | Rationale |
|---|---|---|---|
| `IWikimediaRateLimiter` | `public` | `internal` | No cross-BC consumer; `Api.Tests` access via `InternalsVisibleTo` |
| `IWebpVariantGenerator` | `public` | `internal` | No cross-BC consumer; `Api.Tests` access via `InternalsVisibleTo` |

`ImageProcessingException` **stays `public sealed`** per Sonar S3871 constraint (exception types must be public for catch-across-assembly); documented as known exception to the "no public-leak" rule in the Compliance checklist.

## Documentation updates

- **ADR-082 § Decision Layout** — `WebpVariantGenerator.cs` adapter line corrected from "ImageSharp 2.x" to "Magick.NET-Q8-AnyCPU 14.x per DEC-3d-1" (locked 2026-06-20, supersedes ImageSharp 3.x rejected for Six Labors Split License conflict).
- **`IWikimediaCommonsClient` docstring** — promotion-path target corrected from `SharedKernel/ExternalServices/` to `Api/Infrastructure/ExternalServices/Wikimedia/` (sibling of existing `Api/Infrastructure/ExternalServices/BoardGameGeek/`).
- **`ImageProcessingException` docstring** — "ImageSharp does not recognize" → "Magick.NET does not recognize" + decoders list (PNG, JPEG, WebP, GIF, BMP, TIFF).
- **ADR-082 § Compliance** — checklist expanded with as-shipped evidence + forward action items (CODEOWNERS cross-link + PR template enhancement + promotion PR contract).

## Build verification

- `dotnet build` (Api.csproj) → **0 errors, 0 warnings**.
- `dotnet build` (solution) → **0 errors, 198 pre-existing warnings** (xUnit1030 ConfigureAwait + Sonar S1751 + analyzer AD0001; no regressions from this PR).

## Scope

- #2055 **Phase 1** ✅ completed via this PR.
- #2055 **Phase 8** (staging dry-run ≥30% coverage measurement) is ongoing ops observation post the 2026-06-12 M17 staging dry-run (8/8 acceptance gates). Coverage metric `qid_hit_rate_ratio` accumulates over deploy windows — non-blocking.

## Test plan

- [x] `dotnet build` passes for Api + Api.Tests (solution build).
- [ ] No runtime behavioral change expected — verify CI pipeline green (Quality gate + Backend tests).
- [ ] Reviewer: confirm ADR Status promotion from "Proposed" to "Accepted" is appropriate at this gate.

## Refs

- ADR: `docs/for-claude/architecture/adr/adr-082-external-media-enrichment-ports.md`
- Parent issue: #1823 (closed 2026-06-12)
- Tracking issue: #2055 Phase 1
- Sibling ADR: `adr-2026-06-09-wikidata-enrichment-architecture.md` (DEC-3a..3j Wikidata cover pipeline)
- Sibling BC layout reference: `apps/api/src/Api/Infrastructure/ExternalServices/BoardGameGeek/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)