### PR TITLE
feat(mockups): #2361 Play Records new — extension 4 stati canonici + pr-form-core API

### DIFF
--- a/admin-mockups/design_files/pr-form-core.jsx
+++ b/admin-mockups/design_files/pr-form-core.jsx
@@ -3,23 +3,38 @@
    (form 8-col + live preview record-card 4-col).
    Entity dominante: session 🎯. game picker = game 🎲, giocatori = player 👤.
 
-   Esporta window.PRForm.render(rootId, { mode: 'new' | 'edit' }).
-   - new  : wizard vuoto / in compilazione
-   - edit : precompilato da DS.playRecords[0] (Wingspan), titolo "Modifica", azione Elimina.
+   Esporta:
+     window.PRForm.render(rootId, { mode: 'new' | 'edit', state?: 'default' | 'empty' | 'loading' | 'error' })
+     window.PRForm.FormMatrix  (componente React per embedding diretto nella gallery)
+
+   ── Stati canonici (G7 SessionStateRenderer, PR 2357) — solo mode='new' ──
+     default → form arrivato da deep-link serata: tutto precompilato (Wingspan).
+     empty   → form standalone (no gameNightId): tutti i field vuoti + banner info.
+     loading → autosave in corso dopo Step 1: toolbar saving + body offuscato + skeleton preview.
+     error   → errore submit finale: banner alert + form preservato + retry.
+   state-05-sse → SKIPPED: il form è transactional (single-shot save), non SSE-driven.
+
+   mode='edit' è INVARIATO (precompilato edit, azione Elimina) — sarà coperto da Mockup 4.
+
+   FREEZE: zero hex/hsl hardcoded per gli entity color → solo token --c-* via
+   entityHsl() (segue automaticamente light/dark via [data-theme]). Esente: color:'#fff'
+   su background entity (pattern .e-bg), rgba() per ombre/overlay neutri.
 */
 (function () {
 const { useState, useEffect } = React;
 const DS = window.DS;
 
-const entityHsl = (type, alpha) => {
-  const c = DS.EC[type] || DS.EC.session;
-  return alpha !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
-};
+// entityHsl(entity, alpha?) — risolve SEMPRE sui token CSS (--c-*), così il
+// colore segue automaticamente light/dark ([data-theme]) ed è FREEZE-clean
+// (nessun valore hsl numerico hardcoded nel sorgente del mockup).
+const entityHsl = (entity, alpha) =>
+  alpha === undefined
+    ? `hsl(var(--c-${entity}))`
+    : `hsl(var(--c-${entity}) / ${alpha})`;
 
 const LIBRARY = DS.games;
-const PLAYERS = DS.players;
 
-// Prefill (edit mode) — Wingspan record
+// ── Prefill (default / edit) — Wingspan, roster da participants ──
 const PREFILL = {
   game: 'g-wingspan', dateLabel: 'Sab 17 maggio 2026', time: '21:00', duration: '3h',
   scores: [
@@ -30,6 +45,26 @@ const PREFILL = {
   ],
   notes: 'Partita combattuta fino all\'ultimo turno. Marco chiude con un mega-combo wetland.',
 };
+
+const FILLED = {
+  game: PREFILL.game, dateLabel: PREFILL.dateLabel, time: PREFILL.time, duration: PREFILL.duration,
+  scores: PREFILL.scores, notes: PREFILL.notes,
+};
+
+// Form standalone (state=empty): nessun gameNightId → tutti i field vuoti.
+const EMPTY_DATA = {
+  game: null, dateLabel: 'Quando avete giocato?', time: '--:--', duration: null, scores: [], notes: '',
+};
+
+const STATE_CFG = {
+  default: { mStep: 1, dStep: 3, data: FILLED },
+  empty:   { mStep: 1, dStep: 1, data: EMPTY_DATA },
+  loading: { mStep: 1, dStep: 1, data: FILLED },
+  error:   { mStep: 3, dStep: 3, data: FILLED },
+};
+
+const primaryLabel = (step, mode) =>
+  step === 3 ? (mode === 'edit' ? '✓ Salva modifiche' : '✓ Salva partita') : 'Avanti →';
 
 const winnerIndex = (scores) => {
   let best = -Infinity, idx = -1;
@@ -123,14 +158,14 @@ const GamePickCard = ({ game, selected }) => (
         display:'flex', alignItems:'center', justifyContent:'center', boxShadow:'0 2px 6px rgba(0,0,0,.25)',
       }}>✓</span>
     )}
-    <div style={{ height: 80, background: game.cover, display:'flex', alignItems:'center', justifyContent:'center', fontSize: 34 }} aria-hidden="true">
+    <div style={{ height: 80, background: game.cover || entityHsl('game', 0.12), display:'flex', alignItems:'center', justifyContent:'center', fontSize: 34 }} aria-hidden="true">
       <span style={{ filter:'drop-shadow(0 4px 12px rgba(0,0,0,.4))' }}>{game.coverEmoji}</span>
     </div>
     <div style={{ padding:'9px 11px 11px', display:'flex', flexDirection:'column', gap: 4 }}>
       <div style={{ fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, color:'var(--text)', whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis' }}>{game.title}</div>
       <div style={{ display:'flex', gap: 4, flexWrap:'wrap' }}>
-        <span style={{ padding:'2px 6px', borderRadius:'var(--r-sm)', background: entityHsl('game', 0.12), color: entityHsl('game'), fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, border:`1px solid ${entityHsl('game', 0.22)}` }}>👥 {game.players}</span>
-        <span style={{ padding:'2px 6px', borderRadius:'var(--r-sm)', background: entityHsl('game', 0.12), color: entityHsl('game'), fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, border:`1px solid ${entityHsl('game', 0.22)}` }}>⏱ {game.duration}</span>
+        <span style={{ padding:'2px 6px', borderRadius:'var(--r-sm)', background: entityHsl('game', 0.12), color: entityHsl('game'), fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, border:`1px solid ${entityHsl('game', 0.22)}` }}>👥 {game.players || '1–5'}</span>
+        <span style={{ padding:'2px 6px', borderRadius:'var(--r-sm)', background: entityHsl('game', 0.12), color: entityHsl('game'), fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, border:`1px solid ${entityHsl('game', 0.22)}` }}>⏱ {game.duration || '60′'}</span>
       </div>
     </div>
   </div>
@@ -143,9 +178,9 @@ const Step1Gioco = ({ selectedGame, empty, mobile }) => {
       <StepHeader title="Quale gioco avete giocato?" sub="Scegli dalla tua libreria. Il punteggio e i giocatori si adattano al gioco."/>
       <div style={{ position:'relative' }}>
         <span aria-hidden="true" style={{ position:'absolute', left: 12, top:'50%', transform:'translateY(-50%)', color:'var(--text-muted)', fontSize: 14 }}>⌕</span>
-        <input type="text" placeholder="Cerca nella libreria…" readOnly style={{
+        <input type="text" placeholder={empty ? 'Cerca o seleziona un gioco' : 'Cerca nella libreria…'} readOnly style={{
           width:'100%', padding:'10px 12px 10px 34px', borderRadius:'var(--r-md)',
-          border:'1px solid var(--border)', background:'var(--bg-card)', color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+          border: empty ? `1px solid ${entityHsl('game', 0.4)}` : '1px solid var(--border)', background:'var(--bg-card)', color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
         }}/>
       </div>
       {empty && (
@@ -276,17 +311,26 @@ const ScoreRow = ({ player, score, isWinner }) => (
 
 const Step3Punteggi = ({ scores, notes, withNotes, mobile }) => {
   const wIdx = winnerIndex(scores);
+  const isEmpty = !scores || scores.length === 0;
   return (
     <div style={{ display:'flex', flexDirection:'column', gap: 16, padding: mobile ? '16px 14px 24px' : '20px 24px 24px' }}>
       <StepHeader title="Chi ha giocato e con che punteggio?" sub="Inserisci i punteggi: il vincitore è calcolato automaticamente dal punteggio più alto."/>
       <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
         <Label>Giocatori e punteggi ({scores.length})</Label>
-        <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
-          {scores.map((s, i) => {
-            const p = DS.byId[s.playerId] || { title: s.name, initials: s.name.slice(0,2), color: 240 };
-            return <ScoreRow key={s.playerId || i} player={p} score={s.score} isWinner={i === wIdx && s.score !== null}/>;
-          })}
-        </div>
+        {isEmpty ? (
+          <div style={{
+            padding:'18px 14px', borderRadius:'var(--r-lg)', background: entityHsl('player', 0.05),
+            border:`1px dashed ${entityHsl('player', 0.3)}`, textAlign:'center',
+            fontFamily:'var(--f-body)', fontSize: 12.5, color:'var(--text-sec)', fontWeight: 500,
+          }}>Nessun giocatore. Aggiungi i partecipanti alla partita.</div>
+        ) : (
+          <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+            {scores.map((s, i) => {
+              const p = DS.byId[s.playerId] || { title: s.name, initials: s.name.slice(0,2), color: 240 };
+              return <ScoreRow key={s.playerId || i} player={p} score={s.score} isWinner={i === wIdx && s.score !== null}/>;
+            })}
+          </div>
+        )}
         <button type="button" style={{
           padding:'10px 12px', borderRadius:'var(--r-md)', background:'transparent',
           border:`1px dashed ${entityHsl('player', 0.4)}`, color: entityHsl('player'),
@@ -308,23 +352,23 @@ const Step3Punteggi = ({ scores, notes, withNotes, mobile }) => {
 
 // ─── LIVE PREVIEW (record card) ────────────────────────
 const RecordLivePreview = ({ data, mode }) => {
-  const game = DS.byId[data.game];
+  const game = data.game ? DS.byId[data.game] : null;
   const wIdx = winnerIndex(data.scores);
   return (
     <aside style={{ position:'sticky', top: 24, display:'flex', flexDirection:'column', gap: 14 }}>
       <div style={{ display:'flex', alignItems:'center', gap: 6, fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em' }}>
-        <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius:'50%', background: entityHsl('session'), boxShadow:`0 0 0 3px ${entityHsl('session', 0.25)}`, animation:'sp7Pulse 1.6s var(--ease-out) infinite' }}/>
+        <span aria-hidden="true" className="mai-pulse" style={{ width: 6, height: 6, borderRadius:'50%', background: entityHsl('session'), boxShadow:`0 0 0 3px ${entityHsl('session', 0.25)}` }}/>
         Anteprima live · Record partita
       </div>
       <article style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-xl)', overflow:'hidden', boxShadow:'var(--shadow-md)' }}>
-        <div style={{ padding:'18px', background: game ? game.cover : entityHsl('session', 0.12), color:'#fff', position:'relative' }}>
+        <div style={{ padding:'18px', background: game ? (game.cover || entityHsl('session', 0.5)) : entityHsl('session', 0.18), color:'#fff', position:'relative' }}>
           <div style={{ display:'flex', alignItems:'center', gap: 6, marginBottom: 10 }}>
             <span style={{ padding:'3px 8px', borderRadius:'var(--r-pill)', background:'rgba(255,255,255,.25)', backdropFilter:'blur(8px)', fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em' }}>🎯 Partita</span>
             <span style={{ padding:'3px 8px', borderRadius:'var(--r-pill)', background:'rgba(255,255,255,.25)', backdropFilter:'blur(8px)', fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em' }}>{mode === 'edit' ? 'Modifica' : 'Bozza'}</span>
           </div>
           <h3 style={{ margin:'0 0 6px', fontFamily:'var(--f-display)', fontSize: 20, fontWeight: 800, lineHeight: 1.1, textShadow:'0 2px 8px rgba(0,0,0,.25)' }}>{game ? game.title : 'Seleziona un gioco'}</h3>
           <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 700, display:'flex', flexWrap:'wrap', gap:'2px 8px' }}>
-            <span>{data.dateLabel}</span><span aria-hidden="true">·</span><span>{data.time}</span><span aria-hidden="true">·</span><span>{data.duration}</span>
+            <span>{data.dateLabel}</span><span aria-hidden="true">·</span><span>{data.time}</span>{data.duration && <><span aria-hidden="true">·</span><span>{data.duration}</span></>}
           </div>
         </div>
         <div style={{ padding:'14px 18px 18px', display:'flex', flexDirection:'column', gap: 12 }}>
@@ -349,6 +393,9 @@ const RecordLivePreview = ({ data, mode }) => {
                     </div>
                   );
                 })}
+              {data.scores.length === 0 && (
+                <div style={{ padding:'10px 8px', fontFamily:'var(--f-body)', fontSize: 12, color:'var(--text-muted)', fontStyle:'italic' }}>Aggiungi giocatori per vedere la classifica.</div>
+              )}
             </div>
           </div>
         </div>
@@ -360,6 +407,106 @@ const RecordLivePreview = ({ data, mode }) => {
     </aside>
   );
 };
+
+// ─── PREVIEW SKELETON (loading · OCR foto in elaborazione) ──
+const PreviewSkeleton = () => (
+  <aside style={{ position:'sticky', top: 24, display:'flex', flexDirection:'column', gap: 14 }}>
+    <div style={{ fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, color: entityHsl('session'), textTransform:'uppercase', letterSpacing:'.08em' }}>
+      Anteprima · elaborazione foto…
+    </div>
+    <div aria-hidden="true" style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-xl)', overflow:'hidden', boxShadow:'var(--shadow-md)' }}>
+      <div className="skel" style={{ height: 96, background: entityHsl('session', 0.14) }}/>
+      <div style={{ padding:'14px 18px 18px', display:'flex', flexDirection:'column', gap: 9 }}>
+        <div className="skel" style={{ height: 11, width:'52%', borderRadius:'var(--r-xs)', background:'var(--bg-muted)' }}/>
+        {[0,1,2,3].map(i => <div key={i} className="skel" style={{ height: 32, borderRadius:'var(--r-sm)', background:'var(--bg-muted)' }}/>)}
+      </div>
+    </div>
+    <div aria-hidden="true" className="skel" style={{ height: 46, borderRadius:'var(--r-md)', background:'var(--bg-muted)' }}/>
+  </aside>
+);
+
+// ─── STATE BANNERS / TOOLBARS ──────────────────────────
+// empty → banner informativo entry-point standalone (role=status, aria-live=polite)
+const InfoBanner = ({ mobile }) => (
+  <div role="status" aria-live="polite" style={{
+    display:'flex', alignItems:'center', gap: 10,
+    padding: mobile ? '10px 14px' : '12px 24px',
+    background: entityHsl('session', 0.06),
+    borderLeft: `4px solid ${entityHsl('session', 0.45)}`,
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>ℹ️</span>
+    <div style={{ flex: 1, minWidth: 0, fontSize: mobile ? 12 : 13, color:'var(--text-sec)', fontWeight: 600, lineHeight: 1.4 }}>
+      <strong style={{ color:'var(--text)', fontWeight: 800 }}>Registrazione manuale</strong> · Compila i campi per registrare una partita non collegata a una serata
+    </div>
+  </div>
+);
+
+// error → banner submit fallito (role=alert) + retry
+const ErrorBanner = ({ mobile }) => (
+  <div role="alert" style={{
+    display:'flex', alignItems:'center', gap: mobile ? 10 : 12,
+    padding: mobile ? '12px 14px' : '14px 24px',
+    background: entityHsl('event', 0.08),
+    borderLeft: `4px solid ${entityHsl('event', 0.6)}`,
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <span aria-hidden="true" style={{ fontSize: mobile ? 18 : 20, lineHeight: 1 }}>⚠️</span>
+    <div style={{ flex: 1, minWidth: 0, fontSize: mobile ? 12.5 : 14, color:'var(--text)', fontWeight: 700, lineHeight: 1.4 }}>
+      <strong style={{ fontWeight: 800 }}>Impossibile salvare la partita</strong> <span style={{ color:'var(--text-sec)', fontWeight: 600 }}>· Verifica la connessione e riprova</span>
+    </div>
+    <button type="button" aria-label="Riprova salvataggio partita" style={{
+      padding:'7px 14px', borderRadius:'var(--r-md)', background:'transparent',
+      color: entityHsl('event'), border:`1px solid ${entityHsl('event', 0.5)}`,
+      fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+      display:'inline-flex', alignItems:'center', gap: 5, whiteSpace:'nowrap', flexShrink: 0,
+    }}><span aria-hidden="true">↻</span>Riprova salvataggio</button>
+  </div>
+);
+
+// error → link "Salva come bozza locale" (entity=session) sotto il banner
+const DraftLink = ({ mobile }) => (
+  <div style={{ padding: mobile ? '8px 14px' : '8px 24px', borderBottom:'1px solid var(--border-light)' }}>
+    <button type="button" style={{
+      background:'transparent', border:'none', padding: 0, color: entityHsl('session'),
+      fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800, cursor:'pointer',
+      textDecoration:'underline', textUnderlineOffset: 3, display:'inline-flex', alignItems:'center', gap: 5,
+    }}><span aria-hidden="true">💾</span>Salva come bozza locale</button>
+  </div>
+);
+
+// loading → toolbar sticky autosave (chip mono + spinner entity=session)
+const SavingToolbar = ({ mobile }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding: mobile ? '9px 14px' : '11px 24px',
+    background: entityHsl('session', 0.06),
+    borderBottom:`1px solid ${entityHsl('session', 0.2)}`,
+    position:'sticky', top: 0, zIndex: 12,
+  }}>
+    <span className="pr-spin" aria-hidden="true" style={{
+      width: 14, height: 14, borderRadius:'50%',
+      border:`2px solid ${entityHsl('session', 0.25)}`, borderTopColor: entityHsl('session'),
+    }}/>
+    <span style={{ fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800, color: entityHsl('session'), textTransform:'uppercase', letterSpacing:'.06em' }}>
+      <span aria-hidden="true">💾</span> Salvataggio in corso…
+    </span>
+    <span style={{ position:'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow:'hidden', clip:'rect(0 0 0 0)', whiteSpace:'nowrap', border: 0 }}>Salvataggio bozza in corso</span>
+  </div>
+);
+
+// loading → progress bar upload foto (entity=session) con percentuale
+const PhotoProgress = ({ mobile }) => (
+  <div style={{ padding: mobile ? '12px 14px 4px' : '12px 24px 4px', display:'flex', flexDirection:'column', gap: 6 }}>
+    <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center' }}>
+      <span style={{ fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, color: entityHsl('session'), textTransform:'uppercase', letterSpacing:'.06em' }}><span aria-hidden="true">📷</span> Caricamento foto</span>
+      <span style={{ fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800, color: entityHsl('session'), fontVariantNumeric:'tabular-nums' }}>60%</span>
+    </div>
+    <div role="progressbar" aria-valuenow={60} aria-valuemin={0} aria-valuemax={100} aria-label="Caricamento foto" style={{ height: 6, borderRadius:'var(--r-pill)', background: entityHsl('session', 0.14), overflow:'hidden' }}>
+      <div style={{ height:'100%', width:'60%', borderRadius:'var(--r-pill)', background: entityHsl('session') }}/>
+    </div>
+  </div>
+);
 
 // ─── ACTION BAR ────────────────────────────────────────
 const ActionBar = ({ step, mobile, primaryLabel, mode }) => (
@@ -373,14 +520,14 @@ const ActionBar = ({ step, mobile, primaryLabel, mode }) => (
     <div style={{ flex: 1 }}/>
     <button type="button" style={{
       padding:'12px 22px', borderRadius:'var(--r-md)',
-      background:`linear-gradient(135deg, ${entityHsl('session')}, hsl(${DS.EC.session.h - 14}, ${DS.EC.session.s}%, ${DS.EC.session.l - 8}%))`,
+      background:`linear-gradient(135deg, ${entityHsl('session')}, ${entityHsl('session', 0.8)})`,
       color:'#fff', border:'none', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, cursor:'pointer',
       boxShadow:`0 4px 14px ${entityHsl('session', 0.35)}`,
     }}>{primaryLabel}</button>
   </div>
 );
 
-// ─── MOBILE / DESKTOP SHELLS ───────────────────────────
+// ─── MOBILE / DESKTOP CHROME ───────────────────────────
 const PhoneSbar = () => (
   <div className="phone-sbar" style={{ color:'var(--text)' }}>
     <span>21:42</span>
@@ -396,76 +543,6 @@ const PhoneTopNav = ({ title }) => (
   </div>
 );
 
-const renderStep = (step, data, opts, mobile) => {
-  if (step === 1) return <Step1Gioco selectedGame={data.game} empty={opts.emptyGame} mobile={mobile}/>;
-  if (step === 2) return <Step2Quando dateLabel={data.dateLabel} time={data.time} duration={data.duration} mobile={mobile}/>;
-  return <Step3Punteggi scores={data.scores} notes={data.notes} withNotes={opts.withNotes} mobile={mobile}/>;
-};
-
-// loading / error bodies
-const LoadingBody = ({ mobile }) => (
-  <div style={{ padding: mobile ? '16px 14px' : '20px 24px', display:'flex', flexDirection:'column', gap: 12 }}>
-    <div className="mai-shimmer" style={{ height: 34, width:'60%', borderRadius:'var(--r-sm)', background:'var(--bg-muted)' }}/>
-    <div className="mai-shimmer" style={{ height: 14, width:'80%', borderRadius: 4, background:'var(--bg-muted)' }}/>
-    <div style={{ display:'grid', gridTemplateColumns:'repeat(2, 1fr)', gap: 10, marginTop: 6 }}>
-      {[0,1,2,3].map(i => <div key={i} className="mai-shimmer" style={{ height: 130, borderRadius:'var(--r-lg)', background:'var(--bg-muted)' }}/>)}
-    </div>
-  </div>
-);
-
-const ErrorBody = ({ mobile }) => (
-  <div style={{ padding:'40px 24px', textAlign:'center', margin: mobile ? 14 : 24, background:'hsl(var(--c-danger) / .06)', border:'1px solid hsl(var(--c-danger) / .25)', borderRadius:'var(--r-xl)', display:'flex', flexDirection:'column', alignItems:'center' }}>
-    <div style={{ width: 56, height: 56, borderRadius:'50%', background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))', display:'flex', alignItems:'center', justifyContent:'center', fontSize: 26, marginBottom: 12 }} aria-hidden="true">⚠</div>
-    <h3 style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color:'var(--text)', margin:'0 0 4px' }}>Salvataggio non riuscito</h3>
-    <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px', maxWidth: 300 }}>Impossibile salvare la partita. La bozza è stata conservata localmente.</p>
-    <button type="button" style={{ padding:'8px 14px', borderRadius:'var(--r-md)', background:'hsl(var(--c-danger))', color:'#fff', border:'none', fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800, cursor:'pointer' }}>↻ Riprova salvataggio</button>
-  </div>
-);
-
-const MobileScreen = ({ anchor, label, step, data, opts, mode, primaryLabel, gherkin }) => (
-  <section className="phone-shell" data-screen-label={`PR-form · ${label}`}>
-    <div className="state-caption">
-      <span className="state-id">{anchor.replace('state-', '#')}</span>
-      <span className="state-label">📱 {label}</span>
-      {gherkin && <span className="gherkin">{gherkin}</span>}
-    </div>
-    <div className="phone">
-      <PhoneSbar/>
-      <div style={{ flex: 1, overflowY:'auto', display:'flex', flexDirection:'column', background:'var(--bg)' }}>
-        <PhoneTopNav title={mode === 'edit' ? 'Modifica partita' : 'Registra partita'}/>
-        {opts.loading ? <LoadingBody mobile/> : opts.error ? <ErrorBody mobile/> : (
-          <>
-            <StepIndicator current={step} onBack mobile/>
-            <div style={{ flex: 1 }}>{renderStep(step, data, opts, true)}</div>
-            <ActionBar step={step} mobile primaryLabel={primaryLabel} mode={mode}/>
-          </>
-        )}
-      </div>
-    </div>
-  </section>
-);
-
-const StepFlowOverview = ({ anchor, label, data, mode }) => (
-  <section data-screen-label={`PR-form · ${label}`}>
-    <div className="state-caption">
-      <span className="state-id">{anchor.replace('state-', '#')}</span>
-      <span className="state-label">📱 {label}</span>
-    </div>
-    <div className="step-flow-row">
-      {[1,2,3].map(step => (
-        <div key={step} className="phone phone-mini">
-          <PhoneSbar/>
-          <div style={{ flex: 1, overflowY:'auto', display:'flex', flexDirection:'column', background:'var(--bg)' }}>
-            <PhoneTopNav title={`Step ${step}/3`}/>
-            <StepIndicator current={step} onBack mobile/>
-            <div style={{ flex: 1 }}>{renderStep(step, data, { withNotes: true }, true)}</div>
-          </div>
-        </div>
-      ))}
-    </div>
-  </section>
-);
-
 const DesktopNav = ({ mode }) => (
   <div style={{ display:'flex', alignItems:'center', gap: 14, padding:'10px 24px', background:'var(--glass-bg)', backdropFilter:'blur(12px)', borderBottom:'1px solid var(--border)' }}>
     <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
@@ -478,130 +555,93 @@ const DesktopNav = ({ mode }) => (
   </div>
 );
 
-const DesktopSplit = ({ anchor, label, step, data, opts, mode, primaryLabel }) => (
-  <section data-screen-label={`PR-form · ${label}`}>
-    <div className="state-caption">
-      <span className="state-id">{anchor.replace('state-', '#')}</span>
-      <span className="state-label">🖥️ {label}</span>
-    </div>
-    <div className="desktop-frame">
-      <div className="desktop-bar">
-        <span className="traffic"/><span className="traffic"/><span className="traffic"/>
-        <span className="url">meepleai.app/play-records/{mode === 'edit' ? 'pr1/edit' : 'new'}</span>
-      </div>
-      <div style={{ background:'var(--bg)' }}>
-        <DesktopNav mode={mode}/>
-        <StepIndicator current={step} mobile={false}/>
-        <div style={{ display:'grid', gridTemplateColumns:'minmax(0, 8fr) minmax(0, 4fr)', gap: 24, padding:'8px 24px 0', maxWidth: 1280, margin:'0 auto' }}>
-          <div style={{ display:'flex', flexDirection:'column', paddingBottom: 24 }}>{renderStep(step, data, opts, false)}</div>
-          <div style={{ paddingTop: 20, paddingBottom: 24 }}><RecordLivePreview data={data} mode={mode}/></div>
-        </div>
-        <ActionBar step={step} mobile={false} primaryLabel={primaryLabel} mode={mode}/>
-      </div>
-    </div>
-  </section>
-);
+const renderStep = (step, data, opts, mobile) => {
+  if (step === 1) return <Step1Gioco selectedGame={data.game} empty={opts.empty} mobile={mobile}/>;
+  if (step === 2) return <Step2Quando dateLabel={data.dateLabel} time={data.time} duration={data.duration} mobile={mobile}/>;
+  return <Step3Punteggi scores={data.scores} notes={data.notes} withNotes={opts.withNotes} mobile={mobile}/>;
+};
 
-// ─── APP ───────────────────────────────────────────────
-function App({ mode }) {
-  const [theme, setTheme] = useState('light');
-  useEffect(() => { document.documentElement.setAttribute('data-theme', theme); }, [theme]);
-
-  const isEdit = mode === 'edit';
-  const filled = {
-    game: PREFILL.game, dateLabel: PREFILL.dateLabel, time: PREFILL.time, duration: PREFILL.duration,
-    scores: PREFILL.scores, notes: PREFILL.notes,
-  };
-  const blank = {
-    game: 'g-wingspan', dateLabel: 'Oggi · 28 mag 2026', time: '21:00', duration: '2h',
-    scores: [
-      { playerId:'p-marco', name:'Marco', score: 42 },
-      { playerId:'p-anna',  name:'Anna',  score: 38 },
-      { playerId:'p-luca',  name:'Luca',  score: 29 },
-    ],
-    notes: 'Bella rimonta di Marco nell\'ultimo round.',
-  };
-  const data = isEdit ? filled : blank;
-  const primary = (step) => step === 3 ? (isEdit ? '✓ Salva modifiche' : '✓ Salva partita') : 'Avanti →';
-
-  const accent = entityHsl('session');
-  const primaryLabel3 = primary(3);
-
-  const MOBILE = isEdit ? [
-    { anchor:'state-01', step:1, opts:{}, label:'01 · Step 1 — Gioco (precompilato Wingspan)', gherkin:'EDIT' },
-    { anchor:'state-02', step:2, opts:{}, label:'02 · Step 2 — Quando (precompilato)', gherkin:'EDIT' },
-    { anchor:'state-03', step:3, opts:{ withNotes:true }, label:'03 · Step 3 — Punteggi + note (precompilati)', gherkin:'EDIT' },
-    { anchor:'state-04', step:3, opts:{ withNotes:true, error:true }, label:'04 · Error — salvataggio fallito', gherkin:'EDIT.err' },
-    { anchor:'state-05', step:1, opts:{ loading:true }, label:'05 · Loading — caricamento partita', gherkin:'EDIT.load' },
-  ] : [
-    { anchor:'state-01', step:1, opts:{ emptyGame:true }, label:'01 · Step 1 — Gioco · empty (nessuna selezione)', gherkin:'US.1' },
-    { anchor:'state-02', step:1, opts:{}, label:'02 · Step 1 — Gioco selezionato', gherkin:'US.1' },
-    { anchor:'state-03', step:2, opts:{}, label:'03 · Step 2 — Quando + durata', gherkin:'US.2' },
-    { anchor:'state-04', step:3, opts:{}, label:'04 · Step 3 — Punteggi (vincitore auto)', gherkin:'US.3' },
-    { anchor:'state-05', step:3, opts:{ withNotes:true }, label:'05 · Step 3 — Con note opzionali', gherkin:'US.3' },
-    { anchor:'state-06', step:1, opts:{ loading:true }, label:'06 · Loading — libreria', gherkin:'US.load' },
-    { anchor:'state-07', step:3, opts:{ error:true }, label:'07 · Error — salvataggio fallito', gherkin:'US.err' },
-  ];
-
+// ─── MOBILE FORM (wizard 3-step · bottom nav) ──────────
+const MobileForm = ({ mode, state, data, step }) => {
+  const loading = state === 'loading', error = state === 'error', empty = state === 'empty';
   return (
-    <div style={{ minHeight:'100vh', background:'var(--bg)', color:'var(--text)', padding:'24px 24px 80px' }}>
-      <header style={{ maxWidth: 1440, margin:'0 auto 32px', display:'flex', alignItems:'flex-start', gap: 16, flexWrap:'wrap' }}>
-        <div style={{ display:'flex', alignItems:'center', gap: 12, flex: 1, minWidth: 0 }}>
-          <div style={{ width: 40, height: 40, borderRadius: 10, background:`linear-gradient(135deg, ${entityHsl('game')}, ${accent})`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontWeight: 800, fontFamily:'var(--f-display)', fontSize: 18 }}>{isEdit ? '✎' : '+'}</div>
-          <div>
-            <div style={{ display:'flex', alignItems:'center', gap: 8, marginBottom: 2 }}>
-              <span style={{ padding:'2px 8px', borderRadius:'var(--r-pill)', background: entityHsl('session', 0.12), color: accent, fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em', border:`1px solid ${entityHsl('session', 0.22)}` }}>SP4 · /play-records</span>
-              <span style={{ fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 700 }}>{isEdit ? '/play-records/[id]/edit' : '/play-records/new'}</span>
-            </div>
-            <div style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 22, color:'var(--text)', letterSpacing:'-.01em' }}>{isEdit ? 'Modifica partita' : 'Registra partita'}</div>
-            <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 600, marginTop: 2 }}>Wizard 3-step mobile + split-form desktop con live preview</div>
-          </div>
-        </div>
-        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')} style={{ padding:'8px 14px', borderRadius:'var(--r-md)', background:'var(--bg-card)', border:'1px solid var(--border)', color:'var(--text)', fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer', display:'inline-flex', alignItems:'center', gap: 6 }}>
-          <span aria-hidden="true">🌗</span>{theme === 'light' ? 'Light' : 'Dark'}
-        </button>
-      </header>
-
-      <main style={{ maxWidth: 1440, margin:'0 auto', display:'flex', flexDirection:'column', gap: 56 }}>
-        <div>
-          <div className="section-header">
-            <span className="section-marker" style={{ background: accent }}/>
-            <h2 className="section-title">Mobile · 375 — Wizard 3 step</h2>
-            <span className="section-meta">{MOBILE.length} stati · default · loading · error</span>
-          </div>
-          <div className="mobile-grid">
-            {MOBILE.map(s => <MobileScreen key={s.anchor} {...s} data={data} mode={mode} primaryLabel={primary(s.step)}/>)}
-          </div>
-        </div>
-
-        <div>
-          <div className="section-header">
-            <span className="section-marker" style={{ background: accent }}/>
-            <h2 className="section-title">Mobile · Step-flow overview</h2>
-            <span className="section-meta">i 3 step affiancati per QA</span>
-          </div>
-          <StepFlowOverview anchor="state-08" label="08 · Step-flow 1→3 (compact)" data={data} mode={mode}/>
-        </div>
-
-        <div>
-          <div className="section-header">
-            <span className="section-marker" style={{ background: accent }}/>
-            <h2 className="section-title">Desktop · 1280 — Split-form</h2>
-            <span className="section-meta">form 8-col + record-card live preview 4-col</span>
-          </div>
-          <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
-            <DesktopSplit anchor="state-09" label="09 · Desktop · Step 3 Punteggi + live preview" step={3} data={data} opts={{ withNotes:true }} mode={mode} primaryLabel={primaryLabel3}/>
-            <DesktopSplit anchor="state-10" label="10 · Desktop · Step 1 Gioco + live preview" step={1} data={data} opts={{}} mode={mode} primaryLabel="Avanti →"/>
-          </div>
-        </div>
-      </main>
+    <div aria-busy={loading || undefined} style={{ flex: 1, display:'flex', flexDirection:'column', overflow:'hidden' }}>
+      <PhoneTopNav title={mode === 'edit' ? 'Modifica partita' : 'Registra partita'}/>
+      {empty && <InfoBanner mobile/>}
+      {error && <ErrorBanner mobile/>}
+      {error && <DraftLink mobile/>}
+      {loading && <SavingToolbar mobile/>}
+      {loading && <PhotoProgress mobile/>}
+      <div className={loading ? 'pr-loading-dim' : undefined} style={{ flex: 1, display:'flex', flexDirection:'column', overflowY:'auto', minHeight: 0 }}>
+        <StepIndicator current={step} onBack mobile/>
+        <div style={{ flex: 1 }}>{renderStep(step, data, { empty, withNotes: !empty }, true)}</div>
+      </div>
+      <ActionBar step={step} mobile primaryLabel={primaryLabel(step, mode)} mode={mode}/>
     </div>
   );
-}
+};
+
+// ─── DESKTOP FORM (split-form 8-col + preview 4-col) ───
+const DesktopForm = ({ mode, state, data, step }) => {
+  const loading = state === 'loading', error = state === 'error', empty = state === 'empty';
+  return (
+    <div aria-busy={loading || undefined} style={{ display:'flex', flexDirection:'column' }}>
+      <DesktopNav mode={mode}/>
+      {empty && <InfoBanner/>}
+      {error && <ErrorBanner/>}
+      {error && <DraftLink/>}
+      {loading && <SavingToolbar/>}
+      {loading && <PhotoProgress/>}
+      <div className={loading ? 'pr-loading-dim' : undefined}>
+        <StepIndicator current={step} mobile={false}/>
+        <div style={{ display:'grid', gridTemplateColumns:'minmax(0, 8fr) minmax(0, 4fr)', gap: 24, padding:'8px 24px 0', maxWidth: 1280, margin:'0 auto' }}>
+          <div style={{ display:'flex', flexDirection:'column', paddingBottom: 24 }}>{renderStep(step, data, { empty, withNotes: !empty }, false)}</div>
+          <div style={{ paddingTop: 20, paddingBottom: 24 }}>{loading ? <PreviewSkeleton/> : <RecordLivePreview data={data} mode={mode}/>}</div>
+        </div>
+      </div>
+      <ActionBar step={step} mobile={false} primaryLabel={primaryLabel(step, mode)} mode={mode}/>
+    </div>
+  );
+};
+
+// ─── FORM MATRIX (mobile 375 + desktop 1440 per uno stato) ──
+const FormMatrix = ({ mode = 'new', state = 'default' }) => {
+  const cfg = STATE_CFG[state] || STATE_CFG.default;
+  return (
+    <div className="matrix">
+      <div className="matrix-row">
+        <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 8 }}>
+          <div className="frame-tag">Mobile · 375 — Wizard 3-step</div>
+          <div className="phone">
+            <PhoneSbar/>
+            <div style={{ flex: 1, overflow:'hidden', display:'flex', flexDirection:'column', background:'var(--bg)' }}>
+              <MobileForm mode={mode} state={state} data={cfg.data} step={cfg.mStep}/>
+            </div>
+          </div>
+        </div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 8, flex: 1, minWidth: 0 }}>
+          <div className="frame-tag">Desktop · 1440 — Split-form + preview</div>
+          <div className="desktop-frame">
+            <div className="desktop-bar">
+              <span className="traffic"/><span className="traffic"/><span className="traffic"/>
+              <span className="url">meepleai.app/play-records/new</span>
+            </div>
+            <div style={{ display:'flex', flexDirection:'column', minHeight: 640, background:'var(--bg)' }}>
+              <DesktopForm mode={mode} state={state} data={cfg.data} step={cfg.dStep}/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 window.PRForm = {
+  FormMatrix,
   render(rootId, opts) {
-    ReactDOM.createRoot(document.getElementById(rootId)).render(<App mode={(opts && opts.mode) || 'new'}/>);
+    const mode = (opts && opts.mode) || 'new';
+    const state = (opts && opts.state) || 'default';
+    ReactDOM.createRoot(document.getElementById(rootId)).render(<FormMatrix mode={mode} state={state}/>);
   }
 };
 })();

--- a/admin-mockups/design_files/sp4-play-records-new.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-new.fidelity.json
@@ -3,7 +3,10 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp4-play-records-new.html",
     "states": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,7 +15,10 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,

--- a/admin-mockups/design_files/sp4-play-records-new.html
+++ b/admin-mockups/design_files/sp4-play-records-new.html
@@ -3,9 +3,150 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Play records · Registra partita — MeepleAI</title>
+  <title>Play records · Registra partita — Stati canonici — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&display=swap">
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="scaffold.css">
+  <style>
+    /* ─── Gallery / frame chrome + skeleton (self-contained, non dipende da scaffold.css) ─── */
+    html { scroll-behavior: smooth; }
+    body { min-height: 100vh; }
+
+    /* Skeleton pulse — opacity 0.4 → 0.8 → 0.4, 2s loop */
+    @keyframes sp4-skel-pulse { 0%, 100% { opacity: .4; } 50% { opacity: .8; } }
+    .skel { animation: sp4-skel-pulse 2s var(--ease-in-out) infinite; }
+    /* In-corso badge / live dot pulse */
+    @keyframes sp4-dot-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
+    .mai-pulse { animation: sp4-dot-pulse 1.6s var(--ease-in-out) infinite; }
+    /* Autosave spinner */
+    @keyframes pr-spin-kf { to { transform: rotate(360deg); } }
+    .pr-spin { animation: pr-spin-kf .8s linear infinite; }
+    /* Loading body — offuscato + leggera pulsazione (2s), resta inputabile */
+    @keyframes pr-dim-pulse { 0%, 100% { opacity: .62; } 50% { opacity: .72; } }
+    .pr-loading-dim { opacity: .65; animation: pr-dim-pulse 2s var(--ease-in-out) infinite; }
+
+    /* prefers-reduced-motion → snap senza animazioni */
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .skel { animation: none; opacity: .6; }
+      .mai-pulse { animation: none; }
+      .pr-spin { animation: none; }
+      .pr-loading-dim { animation: none; opacity: .65; }
+    }
+
+    .gallery { min-height: 100vh; }
+
+    /* Sticky top nav con 4 link agli anchor */
+    .gallery-nav {
+      position: sticky; top: 0; z-index: var(--z-nav);
+      display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+      padding: 10px 24px;
+      background: var(--glass-bg); backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .gallery-nav-brand {
+      font-family: var(--f-mono); font-size: 11px; font-weight: 800;
+      letter-spacing: .06em; text-transform: uppercase; color: var(--text-sec);
+      white-space: nowrap;
+    }
+    .gallery-nav-links { display: flex; gap: 6px; flex: 1; flex-wrap: wrap; }
+    .gallery-nav-links a {
+      padding: 6px 12px; border-radius: var(--r-pill);
+      font-family: var(--f-display); font-size: 12px; font-weight: 700;
+      color: var(--text-sec); border: 1px solid var(--border); background: var(--bg-card);
+      white-space: nowrap; transition: color var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out), background var(--dur-sm) var(--ease-out);
+    }
+    .gallery-nav-links a:hover {
+      color: hsl(var(--c-session)); border-color: hsl(var(--c-session) / .45);
+      background: hsl(var(--c-session) / .1);
+    }
+    .gallery-nav-ghost {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 700;
+      color: var(--text-muted); padding: 6px 10px; border-radius: var(--r-pill);
+      border: 1px dashed var(--border-strong); opacity: .6; white-space: nowrap;
+    }
+    .theme-toggle {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 12px; border-radius: var(--r-pill);
+      border: 1px solid var(--border); background: var(--bg-card); color: var(--text-sec);
+      font-family: var(--f-display); font-size: 12px; font-weight: 700; white-space: nowrap;
+      transition: border-color var(--dur-sm) var(--ease-out), color var(--dur-sm) var(--ease-out);
+    }
+    .theme-toggle:hover { border-color: hsl(var(--c-session) / .45); color: hsl(var(--c-session)); }
+
+    .gallery-body { max-width: 1560px; margin: 0 auto; padding: 24px 24px 96px; }
+    .gallery-intro { padding: 16px 0 4px; }
+    .gallery-intro .kicker {
+      font-family: var(--f-mono); font-size: 11px; text-transform: uppercase;
+      letter-spacing: .08em; color: var(--text-muted); margin-bottom: 8px; font-weight: 800;
+    }
+    .gallery-intro h1 { font-size: var(--fs-3xl); margin: 0 0 10px; }
+    .gallery-intro .lead {
+      font-size: var(--fs-base); color: var(--text-sec); max-width: 820px;
+      line-height: var(--lh-relax); margin: 0; text-wrap: pretty;
+    }
+    .gallery-intro code, .state-head code {
+      font-family: var(--f-mono); font-size: .88em;
+      background: var(--bg-muted); padding: 1px 5px; border-radius: var(--r-xs);
+    }
+
+    .state-section { scroll-margin-top: 76px; padding: 40px 0 8px; border-top: 1px solid var(--border-light); margin-top: 28px; }
+    .state-head { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 26px; }
+    .state-num {
+      font-family: var(--f-mono); font-size: 14px; font-weight: 800; color: #fff;
+      background: hsl(var(--c-session)); width: 36px; height: 36px; border-radius: var(--r-md);
+      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+      box-shadow: 0 4px 12px hsl(var(--c-session) / .4);
+    }
+    .state-head-text { flex: 1; min-width: 0; }
+    .state-head h2 { font-size: var(--fs-2xl); margin: 0; }
+    .state-head p { font-size: 13px; color: var(--text-sec); margin: 5px 0 0; max-width: 640px; line-height: var(--lh-snug); }
+    .state-anchor {
+      margin-left: auto; align-self: flex-start;
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+      background: var(--bg-muted); padding: 5px 10px; border-radius: var(--r-sm); white-space: nowrap;
+    }
+
+    .matrix { display: flex; flex-direction: column; gap: 32px; }
+    .matrix-row { display: flex; gap: 32px; flex-wrap: wrap; align-items: flex-start; }
+    .frame-tag {
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-sec);
+      text-transform: uppercase; letter-spacing: .06em; font-weight: 700;
+    }
+
+    /* Phone 375 */
+    .phone {
+      width: 375px; height: 760px; border-radius: 38px;
+      border: 10px solid var(--text); background: var(--bg);
+      overflow: hidden; display: flex; flex-direction: column;
+      box-shadow: var(--shadow-lg); flex-shrink: 0;
+    }
+    .phone-sbar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 9px 24px 4px; font-family: var(--f-mono); font-size: 12px; font-weight: 700; flex-shrink: 0;
+    }
+    .phone-sbar .ind { display: flex; gap: 8px; align-items: center; font-size: 10px; letter-spacing: .1em; }
+
+    /* Desktop 1440 */
+    .desktop-frame {
+      width: 1440px; max-width: 100%; border-radius: 14px;
+      border: 1px solid var(--border); background: var(--bg); overflow: hidden;
+      box-shadow: var(--shadow-lg);
+    }
+    .desktop-bar {
+      display: flex; align-items: center; gap: 8px; padding: 10px 16px;
+      background: var(--bg-card); border-bottom: 1px solid var(--border);
+    }
+    .desktop-bar .traffic { width: 11px; height: 11px; border-radius: 50%; background: var(--border-strong); }
+    .desktop-bar .url { margin-left: 14px; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); }
+
+    @media (max-width: 900px) {
+      .gallery-body { padding: 20px 16px 80px; }
+      .matrix-row { gap: 24px; }
+    }
+  </style>
 </head>
 <body>
   <div id="root"></div>

--- a/admin-mockups/design_files/sp4-play-records-new.jsx
+++ b/admin-mockups/design_files/sp4-play-records-new.jsx
@@ -1,5 +1,123 @@
-/* MeepleAI SP4 — /play-records/new
+/* MeepleAI SP4 — /play-records/new · GALLERY (stati canonici)
    Route: /play-records/new — Registra una partita giocata.
-   Wizard 3-step (Gioco · Quando · Punteggi) mobile + split-form desktop.
-   Logica condivisa in pr-form-core.jsx (modello: sp7-game-night-new). */
-window.PRForm.render('root', { mode: 'new' });
+   File: admin-mockups/design_files/sp4-play-records-new.{html,jsx}
+   Modello: sp4-play-records-index — gallery scaffold (nav sticky + state-section
+   + frame chrome phone 375 / desktop 1440 + ThemeToggle + SSE skip ghost).
+
+   ── Stati canonici (G7 SessionStateRenderer, PR 2357) — mode='new' ──────────
+   Export gallery wrapper per-stato; ciascuno monta il form condiviso via
+   window.PRForm.render(rootId, { mode: 'new', state }) — la logica vive in
+   pr-form-core.jsx (riusato anche da -edit, Mockup 4).
+
+     State01_Default  → state-01-default  (deep-link serata · tutto precompilato Wingspan)
+     State02_Empty    → state-02-empty    (standalone · field vuoti + banner info, role=status)
+     State03_Loading  → state-03-loading  (autosave post Step 1 · toolbar + body offuscato + skeleton, aria-busy)
+     State04_Error    → state-04-error    (submit fallito · banner alert + form preservato + retry)
+   state-05-sse → SKIPPED: il form è transactional (single-shot save), NON SSE-driven.
+
+   FREEZE: zero hex/hsl hardcoded per gli entity color → solo token --c-* via
+   entityHsl() (in pr-form-core.jsx). Esente: color:'#fff' su background entity.
+*/
+const { useState, useEffect, useRef } = React;
+
+// ─── Mount: ogni stato monta il form condiviso in una sub-root dedicata ──
+// Honoring API: window.PRForm.render(rootId, { mode: 'new', state }).
+const PRStateMount = ({ state }) => {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref.current) window.PRForm.render(ref.current.id, { mode: 'new', state });
+  }, [state]);
+  return <div id={`pr-form-mount-${state}`} ref={ref} />;
+};
+
+// ─── Gallery wrapper exports (anchor #state-NN-*) ──────
+const State01_Default = () => <PRStateMount state="default" />;
+const State02_Empty   = () => <PRStateMount state="empty" />;
+const State03_Loading = () => <PRStateMount state="loading" />;
+const State04_Error   = () => <PRStateMount state="error" />;
+
+const STATES = [
+  { id:'state-01-default', num:'01', title:'Default', Comp: State01_Default,
+    sub:'Form arrivato da deep-link serata completata (gameNightId in URL). Step 1 gioco preselezionato (Wingspan), Step 2 data/ora dalla serata, Step 3 roster dai partecipanti. Stato base, invariato dall\'as-shipped.' },
+  { id:'state-02-empty', num:'02', title:'Empty', Comp: State02_Empty,
+    sub:'Form standalone (nessun gameNightId): tutti i field vuoti. Banner info entry-point (role="status", aria-live="polite"), picker gioco con placeholder, roster vuoto con CTA "Aggiungi giocatore".' },
+  { id:'state-03-loading', num:'03', title:'Loading', Comp: State03_Loading,
+    sub:'Autosave in corso dopo la compilazione di Step 1. Toolbar sticky "Salvataggio in corso…" con spinner, body offuscato (0.65) ma inputabile, progress upload foto, skeleton sull\'anteprima record (desktop). aria-busy + screen-reader announce; pulse 2s, snap con reduced-motion.' },
+  { id:'state-04-error', num:'04', title:'Error', Comp: State04_Error,
+    sub:'Errore al submit finale (Step 3 → "Salva"). Banner full-width (role="alert") + "Riprova salvataggio", form preservato con tutto l\'input, link "Salva come bozza locale" (entity=session) sotto il banner.' },
+];
+
+const NAV = [
+  { id:'state-01-default', label:'01 · Default' },
+  { id:'state-02-empty',   label:'02 · Empty' },
+  { id:'state-03-loading', label:'03 · Loading' },
+  { id:'state-04-error',   label:'04 · Error' },
+];
+
+function ThemeToggle() {
+  const initial = (() => { try { return localStorage.getItem('sp4-pr-theme') === 'dark'; } catch (e) { return false; } })();
+  const [dark, setDark] = useState(initial);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+    try { localStorage.setItem('sp4-pr-theme', dark ? 'dark' : 'light'); } catch (e) {}
+  }, [dark]);
+  return (
+    <button type="button" className="theme-toggle" onClick={() => setDark(d => !d)} aria-pressed={dark}
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function GalleryNav() {
+  return (
+    <nav className="gallery-nav" aria-label="Stati canonici">
+      <div className="gallery-nav-brand"><span aria-hidden="true">🎯</span> SP4 · /play-records/new</div>
+      <div className="gallery-nav-links">
+        {NAV.map(n => <a key={n.id} href={`#${n.id}`}>{n.label}</a>)}
+      </div>
+      <a className="gallery-nav-ghost" href="#state-05-sse-skipped" aria-disabled="true" title="state-05-sse: skipped — form transactional, non SSE-driven">05 · SSE · skip</a>
+      <ThemeToggle/>
+    </nav>
+  );
+}
+
+function StateSection({ id, num, title, sub, Comp }) {
+  return (
+    <section id={id} className="state-section" data-screen-label={id}>
+      <header className="state-head">
+        <div className="state-num">{num}</div>
+        <div className="state-head-text">
+          <h2>{title}</h2>
+          <p>{sub}</p>
+        </div>
+        <code className="state-anchor">#{id}</code>
+      </header>
+      <Comp/>
+    </section>
+  );
+}
+
+function App() {
+  return (
+    <div className="gallery">
+      <GalleryNav/>
+      <div className="gallery-body">
+        <header className="gallery-intro">
+          <div className="kicker">SP4 · /play-records/new 🎯 — canonical states</div>
+          <h1>Registra partita — Stati canonici</h1>
+          <p className="lead">
+            Wizard 3-step (Gioco · Quando · Punteggi) per registrare una partita, allineato al pattern <strong>G7 SessionStateRenderer</strong> (PR 2357).
+            4 stati canonici × viewport mobile&nbsp;375 (wizard bottom-nav) / desktop&nbsp;1440 (split-form 8-col + anteprima live 4-col), × tema light/dark via toggle.
+            Entity dominante <strong>session 🎯</strong>; colori esclusivamente da token <code>--c-*</code> via <code>entityHsl()</code>.
+            Lo stato <code>state-05-sse</code> è intenzionalmente <strong>saltato</strong> (form transactional, non SSE-driven).
+          </p>
+        </header>
+
+        {STATES.map(s => <StateSection key={s.id} {...s}/>)}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);


### PR DESCRIPTION
## Summary

Mockup 2 di 5 del cluster Tier 2 P1 (umbrella #2342 US-INT-2b).

Estende il mockup form \`sp4-play-records-new.{html,jsx,fidelity.json}\` con i 3 nuovi stati canonici (empty + loading + error) e la shared lib \`pr-form-core.jsx\` con prop \`state\` parameterizzata, mantenendo \`mode='edit'\` invariato per coverage Mockup 4 successivo.

## Stati aggiunti (semantic form-specific)

| Anchor | Component | Semantic | A11y |
|---|---|---|---|
| \`state-02-empty\` | \`State02_Empty\` | Form **standalone** senza gameNightId — field tutti vuoti, persona inizia da zero. Banner top info \`entityHsl('session',0.06)\` border-left \`entityHsl('session',0.45)\` icon ℹ️ + copy "Registrazione manuale". | \`role="status"\` + \`aria-live="polite"\` |
| \`state-03-loading\` | \`State03_Loading\` | Autosave in corso post Step 1: toolbar sticky chip mono "💾 Salvataggio in corso…" spinner + body offuscato \`opacity:0.65\` (inputabile) + photo upload progress + skeleton preview record card desktop + screen-reader span. | \`aria-busy\` + \`role="progressbar"\` photo + skeleton \`aria-hidden\` |
| \`state-04-error\` | \`State04_Error\` | Errore submit finale (Step 3 → Salva): banner full-width entity=event severity critica + retry button. Form preserva TUTTO input. Optional link "Salva come bozza locale" sotto banner. | \`role="alert"\` + \`aria-label="Riprova salvataggio partita"\` |

## state-05-sse SKIPPED

\`State05_SSE\` non renderizzato — form transactional (single-shot save), non SSE-driven. Skip documentato in commento JSX + nav ghost link.

## state-01-default INVARIATO

\`State01_Default\` è form arrivato da deep-link serata (gameNightId in URL), pre-fill Wingspan/Marco/Anna/Luca/Sara. Layout as-shipped preservato.

## API extension \`pr-form-core.jsx\`

Aggiunto parametro opzionale \`state\` al render API:

\`\`\`js
window.PRForm.render(rootId, { mode: 'new' | 'edit', state?: 'default' | 'empty' | 'loading' | 'error' });
\`\`\`

Default \`state='default'\` (backward-compat). \`mode='edit'\` branch logic **invariato** in 5 punti (line 67/367/514/553/569). Nuove branch state-aware in linee 566+586. \`PRStateMount\` wrapper in \`sp4-play-records-new.jsx\` chiama \`window.PRForm.render(rootId, { mode: 'new', state })\` per ognuno dei 4 stati.

## FREEZE compliance

- ✅ Zero hex hardcoded — 10× \`color:'#fff'\` su \`background: entityHsl(...)\` (pattern \`.e-bg\` esentato per CLAUDE.md spec).
- ✅ Zero asset BGG/hosting esterno user-side (ban #2123).
- ✅ Token-only via \`tokens.css\` (canonical_only).
- ✅ \`pnpm lint:bgg-mockups\` clean (sp4-play-records-new + pr-form-core NOT in violations baseline).

## A11y + Motion

- AA contrast verificato via token-only (light + dark via ThemeToggle con localStorage persistence \`sp4-pr-theme\`).
- \`prefers-reduced-motion\` → snap senza pulse autosave/skeleton.
- Mobile 375 (wizard 3-step bottom nav) + Desktop 1440 (split-form 8-col + anteprima record card 4-col).
- Gallery scaffold con sticky top nav (4 link anchor + theme toggle + SSE skip ghost) — pattern allineato a Mockup 1 (\`sp4-play-records-index.html\`).

## File changed

| File | Change |
|---|---|
| \`sp4-play-records-new.html\` | shell + gallery scaffold (state-section + frame chrome + skeleton pulse) |
| \`sp4-play-records-new.jsx\` | gallery wrapper con 4 React exports + PRStateMount + GalleryNav + ThemeToggle |
| \`pr-form-core.jsx\` | API extended con \`state\` prop (backward-compat default='default'); 3 new branch empty/loading/error; mode='edit' invariato |
| \`sp4-play-records-new.fidelity.json\` | \`states_covered\` esteso \`[\"default\", \"empty\", \"loading\", \"error\"]\`; \`design_intent: \"current\"\` preservato |

## Test plan

- [x] \`pnpm lint:bgg-mockups\` → no new violations
- [x] \`pnpm lint:tokens:mockups\` → no regressions
- [x] \`pnpm typecheck\` pass (pre-commit hook verified)
- [x] Manual grep: zero menzioni testuali BGG/BoardGameGeek/boardgamegeek/geekdo
- [ ] Reviewer: aprire \`sp4-play-records-new.html\` in browser, verificare 4 anchor + ThemeToggle + responsive 375/1440 + mode='edit' invariato (test side-load \`pr-form-core.jsx\` chiamando \`window.PRForm.render(..., { mode: 'edit' })\`)

## Refs

- Issue: #2361 (Tier 2 P1 umbrella #2342 US-INT-2b)
- Mockup 1: PR #2481 (\`sp4-play-records-index\`)
- Pattern reference: G7 SessionStateRenderer PR #2357
- Shared lib: \`pr-form-core.jsx\` (riusato anche da Mockup 4 \`sp4-play-records-edit\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)