### PR TITLE
feat(infra): #2126 snapshot freshness badge (D5) + R-SNAP requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,26 @@ If any of these red-flag, the branch was likely created on top of an in-progress
 
 ---
 
+## Seed snapshot bake ownership
+
+When merging a PR that adds an EF migration, changes `infra/seed-manifest/dev.yml`,
+or bumps `infra/seed-schema.version`, you are responsible for ensuring a fresh
+snapshot is published before the next developer runs `make dev-from-snapshot`:
+
+1. Verify `seed-snapshot-bake-ci.yml` completed green on your PR (it triggers
+   automatically on migration/manifest paths).
+2. If the full snapshot (`dev.yml`, 100+ PDFs) needs refreshing, manually
+   dispatch `seed-snapshot-bake-full.yml` via the GitHub Actions UI.
+3. After a successful bake, run `cd infra && make seed-status-badge` and commit
+   the updated README badge in a follow-up `chore(infra)` PR.
+
+The release captain verifies the same checklist on every sprint release.
+
+Full SLOs and requirements: [`docs/for-developers/workflows/snapshot-seed-workflow.md`
+§ Freshness & ownership requirements](./docs/for-developers/workflows/snapshot-seed-workflow.md#freshness--ownership-requirements).
+
+---
+
 ## References
 
 - [`SECURITY.md`](./SECURITY.md) — security policy + responsible disclosure

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ AI-powered board game assistant with RAG, multi-agent architecture, and living d
 | Backend | 4.30% | 90% | Phase 2 |
 | Frontend | 39% | 85% | Phase 2 |
 
+<!-- snapshot-badge:start -->Snapshot freshness: stale (68 d) 🔴<!-- snapshot-badge:end -->
+
 ## Features
 
 - **RAG System**: Hybrid retrieval (vector + keyword) with multi-model validation

--- a/docs/for-developers/workflows/snapshot-seed-workflow.md
+++ b/docs/for-developers/workflows/snapshot-seed-workflow.md
@@ -226,6 +226,72 @@ Query rapide:
 - *«Cronologia ultimi 30 giorni»* → `git log --since='30 days ago' -- data/snapshots/AUDIT.md`.
 - *«Quale snapshot serviva il dev X durante l'incident del 2026-06-11 alle 14:00?»* → cerca la riga il cui `Published at` precede 14:00 (era il `latest.txt` puntato).
 
+## Freshness & ownership requirements
+
+Formal requirements governing snapshot freshness and bake ownership. These
+requirements are enforced or surfaced by the tooling described in this document.
+
+### R-SNAP-FRESH-01 — Migration alignment
+
+> A published snapshot's `ef_migration_head` MUST equal `main`'s HEAD EF
+> migration at the time the first developer runs `make dev-from-snapshot` after
+> a migration merge.
+
+**Enforcement**: the D4 bake workflow (`seed-snapshot-bake-ci.yml`) triggers on
+push to paths that include migration files and `seed-schema.version`. When a
+migration lands, the smoke bake runs automatically and, if `publish=true`, moves
+`latest.txt` to a snapshot whose `ef_migration_head` matches the new HEAD.
+Developers who run `make dev-from-snapshot` before the bake completes will be
+blocked by `snapshot-verify.sh` exit code `2` (migration drift) and prompted to
+wait for the workflow or run a local bake.
+
+### R-SNAP-FRESH-02 — Age SLO (formalized)
+
+> The delta `created_at → today` of the published snapshot MUST be ≤ 7 days.
+> A snapshot aged 7–30 days is **warning** (orange); ≥ 30 days or missing is
+> **stale** (red).
+
+**Enforcement**:
+
+- `seed-status.sh` surfaces the age in every mode (`default`, `--brief`,
+  `--badge`) using the thresholds `WARNING_AGE_DAYS=7` and `STALE_AGE_DAYS=30`.
+- `seed-status.sh --strict` exits `1` when the snapshot is stale or missing,
+  blocking CI pipelines that depend on a fresh snapshot.
+- `snapshot-verify.sh` exit codes (downstream of the bake) also gate the
+  publish step — a half-baked snapshot never replaces `latest.txt`.
+- The weekly cron on `seed-snapshot-bake-full.yml` (Sundays 03:00 UTC) is the
+  heartbeat that keeps the published snapshot within the 7-day SLO even when no
+  migration or manifest changes are made.
+- The README snapshot-freshness badge (`make seed-status-badge`) provides a
+  visible signal to developers browsing the repository. Refresh it after any
+  successful bake.
+
+### R-SNAP-OWNER-01 — Bake ownership
+
+> Bake ownership is **shared** between:
+>
+> 1. **Merging developer** — responsible for triggering a fresh bake (or
+>    verifying the push-triggered CI smoke completed successfully) when merging
+>    a PR that changes `dev.yml`, EF migrations, or `seed-schema.version`.
+> 2. **Rotating release captain** — responsible for ensuring the weekly cron
+>    (`seed-snapshot-bake-full.yml`) is healthy and that `latest.txt` points to
+>    a snapshot within the 7-day SLO before a sprint release.
+
+**Practical checklist for the merging developer**:
+- After merging a migration PR, verify `seed-snapshot-bake-ci.yml` completed
+  green (or manually dispatch `seed-snapshot-bake-full.yml`).
+- If the bake fails, open a follow-up issue tagged `seed/snapshot` and announce
+  in the team channel that `make dev-from-snapshot` may surface a schema-drift
+  warning until resolved.
+
+**Practical checklist for the release captain**:
+- On release day: `make seed-status` to check age.
+- If ≥ 7 days: `gh workflow run seed-snapshot-bake-full.yml --field publish=true`.
+- After a successful bake: `make seed-status-badge` (from `infra/`) and commit
+  the updated badge in a `chore(infra): refresh snapshot freshness badge` PR.
+
+See also: `CONTRIBUTING.md` §"Seed snapshot bake ownership".
+
 ## Testing
 
 ### Manual e2e con `ci.yml`

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -239,6 +239,12 @@ logs-ui: ## Open Grafana log explorer in browser (staging)
 seed-status: ## Report local snapshot freshness (age, schema drift, embedding model)
 	@bash scripts/seed-status.sh
 
+seed-status-badge: ## Regenerate README snapshot-freshness badge between <!-- snapshot-badge --> markers
+	@BADGE=$$(bash scripts/seed-status.sh --badge 2>/dev/null); \
+	perl -i -0pe "s|<!-- snapshot-badge:start -->.*?<!-- snapshot-badge:end -->|$$BADGE|gs" \
+	  ../README.md && \
+	echo "README.md badge updated: $$BADGE"
+
 seed-index: ## Bake: indicizza tutti i PDF e produce snapshot locale
 	@bash scripts/seed-index-preflight.sh
 	$(COMPOSE) -f compose.dev.yml --profile ai up -d postgres redis api embedding-service smoldocling-service

--- a/infra/scripts/seed-status.sh
+++ b/infra/scripts/seed-status.sh
@@ -26,16 +26,22 @@ set -euo pipefail
 
 BRIEF=false
 STRICT=false
+BADGE=false
 for arg in "$@"; do
   case "$arg" in
     --brief)  BRIEF=true  ;;
     --strict) STRICT=true ;;
+    --badge)  BADGE=true  ;;
     -h|--help)
       cat <<HELP
 seed-status.sh — report on the local seed snapshot freshness.
 
   --brief    one-line banner mode (used by 'make dev' hook)
   --strict   exit 1 on missing / stale snapshot (used by CI)
+  --badge    emit a single Markdown line to stdout (D5 of #2126),
+             wrapped in <!-- snapshot-badge:start/end --> markers.
+             Color: ✅ green ≤7d · ⚠️ yellow 7-30d · 🔴 red ≥30d/missing.
+             Safe to capture: all other output goes to stderr.
 HELP
       exit 0
       ;;
@@ -46,7 +52,8 @@ done
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_DIR="$(cd "$INFRA_DIR/.." && pwd)"
-SNAPSHOTS_DIR="$REPO_DIR/data/snapshots"
+# Allow env override for testing (bats fixtures) and CI (SEED_INDEX_OUT_DIR).
+SNAPSHOTS_DIR="${SNAPSHOTS_DIR:-${SEED_INDEX_OUT_DIR:-$REPO_DIR/data/snapshots}}"
 
 # ── ANSI colours (off when stderr is not a tty, NO_COLOR set, or in brief) ──
 if [[ -t 2 && -z "${NO_COLOR:-}" ]]; then
@@ -76,6 +83,11 @@ if [[ -d "$SNAPSHOTS_DIR" ]]; then
 fi
 
 if [[ -z "$LATEST_META" ]]; then
+  if $BADGE; then
+    printf "<!-- snapshot-badge:start -->🔴 Snapshot freshness: missing<!-- snapshot-badge:end -->\n"
+    $STRICT && exit 1
+    exit 0
+  fi
   if $BRIEF; then
     printf "%s[seed-status]%s no snapshot found in %s — \`make dev\` will run runtime indexing (hours)\n" \
       "$C_DIM" "$C_RST" "$SNAPSHOTS_DIR" >&2
@@ -141,6 +153,30 @@ else
 fi
 if $SCHEMA_DRIFT; then
   STATUS_TAG="$C_RED"; STATUS_LABEL="stale (schema drift)"; STATUS_HARD=true
+fi
+
+# ── Badge mode (D5 of #2126) ───────────────────────────────────────────────
+# Emits ONE stdout line (Markdown) wrapped in HTML markers for splice-in-place.
+# All other output stays on stderr so callers can safely capture stdout only.
+if $BADGE; then
+  case "$STATUS_LABEL" in
+    fresh*)
+      BADGE_EMOJI="✅"
+      BADGE_TEXT="Snapshot freshness: ${AGE_DAYS} days ${BADGE_EMOJI}"
+      ;;
+    warning*)
+      BADGE_EMOJI="⚠️"
+      BADGE_TEXT="Snapshot freshness: ${AGE_DAYS} days ${BADGE_EMOJI}"
+      ;;
+    *)
+      # stale / age unknown / schema drift
+      BADGE_EMOJI="🔴"
+      BADGE_TEXT="Snapshot freshness: ${STATUS_LABEL} ${BADGE_EMOJI}"
+      ;;
+  esac
+  printf "<!-- snapshot-badge:start -->%s<!-- snapshot-badge:end -->\n" "$BADGE_TEXT"
+  $STRICT && $STATUS_HARD && exit 1
+  exit 0
 fi
 
 # ── Brief mode ─────────────────────────────────────────────────────────────

--- a/infra/scripts/tests/seed-status-badge.bats
+++ b/infra/scripts/tests/seed-status-badge.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# Unit tests for seed-status.sh --badge mode (D5 of #2126).
+#
+# Run with: bats infra/scripts/tests/seed-status-badge.bats
+# (requires bats-core: https://github.com/bats-core/bats-core)
+#
+# The --badge flag must:
+#   - emit exactly ONE line to stdout
+#   - contain a Markdown fragment with HTML snapshot-badge markers
+#   - show green / ⚠️ yellow / 🔴 red colour according to age thresholds
+#     (≤7d green, 7-30d yellow, ≥30d red)
+#   - emit nothing to stdout when no snapshot is present (only stderr)
+
+setup() {
+    SCRIPT_DIR="$BATS_TEST_DIRNAME/.."
+    TMPDIR=$(mktemp -d)
+    export SNAPSHOTS_DIR="$TMPDIR/snapshots"
+    mkdir -p "$SNAPSHOTS_DIR"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# Write a meta.json with a created_at N days ago from today.
+install_meta_age_days() {
+    local days=$1
+    # Portable: use GNU date on Linux, BSD date on macOS (CI and dev)
+    if date --version >/dev/null 2>&1; then
+        # GNU date
+        local ts
+        ts=$(date -d "$days days ago" -u +%Y-%m-%dT%H:%M:%SZ)
+    else
+        # BSD date (macOS)
+        local ts
+        ts=$(date -u -v-"${days}d" +%Y-%m-%dT%H:%M:%SZ)
+    fi
+    cat > "$SNAPSHOTS_DIR/meepleai_seed_test.meta.json" <<JSON
+{
+  "schema_version": "20260401_AddSearchVector",
+  "ef_migration_head": "20260401_AddSearchVector",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "embedding_dim": 384,
+  "app_commit": "test0000",
+  "created_at": "$ts",
+  "pdf_count": 130,
+  "chunk_count": 18000,
+  "embedding_count": 18000
+}
+JSON
+}
+
+run_badge() {
+    run bash "$SCRIPT_DIR/seed-status.sh" --badge
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+@test "--badge: fresh snapshot (2 days) emits one stdout line with green marker" {
+    install_meta_age_days 2
+    run_badge
+    [ "$status" -eq 0 ]
+    # Exactly one line on stdout
+    [ "$(echo "$output" | wc -l)" -eq 1 ]
+    # Contains the badge markers
+    [[ "$output" == *"snapshot-badge:start"* ]]
+    [[ "$output" == *"snapshot-badge:end"* ]]
+    # Fresh = green = checkmark emoji
+    [[ "$output" == *"✅"* ]]
+    # Contains the age
+    [[ "$output" == *"2 day"* ]] || [[ "$output" == *"2d"* ]]
+}
+
+@test "--badge: warning snapshot (10 days) emits one stdout line with yellow/warning marker" {
+    install_meta_age_days 10
+    run_badge
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 1 ]
+    [[ "$output" == *"snapshot-badge:start"* ]]
+    [[ "$output" == *"snapshot-badge:end"* ]]
+    # Warning = orange/yellow = warning emoji
+    [[ "$output" == *"⚠️"* ]]
+}
+
+@test "--badge: stale snapshot (35 days) emits one stdout line with red marker" {
+    install_meta_age_days 35
+    run_badge
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 1 ]
+    [[ "$output" == *"snapshot-badge:start"* ]]
+    [[ "$output" == *"snapshot-badge:end"* ]]
+    # Stale = red = cross emoji
+    [[ "$output" == *"🔴"* ]]
+}
+
+@test "--badge: missing snapshot emits one stdout line with missing marker" {
+    # No files in SNAPSHOTS_DIR
+    run_badge
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l)" -eq 1 ]
+    [[ "$output" == *"snapshot-badge:start"* ]]
+    [[ "$output" == *"snapshot-badge:end"* ]]
+    [[ "$output" == *"missing"* ]] || [[ "$output" == *"🔴"* ]]
+}
+
+@test "--badge: stdout is pure Markdown (no ANSI escape codes)" {
+    install_meta_age_days 3
+    run_badge
+    [ "$status" -eq 0 ]
+    # No ESC character (0x1B) in stdout
+    [[ "$output" != *$'\033'* ]]
+}
+
+@test "--badge: compatible with --strict (no interaction)" {
+    install_meta_age_days 3
+    run bash "$SCRIPT_DIR/seed-status.sh" --badge --strict
+    [ "$status" -eq 0 ]
+}
+
+@test "--badge: boundary: exactly 7 days old is still green" {
+    install_meta_age_days 7
+    run_badge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"✅"* ]]
+}
+
+@test "--badge: boundary: 8 days old is yellow warning" {
+    install_meta_age_days 8
+    run_badge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"⚠️"* ]]
+}


### PR DESCRIPTION
## Summary
Residui di #2126 (seed snapshot freshness). **Tier 1-3 erano già shipped** (D1/D2/D3 PR #2130/#2135, D4 #2154, D6 #2155, D7/D9 #2134 — confermato dal commento issue del 2026-06-21). Questa PR chiude i 2 residui fattibili:

- **D5 — README freshness badge**: nuovo flag `seed-status.sh --badge` (emette 1 riga markdown dall'età snapshot, riusa soglie esistenti 7d/30d), badge nel README tra marker `<!-- snapshot-badge:* -->`, Make target `seed-status-badge` per rigenerarlo. **8 test bats** (`seed-status-badge.bats`, TDD).
- **Requirements amendments** in `docs/for-developers/workflows/snapshot-seed-workflow.md` (lo spec file `2026-04-10-*` non esiste, archiviato): R-SNAP-FRESH-01, R-SNAP-FRESH-02, R-SNAP-OWNER-01 + nota ownership in `CONTRIBUTING.md`.

## Decisioni
- **Badge auto-update via Make target, NON CI commit-back**: il bake workflow `seed-snapshot-bake-full.yml` ha `permissions: contents: read`; elevare a `write` per un commit-back del badge in un job di bake da 6h è un'espansione di security surface non giustificata. Refresh via `make seed-status-badge` (documentato nel workflow doc + checklist release-captain).
- **D8** (weekly RAG smoke test) — bloccato su snapshot fresco + fix smoldocling → **spin-out #2480**.

## Verifica
- ✅ 8/8 test bats `seed-status-badge.bats` (fresh/warning/stale/missing + boundary 7d/8d + no-ANSI + strict-compat)
- ✅ `seed-status.sh --badge` emette markdown valido
- ⚠️ 1 failure preesistente in `snapshot-verify.bats` (test "exit 0 when all fields match") — confermato preesistente (git stash), non introdotto da questa PR

## Refs
- Closes #2126 (residui) · D8 → #2480 · workflow doc + CONTRIBUTING aggiornati

🤖 Generated with [Claude Code](https://claude.com/claude-code)